### PR TITLE
Fix order of high and low parts of the trace_id in jaeger links

### DIFF
--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -364,8 +364,8 @@ fn links_to_references(links: &sdk::EvictedQueue<api::Link>) -> Option<Vec<jaege
                 //  see https://github.com/open-telemetry/opentelemetry-specification/issues/65
                 jaeger::SpanRef::new(
                     jaeger::SpanRefType::ChildOf,
-                    trace_id_high,
                     trace_id_low,
+                    trace_id_high,
                     span_context.span_id().to_u64() as i64,
                 )
             })


### PR DESCRIPTION
Fix order of arguments to [`SpanRef::new`](https://github.com/open-telemetry/opentelemetry-rust/blob/master/opentelemetry-jaeger/src/thrift/jaeger.rs#L337) in opentelemetry-jaeger crate.