### PR TITLE
Fix Traceparent to traceparent

### DIFF
--- a/src/api/trace/trace_context_propagator.rs
+++ b/src/api/trace/trace_context_propagator.rs
@@ -22,7 +22,7 @@ use crate::api;
 
 static SUPPORTED_VERSION: u8 = 0;
 static MAX_VERSION: u8 = 254;
-static TRACEPARENT_HEADER: &str = "Traceparent";
+static TRACEPARENT_HEADER: &str = "traceparent";
 
 /// Extracts and injects `SpanContext`s into `Carrier`s using the
 /// trace-context format.


### PR DESCRIPTION
https://w3c.github.io/trace-context/#header-name

Header name: traceparent

In order to increase interoperability across multiple protocols and encourage successful integration, by default vendors SHOULD keep the header name lowercase. The header name is a single word without any delimiters, for example, a hyphen (-).

Vendors MUST expect the header name in any case (upper, lower, mixed), and SHOULD send the header name in lowercase.