### PR TITLE
fix(zipkin): add with_collector_endpoint into config builder

### DIFF
--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -143,6 +143,12 @@ impl ExporterConfigBuilder {
         self.service_endpoint = Some(endpoint);
         self
     }
+    
+    /// Assign the collector endpoint for `ConfigBuilder`
+    pub fn with_collector_endpoint(&mut self, endpoint: String) -> &mut Self {
+        self.collector_endpoint = Some(endpoint);
+        self
+    }
 }
 
 impl Exporter {


### PR DESCRIPTION
Missing method for config builder in zipkin