### PR TITLE
Add datadog exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "examples/aws-xray",
     "examples/basic",
     "examples/basic-otlp",
+    "examples/datadog",
     "examples/grpc",
     "examples/http",
     "examples/zipkin",

--- a/benches/ddsketch.rs
+++ b/benches/ddsketch.rs
@@ -1,12 +1,8 @@
-use criterion::{
-    criterion_group, criterion_main, Criterion
-};
+use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::api::metrics::{InstrumentKind, Number, NumberKind};
 use opentelemetry::sdk::export::metrics::Aggregator;
 use opentelemetry::{
-    api::{
-        metrics::Descriptor,
-    },
+    api::metrics::Descriptor,
     sdk::{
         export::metrics::Quantile,
         metrics::aggregators::{ArrayAggregator, DDSKetchAggregator},
@@ -40,7 +36,9 @@ fn ddsketch(data: Vec<f64>) {
     }
     let new_aggregator: Arc<(dyn Aggregator + Send + Sync)> =
         Arc::new(DDSKetchAggregator::new(0.001, 2048, 1e-9, NumberKind::F64));
-    aggregator.synchronized_move(&new_aggregator, &descriptor).unwrap();
+    aggregator
+        .synchronized_move(&new_aggregator, &descriptor)
+        .unwrap();
     for quantile in get_test_quantile() {
         if let Some(new_aggregator) = new_aggregator.as_any().downcast_ref::<DDSKetchAggregator>() {
             let _ = new_aggregator.quantile(*quantile);
@@ -60,7 +58,9 @@ fn array(data: Vec<f64>) {
         aggregator.update(&Number::from(f), &descriptor).unwrap();
     }
     let new_aggregator: Arc<(dyn Aggregator + Send + Sync)> = Arc::new(ArrayAggregator::default());
-    aggregator.synchronized_move(&new_aggregator, &descriptor).unwrap();
+    aggregator
+        .synchronized_move(&new_aggregator, &descriptor)
+        .unwrap();
     for quantile in get_test_quantile() {
         if let Some(new_aggregator) = new_aggregator.as_any().downcast_ref::<ArrayAggregator>() {
             let _ = new_aggregator.quantile(*quantile);

--- a/examples/datadog/Cargo.toml
+++ b/examples/datadog/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "datadog"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+opentelemetry = { path = "../../" }
+opentelemetry-contrib = { path = "../../opentelemetry-contrib", features = ["datadog"] }

--- a/examples/datadog/README.md
+++ b/examples/datadog/README.md
@@ -1,0 +1,15 @@
+# Datadog Exporter Example
+
+Sends spans to a datadog-agent collector.
+
+## Usage 
+
+First run version 7.22.0 or above of the datadog-agent locally as described [here](https://docs.datadoghq.com/agent/)
+
+Then run the example to report spans:
+
+```shell
+$ cargo run
+```
+
+Traces should appear in the datadog APM dashboard

--- a/examples/datadog/src/main.rs
+++ b/examples/datadog/src/main.rs
@@ -1,0 +1,35 @@
+use opentelemetry::api::{Key, Span, TraceContextExt, Tracer};
+use opentelemetry::global;
+use std::thread;
+use std::time::Duration;
+use opentelemetry_contrib::datadog::ApiVersion;
+
+fn bar() {
+    let tracer = global::tracer("component-bar");
+    let span = tracer.start("bar");
+    span.set_attribute(Key::new("span.type").string("sql"));
+    span.set_attribute(Key::new("sql.query").string("SELECT * FROM table"));
+    thread::sleep(Duration::from_millis(6));
+    span.end()
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tracer = opentelemetry_contrib::datadog::new_pipeline()
+        .with_service_name("trace-demo")
+        .with_version(ApiVersion::Version05)
+        .install()?;
+
+    tracer.in_span("foo", |cx| {
+        let span = cx.span();
+        span.set_attribute(Key::new("span.type").string("web"));
+        span.set_attribute(Key::new("http.url").string("http://localhost:8080/foo"));
+        span.set_attribute(Key::new("http.method").string("GET"));
+        span.set_attribute(Key::new("http.status_code").i64(200));
+
+        thread::sleep(Duration::from_millis(6));
+        bar();
+        thread::sleep(Duration::from_millis(6));
+    });
+
+    Ok(())
+}

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -16,6 +16,16 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+datadog = ["indexmap", "reqwest", "rmp"]
+
 [dependencies]
+indexmap = { version = "1.6.0", optional = true }
 opentelemetry = { version = "0.8.0", path = ".." }
+reqwest = { version = "0.10", features = ["blocking"], optional = true }
+rmp = { version = "0.8", optional = true }
 lazy_static = "1.4"
+
+[dev-dependencies]
+base64 = "0.12.3"

--- a/opentelemetry-contrib/src/datadog/intern.rs
+++ b/opentelemetry-contrib/src/datadog/intern.rs
@@ -1,0 +1,53 @@
+use indexmap::set::IndexSet;
+
+pub(crate) struct StringInterner {
+    data: IndexSet<String>,
+}
+
+impl StringInterner {
+    pub(crate) fn new() -> StringInterner {
+        StringInterner {
+            data: Default::default(),
+        }
+    }
+
+    pub(crate) fn intern(&mut self, data: &str) -> u32 {
+        if let Some(idx) = self.data.get_index_of(data) {
+            return idx as u32;
+        }
+        self.data.insert_full(data.to_string()).0 as u32
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &String> {
+        self.data.iter()
+    }
+
+    pub(crate) fn len(&self) -> u32 {
+        self.data.len() as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_intern() {
+        let a = "a".to_string();
+        let b = "b";
+        let c = "c";
+
+        let mut intern = StringInterner::new();
+        let a_idx = intern.intern(a.as_str());
+        let b_idx = intern.intern(b);
+        let c_idx = intern.intern(c);
+        let d_idx = intern.intern(a.as_str());
+        let e_idx = intern.intern(c);
+
+        assert_eq!(a_idx, 0);
+        assert_eq!(b_idx, 1);
+        assert_eq!(c_idx, 2);
+        assert_eq!(d_idx, a_idx);
+        assert_eq!(e_idx, c_idx);
+    }
+}

--- a/opentelemetry-contrib/src/datadog/mod.rs
+++ b/opentelemetry-contrib/src/datadog/mod.rs
@@ -1,0 +1,213 @@
+//! # OpenTelemetry Datadog Exporter
+//!
+//! An OpenTelemetry exporter implementation
+//!
+//! See the [Datadog Docs](https://docs.datadoghq.com/agent/) for information on how to run the datadog-agent
+//!
+//! ## Quirks
+//!
+//! There are currently some incompatibilities between Datadog and OpenTelemetry, and this manifests
+//! as minor quirks to this exporter.
+//!
+//! Firstly Datadog uses operation_name to describe what OpenTracing would call a component.
+//! Or to put it another way, in OpenTracing the operation / span name's are relatively
+//! granular and might be used to identify a specific endpoint. In datadog, however, they
+//! are less granular - it is expected in Datadog that a service will have single
+//! primary span name that is the root of all traces within that service, with an additional piece of
+//! metadata called resource_name providing granularity - https://docs.datadoghq.com/tracing/guide/configuring-primary-operation/
+//!
+//! The Datadog Golang API takes the approach of using a `resource.name` OpenTelemetry attribute to set the
+//! resource_name - https://github.com/DataDog/dd-trace-go/blob/ecb0b805ef25b00888a2fb62d465a5aa95e7301e/ddtrace/opentracer/tracer.go#L10
+//!
+//! Unfortunately, this breaks compatibility with other OpenTelemetry exporters which expect
+//! a more granular operation name - as per the OpenTracing specification.
+//!
+//! This exporter therefore takes a different approach of naming the span with the name of the
+//! tracing provider, and using the span name to set the resource_name. This should in most cases
+//! lead to the behaviour that users expect.
+//!
+//! Datadog additionally has a span_type string that alters the rendering of the spans in the web UI.
+//! This can be set as the `span.type` OpenTelemetry span attribute.
+//!
+//! For standard values see here - https://github.com/DataDog/dd-trace-go/blob/ecb0b805ef25b00888a2fb62d465a5aa95e7301e/ddtrace/ext/app_types.go#L31
+//!
+//! ## Performance
+//!
+//! For optimal performance, a batch exporter is recommended as the simple
+//! exporter will export each span synchronously on drop. You can enable the
+//! [`tokio`] or [`async-std`] features to have a batch exporter configured for
+//! you automatically for either executor when you install the pipeline.
+//!
+//! ```toml
+//! [dependencies]
+//! opentelemetry = { version = "*", features = ["tokio"] }
+//! opentelemetry-datadog = "*"
+//! ```
+//!
+//! [`tokio`]: https://tokio.rs
+//! [`async-std`]: https://async.rs
+//!
+//! ## Kitchen Sink Full Configuration
+//!
+//! Example showing how to override all configuration options. See the
+//! [`DatadogPipelineBuilder`] docs for details of each option.
+//!
+//! [`DatadogPipelineBuilder`]: struct.DatadogPipelineBuilder.html
+//!
+//! ```no_run
+//! use opentelemetry::api::{KeyValue, Tracer};
+//! use opentelemetry::sdk::{trace, IdGenerator, Resource, Sampler};
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let tracer = opentelemetry_contrib::datadog::new_pipeline()
+//!         .with_service_name("my_app")
+//!         .with_version(opentelemetry_contrib::datadog::ApiVersion::Version05)
+//!         .with_agent_endpoint("http://localhost:8126")
+//!         .with_trace_config(
+//!             trace::config()
+//!                 .with_default_sampler(Sampler::AlwaysOn)
+//!                 .with_id_generator(IdGenerator::default())
+//!         )
+//!         .install()?;
+//!
+//!     tracer.in_span("doing_work", |cx| {
+//!         // Traced app logic here...
+//!     });
+//!
+//!     Ok(())
+//! }
+//! ```
+#![deny(missing_docs, unreachable_pub, missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
+
+mod intern;
+mod model;
+
+pub use model::ApiVersion;
+
+use opentelemetry::{api::TracerProvider, exporter::trace, global, sdk};
+use reqwest::header::CONTENT_TYPE;
+use reqwest::Url;
+use std::error::Error;
+use std::sync::Arc;
+
+/// Default Datadog collector endpoint
+const DEFAULT_AGENT_ENDPOINT: &str = "http://127.0.0.1:8126";
+
+/// Default service name if no service is configured.
+const DEFAULT_SERVICE_NAME: &str = "OpenTelemetry";
+
+/// Datadog span exporter
+#[derive(Debug)]
+pub struct DatadogExporter {
+    client: reqwest::blocking::Client,
+    request_url: Url,
+    service_name: String,
+    version: ApiVersion,
+}
+
+impl DatadogExporter {
+    fn new(service_name: String, agent_endpoint: Url, version: ApiVersion) -> Self {
+        let mut request_url = agent_endpoint;
+        request_url.set_path(version.path());
+
+        DatadogExporter {
+            client: reqwest::blocking::Client::new(),
+            request_url,
+            service_name,
+            version,
+        }
+    }
+}
+
+/// Create a new Datadog exporter pipeline builder.
+pub fn new_pipeline() -> DatadogPipelineBuilder {
+    DatadogPipelineBuilder::default()
+}
+
+/// Builder for `ExporterConfig` struct.
+#[derive(Debug)]
+pub struct DatadogPipelineBuilder {
+    service_name: String,
+    agent_endpoint: String,
+    trace_config: Option<sdk::Config>,
+    version: ApiVersion,
+}
+
+impl Default for DatadogPipelineBuilder {
+    fn default() -> Self {
+        DatadogPipelineBuilder {
+            service_name: DEFAULT_SERVICE_NAME.to_string(),
+            agent_endpoint: DEFAULT_AGENT_ENDPOINT.to_string(),
+            trace_config: None,
+            version: ApiVersion::Version05,
+        }
+    }
+}
+
+impl DatadogPipelineBuilder {
+    /// Create `ExporterConfig` struct from current `ExporterConfigBuilder`
+    pub fn install(mut self) -> Result<sdk::Tracer, Box<dyn Error>> {
+        let exporter = DatadogExporter::new(
+            self.service_name.clone(),
+            self.agent_endpoint.parse()?,
+            self.version,
+        );
+
+        let mut provider_builder = sdk::TracerProvider::builder().with_exporter(exporter);
+        if let Some(config) = self.trace_config.take() {
+            provider_builder = provider_builder.with_config(config);
+        }
+        let provider = provider_builder.build();
+        let tracer = provider.get_tracer("opentelemetry-datadog", Some(env!("CARGO_PKG_VERSION")));
+        global::set_provider(provider);
+
+        Ok(tracer)
+    }
+
+    /// Assign the service name under which to group traces
+    pub fn with_service_name<T: Into<String>>(mut self, name: T) -> Self {
+        self.service_name = name.into();
+        self
+    }
+
+    /// Assign the Datadog collector endpoint
+    pub fn with_agent_endpoint<T: Into<String>>(mut self, endpoint: T) -> Self {
+        self.agent_endpoint = endpoint.into();
+        self
+    }
+
+    /// Assign the SDK trace configuration
+    pub fn with_trace_config(mut self, config: sdk::Config) -> Self {
+        self.trace_config = Some(config);
+        self
+    }
+
+    /// Set version of Datadog trace ingestion API
+    pub fn with_version(mut self, version: ApiVersion) -> Self {
+        self.version = version;
+        self
+    }
+}
+
+impl trace::SpanExporter for DatadogExporter {
+    /// Export spans to datadog-agent
+    fn export(&self, batch: Vec<Arc<trace::SpanData>>) -> trace::ExportResult {
+        let data = match self.version.encode(&self.service_name, batch) {
+            Ok(data) => data,
+            Err(_) => return trace::ExportResult::FailedNotRetryable,
+        };
+
+        let resp = self
+            .client
+            .post(self.request_url.clone())
+            .header(CONTENT_TYPE, self.version.content_type())
+            .body(data)
+            .send();
+
+        match resp {
+            Ok(response) if response.status().is_success() => trace::ExportResult::Success,
+            _ => trace::ExportResult::FailedRetryable,
+        }
+    }
+}

--- a/opentelemetry-contrib/src/datadog/model/mod.rs
+++ b/opentelemetry-contrib/src/datadog/model/mod.rs
@@ -1,0 +1,134 @@
+use opentelemetry::exporter::trace;
+use std::fmt;
+use std::sync::Arc;
+
+mod v03;
+mod v05;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Error {
+    MessagePackError,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::MessagePackError => write!(f, "message pack error"),
+        }
+    }
+}
+
+impl From<rmp::encode::ValueWriteError> for Error {
+    fn from(_: rmp::encode::ValueWriteError) -> Self {
+        Self::MessagePackError
+    }
+}
+
+/// Version of datadog trace ingestion API
+#[derive(Debug, Copy, Clone)]
+pub enum ApiVersion {
+    /// Version 0.3
+    Version03,
+    /// Version 0.5 - requires datadog-agent v7.22.0 or above
+    Version05,
+}
+
+impl ApiVersion {
+    pub(crate) fn path(self) -> &'static str {
+        match self {
+            ApiVersion::Version03 => "/v0.3/traces",
+            ApiVersion::Version05 => "/v0.5/traces",
+        }
+    }
+
+    pub(crate) fn content_type(self) -> &'static str {
+        match self {
+            ApiVersion::Version03 => "application/msgpack",
+            ApiVersion::Version05 => "application/msgpack",
+        }
+    }
+
+    pub(crate) fn encode(
+        self,
+        service_name: &str,
+        spans: Vec<Arc<trace::SpanData>>,
+    ) -> Result<Vec<u8>, Error> {
+        match self {
+            Self::Version03 => v03::encode(service_name, spans),
+            Self::Version05 => v05::encode(service_name, spans),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::sdk::InstrumentationLibrary;
+    use opentelemetry::{api, sdk};
+    use std::time::{Duration, SystemTime};
+    use opentelemetry::api::Key;
+
+    fn get_spans() -> Vec<Arc<trace::SpanData>> {
+        let parent_span_id = 1;
+        let trace_id = 7;
+        let span_id = 99;
+
+        let span_context = api::SpanContext::new(
+            api::TraceId::from_u128(trace_id),
+            api::SpanId::from_u64(span_id),
+            0,
+            false,
+            api::TraceState::default(),
+        );
+
+        let start_time = SystemTime::UNIX_EPOCH;
+        let end_time = start_time.checked_add(Duration::from_secs(1)).unwrap();
+
+        let capacity = 3;
+        let mut attributes = sdk::EvictedHashMap::new(capacity);
+        attributes.insert(Key::new("span.type").string("web"));
+
+        let message_events = sdk::EvictedQueue::new(capacity);
+        let links = sdk::EvictedQueue::new(capacity);
+
+        let span_data = trace::SpanData {
+            span_context,
+            parent_span_id: api::SpanId::from_u64(parent_span_id),
+            span_kind: api::SpanKind::Client,
+            name: "resource".to_string(),
+            start_time,
+            end_time,
+            attributes,
+            message_events,
+            links,
+            status_code: api::StatusCode::OK,
+            status_message: String::new(),
+            resource: Arc::new(sdk::Resource::default()),
+            instrumentation_lib: InstrumentationLibrary::new("component", None),
+        };
+
+        vec![Arc::new(span_data)]
+    }
+
+    #[test]
+    fn test_encode_v03() -> Result<(), Box<dyn std::error::Error>> {
+        let spans = get_spans();
+        let encoded = base64::encode(ApiVersion::Version03.encode("service_name", spans)?);
+
+        assert_eq!(encoded.as_str(), "kZGLpHR5cGWjd2Vip3NlcnZpY2Wsc2VydmljZV9uYW1lpG5hbWWpY29tcG9uZW50qHJlc291cmNlqHJlc291cmNlqHRyYWNlX2lkzwAAAAAAAAAHp3NwYW5faWTPAAAAAAAAAGOpcGFyZW50X2lkzwAAAAAAAAABpXN0YXJ00wAAAAAAAAAAqGR1cmF0aW9u0wAAAAA7msoApWVycm9y0gAAAACkbWV0YYGpc3Bhbi50eXBlo3dlYg==");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_encode_v05() -> Result<(), Box<dyn std::error::Error>> {
+        let spans = get_spans();
+        let encoded = base64::encode(ApiVersion::Version05.encode("service_name", spans)?);
+
+        assert_eq!(encoded.as_str(), "kpWsc2VydmljZV9uYW1lo3dlYqljb21wb25lbnSocmVzb3VyY2Wpc3Bhbi50eXBlkZGczgAAAADOAAAAAs4AAAADzwAAAAAAAAAHzwAAAAAAAABjzwAAAAAAAAAB0wAAAAAAAAAA0wAAAAA7msoA0gAAAACBzgAAAATOAAAAAYDOAAAAAQ==");
+
+        Ok(())
+    }
+}

--- a/opentelemetry-contrib/src/datadog/model/v03.rs
+++ b/opentelemetry-contrib/src/datadog/model/v03.rs
@@ -1,0 +1,77 @@
+use crate::datadog::model::Error;
+use opentelemetry::exporter::trace;
+use std::sync::Arc;
+use std::time::SystemTime;
+use opentelemetry::api::{Key, Value};
+
+pub(crate) fn encode(
+    service_name: &str,
+    spans: Vec<Arc<trace::SpanData>>,
+) -> Result<Vec<u8>, Error> {
+    let mut encoded = Vec::new();
+    rmp::encode::write_array_len(&mut encoded, spans.len() as u32)?;
+
+    for span in spans.iter() {
+        // API supports but doesn't mandate grouping spans with the same trace ID
+        rmp::encode::write_array_len(&mut encoded, 1)?;
+
+        // Safe until the year 2262 when Datadog will need to change their API
+        let start = span
+            .start_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as i64;
+
+        let duration = span
+            .end_time
+            .duration_since(span.start_time)
+            .map(|x| x.as_nanos() as i64)
+            .unwrap_or(0);
+
+        if let Some(Value::String(s)) = span.attributes.get(&Key::new("span.type")) {
+            rmp::encode::write_map_len(&mut encoded, 11)?;
+            rmp::encode::write_str(&mut encoded, "type")?;
+            rmp::encode::write_str(&mut encoded, s.as_str())?;
+        } else {
+            rmp::encode::write_map_len(&mut encoded, 10)?;
+        }
+
+        // Datadog span name is OpenTelemetry component name - see module docs for more information
+        rmp::encode::write_str(&mut encoded, "service")?;
+        rmp::encode::write_str(&mut encoded, service_name)?;
+
+        rmp::encode::write_str(&mut encoded, "name")?;
+        rmp::encode::write_str(&mut encoded, span.instrumentation_lib.name)?;
+
+        rmp::encode::write_str(&mut encoded, "resource")?;
+        rmp::encode::write_str(&mut encoded, &span.name)?;
+
+        rmp::encode::write_str(&mut encoded, "trace_id")?;
+        rmp::encode::write_u64(&mut encoded, span.span_context.trace_id().to_u128() as u64)?;
+
+        rmp::encode::write_str(&mut encoded, "span_id")?;
+        rmp::encode::write_u64(&mut encoded, span.span_context.span_id().to_u64())?;
+
+        rmp::encode::write_str(&mut encoded, "parent_id")?;
+        rmp::encode::write_u64(&mut encoded, span.parent_span_id.to_u64())?;
+
+        rmp::encode::write_str(&mut encoded, "start")?;
+        rmp::encode::write_i64(&mut encoded, start)?;
+
+        rmp::encode::write_str(&mut encoded, "duration")?;
+        rmp::encode::write_i64(&mut encoded, duration)?;
+
+        rmp::encode::write_str(&mut encoded, "error")?;
+        rmp::encode::write_i32(&mut encoded, span.status_code.clone() as i32)?;
+
+        rmp::encode::write_str(&mut encoded, "meta")?;
+        rmp::encode::write_map_len(&mut encoded, span.attributes.len() as u32)?;
+        for (key, value) in span.attributes.iter() {
+            let value_string: String = value.into();
+            rmp::encode::write_str(&mut encoded, key.as_str())?;
+            rmp::encode::write_str(&mut encoded, value_string.as_str())?;
+        }
+    }
+
+    Ok(encoded)
+}

--- a/opentelemetry-contrib/src/datadog/model/v05.rs
+++ b/opentelemetry-contrib/src/datadog/model/v05.rs
@@ -1,0 +1,127 @@
+use crate::datadog::intern::StringInterner;
+use crate::datadog::model::Error;
+use opentelemetry::api::{Key, Value};
+use opentelemetry::exporter::trace;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+// Protocol documentation sourced from https://github.com/DataDog/datadog-agent/blob/c076ea9a1ffbde4c76d35343dbc32aecbbf99cb9/pkg/trace/api/version.go
+//
+// The payload is an array containing exactly 2 elements:
+//
+// 	1. An array of all unique strings present in the payload (a dictionary referred to by index).
+// 	2. An array of traces, where each trace is an array of spans. A span is encoded as an array having
+// 	   exactly 12 elements, representing all span properties, in this exact order:
+//
+// 		 0: Service   (uint32)
+// 		 1: Name      (uint32)
+// 		 2: Resource  (uint32)
+// 		 3: TraceID   (uint64)
+// 		 4: SpanID    (uint64)
+// 		 5: ParentID  (uint64)
+// 		 6: Start     (int64)
+// 		 7: Duration  (int64)
+// 		 8: Error     (int32)
+// 		 9: Meta      (map[uint32]uint32)
+// 		10: Metrics   (map[uint32]float64)
+// 		11: Type      (uint32)
+//
+// 	Considerations:
+//
+// 	- The "uint32" typed values in "Service", "Name", "Resource", "Type", "Meta" and "Metrics" represent
+// 	  the index at which the corresponding string is found in the dictionary. If any of the values are the
+// 	  empty string, then the empty string must be added into the dictionary.
+//
+// 	- None of the elements can be nil. If any of them are unset, they should be given their "zero-value". Here
+// 	  is an example of a span with all unset values:
+//
+// 		 0: 0                    // Service is "" (index 0 in dictionary)
+// 		 1: 0                    // Name is ""
+// 		 2: 0                    // Resource is ""
+// 		 3: 0                    // TraceID
+// 		 4: 0                    // SpanID
+// 		 5: 0                    // ParentID
+// 		 6: 0                    // Start
+// 		 7: 0                    // Duration
+// 		 8: 0                    // Error
+// 		 9: map[uint32]uint32{}  // Meta (empty map)
+// 		10: map[uint32]float64{} // Metrics (empty map)
+// 		11: 0                    // Type is ""
+//
+// 		The dictionary in this case would be []string{""}, having only the empty string at index 0.
+//
+pub(crate) fn encode(
+    service_name: &str,
+    spans: Vec<Arc<trace::SpanData>>,
+) -> Result<Vec<u8>, Error> {
+    let mut interner = StringInterner::new();
+    let mut encoded_spans = encode_spans(&mut interner, service_name, spans)?;
+
+    let mut payload = Vec::new();
+    rmp::encode::write_array_len(&mut payload, 2)?;
+
+    rmp::encode::write_array_len(&mut payload, interner.len() as u32)?;
+    for data in interner.iter() {
+        rmp::encode::write_str(&mut payload, data)?;
+    }
+
+    payload.append(&mut encoded_spans);
+
+    Ok(payload)
+}
+
+fn encode_spans(
+    interner: &mut StringInterner,
+    service_name: &str,
+    spans: Vec<Arc<trace::SpanData>>,
+) -> Result<Vec<u8>, Error> {
+    let mut encoded = Vec::new();
+    rmp::encode::write_array_len(&mut encoded, spans.len() as u32)?;
+
+    let service_interned = interner.intern(&service_name);
+
+    for span in spans.iter() {
+        // API supports but doesn't mandate grouping spans with the same trace ID
+        rmp::encode::write_array_len(&mut encoded, 1)?;
+
+        // Safe until the year 2262 when Datadog will need to change their API
+        let start = span
+            .start_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as i64;
+
+        let duration = span
+            .end_time
+            .duration_since(span.start_time)
+            .map(|x| x.as_nanos() as i64)
+            .unwrap_or(0);
+
+        let span_type = match span.attributes.get(&Key::new("span.type")) {
+            Some(Value::String(s)) => interner.intern(s.as_str()),
+            _ => interner.intern(""),
+        };
+
+        // Datadog span name is OpenTelemetry component name - see module docs for more information
+        rmp::encode::write_array_len(&mut encoded, 12)?;
+        rmp::encode::write_u32(&mut encoded, service_interned)?;
+        rmp::encode::write_u32(&mut encoded, interner.intern(span.instrumentation_lib.name))?;
+        rmp::encode::write_u32(&mut encoded, interner.intern(&span.name))?;
+        rmp::encode::write_u64(&mut encoded, span.span_context.trace_id().to_u128() as u64)?;
+        rmp::encode::write_u64(&mut encoded, span.span_context.span_id().to_u64())?;
+        rmp::encode::write_u64(&mut encoded, span.parent_span_id.to_u64())?;
+        rmp::encode::write_i64(&mut encoded, start)?;
+        rmp::encode::write_i64(&mut encoded, duration)?;
+        rmp::encode::write_i32(&mut encoded, span.status_code.clone() as i32)?;
+        rmp::encode::write_map_len(&mut encoded, span.attributes.len() as u32)?;
+        for (key, value) in span.attributes.iter() {
+            let value_string: String = value.into();
+            rmp::encode::write_u32(&mut encoded, interner.intern(key.as_str()))?;
+            rmp::encode::write_u32(&mut encoded, interner.intern(value_string.as_str()))?;
+        }
+        rmp::encode::write_map_len(&mut encoded, 0)?;
+        rmp::encode::write_u32(&mut encoded, span_type)?;
+    }
+
+    Ok(encoded)
+}

--- a/opentelemetry-contrib/src/lib.rs
+++ b/opentelemetry-contrib/src/lib.rs
@@ -8,6 +8,9 @@
 mod id_generator;
 mod trace_propagator;
 
+#[cfg(feature = "datadog")]
+pub mod datadog;
+
 pub use id_generator::aws_xray_id_generator::XrayIdGenerator;
 
 pub use trace_propagator::{

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,3 +4,6 @@ set -eu
 
 cargo test --all "$@"
 cargo test --all "$@" --features="default serialize base64_format binary_propagator"
+
+# See https://github.com/rust-lang/cargo/issues/5364
+cargo test --manifest-path=opentelemetry-contrib/Cargo.toml --all-features

--- a/src/exporter/trace/mod.rs
+++ b/src/exporter/trace/mod.rs
@@ -85,6 +85,9 @@ pub struct SpanData {
     pub status_message: String,
     /// Resource contains attributes representing an entity that produced this span.
     pub resource: Arc<sdk::Resource>,
+    /// Instrumentation library that produced this span
+    #[cfg_attr(feature = "serialize", serde(skip))]
+    pub instrumentation_lib: sdk::InstrumentationLibrary,
 }
 
 #[cfg(feature = "serialize")]
@@ -136,6 +139,7 @@ mod tests {
             status_code,
             status_message,
             resource,
+            instrumentation_lib: sdk::InstrumentationLibrary::new("", None),
         };
 
         let encoded: Vec<u8> = bincode::serialize(&span_data).unwrap();

--- a/src/sdk/trace/evicted_hash_map.rs
+++ b/src/sdk/trace/evicted_hash_map.rs
@@ -67,6 +67,11 @@ impl EvictedHashMap {
         self.map.iter()
     }
 
+    /// Returns a reference to the value corresponding to the key if it exists
+    pub fn get(&self, key: &api::Key) -> Option<&api::Value> {
+        self.map.get(key)
+    }
+
     fn move_key_to_front(&mut self, key: api::Key) {
         if self.evict_list.is_empty() {
             // If empty, push front

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -241,6 +241,7 @@ impl api::Tracer for Tracer {
                 status_code,
                 status_message,
                 resource,
+                instrumentation_lib: self.instrumentation_lib,
             }
         });
 


### PR DESCRIPTION
Closes #216 

Unfortunately this turned into a bit of a treasure hunt as the Datadog docs aren't particularly helpful, and Datadog has a slightly different design to OpenTelemetry requiring some fudgery. I've tried to document and provide links to where I sourced information from.

This implementation also uses the v0.5 trace ingestion API included in the latest datadog release. I hadn't realised quite how recent the API change was until I had already written most of the code, but the v0.3 is significantly simpler and so could be fairly easily added in future if there is demand for it.

To implement this exporter I made two changes to the actual OpenTelemetry "core"

- Add the ability to get values from EvictedHashMap by key
- Expose the InstrumentationLibrary in SpanData, the Golang OpenTelemetry implementation already does this so hopefully this isn't too controversial - see [here](https://github.com/open-telemetry/opentelemetry-go/blob/a12224a454135a5d7ec17831b6b39cf9723c0cdb/sdk/export/trace/trace.go#L79)