### PR TITLE
trim opentelemetry-jaeger transitive dependencies

### DIFF
--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-opentelemetry = { version = "0.5.0", path = ".." }
+opentelemetry = { version = "0.5.0", default-features = false, features = ["trace"], path = ".." }
 reqwest = { version = "0.10.1", features = ["blocking"], optional = true }
 thrift = "0.13.0"
 


### PR DESCRIPTION
Removes `prometheus`, `protobuf`, etc from the transitive dependencies
of `opentelemetry-jaeger`.