### PR TITLE
Rename Provider to TracerProvider

### DIFF
--- a/benches/trace.rs
+++ b/benches/trace.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::{
-    api::{Key, Provider, Span, Tracer},
+    api::{Key, Span, Tracer, TracerProvider},
     sdk,
 };
 
@@ -68,7 +68,7 @@ fn trace_benchmark_group<F: Fn(&sdk::Tracer)>(c: &mut Criterion, name: &str, f: 
     let mut group = c.benchmark_group(name);
 
     group.bench_function("always-sample", |b| {
-        let always_sample = sdk::Provider::builder()
+        let always_sample = sdk::TracerProvider::builder()
             .with_config(sdk::Config {
                 default_sampler: Box::new(sdk::Sampler::AlwaysOn),
                 ..Default::default()
@@ -80,7 +80,7 @@ fn trace_benchmark_group<F: Fn(&sdk::Tracer)>(c: &mut Criterion, name: &str, f: 
     });
 
     group.bench_function("never-sample", |b| {
-        let never_sample = sdk::Provider::builder()
+        let never_sample = sdk::TracerProvider::builder()
             .with_config(sdk::Config {
                 default_sampler: Box::new(sdk::Sampler::AlwaysOff),
                 ..Default::default()

--- a/examples/aws-xray/src/client.rs
+++ b/examples/aws-xray/src/client.rs
@@ -9,7 +9,7 @@ fn init_tracer() {
 
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
-    let provider = sdk::Provider::builder()
+    let provider = sdk::TracerProvider::builder()
         .with_simple_exporter(exporter)
         .with_config(sdk::Config {
             default_sampler: Box::new(sdk::Sampler::AlwaysOn),

--- a/examples/aws-xray/src/server.rs
+++ b/examples/aws-xray/src/server.rs
@@ -33,7 +33,7 @@ fn init_tracer() {
 
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
-    let provider = sdk::Provider::builder()
+    let provider = sdk::TracerProvider::builder()
         .with_simple_exporter(exporter)
         .with_config(sdk::Config {
             default_sampler: Box::new(sdk::Sampler::AlwaysOn),

--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -11,7 +11,7 @@ fn init_tracer() {
 
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
-    let provider = sdk::Provider::builder()
+    let provider = sdk::TracerProvider::builder()
         .with_simple_exporter(exporter)
         .with_config(sdk::Config {
             default_sampler: Box::new(sdk::Sampler::AlwaysOn),

--- a/examples/http/src/client.rs
+++ b/examples/http/src/client.rs
@@ -8,7 +8,7 @@ fn init_tracer() {
 
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
-    let provider = sdk::Provider::builder()
+    let provider = sdk::TracerProvider::builder()
         .with_simple_exporter(exporter)
         .with_config(sdk::Config {
             default_sampler: Box::new(sdk::Sampler::AlwaysOn),

--- a/examples/http/src/server.rs
+++ b/examples/http/src/server.rs
@@ -22,7 +22,7 @@ fn init_tracer() {
 
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
-    let provider = sdk::Provider::builder()
+    let provider = sdk::TracerProvider::builder()
         .with_simple_exporter(exporter)
         .with_config(sdk::Config {
             default_sampler: Box::new(sdk::Sampler::AlwaysOn),

--- a/examples/stdout.rs
+++ b/examples/stdout.rs
@@ -1,6 +1,6 @@
 use opentelemetry::exporter::trace::stdout;
 use opentelemetry::{
-    api::{Provider, Tracer},
+    api::{Tracer, TracerProvider},
     global, sdk,
 };
 
@@ -10,7 +10,7 @@ fn main() {
 
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
-    let provider = sdk::Provider::builder()
+    let provider = sdk::TracerProvider::builder()
         .with_simple_exporter(exporter)
         .with_config(sdk::Config {
             default_sampler: Box::new(sdk::Sampler::AlwaysOn),

--- a/examples/zipkin/src/main.rs
+++ b/examples/zipkin/src/main.rs
@@ -13,7 +13,7 @@ fn init_tracer() {
 
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBasedSampler` with a desired ratio.
-    let provider = sdk::Provider::builder()
+    let provider = sdk::TracerProvider::builder()
         .with_simple_exporter(exporter)
         .with_config(sdk::Config {
             default_sampler: Box::new(sdk::Sampler::AlwaysOn),

--- a/opentelemetry-contrib/src/id_generator/aws_xray_id_generator.rs
+++ b/opentelemetry-contrib/src/id_generator/aws_xray_id_generator.rs
@@ -26,10 +26,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 /// extern crate opentelemetry;
 /// use opentelemetry::api::NoopSpanExporter;
 /// use opentelemetry::sdk::Config;
-/// use opentelemetry::sdk::trace::provider::Provider;
+/// use opentelemetry::sdk::trace::provider::TracerProvider;
 /// use opentelemetry_contrib::XrayIdGenerator;
 ///
-/// let _provider: Provider = Provider::builder()
+/// let _provider: TracerProvider = TracerProvider::builder()
 ///     .with_simple_exporter(NoopSpanExporter {})
 ///     .with_config(Config {
 ///          id_generator: Box::new(XrayIdGenerator::default()),

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -311,7 +311,7 @@ impl PipelineBuilder {
         Ok(tracer)
     }
 
-    /// Build a configured `sdk::Provider` with the recommended defaults.
+    /// Build a configured `sdk::TraceProvider` with the recommended defaults.
     pub fn build(mut self) -> Result<sdk::TracerProvider, Box<dyn Error>> {
         let config = self.config.take();
         let exporter = self.init_exporter()?;

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -126,7 +126,7 @@ use agent::AgentSyncClientUDP;
 #[cfg(feature = "collector_client")]
 use collector::CollectorSyncClientHttp;
 use opentelemetry::{
-    api::{self, Provider},
+    api::{self, TracerProvider},
     exporter::trace,
     global, sdk,
 };
@@ -312,11 +312,11 @@ impl PipelineBuilder {
     }
 
     /// Build a configured `sdk::Provider` with the recommended defaults.
-    pub fn build(mut self) -> Result<sdk::Provider, Box<dyn Error>> {
+    pub fn build(mut self) -> Result<sdk::TracerProvider, Box<dyn Error>> {
         let config = self.config.take();
         let exporter = self.init_exporter()?;
 
-        let mut builder = configure_exporter(sdk::Provider::builder(), exporter);
+        let mut builder = configure_exporter(sdk::TracerProvider::builder(), exporter);
 
         if let Some(config) = config {
             builder = builder.with_config(config)

--- a/opentelemetry-semantic-conventions/src/resource.rs
+++ b/opentelemetry-semantic-conventions/src/resource.rs
@@ -13,7 +13,7 @@
 //! use std::sync::Arc;
 //!
 //! let exporter = opentelemetry::exporter::trace::stdout::Builder::default().init();
-//! let provider = sdk::Provider::builder()
+//! let provider = sdk::TracerProvider::builder()
 //!    .with_simple_exporter(exporter)
 //!    .with_config(sdk::Config {
 //!        resource: Arc::new(sdk::Resource::new(vec![

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -19,7 +19,7 @@
 //!            .with_service_name("opentelemetry-backend".to_owned())
 //!            .with_service_endpoint(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080))
 //!            .build());
-//!     let provider = sdk::Provider::builder()
+//!     let provider = sdk::TracerProvider::builder()
 //!         .with_simple_exporter(exporter)
 //!         .with_config(sdk::Config {
 //!             default_sampler: Box::new(sdk::Sampler::AlwaysOn),

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -35,7 +35,7 @@ use std::fmt::Debug;
 /// let mut injector = HashMap::new();
 ///
 /// // And a given span
-/// let example_span = sdk::Provider::default().get_tracer("example-component").start("span-name");
+/// let example_span = sdk::TracerProvider::default().get_tracer("example-component").start("span-name");
 ///
 /// // with the current context, call inject to add the headers
 /// composite_propagator.inject_context(&Context::current_with_span(example_span)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -41,7 +41,7 @@ pub use trace::{
     id_generator::IdGenerator,
     link::Link,
     noop::{NoopProvider, NoopSpan, NoopSpanExporter, NoopTracer},
-    provider::Provider,
+    provider::TracerProvider,
     span::{Span, SpanKind, StatusCode},
     span_context::{
         SpanContext, SpanId, TraceId, TRACE_FLAG_DEBUG, TRACE_FLAG_DEFERRED,

--- a/src/api/trace/context.rs
+++ b/src/api/trace/context.rs
@@ -26,12 +26,12 @@ pub trait TraceContextExt {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::{api, api::{Context, Provider, TraceContextExt, Tracer}, sdk};
+    /// use opentelemetry::{api, api::{Context, TracerProvider, TraceContextExt, Tracer}, sdk};
     ///
     /// // returns a reference to an empty span by default
     /// assert_eq!(Context::current().span().span_context(), api::SpanContext::empty_context());
     ///
-    /// sdk::Provider::default().get_tracer("my-component").in_span("my-span", |cx| {
+    /// sdk::TracerProvider::default().get_tracer("my-component").in_span("my-span", |cx| {
     ///     // Returns a reference to the current span if set
     ///     assert_ne!(cx.span().span_context(), api::SpanContext::empty_context());
     /// });

--- a/src/api/trace/noop.rs
+++ b/src/api/trace/noop.rs
@@ -12,7 +12,7 @@ use std::time::SystemTime;
 #[derive(Debug)]
 pub struct NoopProvider {}
 
-impl api::Provider for NoopProvider {
+impl api::TracerProvider for NoopProvider {
     type Tracer = NoopTracer;
 
     /// Returns a new `NoopTracer` instance.

--- a/src/api/trace/noop.rs
+++ b/src/api/trace/noop.rs
@@ -8,7 +8,7 @@ use crate::{api, exporter};
 use std::sync::Arc;
 use std::time::SystemTime;
 
-/// A no-op instance of a `Provider`.
+/// A no-op instance of a `TracerProvider`.
 #[derive(Debug)]
 pub struct NoopProvider {}
 

--- a/src/api/trace/provider.rs
+++ b/src/api/trace/provider.rs
@@ -23,7 +23,7 @@ use crate::api;
 use std::fmt;
 
 /// An interface to create `Tracer` instances.
-pub trait Provider: fmt::Debug + 'static {
+pub trait TracerProvider: fmt::Debug + 'static {
     /// The `Tracer` type that this `Provider` will return.
     type Tracer: api::Tracer;
 

--- a/src/api/trace/provider.rs
+++ b/src/api/trace/provider.rs
@@ -2,7 +2,7 @@
 //!
 //! ### Obtaining a Tracer
 //!
-//! New `Tracer` instances can be created via a `Provider` and its `get_tracer`
+//! New `Tracer` instances can be created via a `TracerProvider` and its `get_tracer`
 //! method. This method expects an Into<String> argument:
 //!
 //! - `name` (required): This name must identify the instrumentation library (also
@@ -14,17 +14,17 @@
 //!   A library, implementing the OpenTelemetry API *may* also ignore this name and
 //!   return a default instance for all calls, if it does not support "named"
 //!   functionality (e.g. an implementation which is not even observability-related).
-//!   A Provider could also return a no-op Tracer here if application owners configure
+//!   A TracerProvider could also return a no-op Tracer here if application owners configure
 //!   the SDK to suppress telemetry produced by this library.
 //!
 //! Implementations might require the user to specify configuration properties at
-//! `Provider` creation time, or rely on external configuration.
+//! `TracerProvider` creation time, or rely on external configuration.
 use crate::api;
 use std::fmt;
 
 /// An interface to create `Tracer` instances.
 pub trait TracerProvider: fmt::Debug + 'static {
-    /// The `Tracer` type that this `Provider` will return.
+    /// The `Tracer` type that this `TracerProvider` will return.
     type Tracer: api::Tracer;
 
     /// Creates a named tracer instance of `Self::Tracer`.

--- a/src/api/trace/span_processor.rs
+++ b/src/api/trace/span_processor.rs
@@ -7,10 +7,10 @@
 //! Built-in span processors are responsible for batching and conversion of spans to
 //! exportable representation and passing batches to exporters.
 //!
-//! Span processors can be registered directly on SDK [`Provider`] and they are
+//! Span processors can be registered directly on SDK [`TracerProvider`] and they are
 //! invoked in the same order as they were registered.
 //!
-//! All `Tracer` instances created by a `Provider` share the same span processors.
+//! All `Tracer` instances created by a `TracerProvider` share the same span processors.
 //! Changes to this collection reflect in all `Tracer` instances.
 //!
 //! The following diagram shows `SpanProcessor`'s relationship to other components
@@ -32,7 +32,7 @@
 //! ```
 //!
 //! [`is_recording`]: ../span/trait.Span.html#method.is_recording
-//! [`Provider`]: ../provider/trait.Provider.html
+//! [`TracerProvider`]: ../provider/trait.TracerProvider.html
 
 use crate::exporter;
 use std::sync::Arc;

--- a/src/api/trace/tracer.rs
+++ b/src/api/trace/tracer.rs
@@ -377,7 +377,7 @@ pub trait Tracer: fmt::Debug + 'static {
 ///
 /// ```rust
 /// use opentelemetry::{
-///     api::{Provider, SpanBuilder, SpanKind, Tracer},
+///     api::{TracerProvider, SpanBuilder, SpanKind, Tracer},
 ///     global,
 /// };
 ///

--- a/src/exporter/trace/stdout.rs
+++ b/src/exporter/trace/stdout.rs
@@ -16,7 +16,7 @@
 //!
 //! // Create a new stdout exporter that writes pretty printed span output
 //! let exporter = stdout::Builder::default().with_pretty_print(true).init();
-//! let provider = sdk::Provider::builder()
+//! let provider = sdk::TracerProvider::builder()
 //!     .with_simple_exporter(exporter)
 //!     .build();
 //! global::set_provider(provider);

--- a/src/global/mod.rs
+++ b/src/global/mod.rs
@@ -1,7 +1,7 @@
 //! # OpenTelemetry Global API
 //!
 //! The global API **provides applications access to their configured
-//! [`Provider`] instance from anywhere in the codebase**. This allows
+//! [`TracerProvider`] instance from anywhere in the codebase**. This allows
 //! applications to be less coupled to the specific Open Telemetry SDK as
 //! well as not manually pass references to each part of the code that needs
 //! to create [`Span`]s. Additionally, **3rd party middleware** or **library code**
@@ -18,7 +18,7 @@
 //! fn init_tracer() {
 //!     let provider = opentelemetry::api::NoopProvider {};
 //!
-//!     // Configure the global `Provider` singleton when your app starts
+//!     // Configure the global `TracerProvider` singleton when your app starts
 //!     // (there is a no-op default if this is not set by your application)
 //!     global::set_provider(provider);
 //! }
@@ -57,7 +57,7 @@
 //! [`GenericTracer`], and [`Span`] respectively allowing the underlying
 //! implementation to be set at runtime.
 //!
-//! [`Provider`]: ../api/trace/provider/trait.Provider.html
+//! [`TracerProvider`]: ../api/trace/provider/trait.TracerProvider.html
 //! [`Tracer`]: ../api/trace/tracer/trait.Tracer.html
 //! [`Span`]: ../api/trace/span/trait.Span.html
 //! [`GenericProvider`]: trait.GenericProvider.html

--- a/src/global/mod.rs
+++ b/src/global/mod.rs
@@ -11,7 +11,7 @@
 //! ## Usage
 //!
 //! ```rust
-//! use opentelemetry::api::{Provider, Tracer};
+//! use opentelemetry::api::{TracerProvider, Tracer};
 //! use opentelemetry::api::metrics::{Meter, MeterProvider};
 //! use opentelemetry::global;
 //!

--- a/src/global/trace.rs
+++ b/src/global/trace.rs
@@ -156,13 +156,13 @@ where
     }
 }
 
-/// Allows a specific [`Provider`] to be used generically by the
+/// Allows a specific [`TracerProvider`] to be used generically by the
 /// [`GlobalProvider`] by mirroring the interface and boxing the return types.
 ///
-/// [`Provider`]: ../api/trace/provider/trait.Provider.html
+/// [`TracerProvider`]: ../api/trace/provider/trait.TracerProvider.html
 /// [`GlobalProvider`]: struct.GlobalProvider.html
 pub trait GenericProvider: fmt::Debug + 'static {
-    /// Creates a named tracer instance that is a trait object through the underlying `Provider`.
+    /// Creates a named tracer instance that is a trait object through the underlying `TracerProvider`.
     fn get_tracer_boxed(&self, name: &'static str) -> Box<dyn GenericTracer + Send + Sync>;
 }
 
@@ -178,11 +178,11 @@ where
     }
 }
 
-/// Represents the globally configured [`Provider`] instance for this
+/// Represents the globally configured [`TracerProvider`] instance for this
 /// application. This allows generic tracing through the returned
 /// [`BoxedTracer`] instances.
 ///
-/// [`Provider`]: ../api/trace/provider/trait.Provider.html
+/// [`TracerProvider`]: ../api/trace/provider/trait.TracerProvider.html
 /// [`BoxedTracer`]: struct.BoxedTracer.html
 #[derive(Clone, Debug)]
 pub struct GlobalProvider {
@@ -190,7 +190,7 @@ pub struct GlobalProvider {
 }
 
 impl GlobalProvider {
-    /// Create a new GlobalProvider instance from a struct that implements `Provider`.
+    /// Create a new GlobalProvider instance from a struct that implements `TracerProvider`.
     fn new<P, T, S>(provider: P) -> Self
     where
         S: api::Span + Send + Sync,
@@ -217,10 +217,10 @@ lazy_static::lazy_static! {
     static ref GLOBAL_TRACER_PROVIDER: RwLock<GlobalProvider> = RwLock::new(GlobalProvider::new(api::NoopProvider {}));
 }
 
-/// Returns an instance of the currently configured global [`Provider`] through
+/// Returns an instance of the currently configured global [`TracerProvider`] through
 /// [`GlobalProvider`].
 ///
-/// [`Provider`]: ../api/trace/provider/trait.Provider.html
+/// [`TracerProvider`]: ../api/trace/provider/trait.TracerProvider.html
 /// [`GlobalProvider`]: struct.GlobalProvider.html
 pub fn trace_provider() -> GlobalProvider {
     GLOBAL_TRACER_PROVIDER
@@ -241,9 +241,9 @@ pub fn tracer(name: &'static str) -> BoxedTracer {
     trace_provider().get_tracer(name)
 }
 
-/// Sets the given [`Provider`] instance as the current global provider.
+/// Sets the given [`TracerProvider`] instance as the current global provider.
 ///
-/// [`Provider`]: ../api/trace/provider/trait.Provider.html
+/// [`TracerProvider`]: ../api/trace/provider/trait.TracerProvider.html
 pub fn set_provider<P, T, S>(new_provider: P)
 where
     S: api::Span + Send + Sync,

--- a/src/global/trace.rs
+++ b/src/global/trace.rs
@@ -1,4 +1,4 @@
-use crate::{api, api::Provider};
+use crate::{api, api::TracerProvider};
 use std::fmt;
 use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
@@ -170,7 +170,7 @@ impl<S, T, P> GenericProvider for P
 where
     S: api::Span + Send + Sync,
     T: api::Tracer<Span = S> + Send + Sync,
-    P: api::Provider<Tracer = T>,
+    P: api::TracerProvider<Tracer = T>,
 {
     /// Return a boxed generic tracer
     fn get_tracer_boxed(&self, name: &'static str) -> Box<dyn GenericTracer + Send + Sync> {
@@ -195,7 +195,7 @@ impl GlobalProvider {
     where
         S: api::Span + Send + Sync,
         T: api::Tracer<Span = S> + Send + Sync,
-        P: api::Provider<Tracer = T> + Send + Sync,
+        P: api::TracerProvider<Tracer = T> + Send + Sync,
     {
         GlobalProvider {
             provider: Arc::new(provider),
@@ -203,7 +203,7 @@ impl GlobalProvider {
     }
 }
 
-impl api::Provider for GlobalProvider {
+impl api::TracerProvider for GlobalProvider {
     type Tracer = BoxedTracer;
 
     /// Find or create a named tracer using the global provider.
@@ -248,7 +248,7 @@ pub fn set_provider<P, T, S>(new_provider: P)
 where
     S: api::Span + Send + Sync,
     T: api::Tracer<Span = S> + Send + Sync,
-    P: api::Provider<Tracer = T> + Send + Sync,
+    P: api::TracerProvider<Tracer = T> + Send + Sync,
 {
     let mut global_provider = GLOBAL_TRACER_PROVIDER
         .write()

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -22,7 +22,7 @@ pub use trace::{
     evicted_hash_map::EvictedHashMap,
     evicted_queue::EvictedQueue,
     id_generator::IdGenerator,
-    provider::{Builder, Provider},
+    provider::{Builder, TracerProvider},
     sampler::{Sampler, SamplingDecision, SamplingResult, ShouldSample},
     span::Span,
     span_processor::{BatchSpanProcessor, SimpleSpanProcessor},

--- a/src/sdk/resource.rs
+++ b/src/sdk/resource.rs
@@ -8,11 +8,11 @@
 //! The primary purpose of resources as a first-class concept in the SDK is decoupling of discovery
 //! of resource information from exporters. This allows for independent development and easy
 //! customization for users that need to integrate with closed source environments. When used with
-//! distributed tracing, a resource can be associated with the [`Provider`] when it is created.
-//! That association cannot be changed later. When associated with a `Provider`, all `Span`s
+//! distributed tracing, a resource can be associated with the [`TracerProvider`] when it is created.
+//! That association cannot be changed later. When associated with a `TracerProvider`, all `Span`s
 //! produced by any `Tracer` from the provider are associated with this `Resource`.
 //!
-//! [`Provider`]: ../../api/trace/provider/trait.Provider.html
+//! [`TracerProvider`]: ../../api/trace/provider/trait.TracerProvider.html
 use crate::api;
 use crate::api::labels;
 use crate::api::KeyValue;

--- a/src/sdk/trace/mod.rs
+++ b/src/sdk/trace/mod.rs
@@ -5,7 +5,7 @@
 //! * The `Tracer` struct which performs all tracing operations.
 //! * The `Span` struct with is a mutable object storing information about the
 //! current operation execution.
-//! * The `Provider` struct which configures and produces `Tracer`s.
+//! * The `TracerProvider` struct which configures and produces `Tracer`s.
 pub mod config;
 pub mod evicted_hash_map;
 pub mod evicted_queue;

--- a/src/sdk/trace/provider.rs
+++ b/src/sdk/trace/provider.rs
@@ -2,12 +2,12 @@
 //!
 //! ## Tracer Creation
 //!
-//! New `Tracer` instances are always created through a `Provider`.
+//! New `Tracer` instances are always created through a `TracerProvider`.
 //!
 //! All configuration objects and extension points (span processors,
-//! propagators) are provided by the `Provider`. `Tracer` instances do
+//! propagators) are provided by the `TracerProvider`. `Tracer` instances do
 //! not duplicate this data to avoid that different `Tracer` instances
-//! of the `Provider` have different versions of these data.
+//! of the `TracerProvider` have different versions of these data.
 use crate::exporter::trace::SpanExporter;
 use crate::{api, sdk};
 use std::collections::HashMap;
@@ -34,17 +34,17 @@ impl Drop for ProviderInner {
 
 /// Creator and registry of named `Tracer` instances.
 #[derive(Clone, Debug)]
-pub struct Provider {
+pub struct TracerProvider {
     inner: Arc<ProviderInner>,
 }
 
-impl Default for Provider {
+impl Default for TracerProvider {
     fn default() -> Self {
-        Provider::builder().build()
+        TracerProvider::builder().build()
     }
 }
 
-impl Provider {
+impl TracerProvider {
     /// Create a new `Provider` builder.
     pub fn builder() -> Builder {
         Builder::default()
@@ -61,7 +61,7 @@ impl Provider {
     }
 }
 
-impl api::Provider for Provider {
+impl api::TracerProvider for TracerProvider {
     /// This implementation of `api::Provider` produces `sdk::Tracer` instances.
     type Tracer = sdk::Tracer;
 
@@ -132,8 +132,8 @@ impl Builder {
     }
 
     /// Create a new provider from this configuration.
-    pub fn build(self) -> Provider {
-        Provider {
+    pub fn build(self) -> TracerProvider {
+        TracerProvider {
             inner: Arc::new(ProviderInner {
                 named_tracers: Default::default(),
                 processors: self.processors,

--- a/src/sdk/trace/provider.rs
+++ b/src/sdk/trace/provider.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, RwLock};
 /// Default tracer name if empty string is provided.
 const DEFAULT_COMPONENT_NAME: &str = "rust.opentelemetry.io/sdk/tracer";
 
-/// Provider
+/// TracerProvider inner type
 #[derive(Debug)]
 struct ProviderInner {
     named_tracers: RwLock<HashMap<&'static str, sdk::Tracer>>,
@@ -45,7 +45,7 @@ impl Default for TracerProvider {
 }
 
 impl TracerProvider {
-    /// Create a new `Provider` builder.
+    /// Create a new `TracerProvider` builder.
     pub fn builder() -> Builder {
         Builder::default()
     }
@@ -62,7 +62,7 @@ impl TracerProvider {
 }
 
 impl api::TracerProvider for TracerProvider {
-    /// This implementation of `api::Provider` produces `sdk::Tracer` instances.
+    /// This implementation of `api::TraceProvider` produces `sdk::Tracer` instances.
     type Tracer = sdk::Tracer;
 
     /// Find or create `Tracer` instance by name.

--- a/src/sdk/trace/span_processor.rs
+++ b/src/sdk/trace/span_processor.rs
@@ -41,7 +41,7 @@
 //! let exporter = api::NoopSpanExporter {};
 //!
 //! // Then use the `with_simple_exporter` method to have the provider export when spans finish.
-//! let provider = sdk::Provider::builder()
+//! let provider = sdk::TracerProvider::builder()
 //!     .with_simple_exporter(exporter)
 //!     .build();
 //!
@@ -73,7 +73,7 @@
 //!         .build();
 //!
 //!     // Then use the `with_batch_exporter` method to have the provider export spans in batches.
-//!     let provider = sdk::Provider::builder()
+//!     let provider = sdk::TracerProvider::builder()
 //!         .with_batch_exporter(batch)
 //!         .build();
 //!

--- a/src/sdk/trace/span_processor.rs
+++ b/src/sdk/trace/span_processor.rs
@@ -5,9 +5,9 @@
 //! is `true`.
 //! Built-in span processors are responsible for batching and conversion of
 //! spans to exportable representation and passing batches to exporters.
-//! Span processors can be registered directly on SDK [`Provider`] and they are
+//! Span processors can be registered directly on SDK [`TracerProvider`] and they are
 //! invoked in the same order as they were registered.
-//! All [`Tracer`] instances created by a [`Provider`] share the same span
+//! All [`Tracer`] instances created by a [`TracerProvider`] share the same span
 //! processors. Changes to this collection reflect in all [`Tracer`] instances.
 //! The following diagram shows [`SpanProcessor`]'s relationship to other
 //! components in the SDK:
@@ -82,7 +82,7 @@
 //! ```
 //!
 //! [`is_recording`]: ../../../api/trace/span/trait.Span.html#tymethod.is_recording
-//! [`Provider`]: ../../../api/trace/provider/trait.Provider.html
+//! [`TracerProvider`]: ../../../api/trace/provider/trait.TracerProvider.html
 //! [`Tracer`]: ../../../api/trace/tracer/trait.Tracer.html
 //! [`SpanProcessor`]: ../../../api/trace/span_processor/trait.SpanProcessor.html
 //! [`SimpleSpanProcessor`]: struct.SimpleSpanProcessor.html

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -18,7 +18,7 @@ use std::time::SystemTime;
 #[derive(Clone)]
 pub struct Tracer {
     name: &'static str,
-    provider: sdk::Provider,
+    provider: sdk::TracerProvider,
 }
 
 impl fmt::Debug for Tracer {
@@ -31,12 +31,12 @@ impl fmt::Debug for Tracer {
 
 impl Tracer {
     /// Create a new tracer (used internally by `Provider`s.
-    pub(crate) fn new(name: &'static str, provider: sdk::Provider) -> Self {
+    pub(crate) fn new(name: &'static str, provider: sdk::TracerProvider) -> Self {
         Tracer { name, provider }
     }
 
     /// Provider associated with this tracer
-    pub fn provider(&self) -> &sdk::Provider {
+    pub fn provider(&self) -> &sdk::TracerProvider {
         &self.provider
     }
 

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -30,12 +30,12 @@ impl fmt::Debug for Tracer {
 }
 
 impl Tracer {
-    /// Create a new tracer (used internally by `Provider`s.
+    /// Create a new tracer (used internally by `TracerProvider`s.
     pub(crate) fn new(name: &'static str, provider: sdk::TracerProvider) -> Self {
         Tracer { name, provider }
     }
 
-    /// Provider associated with this tracer
+    /// TracerProvider associated with this tracer
     pub fn provider(&self) -> &sdk::TracerProvider {
         &self.provider
     }


### PR DESCRIPTION
Fixes #198 

Rename `Provider` to `TracerProvider` for both `api::Provider` and `sdk::Provider`.