### PR TITLE
Add global `tracer` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ and metrics from your application. You can analyze them using [Prometheus], [Jae
 ## Quick Start
 
 ```rust
-use opentelemetry::{api::{Provider, TracerGenerics}, global, sdk};
+use opentelemetry::{api::TracerGenerics, global, sdk};
 
 fn main() {
     global::set_provider(sdk::Provider::default());
 
-    global::trace_provider().get_tracer("component-a").with_span("foo", |_span| {
-        global::trace_provider().get_tracer("component-b").with_span("bar", |_span| {
-            global::trace_provider().get_tracer("component-c").with_span("baz", |_span| {
+    global::tracer("component-a").with_span("foo", |_span| {
+        global::tracer("component-b").with_span("bar", |_span| {
+            global::tracer("component-c").with_span("baz", |_span| {
 
             })
         })

--- a/examples/actix/src/main.rs
+++ b/examples/actix/src/main.rs
@@ -1,4 +1,4 @@
-use opentelemetry::api::{Key, Provider, Span, TracerGenerics};
+use opentelemetry::api::{Key, Span, TracerGenerics};
 use opentelemetry::{global, sdk};
 
 use actix_service::Service;
@@ -29,7 +29,7 @@ fn init_tracer() -> thrift::Result<()> {
 }
 
 fn index() -> &'static str {
-    let tracer = global::trace_provider().get_tracer("request");
+    let tracer = global::tracer("request");
 
     tracer.with_span("index", move |span| {
         span.set_attribute(Key::new("parameter").i64(10));
@@ -43,7 +43,7 @@ fn main() -> thrift::Result<()> {
     HttpServer::new(|| {
         App::new()
             .wrap_fn(|req, srv| {
-                let tracer = global::trace_provider().get_tracer("request");
+                let tracer = global::tracer("request");
                 tracer.with_span("middleware", move |span| {
                     span.set_attribute(Key::new("path").string(req.path()));
                     srv.call(req).map(|res| res)

--- a/examples/async_fn.rs
+++ b/examples/async_fn.rs
@@ -18,7 +18,7 @@
 //!
 //! [`hello_world`]: https://github.com/tokio-rs/tokio/blob/132e9f1da5965530b63554d7a1c59824c3de4e30/tokio/examples/hello_world.rs
 use opentelemetry::{
-    api::{trace::futures::Instrument, Provider, Tracer},
+    api::{trace::futures::Instrument, Tracer},
     global, sdk,
 };
 use std::time::Duration;
@@ -27,21 +27,21 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 
 async fn connect(addr: &SocketAddr) -> io::Result<TcpStream> {
-    let tracer = global::trace_provider().get_tracer("connector");
+    let tracer = global::tracer("connector");
     let span = tracer.start("Connecting", None);
 
     TcpStream::connect(&addr).instrument(span).await
 }
 
 async fn write(stream: &mut TcpStream) -> io::Result<usize> {
-    let tracer = global::trace_provider().get_tracer("writer");
+    let tracer = global::tracer("writer");
     let span = tracer.start("Writing", None);
 
     stream.write(b"hello world\n").instrument(span).await
 }
 
 async fn run(addr: &SocketAddr) -> io::Result<usize> {
-    let tracer = global::trace_provider().get_tracer("runner");
+    let tracer = global::tracer("runner");
     let span = tracer.start(&format!("running: {}", addr), None);
 
     let mut stream = connect(addr).instrument(tracer.clone_span(&span)).await?;
@@ -76,7 +76,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     init_tracer()?;
     let addr = "127.0.0.1:6142".parse()?;
     let addr2 = "127.0.0.1:6143".parse()?;
-    let tracer = global::trace_provider().get_tracer("async_example");
+    let tracer = global::tracer("async_example");
     let span = tracer.start("root", None);
 
     let (run1, run2) = futures::future::join(run(&addr), run(&addr2))

--- a/examples/stdout.rs
+++ b/examples/stdout.rs
@@ -1,6 +1,8 @@
-use opentelemetry::api::trace::tracer::TracerGenerics;
 use opentelemetry::exporter::trace::stdout;
-use opentelemetry::{global, sdk};
+use opentelemetry::{
+    api::{Provider, TracerGenerics},
+    global, sdk,
+};
 
 fn main() {
     let exporter = stdout::Builder::default().init();
@@ -13,5 +15,7 @@ fn main() {
         .build();
     global::set_provider(provider);
 
-    global::tracer("component-main").with_span("operation", move |_span| {});
+    global::trace_provider()
+        .get_tracer("component-main")
+        .with_span("operation", move |_span| {});
 }

--- a/examples/stdout.rs
+++ b/examples/stdout.rs
@@ -1,4 +1,3 @@
-use opentelemetry::api::trace::provider::Provider;
 use opentelemetry::api::trace::tracer::TracerGenerics;
 use opentelemetry::exporter::trace::stdout;
 use opentelemetry::{global, sdk};
@@ -14,7 +13,5 @@ fn main() {
         .build();
     global::set_provider(provider);
 
-    global::trace_provider()
-        .get_tracer("component-main")
-        .with_span("operation", move |_span| {});
+    global::tracer("component-main").with_span("operation", move |_span| {});
 }

--- a/src/api/trace/tracer.rs
+++ b/src/api/trace/tracer.rs
@@ -144,7 +144,7 @@ impl<S: Tracer> TracerGenerics for S {
 ///     global,
 /// };
 ///
-/// let tracer = global::trace_provider().get_tracer("example-tracer");
+/// let tracer = global::tracer("example-tracer");
 ///
 /// // The builder can be used to create a span directly with the tracer
 /// let _span = tracer.build(SpanBuilder {

--- a/src/global.rs
+++ b/src/global.rs
@@ -23,9 +23,13 @@
 //! }
 //!
 //! fn do_something_tracked() {
-//!     // Then you can access the configured provider via `trace_provider`.
+//!     // Then you can use the global provider to create a tracer via `tracer`.
+//!     let _span = global::tracer("my-component").start("span-name", None);
+//!
+//!     // Or access the configured provider via `trace_provider`.
 //!     let provider = global::trace_provider();
-//!     let _span = provider.get_tracer("my-component").start("span-name", None);
+//!     let _tracer_a = provider.get_tracer("my-component-a");
+//!     let _tracer_b = provider.get_tracer("my-component-b");
 //! }
 //!
 //! // in main or other app start
@@ -62,7 +66,7 @@
 //! [`BoxedSpan`]: struct.BoxedSpan.html
 //! [`trace_provider`]: fn.trace_provider.html
 //! [trait objects]: https://doc.rust-lang.org/reference/types/trait-object.html#trait-objects
-use crate::api;
+use crate::{api, api::Provider};
 use std::any::Any;
 use std::fmt;
 use std::sync::{Arc, RwLock};
@@ -369,6 +373,18 @@ pub fn trace_provider() -> GlobalProvider {
         .read()
         .expect("GLOBAL_TRACER_PROVIDER RwLock poisoned")
         .clone()
+}
+
+/// Creates a named instance of [`Tracer`] via the configured [`GlobalProvider`].
+///
+/// If the name is an empty string, the provider will use a default name.
+///
+/// This is a more convenient way of expressing `global::trace_provider().get_tracer(name)`.
+///
+/// [`Tracer`]: ../api/trace/tracer/trait.Tracer.html
+/// [`GlobalProvider`]: struct.GlobalProvider.html
+pub fn tracer(name: &'static str) -> BoxedTracer {
+    trace_provider().get_tracer(name)
 }
 
 /// Sets the given [`Provider`] instance as the current global provider.


### PR DESCRIPTION
This adds `global::tracer(name)` as a simpler way of expressing `global::trace_provider().get_tracer(name)`.