### PR TITLE
Allow array values for attributes

### DIFF
--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -301,6 +301,8 @@ impl Into<jaeger::Tag> for api::KeyValue {
             api::Value::Bytes(b) => jaeger::Tag::new(key.into(), jaeger::TagType::Binary, None, None, None, None, Some(b)),
             // TODO: better u64 handling, jaeger thrift only has i64 support
             api::Value::U64(u) => jaeger::Tag::new(key.into(), jaeger::TagType::String, Some(u.to_string()), None, None, None, None),
+            // TODO: better Array handling, jaeger thrift doesn't support arrays
+            v @ api::Value::Array(_) => jaeger::Tag::new(key.into(), jaeger::TagType::String, Some(v.into()), None, None, None, None),
         }
     }
 }

--- a/src/api/core.rs
+++ b/src/api/core.rs
@@ -184,7 +184,15 @@ impl From<&Value> for String {
             }
             Value::Array(value) => format!(
                 "[{}]",
-                value.iter().map(String::from).collect::<Vec<_>>().join(",")
+                value
+                    .iter()
+                    .map(|elem| match elem {
+                        v @ Value::String(_) | v @ Value::Bytes(_) =>
+                            format!(r#""{}""#, String::from(v)),
+                        v => String::from(v),
+                    })
+                    .collect::<Vec<_>>()
+                    .join(",")
             ),
         }
     }

--- a/src/api/core.rs
+++ b/src/api/core.rs
@@ -62,6 +62,14 @@ impl Key {
         }
     }
 
+    /// Create a `KeyValue` pair for arrays.
+    pub fn array<T: Into<Vec<Value>>>(&self, value: T) -> KeyValue {
+        KeyValue {
+            key: self.clone(),
+            value: Value::Array(value.into()),
+        }
+    }
+
     /// Returns a reference to the underlying key name
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
@@ -105,6 +113,8 @@ pub enum Value {
     String(String),
     /// Byte array values
     Bytes(Vec<u8>),
+    /// Array of homogeneous values
+    Array(Vec<Value>),
 }
 
 macro_rules! from_values {
@@ -130,6 +140,7 @@ from_values!(
     (f64, Value::F64);
     (String, Value::String);
     (Vec<u8>, Value::Bytes);
+    (Vec<Value>, Value::Array);
 );
 
 impl From<&str> for Value {
@@ -150,6 +161,10 @@ impl From<Value> for String {
             Value::F64(value) => value.to_string(),
             Value::String(value) => value,
             Value::Bytes(value) => String::from_utf8(value).unwrap_or_else(|_| String::new()),
+            Value::Array(value) => format!(
+                "[{}]",
+                value.iter().map(String::from).collect::<Vec<_>>().join(",")
+            ),
         }
     }
 }
@@ -167,6 +182,10 @@ impl From<&Value> for String {
             Value::Bytes(value) => {
                 String::from_utf8(value.clone()).unwrap_or_else(|_| String::new())
             }
+            Value::Array(value) => format!(
+                "[{}]",
+                value.iter().map(String::from).collect::<Vec<_>>().join(",")
+            ),
         }
     }
 }

--- a/src/api/core.rs
+++ b/src/api/core.rs
@@ -184,7 +184,7 @@ impl From<&Value> for String {
     }
 }
 
-fn format_value_array_as_string(v: &Vec<Value>) -> String {
+fn format_value_array_as_string(v: &[Value]) -> String {
     format!(
         "[{}]",
         v.iter()

--- a/src/api/core.rs
+++ b/src/api/core.rs
@@ -161,10 +161,7 @@ impl From<Value> for String {
             Value::F64(value) => value.to_string(),
             Value::String(value) => value,
             Value::Bytes(value) => String::from_utf8(value).unwrap_or_else(|_| String::new()),
-            Value::Array(value) => format!(
-                "[{}]",
-                value.iter().map(String::from).collect::<Vec<_>>().join(",")
-            ),
+            Value::Array(value) => format_value_array_as_string(&value),
         }
     }
 }
@@ -182,20 +179,22 @@ impl From<&Value> for String {
             Value::Bytes(value) => {
                 String::from_utf8(value.clone()).unwrap_or_else(|_| String::new())
             }
-            Value::Array(value) => format!(
-                "[{}]",
-                value
-                    .iter()
-                    .map(|elem| match elem {
-                        v @ Value::String(_) | v @ Value::Bytes(_) =>
-                            format!(r#""{}""#, String::from(v)),
-                        v => String::from(v),
-                    })
-                    .collect::<Vec<_>>()
-                    .join(",")
-            ),
+            Value::Array(value) => format_value_array_as_string(value),
         }
     }
+}
+
+fn format_value_array_as_string(v: &Vec<Value>) -> String {
+    format!(
+        "[{}]",
+        v.iter()
+            .map(|elem| match elem {
+                v @ Value::String(_) | v @ Value::Bytes(_) => format!(r#""{}""#, String::from(v)),
+                v => String::from(v),
+            })
+            .collect::<Vec<_>>()
+            .join(",")
+    )
 }
 
 /// `KeyValue` pairs are used by `LabelSet`s and `Span` attributes.

--- a/src/api/correlation/propagation.rs
+++ b/src/api/correlation/propagation.rs
@@ -200,7 +200,7 @@ mod tests {
             (vec![KeyValue::new("key1", "val1"), KeyValue::new("key2", "val2")], vec!["key1=val1", "key2=val2"]),
 	    // "two values with escaped chars"
             (vec![KeyValue::new("key1", "val1,val2"), KeyValue::new("key2", "val3=4")], vec!["key1=val1%2Cval2", "key2=val3%3D4"]),
-	    // "values of non-string types"
+	    // "values of non-string non-array types"
             (
                 vec![
                     KeyValue::new("key1", true),
@@ -215,6 +215,19 @@ mod tests {
                         "key4=123.567",
                 ],
             ),
+        // "values of array types"
+            (
+                vec![
+                    KeyValue::new("key1", Value::Array(vec![Value::Bool(true), Value::Bool(false)])),
+                    KeyValue::new("key2", Value::Array(vec![Value::String("val1".to_string()), Value::String("val2".to_string())])),
+                    KeyValue::new("key3", Value::Array(vec![Value::I64(123), Value::I64(456)])),
+                ],
+                vec![
+                        "key1=[true%2Cfalse]",
+                        "key2=[val1%2Cval2]",
+                        "key3=[123%2C456]",
+                ],
+            )
         ]
     }
 

--- a/src/api/correlation/propagation.rs
+++ b/src/api/correlation/propagation.rs
@@ -219,13 +219,15 @@ mod tests {
             (
                 vec![
                     KeyValue::new("key1", Value::Array(vec![Value::Bool(true), Value::Bool(false)])),
-                    KeyValue::new("key2", Value::Array(vec![Value::String("val1".to_string()), Value::String("val2".to_string())])),
-                    KeyValue::new("key3", Value::Array(vec![Value::I64(123), Value::I64(456)])),
+                    KeyValue::new("key2", Value::Array(vec![Value::I64(123), Value::I64(456)])),
+                    KeyValue::new("key3", Value::Array(vec![Value::String("val1".to_string()), Value::String("val2".to_string())])),
+                    KeyValue::new("key4", Value::Array(vec![Value::Bytes(vec![118, 97, 108, 49]), Value::Bytes(vec![118, 97, 108, 50])])),
                 ],
                 vec![
                         "key1=[true%2Cfalse]",
-                        "key2=[val1%2Cval2]",
-                        "key3=[123%2C456]",
+                        "key2=[123%2C456]",
+                        "key3=[%22val1%22%2C%22val2%22]",
+                        "key4=[%22val1%22%2C%22val2%22]",
                 ],
             )
         ]


### PR DESCRIPTION
The spec says that the string value of the array should look like a JSON string, so I attempted that here. And, as I mentioned earlier, this will allow for non-homogeneous arrays so some there is something to do there. Please let me know if any other changes required. Thank you!

Closes #142.