### PR TITLE
Add initial trace benchmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,10 +92,12 @@ your Rust code
 * Run `cargo fmt` - this will find and fix code formatting
 issues.
 
-## Testing
+## Testing and Benchmarking
 
 * Run `cargo test --all` - this will execute code and doc tests for all
 projects in this workspace.
+* Run `cargo bench` - this will run benchmarks to show performance 
+regressions
 
 ## Approvers and Maintainers
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.104", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 
 [dev-dependencies]
+criterion = "0.3.1"
 hyper = "0.12.0"
 opentelemetry-jaeger = "0.1.0"
 thrift = "0.13.0"
@@ -41,3 +42,7 @@ members = [
 [patch.crates-io]
 opentelemetry-jaeger = { path = "opentelemetry-jaeger" }
 opentelemetry = { path = "." }
+
+[[bench]]
+name = "trace"
+harness = false

--- a/benches/trace.rs
+++ b/benches/trace.rs
@@ -1,0 +1,99 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use opentelemetry::{
+    api::{Key, Provider, Span, Tracer},
+    sdk,
+};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    trace_benchmark_group(c, "start-end-span", |tracer| {
+        tracer.start("foo", None).end()
+    });
+
+    trace_benchmark_group(c, "start-end-span-4-attrs", |tracer| {
+        let mut span = tracer.start("foo", None);
+        span.set_attribute(Key::new("key1").bool(false));
+        span.set_attribute(Key::new("key2").string("hello"));
+        span.set_attribute(Key::new("key3").u64(123));
+        span.set_attribute(Key::new("key4").f64(123.456));
+        span.end();
+    });
+
+    trace_benchmark_group(c, "start-end-span-8-attrs", |tracer| {
+        let mut span = tracer.start("foo", None);
+        span.set_attribute(Key::new("key1").bool(false));
+        span.set_attribute(Key::new("key2").string("hello"));
+        span.set_attribute(Key::new("key3").u64(123));
+        span.set_attribute(Key::new("key4").f64(123.456));
+        span.set_attribute(Key::new("key11").bool(false));
+        span.set_attribute(Key::new("key12").string("hello"));
+        span.set_attribute(Key::new("key13").u64(123));
+        span.set_attribute(Key::new("key14").f64(123.456));
+        span.end();
+    });
+
+    trace_benchmark_group(c, "start-end-span-all-attr-types", |tracer| {
+        let mut span = tracer.start("foo", None);
+        span.set_attribute(Key::new("key1").bool(false));
+        span.set_attribute(Key::new("key2").string("hello"));
+        span.set_attribute(Key::new("key3").i64(123));
+        span.set_attribute(Key::new("key4").u64(123));
+        span.set_attribute(Key::new("key5").f64(123.456));
+        span.set_attribute(
+            Key::new("key6").bytes(vec![104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]),
+        );
+        span.end();
+    });
+
+    trace_benchmark_group(c, "start-end-span-all-attr-types-2x", |tracer| {
+        let mut span = tracer.start("foo", None);
+        span.set_attribute(Key::new("key1").bool(false));
+        span.set_attribute(Key::new("key2").string("hello"));
+        span.set_attribute(Key::new("key3").i64(123));
+        span.set_attribute(Key::new("key4").u64(123));
+        span.set_attribute(Key::new("key5").f64(123.456));
+        span.set_attribute(
+            Key::new("key6").bytes(vec![104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]),
+        );
+        span.set_attribute(Key::new("key11").bool(false));
+        span.set_attribute(Key::new("key12").string("hello"));
+        span.set_attribute(Key::new("key13").i64(123));
+        span.set_attribute(Key::new("key14").u64(123));
+        span.set_attribute(Key::new("key15").f64(123.456));
+        span.set_attribute(
+            Key::new("key16").bytes(vec![104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]),
+        );
+        span.end();
+    });
+}
+
+fn trace_benchmark_group<F: Fn(&sdk::Tracer) -> ()>(c: &mut Criterion, name: &str, f: F) {
+    let mut group = c.benchmark_group(name);
+
+    group.bench_function("always-sample", |b| {
+        let always_sample = sdk::Provider::builder()
+            .with_config(sdk::Config {
+                default_sampler: Box::new(sdk::Sampler::Always),
+                ..Default::default()
+            })
+            .build()
+            .get_tracer("always-sample");
+
+        b.iter(|| f(&always_sample));
+    });
+
+    group.bench_function("never-sample", |b| {
+        let never_sample = sdk::Provider::builder()
+            .with_config(sdk::Config {
+                default_sampler: Box::new(sdk::Sampler::Never),
+                ..Default::default()
+            })
+            .build()
+            .get_tracer("never-sample");
+        b.iter(|| f(&never_sample));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Benchmarks provided by the [criterion](https://github.com/bheisler/criterion.rs) crate. Initially only benchmarking span creation with various combinations of attributes.

Resolves #42 