### PR TITLE
Update probability sampler

### DIFF
--- a/src/api/trace/sampler.rs
+++ b/src/api/trace/sampler.rs
@@ -67,7 +67,7 @@ pub struct SamplingResult {
 }
 
 /// Decision about whether or not to sample
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum SamplingDecision {
     /// `is_recording() == false`, span will not be recorded and all events and
     /// attributes will be dropped.

--- a/src/sdk/trace/sampler.rs
+++ b/src/sdk/trace/sampler.rs
@@ -97,7 +97,7 @@ mod tests {
             ("sampled_parent_with_probability_2.0", Sampler::Probability(2.0),  1.0, true, true),
 
             // Spans with a sampled parent, but when using the NeverSample Sampler, aren't sampled
-            ("SampledParentSpanWithNeverSample", Sampler::Never, 0.0, true, true),
+            ("sampled_parent_span_with_never_sample", Sampler::Never, 0.0, true, true),
         ]
     }
 


### PR DESCRIPTION
Update the probability sampler to match the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/bdf39cb935a6f48badc687daeb78a66dc352761f/specification/trace/sdk.md#built-in-samplers).

This change also removes the need to generate a second random number as it can rely on randomness from the `trace_id` to come to a sampling decision.

Resolves #78 