### PR TITLE
Use last value aggregator for value observers

### DIFF
--- a/benches/ddsketch.rs
+++ b/benches/ddsketch.rs
@@ -5,7 +5,7 @@ use opentelemetry::{
     api::metrics::Descriptor,
     sdk::{
         export::metrics::Quantile,
-        metrics::aggregators::{ArrayAggregator, DDSKetchAggregator},
+        metrics::aggregators::{ArrayAggregator, DDSKetchAggregator, DDSketchConfig},
     },
 };
 use rand::Rng;
@@ -24,7 +24,8 @@ fn get_test_quantile() -> &'static [f64] {
 }
 
 fn ddsketch(data: Vec<f64>) {
-    let aggregator = DDSKetchAggregator::new(0.001, 2048, 1e-9, NumberKind::F64);
+    let aggregator =
+        DDSKetchAggregator::new(&DDSketchConfig::new(0.001, 2048, 1e-9), NumberKind::F64);
     let descriptor = Descriptor::new(
         "test".to_string(),
         "test".to_string(),
@@ -34,8 +35,10 @@ fn ddsketch(data: Vec<f64>) {
     for f in data {
         aggregator.update(&Number::from(f), &descriptor).unwrap();
     }
-    let new_aggregator: Arc<(dyn Aggregator + Send + Sync)> =
-        Arc::new(DDSKetchAggregator::new(0.001, 2048, 1e-9, NumberKind::F64));
+    let new_aggregator: Arc<(dyn Aggregator + Send + Sync)> = Arc::new(DDSKetchAggregator::new(
+        &DDSketchConfig::new(0.001, 2048, 1e-9),
+        NumberKind::F64,
+    ));
     aggregator
         .synchronized_move(&new_aggregator, &descriptor)
         .unwrap();

--- a/src/sdk/export/metrics/aggregation.rs
+++ b/src/sdk/export/metrics/aggregation.rs
@@ -79,7 +79,7 @@ impl Buckets {
 }
 
 /// Histogram returns the count of events in pre-determined buckets.
-pub trait Histogram: Sum {
+pub trait Histogram: Sum + Count {
     /// Buckets for this histogram.
     fn histogram(&self) -> Result<Buckets>;
 }

--- a/src/sdk/metrics/aggregators/histogram.rs
+++ b/src/sdk/metrics/aggregators/histogram.rs
@@ -58,6 +58,7 @@ impl Sum for HistogramAggregator {
             .map(|inner| inner.state.sum.load())
     }
 }
+
 impl Count for HistogramAggregator {
     fn count(&self) -> Result<u64> {
         self.inner
@@ -66,6 +67,7 @@ impl Count for HistogramAggregator {
             .map(|inner| inner.state.sum.load().to_u64(&NumberKind::U64))
     }
 }
+
 impl Histogram for HistogramAggregator {
     fn histogram(&self) -> Result<Buckets> {
         self.inner

--- a/src/sdk/metrics/aggregators/mod.rs
+++ b/src/sdk/metrics/aggregators/mod.rs
@@ -9,7 +9,7 @@ mod min_max_sum_count;
 mod sum;
 
 pub use array::{array, ArrayAggregator};
-pub use ddsketch::{ddsketch, DDSKetchAggregator};
+pub use ddsketch::{ddsketch, DDSKetchAggregator, DDSketchConfig};
 pub use histogram::{histogram, HistogramAggregator};
 pub use last_value::{last_value, LastValueAggregator};
 pub use min_max_sum_count::{min_max_sum_count, MinMaxSumCountAggregator};


### PR DESCRIPTION
* Switch to last value aggregator for value observers per https://github.com/open-telemetry/opentelemetry-specification/pull/984
* Add ddsketch to simple selector options
* Extract ddsketch config for use in selectors
* Add missing `Count` bound on `Histogram` aggregator trait.