### PR TITLE
Export OTLP types

### DIFF
--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -5,4 +5,4 @@ mod proto;
 mod span;
 mod transform;
 
-pub use crate::span::Exporter;
+pub use crate::span::{Compression, Credentials, Exporter, ExporterConfig, Protocol};


### PR DESCRIPTION
Bugfix from #173 - Actually export OTLP configuration types. 🤦 