### PR TITLE
 Remove SpanID from sampling parameters

### DIFF
--- a/benches/trace.rs
+++ b/benches/trace.rs
@@ -64,7 +64,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 }
 
-fn trace_benchmark_group<F: Fn(&sdk::Tracer) -> ()>(c: &mut Criterion, name: &str, f: F) {
+fn trace_benchmark_group<F: Fn(&sdk::Tracer)>(c: &mut Criterion, name: &str, f: F) {
     let mut group = c.benchmark_group(name);
 
     group.bench_function("always-sample", |b| {

--- a/src/api/trace/sampler.rs
+++ b/src/api/trace/sampler.rs
@@ -49,7 +49,6 @@ pub trait Sampler: Send + Sync + std::fmt::Debug {
         &self,
         parent_context: Option<&api::SpanContext>,
         trace_id: api::TraceId,
-        span_id: api::SpanId,
         name: &str,
         span_kind: &api::SpanKind,
         attributes: &[api::KeyValue],

--- a/src/sdk/trace/sampler.rs
+++ b/src/sdk/trace/sampler.rs
@@ -21,7 +21,6 @@ impl api::Sampler for Sampler {
         &self,
         parent_context: Option<&api::SpanContext>,
         trace_id: api::TraceId,
-        _span_id: api::SpanId,
         _name: &str,
         _span_kind: &api::SpanKind,
         _attributes: &[api::KeyValue],
@@ -128,7 +127,6 @@ mod tests {
                     .should_sample(
                         parent_context.as_ref(),
                         trace_id,
-                        api::SpanId::from_u64(1),
                         name,
                         &api::SpanKind::Internal,
                         &[],

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -46,22 +46,14 @@ impl Tracer {
         &self,
         parent_context: Option<&api::SpanContext>,
         trace_id: api::TraceId,
-        span_id: api::SpanId,
         name: &str,
         span_kind: &api::SpanKind,
         attributes: &[api::KeyValue],
         links: &[api::Link],
     ) -> Option<(u8, Vec<api::KeyValue>)> {
         let sampler = &self.provider.config().default_sampler;
-        let sampling_result = sampler.should_sample(
-            parent_context,
-            trace_id,
-            span_id,
-            name,
-            span_kind,
-            attributes,
-            links,
-        );
+        let sampling_result =
+            sampler.should_sample(parent_context, trace_id, name, span_kind, attributes, links);
 
         self.process_sampling_result(sampling_result, parent_context)
     }
@@ -182,7 +174,6 @@ impl api::Tracer for Tracer {
             self.make_sampling_decision(
                 parent_span_context.as_ref(),
                 trace_id,
-                span_id,
                 &builder.name,
                 &span_kind,
                 &attribute_options,


### PR DESCRIPTION
 Remove SpanID from sampling parameters as per open-telemetry/opentelemetry-specification#621.

Resolves #123.