### PR TITLE
Add #[non_exhaustive] to metrics errors

### DIFF
--- a/src/api/metrics/mod.rs
+++ b/src/api/metrics/mod.rs
@@ -39,6 +39,7 @@ pub type Result<T> = result::Result<T, MetricsError>;
 
 /// Errors returned by the metrics API.
 #[derive(Error, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum MetricsError {
     /// Other errors not covered by specific cases.
     #[error("Metrics error: {0}")]


### PR DESCRIPTION
Make `MetricsError` non-exhaustive to support extending error cases without introducing breaking changes.