### PR TITLE
Adding Context implemenations for HeaderMap and MetadataMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,6 @@ base64_format = ["base64"]
 trace = ["futures", "rand", "pin-project"]
 metrics = ["prometheus"]
 serialize = ["serde", "bincode"]
-http_context = ["http"]
-tonic_context = ["tonic"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ prometheus = { version = "0.7", optional = true }
 rand = { version = "0.7", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 bincode = { version = "1.2", optional = true }
+http = { version = "0.2.1", optional = true }
+tonic = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.1"
@@ -36,6 +38,8 @@ base64_format = ["base64"]
 trace = ["futures", "rand", "pin-project"]
 metrics = ["prometheus"]
 serialize = ["serde", "bincode"]
+http_context = ["http"]
+tonic_context = ["tonic"]
 
 [workspace]
 members = [

--- a/examples/grpc/Cargo.toml
+++ b/examples/grpc/Cargo.toml
@@ -16,7 +16,7 @@ http = "0.2"
 tonic = "0.2"
 prost = "0.6"
 tokio = { version = "0.2", features = ["full"] }
-opentelemetry = { path = "../../" }
+opentelemetry = { path = "../../", features = ["tonic_context"] }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }
 
 [build-dependencies]

--- a/examples/grpc/Cargo.toml
+++ b/examples/grpc/Cargo.toml
@@ -16,7 +16,7 @@ http = "0.2"
 tonic = "0.2"
 prost = "0.6"
 tokio = { version = "0.2", features = ["full"] }
-opentelemetry = { path = "../../", features = ["tonic_context"] }
+opentelemetry = { path = "../../", features = ["tonic"] }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }
 
 [build-dependencies]

--- a/examples/grpc/src/server.rs
+++ b/examples/grpc/src/server.rs
@@ -7,7 +7,7 @@ use opentelemetry::global;
 use opentelemetry::sdk::{self, Sampler};
 
 pub mod hello_world {
-    tonic::include_proto!("helloworld"); // The string specified here must match the proto package name
+    tonic::include_proto!("helloworld"); // The string specified here must match the proto package name.
 }
 
 #[derive(Debug, Default)]

--- a/examples/grpc/src/server.rs
+++ b/examples/grpc/src/server.rs
@@ -20,7 +20,7 @@ impl Greeter for MyGreeter {
         request: Request<HelloRequest>, // Accept request of type HelloRequest
     ) -> Result<Response<HelloReply>, Status> {
         let propagator = api::TraceContextPropagator::new();
-        let parent_cx = propagator.extract(&HttpHeaderMapCarrier(request.metadata()));
+        let parent_cx = propagator.extract(request.metadata());
         let span = global::tracer("greeter").start_from_context("Processing reply", &parent_cx);
         span.set_attribute(KeyValue::new("request", format!("{:?}", request)));
 
@@ -57,19 +57,6 @@ fn tracing_init() -> Result<(), Box<dyn std::error::Error>> {
     global::set_provider(provider);
 
     Ok(())
-}
-
-struct HttpHeaderMapCarrier<'a>(&'a tonic::metadata::MetadataMap);
-impl<'a> api::Carrier for HttpHeaderMapCarrier<'a> {
-    fn get(&self, key: &'static str) -> Option<&str> {
-        self.0
-            .get(key.to_lowercase().as_str())
-            .and_then(|value| value.to_str().ok())
-    }
-
-    fn set(&mut self, _key: &'static str, _value: String) {
-        unimplemented!()
-    }
 }
 
 #[tokio::main]

--- a/examples/http/Cargo.toml
+++ b/examples/http/Cargo.toml
@@ -14,5 +14,5 @@ path = "src/client.rs"
 [dependencies]
 hyper = "0.13"
 tokio = { version = "0.2", features = ["full"] }
-opentelemetry = { path = "../../" }
+opentelemetry = { path = "../../", features = ["http_context"] }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }

--- a/examples/http/Cargo.toml
+++ b/examples/http/Cargo.toml
@@ -14,5 +14,5 @@ path = "src/client.rs"
 [dependencies]
 hyper = "0.13"
 tokio = { version = "0.2", features = ["full"] }
-opentelemetry = { path = "../../", features = ["http_context"] }
+opentelemetry = { path = "../../", features = ["http"] }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }

--- a/examples/http/src/server.rs
+++ b/examples/http/src/server.rs
@@ -7,20 +7,9 @@ use opentelemetry::{
 };
 use std::{convert::Infallible, net::SocketAddr};
 
-struct HttpHeaderMapCarrier<'a>(&'a hyper::header::HeaderMap);
-impl<'a> api::Carrier for HttpHeaderMapCarrier<'a> {
-    fn get(&self, key: &'static str) -> Option<&str> {
-        self.0.get(key).and_then(|value| value.to_str().ok())
-    }
-
-    fn set(&mut self, _key: &'static str, _value: String) {
-        unimplemented!()
-    }
-}
-
 async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     let propagator = api::TraceContextPropagator::new();
-    let parent_cx = propagator.extract(&HttpHeaderMapCarrier(req.headers()));
+    let parent_cx = propagator.extract(req.headers());
     let span = global::tracer("example/server").start_from_context("hello", &parent_cx);
     span.add_event("handling this...".to_string(), Vec::new());
 

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -151,7 +151,7 @@ mod tests {
 
         for (header_name, header_value) in test_data() {
             let mut carrier = HashMap::new();
-            carrier.insert(header_name, header_value.to_string());
+            carrier.insert(header_name.to_string(), header_value.to_string());
             assert_eq!(
                 composite_propagator.extract(&carrier).remote_span_context(),
                 Some(&SpanContext::new(

--- a/src/api/context/propagation/mod.rs
+++ b/src/api/context/propagation/mod.rs
@@ -212,12 +212,12 @@ impl api::Carrier for http::HeaderMap {
 
 #[cfg(feature = "tonic")]
 impl api::Carrier for tonic::metadata::MetadataMap {
-    /// Get a value for a key from the MetadataMap.  If the value can't be converted to &str, returns None.
+    /// Get a value for a key from the MetadataMap.  If the value can't be converted to &str, returns None
     fn get(&self, key: &str) -> Option<&str> {
         self.get(key).and_then(|metadata| metadata.to_str().ok())
     }
 
-    /// Set a key and value in the MetadataMap.  Does nothing if the key or value are not valid inputs.
+    /// Set a key and value in the MetadataMap.  Does nothing if the key or value are not valid inputs
     fn set(&mut self, key: &str, value: String) {
         if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.to_lowercase().as_bytes()) {
             if let Ok(val) = tonic::metadata::MetadataValue::from_str(&value) {

--- a/src/api/context/propagation/mod.rs
+++ b/src/api/context/propagation/mod.rs
@@ -187,7 +187,7 @@ impl<S: std::hash::BuildHasher> api::Carrier for HashMap<String, String, S> {
     }
 }
 
-#[cfg(feature = "http_context")]
+#[cfg(feature = "http")]
 impl api::Carrier for http::HeaderMap {
     /// Get a value for a key from the HeaderMap.  If the value is not valid ASCII, returns None.
     fn get(&self, key: &str) -> Option<&str> {
@@ -210,14 +210,14 @@ impl api::Carrier for http::HeaderMap {
     }
 }
 
-#[cfg(feature = "tonic_context")]
+#[cfg(feature = "tonic")]
 impl api::Carrier for tonic::metadata::MetadataMap {
-    /// Get a value for a key from the HeaderMap.  If the value is not valid ASCII, returns None.
+    /// Get a value for a key from the MetadataMap.  If the value can't be converted to &str, returns None.
     fn get(&self, key: &str) -> Option<&str> {
         self.get(key).and_then(|metadata| metadata.to_str().ok())
     }
 
-    /// Set a key and value in the HeaderMap.  Does nothing if the key or value are not valid inputs.
+    /// Set a key and value in the MetadataMap.  Does nothing if the key or value are not valid inputs.
     fn set(&mut self, key: &str, value: String) {
         if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.to_lowercase().as_bytes()) {
             if let Ok(val) = tonic::metadata::MetadataValue::from_str(&value) {

--- a/src/api/correlation/mod.rs
+++ b/src/api/correlation/mod.rs
@@ -20,7 +20,7 @@
 //!
 //! // Example correlation value passed in externally via http headers
 //! let mut headers = HashMap::new();
-//! headers.insert("Correlation-Context", "user_id=1".to_string());
+//! headers.insert("Correlation-Context".to_string(), "user_id=1".to_string());
 //!
 //! let propagator = CorrelationContextPropagator::new();
 //! // can extract from any type that impls `Carrier`, usually an HTTP header map

--- a/src/api/correlation/propagation.rs
+++ b/src/api/correlation/propagation.rs
@@ -223,8 +223,11 @@ mod tests {
         let propagator = CorrelationContextPropagator::new();
 
         for (header_value, kvs) in valid_extract_data() {
-            let mut carrier: HashMap<&'static str, String> = HashMap::new();
-            carrier.insert(CORRELATION_CONTEXT_HEADER, header_value.to_string());
+            let mut carrier: HashMap<String, String> = HashMap::new();
+            carrier.insert(
+                CORRELATION_CONTEXT_HEADER.to_string(),
+                header_value.to_string(),
+            );
             let context = propagator.extract(&carrier);
             let correlations = context.correlation_context();
 
@@ -240,7 +243,7 @@ mod tests {
         let propagator = CorrelationContextPropagator::new();
 
         for (kvs, header_parts) in valid_inject_data() {
-            let mut carrier: HashMap<&'static str, String> = HashMap::new();
+            let mut carrier = HashMap::new();
             let cx = Context::current_with_correlations(kvs);
             propagator.inject_context(&cx, &mut carrier);
             let header_value = carrier.get(CORRELATION_CONTEXT_HEADER).unwrap();

--- a/src/api/trace/b3_propagator.rs
+++ b/src/api/trace/b3_propagator.rs
@@ -231,8 +231,8 @@ mod tests {
         let multi_header_propagator = B3Propagator::new(false);
 
         for (header, expected_context) in single_header_extract_data() {
-            let mut carrier: HashMap<&'static str, String> = HashMap::new();
-            carrier.insert(B3_SINGLE_HEADER, header.to_owned());
+            let mut carrier: HashMap<String, String> = HashMap::new();
+            carrier.insert(B3_SINGLE_HEADER.to_string(), header.to_owned());
             assert_eq!(
                 single_header_propagator
                     .extract(&carrier)
@@ -243,21 +243,21 @@ mod tests {
 
         for ((trace, span, sampled, debug, parent), expected_context) in multi_header_extract_data()
         {
-            let mut carrier: HashMap<&'static str, String> = HashMap::new();
+            let mut carrier = HashMap::new();
             if let Some(trace_id) = trace {
-                carrier.insert(B3_TRACE_ID_HEADER, trace_id.to_owned());
+                carrier.insert(B3_TRACE_ID_HEADER.to_string(), trace_id.to_owned());
             }
             if let Some(span_id) = span {
-                carrier.insert(B3_SPAN_ID_HEADER, span_id.to_owned());
+                carrier.insert(B3_SPAN_ID_HEADER.to_string(), span_id.to_owned());
             }
             if let Some(sampled) = sampled {
-                carrier.insert(B3_SAMPLED_HEADER, sampled.to_owned());
+                carrier.insert(B3_SAMPLED_HEADER.to_string(), sampled.to_owned());
             }
             if let Some(debug) = debug {
-                carrier.insert(B3_DEBUG_FLAG_HEADER, debug.to_owned());
+                carrier.insert(B3_DEBUG_FLAG_HEADER.to_string(), debug.to_owned());
             }
             if let Some(parent) = parent {
-                carrier.insert(B3_PARENT_SPAN_ID_HEADER, parent.to_owned());
+                carrier.insert(B3_PARENT_SPAN_ID_HEADER.to_string(), parent.to_owned());
             }
             assert_eq!(
                 multi_header_propagator

--- a/src/api/trace/trace_context_propagator.rs
+++ b/src/api/trace/trace_context_propagator.rs
@@ -144,8 +144,8 @@ mod tests {
         let propagator = TraceContextPropagator::new();
 
         for (header, expected_context) in extract_data() {
-            let mut carrier: HashMap<&'static str, String> = HashMap::new();
-            carrier.insert(TRACEPARENT_HEADER, header.to_owned());
+            let mut carrier = HashMap::new();
+            carrier.insert(TRACEPARENT_HEADER.to_string(), header.to_owned());
             assert_eq!(
                 propagator.extract(&carrier).remote_span_context(),
                 Some(&expected_context)


### PR DESCRIPTION
To make it easier to use opentelemetry from `hyper` and `tonic`, I added implementations for api::context::propagation::Carrier for [HeaderMap](https://docs.rs/http/0.2.1/http/header/struct.HeaderMap.html) and [MetadataMap](https://docs.rs/tonic/0.2.1/tonic/metadata/struct.MetadataMap.html) under feature flags `http_context` and `tonic_context` respectively.  

`cargo test --all` passes, `cargo clippy --all` passes.  Output in Jaeger of grpc example is the same.  Output of `cargo bench`:
```
start-end-span/always-sample
                        time:   [1.3808 us 1.4051 us 1.4427 us]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) high mild
  7 (7.00%) high severe
start-end-span/never-sample
                        time:   [342.14 ns 356.66 ns 379.42 ns]
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

start-end-span-4-attrs/always-sample
                        time:   [3.0217 us 3.0788 us 3.1451 us]
Found 20 outliers among 100 measurements (20.00%)
  3 (3.00%) high mild
  17 (17.00%) high severe
start-end-span-4-attrs/never-sample
                        time:   [463.06 ns 504.61 ns 568.48 ns]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

start-end-span-8-attrs/always-sample
                        time:   [4.9835 us 5.0433 us 5.1100 us]
Found 20 outliers among 100 measurements (20.00%)
  15 (15.00%) high mild
  5 (5.00%) high severe
start-end-span-8-attrs/never-sample
                        time:   [550.82 ns 577.73 ns 626.42 ns]
  5 (5.00%) high mild
  6 (6.00%) high severe

start-end-span-all-attr-types/always-sample
                        time:   [3.6182 us 3.6591 us 3.7112 us]
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  10 (10.00%) high severe
start-end-span-all-attr-types/never-sample
                        time:   [521.50 ns 537.08 ns 563.59 ns]
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

start-end-span-all-attr-types-2x/always-sample
                        time:   [6.2272 us 6.2923 us 6.3647 us]
Found 11 outliers among 100 measurements (11.00%)
  9 (9.00%) high mild
  2 (2.00%) high severe
start-end-span-all-attr-types-2x/never-sample
                        time:   [693.60 ns 711.69 ns 751.74 ns]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
```
