### PR TITLE
AWS X-Ray Trace Context Propagator

### DIFF
--- a/opentelemetry-contrib/src/lib.rs
+++ b/opentelemetry-contrib/src/lib.rs
@@ -11,6 +11,7 @@ mod trace_propagator;
 pub use id_generator::aws_xray_id_generator::XrayIdGenerator;
 
 pub use trace_propagator::{
+    aws_xray_propagator::XrayTraceContextPropagator,
     b3_propagator::{B3Encoding, B3Propagator},
     jaeger_propagator::JaegerPropagator,
 };

--- a/opentelemetry-contrib/src/trace_propagator/aws_xray_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/aws_xray_propagator.rs
@@ -1,0 +1,280 @@
+use opentelemetry::api::{
+    Context, Extractor, FieldIter, Injector, SpanContext, SpanId, TextMapFormat, TraceContextExt,
+    TraceId, TRACE_FLAG_DEFERRED, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
+};
+use std::collections::HashMap;
+
+const AWS_XRAY_TRACE_HEADER: &str = "x-amzn-trace-id";
+const AWS_XRAY_VERSION_KEY: &str = "1";
+const HEADER_PARENT_KEY: &str = "Parent";
+const HEADER_ROOT_KEY: &str = "Root";
+const HEADER_SAMPLED_KEY: &str = "Sampled";
+
+const SAMPLED: &str = "1";
+const NOT_SAMPLED: &str = "0";
+const REQUESTED_SAMPLE_DECISION: &str = "?";
+
+lazy_static::lazy_static! {
+    static ref AWS_XRAY_HEADER_FIELD: [String; 1] = [AWS_XRAY_TRACE_HEADER.to_string()];
+}
+
+/// # AWS X-Ray Trace Propagator
+///
+/// Extracts and injects values to/from the `x-amzn-trace-id` header. Converting between
+/// OpenTelemetry [SpanContext][otel-spec] and [X-Ray Trace format][xray-trace-id].
+///
+/// For details on the [`x-amzn-trace-id` header][xray-header] see the AWS X-Ray Docs.
+///
+/// ## Example
+///
+/// ```
+/// extern crate opentelemetry;
+/// use opentelemetry::global;
+/// use opentelemetry_contrib::XrayTraceContextPropagator;
+///
+/// global::set_text_map_propagator(XrayTraceContextPropagator::default());
+/// ```
+///
+/// [otel-spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spancontext
+/// [xray-trace-id]: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids
+/// [xray-header]: https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader
+#[derive(Clone, Debug, Default)]
+pub struct XrayTraceContextPropagator {
+    _private: (),
+}
+
+impl XrayTraceContextPropagator {
+    fn extract_span_context(&self, extractor: &dyn Extractor) -> Result<SpanContext, ()> {
+        let header_value: &str = extractor.get(AWS_XRAY_TRACE_HEADER).unwrap_or("").trim();
+
+        let parts: HashMap<&str, &str> = header_value
+            .split_terminator(';')
+            .filter_map(from_key_value_pair)
+            .collect();
+
+        let trace_id: TraceId = match parts.get(HEADER_ROOT_KEY) {
+            None => return Err(()),
+            Some(root) => {
+                let trace_id: Result<TraceId, ()> = XrayTraceId(root.to_string()).into();
+                match trace_id {
+                    Err(_) => return Err(()),
+                    Ok(trace_id) => trace_id,
+                }
+            }
+        };
+
+        let mut parent_segment_id: SpanId = SpanId::invalid();
+
+        if let Some(parent) = parts.get(HEADER_PARENT_KEY) {
+            parent_segment_id = SpanId::from_hex(parent);
+        }
+
+        let mut sampling_decision: u8 = TRACE_FLAG_DEFERRED;
+
+        if let Some(sampled_flag) = parts.get(HEADER_SAMPLED_KEY) {
+            sampling_decision = match sampled_flag.to_owned() {
+                NOT_SAMPLED => TRACE_FLAG_NOT_SAMPLED,
+                SAMPLED => TRACE_FLAG_SAMPLED,
+                REQUESTED_SAMPLE_DECISION => TRACE_FLAG_DEFERRED,
+                _ => TRACE_FLAG_DEFERRED,
+            }
+        }
+
+        Ok(SpanContext::new(
+            trace_id,
+            parent_segment_id,
+            sampling_decision,
+            true,
+        ))
+    }
+}
+
+impl TextMapFormat for XrayTraceContextPropagator {
+    fn inject_context(&self, cx: &Context, injector: &mut dyn Injector) {
+        let span_context: SpanContext = cx.span().span_context();
+        if span_context.is_valid() {
+            let xray_trace_id: XrayTraceId = span_context.trace_id().into();
+            let mut components: Vec<String> =
+                vec![format!("{}={}", HEADER_ROOT_KEY, xray_trace_id.0)];
+
+            components.push(format!(
+                "{}={:016x}",
+                HEADER_PARENT_KEY,
+                span_context.span_id().to_u64()
+            ));
+
+            let sampling_decision: &str = if span_context.is_deferred() {
+                REQUESTED_SAMPLE_DECISION
+            } else if span_context.is_sampled() {
+                SAMPLED
+            } else {
+                NOT_SAMPLED
+            };
+
+            components.push(format!("{}={}", HEADER_SAMPLED_KEY, sampling_decision));
+
+            injector.set(AWS_XRAY_TRACE_HEADER, components.join(";"));
+        }
+    }
+
+    fn extract_with_context(&self, cx: &Context, extractor: &dyn Extractor) -> Context {
+        let extracted = self
+            .extract_span_context(extractor)
+            .unwrap_or_else(|_| SpanContext::empty_context());
+
+        cx.with_remote_span_context(extracted)
+    }
+
+    fn fields(&self) -> FieldIter {
+        FieldIter::new(AWS_XRAY_HEADER_FIELD.as_ref())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct XrayTraceId(String);
+
+impl Into<Result<TraceId, ()>> for XrayTraceId {
+    fn into(self) -> Result<TraceId, ()> {
+        let parts: Vec<&str> = self.0.split_terminator('-').collect();
+
+        if parts.len() != 3 {
+            return Err(());
+        }
+
+        let trace_id: TraceId = TraceId::from_hex(format!("{}{}", parts[1], parts[2]).as_str());
+
+        if trace_id.to_u128() == 0 {
+            Err(())
+        } else {
+            Ok(trace_id)
+        }
+    }
+}
+
+impl From<TraceId> for XrayTraceId {
+    fn from(trace_id: TraceId) -> Self {
+        let trace_id_as_hex: String = trace_id.to_hex();
+        let (timestamp, xray_id) = trace_id_as_hex.split_at(8_usize);
+
+        XrayTraceId(format!(
+            "{}-{}-{}",
+            AWS_XRAY_VERSION_KEY, timestamp, xray_id
+        ))
+    }
+}
+
+fn from_key_value_pair(pair: &str) -> Option<(&str, &str)> {
+    let mut key_value_pair: Option<(&str, &str)> = None;
+
+    if let Some(index) = pair.find('=') {
+        let (key, value) = pair.split_at(index);
+        key_value_pair = Some((key, value.trim_start_matches('=')));
+    }
+    key_value_pair
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::api;
+    use std::time::SystemTime;
+
+    #[rustfmt::skip]
+    fn extract_test_data() -> Vec<(&'static str, SpanContext)> {
+        vec![
+            ("", SpanContext::empty_context()),
+            ("Sampled=1;Self=foo", SpanContext::empty_context()),
+            ("Root=1-bogus-bad", SpanContext::empty_context()),
+            ("Root=1-too-many-parts", SpanContext::empty_context()),
+            ("Root=1-58406520-a006649127e371903a2de979;Parent=garbage", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::invalid(), TRACE_FLAG_DEFERRED, true)),
+            ("Root=1-58406520-a006649127e371903a2de979;Sampled=1", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::invalid(), TRACE_FLAG_SAMPLED, true)),
+            ("Root=1-58406520-a006649127e371903a2de979;Parent=4c721bf33e3caf8f;Sampled=0", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::from_hex("4c721bf33e3caf8f"), TRACE_FLAG_NOT_SAMPLED, true)),
+            ("Root=1-58406520-a006649127e371903a2de979;Parent=4c721bf33e3caf8f;Sampled=1", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::from_hex("4c721bf33e3caf8f"), TRACE_FLAG_SAMPLED, true)),
+            ("Root=1-58406520-a006649127e371903a2de979;Parent=4c721bf33e3caf8f", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::from_hex("4c721bf33e3caf8f"), TRACE_FLAG_DEFERRED, true)),
+            ("Root=1-58406520-a006649127e371903a2de979;Parent=4c721bf33e3caf8f;Sampled=?", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::from_hex("4c721bf33e3caf8f"), TRACE_FLAG_DEFERRED, true)),
+            ("Root=1-58406520-a006649127e371903a2de979;Self=1-58406520-bf42676c05e20ba4a90e448e;Parent=4c721bf33e3caf8f;Sampled=1", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::from_hex("4c721bf33e3caf8f"), TRACE_FLAG_SAMPLED, true)),
+            ("Root=1-58406520-a006649127e371903a2de979;Parent=4c721bf33e3caf8f;Sampled=1;RandomKey=RandomValue", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::from_hex("4c721bf33e3caf8f"), TRACE_FLAG_SAMPLED, true)),
+        ]
+    }
+
+    #[rustfmt::skip]
+    fn inject_test_data() -> Vec<(&'static str, SpanContext)> {
+        vec![
+            ("", SpanContext::empty_context()),
+            ("", SpanContext::new(TraceId::from_hex("garbage"), SpanId::invalid(), TRACE_FLAG_DEFERRED, true)),
+            ("", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::invalid(), TRACE_FLAG_DEFERRED, true)),
+            ("", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::invalid(), TRACE_FLAG_SAMPLED, true)),
+            ("Root=1-58406520-a006649127e371903a2de979;Parent=4c721bf33e3caf8f;Sampled=0", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::from_hex("4c721bf33e3caf8f"), TRACE_FLAG_NOT_SAMPLED, true)),
+            ("Root=1-58406520-a006649127e371903a2de979;Parent=4c721bf33e3caf8f;Sampled=1", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::from_hex("4c721bf33e3caf8f"), TRACE_FLAG_SAMPLED, true)),
+            ("Root=1-58406520-a006649127e371903a2de979;Parent=4c721bf33e3caf8f;Sampled=?", SpanContext::new(TraceId::from_hex("58406520a006649127e371903a2de979"), SpanId::from_hex("4c721bf33e3caf8f"), TRACE_FLAG_DEFERRED, true)),
+        ]
+    }
+
+    #[test]
+    fn test_extract() {
+        for (header, expected) in extract_test_data() {
+            let map: HashMap<String, String> =
+                vec![(AWS_XRAY_TRACE_HEADER.to_string(), header.to_string())]
+                    .into_iter()
+                    .collect();
+
+            let propagator = XrayTraceContextPropagator::default();
+            let context = propagator.extract(&map);
+            assert_eq!(context.remote_span_context(), Some(&expected));
+        }
+    }
+
+    #[test]
+    fn test_extract_empty() {
+        let map: HashMap<String, String> = HashMap::new();
+        let propagator = XrayTraceContextPropagator::default();
+        let context = propagator.extract(&map);
+        assert_eq!(
+            context.remote_span_context(),
+            Some(&SpanContext::empty_context())
+        )
+    }
+
+    #[derive(Debug)]
+    struct TestSpan(SpanContext);
+
+    impl api::Span for TestSpan {
+        fn add_event_with_timestamp(
+            &self,
+            _name: String,
+            _timestamp: std::time::SystemTime,
+            _attributes: Vec<api::KeyValue>,
+        ) {
+        }
+        fn span_context(&self) -> SpanContext {
+            self.0.clone()
+        }
+        fn is_recording(&self) -> bool {
+            false
+        }
+        fn set_attribute(&self, _attribute: api::KeyValue) {}
+        fn set_status(&self, _code: api::StatusCode, _message: String) {}
+        fn update_name(&self, _new_name: String) {}
+        fn end_with_timestamp(&self, _timestamp: SystemTime) {}
+    }
+
+    #[test]
+    fn test_inject() {
+        let propagator = XrayTraceContextPropagator::default();
+        for (header_value, span_context) in inject_test_data() {
+            let mut injector: HashMap<String, String> = HashMap::new();
+            propagator.inject_context(
+                &Context::current_with_span(TestSpan(span_context)),
+                &mut injector,
+            );
+
+            let injected_value: Option<&String> = injector.get(AWS_XRAY_TRACE_HEADER);
+
+            if header_value.is_empty() {
+                assert!(injected_value.is_none());
+            } else {
+                assert_eq!(injected_value, Some(&header_value.to_string()));
+            }
+        }
+    }
+}

--- a/opentelemetry-contrib/src/trace_propagator/mod.rs
+++ b/opentelemetry-contrib/src/trace_propagator/mod.rs
@@ -2,5 +2,6 @@
 //!
 //!
 
+pub mod aws_xray_propagator;
 pub mod b3_propagator;
 pub mod jaeger_propagator;


### PR DESCRIPTION
Create Trace Context Propagator for AWS X-Ray. Collect Root TraceId, Parent SegmentId and Sampling decision in new SpanContext. Will add to `/examples` later. 