### PR TITLE
Add end_with_timestamp method for trace span.

### DIFF
--- a/opentelemetry-contrib/src/trace_propagator/b3_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/b3_propagator.rs
@@ -501,7 +501,7 @@ mod tests {
         }
 
         for ((trace, span, sampled, debug, parent), single_header, expected_context) in
-        single_multi_header_extract_data()
+            single_multi_header_extract_data()
         {
             let mut extractor =
                 extract_extrator_from_test_data(trace, span, sampled, debug, parent);
@@ -555,7 +555,8 @@ mod tests {
             _name: String,
             _timestamp: std::time::SystemTime,
             _attributes: Vec<api::KeyValue>,
-        ) {}
+        ) {
+        }
         fn span_context(&self) -> api::SpanContext {
             self.0.clone()
         }

--- a/opentelemetry-contrib/src/trace_propagator/b3_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/b3_propagator.rs
@@ -566,7 +566,6 @@ mod tests {
         fn set_attribute(&self, _attribute: api::KeyValue) {}
         fn set_status(&self, _code: api::StatusCode, _message: String) {}
         fn update_name(&self, _new_name: String) {}
-        fn end(&self) {}
         fn end_with_timestamp(&self, _timestamp: std::time::SystemTime) {}
     }
 

--- a/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
@@ -360,7 +360,6 @@ mod tests {
         fn set_attribute(&self, _attribute: api::KeyValue) {}
         fn set_status(&self, _code: api::StatusCode, _message: String) {}
         fn update_name(&self, _new_name: String) {}
-        fn end(&self) {}
         fn end_with_timestamp(&self, _timestamp: SystemTime) {}
     }
 

--- a/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
@@ -158,6 +158,7 @@ mod tests {
         TRACE_FLAG_DEBUG, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
     };
     use std::collections::HashMap;
+    use std::time::SystemTime;
 
     const LONG_TRACE_ID_STR: &str = "000000000000004d0000000000000016";
     const SHORT_TRACE_ID_STR: &str = "4d0000000000000016";
@@ -360,6 +361,7 @@ mod tests {
         fn set_status(&self, _code: api::StatusCode, _message: String) {}
         fn update_name(&self, _new_name: String) {}
         fn end(&self) {}
+        fn end_with_timestamp(&self, _timestamp: SystemTime) {}
     }
 
     #[test]

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -137,6 +137,7 @@ mod tests {
         fn set_status(&self, _code: api::StatusCode, _message: String) {}
         fn update_name(&self, _new_name: String) {}
         fn end(&self) {}
+        fn end_with_timestamp(&self, _timestamp: std::time::SystemTime) {}
     }
 
     #[test]

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -195,7 +195,6 @@ mod tests {
         fn set_attribute(&self, _attribute: api::KeyValue) {}
         fn set_status(&self, _code: api::StatusCode, _message: String) {}
         fn update_name(&self, _new_name: String) {}
-        fn end(&self) {}
         fn end_with_timestamp(&self, _timestamp: std::time::SystemTime) {}
     }
 

--- a/src/api/trace/b3_propagator.rs
+++ b/src/api/trace/b3_propagator.rs
@@ -499,7 +499,7 @@ mod tests {
         }
 
         for ((trace, span, sampled, debug, parent), single_header, expected_context) in
-            single_multi_header_extract_data()
+        single_multi_header_extract_data()
         {
             let mut extractor =
                 extract_extrator_from_test_data(trace, span, sampled, debug, parent);
@@ -553,8 +553,7 @@ mod tests {
             _name: String,
             _timestamp: std::time::SystemTime,
             _attributes: Vec<api::KeyValue>,
-        ) {
-        }
+        ) {}
         fn span_context(&self) -> api::SpanContext {
             self.0.clone()
         }
@@ -565,6 +564,7 @@ mod tests {
         fn set_status(&self, _code: api::StatusCode, _message: String) {}
         fn update_name(&self, _new_name: String) {}
         fn end(&self) {}
+        fn end_with_timestamp(&self, _timestamp: std::time::SystemTime) {}
     }
 
     #[test]

--- a/src/api/trace/noop.rs
+++ b/src/api/trace/noop.rs
@@ -87,11 +87,6 @@ impl api::Span for NoopSpan {
         // Ignored
     }
 
-    /// Ignores `Span` endings.
-    fn end(&self) {
-        // Ignored
-    }
-
     /// Ignores `Span` endings
     fn end_with_timestamp(&self, _timestamp: SystemTime) {
         // Ignored

--- a/src/api/trace/noop.rs
+++ b/src/api/trace/noop.rs
@@ -91,6 +91,11 @@ impl api::Span for NoopSpan {
     fn end(&self) {
         // Ignored
     }
+
+    /// Ignores `Span` endings
+    fn end_with_timestamp(&self, _timestamp: SystemTime) {
+        // Ignored
+    }
 }
 
 /// A no-op instance of a `Tracer`.

--- a/src/api/trace/span.rs
+++ b/src/api/trace/span.rs
@@ -152,8 +152,15 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     /// Calls to `end` a Span MUST not have any effects on child `Span`s as they may
     /// still be running and can be ended later.
     ///
-    ///This API MUST be non-blocking.
+    /// This API MUST be non-blocking.
     fn end(&self);
+
+    /// Finishes the `Span` with given timestamp
+    ///
+    /// For more details, refer to [`Span::end`]
+    ///
+    /// [`Span::end`]: trait.Span.html#method.end
+    fn end_with_timestamp(&self, timestamp: SystemTime);
 }
 
 /// `SpanKind` describes the relationship between the Span, its parents,

--- a/src/api/trace/span.rs
+++ b/src/api/trace/span.rs
@@ -153,7 +153,9 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     /// still be running and can be ended later.
     ///
     /// This API MUST be non-blocking.
-    fn end(&self);
+    fn end(&self) {
+        self.end_with_timestamp(SystemTime::now());
+    }
 
     /// Finishes the `Span` with given timestamp
     ///

--- a/src/api/trace/trace_context_propagator.rs
+++ b/src/api/trace/trace_context_propagator.rs
@@ -21,23 +21,40 @@
 use crate::api::context::propagation::text_propagator::FieldIter;
 use crate::{api, api::TraceContextExt};
 
-static SUPPORTED_VERSION: u8 = 0;
-static MAX_VERSION: u8 = 254;
-static TRACEPARENT_HEADER: &str = "traceparent";
+const SUPPORTED_VERSION: u8 = 0;
+const MAX_VERSION: u8 = 254;
+const TRACEPARENT_HEADER: &str = "traceparent";
+const TRACESTATE_HEADER: &str = "tracestate";
 
 lazy_static::lazy_static! {
-    static ref TRANSPARENT_HEADER_FIELD: [String; 1] = [TRACEPARENT_HEADER.to_string()];
+    static ref TRACE_CONTEXT_HEADER_FIELDS: [String; 2] = [
+        TRACEPARENT_HEADER.to_string(),
+        TRACESTATE_HEADER.to_string()
+    ];
 }
 
-/// Extracts and injects `SpanContext`s into `Extractor`s and `Injector`s using the
-/// trace-context format.
-#[derive(Debug, Default)]
-pub struct TraceContextPropagator {}
+/// Propagates `SpanContext`s in [W3C TraceContext] format.
+///
+/// [W3C TraceContext]: https://www.w3.org/TR/trace-context/
+#[derive(Clone, Debug, Default)]
+pub struct TraceContextPropagator {
+    _private: (),
+}
+
+/// TraceState carries system-specific configuration data, represented as a list
+/// of key-value pairs. TraceState allows multiple tracing systems to
+/// participate in the same trace.
+///
+/// Please review the [W3C specification] for details on this field.
+///
+/// [W3C specification]: https://www.w3.org/TR/trace-context/#tracestate-header
+#[derive(Debug)]
+struct TraceState(String);
 
 impl TraceContextPropagator {
     /// Create a new `TraceContextPropagator`.
     pub fn new() -> Self {
-        TraceContextPropagator {}
+        TraceContextPropagator { _private: () }
     }
 
     /// Extract span context from w3c trace-context header.
@@ -55,10 +72,20 @@ impl TraceContextPropagator {
             return Err(());
         }
 
+        // Ensure trace id is lowercase
+        if parts[1].chars().any(|c| c.is_ascii_uppercase()) {
+            return Err(());
+        }
+
         // Parse trace id section
         let trace_id = u128::from_str_radix(parts[1], 16)
             .map_err(|_| ())
             .map(api::TraceId::from_u128)?;
+
+        // Ensure span id is lowercase
+        if parts[2].chars().any(|c| c.is_ascii_uppercase()) {
+            return Err(());
+        }
 
         // Parse span id section
         let span_id = u64::from_str_radix(parts[2], 16)
@@ -72,7 +99,9 @@ impl TraceContextPropagator {
         if version == 0 && opts > 2 {
             return Err(());
         }
-        // Build trace flags
+
+        // Build trace flags clearing all flags other than the trace-context
+        // supported sampling bit.
         let trace_flags = opts & api::TRACE_FLAG_SAMPLED;
 
         // create context
@@ -90,8 +119,12 @@ impl TraceContextPropagator {
 impl api::HttpTextFormat for TraceContextPropagator {
     /// Properly encodes the values of the `SpanContext` and injects them
     /// into the `Injector`.
-    fn inject_context(&self, context: &api::Context, injector: &mut dyn api::Injector) {
-        let span_context = context.span().span_context();
+    fn inject_context(&self, cx: &api::Context, injector: &mut dyn api::Injector) {
+        if let Some(TraceState(header_value)) = cx.get() {
+            injector.set(TRACESTATE_HEADER, header_value.clone());
+        }
+
+        let span_context = cx.span().span_context();
         if span_context.is_valid() {
             let header_value = format!(
                 "{:02x}-{:032x}-{:016x}-{:02x}",
@@ -114,12 +147,24 @@ impl api::HttpTextFormat for TraceContextPropagator {
         extractor: &dyn api::Extractor,
     ) -> api::Context {
         self.extract_span_context(extractor)
-            .map(|sc| cx.with_remote_span_context(sc))
+            .map(|sc| {
+                let cx = cx.with_remote_span_context(sc);
+
+                // If successfully parsed span context, check trace state
+                if let Some(state) = extractor
+                    .get(TRACESTATE_HEADER)
+                    .filter(|val| !val.is_empty())
+                {
+                    cx.with_value(TraceState(state.to_string()))
+                } else {
+                    cx
+                }
+            })
             .unwrap_or_else(|_| cx.clone())
     }
 
     fn fields(&self) -> FieldIter {
-        FieldIter::new(TRANSPARENT_HEADER_FIELD.as_ref())
+        FieldIter::new(TRACE_CONTEXT_HEADER_FIELDS.as_ref())
     }
 }
 
@@ -144,6 +189,28 @@ mod tests {
     }
 
     #[rustfmt::skip]
+    fn extract_data_invalid() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("0000-00000000000000000000000000000000-0000000000000000-01", "wrong version length"),
+            ("00-ab00000000000000000000000000000000-cd00000000000000-01", "wrong trace ID length"),
+            ("00-ab000000000000000000000000000000-cd0000000000000000-01", "wrong span ID length"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-0100", "wrong trace flag length"),
+            ("qw-00000000000000000000000000000000-0000000000000000-01",   "bogus version"),
+            ("00-qw000000000000000000000000000000-cd00000000000000-01",   "bogus trace ID"),
+            ("00-ab000000000000000000000000000000-qw00000000000000-01",   "bogus span ID"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-qw",   "bogus trace flag"),
+            ("A0-00000000000000000000000000000000-0000000000000000-01",   "upper case version"),
+            ("00-AB000000000000000000000000000000-cd00000000000000-01",   "upper case trace ID"),
+            ("00-ab000000000000000000000000000000-CD00000000000000-01",   "upper case span ID"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-A1",   "upper case trace flag"),
+            ("00-00000000000000000000000000000000-0000000000000000-01",   "zero trace ID and span ID"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-09",   "trace-flag unused bits set"),
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",      "missing options"),
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-",     "empty options"),
+        ]
+    }
+
+    #[rustfmt::skip]
     fn inject_data() -> Vec<(&'static str, api::SpanContext)> {
         vec![
             ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", api::SpanContext::new(api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true)),
@@ -159,10 +226,48 @@ mod tests {
 
         for (header, expected_context) in extract_data() {
             let mut extractor = HashMap::new();
-            extractor.insert(TRACEPARENT_HEADER.to_string(), header.to_owned());
+            extractor.insert(TRACEPARENT_HEADER.to_string(), header.to_string());
+
             assert_eq!(
                 propagator.extract(&extractor).remote_span_context(),
                 Some(&expected_context)
+            )
+        }
+    }
+
+    #[test]
+    fn extract_w3c_tracestate() {
+        let propagator = TraceContextPropagator::new();
+        let state = "opaque_value".to_string();
+        let parent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00".to_string();
+
+        let mut extractor = HashMap::new();
+        extractor.insert(TRACEPARENT_HEADER.to_string(), parent);
+        extractor.insert(TRACESTATE_HEADER.to_string(), state.clone());
+
+        assert_eq!(
+            propagator
+                .extract(&extractor)
+                .get::<TraceState>()
+                .unwrap()
+                .0,
+            state
+        )
+    }
+
+    #[test]
+    fn extract_w3c_reject_invalid() {
+        let propagator = TraceContextPropagator::new();
+
+        for (invalid_header, reason) in extract_data_invalid() {
+            let mut extractor = HashMap::new();
+            extractor.insert(TRACEPARENT_HEADER.to_string(), invalid_header.to_string());
+
+            assert_eq!(
+                propagator.extract(&extractor).remote_span_context(),
+                None,
+                "{}",
+                reason
             )
         }
     }
@@ -206,5 +311,19 @@ mod tests {
                 expected_header
             )
         }
+    }
+
+    #[test]
+    fn inject_w3c_tracestate() {
+        let propagator = TraceContextPropagator::new();
+        let state = "opaque_value";
+
+        let mut injector = HashMap::new();
+        propagator.inject_context(
+            &api::Context::current_with_value(TraceState(state.to_string())),
+            &mut injector,
+        );
+
+        assert_eq!(Extractor::get(&injector, TRACESTATE_HEADER), Some(state))
     }
 }

--- a/src/api/trace/trace_context_propagator.rs
+++ b/src/api/trace/trace_context_propagator.rs
@@ -293,6 +293,7 @@ mod tests {
         fn set_status(&self, _code: api::StatusCode, _message: String) {}
         fn update_name(&self, _new_name: String) {}
         fn end(&self) {}
+        fn end_with_timestamp(&self, _timestamp: std::time::SystemTime) {}
     }
 
     #[test]

--- a/src/api/trace/trace_context_propagator.rs
+++ b/src/api/trace/trace_context_propagator.rs
@@ -292,7 +292,6 @@ mod tests {
         fn set_attribute(&self, _attribute: api::KeyValue) {}
         fn set_status(&self, _code: api::StatusCode, _message: String) {}
         fn update_name(&self, _new_name: String) {}
-        fn end(&self) {}
         fn end_with_timestamp(&self, _timestamp: std::time::SystemTime) {}
     }
 

--- a/src/global/trace.rs
+++ b/src/global/trace.rs
@@ -64,7 +64,7 @@ impl api::Span for BoxedSpan {
     }
 
     /// Finishes the span with given timestamp.
-    fn end_with_timestamp(&self, timestamp: SystemTime){
+    fn end_with_timestamp(&self, timestamp: SystemTime) {
         self.0.end_with_timestamp(timestamp);
     }
 }

--- a/src/global/trace.rs
+++ b/src/global/trace.rs
@@ -62,6 +62,11 @@ impl api::Span for BoxedSpan {
     fn end(&self) {
         self.0.end()
     }
+
+    /// Finishes the span with given timestamp.
+    fn end_with_timestamp(&self, timestamp: SystemTime){
+        self.0.end_with_timestamp(timestamp);
+    }
 }
 
 /// Wraps the [`GlobalProvider`]'s [`Tracer`] so it can be used generically by

--- a/src/global/trace.rs
+++ b/src/global/trace.rs
@@ -58,11 +58,6 @@ impl api::Span for BoxedSpan {
         self.0.update_name(new_name)
     }
 
-    /// Finishes the span.
-    fn end(&self) {
-        self.0.end()
-    }
-
     /// Finishes the span with given timestamp.
     fn end_with_timestamp(&self, timestamp: SystemTime) {
         self.0.end_with_timestamp(timestamp);

--- a/src/sdk/metrics/aggregators/array.rs
+++ b/src/sdk/metrics/aggregators/array.rs
@@ -184,13 +184,13 @@ impl PointsData {
 
     fn sort(&mut self, kind: &NumberKind) {
         match kind {
-            NumberKind::I64 => self.0.sort_by(|a, b| a.to_i64(kind).cmp(&b.to_i64(kind))),
+            NumberKind::I64 => self.0.sort_by_key(|a| a.to_u64(kind)),
             NumberKind::F64 => self.0.sort_by(|a, b| {
                 a.to_f64(kind)
                     .partial_cmp(&b.to_f64(kind))
                     .expect("nan values should be rejected. This is a bug.")
             }),
-            NumberKind::U64 => self.0.sort_by(|a, b| a.to_u64(kind).cmp(&b.to_u64(kind))),
+            NumberKind::U64 => self.0.sort_by_key(|a| a.to_u64(kind)),
         }
     }
     fn combine(&mut self, kind: &NumberKind, other: &PointsData) {

--- a/src/sdk/trace/span.rs
+++ b/src/sdk/trace/span.rs
@@ -128,9 +128,9 @@ impl api::Span for Span {
         self.end_with_timestamp(SystemTime::now());
     }
 
-    /// Finishes the span with give timestamp
-    fn end_with_timestamp(&self, timestamp: SystemTime){
-        self.with_data_mut(|data|{
+    /// Finishes the span with given timestamp.
+    fn end_with_timestamp(&self, timestamp: SystemTime) {
+        self.with_data_mut(|data| {
             data.end_time = timestamp;
         });
     }

--- a/src/sdk/trace/span.rs
+++ b/src/sdk/trace/span.rs
@@ -125,8 +125,13 @@ impl api::Span for Span {
 
     /// Finishes the span.
     fn end(&self) {
-        self.with_data_mut(|data| {
-            data.end_time = SystemTime::now();
+        self.end_with_timestamp(SystemTime::now());
+    }
+
+    /// Finishes the span with give timestamp
+    fn end_with_timestamp(&self, timestamp: SystemTime){
+        self.with_data_mut(|data|{
+            data.end_time = timestamp;
         });
     }
 }

--- a/src/sdk/trace/span.rs
+++ b/src/sdk/trace/span.rs
@@ -123,11 +123,6 @@ impl api::Span for Span {
         });
     }
 
-    /// Finishes the span.
-    fn end(&self) {
-        self.end_with_timestamp(SystemTime::now());
-    }
-
     /// Finishes the span with given timestamp.
     fn end_with_timestamp(&self, timestamp: SystemTime) {
         self.with_data_mut(|data| {


### PR DESCRIPTION
closes #14 

On a side note, maybe we could create a mod for test utils. We have `TestSpan` in four different files, which could be put into one place.