### PR TITLE
Adding actix-web example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ thrift = "0.13.0"
 futures = "0.3.1"
 tokio = { version = "0.2.10", features = ["full"] }
 
-
 [features]
 default = ["metrics", "trace"]
 trace = ["rand", "pin-project"]
@@ -36,4 +35,5 @@ serialize = ["serde", "bincode"]
 [workspace]
 members = [
     "opentelemetry-jaeger",
+    "examples/actix",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ thrift = "0.13.0"
 futures = "0.3.1"
 tokio = { version = "0.2.10", features = ["full"] }
 
+
 [features]
 default = ["metrics", "trace"]
 trace = ["rand", "pin-project"]

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -1,0 +1,58 @@
+use opentelemetry::api::{Key, Provider, Span, TracerGenerics};
+use opentelemetry::{global, sdk};
+
+use actix_service::Service;
+use actix_web::{web, App, HttpServer};
+use futures::future::Future;
+
+fn init_tracer() -> thrift::Result<()> {
+    let exporter = opentelemetry_jaeger::Exporter::builder()
+        .with_agent_endpoint("127.0.0.1:6831".parse().unwrap())
+        .with_process(opentelemetry_jaeger::Process {
+            service_name: "trace-demo".to_string(),
+            tags: vec![
+                Key::new("exporter").string("jaeger"),
+                Key::new("float").f64(312.23),
+            ],
+        })
+        .init()?;
+    let provider = sdk::Provider::builder()
+        .with_simple_exporter(exporter)
+        .with_config(sdk::Config {
+            default_sampler: Box::new(sdk::Sampler::Always),
+            ..Default::default()
+        })
+        .build();
+    global::set_provider(provider);
+
+    Ok(())
+}
+
+fn index() -> &'static str {
+    let tracer = global::trace_provider().get_tracer("request");
+
+    tracer.with_span("index", move |span| {
+        span.set_attribute(Key::new("parameter").i64(10));
+        "Index"
+    })
+}
+
+fn main() -> std::io::Result<()> {
+    init_tracer();
+
+    HttpServer::new(|| {
+        App::new()
+            .wrap_fn(|req, srv| {
+                let tracer = global::trace_provider().get_tracer("request");
+                tracer.with_span("middleware", move |span| {
+                    span.set_attribute(Key::new("path").string(req.path()));
+
+                    srv.call(req).map(|res| res)
+                })
+            })
+            .route("/", web::get().to(index))
+    })
+    .bind("127.0.0.1:8088")
+    .unwrap()
+    .run()
+}

--- a/examples/actix/Cargo.toml
+++ b/examples/actix/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "actix-example"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+opentelemetry = { path = "../../", version = "0.1.5" }
+opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", version = "0.1.0" }
+thrift = "0.13.0"
+
+futures = "0.1.25"
+actix-web = "1.0.9"
+actix-service = "0.4.1"

--- a/examples/actix/src/main.rs
+++ b/examples/actix/src/main.rs
@@ -37,8 +37,8 @@ fn index() -> &'static str {
     })
 }
 
-fn main() -> std::io::Result<()> {
-    init_tracer();
+fn main() -> thrift::Result<()> {
+    init_tracer()?;
 
     HttpServer::new(|| {
         App::new()
@@ -46,7 +46,6 @@ fn main() -> std::io::Result<()> {
                 let tracer = global::trace_provider().get_tracer("request");
                 tracer.with_span("middleware", move |span| {
                     span.set_attribute(Key::new("path").string(req.path()));
-
                     srv.call(req).map(|res| res)
                 })
             })
@@ -54,5 +53,7 @@ fn main() -> std::io::Result<()> {
     })
     .bind("127.0.0.1:8088")
     .unwrap()
-    .run()
+    .run()?;
+
+    Ok(())
 }


### PR DESCRIPTION
Initial actix-web middleware and parent span testing.

![image](https://user-images.githubusercontent.com/1223213/71313590-df205d80-2408-11ea-8d33-a8fcd9387b52.png)

Missing metrics and move init_trace to a reusable module.

Run with: cargo run --example actix
Test with: curl localhost:8088/