### PR TITLE
export EvictedQueue::new

### DIFF
--- a/src/sdk/trace/evicted_queue.rs
+++ b/src/sdk/trace/evicted_queue.rs
@@ -17,7 +17,7 @@ pub struct EvictedQueue<T> {
 
 impl<T> EvictedQueue<T> {
     /// Create a new `EvictedQueue` with a given capacity.
-    pub(crate) fn new(capacity: u32) -> Self {
+    pub fn new(capacity: u32) -> Self {
         EvictedQueue {
             queue: Default::default(),
             capacity,


### PR DESCRIPTION
Allow for the construction of `EvictedQueue`, as with `EvictedHashMap`. This would allow users of your library to construct `SpanData` instances directly - every other field of that struct can be initialized using public constructors.

Thanks for making this open source, btw!