### PR TITLE
Add Resource API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = "1.4.0"
 pin-project = { version = "0.4.6", optional = true }
 prometheus = { version = "0.7.0", optional = true }
 rand = { version = "0.7.2", optional = true }
-serde = { version = "1.0.104", features = ["derive"], optional = true }
+serde = { version = "1.0.104", features = ["derive", "rc"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 
 [dev-dependencies]

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -382,13 +382,18 @@ fn links_to_references(links: &sdk::EvictedQueue<api::Link>) -> Option<Vec<jaege
 }
 
 fn build_tags(span_data: &Arc<trace::SpanData>) -> Option<Vec<jaeger::Tag>> {
-    let mut tags = Vec::with_capacity(span_data.attributes.len() + 4);
+    let mut tags = Vec::with_capacity(span_data.attributes.len() + span_data.resource.len() + 4);
     let mut user_specified_error = false;
     for (key, value) in span_data.attributes.iter() {
         tags.push(api::KeyValue::new(key.clone(), value.clone()).into());
         if key == &api::Key::new("error") {
             user_specified_error = true;
         }
+    }
+
+    // TODO determine if namespacing is required to avoid colisions with set attributes
+    for (key, value) in span_data.resource.iter() {
+        tags.push(api::KeyValue::new(key.clone(), value.clone()).into());
     }
 
     // Ensure error status is set

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -239,7 +239,13 @@ fn into_zipkin_span(config: &ExporterConfig, span_data: Arc<trace::SpanData>) ->
             span_data
                 .attributes
                 .iter()
-                .map(|(k, v)| api::KeyValue::new(k.clone(), v.clone())),
+                .map(|(k, v)| api::KeyValue::new(k.clone(), v.clone()))
+                .chain(
+                    span_data
+                        .resource
+                        .iter()
+                        .map(|(k, v)| api::KeyValue::new(k.clone(), v.clone())),
+                ),
         ))
         .build()
 }

--- a/src/api/core.rs
+++ b/src/api/core.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 
 /// Key used for metric `LabelSet`s and trace `Span` attributes.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Key(Cow<'static, str>);
 
 impl Key {

--- a/src/exporter/trace/mod.rs
+++ b/src/exporter/trace/mod.rs
@@ -87,7 +87,7 @@ pub struct SpanData {
     /// Span status message
     pub status_message: String,
     /// Resource contains attributes representing an entity that produced this span.
-    pub resource: sdk::Resource,
+    pub resource: Arc<sdk::Resource>,
 }
 
 #[cfg(feature = "serialize")]
@@ -122,7 +122,7 @@ mod tests {
 
         let status_code = api::StatusCode::OK;
         let status_message = String::new();
-        let resource = sdk::Resource::default();
+        let resource = Arc::new(sdk::Resource::default());
 
         let span_data = SpanData {
             context,

--- a/src/exporter/trace/mod.rs
+++ b/src/exporter/trace/mod.rs
@@ -86,6 +86,8 @@ pub struct SpanData {
     pub status_code: api::StatusCode,
     /// Span status message
     pub status_message: String,
+    /// Resource contains attributes representing an entity that produced this span.
+    pub resource: sdk::Resource,
 }
 
 #[cfg(feature = "serialize")]
@@ -120,6 +122,7 @@ mod tests {
 
         let status_code = api::StatusCode::OK;
         let status_message = String::new();
+        let resource = sdk::Resource::default();
 
         let span_data = SpanData {
             context,
@@ -133,6 +136,7 @@ mod tests {
             links,
             status_code,
             status_message,
+            resource,
         };
 
         let encoded: Vec<u8> = bincode::serialize(&span_data).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,19 @@
 //! well-known metric names in [Semantic Conventions](data-semantic-conventions.md)
 //! document.
 //!
+//!
+//! ## Resources
+//!
+//! A `Resource` captures information about the entity for which telemetry is recorded. For
+//! example, metrics exposed by a Kubernetes container can be linked to a resource that specifies
+//! the cluster, namespace, pod, and container name.
+//!
+//! A `Resource` may also capture an entire hierarchy of entity identification. It may describe the
+//! host in the cloud and specific container or an application running in the process.
+//!
+//! Note, that some of the process identification information can be associated with telemetry
+//! automatically by the OpenTelemetry SDK or a specific exporter.
+//!
 //! ## Propagators
 //!
 //! OpenTelemetry uses `Propagators` to serialize and deserialize `SpanContext` and

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -8,11 +8,13 @@
 //! `Meter` creation.
 #[cfg(feature = "metrics")]
 pub mod metrics;
+pub mod resource;
 #[cfg(feature = "trace")]
 pub mod trace;
 
 #[cfg(feature = "metrics")]
 pub use metrics::{LabelSet, Meter};
+pub use resource::Resource;
 #[cfg(feature = "trace")]
 pub use trace::{
     config::Config,

--- a/src/sdk/resource.rs
+++ b/src/sdk/resource.rs
@@ -1,0 +1,193 @@
+//! # Resource
+//!
+//! A `Resource` is an immutable representation of the entity producing telemetry. For example, a
+//! process producing telemetry that is running in a container on Kubernetes has a Pod name, it is
+//! in a namespace, and possibly is part of a Deployment which also has a name. All three of these
+//! attributes can be included in the `Resource`.
+//!
+//! The primary purpose of resources as a first-class concept in the SDK is decoupling of discovery
+//! of resource information from exporters. This allows for independent development and easy
+//! customization for users that need to integrate with closed source environments. When used with
+//! distributed tracing, a resource can be associated with the [`Provider`] when it is created.
+//! That association cannot be changed later. When associated with a `Provider`, all `Span`s
+//! produced by any `Tracer` from the provider are associated with this `Resource`.
+//!
+//! [`Provider`]: ../../../api/trace/provider/trait.Provider.html
+use crate::api;
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
+use std::collections::{btree_map, btree_map::Entry, BTreeMap};
+
+/// Describes an entity about which identifying information and metadata is exposed.
+///
+/// Items are sorted by key, and are only overwritten if the value is an empty string.
+#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Resource {
+    attrs: BTreeMap<api::Key, api::Value>,
+}
+
+impl Resource {
+    /// Create a new `Resource` from key value pairs.
+    ///
+    /// Values are de-duplicated by key, and the first key-value pair with a non-empty string value
+    /// will be retained
+    pub fn new<T: IntoIterator<Item = api::KeyValue>>(kvs: T) -> Self {
+        let mut resource = Resource::default();
+
+        for kv in kvs.into_iter() {
+            resource.insert(kv);
+        }
+
+        resource
+    }
+
+    /// Create a new `Resource` by combining two resources.
+    ///
+    /// Keys from this resource have priority over keys from the merged resource.
+    pub fn merge(&self, other: &Self) -> Self {
+        if self.attrs.is_empty() {
+            return other.clone();
+        }
+        if other.attrs.is_empty() {
+            return self.clone();
+        }
+
+        let mut resource = Resource::default();
+
+        // attrs from self must be added first so they have priority
+        for (k, v) in self.attrs.iter() {
+            resource.insert(api::KeyValue {
+                key: k.clone(),
+                value: v.clone(),
+            });
+        }
+        for (k, v) in other.attrs.iter() {
+            resource.insert(api::KeyValue {
+                key: k.clone(),
+                value: v.clone(),
+            });
+        }
+
+        resource
+    }
+
+    /// Returns the number of attributes for this resource
+    pub fn len(&self) -> usize {
+        self.attrs.len()
+    }
+
+    /// Returns `true` if the resource contains no attributes.
+    pub fn is_empty(&self) -> bool {
+        self.attrs.is_empty()
+    }
+
+    /// Gets an iterator over the attributes of this resource, sorted by key.
+    pub fn iter(&self) -> Iter {
+        self.into_iter()
+    }
+
+    /// Insert a key-value pair into a `Resource`
+    fn insert(&mut self, item: api::KeyValue) {
+        match self.attrs.entry(item.key) {
+            Entry::Occupied(mut existing_item) => {
+                if let api::Value::String(s) = existing_item.get() {
+                    if s.is_empty() {
+                        existing_item.insert(item.value);
+                    }
+                }
+            }
+            Entry::Vacant(v) => {
+                v.insert(item.value);
+            }
+        }
+    }
+}
+
+/// An owned iterator over the entries of a `Resource`.
+#[derive(Debug)]
+pub struct IntoIter(btree_map::IntoIter<api::Key, api::Value>);
+impl Iterator for IntoIter {
+    type Item = (api::Key, api::Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl IntoIterator for Resource {
+    type Item = (api::Key, api::Value);
+    type IntoIter = IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter(self.attrs.into_iter())
+    }
+}
+
+/// An iterator over the entries of a `Resource`.
+#[derive(Debug)]
+pub struct Iter<'a>(btree_map::Iter<'a, api::Key, api::Value>);
+impl<'a> Iterator for Iter<'a> {
+    type Item = (&'a api::Key, &'a api::Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a> IntoIterator for &'a Resource {
+    type Item = (&'a api::Key, &'a api::Value);
+    type IntoIter = Iter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Iter(self.attrs.iter())
+    }
+}
+
+#[cfg(Test)]
+mod tests {
+    use super::Resource;
+
+    #[test]
+    fn new_resource() {
+        let args_with_dupe_keys = vec![
+            api::KeyValue::new("a", ""),
+            api::KeyValue::new("a", "final"),
+        ];
+
+        let mut expected_attrs = BTreeMap::new();
+        expected_attrs.insert(api::Key::new("a"), api::Value::from("final"));
+
+        assert_eq!(
+            Resource::new(args_with_dupe_keys),
+            Resource {
+                attrs: expected_attrs
+            }
+        );
+    }
+
+    #[test]
+    fn merge_resource() {
+        let resource_a = Resource::new(vec![
+            api::KeyValue::new("a", ""),
+            api::KeyValue::new("b", "b-value"),
+        ]);
+
+        let resource_b = Resource::new(vec![
+            api::KeyValue::new("a", "final"),
+            api::KeyValue::new("c", "c-value"),
+        ]);
+
+        let mut expected_attrs = BTreeMap::new();
+        expected_attrs.insert(api::Key::new("a"), api::Value::from("final"));
+        expected_attrs.insert(api::Key::new("b"), api::Value::from("b-value"));
+        expected_attrs.insert(api::Key::new("c"), api::Value::from("c-value"));
+
+        assert_eq!(
+            resource_a.merge(resource_b)
+            Resource {
+                attrs: expected_attrs
+            }
+        );
+    }
+}

--- a/src/sdk/trace/config.rs
+++ b/src/sdk/trace/config.rs
@@ -17,6 +17,8 @@ pub struct Config {
     pub max_attributes_per_span: u32,
     /// The max links that can be added to a `Span`.
     pub max_links_per_span: u32,
+    /// Contains attributes representing an entity that produces telemetry.
+    pub resource: sdk::Resource,
 }
 
 impl Default for Config {
@@ -28,6 +30,7 @@ impl Default for Config {
             max_events_per_span: 128,
             max_attributes_per_span: 32,
             max_links_per_span: 32,
+            resource: sdk::Resource::default(),
         }
     }
 }

--- a/src/sdk/trace/config.rs
+++ b/src/sdk/trace/config.rs
@@ -3,6 +3,7 @@
 //! Configuration represents the global tracing configuration, overrides
 //! can be set for the default OpenTelemetry limits and Sampler.
 use crate::{api, sdk};
+use std::sync::Arc;
 
 /// Tracer configuration
 #[derive(Debug)]
@@ -18,7 +19,7 @@ pub struct Config {
     /// The max links that can be added to a `Span`.
     pub max_links_per_span: u32,
     /// Contains attributes representing an entity that produces telemetry.
-    pub resource: sdk::Resource,
+    pub resource: Arc<sdk::Resource>,
 }
 
 impl Default for Config {
@@ -30,7 +31,7 @@ impl Default for Config {
             max_events_per_span: 128,
             max_attributes_per_span: 32,
             max_links_per_span: 32,
-            resource: sdk::Resource::default(),
+            resource: Arc::new(sdk::Resource::default()),
         }
     }
 }

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -197,6 +197,7 @@ impl api::Tracer for Tracer {
             }
             let status_code = builder.status_code.unwrap_or(api::StatusCode::OK);
             let status_message = builder.status_message.unwrap_or_else(String::new);
+            let resource = config.resource.clone();
 
             exporter::trace::SpanData {
                 context: api::SpanContext::new(trace_id, span_id, trace_flags, false),
@@ -210,6 +211,7 @@ impl api::Tracer for Tracer {
                 links,
                 status_code,
                 status_message,
+                resource,
             }
         });
 


### PR DESCRIPTION
Allow providers to be configured with information about the entity for which telemetry is recorded. See the [Resources Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/bdf39cb935a6f48badc687daeb78a66dc352761f/specification/overview.md#resources) for more information.