### PR TITLE
Add otlp exporter pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
+async-std = { version = "1.6", features = ["unstable"], optional = true }
 base64 = { version = "0.12", optional = true }
 bincode = { version = "1.2", optional = true }
 dashmap = { version = "4.0.0-rc6", optional = true }
@@ -29,6 +30,7 @@ rand = { version = "0.7", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 http = { version = "0.2", optional = true }
 thiserror = { version = "1.0", optional = true }
+tokio = { version = "0.2", features = ["rt-core", "blocking", "time", "stream"], optional = true }
 tonic = { version = "0.2.1", optional = true }
 
 [dev-dependencies]

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 futures = "0.3"
 thrift = "0.13"
 tokio = { version = "0.2", features = ["full"] }
-opentelemetry = { path = "../../" }
-opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["tokio"] }
+opentelemetry = { path = "../../", features = ["tokio"] }
+opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }

--- a/examples/basic-otlp/Cargo.toml
+++ b/examples/basic-otlp/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3"
 lazy_static = "1.4"
-opentelemetry = { path = "../../" }
+opentelemetry = { path = "../../", features = ["tokio"] }
 opentelemetry-otlp = { path = "../../opentelemetry-otlp" }
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["full"] }

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,6 +1,6 @@
 use futures::stream::{Stream, StreamExt};
 use opentelemetry::api::metrics::{self, MetricsError, ObserverResult};
-use opentelemetry::api::{Context, BaggageExt, Key, KeyValue, TraceContextExt, Tracer};
+use opentelemetry::api::{BaggageExt, Context, Key, KeyValue, TraceContextExt, Tracer};
 use opentelemetry::exporter;
 use opentelemetry::sdk::metrics::PushController;
 use opentelemetry::{global, sdk};

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -19,8 +19,6 @@ edition = "2018"
 opentelemetry = { version = "0.8", default-features = false, features = ["trace"], path = ".." }
 ureq = { version = "1.4", optional = true }
 thrift = "0.13"
-tokio = { version = "0.2", features = ["rt-core", "time", "stream"], optional = true }
-async-std = { version = "1.6", features = ["unstable"], optional = true }
 
 [features]
 default = []

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -1,3 +1,98 @@
 # OpenTelemetry Collector Rust Exporter
 
-This exporter exports OpenTelemetry spans and metrics to the OpenTelemetry Collector.
+The OTLP Exporter supports exporting trace and metric data in the OTLP format to
+the OpenTelemetry collector. The OpenTelemetry Collector offers a
+vendor-agnostic implementation on how to receive, process, and export telemetry
+data. In addition, it removes the need to run, operate, and maintain multiple
+agents/collectors in order to support open-source telemetry data formats (e.g.
+Jaeger, Prometheus, etc.) sending to multiple open-source or commercial
+back-ends.
+
+## Quickstart
+
+First make sure you have a running version of the opentelemetry collector you
+want to send data to:
+
+```shell
+$ docker run -p 55680:55680 otel/opentelemetry-collector-dev:latest
+```
+
+Then install a new pipeline with the recommended defaults to start exporting
+telemetry:
+
+```rust
+use opentelemetry::api::Tracer;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tracer = opentelemetry_otlp::new_pipeline().install()?;
+
+    tracer.in_span("doing_work", |cx| {
+        // Traced app logic here...
+    });
+
+    Ok(())
+}
+```
+## Performance
+
+For optimal performance, a batch exporter is recommended as the simple
+exporter will export each span synchronously on drop. You can enable the
+[`tokio`] or [`async-std`] features to have a batch exporter configured for
+you automatically for either executor when you install the pipeline.
+
+```toml
+[dependencies]
+opentelemetry = { version = "*", features = ["tokio"] }
+opentelemetry-otlp = "*"
+```
+
+[`tokio`]: https://tokio.rs
+[`async-std`]: https://async.rs
+
+## Kitchen Sink Full Configuration
+
+Example showing how to override all configuration options. See the
+[`OtlpPipelineBuilder`] docs for details of each option.
+
+[`OtlpPipelineBuilder`]: struct.OtlpPipelineBuilder.html
+
+```rust
+use opentelemetry::api::{KeyValue, Tracer};
+use opentelemetry::sdk::{trace, IdGenerator, Resource, Sampler};
+use opentelemetry_otlp::{Compression, Credentials, Protocol};
+use std::time::Duration;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let headers = vec![("X-Custom".to_string(), "Custom-Value".to_string())]
+        .into_iter()
+        .collect();
+
+    let tracer = opentelemetry_otlp::new_pipeline()
+        .with_endpoint("localhost:55680")
+        .with_protocol(Protocol::Grpc)
+        .with_headers(headers)
+        .with_compression(Compression::Gzip)
+        .with_timeout(Duration::from_secs(3))
+        .with_completion_queue_count(2)
+        .with_credentials(Credentials {
+            cert: "tls.cert".to_string(),
+            key: "tls.key".to_string(),
+        })
+        .with_trace_config(
+            trace::config()
+                .with_default_sampler(Sampler::AlwaysOn)
+                .with_id_generator(IdGenerator::default())
+                .with_max_events_per_span(64)
+                .with_max_attributes_per_span(16)
+                .with_max_events_per_span(16)
+                .with_resource(Resource::new(vec![KeyValue::new("key", "value")])),
+        )
+        .install()?;
+
+    tracer.in_span("doing_work", |cx| {
+        // Traced app logic here...
+    });
+
+    Ok(())
+}
+```

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -1,8 +1,206 @@
-//! # OpenTelemetry OTLP Exporter
+//! The OTLP Exporter supports exporting trace and metric data in the OTLP format to the OpenTelemetry collector. The OpenTelemetry Collector offers a
+//! vendor-agnostic implementation on how to receive, process, and export
+//! telemetry data. In addition, it removes the need to run, operate, and
+//! maintain multiple agents/collectors in order to support open-source
+//! telemetry data formats (e.g. Jaeger, Prometheus, etc.) sending to multiple
+//! open-source or commercial back-ends.
 //!
-//! The OpenTelemetry OTLP Exporter supports exporting of trace and metric data in the OTLP format.
+//! ## Quickstart
+//!
+//! First make sure you have a running version of the opentelemetry collector
+//! you want to send data to:
+//!
+//! ```shell
+//! $ docker run -p 55680:55680 otel/opentelemetry-collector-dev:latest
+//! ```
+//!
+//! Then install a new pipeline with the recommended defaults to start exporting
+//! telemetry:
+//!
+//! ```no_run
+//! use opentelemetry::api::Tracer;
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let tracer = opentelemetry_otlp::new_pipeline().install()?;
+//!
+//!     tracer.in_span("doing_work", |cx| {
+//!         // Traced app logic here...
+//!     });
+//!
+//!     Ok(())
+//! }
+//! ```
+//! ## Performance
+//!
+//! For optimal performance, a batch exporter is recommended as the simple
+//! exporter will export each span synchronously on drop. You can enable the
+//! [`tokio`] or [`async-std`] features to have a batch exporter configured for
+//! you automatically for either executor when you install the pipeline.
+//!
+//! ```toml
+//! [dependencies]
+//! opentelemetry = { version = "*", features = ["tokio"] }
+//! opentelemetry-otlp = "*"
+//! ```
+//!
+//! [`tokio`]: https://tokio.rs
+//! [`async-std`]: https://async.rs
+//!
+//! ## Kitchen Sink Full Configuration
+//!
+//! Example showing how to override all configuration options. See the
+//! [`OtlpPipelineBuilder`] docs for details of each option.
+//!
+//! [`OtlpPipelineBuilder`]: struct.OtlpPipelineBuilder.html
+//!
+//! ```no_run
+//! use opentelemetry::api::{KeyValue, Tracer};
+//! use opentelemetry::sdk::{trace, IdGenerator, Resource, Sampler};
+//! use opentelemetry_otlp::{Compression, Credentials, Protocol};
+//! use std::time::Duration;
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let headers = vec![("X-Custom".to_string(), "Custom-Value".to_string())]
+//!         .into_iter()
+//!         .collect();
+//!
+//!     let tracer = opentelemetry_otlp::new_pipeline()
+//!         .with_endpoint("localhost:55680")
+//!         .with_protocol(Protocol::Grpc)
+//!         .with_headers(headers)
+//!         .with_compression(Compression::Gzip)
+//!         .with_timeout(Duration::from_secs(3))
+//!         .with_completion_queue_count(2)
+//!         .with_credentials(Credentials {
+//!             cert: "tls.cert".to_string(),
+//!             key: "tls.key".to_string(),
+//!         })
+//!         .with_trace_config(
+//!             trace::config()
+//!                 .with_default_sampler(Sampler::AlwaysOn)
+//!                 .with_id_generator(IdGenerator::default())
+//!                 .with_max_events_per_span(64)
+//!                 .with_max_attributes_per_span(16)
+//!                 .with_max_events_per_span(16)
+//!                 .with_resource(Resource::new(vec![KeyValue::new("key", "value")])),
+//!         )
+//!         .install()?;
+//!
+//!     tracer.in_span("doing_work", |cx| {
+//!         // Traced app logic here...
+//!     });
+//!
+//!     Ok(())
+//! }
+//! ```
+#![deny(missing_docs, unreachable_pub, missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
+use opentelemetry::{api::TracerProvider, global, sdk};
+use std::collections::HashMap;
+use std::error::Error;
+use std::time::Duration;
+
+#[allow(clippy::all, unreachable_pub, dead_code)]
+#[rustfmt::skip]
 mod proto;
 mod span;
 mod transform;
 
 pub use crate::span::{Compression, Credentials, Exporter, ExporterConfig, Protocol};
+
+/// Create a new pipeline builder with the recommended configuration.
+///
+/// ## Examples
+///
+/// ```no_run
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let tracer = opentelemetry_otlp::new_pipeline().install()?;
+///
+///     Ok(())
+/// }
+/// ```
+pub fn new_pipeline() -> OtlpPipelineBuilder {
+    OtlpPipelineBuilder::default()
+}
+
+/// Recommended configuration for an Otlp exporter pipeline.
+///
+/// ## Examples
+///
+/// ```no_run
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let tracer = opentelemetry_otlp::new_pipeline().install()?;
+///
+///     Ok(())
+/// }
+/// ```
+#[derive(Default, Debug)]
+pub struct OtlpPipelineBuilder {
+    exporter_config: ExporterConfig,
+    trace_config: Option<sdk::Config>,
+}
+
+impl OtlpPipelineBuilder {
+    /// Set the address of the OTLP collector. If not set, the default address is used.
+    pub fn with_endpoint<T: Into<String>>(mut self, endpoint: T) -> Self {
+        self.exporter_config.endpoint = endpoint.into();
+        self
+    }
+
+    /// Set the protocol to use when communicating with the collector.
+    pub fn with_protocol(mut self, protocol: Protocol) -> Self {
+        self.exporter_config.protocol = protocol;
+        self
+    }
+
+    /// Set the credentials to use when communicating with the collector.
+    pub fn with_credentials(mut self, credentials: Credentials) -> Self {
+        self.exporter_config.credentials = Some(credentials);
+        self
+    }
+
+    /// Set Additional headers to send to the collector.
+    pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.exporter_config.headers = Some(headers);
+        self
+    }
+
+    /// Set the compression algorithm to use when communicating with the collector.
+    pub fn with_compression(mut self, compression: Compression) -> Self {
+        self.exporter_config.compression = Some(compression);
+        self
+    }
+
+    /// Set the timeout to the collector.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.exporter_config.timeout = timeout;
+        self
+    }
+
+    /// Set the number of GRPC worker threads to poll queues.
+    pub fn with_completion_queue_count(mut self, count: usize) -> Self {
+        self.exporter_config.completion_queue_count = count;
+        self
+    }
+
+    /// Set the trace provider configuration.
+    pub fn with_trace_config(mut self, trace_config: sdk::Config) -> Self {
+        self.trace_config = Some(trace_config);
+        self
+    }
+
+    /// Install the OTLP exporter pipeline with the recommended defaults.
+    pub fn install(mut self) -> Result<sdk::Tracer, Box<dyn Error>> {
+        let exporter = Exporter::default();
+
+        let mut provider_builder = sdk::TracerProvider::builder().with_exporter(exporter);
+        if let Some(config) = self.trace_config.take() {
+            provider_builder = provider_builder.with_config(config);
+        }
+        let provider = provider_builder.build();
+        let tracer = provider.get_tracer("opentelemetry-otlp", Some(env!("CARGO_PKG_VERSION")));
+        global::set_provider(provider);
+
+        Ok(tracer)
+    }
+}

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -1,4 +1,5 @@
-//! The OTLP Exporter supports exporting trace and metric data in the OTLP format to the OpenTelemetry collector. The OpenTelemetry Collector offers a
+//! The OTLP Exporter supports exporting trace and metric data in the 
+//! OTLP format to the OpenTelemetry collector. The OpenTelemetry Collector offers a
 //! vendor-agnostic implementation on how to receive, process, and export
 //! telemetry data. In addition, it removes the need to run, operate, and
 //! maintain multiple agents/collectors in order to support open-source

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -15,39 +15,55 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
+/// Exporter that sends data in OTLP format.
 pub struct Exporter {
     headers: Option<HashMap<String, String>>,
     timeout: Duration,
     trace_exporter: TraceServiceClient,
 }
 
+/// Configuration for the OTLP exporter.
 #[derive(Debug)]
 pub struct ExporterConfig {
+    /// The address of the OTLP collector. If not set, the default address is used.
     pub endpoint: String,
+    /// The protocol to use when communicating with the collector.
     pub protocol: Protocol,
+    /// The credentials to use when communicating with the collector.
     pub credentials: Option<Credentials>,
+    /// Additional headers to send to the collector.
     pub headers: Option<HashMap<String, String>>,
+    /// The compression algorithm to use when communicating with the collector.
     pub compression: Option<Compression>,
+    /// The timeout to the collector.
     pub timeout: Duration,
+    /// The number of GRPC worker threads to poll queues.
     pub completion_queue_count: usize,
 }
 
+/// Credential configuration for authenticated requests.
 #[derive(Debug)]
 pub struct Credentials {
+    /// Credential cert
     pub cert: String,
+    /// Credential key
     pub key: String,
 }
 
+/// The communication protocol to use when sending data.
 #[derive(Clone, Copy, Debug)]
 pub enum Protocol {
+    /// GRPC protocol
     Grpc,
     // TODO add support for other protocols
     // HttpJson,
     // HttpProto,
 }
 
+/// The compression algorithm to use when sending data.
 #[derive(Clone, Copy, Debug)]
 pub enum Compression {
+    /// Compresses data using gzip.
     Gzip,
 }
 
@@ -93,8 +109,9 @@ impl Default for Exporter {
 impl Debug for Exporter {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Exporter")
-            .field("metrics_exporter", &String::from("MetricsServiceClient"))
-            .field("trace_exporter", &String::from("TraceServiceClient"))
+            .field("headers", &self.headers)
+            .field("timeout", &self.timeout)
+            .field("trace_exporter", &"TraceServiceClient")
             .finish()
     }
 }
@@ -154,7 +171,4 @@ impl SpanExporter for Exporter {
             Err(_) => FailedNotRetryable,
         }
     }
-
-    /// Unimplemented for now. Channel will shutdown on drop
-    fn shutdown(&self) {}
 }

--- a/src/api/baggage/propagation.rs
+++ b/src/api/baggage/propagation.rs
@@ -92,7 +92,6 @@ impl api::TextMapFormat for BaggagePropagator {
     }
 }
 
-
 /// Methods for sorting and retrieving baggage data in a context.
 pub trait BaggageExt {
     /// Returns a clone of the current context with the included name / value pairs.
@@ -167,8 +166,7 @@ impl BaggageExt for Context {
     }
 
     fn baggage(&self) -> &Baggage {
-        self.get::<Baggage>()
-            .unwrap_or_else(|| &DEFAULT_BAGGAGE)
+        self.get::<Baggage>().unwrap_or_else(|| &DEFAULT_BAGGAGE)
     }
 }
 
@@ -243,10 +241,7 @@ mod tests {
 
         for (header_value, kvs) in valid_extract_data() {
             let mut extractor: HashMap<String, String> = HashMap::new();
-            extractor.insert(
-                BAGGAGE_HEADER.to_string(),
-                header_value.to_string(),
-            );
+            extractor.insert(BAGGAGE_HEADER.to_string(), header_value.to_string());
             let context = propagator.extract(&extractor);
             let baggage = context.baggage();
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,10 +13,10 @@
 //! In order to enable telemetry the application must take a dependency on the OpenTelemetry SDK,
 //! which implements the delivery of the telemetry. The application must also configure exporters
 //! so that the SDK knows where and how to deliver the telemetry.
-pub mod context;
-pub mod core;
 #[cfg(feature = "trace")]
 pub mod baggage;
+pub mod context;
+pub mod core;
 pub mod labels;
 #[cfg(feature = "metrics")]
 pub mod metrics;
@@ -25,13 +25,13 @@ pub mod trace;
 
 pub use self::core::{Key, KeyValue, Unit, Value};
 #[cfg(feature = "trace")]
+pub use baggage::{Baggage, BaggageExt, BaggagePropagator};
+#[cfg(feature = "trace")]
 pub use context::propagation::{
     composite_propagator::TextMapCompositePropagator, text_propagator::FieldIter,
     text_propagator::TextMapFormat, Extractor, Injector,
 };
 pub use context::Context;
-#[cfg(feature = "trace")]
-pub use baggage::{Baggage, BaggageExt, BaggagePropagator};
 
 #[cfg(feature = "trace")]
 pub use trace::{

--- a/src/sdk/trace/config.rs
+++ b/src/sdk/trace/config.rs
@@ -5,6 +5,11 @@
 use crate::{api, sdk};
 use std::sync::Arc;
 
+/// Default trace configuration
+pub fn config() -> Config {
+    Config::default()
+}
+
 /// Tracer configuration
 #[derive(Debug)]
 pub struct Config {
@@ -20,6 +25,44 @@ pub struct Config {
     pub max_links_per_span: u32,
     /// Contains attributes representing an entity that produces telemetry.
     pub resource: Arc<sdk::Resource>,
+}
+
+impl Config {
+    /// Specify the default sampler to be used.
+    pub fn with_default_sampler<T: sdk::ShouldSample + 'static>(mut self, sampler: T) -> Self {
+        self.default_sampler = Box::new(sampler);
+        self
+    }
+
+    /// Specify the id generator to be used.
+    pub fn with_id_generator<T: api::IdGenerator + 'static>(mut self, id_generator: T) -> Self {
+        self.id_generator = Box::new(id_generator);
+        self
+    }
+
+    /// Specify the number of events to be recorded per span.
+    pub fn with_max_events_per_span(mut self, max_events: u32) -> Self {
+        self.max_events_per_span = max_events;
+        self
+    }
+
+    /// Specify the number of attributes to be recorded per span.
+    pub fn with_max_attributes_per_span(mut self, max_attributes: u32) -> Self {
+        self.max_attributes_per_span = max_attributes;
+        self
+    }
+
+    /// Specify the number of events to be recorded per span.
+    pub fn with_max_links_per_span(mut self, max_links: u32) -> Self {
+        self.max_links_per_span = max_links;
+        self
+    }
+
+    /// Specify the attributes representing the entity that produces telemetry
+    pub fn with_resource(mut self, resource: sdk::Resource) -> Self {
+        self.resource = Arc::new(resource);
+        self
+    }
 }
 
 impl Default for Config {

--- a/src/sdk/trace/mod.rs
+++ b/src/sdk/trace/mod.rs
@@ -15,3 +15,5 @@ pub mod sampler;
 pub mod span;
 pub mod span_processor;
 pub mod tracer;
+
+pub use config::config;


### PR DESCRIPTION
This change adds a pipeline builder to `opentelemetry-otlp`. It simplifies recommended configuration and adds documentation to help people get started quickly. Simple example:

```rust
use opentelemetry::api::Tracer;

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let tracer = opentelemetry_otlp::new_pipeline().install()?;

    tracer.in_span("doing_work", |cx| {
        // Traced app logic here...
    });

    Ok(())
}
```

A builder style pattern is also added to the sdk trace `Config` to allow for a consistent configuration in the full kitchen sink example added to the docs as well.

The `tokio` and `async-std` optional features are moved to `opentelemetry` from `opentelemetry-jaeger` to avoid duplicating the logic in `opentelemetry-otlp`. This allows trace provider builders to have a `with_exporter` that can be a batch exporter or simple exporter depending on the specified feature.