### PR TITLE
Add custom span processors to Provider::Builder

### DIFF
--- a/src/sdk/trace/provider.rs
+++ b/src/sdk/trace/provider.rs
@@ -110,8 +110,16 @@ impl Builder {
         Builder { processors, ..self }
     }
 
-    /// The `SpanExporter` that this provider should use.
+    /// The `BatchProcessor` that this provider should use.
     pub fn with_batch_exporter(self, processor: sdk::BatchSpanProcessor) -> Self {
+        let mut processors = self.processors;
+        processors.push(Box::new(processor));
+
+        Builder { processors, ..self }
+    }
+
+    /// The `SpanProcessor` that this provider should use.
+    pub fn with_span_processor<T: api::SpanProcessor + 'static>(self, processor: T) -> Self {
         let mut processors = self.processors;
         processors.push(Box::new(processor));
 


### PR DESCRIPTION
As mentioned in https://github.com/open-telemetry/opentelemetry-rust/issues/165#issuecomment-667710511 by @jtescher, i'm adding a method that makes possible to add "any" span processor to Provider::Builder