### PR TITLE
Rename Correlation Context into Baggage

### DIFF
--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -1,6 +1,6 @@
 use futures::stream::{Stream, StreamExt};
 use opentelemetry::api::metrics::{self, MetricsError, ObserverResult};
-use opentelemetry::api::{Context, CorrelationContextExt, Key, KeyValue, TraceContextExt, Tracer};
+use opentelemetry::api::{Context, BaggageExt, Key, KeyValue, TraceContextExt, Tracer};
 use opentelemetry::exporter;
 use opentelemetry::sdk::metrics::PushController;
 use opentelemetry::{global, sdk};
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let value_recorder_two = meter.f64_value_recorder("ex.com.two").init();
 
     let _correlations =
-        Context::current_with_correlations(vec![FOO_KEY.string("foo1"), BAR_KEY.string("bar1")])
+        Context::current_with_baggage(vec![FOO_KEY.string("foo1"), BAR_KEY.string("bar1")])
             .attach();
 
     let value_recorder = value_recorder_two.bind(COMMON_LABELS.as_ref());
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         meter.record_batch_with_context(
             // Note: call-site variables added as context Entries:
-            &Context::current_with_correlations(vec![ANOTHER_KEY.string("xyz")]),
+            &Context::current_with_baggage(vec![ANOTHER_KEY.string("xyz")]),
             COMMON_LABELS.as_ref(),
             vec![value_recorder_two.measurement(2.0)],
         );

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,6 +1,6 @@
 use futures::stream::{Stream, StreamExt};
 use opentelemetry::api::metrics::{self, MetricsError, ObserverResult};
-use opentelemetry::api::{Context, CorrelationContextExt, Key, KeyValue, TraceContextExt, Tracer};
+use opentelemetry::api::{Context, BaggageExt, Key, KeyValue, TraceContextExt, Tracer};
 use opentelemetry::exporter;
 use opentelemetry::sdk::metrics::PushController;
 use opentelemetry::{global, sdk};
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let value_recorder_two = meter.f64_value_recorder("ex.com.two").init();
 
     let _correlations =
-        Context::current_with_correlations(vec![FOO_KEY.string("foo1"), BAR_KEY.string("bar1")])
+        Context::current_with_baggage(vec![FOO_KEY.string("foo1"), BAR_KEY.string("bar1")])
             .attach();
 
     let value_recorder = value_recorder_two.bind(COMMON_LABELS.as_ref());
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         meter.record_batch_with_context(
             // Note: call-site variables added as context Entries:
-            &Context::current_with_correlations(vec![ANOTHER_KEY.string("xyz")]),
+            &Context::current_with_baggage(vec![ANOTHER_KEY.string("xyz")]),
             COMMON_LABELS.as_ref(),
             vec![value_recorder_two.measurement(2.0)],
         );

--- a/src/api/baggage/mod.rs
+++ b/src/api/baggage/mod.rs
@@ -1,40 +1,40 @@
-//! # OpenTelemetry Correlation Context API
+//! # OpenTelemetry Baggage API
 //!
-//! A Correlation Context is used to annotate telemetry, adding context and
+//! Baggage is used to annotate telemetry, adding context and
 //! information to metrics, traces, and logs. It is an abstract data type
 //! represented by a set of name/value pairs describing user-defined properties.
-//! Each name in a [`CorrelationContext`] is associated with exactly one value.
-//! `CorrelationContext`s are serialized according to the editor's draft of
-//! the [W3C Correlation Context] specification.
+//! Each name in a [`Baggage`] is associated with exactly one value.
+//! `Baggage`s are serialized according to the editor's draft of
+//! the [W3C Baggage] specification.
 //!
-//! [`CorrelationContext`]: struct.CorrelationContext.html
-//! [W3C Correlation Context]: https://w3c.github.io/correlation-context/
+//! [`CorrelationContext`]: struct.Baggage.html
+//! [W3C Baggage]: https://w3c.github.io/baggage/
 //!
 //! # Examples
 //!
 //! ```
 //! use opentelemetry::api::{
-//!     CorrelationContextExt, CorrelationContextPropagator, TextMapFormat, Key
+//!     BaggageExt, BaggagePropagator, TextMapFormat, Key
 //! };
 //! use std::collections::HashMap;
 //!
-//! // Example correlation value passed in externally via http headers
+//! // Example baggage value passed in externally via http headers
 //! let mut headers = HashMap::new();
 //! headers.insert("otcorrelations".to_string(), "user_id=1".to_string());
 //!
-//! let propagator = CorrelationContextPropagator::new();
+//! let propagator = BaggagePropagator::new();
 //! // can extract from any type that impls `Extractor`, usually an HTTP header map
 //! let cx = propagator.extract(&headers);
 //!
 //! // Iterate over extracted name / value pairs
-//! for (name, value) in cx.correlation_context() {
+//! for (name, value) in cx.baggage() {
 //!   // ...
 //! }
 //!
-//! // Add new correlations
-//! let cx_with_additions = cx.with_correlations(vec![Key::new("server_id").u64(42)]);
+//! // Add new baggage
+//! let cx_with_additions = cx.with_baggage(vec![Key::new("server_id").u64(42)]);
 //!
-//! // Inject correlations into http request
+//! // Inject aggage into http request
 //! propagator.inject_context(&cx_with_additions, &mut headers);
 //!
 //! let header_value = headers.get("otcorrelations").expect("header is injected");
@@ -48,18 +48,18 @@ use std::iter::FromIterator;
 mod propagation;
 
 #[cfg(feature = "trace")]
-pub use propagation::{CorrelationContextExt, CorrelationContextPropagator};
+pub use propagation::{BaggageExt, BaggagePropagator};
 
 /// A set of name/value pairs describing user-defined properties across systems.
 #[derive(Debug, Default)]
-pub struct CorrelationContext {
+pub struct Baggage {
     inner: HashMap<api::Key, api::Value>,
 }
 
-impl CorrelationContext {
-    /// Creates an empty `CorrelationContext`.
+impl Baggage {
+    /// Creates an empty `Baggage`.
     pub fn new() -> Self {
-        CorrelationContext {
+        Baggage {
             inner: HashMap::default(),
         }
     }
@@ -69,9 +69,9 @@ impl CorrelationContext {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::api::{CorrelationContext, Value};
+    /// use opentelemetry::api::{Baggage, Value};
     ///
-    /// let mut cc = CorrelationContext::new();
+    /// let mut cc = Baggage::new();
     /// let _ = cc.insert("my-name", "my-value");
     ///
     /// assert_eq!(cc.get("my-name"), Some(&Value::String("my-value".to_string())))
@@ -80,7 +80,7 @@ impl CorrelationContext {
         self.inner.get(&key.into())
     }
 
-    /// Inserts a name-value pair into the correlation context.
+    /// Inserts a name-value pair into the baggage.
     ///
     /// If the name was not present, [`None`] is returned. If the name was present,
     /// the value is updated, and the old value is returned.
@@ -88,9 +88,9 @@ impl CorrelationContext {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::api::{CorrelationContext, Value};
+    /// use opentelemetry::api::{Baggage, Value};
     ///
-    /// let mut cc = CorrelationContext::new();
+    /// let mut cc = Baggage::new();
     /// let _ = cc.insert("my-name", "my-value");
     ///
     /// assert_eq!(cc.get("my-name"), Some(&Value::String("my-value".to_string())))
@@ -103,29 +103,29 @@ impl CorrelationContext {
         self.inner.insert(key.into(), value.into())
     }
 
-    /// Removes a name from the correlation context, returning the value
+    /// Removes a name from the baggage, returning the value
     /// corresponding to the name if the pair was previously in the map.
     pub fn remove<K: Into<api::Key>>(&mut self, key: K) -> Option<api::Value> {
         self.inner.remove(&key.into())
     }
 
-    /// Returns the number of attributes for this correlation context
+    /// Returns the number of attributes for this baggage
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
-    /// Returns `true` if the correlation context contains no items.
+    /// Returns `true` if the baggage contains no items.
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
-    /// Gets an iterator over the correlation context items, sorted by name.
+    /// Gets an iterator over the baggage items, sorted by name.
     pub fn iter(&self) -> Iter {
         self.into_iter()
     }
 }
 
-/// An iterator over the entries of a `CorrelationContext`.
+/// An iterator over the entries of a `Baggage`.
 #[derive(Debug)]
 pub struct Iter<'a>(hash_map::Iter<'a, api::Key, api::Value>);
 impl<'a> Iterator for Iter<'a> {
@@ -136,7 +136,7 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-impl<'a> IntoIterator for &'a CorrelationContext {
+impl<'a> IntoIterator for &'a Baggage {
     type Item = (&'a api::Key, &'a api::Value);
     type IntoIter = Iter<'a>;
 
@@ -145,17 +145,17 @@ impl<'a> IntoIterator for &'a CorrelationContext {
     }
 }
 
-impl FromIterator<(api::Key, api::Value)> for CorrelationContext {
+impl FromIterator<(api::Key, api::Value)> for Baggage {
     fn from_iter<I: IntoIterator<Item = (api::Key, api::Value)>>(iter: I) -> Self {
-        CorrelationContext {
+        Baggage {
             inner: iter.into_iter().collect(),
         }
     }
 }
 
-impl FromIterator<api::KeyValue> for CorrelationContext {
+impl FromIterator<api::KeyValue> for Baggage {
     fn from_iter<I: IntoIterator<Item = api::KeyValue>>(iter: I) -> Self {
-        CorrelationContext {
+        Baggage {
             inner: iter.into_iter().map(|kv| (kv.key, kv.value)).collect(),
         }
     }

--- a/src/api/baggage/propagation.rs
+++ b/src/api/baggage/propagation.rs
@@ -92,7 +92,6 @@ impl api::TextMapFormat for BaggagePropagator {
     }
 }
 
-struct BaggageWrapper(Baggage);
 
 /// Methods for sorting and retrieving baggage data in a context.
 pub trait BaggageExt {
@@ -153,23 +152,22 @@ impl BaggageExt for Context {
     }
 
     fn with_baggage<T: IntoIterator<Item = KeyValue>>(&self, kvs: T) -> Self {
-        let merged = self
+        let merged: Baggage = self
             .baggage()
             .iter()
             .map(|(key, value)| KeyValue::new(key.clone(), value.clone()))
             .chain(kvs.into_iter())
             .collect();
 
-        self.with_value(BaggageWrapper(merged))
+        self.with_value(merged)
     }
 
     fn with_cleared_baggage(&self) -> Self {
-        self.with_value(BaggageWrapper(Baggage::new()))
+        self.with_value(Baggage::new())
     }
 
     fn baggage(&self) -> &Baggage {
-        self.get::<BaggageWrapper>()
-            .map(|baggage| &baggage.0)
+        self.get::<Baggage>()
             .unwrap_or_else(|| &DEFAULT_BAGGAGE)
     }
 }

--- a/src/api/baggage/propagation.rs
+++ b/src/api/baggage/propagation.rs
@@ -1,38 +1,38 @@
-use super::CorrelationContext;
+use super::Baggage;
 use crate::api::context::propagation::text_propagator::FieldIter;
 use crate::api::{self, Context, KeyValue};
 use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
 use std::iter;
 
-static CORRELATION_CONTEXT_HEADER: &str = "otcorrelations";
+static BAGGAGE_HEADER: &str = "otcorrelations";
 const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b';').add(b',').add(b'=');
 
 lazy_static::lazy_static! {
-    static ref DEFAULT_CORRELATION_CONTEXT: CorrelationContext = CorrelationContext::default();
-    static ref CORRELATION_CONTEXT_FIELDS: [String; 1] = [CORRELATION_CONTEXT_HEADER.to_string()];
+    static ref DEFAULT_BAGGAGE: Baggage = Baggage::default();
+    static ref BAGGAGE_FIELDS: [String; 1] = [BAGGAGE_HEADER.to_string()];
 }
 
-/// Propagates name/value pairs in [W3C Correlation Context] format.
+/// Propagates name/value pairs in [W3C Baggage] format.
 ///
-/// [W3C Correlation Context]: https://w3c.github.io/correlation-context/
+/// [W3C Baggage]: https://w3c.github.io/baggage
 #[derive(Debug, Default)]
-pub struct CorrelationContextPropagator {
+pub struct BaggagePropagator {
     _private: (),
 }
 
-impl CorrelationContextPropagator {
-    /// Construct a new correlation context provider.
+impl BaggagePropagator {
+    /// Construct a new baggage propagator.
     pub fn new() -> Self {
-        CorrelationContextPropagator { _private: () }
+        BaggagePropagator { _private: () }
     }
 }
 
-impl api::TextMapFormat for CorrelationContextPropagator {
+impl api::TextMapFormat for BaggagePropagator {
     /// Encodes the values of the `Context` and injects them into the provided `Injector`.
     fn inject_context(&self, cx: &Context, injector: &mut dyn api::Injector) {
-        let correlation_cx = cx.correlation_context();
-        if !correlation_cx.is_empty() {
-            let header_value = correlation_cx
+        let baggage = cx.baggage();
+        if !baggage.is_empty() {
+            let header_value = baggage
                 .iter()
                 .map(|(name, value)| {
                     utf8_percent_encode(name.as_str().trim(), FRAGMENT)
@@ -42,14 +42,14 @@ impl api::TextMapFormat for CorrelationContextPropagator {
                 })
                 .collect::<Vec<String>>()
                 .join(",");
-            injector.set(CORRELATION_CONTEXT_HEADER, header_value);
+            injector.set(BAGGAGE_HEADER, header_value);
         }
     }
 
-    /// Extracts a `Context` with correlation context values from a `Extractor`.
+    /// Extracts a `Context` with baggage values from a `Extractor`.
     fn extract_with_context(&self, cx: &Context, extractor: &dyn api::Extractor) -> Context {
-        if let Some(header_value) = extractor.get(CORRELATION_CONTEXT_HEADER) {
-            let correlations = header_value.split(',').flat_map(|context_value| {
+        if let Some(header_value) = extractor.get(BAGGAGE_HEADER) {
+            let baggage = header_value.split(',').flat_map(|context_value| {
                 if let Some((name_and_value, props)) = context_value
                     .split(';')
                     .collect::<Vec<&str>>()
@@ -60,7 +60,7 @@ impl api::TextMapFormat for CorrelationContextPropagator {
                         let name = percent_decode_str(name).decode_utf8().map_err(|_| ())?;
                         let value = percent_decode_str(value).decode_utf8().map_err(|_| ())?;
 
-                        // TODO: handle props from https://w3c.github.io/correlation-context/
+                        // TODO: handle props from https://w3c.github.io/baggage/
                         // for now just append to value
                         let decoded_props = props
                             .iter()
@@ -77,100 +77,100 @@ impl api::TextMapFormat for CorrelationContextPropagator {
                         Err(())
                     }
                 } else {
-                    // Invalid correlation context value format
+                    // Invalid baggage value format
                     Err(())
                 }
             });
-            cx.with_correlations(correlations)
+            cx.with_baggage(baggage)
         } else {
             cx.clone()
         }
     }
 
     fn fields(&self) -> FieldIter {
-        FieldIter::new(CORRELATION_CONTEXT_FIELDS.as_ref())
+        FieldIter::new(BAGGAGE_FIELDS.as_ref())
     }
 }
 
-struct Correlations(CorrelationContext);
+struct BaggageWrapper(Baggage);
 
-/// Methods for soring and retrieving correlation data in a context.
-pub trait CorrelationContextExt {
+/// Methods for sorting and retrieving baggage data in a context.
+pub trait BaggageExt {
     /// Returns a clone of the current context with the included name / value pairs.
     ///
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::api::{Context, CorrelationContextExt, KeyValue, Value};
+    /// use opentelemetry::api::{Context, BaggageExt, KeyValue, Value};
     ///
-    /// let cx = Context::current_with_correlations(vec![KeyValue::new("my-name", "my-value")]);
+    /// let cx = Context::current_with_baggage(vec![KeyValue::new("my-name", "my-value")]);
     ///
     /// assert_eq!(
-    ///     cx.correlation_context().get("my-name"),
+    ///     cx.baggage().get("my-name"),
     ///     Some(&Value::String("my-value".to_string())),
     /// )
     /// ```
-    fn current_with_correlations<T: IntoIterator<Item = KeyValue>>(correlations: T) -> Self;
+    fn current_with_baggage<T: IntoIterator<Item = KeyValue>>(baggage: T) -> Self;
 
     /// Returns a clone of the given context with the included name / value pairs.
     ///
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::api::{Context, CorrelationContextExt, KeyValue, Value};
+    /// use opentelemetry::api::{Context, BaggageExt, KeyValue, Value};
     ///
     /// let some_context = Context::current();
-    /// let cx = some_context.with_correlations(vec![KeyValue::new("my-name", "my-value")]);
+    /// let cx = some_context.with_baggage(vec![KeyValue::new("my-name", "my-value")]);
     ///
     /// assert_eq!(
-    ///     cx.correlation_context().get("my-name"),
+    ///     cx.baggage().get("my-name"),
     ///     Some(&Value::String("my-value".to_string())),
     /// )
     /// ```
-    fn with_correlations<T: IntoIterator<Item = KeyValue>>(&self, correlations: T) -> Self;
+    fn with_baggage<T: IntoIterator<Item = KeyValue>>(&self, baggage: T) -> Self;
 
     /// Returns a clone of the given context with the included name / value pairs.
     ///
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::api::{Context, CorrelationContextExt, KeyValue, Value};
+    /// use opentelemetry::api::{Context, BaggageExt, KeyValue, Value};
     ///
-    /// let cx = Context::current().with_cleared_correlations();
+    /// let cx = Context::current().with_cleared_baggage();
     ///
-    /// assert_eq!(cx.correlation_context().len(), 0);
+    /// assert_eq!(cx.baggage().len(), 0);
     /// ```
-    fn with_cleared_correlations(&self) -> Self;
+    fn with_cleared_baggage(&self) -> Self;
 
-    /// Returns a reference to this context's correlation context, or the default
-    /// empty correlation context if none has been set.
-    fn correlation_context(&self) -> &CorrelationContext;
+    /// Returns a reference to this context's baggage, or the default
+    /// empty baggage if none has been set.
+    fn baggage(&self) -> &Baggage;
 }
 
-impl CorrelationContextExt for Context {
-    fn current_with_correlations<T: IntoIterator<Item = KeyValue>>(kvs: T) -> Self {
-        Context::current().with_correlations(kvs)
+impl BaggageExt for Context {
+    fn current_with_baggage<T: IntoIterator<Item = KeyValue>>(kvs: T) -> Self {
+        Context::current().with_baggage(kvs)
     }
 
-    fn with_correlations<T: IntoIterator<Item = KeyValue>>(&self, kvs: T) -> Self {
+    fn with_baggage<T: IntoIterator<Item = KeyValue>>(&self, kvs: T) -> Self {
         let merged = self
-            .correlation_context()
+            .baggage()
             .iter()
             .map(|(key, value)| KeyValue::new(key.clone(), value.clone()))
             .chain(kvs.into_iter())
             .collect();
 
-        self.with_value(Correlations(merged))
+        self.with_value(BaggageWrapper(merged))
     }
 
-    fn with_cleared_correlations(&self) -> Self {
-        self.with_value(Correlations(CorrelationContext::new()))
+    fn with_cleared_baggage(&self) -> Self {
+        self.with_value(BaggageWrapper(Baggage::new()))
     }
 
-    fn correlation_context(&self) -> &CorrelationContext {
-        self.get::<Correlations>()
-            .map(|correlations| &correlations.0)
-            .unwrap_or_else(|| &DEFAULT_CORRELATION_CONTEXT)
+    fn baggage(&self) -> &Baggage {
+        self.get::<BaggageWrapper>()
+            .map(|baggage| &baggage.0)
+            .unwrap_or_else(|| &DEFAULT_BAGGAGE)
     }
 }
 
@@ -240,34 +240,34 @@ mod tests {
     }
 
     #[test]
-    fn extract_correlations() {
-        let propagator = CorrelationContextPropagator::new();
+    fn extract_baggage() {
+        let propagator = BaggagePropagator::new();
 
         for (header_value, kvs) in valid_extract_data() {
             let mut extractor: HashMap<String, String> = HashMap::new();
             extractor.insert(
-                CORRELATION_CONTEXT_HEADER.to_string(),
+                BAGGAGE_HEADER.to_string(),
                 header_value.to_string(),
             );
             let context = propagator.extract(&extractor);
-            let correlations = context.correlation_context();
+            let baggage = context.baggage();
 
-            assert_eq!(kvs.len(), correlations.len());
-            for (key, value) in correlations {
+            assert_eq!(kvs.len(), baggage.len());
+            for (key, value) in baggage {
                 assert_eq!(Some(value), kvs.get(key))
             }
         }
     }
 
     #[test]
-    fn inject_correlations() {
-        let propagator = CorrelationContextPropagator::new();
+    fn inject_baggage() {
+        let propagator = BaggagePropagator::new();
 
         for (kvs, header_parts) in valid_inject_data() {
             let mut injector = HashMap::new();
-            let cx = Context::current_with_correlations(kvs);
+            let cx = Context::current_with_baggage(kvs);
             propagator.inject_context(&cx, &mut injector);
-            let header_value = injector.get(CORRELATION_CONTEXT_HEADER).unwrap();
+            let header_value = injector.get(BAGGAGE_HEADER).unwrap();
 
             assert_eq!(header_parts.join(",").len(), header_value.len(),);
             for header_part in &header_parts {

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -22,12 +22,12 @@ use std::fmt::Debug;
 /// use std::collections::HashMap;
 ///
 /// // First create 1 or more propagators
-/// let correlation_propagator = CorrelationContextPropagator::new();
+/// let baggage_propagator = BaggagePropagator::new();
 /// let trace_context_propagator = TraceContextPropagator::new();
 ///
 /// // Then create a composite propagator
 /// let composite_propagator = TextMapCompositePropagator::new(vec![
-///     Box::new(correlation_propagator),
+///     Box::new(baggage_propagator),
 ///     Box::new(trace_context_propagator),
 /// ]);
 ///
@@ -39,7 +39,7 @@ use std::fmt::Debug;
 ///
 /// // with the current context, call inject to add the headers
 /// composite_propagator.inject_context(&Context::current_with_span(example_span)
-///                                     .with_correlations(vec![KeyValue::new("test", "example")]),
+///                                     .with_baggage(vec![KeyValue::new("test", "example")]),
 ///                                     &mut injector);
 ///
 /// // The injector now has both `otcorrelations` and `traceparent` headers

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,7 +16,7 @@
 pub mod context;
 pub mod core;
 #[cfg(feature = "trace")]
-pub mod correlation;
+pub mod baggage;
 pub mod labels;
 #[cfg(feature = "metrics")]
 pub mod metrics;
@@ -31,7 +31,7 @@ pub use context::propagation::{
 };
 pub use context::Context;
 #[cfg(feature = "trace")]
-pub use correlation::{CorrelationContext, CorrelationContextExt, CorrelationContextPropagator};
+pub use baggage::{Baggage, BaggageExt, BaggagePropagator};
 
 #[cfg(feature = "trace")]
 pub use trace::{

--- a/src/global/propagation.rs
+++ b/src/global/propagation.rs
@@ -3,9 +3,9 @@ use std::sync::RwLock;
 
 lazy_static::lazy_static! {
     /// The current global `TextMapFormat` propagator.
-    static ref GLOBAL_TEXT_MAP_PROPAGATOR: RwLock<Box<dyn api::TextMapFormat + Send + Sync>> = RwLock::new(Box::new(api::TextMapCompositePropagator::new(vec![Box::new(api::TraceContextPropagator::new()), Box::new(api::CorrelationContextPropagator::new())])));
+    static ref GLOBAL_TEXT_MAP_PROPAGATOR: RwLock<Box<dyn api::TextMapFormat + Send + Sync>> = RwLock::new(Box::new(api::TextMapCompositePropagator::new(vec![Box::new(api::TraceContextPropagator::new()), Box::new(api::BaggagePropagator::new())])));
     /// The global default `TextMapFormat` propagator.
-    static ref DEFAULT_TEXT_MAP_PROPAGATOR: api::TextMapCompositePropagator = api::TextMapCompositePropagator::new(vec![Box::new(api::TraceContextPropagator::new()), Box::new(api::CorrelationContextPropagator::new())]);
+    static ref DEFAULT_TEXT_MAP_PROPAGATOR: api::TextMapCompositePropagator = api::TextMapCompositePropagator::new(vec![Box::new(api::TraceContextPropagator::new()), Box::new(api::BaggagePropagator::new())]);
 }
 
 /// Sets the given [`TextMapFormat`] propagator as the current global propagator.

--- a/src/sdk/export/metrics/mod.rs
+++ b/src/sdk/export/metrics/mod.rs
@@ -114,7 +114,7 @@ pub trait Aggregator: fmt::Debug {
     /// `Descriptor::number_kind` should be consulted to determine whether the
     /// provided number is an `i64`, `u64` or `f64`.
     ///
-    /// The current Context could be inspected for a `CorrelationContext` or
+    /// The current Context could be inspected for a `Baggage` or
     /// `SpanContext`.
     fn update(&self, number: &Number, descriptor: &Descriptor) -> Result<()>;
 


### PR DESCRIPTION
Fix #196 
This PR:

- Rename `CorrelationContextPropagator` into `BaggagePropagator`
- Rename `CorrelationContextExt` into `BaggageExt`
- Delete `Correlations` since it seems OK to use `Baggage/CorrlectionContext` directly.