### PR TITLE
Example usage of AWS X-Ray propagator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "examples/actix-udp",
     "examples/actix-http",
     "examples/async",
+    "examples/aws-xray",
     "examples/basic",
     "examples/basic-otlp",
     "examples/grpc",

--- a/examples/aws-xray/Cargo.toml
+++ b/examples/aws-xray/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "aws-xray"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bin]] # Bin to run the http server
+name = "http-server"
+path = "src/server.rs"
+
+[[bin]] # Bin to run the client
+name = "http-client"
+path = "src/client.rs"
+
+[dependencies]
+hyper = "0.13"
+tokio = { version = "0.2", features = ["full"] }
+opentelemetry = { path = "../../", features = ["http"] }
+opentelemetry-contrib = { path = "../../opentelemetry-contrib" }

--- a/examples/aws-xray/README.md
+++ b/examples/aws-xray/README.md
@@ -1,0 +1,27 @@
+# AWS X-Ray HTTP Client/Server Example
+
+This is a simple example using [hyper] that demonstrates tracing http request from client to server using AWS X-Ray formatted trace IDs. The example
+shows key aspects of tracing such as:
+
+- Root Span (on Client)
+  - Injecting `x-amzn-trace-id` on request
+- Child Span (on Client)
+- Child Span from a Remote Parent (on Server)
+  - Extracting parent information from `x-amzn-trace-id`
+- SpanContext Propagation (from Client to Server)
+- Span Events
+- Span Attributes
+
+[hyper]: https://hyper.rs/
+
+## Usage
+
+```shell
+# Run server
+$ cargo run --bin http-server
+
+# In another tab, run client
+$ cargo run --bin http-client
+
+# The spans should be visible in stdout in the order that they were exported.
+```

--- a/examples/aws-xray/src/client.rs
+++ b/examples/aws-xray/src/client.rs
@@ -1,0 +1,49 @@
+use hyper::{body::Body, Client};
+use opentelemetry::api::{Context, TraceContextExt, Tracer};
+use opentelemetry::{api, exporter::trace::stdout, global, sdk};
+use opentelemetry_contrib::{XrayIdGenerator, XrayTraceContextPropagator};
+
+fn init_tracer() {
+    // Create stdout exporter to be able to retrieve the collected spans.
+    let exporter = stdout::Builder::default().init();
+
+    // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
+    // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
+    let provider = sdk::Provider::builder()
+        .with_simple_exporter(exporter)
+        .with_config(sdk::Config {
+            default_sampler: Box::new(sdk::Sampler::AlwaysOn),
+            id_generator: Box::new(XrayIdGenerator::default()),
+            ..Default::default()
+        })
+        .build();
+
+    global::set_provider(provider);
+    global::set_text_map_propagator(XrayTraceContextPropagator::new());
+}
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    init_tracer();
+
+    let client = Client::new();
+    let span = global::tracer("example/client").start("say hello");
+    let cx = Context::current_with_span(span);
+
+    let mut req = hyper::Request::builder().uri("http://127.0.0.1:3000");
+
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&cx, req.headers_mut().unwrap());
+
+        println!("Headers: {:?}", req.headers_ref());
+    });
+
+    let res = client.request(req.body(Body::from("Hallo!"))?).await?;
+
+    cx.span().add_event(
+        "Got response!".to_string(),
+        vec![api::KeyValue::new("status", res.status().to_string())],
+    );
+
+    Ok(())
+}

--- a/examples/aws-xray/src/server.rs
+++ b/examples/aws-xray/src/server.rs
@@ -1,0 +1,62 @@
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Request, Response, Server};
+use opentelemetry::{
+    api::{Span, Tracer},
+    exporter::trace::stdout,
+    global, sdk,
+};
+use opentelemetry_contrib::{XrayIdGenerator, XrayTraceContextPropagator};
+use std::{convert::Infallible, net::SocketAddr};
+
+async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
+    let parent_context =
+        global::get_text_map_propagator(|propagator| propagator.extract(req.headers()));
+
+    let x_amzn_trace_id = req
+        .headers()
+        .get("x-amzn-trace-id")
+        .unwrap()
+        .to_str()
+        .unwrap();
+
+    let span = global::tracer("example/server").start_from_context("hello", &parent_context);
+    span.add_event(format!("Handling - {}", x_amzn_trace_id), Vec::new());
+
+    Ok(Response::new(
+        format!("Hello!, X-Ray Trace Header: {}", x_amzn_trace_id).into(),
+    ))
+}
+
+fn init_tracer() {
+    // Create stdout exporter to be able to retrieve the collected spans.
+    let exporter = stdout::Builder::default().init();
+
+    // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
+    // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
+    let provider = sdk::Provider::builder()
+        .with_simple_exporter(exporter)
+        .with_config(sdk::Config {
+            default_sampler: Box::new(sdk::Sampler::AlwaysOn),
+            id_generator: Box::new(XrayIdGenerator::default()),
+            ..Default::default()
+        })
+        .build();
+
+    global::set_provider(provider);
+    global::set_text_map_propagator(XrayTraceContextPropagator::new());
+}
+
+#[tokio::main]
+async fn main() {
+    init_tracer();
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+
+    let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
+
+    let server = Server::bind(&addr).serve(make_svc);
+
+    println!("Listening on {}", addr);
+    if let Err(e) = server.await {
+        eprintln!("server error: {}", e);
+    }
+}


### PR DESCRIPTION
Example usage of AWS X-Ray propagator and ID generator. Mostly copied from `example/http`, includes print out of generated `x-amzn-trace-id`.