### PR TITLE
Ignore nightly failures for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,15 @@ on:
     - master
 jobs:
   test:
+    continue-on-error: ${{ matrix.nightly }}
     strategy:
       fail-fast: false
       matrix:
-        image:
-        - rust:latest
-        - rustlang/rust:nightly
+        image: ["rust:latest"]
+        nightly: [false]
+        include:
+        - image: "rustlang/rust:nightly"
+          nightly: true
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}
@@ -22,12 +25,15 @@ jobs:
     - name: Test
       run: ./scripts/test.sh
   lint:
+    continue-on-error: ${{ matrix.nightly }}
     strategy:
       fail-fast: false
       matrix:
-        image:
-        - rust:latest
-        - rustlang/rust:nightly
+        image: ["rust:latest"]
+        nightly: [false]
+        include:
+        - image: "rustlang/rust:nightly"
+          nightly: true
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}


### PR DESCRIPTION
Nightly issues with CI should not block PRs and releases. This allows the error to be reported, but not block merging.