### PR TITLE
Add TraceState to SpanContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ lazy_static = "1.4"
 percent-encoding = "2.0"
 pin-project = { version = "0.4", optional = true }
 rand = { version = "0.7", optional = true }
+regex = "1.3.9"
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 http = { version = "0.2", optional = true }
 thiserror = { version = "1.0", optional = true }

--- a/opentelemetry-contrib/src/trace_propagator/aws_xray_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/aws_xray_propagator.rs
@@ -116,22 +116,24 @@ impl TextMapFormat for XrayTraceContextPropagator {
                 NOT_SAMPLED
             };
 
-            let mut trace_state_header: String =
-                span_context.trace_state().header_delimited("=", ";");
-            if !trace_state_header.is_empty() {
-                trace_state_header = format!(";{}", trace_state_header);
-            }
+            let trace_state_header: String = span_context.trace_state().header_delimited("=", ";");
+            let trace_state_prefix = if trace_state_header.is_empty() {
+                ""
+            } else {
+                ";"
+            };
 
             injector.set(
                 AWS_XRAY_TRACE_HEADER,
                 format!(
-                    "{}={};{}={};{}={}{}",
+                    "{}={};{}={};{}={}{}{}",
                     HEADER_ROOT_KEY,
                     xray_trace_id.0,
                     HEADER_PARENT_KEY,
                     span_context.span_id().to_hex(),
                     HEADER_SAMPLED_KEY,
                     sampling_decision,
+                    trace_state_prefix,
                     trace_state_header
                 ),
             );

--- a/opentelemetry-contrib/src/trace_propagator/aws_xray_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/aws_xray_propagator.rs
@@ -1,7 +1,7 @@
 use opentelemetry::api::trace::span_context::TraceState;
 use opentelemetry::api::{
-    Context, Extractor, FieldIter, Injector, KeyValue, SpanContext, SpanId, TextMapFormat,
-    TraceContextExt, TraceId, TRACE_FLAG_DEFERRED, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
+    Context, Extractor, FieldIter, Injector, SpanContext, SpanId, TextMapFormat, TraceContextExt,
+    TraceId, TRACE_FLAG_DEFERRED, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
 };
 
 const AWS_XRAY_TRACE_HEADER: &str = "x-amzn-trace-id";
@@ -59,7 +59,7 @@ impl XrayTraceContextPropagator {
         let mut trace_id: TraceId = TraceId::invalid();
         let mut parent_segment_id: SpanId = SpanId::invalid();
         let mut sampling_decision: u8 = TRACE_FLAG_DEFERRED;
-        let mut kv_vec: Vec<KeyValue> = Vec::with_capacity(parts.len());
+        let mut kv_vec: Vec<(String, String)> = Vec::with_capacity(parts.len());
 
         for (key, value) in parts {
             match key {
@@ -80,7 +80,7 @@ impl XrayTraceContextPropagator {
                         _ => TRACE_FLAG_DEFERRED,
                     }
                 }
-                _ => kv_vec.push(KeyValue::new(key.to_string(), value.to_string())),
+                _ => kv_vec.push((key.to_string(), value.to_string())),
             }
         }
 

--- a/opentelemetry-contrib/src/trace_propagator/aws_xray_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/aws_xray_propagator.rs
@@ -84,7 +84,7 @@ impl XrayTraceContextPropagator {
             }
         }
 
-        let trace_state: TraceState = TraceState::from_key_value(kv_vec);
+        let trace_state: TraceState = TraceState::from_key_value(kv_vec)?;
 
         if trace_id.to_u128() == 0 {
             return Err(());

--- a/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
@@ -6,13 +6,15 @@
 //!
 //! [`Jaeger documentation`]: https://www.jaegertracing.io/docs/1.18/client-libraries/#propagation-format
 
+use opentelemetry::api::trace::span_context::TraceState;
 use opentelemetry::api::{
-    Context, Extractor, FieldIter, Injector, SpanContext, SpanId, TextMapFormat, TraceContextExt,
-    TraceId, TRACE_FLAG_DEBUG, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
+    Context, Extractor, FieldIter, Injector, KeyValue, SpanContext, SpanId, TextMapFormat,
+    TraceContextExt, TraceId, TRACE_FLAG_DEBUG, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
 };
 use std::str::FromStr;
 
 const JAEGER_HEADER: &str = "uber-trace-id";
+const JAEGER_BAGGAGE_PREFIX: &str = "uberctx-";
 const DEPRECATED_PARENT_SPAN: &str = "0";
 
 lazy_static::lazy_static! {
@@ -44,7 +46,13 @@ impl JaegerPropagator {
     }
 
     /// Extract span context from header value
-    fn extract_span_context(&self, header_value: &str) -> Result<SpanContext, ()> {
+    fn extract_span_context(&self, extractor: &dyn Extractor) -> Result<SpanContext, ()> {
+        let mut header_value: String = extractor.get(JAEGER_HEADER).unwrap_or("").to_string();
+        // if there is no :, it means header_value could be encoded as url, try decode first
+        if !header_value.contains(':') {
+            header_value = header_value.replace("%3A", ":");
+        }
+
         let parts = header_value.split_terminator(':').collect::<Vec<&str>>();
         if parts.len() != 4 {
             return Err(());
@@ -55,8 +63,9 @@ impl JaegerPropagator {
         let span_id = self.extract_span_id(parts[1])?;
         // Ignore parent span id since it's deprecated.
         let flag = self.extract_flag(parts[3])?;
+        let trace_state = self.extract_trace_state(extractor)?;
 
-        Ok(SpanContext::new(trace_id, span_id, flag, true))
+        Ok(SpanContext::new(trace_id, span_id, flag, true, trace_state))
     }
 
     /// Extract trace id from the header.
@@ -107,6 +116,24 @@ impl JaegerPropagator {
             Ok(TRACE_FLAG_NOT_SAMPLED)
         }
     }
+
+    fn extract_trace_state(&self, extractor: &dyn Extractor) -> Result<TraceState, ()> {
+        let uber_context_keys: Vec<&str> = extractor
+            .keys()
+            .into_iter()
+            .filter(|key| key.starts_with(JAEGER_BAGGAGE_PREFIX))
+            .collect();
+
+        let mut kv: Vec<KeyValue> = Vec::with_capacity(uber_context_keys.len());
+
+        for key in uber_context_keys {
+            if let Some(value) = extractor.get(key) {
+                kv.push(KeyValue::new(key.to_string(), value.to_string()));
+            }
+        }
+
+        Ok(TraceState::from_key_value(kv))
+    }
 }
 
 impl TextMapFormat for JaegerPropagator {
@@ -134,14 +161,10 @@ impl TextMapFormat for JaegerPropagator {
     }
 
     fn extract_with_context(&self, cx: &Context, extractor: &dyn Extractor) -> Context {
-        let header_value = extractor.get(JAEGER_HEADER).unwrap_or("");
-        // if there is no :, it means header_value could be encoded as url, try decode first
-        let extract_result = if !header_value.contains(':') {
-            self.extract_span_context(header_value.replace("%3A", ":").as_str())
-        } else {
-            self.extract_span_context(header_value)
-        };
-        cx.with_remote_span_context(extract_result.unwrap_or_else(|_| SpanContext::empty_context()))
+        cx.with_remote_span_context(
+            self.extract_span_context(extractor)
+                .unwrap_or_else(|_| SpanContext::empty_context()),
+        )
     }
 
     fn fields(&self) -> FieldIter {
@@ -153,6 +176,7 @@ impl TextMapFormat for JaegerPropagator {
 mod tests {
     use crate::trace_propagator::jaeger_propagator::{JaegerPropagator, JAEGER_HEADER};
     use opentelemetry::api;
+    use opentelemetry::api::trace::span_context::TraceState;
     use opentelemetry::api::{
         Context, Injector, Span, SpanContext, SpanId, TextMapFormat, TraceContextExt, TraceId,
         TRACE_FLAG_DEBUG, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
@@ -177,6 +201,7 @@ mod tests {
                     SpanId::from_u64(SPAN_ID),
                     TRACE_FLAG_SAMPLED,
                     true,
+                    TraceState::default(),
                 ),
             ),
             (
@@ -188,6 +213,7 @@ mod tests {
                     SpanId::from_u64(SPAN_ID),
                     TRACE_FLAG_SAMPLED,
                     true,
+                    TraceState::default(),
                 ),
             ),
             (
@@ -199,6 +225,7 @@ mod tests {
                     SpanId::from_u64(SPAN_ID),
                     TRACE_FLAG_DEBUG | TRACE_FLAG_SAMPLED,
                     true,
+                    TraceState::default(),
                 ),
             ),
             (
@@ -210,6 +237,7 @@ mod tests {
                     SpanId::from_u64(SPAN_ID),
                     TRACE_FLAG_NOT_SAMPLED,
                     true,
+                    TraceState::default(),
                 ),
             ),
             (
@@ -241,6 +269,7 @@ mod tests {
                     SpanId::from_u64(SPAN_ID),
                     TRACE_FLAG_SAMPLED,
                     true,
+                    TraceState::default(),
                 ),
                 format!("{}:{}:0:1", LONG_TRACE_ID_STR, SPAN_ID_STR),
             ),
@@ -250,6 +279,7 @@ mod tests {
                     SpanId::from_u64(SPAN_ID),
                     TRACE_FLAG_NOT_SAMPLED,
                     true,
+                    TraceState::default(),
                 ),
                 format!("{}:{}:0:0", LONG_TRACE_ID_STR, SPAN_ID_STR),
             ),
@@ -259,6 +289,7 @@ mod tests {
                     SpanId::from_u64(SPAN_ID),
                     TRACE_FLAG_DEBUG | TRACE_FLAG_SAMPLED,
                     true,
+                    TraceState::default(),
                 ),
                 format!("{}:{}:0:3", LONG_TRACE_ID_STR, SPAN_ID_STR),
             ),
@@ -335,7 +366,8 @@ mod tests {
                 TraceId::from_u128(TRACE_ID),
                 SpanId::from_u64(SPAN_ID),
                 1,
-                true
+                true,
+                TraceState::default(),
             ))
         );
     }

--- a/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
@@ -8,8 +8,8 @@
 
 use opentelemetry::api::trace::span_context::TraceState;
 use opentelemetry::api::{
-    Context, Extractor, FieldIter, Injector, KeyValue, SpanContext, SpanId, TextMapFormat,
-    TraceContextExt, TraceId, TRACE_FLAG_DEBUG, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
+    Context, Extractor, FieldIter, Injector, SpanContext, SpanId, TextMapFormat, TraceContextExt,
+    TraceId, TRACE_FLAG_DEBUG, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
 };
 use std::borrow::Cow;
 use std::str::FromStr;
@@ -119,16 +119,15 @@ impl JaegerPropagator {
     }
 
     fn extract_trace_state(&self, extractor: &dyn Extractor) -> Result<TraceState, ()> {
-        let uber_context_keys: Vec<KeyValue> = extractor
+        let uber_context_keys = extractor
             .keys()
             .into_iter()
             .filter(|key| key.starts_with(JAEGER_BAGGAGE_PREFIX))
             .filter_map(|key| {
                 extractor
                     .get(key)
-                    .map(|value| KeyValue::new(key.to_string(), value.to_string()))
-            })
-            .collect();
+                    .map(|value| (key.to_string(), value.to_string()))
+            });
 
         Ok(TraceState::from_key_value(uber_context_keys))
     }

--- a/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
@@ -129,7 +129,7 @@ impl JaegerPropagator {
                     .map(|value| (key.to_string(), value.to_string()))
             });
 
-        Ok(TraceState::from_key_value(uber_context_keys))
+        TraceState::from_key_value(uber_context_keys)
     }
 }
 

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -102,6 +102,7 @@ impl TextMapFormat for TextMapCompositePropagator {
 #[cfg(test)]
 mod tests {
     use crate::api;
+    use crate::api::trace::span_context::TraceState;
     use crate::api::{
         Context, Extractor, FieldIter, Injector, SpanContext, SpanId, TextMapCompositePropagator,
         TextMapFormat, TraceContextExt, TraceContextPropagator, TraceId,
@@ -151,6 +152,7 @@ mod tests {
                         SpanId::from_u64(u64::from_str(parts[1]).unwrap_or(0)),
                         u8::from_str(parts[2]).unwrap_or(0),
                         true,
+                        TraceState::default(),
                     )
                 }
             } else {
@@ -212,6 +214,7 @@ mod tests {
             SpanId::from_u64(1),
             0,
             false,
+            TraceState::default(),
         )));
         let mut injector = HashMap::new();
         composite_propagator.inject_context(&cx, &mut injector);
@@ -242,6 +245,7 @@ mod tests {
                     SpanId::from_u64(1),
                     0,
                     true,
+                    TraceState::default(),
                 ))
             );
         }

--- a/src/api/context/propagation/mod.rs
+++ b/src/api/context/propagation/mod.rs
@@ -247,10 +247,12 @@ impl api::Extractor for tonic::metadata::MetadataMap {
 
     /// Collect all the keys from the MetadataMap.
     fn keys(&self) -> Vec<&str> {
-        self.keys().map(|key| match key {
-            tonic::metadata::KeyRef::Ascii(v) => v.as_str(),
-            tonic::metadata::KeyRef::Binary(v) => v.as_str(),
-        }).collect::<Vec<_>>()
+        self.keys()
+            .map(|key| match key {
+                tonic::metadata::KeyRef::Ascii(v) => v.as_str(),
+                tonic::metadata::KeyRef::Binary(v) => v.as_str(),
+            })
+            .collect::<Vec<_>>()
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -44,7 +44,7 @@ pub use trace::{
     provider::TracerProvider,
     span::{Span, SpanKind, StatusCode},
     span_context::{
-        SpanContext, SpanId, TraceId, TRACE_FLAG_DEBUG, TRACE_FLAG_DEFERRED,
+        SpanContext, SpanId, TraceId, TraceState, TRACE_FLAG_DEBUG, TRACE_FLAG_DEFERRED,
         TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
     },
     span_processor::SpanProcessor,

--- a/src/api/trace/noop.rs
+++ b/src/api/trace/noop.rs
@@ -3,6 +3,7 @@
 //! This implementation is returned as the global tracer if no `Tracer`
 //! has been set. It is also useful for testing purposes as it is intended
 //! to have minimal resource utilization and runtime impact.
+use crate::api::trace::span_context::TraceState;
 use crate::api::TraceContextExt;
 use crate::{api, exporter};
 use std::sync::Arc;
@@ -42,6 +43,7 @@ impl NoopSpan {
                 api::SpanId::invalid(),
                 0,
                 false,
+                TraceState::default(),
             ),
         }
     }
@@ -156,6 +158,7 @@ impl exporter::trace::SpanExporter for NoopSpanExporter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::trace::span_context::TraceState;
     use crate::api::{Span, Tracer};
 
     fn valid_span_context() -> api::SpanContext {
@@ -164,6 +167,7 @@ mod tests {
             api::SpanId::from_u64(42),
             0,
             true,
+            TraceState::default(),
         )
     }
 

--- a/src/api/trace/span_context.rs
+++ b/src/api/trace/span_context.rs
@@ -28,7 +28,7 @@ pub const TRACE_FLAG_DEFERRED: u8 = 0x02;
 pub const TRACE_FLAG_DEBUG: u8 = 0x04;
 
 lazy_static::lazy_static! {
-    static ref TRACE_STATE_KEY: regex::Regex = regex::Regex::new(r#"^[a-zA-Z0-9]+[a-zA-Z0-9|\\_|\\-|\\*|\\/]*$"#).unwrap();
+    static ref TRACE_STATE_KEY: regex::Regex = regex::Regex::new(r#"^[a-z0-9]+[a-z0-9|\\_|\\-|\\*|\\/]*$"#).unwrap();
 }
 
 /// TraceId is an 16-byte value which uniquely identifies a given trace

--- a/src/api/trace/span_context.rs
+++ b/src/api/trace/span_context.rs
@@ -175,17 +175,22 @@ impl TraceState {
     /// Creates a new `TraceState` header string, delimiting each key and value with a `=` and each
     /// entry with a `,`.
     pub fn header(&self) -> String {
+        self.header_delimited("=", ",")
+    }
+
+    /// Creates a new `TraceState` header string, with the given key/value delimiter and entry delimiter.
+    pub fn header_delimited(&self, entry_delimiter: &str, list_delimiter: &str) -> String {
         let mut ordered: Vec<String> = Vec::with_capacity(self.ordered_keys.len());
         for key in self.ordered_keys.clone() {
             ordered.push(format!(
                 "{}{}{}",
                 key,
-                "=",
+                entry_delimiter,
                 self.data.get(key.as_str()).cloned().unwrap()
             ))
         }
 
-        ordered.join(",")
+        ordered.join(list_delimiter)
     }
 }
 

--- a/src/api/trace/span_context.rs
+++ b/src/api/trace/span_context.rs
@@ -154,9 +154,9 @@ impl TraceState {
     }
 
     /// Retrieves a value for a given key from the `TraceState` if it exists.
-    pub fn get(&self, key: String) -> Option<&str> {
+    pub fn get(&self, key: &str) -> Option<&str> {
         self.ordered_data.iter().find_map(|item| {
-            if item.0.as_str() == key.as_str() {
+            if item.0.as_str() == key {
                 Some(item.1.as_str())
             } else {
                 None
@@ -369,11 +369,7 @@ mod tests {
         for test_case in trace_state_test_data() {
             assert_eq!(test_case.0.clone().header(), test_case.1);
 
-            let new_key = format!(
-                "{}-{}",
-                test_case.0.get(test_case.2.to_string()).unwrap(),
-                "test"
-            );
+            let new_key = format!("{}-{}", test_case.0.get(test_case.2).unwrap(), "test");
 
             let updated_trace_state = test_case.0.insert(test_case.2.into(), new_key.clone());
 
@@ -386,7 +382,7 @@ mod tests {
 
             let deleted_trace_state = updated_trace_state.delete(test_case.2.to_string());
 
-            assert!(deleted_trace_state.get(test_case.2.to_string()).is_none());
+            assert!(deleted_trace_state.get(test_case.2).is_none());
         }
     }
 }

--- a/src/api/trace/span_context.rs
+++ b/src/api/trace/span_context.rs
@@ -301,8 +301,8 @@ impl SpanContext {
     }
 
     /// Returns the context's `TraceState`.
-    pub fn trace_state(&self) -> TraceState {
-        self.trace_state.clone()
+    pub fn trace_state(&self) -> &TraceState {
+        &self.trace_state
     }
 }
 

--- a/src/api/trace/span_context.rs
+++ b/src/api/trace/span_context.rs
@@ -128,6 +128,17 @@ pub struct TraceState {
 
 impl TraceState {
     /// Creates a new `TraceState` from the given key-value collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use opentelemetry::api;
+    ///
+    /// let kvs = vec![("foo", "bar"), ("apple", "banana")];
+    /// let trace_state: api::TraceState = api::TraceState::from_key_value(kvs);
+    ///
+    /// assert_eq!(trace_state.header(), String::from("foo=bar,apple=banana"))
+    /// ```
     pub fn from_key_value<T, K, V>(trace_state: T) -> Self
     where
         T: IntoIterator<Item = (K, V)>,

--- a/src/api/trace/trace_context_propagator.rs
+++ b/src/api/trace/trace_context_propagator.rs
@@ -157,7 +157,7 @@ mod tests {
     use std::str::FromStr;
 
     #[rustfmt::skip]
-    fn  extract_data() -> Vec<(&'static str, &'static str, api::SpanContext)> {
+    fn extract_data() -> Vec<(&'static str, &'static str, api::SpanContext)> {
         vec![
             ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00", "foo=bar", api::SpanContext::new(api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 0, true, TraceState::from_str("foo=bar").unwrap())),
             ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", "foo=bar", api::SpanContext::new(api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true, TraceState::from_str("foo=bar").unwrap())),

--- a/src/experimental/api/context/propagation/base64_format.rs
+++ b/src/experimental/api/context/propagation/base64_format.rs
@@ -42,18 +42,19 @@ where
 mod tests {
     use super::super::binary_propagator::BinaryPropagator;
     use super::*;
+    use crate::api::trace::span_context::TraceState;
 
     #[rustfmt::skip]
     fn to_base64_data() -> Vec<(api::SpanContext, String)> {
         vec![
             (api::SpanContext::new(
                 api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736),
-                api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true),
+                api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true, TraceState::default()),
                 "AABL+S81d7NNpqPOkp0ODkc2AQDwZ6oLqQK3AgE=".to_string()
             ),
             (api::SpanContext::new(
                 api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736),
-                api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 0, true),
+                api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 0, true, TraceState::default()),
                 "AABL+S81d7NNpqPOkp0ODkc2AQDwZ6oLqQK3AgA=".to_string()
             ),
         ]

--- a/src/exporter/trace/mod.rs
+++ b/src/exporter/trace/mod.rs
@@ -91,6 +91,7 @@ pub struct SpanData {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::trace::span_context::TraceState;
 
     #[test]
     fn test_serialise() {
@@ -104,6 +105,7 @@ mod tests {
             api::SpanId::from_u64(span_id),
             trace_flags,
             remote,
+            TraceState::default(),
         );
 
         let parent_span_id = 1;

--- a/src/sdk/trace/sampler.rs
+++ b/src/sdk/trace/sampler.rs
@@ -149,6 +149,7 @@ impl ShouldSample for Sampler {
 #[cfg(test)]
 mod tests {
     use crate::api;
+    use crate::api::trace::span_context::TraceState;
     use crate::sdk::{Sampler, SamplingDecision, ShouldSample};
     use rand::Rng;
 
@@ -216,6 +217,7 @@ mod tests {
                         api::SpanId::from_u64(1),
                         trace_flags,
                         false,
+                        TraceState::default(),
                     ))
                 } else {
                     None

--- a/src/sdk/trace/span.rs
+++ b/src/sdk/trace/span.rs
@@ -8,6 +8,7 @@
 //! start time is set to the current time on span creation. After the `Span` is created, it
 //! is possible to change its name, set its `Attributes`, and add `Links` and `Events`.
 //! These cannot be changed after the `Span`'s end time has been set.
+use crate::api::trace::span_context::TraceState;
 use crate::{api, exporter, sdk};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
@@ -86,7 +87,13 @@ impl api::Span for Span {
     fn span_context(&self) -> api::SpanContext {
         self.with_data(|data| data.span_context.clone())
             .unwrap_or_else(|| {
-                api::SpanContext::new(api::TraceId::invalid(), api::SpanId::invalid(), 0, false)
+                api::SpanContext::new(
+                    api::TraceId::invalid(),
+                    api::SpanId::invalid(),
+                    0,
+                    false,
+                    TraceState::default(),
+                )
             })
     }
 

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -166,7 +166,7 @@ impl api::Tracer for Tracer {
                         ctx.span_id(),
                         ctx.is_remote(),
                         ctx.trace_flags(),
-                        ctx.trace_state(),
+                        ctx.trace_state().clone(),
                     )
                 })
                 .unwrap_or((


### PR DESCRIPTION
Resolves #211 

Adds `TraceState` to `SpanContext` and gives `TraceState` new methods per [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracestate).