### PR TITLE
Ensure trace noop structs use `new`

### DIFF
--- a/opentelemetry-contrib/src/id_generator/aws_xray_id_generator.rs
+++ b/opentelemetry-contrib/src/id_generator/aws_xray_id_generator.rs
@@ -30,7 +30,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 /// use opentelemetry_contrib::XrayIdGenerator;
 ///
 /// let _provider: TracerProvider = TracerProvider::builder()
-///     .with_simple_exporter(NoopSpanExporter {})
+///     .with_simple_exporter(NoopSpanExporter::new())
 ///     .with_config(Config {
 ///          id_generator: Box::new(XrayIdGenerator::default()),
 ///          ..Default::default()

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -355,7 +355,7 @@ impl PipelineBuilder {
         Ok((tracer, Uninstall(provider_guard)))
     }
 
-    /// Build a configured `sdk::TraceProvider` with the recommended defaults.
+    /// Build a configured `sdk::TracerProvider` with the recommended defaults.
     pub fn build(mut self) -> Result<sdk::TracerProvider, Box<dyn Error>> {
         let config = self.config.take();
         let exporter = self.init_exporter()?;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -40,7 +40,7 @@ pub use trace::{
     futures::FutureExt,
     id_generator::IdGenerator,
     link::Link,
-    noop::{NoopProvider, NoopSpan, NoopSpanExporter, NoopTracer},
+    noop::{NoopSpan, NoopSpanExporter, NoopTracer, NoopTracerProvider},
     provider::TracerProvider,
     span::{Span, SpanKind, StatusCode},
     span_context::{

--- a/src/api/trace/noop.rs
+++ b/src/api/trace/noop.rs
@@ -161,9 +161,16 @@ impl api::Tracer for NoopTracer {
 /// A no-op instance of an [`SpanExporter`].
 ///
 /// [`SpanExporter`]: ../../../exporter/trace/trait.SpanExporter.html
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct NoopSpanExporter {
     _private: (),
+}
+
+impl NoopSpanExporter {
+    /// Create a new noop span exporter
+    pub fn new() -> Self {
+        NoopSpanExporter { _private: () }
+    }
 }
 
 #[async_trait]

--- a/src/api/trace/noop.rs
+++ b/src/api/trace/noop.rs
@@ -11,15 +11,24 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 /// A no-op instance of a `TracerProvider`.
-#[derive(Debug)]
-pub struct NoopProvider {}
+#[derive(Debug, Default)]
+pub struct NoopTracerProvider {
+    _private: (),
+}
 
-impl api::TracerProvider for NoopProvider {
+impl NoopTracerProvider {
+    /// Create a new no-op tracer provider
+    pub fn new() -> Self {
+        NoopTracerProvider { _private: () }
+    }
+}
+
+impl api::TracerProvider for NoopTracerProvider {
     type Tracer = NoopTracer;
 
     /// Returns a new `NoopTracer` instance.
     fn get_tracer(&self, _name: &'static str, _version: Option<&'static str>) -> Self::Tracer {
-        NoopTracer {}
+        NoopTracer::new()
     }
 }
 
@@ -98,8 +107,17 @@ impl api::Span for NoopSpan {
 }
 
 /// A no-op instance of a `Tracer`.
-#[derive(Debug)]
-pub struct NoopTracer {}
+#[derive(Debug, Default)]
+pub struct NoopTracer {
+    _private: (),
+}
+
+impl NoopTracer {
+    /// Create a new no-op tracer
+    pub fn new() -> Self {
+        NoopTracer { _private: () }
+    }
+}
 
 impl api::Tracer for NoopTracer {
     type Span = api::NoopSpan;
@@ -144,7 +162,9 @@ impl api::Tracer for NoopTracer {
 ///
 /// [`SpanExporter`]: ../../../exporter/trace/trait.SpanExporter.html
 #[derive(Debug)]
-pub struct NoopSpanExporter {}
+pub struct NoopSpanExporter {
+    _private: (),
+}
 
 #[async_trait]
 impl exporter::trace::SpanExporter for NoopSpanExporter {
@@ -174,14 +194,14 @@ mod tests {
 
     #[test]
     fn noop_tracer_defaults_to_invalid_span() {
-        let tracer = NoopTracer {};
+        let tracer = NoopTracer::new();
         let span = tracer.start_from_context("foo", &api::Context::new());
         assert!(!span.span_context().is_valid());
     }
 
     #[test]
     fn noop_tracer_propagates_valid_span_context_from_builder() {
-        let tracer = NoopTracer {};
+        let tracer = NoopTracer::new();
         let builder = tracer.span_builder("foo").with_parent(valid_span_context());
         let span = tracer.build_with_context(builder, &api::Context::new());
         assert!(span.span_context().is_valid());
@@ -189,7 +209,7 @@ mod tests {
 
     #[test]
     fn noop_tracer_propagates_valid_span_context_from_span() {
-        let tracer = NoopTracer {};
+        let tracer = NoopTracer::new();
         let cx = api::Context::new().with_span(NoopSpan {
             span_context: valid_span_context(),
         });
@@ -199,7 +219,7 @@ mod tests {
 
     #[test]
     fn noop_tracer_propagates_valid_span_context_from_remote_span_context() {
-        let tracer = NoopTracer {};
+        let tracer = NoopTracer::new();
         let cx = api::Context::new().with_remote_span_context(valid_span_context());
         let span = tracer.start_from_context("foo", &cx);
         assert!(span.span_context().is_valid());

--- a/src/global/mod.rs
+++ b/src/global/mod.rs
@@ -16,7 +16,7 @@
 //! use opentelemetry::global;
 //!
 //! fn init_tracer() -> global::TracerProviderGuard {
-//!     let provider = opentelemetry::api::NoopProvider {};
+//!     let provider = opentelemetry::api::NoopTracerProvider::new();
 //!
 //!     // Configure the global `TracerProvider` singleton when your app starts
 //!     // (there is a no-op default if this is not set by your application)

--- a/src/sdk/trace/provider.rs
+++ b/src/sdk/trace/provider.rs
@@ -65,7 +65,7 @@ impl TracerProvider {
 }
 
 impl api::TracerProvider for TracerProvider {
-    /// This implementation of `api::TraceProvider` produces `sdk::Tracer` instances.
+    /// This implementation of `api::TracerProvider` produces `sdk::Tracer` instances.
     type Tracer = sdk::Tracer;
 
     /// Find or create `Tracer` instance by name.

--- a/src/sdk/trace/span_processor.rs
+++ b/src/sdk/trace/span_processor.rs
@@ -38,7 +38,7 @@
 //! use opentelemetry::{api, sdk, global};
 //!
 //! // Configure your preferred exporter
-//! let exporter = api::NoopSpanExporter {};
+//! let exporter = api::NoopSpanExporter::new();
 //!
 //! // Then use the `with_simple_exporter` method to have the provider export when spans finish.
 //! let provider = sdk::TracerProvider::builder()
@@ -64,7 +64,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     // Configure your preferred exporter
-//!     let exporter = api::NoopSpanExporter {};
+//!     let exporter = api::NoopSpanExporter::new();
 //!
 //!     // Then build a batch processor. You can use whichever executor you have available, for
 //!     // example if you are using `async-std` instead of `tokio` you can replace the spawn and


### PR DESCRIPTION
Add private fields to trace module's noop structs to be consistent with this crate's conventions around backwards compatibility. 