### PR TITLE
Make trace and metrics features optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,17 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-crossbeam-channel = "0.3.9"
+crossbeam-channel = { version = "0.3.9", optional = true }
 lazy_static = "1.4.0"
-prometheus = "0.7.0"
+prometheus = { version = "0.7.0", optional = true }
 rand = "0.7.2"
-rustracing = "0.2.0"
-rustracing_jaeger = "0.2.1"
+rustracing = { version = "0.2.0", optional = true }
+rustracing_jaeger = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 hyper = "0.12.0"
+
+[features]
+default = ["metrics", "trace"]
+trace = ["crossbeam-channel", "rustracing", "rustracing_jaeger"]
+metrics = ["prometheus"]

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -8,5 +8,7 @@
 //! Exporters define the interface that protocol-specific exporters must
 //! implement so that they can be plugged into OpenTelemetry SDK and support
 //! sending of telemetry data.
+#[cfg(feature = "metrics")]
 pub mod metrics;
+#[cfg(feature = "trace")]
 pub mod trace;

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -6,9 +6,14 @@
 //! facilitates the delivery of telemetry data to storage systems
 //! through `Exporter`s. These can be configured on `Tracer` and
 //! `Meter` creation.
+#[cfg(feature = "metrics")]
 pub mod metrics;
+#[cfg(feature = "trace")]
 pub mod trace;
 
+#[cfg(feature = "trace")]
 pub use crate::exporter::trace::jaeger::AllSampler as AlwaysSample;
+#[cfg(feature = "metrics")]
 pub use metrics::{LabelSet, Meter};
+#[cfg(feature = "trace")]
 pub use trace::{config::Config, provider::Provider, span::Span, tracer::Tracer};


### PR DESCRIPTION
Allow `trace` and `metrics` sdk features to be used optionally. This also allows the API to be used without including any SDK features for other potential SDK implementations.