### PR TITLE
Separate Carrier into Injector and Extractor

### DIFF
--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -69,7 +69,11 @@ impl HttpTextFormat for HttpTextCompositePropagator {
     /// Retrieves encoded `Context` information using the `Extractor`. If no data was
     /// retrieved OR if the retrieved data is invalid, then the current `Context` is
     /// returned.
-    fn extract_with_context(&self, cx: &api::Context, extractor: &dyn api::Extractor) -> api::Context {
+    fn extract_with_context(
+        &self,
+        cx: &api::Context,
+        extractor: &dyn api::Extractor,
+    ) -> api::Context {
         self.propagators
             .iter()
             .fold(cx.clone(), |current_cx, propagator| {

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -31,18 +31,18 @@ use std::fmt::Debug;
 ///     Box::new(trace_context_propagator),
 /// ]);
 ///
-/// // Then for a given implementation of `Carrier`
-/// let mut carrier = HashMap::new();
+/// // Then for a given implementation of `Injector`
+/// let mut injector = HashMap::new();
 ///
 /// // And a given span
 /// let example_span = sdk::Provider::default().get_tracer("example-component").start("span-name");
 ///
 /// // with the current context, call inject to add the headers
-/// composite_propagator.inject_context(&Context::current_with_span(example_span), &mut carrier);
+/// composite_propagator.inject_context(&Context::current_with_span(example_span), &mut injector);
 ///
-/// // The carrier now has both `X-B3` and `traceparent` headers
-/// assert!(carrier.get("b3").is_some());
-/// assert!(carrier.get("traceparent").is_some());
+/// // The injector now has both `X-B3` and `traceparent` headers
+/// assert!(injector.get("b3").is_some());
+/// assert!(injector.get("traceparent").is_some());
 /// ```
 #[derive(Debug)]
 pub struct HttpTextCompositePropagator {
@@ -136,11 +136,11 @@ mod tests {
             0,
             false,
         )));
-        let mut carrier = HashMap::new();
-        composite_propagator.inject_context(&cx, &mut carrier);
+        let mut injector = HashMap::new();
+        composite_propagator.inject_context(&cx, &mut injector);
 
         for (header_name, header_value) in test_data() {
-            assert_eq!(carrier.get(header_name), Some(&header_value.to_string()));
+            assert_eq!(injector.get(header_name), Some(&header_value.to_string()));
         }
     }
 
@@ -153,10 +153,12 @@ mod tests {
         };
 
         for (header_name, header_value) in test_data() {
-            let mut carrier = HashMap::new();
-            carrier.insert(header_name.to_string(), header_value.to_string());
+            let mut extractor = HashMap::new();
+            extractor.insert(header_name.to_string(), header_value.to_string());
             assert_eq!(
-                composite_propagator.extract(&carrier).remote_span_context(),
+                composite_propagator
+                    .extract(&extractor)
+                    .remote_span_context(),
                 Some(&SpanContext::new(
                     TraceId::from_u128(1),
                     SpanId::from_u64(1),

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -59,21 +59,21 @@ impl HttpTextCompositePropagator {
 }
 
 impl HttpTextFormat for HttpTextCompositePropagator {
-    /// Encodes the values of the `Context` and injects them into the `Carrier`.
-    fn inject_context(&self, context: &api::Context, carrier: &mut dyn api::Carrier) {
+    /// Encodes the values of the `Context` and injects them into the `Injector`.
+    fn inject_context(&self, context: &api::Context, injector: &mut dyn api::Injector) {
         for propagator in &self.propagators {
-            propagator.inject_context(context, carrier)
+            propagator.inject_context(context, injector)
         }
     }
 
-    /// Retrieves encoded `Context` information using the `Carrier`. If no data was
+    /// Retrieves encoded `Context` information using the `Extractor`. If no data was
     /// retrieved OR if the retrieved data is invalid, then the current `Context` is
     /// returned.
-    fn extract_with_context(&self, cx: &api::Context, carrier: &dyn api::Carrier) -> api::Context {
+    fn extract_with_context(&self, cx: &api::Context, extractor: &dyn api::Extractor) -> api::Context {
         self.propagators
             .iter()
             .fold(cx.clone(), |current_cx, propagator| {
-                propagator.extract_with_context(&current_cx, carrier)
+                propagator.extract_with_context(&current_cx, extractor)
             })
     }
 }

--- a/src/api/context/propagation/mod.rs
+++ b/src/api/context/propagation/mod.rs
@@ -5,7 +5,7 @@
 //! - `BinaryFormat` is used to serialize and deserialize a value
 //! into a binary representation.
 //! - `HttpTextFormat` is used to inject and extract a value as
-//! text into carriers that travel in-band across process boundaries.
+//! text into injectors and extractors that travel in-band across process boundaries.
 //!
 //! Deserializing must set `is_remote` to true on the returned
 //! `SpanContext`.
@@ -45,25 +45,25 @@
 //! ## HTTP Text Format
 //!
 //! `HttpTextFormat` is a formatter that injects and extracts a value
-//! as text into carriers that travel in-band across process boundaries.
+//! as text into injectors and extractors that travel in-band across process boundaries.
 //!
 //! Encoding is expected to conform to the HTTP Header Field semantics.
 //! Values are often encoded as RPC/HTTP request headers.
 //!
 //! The carrier of propagated data on both the client (injector) and
-//! server (extractor) side is usually an http request. Propagation is
+//! server (extractor) side is usually a http request. Propagation is
 //! usually implemented via library-specific request interceptors, where
 //! the client-side injects values and the server-side extracts them.
 //!
-//! `HttpTextFormat` MUST expose the APIs that injects values into carriers,
-//! and extracts values from carriers.
+//! `HttpTextFormat` MUST expose the APIs that injects values into injectors,
+//! and extracts values from extractors.
 //!
 //! ### Fields
 //!
-//! The propagation fields defined. If your carrier is reused, you should
+//! The propagation fields defined. If your injector is reused, you should
 //! delete the fields here before calling `inject`.
 //!
-//! For example, if the carrier is a single-use or immutable request object,
+//! For example, if the injector is a single-use or immutable request object,
 //! you don't need to clear fields as they couldn't have been set before.
 //! If it is a mutable, retryable object, successive calls should clear
 //! these fields first.
@@ -83,7 +83,7 @@
 //! Required arguments:
 //!
 //! - the `SpanContext` to be injected.
-//! - the carrier that holds propagation fields. For example, an outgoing
+//! - the injector that holds propagation fields. For example, an outgoing
 //! message or http request.
 //! - the `Setter` invoked for each propagation key to add or remove.
 //!
@@ -92,7 +92,7 @@
 //! Setter is an argument in `Inject` that puts value into given field.
 //!
 //! `Setter` allows a `HttpTextFormat` to set propagated fields into a
-//! carrier.
+//! injector.
 //!
 //! `Setter` MUST be stateless and allowed to be saved as a constant to
 //! avoid runtime allocations. One of the ways to implement it is `Setter`
@@ -104,7 +104,7 @@
 //!
 //! Required arguments:
 //!
-//! - the carrier holds propagation fields. For example, an outgoing message
+//! - the injector holds propagation fields. For example, an outgoing message
 //! or http request.
 //! - the key of the field.
 //! - the value of the field.
@@ -123,7 +123,7 @@
 //!
 //! Required arguments:
 //!
-//! - the carrier holds propagation fields. For example, an outgoing message
+//! - the extractor holds propagation fields. For example, an outgoing message
 //! or http request.
 //! - the instance of `Getter` invoked for each propagation key to get.
 //!
@@ -134,7 +134,7 @@
 //! Getter is an argument in `Extract` that get value from given field
 //!
 //! `Getter` allows a `HttpTextFormat` to read propagated fields from a
-//! carrier.
+//! extractor.
 //!
 //! `Getter` MUST be stateless and allowed to be saved as a constant to avoid
 //! runtime allocations. One of the ways to implement it is `Getter` class
@@ -147,7 +147,7 @@
 //!
 //! Required arguments:
 //!
-//! - the carrier of propagation fields, such as an HTTP request.
+//! - the extractor of propagation fields, such as an HTTP request.
 //! - the key of the field.
 //!
 //! The `get` function is responsible for handling case sensitivity. If

--- a/src/api/context/propagation/mod.rs
+++ b/src/api/context/propagation/mod.rs
@@ -163,13 +163,6 @@ use std::collections::HashMap;
 pub mod composite_propagator;
 pub mod text_propagator;
 
-// /// Carriers provide an interface for adding and removing fields from an
-// /// underlying struct like `HashMap`.
-// pub trait Carrier {
-//     /// Get a value for a key from the underlying data.
-//     fn get(&self, key: &str) -> Option<&str>;
-// }
-
 /// Injector provides an interface for adding fields from an underlying struct like `HashMap`
 pub trait Injector {
     /// Add a key and value to the underlying.

--- a/src/api/context/propagation/text_propagator.rs
+++ b/src/api/context/propagation/text_propagator.rs
@@ -9,36 +9,36 @@ use std::fmt::Debug;
 /// in-band across process boundaries.
 pub trait HttpTextFormat: Debug {
     /// Properly encodes the values of the current [`Context`] and injects them into
-    /// the [`Carrier`].
+    /// the [`Injector`].
     ///
     /// [`Context`]: ../../struct.Context.html
-    /// [`Carrier`]: ../trait.Carrier.html
-    fn inject(&self, carrier: &mut dyn api::Carrier) {
-        self.inject_context(&Context::current(), carrier)
+    /// [`Injector`]: ../trait.Injector.html
+    fn inject(&self, injector: &mut dyn api::Injector) {
+        self.inject_context(&Context::current(), injector)
     }
 
     /// Properly encodes the values of the [`Context`] and injects them into the
-    /// [`Carrier`].
+    /// [`Injector`].
     ///
     /// [`Context`]: ../../struct.Context.html
-    /// [`Carrier`]: ../trait.Carrier.html
-    fn inject_context(&self, cx: &Context, carrier: &mut dyn api::Carrier);
+    /// [`Injector`]: ../trait.Carrier.html
+    fn inject_context(&self, cx: &Context, injector: &mut dyn api::Injector);
 
-    /// Retrieves encoded data using the provided [`Carrier`]. If no data for this
+    /// Retrieves encoded data using the provided [`Extractor`]. If no data for this
     /// format was retrieved OR if the retrieved data is invalid, then the current
     /// [`Context`] is returned.
     ///
     /// [`Context`]: ../../struct.Context.html
-    /// [`Carrier`]: ../trait.Carrier.html
-    fn extract(&self, carrier: &dyn api::Carrier) -> Context {
-        self.extract_with_context(&Context::current(), carrier)
+    /// [`Extractor`]: ../trait.Carrier.html
+    fn extract(&self, extractor: &dyn api::Extractor) -> Context {
+        self.extract_with_context(&Context::current(), extractor)
     }
 
-    /// Retrieves encoded data using the provided [`Carrier`]. If no data for this
+    /// Retrieves encoded data using the provided [`Extractor`]. If no data for this
     /// format was retrieved OR if the retrieved data is invalid, then the given
     /// [`Context`] is returned.
     ///
     /// [`Context`]: ../../struct.Context.html
-    /// [`Carrier`]: ../trait.Carrier.html
-    fn extract_with_context(&self, cx: &Context, carrier: &dyn api::Carrier) -> Context;
+    /// [`Extractor`]: ../trait.Carrier.html
+    fn extract_with_context(&self, cx: &Context, extractor: &dyn api::Extractor) -> Context;
 }

--- a/src/api/context/propagation/text_propagator.rs
+++ b/src/api/context/propagation/text_propagator.rs
@@ -5,7 +5,7 @@
 use crate::{api, api::Context};
 use std::fmt::Debug;
 
-/// Methods to inject and extract a value as text into carriers that travel
+/// Methods to inject and extract a value as text into injectors and extractors that travel
 /// in-band across process boundaries.
 pub trait HttpTextFormat: Debug {
     /// Properly encodes the values of the current [`Context`] and injects them into
@@ -21,7 +21,7 @@ pub trait HttpTextFormat: Debug {
     /// [`Injector`].
     ///
     /// [`Context`]: ../../struct.Context.html
-    /// [`Injector`]: ../trait.Carrier.html
+    /// [`Injector`]: ../trait.Injector.html
     fn inject_context(&self, cx: &Context, injector: &mut dyn api::Injector);
 
     /// Retrieves encoded data using the provided [`Extractor`]. If no data for this
@@ -29,7 +29,7 @@ pub trait HttpTextFormat: Debug {
     /// [`Context`] is returned.
     ///
     /// [`Context`]: ../../struct.Context.html
-    /// [`Extractor`]: ../trait.Carrier.html
+    /// [`Extractor`]: ../trait.Extractor.html
     fn extract(&self, extractor: &dyn api::Extractor) -> Context {
         self.extract_with_context(&Context::current(), extractor)
     }
@@ -39,6 +39,6 @@ pub trait HttpTextFormat: Debug {
     /// [`Context`] is returned.
     ///
     /// [`Context`]: ../../struct.Context.html
-    /// [`Extractor`]: ../trait.Carrier.html
+    /// [`Extractor`]: ../trait.Extractor.html
     fn extract_with_context(&self, cx: &Context, extractor: &dyn api::Extractor) -> Context;
 }

--- a/src/api/correlation/mod.rs
+++ b/src/api/correlation/mod.rs
@@ -23,7 +23,7 @@
 //! headers.insert("otcorrelations".to_string(), "user_id=1".to_string());
 //!
 //! let propagator = CorrelationContextPropagator::new();
-//! // can extract from any type that impls `Carrier`, usually an HTTP header map
+//! // can extract from any type that impls `Extractor`, usually an HTTP header map
 //! let cx = propagator.extract(&headers);
 //!
 //! // Iterate over extracted name / value pairs

--- a/src/api/correlation/propagation.rs
+++ b/src/api/correlation/propagation.rs
@@ -26,8 +26,8 @@ impl CorrelationContextPropagator {
 }
 
 impl api::HttpTextFormat for CorrelationContextPropagator {
-    /// Encodes the values of the `Context` and injects them into the provided `Carrier`.
-    fn inject_context(&self, cx: &Context, carrier: &mut dyn api::Carrier) {
+    /// Encodes the values of the `Context` and injects them into the provided `Injector`.
+    fn inject_context(&self, cx: &Context, injector: &mut dyn api::Injector) {
         let correlation_cx = cx.correlation_context();
         if !correlation_cx.is_empty() {
             let header_value = correlation_cx
@@ -40,13 +40,13 @@ impl api::HttpTextFormat for CorrelationContextPropagator {
                 })
                 .collect::<Vec<String>>()
                 .join(",");
-            carrier.set(CORRELATION_CONTEXT_HEADER, header_value);
+            injector.set(CORRELATION_CONTEXT_HEADER, header_value);
         }
     }
 
-    /// Extracts a `Context` with correlation context values from a `Carrier`.
-    fn extract_with_context(&self, cx: &Context, carrier: &dyn api::Carrier) -> Context {
-        if let Some(header_value) = carrier.get(CORRELATION_CONTEXT_HEADER) {
+    /// Extracts a `Context` with correlation context values from a `Extractor`.
+    fn extract_with_context(&self, cx: &Context, extractor: &dyn api::Extractor) -> Context {
+        if let Some(header_value) = extractor.get(CORRELATION_CONTEXT_HEADER) {
             let correlations = header_value.split(',').flat_map(|context_value| {
                 if let Some((name_and_value, props)) = context_value
                     .split(';')

--- a/src/api/correlation/propagation.rs
+++ b/src/api/correlation/propagation.rs
@@ -238,12 +238,12 @@ mod tests {
         let propagator = CorrelationContextPropagator::new();
 
         for (header_value, kvs) in valid_extract_data() {
-            let mut carrier: HashMap<String, String> = HashMap::new();
-            carrier.insert(
+            let mut extractor: HashMap<String, String> = HashMap::new();
+            extractor.insert(
                 CORRELATION_CONTEXT_HEADER.to_string(),
                 header_value.to_string(),
             );
-            let context = propagator.extract(&carrier);
+            let context = propagator.extract(&extractor);
             let correlations = context.correlation_context();
 
             assert_eq!(kvs.len(), correlations.len());
@@ -258,10 +258,10 @@ mod tests {
         let propagator = CorrelationContextPropagator::new();
 
         for (kvs, header_parts) in valid_inject_data() {
-            let mut carrier = HashMap::new();
+            let mut injector = HashMap::new();
             let cx = Context::current_with_correlations(kvs);
-            propagator.inject_context(&cx, &mut carrier);
-            let header_value = carrier.get(CORRELATION_CONTEXT_HEADER).unwrap();
+            propagator.inject_context(&cx, &mut injector);
+            let header_value = injector.get(CORRELATION_CONTEXT_HEADER).unwrap();
 
             assert_eq!(header_parts.join(",").len(), header_value.len(),);
             for header_part in &header_parts {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -22,7 +22,8 @@ pub mod trace;
 pub use self::core::{Key, KeyValue, Unit, Value};
 pub use context::{
     propagation::{
-        composite_propagator::HttpTextCompositePropagator, text_propagator::HttpTextFormat, Carrier,
+        composite_propagator::HttpTextCompositePropagator, text_propagator::HttpTextFormat, Injector,
+        Extractor,
     },
     Context,
 };

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -22,8 +22,8 @@ pub mod trace;
 pub use self::core::{Key, KeyValue, Unit, Value};
 pub use context::{
     propagation::{
-        composite_propagator::HttpTextCompositePropagator, text_propagator::HttpTextFormat, Injector,
-        Extractor,
+        composite_propagator::HttpTextCompositePropagator, text_propagator::HttpTextFormat,
+        Extractor, Injector,
     },
     Context,
 };

--- a/src/api/trace/b3_propagator.rs
+++ b/src/api/trace/b3_propagator.rs
@@ -129,7 +129,10 @@ impl B3Propagator {
     }
 
     /// Extract a `SpanContext` from a single B3 header.
-    fn extract_single_header(&self, extractor: &dyn api::Extractor) -> Result<api::SpanContext, ()> {
+    fn extract_single_header(
+        &self,
+        extractor: &dyn api::Extractor,
+    ) -> Result<api::SpanContext, ()> {
         let header_value = extractor.get(B3_SINGLE_HEADER).unwrap_or("");
         let parts = header_value.split_terminator('-').collect::<Vec<&str>>();
         // Ensure length is within range.
@@ -258,7 +261,11 @@ impl api::HttpTextFormat for B3Propagator {
     /// Retrieves encoded data using the provided `Extractor`. If no data for this
     /// format was retrieved OR if the retrieved data is invalid, then the current
     /// `Context` is returned.
-    fn extract_with_context(&self, cx: &api::Context, extractor: &dyn api::Extractor) -> api::Context {
+    fn extract_with_context(
+        &self,
+        cx: &api::Context,
+        extractor: &dyn api::Extractor,
+    ) -> api::Context {
         let span_context = if self.inject_encoding.support(&B3Encoding::SingleHeader) {
             self.extract_single_header(extractor).unwrap_or_else(|_|
                     // if invalid single header should fallback to multiple

--- a/src/api/trace/trace_context_propagator.rs
+++ b/src/api/trace/trace_context_propagator.rs
@@ -103,7 +103,11 @@ impl api::HttpTextFormat for TraceContextPropagator {
     /// the `SpanContext` and returns it. If no `SpanContext` was retrieved
     /// OR if the retrieved SpanContext is invalid then an empty `SpanContext`
     /// is returned.
-    fn extract_with_context(&self, cx: &api::Context, extractor: &dyn api::Extractor) -> api::Context {
+    fn extract_with_context(
+        &self,
+        cx: &api::Context,
+        extractor: &dyn api::Extractor,
+    ) -> api::Context {
         self.extract_span_context(extractor)
             .map(|sc| cx.with_remote_span_context(sc))
             .unwrap_or_else(|_| cx.clone())
@@ -113,7 +117,7 @@ impl api::HttpTextFormat for TraceContextPropagator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::{HttpTextFormat, Extractor};
+    use crate::api::{Extractor, HttpTextFormat};
     use std::collections::HashMap;
 
     #[rustfmt::skip]

--- a/src/api/trace/trace_context_propagator.rs
+++ b/src/api/trace/trace_context_propagator.rs
@@ -24,7 +24,7 @@ static SUPPORTED_VERSION: u8 = 0;
 static MAX_VERSION: u8 = 254;
 static TRACEPARENT_HEADER: &str = "traceparent";
 
-/// Extracts and injects `SpanContext`s into `Carrier`s using the
+/// Extracts and injects `SpanContext`s into `Extractor`s and `Injector`s using the
 /// trace-context format.
 #[derive(Debug, Default)]
 pub struct TraceContextPropagator {}
@@ -148,10 +148,10 @@ mod tests {
         let propagator = TraceContextPropagator::new();
 
         for (header, expected_context) in extract_data() {
-            let mut carrier = HashMap::new();
-            carrier.insert(TRACEPARENT_HEADER.to_string(), header.to_owned());
+            let mut extractor = HashMap::new();
+            extractor.insert(TRACEPARENT_HEADER.to_string(), header.to_owned());
             assert_eq!(
-                propagator.extract(&carrier).remote_span_context(),
+                propagator.extract(&extractor).remote_span_context(),
                 Some(&expected_context)
             )
         }
@@ -184,14 +184,14 @@ mod tests {
         let propagator = TraceContextPropagator::new();
 
         for (expected_header, context) in inject_data() {
-            let mut carrier = HashMap::new();
+            let mut injector = HashMap::new();
             propagator.inject_context(
                 &api::Context::current_with_span(TestSpan(context)),
-                &mut carrier,
+                &mut injector,
             );
 
             assert_eq!(
-                Extractor::get(&carrier, TRACEPARENT_HEADER).unwrap_or(""),
+                Extractor::get(&injector, TRACEPARENT_HEADER).unwrap_or(""),
                 expected_header
             )
         }

--- a/src/global.rs
+++ b/src/global.rs
@@ -359,14 +359,14 @@ pub fn set_http_text_propagator<P: api::HttpTextFormat + Send + Sync + 'static>(
 /// use opentelemetry::{api, api::HttpTextFormat, global};
 /// use std::collections::HashMap;
 ///
-/// let example_carrier = HashMap::new();
+/// let example_extractor = HashMap::new();
 ///
 /// // create your http text propagator
 /// let tc_propagator = api::TraceContextPropagator::new();
 /// global::set_http_text_propagator(tc_propagator);
 ///
 /// // use the global http text propagator to extract contexts
-/// let _cx = global::get_http_text_propagator(|propagator| propagator.extract(&example_carrier));
+/// let _cx = global::get_http_text_propagator(|propagator| propagator.extract(&example_extractor));
 /// ```
 pub fn get_http_text_propagator<T, F>(mut f: F) -> T
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,8 +211,8 @@
 //! `DistributedContext` into a binary or text format. Currently there are two types of propagators:
 //!
 //! - `BinaryFormat` which is used to serialize and deserialize a value into a binary representation.
-//! - `HTTPTextFormat` which is used to inject and extract a value as text into carriers that travel
-//!   in-band across process boundaries.
+//! - `HTTPTextFormat` which is used to inject and extract a value as text into injectors or extractors
+//!    that travel in-band across process boundaries.
 //!
 //! [Semantic Conventions]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/README.md
 #![recursion_limit = "256"]


### PR DESCRIPTION
Although it feels like we should separate `HttpTextFormat` instead of `Carrier`
close #105 