### PR TITLE
Introduce Zipkin exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serialize = ["serde", "bincode"]
 [workspace]
 members = [
     "opentelemetry-jaeger",
+    "opentelemetry-zipkin",
     "examples/actix",
 ]
 

--- a/opentelemetry-zipkin/CHANGELOG.md
+++ b/opentelemetry-zipkin/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v0.0.1
+
+### Added
+
+- Exporter to Zipkin collector through HTTP API 
+

--- a/opentelemetry-zipkin/CODEOWNERS
+++ b/opentelemetry-zipkin/CODEOWNERS
@@ -1,0 +1,6 @@
+
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For anything not explicitly taken by someone else:
+*  @open-telemetry/rust-approvers

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "opentelemetry-zipkin"
+version = "0.0.1"
+authors = ["OpenTelemetry Authors <cncf-opentelemetry-contributors@lists.cncf.io>"]
+description = "Zipkin exporter for OpenTelemetry"
+homepage = "https://github.com/open-telemetry/opentelemetry-rust"
+repository = "https://github.com/open-telemetry/opentelemetry-rust"
+readme = "README.md"
+categories = ["development-tools::debugging"]
+keywords = ["opentelemetry", "zipkin"]
+license = "Apache-2.0"
+edition = "2018"
+
+[dependencies]
+opentelemetry = "0.2.0"
+reqwest = { version = "0.10.4", features = ["blocking"] }
+serde_json = "1.0"
+serde = { version = "1.0.104", features = ["derive"] }
+typed-builder = "0.5.1"

--- a/opentelemetry-zipkin/LICENSE
+++ b/opentelemetry-zipkin/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -1,0 +1,3 @@
+# OpenTelemetry Zipkin 
+
+A Zipkin exporter implementation for OpenTelemetry Rust.

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -1,0 +1,248 @@
+//! # OpenTelemetry Zipkin Exporter
+//!
+//! Collects OpenTelemetry spans and reports them to a given Zipkin
+//! `collector` endpoint. See the [Zipkin Docs](https://zipkin.io/) for details
+//! and deployment information.
+//!
+//! ### Zipkin collector example
+//!
+//! This example expects a Zipkin collector running on `localhost:9411`.
+//!
+//! ```rust,no_run
+//! use opentelemetry::{api::Key, global, sdk};
+//! use opentelemetry_zipkin::ExporterConfig;
+//! use std::net::{SocketAddr, IpAddr, Ipv4Addr};
+//!
+//! fn init_tracer() {
+//!     let exporter = opentelemetry_zipkin::Exporter::from_config(
+//!        ExporterConfig::builder()
+//!            .with_service_name("opentelemetry-backend".to_owned())
+//!            .with_service_endpoint(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080))
+//!            .build());
+//!     let provider = sdk::Provider::builder()
+//!         .with_simple_exporter(exporter)
+//!         .with_config(sdk::Config {
+//!             default_sampler: Box::new(sdk::Sampler::Always),
+//!             ..Default::default()
+//!         })
+//!         .build();
+//!
+//!     global::set_provider(provider);
+//! }
+//! ```
+//!
+
+#[macro_use]
+extern crate typed_builder;
+
+mod model;
+mod uploader;
+
+use core::any;
+use model::{annotation, endpoint, span};
+use opentelemetry::api;
+use opentelemetry::exporter::trace;
+use std::collections::HashMap;
+use std::net;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+/// Default Zipkin collector endpoint if none specified
+static DEFAULT_COLLECTOR_ENDPOINT: &str = "127.0.0.1:9411";
+
+/// Zipkin span exporter
+#[derive(Debug)]
+pub struct Exporter {
+    config: ExporterConfig,
+    uploader: uploader::Uploader,
+}
+
+/// Zipkin-specific configuration used to initialize the `Exporter`.
+#[derive(Clone, Debug)]
+pub struct ExporterConfig {
+    local_endpoint: endpoint::Endpoint,
+    collector_endpoint: String,
+}
+
+/// Builder for `ExporterConfig` struct.
+#[derive(Debug)]
+pub struct ExporterConfigBuilder {
+    service_name: Option<String>,
+    service_endpoint: Option<net::SocketAddr>,
+    collector_endpoint: Option<String>,
+}
+
+impl Default for ExporterConfigBuilder {
+    fn default() -> Self {
+        ExporterConfigBuilder {
+            collector_endpoint: None,
+            service_name: None,
+            service_endpoint: None,
+        }
+    }
+}
+
+impl ExporterConfig {
+    pub fn builder() -> ExporterConfigBuilder {
+        ExporterConfigBuilder::default()
+    }
+}
+
+impl ExporterConfigBuilder {
+    /// Create `ExporterConfig` struct from current `ExporterConfigBuilder`
+    pub fn build(&self) -> ExporterConfig {
+        let local_endpoint: endpoint::Endpoint;
+        let service_name = self
+            .service_name
+            .clone()
+            .unwrap_or_else(|| "DEFAULT".to_owned());
+        match self.service_endpoint {
+            Some(socket_addr) => {
+                match socket_addr.ip() {
+                    net::IpAddr::V4(addr) => {
+                        local_endpoint = endpoint::Endpoint::builder()
+                            .service_name(service_name)
+                            .ipv4(addr)
+                            .port(socket_addr.port())
+                            .build()
+                    }
+                    net::IpAddr::V6(addr) => {
+                        local_endpoint = endpoint::Endpoint::builder()
+                            .service_name(service_name)
+                            .ipv6(addr)
+                            .port(socket_addr.port())
+                            .build()
+                    }
+                };
+            }
+            None => {
+                local_endpoint = endpoint::Endpoint::builder()
+                    .service_name(service_name)
+                    .build()
+            }
+        };
+        ExporterConfig {
+            collector_endpoint: self
+                .collector_endpoint
+                .clone()
+                .unwrap_or_else(|| DEFAULT_COLLECTOR_ENDPOINT.parse().unwrap()),
+            local_endpoint,
+        }
+    }
+
+    /// Assign the service name for `ConfigBuilder`
+    pub fn with_service_name(&mut self, name: String) -> &mut Self {
+        self.service_name = Some(name);
+        self
+    }
+
+    /// Assign the service endpoint for `ConfigBuilder`
+    pub fn with_service_endpoint(&mut self, endpoint: net::SocketAddr) -> &mut Self {
+        self.service_endpoint = Some(endpoint);
+        self
+    }
+}
+
+impl Exporter {
+    /// Creates new `Exporter` from a given `ExporterConfig`.
+    pub fn from_config(config: ExporterConfig) -> Self {
+        Exporter {
+            config: config.clone(),
+            uploader: uploader::Uploader::new(
+                config.collector_endpoint,
+                uploader::UploaderFormat::HTTP,
+            ),
+        }
+    }
+}
+
+impl trace::SpanExporter for Exporter {
+    /// Export spans to Zipkin collector.
+    fn export(&self, batch: Vec<Arc<trace::SpanData>>) -> trace::ExportResult {
+        let zipkin_spans: Vec<span::Span> = batch
+            .into_iter()
+            .map(|span| into_zipkin_span(&self.config, span))
+            .collect();
+        self.uploader.upload(span::ListOfSpans(zipkin_spans))
+    }
+
+    fn shutdown(&self) {}
+
+    fn as_any(&self) -> &dyn any::Any {
+        self
+    }
+}
+
+/// Converts `api::Event` into an `annotation::Annotation`
+impl Into<annotation::Annotation> for api::Event {
+    fn into(self) -> annotation::Annotation {
+        let timestamp = self
+            .timestamp
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_else(|_| Duration::from_secs(0))
+            .as_micros() as u64;
+
+        annotation::Annotation::builder()
+            .timestamp(timestamp)
+            .value(self.message)
+            .build()
+    }
+}
+
+/// Converts `api::SpanKind` into an `Option<span::Kind>`
+fn into_zipkin_span_kind(kind: api::SpanKind) -> Option<span::Kind> {
+    match kind {
+        api::SpanKind::Client => Some(span::Kind::Client),
+        api::SpanKind::Server => Some(span::Kind::Server),
+        api::SpanKind::Producer => Some(span::Kind::Producer),
+        api::SpanKind::Consumer => Some(span::Kind::Consumer),
+        api::SpanKind::Internal => None,
+    }
+}
+
+/// Converts a `trace::SpanData` to a `span::SpanData` for a given `ExporterConfig`, which can then
+/// be ingested into a Zipkin collector.
+fn into_zipkin_span(config: &ExporterConfig, span_data: Arc<trace::SpanData>) -> span::Span {
+    span::Span::builder()
+        .trace_id(format!("{:032x}", span_data.context.trace_id().to_u128()))
+        .parent_id(format!("{:016x}", span_data.parent_span_id.to_u64()))
+        .id(format!("{:016x}", span_data.context.span_id().to_u64()))
+        .name(span_data.name.clone())
+        .kind(into_zipkin_span_kind(span_data.span_kind.clone()))
+        .timestamp(
+            span_data
+                .start_time
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or(Duration::from_secs(0))
+                .as_micros() as u64,
+        )
+        .duration(
+            span_data
+                .end_time
+                .duration_since(span_data.start_time)
+                .unwrap_or(Duration::from_secs(0))
+                .as_micros() as u64,
+        )
+        .local_endpoint(config.local_endpoint.clone())
+        .annotations(
+            span_data
+                .message_events
+                .iter()
+                .cloned()
+                .map(Into::into)
+                .collect(),
+        )
+        .tags(map_from_kvs(span_data.attributes.clone().into_iter()))
+        .build()
+}
+
+fn map_from_kvs<T>(kvs: T) -> HashMap<String, String>
+where
+    T: IntoIterator<Item = api::KeyValue>,
+{
+    let mut map: HashMap<String, String> = HashMap::new();
+    for kv in kvs {
+        map.insert(kv.key.into(), kv.value.to_string());
+    }
+    map
+}

--- a/opentelemetry-zipkin/src/model/annotation.rs
+++ b/opentelemetry-zipkin/src/model/annotation.rs
@@ -1,0 +1,38 @@
+use serde::Serialize;
+
+#[derive(TypedBuilder, Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Annotation {
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timestamp: Option<u64>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value: Option<String>,
+}
+
+#[cfg(test)]
+mod annotation_serialization_tests {
+    use crate::model::annotation::Annotation;
+
+    #[test]
+    fn test_empty() {
+        test_json_serialization(Annotation::builder().build(), "{}");
+    }
+
+    #[test]
+    fn test_full_annotation() {
+        test_json_serialization(
+            Annotation::builder()
+                .timestamp(1_502_787_600_000_000)
+                .value("open-telemetry".to_owned())
+                .build(),
+            "{\"timestamp\":1502787600000000,\"value\":\"open-telemetry\"}",
+        );
+    }
+
+    fn test_json_serialization(annotation: Annotation, desired: &str) {
+        let result = serde_json::to_string(&annotation).unwrap();
+        assert_eq!(result, desired.to_owned());
+    }
+}

--- a/opentelemetry-zipkin/src/model/endpoint.rs
+++ b/opentelemetry-zipkin/src/model/endpoint.rs
@@ -1,0 +1,47 @@
+use serde::Serialize;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+#[derive(TypedBuilder, Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Endpoint {
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service_name: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ipv4: Option<Ipv4Addr>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ipv6: Option<Ipv6Addr>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    port: Option<u16>,
+}
+
+#[cfg(test)]
+mod endpoint_serialization_tests {
+    use crate::model::endpoint::Endpoint;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn test_empty() {
+        test_json_serialization(Endpoint::builder().build(), "{}");
+    }
+
+    #[test]
+    fn test_ipv4_empty() {
+        test_json_serialization(
+            Endpoint::builder()
+                .service_name("open-telemetry".to_owned())
+                .ipv4(Ipv4Addr::new(127, 0, 0, 1))
+                .port(8080)
+                .build(),
+            "{\"serviceName\":\"open-telemetry\",\"ipv4\":\"127.0.0.1\",\"port\":8080}",
+        );
+    }
+
+    fn test_json_serialization(endpoint: Endpoint, desired: &str) {
+        let result = serde_json::to_string(&endpoint).unwrap();
+        assert_eq!(result, desired.to_owned());
+    }
+}

--- a/opentelemetry-zipkin/src/model/mod.rs
+++ b/opentelemetry-zipkin/src/model/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod annotation;
+pub(crate) mod endpoint;
+pub(crate) mod span;

--- a/opentelemetry-zipkin/src/model/span.rs
+++ b/opentelemetry-zipkin/src/model/span.rs
@@ -1,0 +1,118 @@
+use crate::model::{annotation::Annotation, endpoint::Endpoint};
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Serialize)]
+pub struct ListOfSpans(pub(crate) Vec<Span>);
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Kind {
+    Client,
+    Server,
+    Producer,
+    Consumer,
+}
+
+#[derive(TypedBuilder, Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Span {
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trace_id: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_id: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+    #[builder(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kind: Option<Kind>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timestamp: Option<u64>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration: Option<u64>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    local_endpoint: Option<Endpoint>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remote_endpoint: Option<Endpoint>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    annotations: Option<Vec<Annotation>>,
+    #[builder(setter(strip_option), default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tags: Option<HashMap<String, String>>,
+    #[builder(default = false)]
+    debug: bool,
+    #[builder(default = false)]
+    shared: bool,
+}
+
+#[cfg(test)]
+mod span_serialization_tests {
+    use crate::model::annotation::Annotation;
+    use crate::model::endpoint::Endpoint;
+    use crate::model::span::{Kind, Span};
+    use std::collections::HashMap;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn test_empty() {
+        test_json_serialization(
+            Span::builder().build(),
+            "{\"debug\":false,\"shared\":false}",
+        );
+    }
+
+    #[test]
+    fn test_full_span() {
+        let mut tags = HashMap::new();
+        tags.insert("a".to_owned(), "b".to_owned());
+        test_json_serialization(
+            Span::builder()
+                .trace_id("4e441824ec2b6a44ffdc9bb9a6453df3".to_owned())
+                .parent_id("ffdc9bb9a6453df3".to_owned())
+                .id("efdc9cd9a1849df3".to_owned())
+                .kind(Some(Kind::Server))
+                .name("main".to_owned())
+                .timestamp(1_502_787_600_000_000)
+                .duration(150_000)
+                .local_endpoint(
+                    Endpoint::builder()
+                        .service_name("remote-service".to_owned())
+                        .ipv4(Ipv4Addr::new(192, 168, 0, 1))
+                        .port(8080)
+                        .build()
+                )
+                .remote_endpoint(
+                    Endpoint::builder()
+                        .service_name("open-telemetry".to_owned())
+                        .ipv4(Ipv4Addr::new(127, 0, 0, 1))
+                        .port(8080)
+                        .build()
+                )
+                .annotations(vec![
+                    Annotation::builder()
+                        .timestamp(1_502_780_000_000_000)
+                        .value("interesting event".to_string())
+                        .build()
+                ])
+                .tags(tags)
+                .build(),
+            "{\"traceId\":\"4e441824ec2b6a44ffdc9bb9a6453df3\",\"parentId\":\"ffdc9bb9a6453df3\",\"id\":\"efdc9cd9a1849df3\",\"kind\":\"SERVER\",\"name\":\"main\",\"timestamp\":1502787600000000,\"duration\":150000,\"localEndpoint\":{\"serviceName\":\"remote-service\",\"ipv4\":\"192.168.0.1\",\"port\":8080},\"remoteEndpoint\":{\"serviceName\":\"open-telemetry\",\"ipv4\":\"127.0.0.1\",\"port\":8080},\"annotations\":[{\"timestamp\":1502780000000000,\"value\":\"interesting event\"}],\"tags\":{\"a\":\"b\"},\"debug\":false,\"shared\":false}",
+        );
+    }
+
+    fn test_json_serialization(span: Span, desired: &str) {
+        let result = serde_json::to_string(&span).unwrap();
+        assert_eq!(result, desired.to_owned());
+    }
+}

--- a/opentelemetry-zipkin/src/uploader.rs
+++ b/opentelemetry-zipkin/src/uploader.rs
@@ -1,0 +1,57 @@
+//! # Zipkin Span Exporter
+use crate::model::span::ListOfSpans;
+use opentelemetry::exporter::trace;
+
+/// Default v2 HTTP Zipkin API route for recording spans
+static API_V2_COLLECTOR_ROUTE: &str = "/api/v2/spans";
+
+#[derive(Clone, Debug)]
+pub enum UploaderFormat {
+    HTTP,
+}
+
+#[derive(Debug)]
+pub(crate) struct Uploader {
+    client: reqwest::blocking::Client,
+    collector_endpoint: String,
+    format: UploaderFormat,
+}
+
+impl Uploader {
+    pub(crate) fn new(collector_endpoint: String, format: UploaderFormat) -> Self {
+        Uploader {
+            format,
+            client: reqwest::blocking::Client::new(),
+            collector_endpoint: format!("http://{}{}", collector_endpoint, API_V2_COLLECTOR_ROUTE),
+        }
+    }
+
+    /// Upload a `ListOfSpans` to the designated Zipkin collector
+    pub(crate) fn upload(&self, spans: ListOfSpans) -> trace::ExportResult {
+        match self.format {
+            UploaderFormat::HTTP => self.upload_http(spans),
+        }
+    }
+
+    fn upload_http(&self, spans: ListOfSpans) -> trace::ExportResult {
+        let zipkin_span_json = match serde_json::to_string(&spans) {
+            Ok(json) => json,
+            Err(_) => return trace::ExportResult::FailedNotRetryable,
+        };
+
+        let resp = self
+            .client
+            .post(&self.collector_endpoint)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(zipkin_span_json)
+            .send();
+
+        if let Ok(response) = resp {
+            if response.status().is_success() {
+                return trace::ExportResult::Success;
+            }
+        }
+
+        trace::ExportResult::FailedRetryable
+    }
+}


### PR DESCRIPTION
This PR adds an experimental Zipkin exporter with configurable collector endpoint. Wanted to put up a draft PR to get a critique on the high-level implementation direction before I delved further into it (below implementation exports spans correctly into the Zipkin collector!)

As I understand it, [to ingest spans into a Zipkin collector](https://github.com/openzipkin/zipkin/tree/master/zipkin-server#collector-1), you can either: 1) post JSON to their HTTP API at /api/v2, 2) post Protobuf to their HTTP API with the `Content-Type: x-protobuf` header, or 3) gRPC service running on same port as HTTP API (experimental, off by default). This WIP implements only POST to the collector's HTTP API, but in the future will be extensible with the `UploaderFormat` being configurable.

There are definitely rough edges around the implementation below. Obvious work remaining:

- [x] ~~Add Protobuf export format support~~ pushing back, scoping this PR to the basic HTTP exporter
- [x] Get rid of the `.unwrap()`s from the `derive_builder` builders (either manually writing Builders or using [rust typed builder](https://github.com/idanarye/rust-typed-builder)) update: ended up switching to rust-typed-builder (which poses its own limitations with not being able to pass around the builder)
- [x] Finish adding fields on the Zipkin model structs (there are a few fields missing from the Span model)
- [x] Improve the clunkiness around the `LocalEndpoint` configuration of the `Exporter`
- [x] Document usage in `lib.rs`

Adding for reference, implementation of Python [OC span to Zipkin span conversion](https://github.com/census-instrumentation/opencensus-python/blob/bb02e5bc7c298743a0c86088ed960f650e5c171a/contrib/opencensus-ext-zipkin/opencensus/ext/zipkin/trace_exporter/__init__.py#L124).