### PR TITLE
Add id generator

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -33,6 +33,7 @@ pub use propagation::{binary_propagator::BinaryFormat, text_propagator::HttpText
 pub use trace::{
     b3_propagator::B3Propagator,
     event::Event,
+    id_generator::IdGenerator,
     link::Link,
     noop::{NoopProvider, NoopSpan, NoopSpanExporter, NoopTracer},
     provider::Provider,

--- a/src/api/trace/id_generator.rs
+++ b/src/api/trace/id_generator.rs
@@ -1,0 +1,14 @@
+//! # OpenTelemetry Id Generator Interface
+use crate::api;
+use std::fmt;
+
+/// Interface for generating IDs
+pub trait IdGenerator: Send + Sync + fmt::Debug {
+    /// Generate a new `TraceId`
+    fn new_trace_id(&self) -> api::TraceId;
+
+    /// Generate a new `SpanId`
+    fn new_span_id(&self) -> api::SpanId {
+        api::SpanId::from_u64(0)
+    }
+}

--- a/src/api/trace/id_generator.rs
+++ b/src/api/trace/id_generator.rs
@@ -8,7 +8,5 @@ pub trait IdGenerator: Send + Sync + fmt::Debug {
     fn new_trace_id(&self) -> api::TraceId;
 
     /// Generate a new `SpanId`
-    fn new_span_id(&self) -> api::SpanId {
-        api::SpanId::from_u64(0)
-    }
+    fn new_span_id(&self) -> api::SpanId;
 }

--- a/src/api/trace/mod.rs
+++ b/src/api/trace/mod.rs
@@ -113,6 +113,7 @@
 pub mod b3_propagator;
 pub mod event;
 pub mod futures;
+pub mod id_generator;
 pub mod link;
 pub mod noop;
 pub mod provider;

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -18,6 +18,7 @@ pub use trace::{
     config::Config,
     evicted_hash_map::EvictedHashMap,
     evicted_queue::EvictedQueue,
+    id_generator::IdGenerator,
     provider::Provider,
     sampler::Sampler,
     span::Span,

--- a/src/sdk/trace/config.rs
+++ b/src/sdk/trace/config.rs
@@ -9,6 +9,8 @@ use crate::{api, sdk};
 pub struct Config {
     /// The sampler that the sdk should use
     pub default_sampler: Box<dyn api::Sampler>,
+    /// The id generator that the sdk should use
+    pub id_generator: Box<dyn api::IdGenerator>,
     /// The max events that can be added to a `Span`.
     pub max_events_per_span: u32,
     /// The max attributes that can be added to a `Span`.
@@ -22,6 +24,7 @@ impl Default for Config {
     fn default() -> Self {
         Config {
             default_sampler: Box::new(sdk::Sampler::Always),
+            id_generator: Box::new(sdk::IdGenerator::default()),
             max_events_per_span: 128,
             max_attributes_per_span: 32,
             max_links_per_span: 32,

--- a/src/sdk/trace/id_generator.rs
+++ b/src/sdk/trace/id_generator.rs
@@ -1,0 +1,25 @@
+//! Id Generator
+use crate::api;
+use rand::{rngs, Rng};
+use std::cell::RefCell;
+
+/// Generates Trace and Span ids
+#[derive(Clone, Debug, Default)]
+pub struct IdGenerator {}
+
+impl api::IdGenerator for IdGenerator {
+    /// Generate new `TraceId` using thread local rng
+    fn new_trace_id(&self) -> api::TraceId {
+        CURRENT_RNG.with(|rng| api::TraceId::from_u128(rng.borrow_mut().gen()))
+    }
+
+    /// Generate new `SpanId` using thread local rng
+    fn new_span_id(&self) -> api::SpanId {
+        CURRENT_RNG.with(|rng| api::SpanId::from_u64(rng.borrow_mut().gen()))
+    }
+}
+
+thread_local! {
+    /// Store random number generator for each thread
+    static CURRENT_RNG: RefCell<rngs::ThreadRng> = RefCell::new(rngs::ThreadRng::default());
+}

--- a/src/sdk/trace/id_generator.rs
+++ b/src/sdk/trace/id_generator.rs
@@ -5,7 +5,9 @@ use std::cell::RefCell;
 
 /// Generates Trace and Span ids
 #[derive(Clone, Debug, Default)]
-pub struct IdGenerator {}
+pub struct IdGenerator {
+    _private: (),
+}
 
 impl api::IdGenerator for IdGenerator {
     /// Generate new `TraceId` using thread local rng

--- a/src/sdk/trace/mod.rs
+++ b/src/sdk/trace/mod.rs
@@ -9,6 +9,7 @@
 pub mod config;
 pub mod evicted_hash_map;
 pub mod evicted_queue;
+pub mod id_generator;
 pub mod provider;
 pub mod sampler;
 pub mod span;

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -134,7 +134,7 @@ impl api::Tracer for Tracer {
         let span_id = builder
             .span_id
             .take()
-            .unwrap_or_else(|| api::SpanId::from_u64(rand::random()));
+            .unwrap_or_else(|| self.provider().config().id_generator.new_span_id());
 
         let span_kind = builder.span_kind.take().unwrap_or(api::SpanKind::Internal);
         let mut attribute_options = builder.attributes.take().unwrap_or_else(Vec::new);
@@ -159,7 +159,7 @@ impl api::Tracer for Tracer {
                 true,
                 builder
                     .trace_id
-                    .unwrap_or_else(|| api::TraceId::from_u128(rand::random::<u128>())),
+                    .unwrap_or_else(|| self.provider().config().id_generator.new_trace_id()),
                 api::SpanId::invalid(),
                 false,
                 0,


### PR DESCRIPTION
Allow span and trace id generation to be customized. The default impl uses the `rand` crate's thread local rng.