### PR TITLE
Add Futures compatibility API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.4.0"
+pin-project = { version = "0.4.6", optional = true }
 prometheus = { version = "0.7.0", optional = true }
 rand = { version = "0.7.2", optional = true }
 
@@ -23,7 +24,7 @@ thrift = "0.13.0"
 
 [features]
 default = ["metrics", "trace"]
-trace = ["rand"]
+trace = ["rand", "pin-project"]
 metrics = ["prometheus"]
 
 [workspace]

--- a/opentelemetry-jaeger/src/thrift/agent.rs
+++ b/opentelemetry-jaeger/src/thrift/agent.rs
@@ -138,7 +138,7 @@ impl TAgentProcessFunctions {
             let ret_err = {
               ApplicationError::new(
                 ApplicationErrorKind::Unknown,
-                e.description()
+                e.to_string()
               )
             };
             Err(thrift::Error::Application(ret_err))
@@ -162,7 +162,7 @@ impl TAgentProcessFunctions {
             let ret_err = {
               ApplicationError::new(
                 ApplicationErrorKind::Unknown,
-                e.description()
+                e.to_string()
               )
             };
             Err(thrift::Error::Application(ret_err))

--- a/opentelemetry-jaeger/src/thrift/jaeger.rs
+++ b/opentelemetry-jaeger/src/thrift/jaeger.rs
@@ -943,7 +943,7 @@ impl TCollectorProcessFunctions {
             let ret_err = {
               ApplicationError::new(
                 ApplicationErrorKind::Unknown,
-                e.description()
+                e.to_string()
               )
             };
             let message_ident = TMessageIdentifier::new("submitBatches", TMessageType::Exception, incoming_sequence_number);

--- a/opentelemetry-jaeger/src/thrift/zipkincore.rs
+++ b/opentelemetry-jaeger/src/thrift/zipkincore.rs
@@ -919,7 +919,7 @@ impl TZipkinCollectorProcessFunctions {
             let ret_err = {
               ApplicationError::new(
                 ApplicationErrorKind::Unknown,
-                e.description()
+                e.to_string()
               )
             };
             let message_ident = TMessageIdentifier::new("submitZipkinBatch", TMessageType::Exception, incoming_sequence_number);

--- a/opentelemetry-jaeger/src/transport/udp.rs
+++ b/opentelemetry-jaeger/src/transport/udp.rs
@@ -1,5 +1,4 @@
 //! Thrift UDP transport
-use std::error::Error;
 use std::net::{ToSocketAddrs, UdpSocket};
 use std::sync::{Arc, Mutex};
 use thrift::transport::{ReadHalf, WriteHalf};
@@ -46,7 +45,7 @@ impl std::io::Write for TUdpChannel {
         let mut write_buffer = self
             .write_buffer
             .lock()
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.description()))?;
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.to_string()))?;
         if write_buffer.len() + buf.len() > self.max_packet_size {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -67,7 +66,7 @@ impl std::io::Write for TUdpChannel {
         let mut write_buffer = self
             .write_buffer
             .lock()
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.description()))?;
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.to_string()))?;
         self.conn
             .send(write_buffer.as_slice())
             .map(|_| write_buffer.clear())

--- a/src/api/trace/futures.rs
+++ b/src/api/trace/futures.rs
@@ -1,0 +1,53 @@
+//! # OpenTelemetry Futures Compatibility
+//!
+//! This module provides utilities for instrumenting asynchronous code written
+//! using [`futures`] and async/await.
+//!
+//! This main trait is [`Instrument`], which allows a [`Tracer`], and a [`Span`]
+//! to be attached to a future, sink, stream, or executor.
+//!
+//! [`futures`]: https://doc.rust-lang.org/std/future/trait.Future.html
+//! [`Instrument`]: trait.Instrument.html
+//! [`Tracer`]: ../tracer/trait.Tracer.html
+//! [`Span`]: ../span/trait.Span.html
+
+use crate::api;
+use pin_project::pin_project;
+use std::{pin::Pin, task::Context};
+
+/// A future, stream, sink, or executor that has been instrumented with a tracer and span.
+#[pin_project]
+#[derive(Debug, Clone)]
+pub struct Instrumented<F, S: api::Span> {
+    #[pin]
+    inner: F,
+    span: S,
+}
+
+impl<F: Sized> Instrument for F {}
+
+impl<F: std::future::Future, S: api::Span> std::future::Future for Instrumented<F, S> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        this.span.mark_as_active();
+        let res = this.inner.poll(cx);
+        this.span.mark_as_inactive();
+        res
+    }
+}
+
+/// Extension trait allowing futures, streams, sinks, and executors to be traced with a span.
+pub trait Instrument: Sized {
+    /// Traces this type with the provided `Span`, returning a `Instrumented` wrapper.
+    fn instrument<S: api::Span>(self, span: S) -> Instrumented<Self, S> {
+        Instrumented { inner: self, span }
+    }
+
+    /// Traces this type with the provided `Tracer`'s active span, returning a `Instrumented` wrapper.
+    fn in_active_span<T: api::Tracer>(self, tracer: T) -> Instrumented<Self, T::Span> {
+        let span = tracer.get_active_span();
+        self.instrument(span)
+    }
+}

--- a/src/api/trace/mod.rs
+++ b/src/api/trace/mod.rs
@@ -92,6 +92,7 @@
 //! field](https://www.w3.org/TR/trace-context/#tracestate-field).
 //!
 pub mod event;
+pub mod futures;
 pub mod link;
 pub mod noop;
 pub mod propagator;

--- a/src/api/trace/noop.rs
+++ b/src/api/trace/noop.rs
@@ -86,6 +86,16 @@ impl api::Span for NoopSpan {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    /// Ignores being marked as active
+    fn mark_as_active(&self) {
+        // Ignored
+    }
+
+    /// Ignores being marked as inactive
+    fn mark_as_inactive(&self) {
+        // Ignored
+    }
 }
 
 /// A no-op instance of a `Tracer`.
@@ -118,5 +128,9 @@ impl api::Tracer for NoopTracer {
     /// Ignores active span state.
     fn mark_span_as_inactive(&self, _span_id: u64) {
         // Noop
+    }
+
+    fn clone_span(&self, _span: &Self::Span) -> Self::Span {
+        self.invalid()
     }
 }

--- a/src/api/trace/span.rs
+++ b/src/api/trace/span.rs
@@ -117,6 +117,22 @@ pub trait Span: Send + Sync + std::fmt::Debug {
 
     /// Used by global tracer to downcast to specific span type.
     fn as_any(&self) -> &dyn std::any::Any;
+
+    /// Mark as currently active span.
+    ///
+    /// This is the _synchronous_ api. If you are using futures, you
+    /// need to use the async api via [`instrument`].
+    ///
+    /// [`instrument`]: ../futures/trait.Instrument.html#method.instrument
+    fn mark_as_active(&self);
+
+    /// Mark as no longer active.
+    ///
+    /// This is the _synchronous_ api. If you are using futures, you
+    /// need to use the async api via [`instrument`].
+    ///
+    /// [`instrument`]: ../futures/trait.Instrument.html#method.instrument
+    fn mark_as_inactive(&self);
 }
 
 /// `SpanKind` describes the relationship between the Span, its parents,

--- a/src/api/trace/tracer.rs
+++ b/src/api/trace/tracer.rs
@@ -89,6 +89,9 @@ pub trait Tracer: Send + Sync {
     /// If you do not want to manage active state of `Span`s manually, use the `with_span`
     /// API defined for all `Tracer`s via `TracerGenerics`
     fn mark_span_as_inactive(&self, span_id: u64);
+
+    /// Clone a span created by this tracer.
+    fn clone_span(&self, span: &Self::Span) -> Self::Span;
 }
 
 /// TracerGenerics are functions that have generic type parameters. They are a separate


### PR DESCRIPTION
This adds an `Instrument` trait which allows futures to be extended with an `instrument` method, inspired by [tracing-futures](https://github.com/tokio-rs/tracing/tree/master/tracing-futures). This allows a span to be correctly associated with a given task, and fixes the issues highlighted by #43.

Using this API requires moving the span into the future it is instrumenting, so a `clone_span` method on `Tracer` was added to allow a given span to be associated with many futures.