### PR TITLE
[b3_propagator] Follow the b3 spec

### DIFF
--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -19,9 +19,10 @@ use std::fmt::Debug;
 /// use opentelemetry::api::*;
 /// use opentelemetry::sdk;
 /// use std::collections::HashMap;
+/// use opentelemetry::api::trace::b3_propagator::B3Encoding;
 ///
 /// // First create 1 or more propagators
-/// let b3_propagator = B3Propagator::new(true);
+/// let b3_propagator = B3Propagator::new(B3Encoding::B3SingleHeader);
 /// let trace_context_propagator = TraceContextPropagator::new();
 ///
 /// // Then create a composite propagator
@@ -40,7 +41,7 @@ use std::fmt::Debug;
 /// composite_propagator.inject_context(&Context::current_with_span(example_span), &mut carrier);
 ///
 /// // The carrier now has both `X-B3` and `traceparent` headers
-/// assert!(carrier.get("X-B3").is_some());
+/// assert!(carrier.get("b3").is_some());
 /// assert!(carrier.get("traceparent").is_some());
 /// ```
 #[derive(Debug)]
@@ -80,6 +81,7 @@ impl HttpTextFormat for HttpTextCompositePropagator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::trace::b3_propagator::B3Encoding;
     use crate::api::TraceContextExt;
     use crate::api::{B3Propagator, Context, SpanContext, SpanId, TraceContextPropagator, TraceId};
     use std::collections::HashMap;
@@ -87,7 +89,7 @@ mod tests {
     fn test_data() -> Vec<(&'static str, &'static str)> {
         vec![
             (
-                "X-B3",
+                "b3",
                 "00000000000000000000000000000001-0000000000000001-0",
             ),
             (
@@ -121,7 +123,7 @@ mod tests {
 
     #[test]
     fn inject_multiple_propagators() {
-        let b3 = B3Propagator::new(true);
+        let b3 = B3Propagator::new(B3Encoding::B3SingleHeader);
         let trace_context = TraceContextPropagator::new();
         let composite_propagator = HttpTextCompositePropagator {
             propagators: vec![Box::new(b3), Box::new(trace_context)],
@@ -143,7 +145,7 @@ mod tests {
 
     #[test]
     fn extract_multiple_propagators() {
-        let b3 = B3Propagator::new(true);
+        let b3 = B3Propagator::new(B3Encoding::B3SingleHeader);
         let trace_context = TraceContextPropagator::new();
         let composite_propagator = HttpTextCompositePropagator {
             propagators: vec![Box::new(b3), Box::new(trace_context)],

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -22,7 +22,7 @@ use std::fmt::Debug;
 /// use opentelemetry::api::trace::b3_propagator::B3Encoding;
 ///
 /// // First create 1 or more propagators
-/// let b3_propagator = B3Propagator::new(B3Encoding::B3SingleHeader);
+/// let b3_propagator = B3Propagator::with_encoding(B3Encoding::SingleHeader);
 /// let trace_context_propagator = TraceContextPropagator::new();
 ///
 /// // Then create a composite propagator
@@ -123,7 +123,7 @@ mod tests {
 
     #[test]
     fn inject_multiple_propagators() {
-        let b3 = B3Propagator::new(B3Encoding::B3SingleHeader);
+        let b3 = B3Propagator::with_encoding(B3Encoding::SingleHeader);
         let trace_context = TraceContextPropagator::new();
         let composite_propagator = HttpTextCompositePropagator {
             propagators: vec![Box::new(b3), Box::new(trace_context)],
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn extract_multiple_propagators() {
-        let b3 = B3Propagator::new(B3Encoding::B3SingleHeader);
+        let b3 = B3Propagator::with_encoding(B3Encoding::SingleHeader);
         let trace_context = TraceContextPropagator::new();
         let composite_propagator = HttpTextCompositePropagator {
             propagators: vec![Box::new(b3), Box::new(trace_context)],

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -48,7 +48,7 @@ pub use trace::{
     sampler::{Sampler, SamplingDecision, SamplingResult},
     span::{Span, SpanKind, StatusCode},
     span_context::{
-        SpanContext, SpanId, TraceId, TRACE_FLAG_DEBUG, TRACE_FLAG_DEFERRED, TRACE_FLAG_SAMPLED,
+        SpanContext, SpanId, TraceId, TRACE_FLAG_DEBUG, TRACE_FLAG_DEFERRED, TRACE_FLAG_SAMPLED, TRACE_FLAG_NOT_SAMPLED
     },
     span_processor::SpanProcessor,
     trace_context_propagator::TraceContextPropagator,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -47,7 +47,9 @@ pub use trace::{
     provider::Provider,
     sampler::{Sampler, SamplingDecision, SamplingResult},
     span::{Span, SpanKind, StatusCode},
-    span_context::{SpanContext, SpanId, TraceId, TRACE_FLAGS_UNUSED, TRACE_FLAG_SAMPLED},
+    span_context::{
+        SpanContext, SpanId, TraceId, TRACE_FLAG_DEBUG, TRACE_FLAG_DEFERRED, TRACE_FLAG_SAMPLED,
+    },
     span_processor::SpanProcessor,
     trace_context_propagator::TraceContextPropagator,
     tracer::{SpanBuilder, Tracer},

--- a/src/api/trace/b3_propagator.rs
+++ b/src/api/trace/b3_propagator.rs
@@ -11,7 +11,7 @@
 //!    X-B3-Sampled: {sampling_state}
 //!    X-B3-Flags: {debug_flag}
 //!
-//! If `inject_encoding` is set to `B3Encoding::B3SingleHeader` then `b3` header is used to inject
+//! If `inject_encoding` is set to `B3Encoding::SingleHeader` then `b3` header is used to inject
 //! and extract. Otherwise, separate headers are used to inject and extract.
 use crate::{api, api::TraceContextExt};
 use crate::api::TRACE_FLAG_DEFERRED;

--- a/src/api/trace/span_context.rs
+++ b/src/api/trace/span_context.rs
@@ -14,13 +14,20 @@
 use serde::{Deserialize, Serialize};
 
 const TRACE_FLAGS_BIT_MASK_SAMPLED: u8 = 0x01;
-const TRACE_FLAGS_BIT_MASK_UNUSED: u8 = 0xFE;
+const TRACE_FLAGS_BIT_MASK_DEFERRED: u8 = 0x02;
+const TRACE_FLAGS_BIT_MASK_DEBUG: u8 = 0x04;
 
-/// TraceFlagsSampled is a byte with sampled bit set. It is a convenient value initializer
-/// for SpanContext TraceFlags field when a trace is sampled.
+/// A SpanContext with TRACE_FLAG_NOT_SAMPLED means the span is not sampled.
+pub const TRACE_FLAG_NOT_SAMPLED: u8 = 0x00;
+/// TRACE_FLAG_SAMPLED is a bitmask with the sampled bit set. A SpanContext
+/// with the sampling bit set means the span is sampled.
 pub const TRACE_FLAG_SAMPLED: u8 = TRACE_FLAGS_BIT_MASK_SAMPLED;
-/// Useful for extracting trace context
-pub const TRACE_FLAGS_UNUSED: u8 = TRACE_FLAGS_BIT_MASK_UNUSED;
+/// TRACE_FLAGS_DEFERRED is a bitmask with the deferred bit set. A SpanContext
+/// with the deferred bit set means the sampling decision has been
+/// defered to the receiver.
+pub const TRACE_FLAG_DEFERRED: u8 = TRACE_FLAGS_BIT_MASK_DEFERRED;
+/// TRACE_FLAGS_DEBUG is a bitmask with the debug bit set. Note that debug implies sampled
+pub const TRACE_FLAG_DEBUG: u8 = TRACE_FLAGS_BIT_MASK_DEBUG | TRACE_FLAGS_BIT_MASK_SAMPLED;
 
 /// TraceId is an 16-byte value which uniquely identifies a given trace
 /// The actual `u128` value is wrapped in a tuple struct in order to leverage the newtype pattern
@@ -121,8 +128,18 @@ impl SpanContext {
         self.is_remote
     }
 
+    /// Returns if the deferred bit is set in the trace flags
+    pub fn is_deferred(&self) -> bool {
+        (self.trace_flags & TRACE_FLAG_DEFERRED) == TRACE_FLAG_DEFERRED
+    }
+
+    /// Returns if the debug bit is set in the trace flags
+    pub fn is_debug(&self) -> bool {
+        (self.trace_flags & TRACE_FLAG_DEBUG) == TRACE_FLAG_DEBUG
+    }
+
     /// Returns true if the `SpanContext` is sampled.
     pub fn is_sampled(&self) -> bool {
-        (self.trace_flags & TRACE_FLAGS_BIT_MASK_SAMPLED) == TRACE_FLAGS_BIT_MASK_SAMPLED
+        (self.trace_flags & TRACE_FLAG_SAMPLED) == TRACE_FLAG_SAMPLED
     }
 }

--- a/src/api/trace/span_context.rs
+++ b/src/api/trace/span_context.rs
@@ -13,21 +13,18 @@
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
-const TRACE_FLAGS_BIT_MASK_SAMPLED: u8 = 0x01;
-const TRACE_FLAGS_BIT_MASK_DEFERRED: u8 = 0x02;
-const TRACE_FLAGS_BIT_MASK_DEBUG: u8 = 0x04;
 
 /// A SpanContext with TRACE_FLAG_NOT_SAMPLED means the span is not sampled.
 pub const TRACE_FLAG_NOT_SAMPLED: u8 = 0x00;
 /// TRACE_FLAG_SAMPLED is a bitmask with the sampled bit set. A SpanContext
 /// with the sampling bit set means the span is sampled.
-pub const TRACE_FLAG_SAMPLED: u8 = TRACE_FLAGS_BIT_MASK_SAMPLED;
+pub const TRACE_FLAG_SAMPLED: u8 = 0x01;
 /// TRACE_FLAGS_DEFERRED is a bitmask with the deferred bit set. A SpanContext
 /// with the deferred bit set means the sampling decision has been
 /// defered to the receiver.
-pub const TRACE_FLAG_DEFERRED: u8 = TRACE_FLAGS_BIT_MASK_DEFERRED;
-/// TRACE_FLAGS_DEBUG is a bitmask with the debug bit set. Note that debug implies sampled
-pub const TRACE_FLAG_DEBUG: u8 = TRACE_FLAGS_BIT_MASK_DEBUG | TRACE_FLAGS_BIT_MASK_SAMPLED;
+pub const TRACE_FLAG_DEFERRED: u8 = 0x02;
+/// TRACE_FLAGS_DEBUG is a bitmask with the debug bit set.
+pub const TRACE_FLAG_DEBUG: u8 = 0x04;
 
 /// TraceId is an 16-byte value which uniquely identifies a given trace
 /// The actual `u128` value is wrapped in a tuple struct in order to leverage the newtype pattern

--- a/src/api/trace/trace_context_propagator.rs
+++ b/src/api/trace/trace_context_propagator.rs
@@ -68,7 +68,7 @@ impl TraceContextPropagator {
             return Err(());
         }
         // Build trace flags
-        let trace_flags = opts & !api::TRACE_FLAGS_UNUSED;
+        let trace_flags = opts & api::TRACE_FLAG_SAMPLED;
 
         // create context
         let span_context = api::SpanContext::new(trace_id, span_id, trace_flags, true);


### PR DESCRIPTION
Update B3 propagator to follow [spec](https://github.com/openzipkin/b3-propagation). Also added some test cases.

Detail changes includes:
- Add `B3Encoding` enum as parameter of `B3Propagator`.
- Add `TRACE_FLAG_NOT_SAMPLED `, `TRACE_FLAG_SAMPLED`, `TRACE_FLAG_DEFERRED`, `TRACE_FLAG_DEBUG` flag in span context.
- Change the keys in single header and multiple headers.
- Allow only certain length of lower case string as value of `span id` and `trace id` in b3 headers
- Support send sample decision along using b3 headers.

One difference between Rust and Go implementation:

As per spec, when the sampled decision is debug, it implies sampled. So When `X-B3-Flag` is 1, we will set span context to be `sampled` and `debug`. But in Go implementation, we set the span context to be `debug` and `deferred`.  The spec isn't really clear about it. On the one hand, it says `debug` implies sampled. On the other hand, it says if `X-B3-Flag` is 1, then no `X-B3-Sampled` should be sent and when `X-B3-Sampled` is not present, it means the sample decision is deferred. 

close #147 