### PR TITLE
Call shutdown as needed

### DIFF
--- a/src/sdk/trace/provider.rs
+++ b/src/sdk/trace/provider.rs
@@ -24,6 +24,14 @@ struct ProviderInner {
     config: sdk::Config,
 }
 
+impl Drop for ProviderInner {
+    fn drop(&mut self) {
+        for processor in &self.processors {
+            processor.shutdown();
+        }
+    }
+}
+
 /// Creator and registry of named `Tracer` instances.
 #[derive(Clone, Debug)]
 pub struct Provider {

--- a/src/sdk/trace/span_processor.rs
+++ b/src/sdk/trace/span_processor.rs
@@ -63,6 +63,6 @@ impl api::SpanProcessor for SimpleSpanProcessor {
     }
 
     fn shutdown(&self) {
-        // Ignored
+        self.exporter.shutdown();
     }
 }


### PR DESCRIPTION
Currently the shutdown method is simply never called. This presents issues for data integrity in exporters, so this PR adds a call to the shutdown methods as needed.