### PR TITLE
Update OTLP exporter metadata

### DIFF
--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -3,8 +3,8 @@ name = "opentelemetry-jaeger"
 version = "0.7.0"
 authors = ["OpenTelemetry Authors <cncf-opentelemetry-contributors@lists.cncf.io>"]
 description = "Jaeger exporter for OpenTelemetry"
-homepage = "https://github.com/open-telemetry/opentelemetry-rust"
-repository = "https://github.com/open-telemetry/opentelemetry-rust"
+homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/master/opentelemetry-jaeger"
+repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/master/opentelemetry-jaeger"
 readme = "README.md"
 categories = [
     "development-tools::debugging",

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -2,16 +2,19 @@
 name = "opentelemetry-otlp"
 version = "0.1.0"
 authors = ["OpenTelemetry Authors <cncf-opentelemetry-contributors@lists.cncf.io>"]
-description = "A metrics collection and distributed tracing framework"
-homepage = "https://github.com/open-telemetry/opentelemetry-rust/opentelemetry-otlp"
-repository = "https://github.com/open-telemetry/opentelemetry-rust/opentelemetry-otlp"
+description = "Exporter for the OpenTelemetry Collector"
+homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/master/opentelemetry-otlp"
+repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/master/opentelemetry-otlp"
 readme = "README.md"
-keywords = ["opentelemetry", "otel", "otlp", "logging", "tracing", "metrics", "async"]
+categories = [
+    "development-tools::debugging",
+    "development-tools::profiling",
+    "asynchronous",
+]
+keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2018"
 build = "build.rs"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 futures = "0.3.5"

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -1,0 +1,3 @@
+# OpenTelemetry Collector Rust Exporter
+
+This exporter exports OpenTelemetry spans and metrics to the OpenTelemetry Collector.

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -3,8 +3,8 @@ name = "opentelemetry-zipkin"
 version = "0.5.0"
 authors = ["OpenTelemetry Authors <cncf-opentelemetry-contributors@lists.cncf.io>"]
 description = "Zipkin exporter for OpenTelemetry"
-homepage = "https://github.com/open-telemetry/opentelemetry-rust"
-repository = "https://github.com/open-telemetry/opentelemetry-rust"
+homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/master/opentelemetry-zipkin"
+repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/master/opentelemetry-zipkin"
 readme = "README.md"
 categories = [
     "development-tools::debugging",


### PR DESCRIPTION
Fix invalid crate metadata (max 5 keywords) and add placeholder README