### PR TITLE
Fix some broken links

### DIFF
--- a/src/api/trace/span.rs
+++ b/src/api/trace/span.rs
@@ -32,7 +32,7 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     /// the ordering of the events' timestamps.
     ///
     /// Note that the OpenTelemetry project documents certain ["standard event names and
-    /// keys"](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md)
+    /// keys"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
     /// which have prescribed semantic meanings.
     fn add_event(&self, name: String, attributes: Vec<api::KeyValue>) {
         self.add_event_with_timestamp(name, SystemTime::now(), attributes)
@@ -44,7 +44,7 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     /// the ordering of the events' timestamps.
     ///
     /// Note that the OpenTelemetry project documents certain ["standard event names and
-    /// keys"](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md)
+    /// keys"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
     /// which have prescribed semantic meanings.
     fn add_event_with_timestamp(
         &self,
@@ -86,7 +86,7 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     /// attribute's value.
     ///
     /// Note that the OpenTelemetry project documents certain ["standard
-    /// attributes"](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md)
+    /// attributes"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
     /// that have prescribed semantic meanings.
     fn set_attribute(&self, attribute: api::KeyValue);
 

--- a/src/global.rs
+++ b/src/global.rs
@@ -84,7 +84,7 @@ impl api::Span for BoxedSpan {
     /// Records events at a specific time in the context of a given `Span`.
     ///
     /// Note that the OpenTelemetry project documents certain ["standard event names and
-    /// keys"](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md)
+    /// keys"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
     /// which have prescribed semantic meanings.
     fn add_event_with_timestamp(
         &self,
@@ -109,7 +109,7 @@ impl api::Span for BoxedSpan {
     /// Sets a single `Attribute` where the attribute properties are passed as arguments.
     ///
     /// Note that the OpenTelemetry project documents certain ["standard
-    /// attributes"](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md)
+    /// attributes"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
     /// that have prescribed semantic meanings.
     fn set_attribute(&self, attribute: api::KeyValue) {
         self.0.set_attribute(attribute)

--- a/src/sdk/trace/span.rs
+++ b/src/sdk/trace/span.rs
@@ -68,7 +68,7 @@ impl api::Span for Span {
     /// Records events at a specific time in the context of a given `Span`.
     ///
     /// Note that the OpenTelemetry project documents certain ["standard event names and
-    /// keys"](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md)
+    /// keys"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
     /// which have prescribed semantic meanings.
     fn add_event_with_timestamp(
         &self,
@@ -99,7 +99,7 @@ impl api::Span for Span {
     /// Sets a single `Attribute` where the attribute properties are passed as arguments.
     ///
     /// Note that the OpenTelemetry project documents certain ["standard
-    /// attributes"](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md)
+    /// attributes"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
     /// that have prescribed semantic meanings.
     fn set_attribute(&self, attribute: api::KeyValue) {
         self.with_data_mut(|data| {


### PR DESCRIPTION
Replace all occurrences of the broken https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md with
https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md

Resolves #138.