### PR TITLE
Add support for tracestate in TraceContextPropagator

### DIFF
--- a/src/api/trace/trace_context_propagator.rs
+++ b/src/api/trace/trace_context_propagator.rs
@@ -21,23 +21,40 @@
 use crate::api::context::propagation::text_propagator::FieldIter;
 use crate::{api, api::TraceContextExt};
 
-static SUPPORTED_VERSION: u8 = 0;
-static MAX_VERSION: u8 = 254;
-static TRACEPARENT_HEADER: &str = "traceparent";
+const SUPPORTED_VERSION: u8 = 0;
+const MAX_VERSION: u8 = 254;
+const TRACEPARENT_HEADER: &str = "traceparent";
+const TRACESTATE_HEADER: &str = "tracestate";
 
 lazy_static::lazy_static! {
-    static ref TRANSPARENT_HEADER_FIELD: [String; 1] = [TRACEPARENT_HEADER.to_string()];
+    static ref TRACE_CONTEXT_HEADER_FIELDS: [String; 2] = [
+        TRACEPARENT_HEADER.to_string(),
+        TRACESTATE_HEADER.to_string()
+    ];
 }
 
-/// Extracts and injects `SpanContext`s into `Extractor`s and `Injector`s using the
-/// trace-context format.
-#[derive(Debug, Default)]
-pub struct TraceContextPropagator {}
+/// Propagates `SpanContext`s in [W3C TraceContext] format.
+///
+/// [W3C TraceContext]: https://www.w3.org/TR/trace-context/
+#[derive(Clone, Debug, Default)]
+pub struct TraceContextPropagator {
+    _private: (),
+}
+
+/// TraceState carries system-specific configuration data, represented as a list
+/// of key-value pairs. TraceState allows multiple tracing systems to
+/// participate in the same trace.
+///
+/// Please review the [W3C specification] for details on this field.
+///
+/// [W3C specification]: https://www.w3.org/TR/trace-context/#tracestate-header
+#[derive(Debug)]
+struct TraceState(String);
 
 impl TraceContextPropagator {
     /// Create a new `TraceContextPropagator`.
     pub fn new() -> Self {
-        TraceContextPropagator {}
+        TraceContextPropagator { _private: () }
     }
 
     /// Extract span context from w3c trace-context header.
@@ -55,10 +72,20 @@ impl TraceContextPropagator {
             return Err(());
         }
 
+        // Ensure trace id is lowercase
+        if parts[1].chars().any(|c| c.is_ascii_uppercase()) {
+            return Err(());
+        }
+
         // Parse trace id section
         let trace_id = u128::from_str_radix(parts[1], 16)
             .map_err(|_| ())
             .map(api::TraceId::from_u128)?;
+
+        // Ensure span id is lowercase
+        if parts[2].chars().any(|c| c.is_ascii_uppercase()) {
+            return Err(());
+        }
 
         // Parse span id section
         let span_id = u64::from_str_radix(parts[2], 16)
@@ -72,7 +99,9 @@ impl TraceContextPropagator {
         if version == 0 && opts > 2 {
             return Err(());
         }
-        // Build trace flags
+
+        // Build trace flags clearing all flags other than the trace-context
+        // supported sampling bit.
         let trace_flags = opts & api::TRACE_FLAG_SAMPLED;
 
         // create context
@@ -90,8 +119,12 @@ impl TraceContextPropagator {
 impl api::HttpTextFormat for TraceContextPropagator {
     /// Properly encodes the values of the `SpanContext` and injects them
     /// into the `Injector`.
-    fn inject_context(&self, context: &api::Context, injector: &mut dyn api::Injector) {
-        let span_context = context.span().span_context();
+    fn inject_context(&self, cx: &api::Context, injector: &mut dyn api::Injector) {
+        if let Some(TraceState(header_value)) = cx.get() {
+            injector.set(TRACESTATE_HEADER, header_value.clone());
+        }
+
+        let span_context = cx.span().span_context();
         if span_context.is_valid() {
             let header_value = format!(
                 "{:02x}-{:032x}-{:016x}-{:02x}",
@@ -113,13 +146,23 @@ impl api::HttpTextFormat for TraceContextPropagator {
         cx: &api::Context,
         extractor: &dyn api::Extractor,
     ) -> api::Context {
-        self.extract_span_context(extractor)
+        let cx = self
+            .extract_span_context(extractor)
             .map(|sc| cx.with_remote_span_context(sc))
-            .unwrap_or_else(|_| cx.clone())
+            .unwrap_or_else(|_| cx.clone());
+
+        if let Some(state) = extractor
+            .get(TRACESTATE_HEADER)
+            .filter(|val| !val.is_empty())
+        {
+            cx.with_value(TraceState(state.to_string()))
+        } else {
+            cx
+        }
     }
 
     fn fields(&self) -> FieldIter {
-        FieldIter::new(TRANSPARENT_HEADER_FIELD.as_ref())
+        FieldIter::new(TRACE_CONTEXT_HEADER_FIELDS.as_ref())
     }
 }
 
@@ -144,6 +187,28 @@ mod tests {
     }
 
     #[rustfmt::skip]
+    fn extract_data_invalid() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("0000-00000000000000000000000000000000-0000000000000000-01", "wrong version length"),
+            ("00-ab00000000000000000000000000000000-cd00000000000000-01", "wrong trace ID length"),
+            ("00-ab000000000000000000000000000000-cd0000000000000000-01", "wrong span ID length"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-0100", "wrong trace flag length"),
+            ("qw-00000000000000000000000000000000-0000000000000000-01",   "bogus version"),
+            ("00-qw000000000000000000000000000000-cd00000000000000-01",   "bogus trace ID"),
+            ("00-ab000000000000000000000000000000-qw00000000000000-01",   "bogus span ID"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-qw",   "bogus trace flag"),
+            ("A0-00000000000000000000000000000000-0000000000000000-01",   "upper case version"),
+            ("00-AB000000000000000000000000000000-cd00000000000000-01",   "upper case trace ID"),
+            ("00-ab000000000000000000000000000000-CD00000000000000-01",   "upper case span ID"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-A1",   "upper case trace flag"),
+            ("00-00000000000000000000000000000000-0000000000000000-01",   "zero trace ID and span ID"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-09",   "trace-flag unused bits set"),
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",      "missing options"),
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-",     "empty options"),
+        ]
+    }
+
+    #[rustfmt::skip]
     fn inject_data() -> Vec<(&'static str, api::SpanContext)> {
         vec![
             ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", api::SpanContext::new(api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true)),
@@ -159,10 +224,46 @@ mod tests {
 
         for (header, expected_context) in extract_data() {
             let mut extractor = HashMap::new();
-            extractor.insert(TRACEPARENT_HEADER.to_string(), header.to_owned());
+            extractor.insert(TRACEPARENT_HEADER.to_string(), header.to_string());
+
             assert_eq!(
                 propagator.extract(&extractor).remote_span_context(),
                 Some(&expected_context)
+            )
+        }
+    }
+
+    #[test]
+    fn extract_w3c_tracestate() {
+        let propagator = TraceContextPropagator::new();
+        let state = "opaque_value".to_string();
+
+        let mut extractor = HashMap::new();
+        extractor.insert(TRACESTATE_HEADER.to_string(), state.clone());
+
+        assert_eq!(
+            propagator
+                .extract(&extractor)
+                .get::<TraceState>()
+                .unwrap()
+                .0,
+            state
+        )
+    }
+
+    #[test]
+    fn extract_w3c_reject_invalid() {
+        let propagator = TraceContextPropagator::new();
+
+        for (invalid_header, reason) in extract_data_invalid() {
+            let mut extractor = HashMap::new();
+            extractor.insert(TRACEPARENT_HEADER.to_string(), invalid_header.to_string());
+
+            assert_eq!(
+                propagator.extract(&extractor).remote_span_context(),
+                None,
+                "{}",
+                reason
             )
         }
     }
@@ -206,5 +307,19 @@ mod tests {
                 expected_header
             )
         }
+    }
+
+    #[test]
+    fn inject_w3c_tracestate() {
+        let propagator = TraceContextPropagator::new();
+        let state = "opaque_value";
+
+        let mut injector = HashMap::new();
+        propagator.inject_context(
+            &api::Context::current_with_value(TraceState(state.to_string())),
+            &mut injector,
+        );
+
+        assert_eq!(Extractor::get(&injector, TRACESTATE_HEADER), Some(state))
     }
 }


### PR DESCRIPTION
Allows w3c tracestate to be passsed through to downstream traces.