### PR TITLE
Clean up core key value types

### DIFF
--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -250,7 +250,7 @@ where
 {
     let mut map: HashMap<String, String> = HashMap::new();
     for kv in kvs {
-        map.insert(kv.key.into(), kv.value.to_string());
+        map.insert(kv.key.into(), kv.value.into());
     }
     map
 }

--- a/src/exporter/metrics/prometheus/mod.rs
+++ b/src/exporter/metrics/prometheus/mod.rs
@@ -26,11 +26,7 @@ fn convert_label_set(label_set: &sdk::LabelSet) -> HashMap<&str, &str> {
 
 /// Convert from list of `Key`s to prometheus' label format.
 pub(crate) fn convert_labels(labels: &[Key]) -> Vec<&str> {
-    labels
-        .iter()
-        .map(|k| k.inner())
-        .map(|k| k.as_ref())
-        .collect()
+    labels.iter().map(|k| k.as_str()).collect()
 }
 
 /// Prometheus IntCounterHandle

--- a/src/sdk/metrics/mod.rs
+++ b/src/sdk/metrics/mod.rs
@@ -76,7 +76,7 @@ impl api::Meter for Meter {
         let mut label_set: Self::LabelSet = Default::default();
 
         for api::KeyValue { key, value } in key_values.into_iter() {
-            label_set.insert(key.into(), value.into());
+            label_set.insert(Cow::Owned(key.into()), Cow::Owned(value.into()));
         }
 
         label_set


### PR DESCRIPTION
Improve `Key`, `Value`, and `KeyValue` types by:

* Implementing `From<TargetType>` for key's buillder methods
* Removing `Cow` type from key and value method signatures
* Deriving `From<SourceType>` for common value types