### PR TITLE
Add async tokio client example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ rand = { version = "0.7.2", optional = true }
 hyper = "0.12.0"
 opentelemetry-jaeger = { path = "opentelemetry-jaeger", version = "0.1.0" }
 thrift = "0.13.0"
+futures = "0.3.1"
+tokio = { version = "0.2.10", features = ["full"] }
 
 [features]
 default = ["metrics", "trace"]

--- a/examples/async_fn.rs
+++ b/examples/async_fn.rs
@@ -1,0 +1,88 @@
+//! Demonstrates using OpenTelemetry to instrument `async` functions.
+//!
+//! This is based on the [`hello_world`] example from `tokio`. and implements a
+//! simple client that opens a TCP stream, writes "hello world\n", and closes
+//! the connection.
+//!
+//! You can test this out by running:
+//!
+//!     ncat -l 6142
+//!
+//! And then in a second terminal run:
+//!
+//!     ncat -l 6143
+//!
+//! And then in a third terminal run:
+//!
+//!     cargo run --example async_fn
+//!
+//! [`hello_world`]: https://github.com/tokio-rs/tokio/blob/132e9f1da5965530b63554d7a1c59824c3de4e30/tokio/examples/hello_world.rs
+use opentelemetry::{
+    api::{trace::futures::Instrument, Provider, Tracer},
+    global, sdk,
+};
+use std::time::Duration;
+use std::{error::Error, io, net::SocketAddr, thread};
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+
+async fn connect(addr: &SocketAddr) -> io::Result<TcpStream> {
+    let tracer = global::trace_provider().get_tracer("connector");
+    let span = tracer.start("Connecting", None);
+
+    TcpStream::connect(&addr).instrument(span).await
+}
+
+async fn write(stream: &mut TcpStream) -> io::Result<usize> {
+    let tracer = global::trace_provider().get_tracer("writer");
+    let span = tracer.start("Writing", None);
+
+    stream.write(b"hello world\n").instrument(span).await
+}
+
+async fn run(addr: &SocketAddr) -> io::Result<usize> {
+    let tracer = global::trace_provider().get_tracer("runner");
+    let span = tracer.start(&format!("running: {}", addr), None);
+
+    let mut stream = connect(addr).instrument(tracer.clone_span(&span)).await?;
+    write(&mut stream).instrument(span).await
+}
+
+fn init_tracer() -> thrift::Result<()> {
+    let exporter = opentelemetry_jaeger::Exporter::builder()
+        .with_agent_endpoint("127.0.0.1:6831".parse().unwrap())
+        .with_process(opentelemetry_jaeger::Process {
+            service_name: "trace-demo".to_string(),
+            tags: vec![],
+        })
+        .init()?;
+    let provider = sdk::Provider::builder()
+        .with_simple_exporter(exporter)
+        .with_config(sdk::Config {
+            default_sampler: Box::new(sdk::Sampler::Always),
+            ..Default::default()
+        })
+        .build();
+    global::set_provider(provider);
+
+    Ok(())
+}
+
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn Error>> {
+    init_tracer()?;
+    let addr = "127.0.0.1:6142".parse()?;
+    let addr2 = "127.0.0.1:6143".parse()?;
+    let tracer = global::trace_provider().get_tracer("async_example");
+    let span = tracer.start("root", None);
+
+    let (run1, run2) = futures::future::join(run(&addr), run(&addr2))
+        .instrument(span)
+        .await;
+    run1?;
+    run2?;
+
+    thread::sleep(Duration::from_millis(250));
+
+    Ok(())
+}


### PR DESCRIPTION
Example of simple tokio client using async/await. This uses the current (and somewhat awkward) `mark_span_as_active`/`mark_span_as_inactive` API for demo and API improvement purposes.

Resulting traces:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/175237/73145401-4661ab00-4062-11ea-8d60-deb8d9140443.png">


Resolves #35