### PR TITLE
Trace module exports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rand_distr = "0.3.0"
 tokio = { version = "0.2", features = ["full"] }
 
 [features]
-default = ["metrics", "trace"]
+default = ["trace"]
 base64_format = ["base64", "binary_propagator"]
 trace = ["rand", "pin-project", "async-trait"]
 metrics = ["thiserror", "dashmap", "fnv"]

--- a/benches/trace.rs
+++ b/benches/trace.rs
@@ -4,7 +4,7 @@ use opentelemetry::{
         trace::{Span, Tracer, TracerProvider},
         Key,
     },
-    sdk,
+    sdk::trace as sdktrace,
 };
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -67,13 +67,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 }
 
-fn trace_benchmark_group<F: Fn(&sdk::trace::Tracer)>(c: &mut Criterion, name: &str, f: F) {
+fn trace_benchmark_group<F: Fn(&sdktrace::Tracer)>(c: &mut Criterion, name: &str, f: F) {
     let mut group = c.benchmark_group(name);
 
     group.bench_function("always-sample", |b| {
-        let always_sample = sdk::trace::TracerProvider::builder()
-            .with_config(sdk::trace::Config {
-                default_sampler: Box::new(sdk::trace::Sampler::AlwaysOn),
+        let always_sample = sdktrace::TracerProvider::builder()
+            .with_config(sdktrace::Config {
+                default_sampler: Box::new(sdktrace::Sampler::AlwaysOn),
                 ..Default::default()
             })
             .build()
@@ -83,9 +83,9 @@ fn trace_benchmark_group<F: Fn(&sdk::trace::Tracer)>(c: &mut Criterion, name: &s
     });
 
     group.bench_function("never-sample", |b| {
-        let never_sample = sdk::trace::TracerProvider::builder()
-            .with_config(sdk::trace::Config {
-                default_sampler: Box::new(sdk::trace::Sampler::AlwaysOff),
+        let never_sample = sdktrace::TracerProvider::builder()
+            .with_config(sdktrace::Config {
+                default_sampler: Box::new(sdktrace::Sampler::AlwaysOff),
                 ..Default::default()
             })
             .build()

--- a/benches/trace.rs
+++ b/benches/trace.rs
@@ -64,13 +64,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 }
 
-fn trace_benchmark_group<F: Fn(&sdk::Tracer)>(c: &mut Criterion, name: &str, f: F) {
+fn trace_benchmark_group<F: Fn(&sdk::trace::Tracer)>(c: &mut Criterion, name: &str, f: F) {
     let mut group = c.benchmark_group(name);
 
     group.bench_function("always-sample", |b| {
-        let always_sample = sdk::TracerProvider::builder()
-            .with_config(sdk::Config {
-                default_sampler: Box::new(sdk::Sampler::AlwaysOn),
+        let always_sample = sdk::trace::TracerProvider::builder()
+            .with_config(sdk::trace::Config {
+                default_sampler: Box::new(sdk::trace::Sampler::AlwaysOn),
                 ..Default::default()
             })
             .build()
@@ -80,9 +80,9 @@ fn trace_benchmark_group<F: Fn(&sdk::Tracer)>(c: &mut Criterion, name: &str, f: 
     });
 
     group.bench_function("never-sample", |b| {
-        let never_sample = sdk::TracerProvider::builder()
-            .with_config(sdk::Config {
-                default_sampler: Box::new(sdk::Sampler::AlwaysOff),
+        let never_sample = sdk::trace::TracerProvider::builder()
+            .with_config(sdk::trace::Config {
+                default_sampler: Box::new(sdk::trace::Sampler::AlwaysOff),
                 ..Default::default()
             })
             .build()

--- a/benches/trace.rs
+++ b/benches/trace.rs
@@ -1,6 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::{
-    api::{Key, Span, Tracer, TracerProvider},
+    api::{
+        trace::{Span, Tracer, TracerProvider},
+        Key,
+    },
     sdk,
 };
 

--- a/examples/actix-http/src/main.rs
+++ b/examples/actix-http/src/main.rs
@@ -1,8 +1,10 @@
 use actix_service::Service;
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpServer};
-use opentelemetry::api::trace::futures::FutureExt;
-use opentelemetry::api::{Key, TraceContextExt, Tracer};
+use opentelemetry::api::{
+    trace::{FutureExt, TraceContextExt, Tracer},
+    Key,
+};
 use opentelemetry::{global, sdk};
 use std::error::Error;
 

--- a/examples/actix-http/src/main.rs
+++ b/examples/actix-http/src/main.rs
@@ -5,10 +5,10 @@ use opentelemetry::api::{
     trace::{FutureExt, TraceContextExt, Tracer},
     Key,
 };
-use opentelemetry::{global, sdk};
+use opentelemetry::{global, sdk::trace as sdktrace};
 use std::error::Error;
 
-fn init_tracer() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_collector_endpoint("http://127.0.0.1:14268/api/traces")
         .with_service_name("trace-http-demo")

--- a/examples/actix-http/src/main.rs
+++ b/examples/actix-http/src/main.rs
@@ -6,7 +6,7 @@ use opentelemetry::api::{Key, TraceContextExt, Tracer};
 use opentelemetry::{global, sdk};
 use std::error::Error;
 
-fn init_tracer() -> Result<(sdk::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn init_tracer() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_collector_endpoint("http://127.0.0.1:14268/api/traces")
         .with_service_name("trace-http-demo")

--- a/examples/actix-udp/src/main.rs
+++ b/examples/actix-udp/src/main.rs
@@ -1,8 +1,10 @@
 use actix_service::Service;
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpServer};
-use opentelemetry::api::trace::futures::FutureExt;
-use opentelemetry::api::{Key, TraceContextExt, Tracer};
+use opentelemetry::api::{
+    trace::{FutureExt, TraceContextExt, Tracer},
+    Key,
+};
 use opentelemetry::{global, sdk};
 use std::error::Error;
 

--- a/examples/actix-udp/src/main.rs
+++ b/examples/actix-udp/src/main.rs
@@ -6,7 +6,7 @@ use opentelemetry::api::{Key, TraceContextExt, Tracer};
 use opentelemetry::{global, sdk};
 use std::error::Error;
 
-fn init_tracer() -> Result<(sdk::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn init_tracer() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_agent_endpoint("localhost:6831")
         .with_service_name("trace-udp-demo")

--- a/examples/actix-udp/src/main.rs
+++ b/examples/actix-udp/src/main.rs
@@ -5,10 +5,10 @@ use opentelemetry::api::{
     trace::{FutureExt, TraceContextExt, Tracer},
     Key,
 };
-use opentelemetry::{global, sdk};
+use opentelemetry::{global, sdk::trace as sdktrace};
 use std::error::Error;
 
-fn init_tracer() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_agent_endpoint("localhost:6831")
         .with_service_name("trace-udp-demo")

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -18,7 +18,10 @@
 //!
 //! [`hello_world`]: https://github.com/tokio-rs/tokio/blob/132e9f1da5965530b63554d7a1c59824c3de4e30/tokio/examples/hello_world.rs
 use opentelemetry::{
-    api::{trace::futures::FutureExt, Context, TraceContextExt, Tracer},
+    api::{
+        trace::{FutureExt, TraceContextExt, Tracer},
+        Context,
+    },
     global, sdk,
 };
 use std::{error::Error, io, net::SocketAddr};

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -22,7 +22,8 @@ use opentelemetry::{
         trace::{FutureExt, TraceContextExt, Tracer},
         Context,
     },
-    global, sdk,
+    global,
+    sdk::trace as sdktrace,
 };
 use std::{error::Error, io, net::SocketAddr};
 use tokio::io::AsyncWriteExt;
@@ -53,7 +54,7 @@ async fn run(addr: &SocketAddr) -> io::Result<usize> {
     write(&mut stream).with_context(cx).await
 }
 
-fn init_tracer() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("trace-demo")
         .install()

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -50,7 +50,7 @@ async fn run(addr: &SocketAddr) -> io::Result<usize> {
     write(&mut stream).with_context(cx).await
 }
 
-fn init_tracer() -> Result<(sdk::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn init_tracer() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("trace-demo")
         .install()

--- a/examples/aws-xray/src/client.rs
+++ b/examples/aws-xray/src/client.rs
@@ -3,15 +3,15 @@ use opentelemetry::api::{Context, TraceContextExt, Tracer};
 use opentelemetry::{api, exporter::trace::stdout, global, sdk};
 use opentelemetry_contrib::{XrayIdGenerator, XrayTraceContextPropagator};
 
-fn init_tracer() -> (sdk::Tracer, stdout::Uninstall) {
+fn init_tracer() -> (sdk::trace::Tracer, stdout::Uninstall) {
     global::set_text_map_propagator(XrayTraceContextPropagator::new());
 
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
     stdout::new_pipeline()
-        .with_trace_config(sdk::Config {
-            default_sampler: Box::new(sdk::Sampler::AlwaysOn),
+        .with_trace_config(sdk::trace::Config {
+            default_sampler: Box::new(sdk::trace::Sampler::AlwaysOn),
             id_generator: Box::new(XrayIdGenerator::default()),
             ..Default::default()
         })

--- a/examples/aws-xray/src/client.rs
+++ b/examples/aws-xray/src/client.rs
@@ -1,6 +1,13 @@
 use hyper::{body::Body, Client};
-use opentelemetry::api::{Context, TraceContextExt, Tracer};
-use opentelemetry::{api, exporter::trace::stdout, global, sdk};
+use opentelemetry::{
+    api::{
+        self,
+        trace::{TraceContextExt, Tracer},
+        Context,
+    },
+    exporter::trace::stdout,
+    global, sdk,
+};
 use opentelemetry_contrib::{XrayIdGenerator, XrayTraceContextPropagator};
 
 fn init_tracer() -> (sdk::trace::Tracer, stdout::Uninstall) {

--- a/examples/aws-xray/src/client.rs
+++ b/examples/aws-xray/src/client.rs
@@ -6,19 +6,20 @@ use opentelemetry::{
         Context,
     },
     exporter::trace::stdout,
-    global, sdk,
+    global,
+    sdk::trace as sdktrace,
 };
 use opentelemetry_contrib::{XrayIdGenerator, XrayTraceContextPropagator};
 
-fn init_tracer() -> (sdk::trace::Tracer, stdout::Uninstall) {
+fn init_tracer() -> (sdktrace::Tracer, stdout::Uninstall) {
     global::set_text_map_propagator(XrayTraceContextPropagator::new());
 
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
     stdout::new_pipeline()
-        .with_trace_config(sdk::trace::Config {
-            default_sampler: Box::new(sdk::trace::Sampler::AlwaysOn),
+        .with_trace_config(sdktrace::Config {
+            default_sampler: Box::new(sdktrace::Sampler::AlwaysOn),
             id_generator: Box::new(XrayIdGenerator::default()),
             ..Default::default()
         })

--- a/examples/aws-xray/src/server.rs
+++ b/examples/aws-xray/src/server.rs
@@ -27,15 +27,15 @@ async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     ))
 }
 
-fn init_tracer() -> (sdk::Tracer, stdout::Uninstall) {
+fn init_tracer() -> (sdk::trace::Tracer, stdout::Uninstall) {
     global::set_text_map_propagator(XrayTraceContextPropagator::new());
 
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
     stdout::new_pipeline()
-        .with_trace_config(sdk::Config {
-            default_sampler: Box::new(sdk::Sampler::AlwaysOn),
+        .with_trace_config(sdk::trace::Config {
+            default_sampler: Box::new(sdk::trace::Sampler::AlwaysOn),
             id_generator: Box::new(XrayIdGenerator::default()),
             ..Default::default()
         })

--- a/examples/aws-xray/src/server.rs
+++ b/examples/aws-xray/src/server.rs
@@ -3,7 +3,8 @@ use hyper::{Body, Request, Response, Server};
 use opentelemetry::{
     api::trace::{Span, Tracer},
     exporter::trace::stdout,
-    global, sdk,
+    global,
+    sdk::trace as sdktrace,
 };
 use opentelemetry_contrib::{XrayIdGenerator, XrayTraceContextPropagator};
 use std::{convert::Infallible, net::SocketAddr};
@@ -27,15 +28,15 @@ async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     ))
 }
 
-fn init_tracer() -> (sdk::trace::Tracer, stdout::Uninstall) {
+fn init_tracer() -> (sdktrace::Tracer, stdout::Uninstall) {
     global::set_text_map_propagator(XrayTraceContextPropagator::new());
 
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
     stdout::new_pipeline()
-        .with_trace_config(sdk::trace::Config {
-            default_sampler: Box::new(sdk::trace::Sampler::AlwaysOn),
+        .with_trace_config(sdktrace::Config {
+            default_sampler: Box::new(sdktrace::Sampler::AlwaysOn),
             id_generator: Box::new(XrayIdGenerator::default()),
             ..Default::default()
         })

--- a/examples/aws-xray/src/server.rs
+++ b/examples/aws-xray/src/server.rs
@@ -1,7 +1,7 @@
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request, Response, Server};
 use opentelemetry::{
-    api::{Span, Tracer},
+    api::trace::{Span, Tracer},
     exporter::trace::stdout,
     global, sdk,
 };

--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -1,6 +1,9 @@
 use futures::stream::{Stream, StreamExt};
-use opentelemetry::api::metrics::{self, MetricsError, ObserverResult};
-use opentelemetry::api::{BaggageExt, Context, Key, KeyValue, TraceContextExt, Tracer};
+use opentelemetry::api::{
+    metrics::{self, MetricsError, ObserverResult},
+    trace::{TraceContextExt, Tracer},
+    BaggageExt, Context, Key, KeyValue,
+};
 use opentelemetry::exporter;
 use opentelemetry::sdk::metrics::PushController;
 use opentelemetry::{global, sdk};

--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -6,11 +6,11 @@ use opentelemetry::api::{
 };
 use opentelemetry::exporter;
 use opentelemetry::sdk::metrics::PushController;
-use opentelemetry::{global, sdk};
+use opentelemetry::{global, sdk::trace as sdktrace};
 use std::error::Error;
 use std::time::Duration;
 
-fn init_tracer() -> Result<(sdk::trace::Tracer, opentelemetry_otlp::Uninstall), Box<dyn Error>> {
+fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_otlp::Uninstall), Box<dyn Error>> {
     opentelemetry_otlp::new_pipeline().install()
 }
 

--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -7,7 +7,7 @@ use opentelemetry::{global, sdk};
 use std::error::Error;
 use std::time::Duration;
 
-fn init_tracer() -> Result<(sdk::Tracer, opentelemetry_otlp::Uninstall), Box<dyn Error>> {
+fn init_tracer() -> Result<(sdk::trace::Tracer, opentelemetry_otlp::Uninstall), Box<dyn Error>> {
     opentelemetry_otlp::new_pipeline().install()
 }
 

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -5,12 +5,13 @@ use opentelemetry::api::{
     BaggageExt, Context, Key, KeyValue,
 };
 use opentelemetry::exporter;
+use opentelemetry::global;
 use opentelemetry::sdk::metrics::PushController;
-use opentelemetry::{global, sdk};
+use opentelemetry::sdk::trace as sdktrace;
 use std::error::Error;
 use std::time::Duration;
 
-fn init_tracer() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("trace-demo")
         .with_tags(vec![

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,6 +1,9 @@
 use futures::stream::{Stream, StreamExt};
-use opentelemetry::api::metrics::{self, MetricsError, ObserverResult};
-use opentelemetry::api::{BaggageExt, Context, Key, KeyValue, TraceContextExt, Tracer};
+use opentelemetry::api::{
+    metrics::{self, MetricsError, ObserverResult},
+    trace::{TraceContextExt, Tracer},
+    BaggageExt, Context, Key, KeyValue,
+};
 use opentelemetry::exporter;
 use opentelemetry::sdk::metrics::PushController;
 use opentelemetry::{global, sdk};

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -7,7 +7,7 @@ use opentelemetry::{global, sdk};
 use std::error::Error;
 use std::time::Duration;
 
-fn init_tracer() -> Result<(sdk::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn init_tracer() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("trace-demo")
         .with_tags(vec![

--- a/examples/datadog/src/main.rs
+++ b/examples/datadog/src/main.rs
@@ -1,4 +1,7 @@
-use opentelemetry::api::{Key, Span, TraceContextExt, Tracer};
+use opentelemetry::api::{
+    trace::{Span, TraceContextExt, Tracer},
+    Key,
+};
 use opentelemetry::global;
 use opentelemetry_contrib::datadog::ApiVersion;
 use std::thread;

--- a/examples/grpc/src/client.rs
+++ b/examples/grpc/src/client.rs
@@ -10,7 +10,7 @@ pub mod hello_world {
     tonic::include_proto!("helloworld");
 }
 
-fn tracing_init() -> Result<(sdk::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn tracing_init() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("grpc-client")
         .install()

--- a/examples/grpc/src/client.rs
+++ b/examples/grpc/src/client.rs
@@ -4,14 +4,14 @@ use opentelemetry::api::{
     trace::{TraceContextExt, TraceContextPropagator, Tracer},
     Context, KeyValue, TextMapFormat,
 };
-use opentelemetry::sdk;
+use opentelemetry::sdk::trace as sdktrace;
 use std::error::Error;
 
 pub mod hello_world {
     tonic::include_proto!("helloworld");
 }
 
-fn tracing_init() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn tracing_init() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("grpc-client")
         .install()

--- a/examples/grpc/src/client.rs
+++ b/examples/grpc/src/client.rs
@@ -1,7 +1,8 @@
 use hello_world::greeter_client::GreeterClient;
 use hello_world::HelloRequest;
 use opentelemetry::api::{
-    Context, KeyValue, TextMapFormat, TraceContextExt, TraceContextPropagator, Tracer,
+    trace::{TraceContextExt, TraceContextPropagator, Tracer},
+    Context, KeyValue, TextMapFormat,
 };
 use opentelemetry::sdk;
 use std::error::Error;

--- a/examples/grpc/src/server.rs
+++ b/examples/grpc/src/server.rs
@@ -34,7 +34,7 @@ impl Greeter for MyGreeter {
     }
 }
 
-fn tracing_init() -> Result<(sdk::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn tracing_init() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("grpc-server")
         .install()

--- a/examples/grpc/src/server.rs
+++ b/examples/grpc/src/server.rs
@@ -2,7 +2,11 @@ use tonic::{transport::Server, Request, Response, Status};
 
 use hello_world::greeter_server::{Greeter, GreeterServer};
 use hello_world::{HelloReply, HelloRequest};
-use opentelemetry::api::{self, KeyValue, Span, TextMapFormat, Tracer};
+use opentelemetry::api::{
+    self,
+    trace::{Span, Tracer},
+    KeyValue, TextMapFormat,
+};
 use opentelemetry::global;
 use opentelemetry::sdk;
 use std::error::Error;
@@ -20,7 +24,7 @@ impl Greeter for MyGreeter {
         &self,
         request: Request<HelloRequest>, // Accept request of type HelloRequest
     ) -> Result<Response<HelloReply>, Status> {
-        let propagator = api::TraceContextPropagator::new();
+        let propagator = api::trace::TraceContextPropagator::new();
         let parent_cx = propagator.extract(request.metadata());
         let span = global::tracer("greeter").start_from_context("Processing reply", &parent_cx);
         span.set_attribute(KeyValue::new("request", format!("{:?}", request)));

--- a/examples/grpc/src/server.rs
+++ b/examples/grpc/src/server.rs
@@ -8,7 +8,7 @@ use opentelemetry::api::{
     KeyValue, TextMapFormat,
 };
 use opentelemetry::global;
-use opentelemetry::sdk;
+use opentelemetry::sdk::trace as sdktrace;
 use std::error::Error;
 
 pub mod hello_world {
@@ -38,7 +38,7 @@ impl Greeter for MyGreeter {
     }
 }
 
-fn tracing_init() -> Result<(sdk::trace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
+fn tracing_init() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error>> {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("grpc-server")
         .install()

--- a/examples/http/src/client.rs
+++ b/examples/http/src/client.rs
@@ -3,15 +3,15 @@ use opentelemetry::api::{
     trace::{TraceContextExt, Tracer},
     Context, TextMapFormat,
 };
-use opentelemetry::{api, exporter::trace::stdout, global, sdk};
+use opentelemetry::{api, exporter::trace::stdout, global, sdk::trace as sdktrace};
 
-fn init_tracer() -> (sdk::trace::Tracer, stdout::Uninstall) {
+fn init_tracer() -> (sdktrace::Tracer, stdout::Uninstall) {
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
     stdout::new_pipeline()
-        .with_trace_config(sdk::trace::Config {
-            default_sampler: Box::new(sdk::trace::Sampler::AlwaysOn),
+        .with_trace_config(sdktrace::Config {
+            default_sampler: Box::new(sdktrace::Sampler::AlwaysOn),
             ..Default::default()
         })
         .install()

--- a/examples/http/src/client.rs
+++ b/examples/http/src/client.rs
@@ -1,5 +1,8 @@
 use hyper::{body::Body, Client};
-use opentelemetry::api::{Context, TextMapFormat, TraceContextExt, Tracer};
+use opentelemetry::api::{
+    trace::{TraceContextExt, Tracer},
+    Context, TextMapFormat,
+};
 use opentelemetry::{api, exporter::trace::stdout, global, sdk};
 
 fn init_tracer() -> (sdk::trace::Tracer, stdout::Uninstall) {
@@ -19,7 +22,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sy
     let _guard = init_tracer();
 
     let client = Client::new();
-    let propagator = api::TraceContextPropagator::new();
+    let propagator = api::trace::TraceContextPropagator::new();
     let span = global::tracer("example/client").start("say hello");
     let cx = Context::current_with_span(span);
 

--- a/examples/http/src/client.rs
+++ b/examples/http/src/client.rs
@@ -2,13 +2,13 @@ use hyper::{body::Body, Client};
 use opentelemetry::api::{Context, TextMapFormat, TraceContextExt, Tracer};
 use opentelemetry::{api, exporter::trace::stdout, global, sdk};
 
-fn init_tracer() -> (sdk::Tracer, stdout::Uninstall) {
+fn init_tracer() -> (sdk::trace::Tracer, stdout::Uninstall) {
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
     stdout::new_pipeline()
-        .with_trace_config(sdk::Config {
-            default_sampler: Box::new(sdk::Sampler::AlwaysOn),
+        .with_trace_config(sdk::trace::Config {
+            default_sampler: Box::new(sdk::trace::Sampler::AlwaysOn),
             ..Default::default()
         })
         .install()

--- a/examples/http/src/server.rs
+++ b/examples/http/src/server.rs
@@ -16,14 +16,14 @@ async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     Ok(Response::new("Hello, World!".into()))
 }
 
-fn init_tracer() -> (sdk::Tracer, stdout::Uninstall) {
+fn init_tracer() -> (sdk::trace::Tracer, stdout::Uninstall) {
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
 
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
     stdout::new_pipeline()
-        .with_trace_config(sdk::Config {
-            default_sampler: Box::new(sdk::Sampler::AlwaysOn),
+        .with_trace_config(sdk::trace::Config {
+            default_sampler: Box::new(sdk::trace::Sampler::AlwaysOn),
             ..Default::default()
         })
         .install()

--- a/examples/http/src/server.rs
+++ b/examples/http/src/server.rs
@@ -1,14 +1,18 @@
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request, Response, Server};
 use opentelemetry::{
-    api::{self, Span, TextMapFormat, Tracer},
+    api::{
+        self,
+        trace::{Span, Tracer},
+        TextMapFormat,
+    },
     exporter::trace::stdout,
     global, sdk,
 };
 use std::{convert::Infallible, net::SocketAddr};
 
 async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
-    let propagator = api::TraceContextPropagator::new();
+    let propagator = api::trace::TraceContextPropagator::new();
     let parent_cx = propagator.extract(req.headers());
     let span = global::tracer("example/server").start_from_context("hello", &parent_cx);
     span.add_event("handling this...".to_string(), Vec::new());

--- a/examples/stdout.rs
+++ b/examples/stdout.rs
@@ -1,7 +1,7 @@
 use opentelemetry::{
     api::Tracer,
     exporter::trace::stdout,
-    sdk::{trace, Sampler},
+    sdk::trace::{self, Sampler},
 };
 
 fn main() {

--- a/examples/stdout.rs
+++ b/examples/stdout.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{
-    api::Tracer,
+    api::trace::Tracer,
     exporter::trace::stdout,
     sdk::trace::{self, Sampler},
 };

--- a/examples/zipkin/src/main.rs
+++ b/examples/zipkin/src/main.rs
@@ -1,4 +1,4 @@
-use opentelemetry::api::{Span, Tracer};
+use opentelemetry::api::trace::{Span, Tracer};
 use opentelemetry::global;
 use std::thread;
 use std::time::Duration;

--- a/opentelemetry-contrib/src/datadog/mod.rs
+++ b/opentelemetry-contrib/src/datadog/mod.rs
@@ -56,7 +56,7 @@
 //!
 //! ```no_run
 //! use opentelemetry::api::{KeyValue, Tracer};
-//! use opentelemetry::sdk::{trace, IdGenerator, Resource, Sampler};
+//! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let (tracer, _uninstall) = opentelemetry_contrib::datadog::new_pipeline()
@@ -131,7 +131,7 @@ pub fn new_pipeline() -> DatadogPipelineBuilder {
 pub struct DatadogPipelineBuilder {
     service_name: String,
     agent_endpoint: String,
-    trace_config: Option<sdk::Config>,
+    trace_config: Option<sdk::trace::Config>,
     version: ApiVersion,
 }
 
@@ -148,14 +148,14 @@ impl Default for DatadogPipelineBuilder {
 
 impl DatadogPipelineBuilder {
     /// Create `ExporterConfig` struct from current `ExporterConfigBuilder`
-    pub fn install(mut self) -> Result<(sdk::Tracer, Uninstall), Box<dyn Error>> {
+    pub fn install(mut self) -> Result<(sdk::trace::Tracer, Uninstall), Box<dyn Error>> {
         let exporter = DatadogExporter::new(
             self.service_name.clone(),
             self.agent_endpoint.parse()?,
             self.version,
         );
 
-        let mut provider_builder = sdk::TracerProvider::builder().with_exporter(exporter);
+        let mut provider_builder = sdk::trace::TracerProvider::builder().with_exporter(exporter);
         if let Some(config) = self.trace_config.take() {
             provider_builder = provider_builder.with_config(config);
         }
@@ -179,7 +179,7 @@ impl DatadogPipelineBuilder {
     }
 
     /// Assign the SDK trace configuration
-    pub fn with_trace_config(mut self, config: sdk::Config) -> Self {
+    pub fn with_trace_config(mut self, config: sdk::trace::Config) -> Self {
         self.trace_config = Some(config);
         self
     }

--- a/opentelemetry-contrib/src/datadog/mod.rs
+++ b/opentelemetry-contrib/src/datadog/mod.rs
@@ -55,7 +55,7 @@
 //! [`DatadogPipelineBuilder`]: struct.DatadogPipelineBuilder.html
 //!
 //! ```no_run
-//! use opentelemetry::api::{KeyValue, Tracer};
+//! use opentelemetry::api::{KeyValue, trace::Tracer};
 //! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -86,7 +86,7 @@ mod model;
 pub use model::ApiVersion;
 
 use async_trait::async_trait;
-use opentelemetry::{api::TracerProvider, exporter::trace, global, sdk};
+use opentelemetry::{api::trace::TracerProvider, exporter::trace, global, sdk};
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Url;
 use std::error::Error;

--- a/opentelemetry-contrib/src/datadog/model/mod.rs
+++ b/opentelemetry-contrib/src/datadog/model/mod.rs
@@ -87,11 +87,11 @@ mod tests {
         let end_time = start_time.checked_add(Duration::from_secs(1)).unwrap();
 
         let capacity = 3;
-        let mut attributes = sdk::EvictedHashMap::new(capacity);
+        let mut attributes = sdk::trace::EvictedHashMap::new(capacity);
         attributes.insert(Key::new("span.type").string("web"));
 
-        let message_events = sdk::EvictedQueue::new(capacity);
-        let links = sdk::EvictedQueue::new(capacity);
+        let message_events = sdk::trace::EvictedQueue::new(capacity);
+        let links = sdk::trace::EvictedQueue::new(capacity);
 
         let span_data = trace::SpanData {
             span_context,

--- a/opentelemetry-contrib/src/datadog/model/mod.rs
+++ b/opentelemetry-contrib/src/datadog/model/mod.rs
@@ -75,12 +75,12 @@ mod tests {
         let trace_id = 7;
         let span_id = 99;
 
-        let span_context = api::SpanContext::new(
-            api::TraceId::from_u128(trace_id),
-            api::SpanId::from_u64(span_id),
+        let span_context = api::trace::SpanContext::new(
+            api::trace::TraceId::from_u128(trace_id),
+            api::trace::SpanId::from_u64(span_id),
             0,
             false,
-            api::TraceState::default(),
+            api::trace::TraceState::default(),
         );
 
         let start_time = SystemTime::UNIX_EPOCH;
@@ -95,15 +95,15 @@ mod tests {
 
         let span_data = trace::SpanData {
             span_context,
-            parent_span_id: api::SpanId::from_u64(parent_span_id),
-            span_kind: api::SpanKind::Client,
+            parent_span_id: api::trace::SpanId::from_u64(parent_span_id),
+            span_kind: api::trace::SpanKind::Client,
             name: "resource".to_string(),
             start_time,
             end_time,
             attributes,
             message_events,
             links,
-            status_code: api::StatusCode::OK,
+            status_code: api::trace::StatusCode::OK,
             status_message: String::new(),
             resource: Arc::new(sdk::Resource::default()),
             instrumentation_lib: InstrumentationLibrary::new("component", None),

--- a/opentelemetry-contrib/src/id_generator/aws_xray_id_generator.rs
+++ b/opentelemetry-contrib/src/id_generator/aws_xray_id_generator.rs
@@ -1,4 +1,4 @@
-use opentelemetry::api::{IdGenerator, SpanId, TraceId};
+use opentelemetry::api::trace::{IdGenerator, SpanId, TraceId};
 use opentelemetry::sdk;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -24,9 +24,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 ///
 /// ```
 /// extern crate opentelemetry;
-/// use opentelemetry::api::NoopSpanExporter;
-/// use opentelemetry::sdk::trace::Config;
-/// use opentelemetry::sdk::trace::TracerProvider;
+/// use opentelemetry::api::trace::NoopSpanExporter;
+/// use opentelemetry::sdk::trace::{Config, TracerProvider};
 /// use opentelemetry_contrib::XrayIdGenerator;
 ///
 /// let _provider: TracerProvider = TracerProvider::builder()

--- a/opentelemetry-contrib/src/id_generator/aws_xray_id_generator.rs
+++ b/opentelemetry-contrib/src/id_generator/aws_xray_id_generator.rs
@@ -25,8 +25,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 /// ```
 /// extern crate opentelemetry;
 /// use opentelemetry::api::NoopSpanExporter;
-/// use opentelemetry::sdk::Config;
-/// use opentelemetry::sdk::trace::provider::TracerProvider;
+/// use opentelemetry::sdk::trace::Config;
+/// use opentelemetry::sdk::trace::TracerProvider;
 /// use opentelemetry_contrib::XrayIdGenerator;
 ///
 /// let _provider: TracerProvider = TracerProvider::builder()
@@ -43,7 +43,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 /// [xray-trace-id]: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids
 #[derive(Debug, Default)]
 pub struct XrayIdGenerator {
-    sdk_default_generator: sdk::IdGenerator,
+    sdk_default_generator: sdk::trace::IdGenerator,
 }
 
 impl IdGenerator for XrayIdGenerator {

--- a/opentelemetry-contrib/src/trace_propagator/aws_xray_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/aws_xray_propagator.rs
@@ -1,7 +1,9 @@
-use opentelemetry::api::trace::span_context::TraceState;
 use opentelemetry::api::{
-    Context, Extractor, FieldIter, Injector, SpanContext, SpanId, TextMapFormat, TraceContextExt,
-    TraceId, TRACE_FLAG_DEFERRED, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
+    trace::{
+        SpanContext, SpanId, TraceContextExt, TraceId, TraceState, TRACE_FLAG_DEFERRED,
+        TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
+    },
+    Context, Extractor, FieldIter, Injector, TextMapFormat,
 };
 
 const AWS_XRAY_TRACE_HEADER: &str = "x-amzn-trace-id";
@@ -234,7 +236,7 @@ fn title_case(s: &str) -> String {
 mod tests {
     use super::*;
     use opentelemetry::api;
-    use opentelemetry::api::trace::span_context::TraceState;
+    use opentelemetry::api::trace::TraceState;
     use std::collections::HashMap;
     use std::str::FromStr;
     use std::time::SystemTime;
@@ -298,7 +300,7 @@ mod tests {
     #[derive(Debug)]
     struct TestSpan(SpanContext);
 
-    impl api::Span for TestSpan {
+    impl api::trace::Span for TestSpan {
         fn add_event_with_timestamp(
             &self,
             _name: String,
@@ -313,7 +315,7 @@ mod tests {
             false
         }
         fn set_attribute(&self, _attribute: api::KeyValue) {}
-        fn set_status(&self, _code: api::StatusCode, _message: String) {}
+        fn set_status(&self, _code: api::trace::StatusCode, _message: String) {}
         fn update_name(&self, _new_name: String) {}
         fn end_with_timestamp(&self, _timestamp: SystemTime) {}
     }

--- a/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
+++ b/opentelemetry-contrib/src/trace_propagator/jaeger_propagator.rs
@@ -6,10 +6,12 @@
 //!
 //! [`Jaeger documentation`]: https://www.jaegertracing.io/docs/1.18/client-libraries/#propagation-format
 
-use opentelemetry::api::trace::span_context::TraceState;
 use opentelemetry::api::{
-    Context, Extractor, FieldIter, Injector, SpanContext, SpanId, TextMapFormat, TraceContextExt,
-    TraceId, TRACE_FLAG_DEBUG, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
+    trace::{
+        SpanContext, SpanId, TraceContextExt, TraceId, TraceState, TRACE_FLAG_DEBUG,
+        TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
+    },
+    Context, Extractor, FieldIter, Injector, TextMapFormat,
 };
 use std::borrow::Cow;
 use std::str::FromStr;
@@ -172,11 +174,13 @@ impl TextMapFormat for JaegerPropagator {
 #[cfg(test)]
 mod tests {
     use crate::trace_propagator::jaeger_propagator::{JaegerPropagator, JAEGER_HEADER};
-    use opentelemetry::api;
-    use opentelemetry::api::trace::span_context::TraceState;
     use opentelemetry::api::{
-        Context, Injector, Span, SpanContext, SpanId, TextMapFormat, TraceContextExt, TraceId,
-        TRACE_FLAG_DEBUG, TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
+        self,
+        trace::{
+            Span, SpanContext, SpanId, TraceContextExt, TraceId, TraceState, TRACE_FLAG_DEBUG,
+            TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
+        },
+        Context, Injector, TextMapFormat,
     };
     use std::collections::HashMap;
     use std::time::SystemTime;
@@ -380,14 +384,14 @@ mod tests {
             _attributes: Vec<api::KeyValue>,
         ) {
         }
-        fn span_context(&self) -> api::SpanContext {
+        fn span_context(&self) -> api::trace::SpanContext {
             self.0.clone()
         }
         fn is_recording(&self) -> bool {
             false
         }
         fn set_attribute(&self, _attribute: api::KeyValue) {}
-        fn set_status(&self, _code: api::StatusCode, _message: String) {}
+        fn set_status(&self, _code: api::trace::StatusCode, _message: String) {}
         fn update_name(&self, _new_name: String) {}
         fn end_with_timestamp(&self, _timestamp: SystemTime) {}
     }

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -114,7 +114,7 @@
 //!
 //! ```no_run
 //! use opentelemetry::api::{KeyValue, Tracer};
-//! use opentelemetry::sdk::{trace, IdGenerator, Resource, Sampler};
+//! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
@@ -254,7 +254,7 @@ pub struct PipelineBuilder {
     #[cfg(feature = "collector_client")]
     collector_password: Option<String>,
     process: Process,
-    config: Option<sdk::Config>,
+    config: Option<sdk::trace::Config>,
 }
 
 impl Default for PipelineBuilder {
@@ -345,7 +345,7 @@ impl PipelineBuilder {
     }
 
     /// Assign the SDK config for the exporter pipeline.
-    pub fn with_trace_config(self, config: sdk::Config) -> Self {
+    pub fn with_trace_config(self, config: sdk::trace::Config) -> Self {
         PipelineBuilder {
             config: Some(config),
             ..self
@@ -353,7 +353,7 @@ impl PipelineBuilder {
     }
 
     /// Install a Jaeger pipeline with the recommended defaults.
-    pub fn install(self) -> Result<(sdk::Tracer, Uninstall), Box<dyn Error>> {
+    pub fn install(self) -> Result<(sdk::trace::Tracer, Uninstall), Box<dyn Error>> {
         let tracer_provider = self.build()?;
         let tracer =
             tracer_provider.get_tracer("opentelemetry-jaeger", Some(env!("CARGO_PKG_VERSION")));
@@ -363,12 +363,12 @@ impl PipelineBuilder {
         Ok((tracer, Uninstall(provider_guard)))
     }
 
-    /// Build a configured `sdk::TracerProvider` with the recommended defaults.
-    pub fn build(mut self) -> Result<sdk::TracerProvider, Box<dyn Error>> {
+    /// Build a configured `sdk::trace::TracerProvider` with the recommended defaults.
+    pub fn build(mut self) -> Result<sdk::trace::TracerProvider, Box<dyn Error>> {
         let config = self.config.take();
         let exporter = self.init_exporter()?;
 
-        let mut builder = sdk::TracerProvider::builder().with_exporter(exporter);
+        let mut builder = sdk::trace::TracerProvider::builder().with_exporter(exporter);
 
         if let Some(config) = config {
             builder = builder.with_config(config)
@@ -478,7 +478,9 @@ impl Into<jaeger::Span> for &Arc<trace::SpanData> {
     }
 }
 
-fn links_to_references(links: &sdk::EvictedQueue<api::Link>) -> Option<Vec<jaeger::SpanRef>> {
+fn links_to_references(
+    links: &sdk::trace::EvictedQueue<api::Link>,
+) -> Option<Vec<jaeger::SpanRef>> {
     if !links.is_empty() {
         let refs = links
             .iter()
@@ -596,7 +598,7 @@ impl UserOverrides {
     }
 }
 
-fn events_to_logs(events: &sdk::EvictedQueue<api::Event>) -> Option<Vec<jaeger::Log>> {
+fn events_to_logs(events: &sdk::trace::EvictedQueue<api::Event>) -> Option<Vec<jaeger::Log>> {
     if events.is_empty() {
         None
     } else {

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -17,7 +17,7 @@
 //! exporting telemetry:
 //!
 //! ```no_run
-//! use opentelemetry::api::Tracer;
+//! use opentelemetry::api::trace::Tracer;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline().install()?;
@@ -56,7 +56,7 @@
 //! [jaeger variables spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md#jaeger-exporter
 //!
 //! ```no_run
-//! use opentelemetry::api::Tracer;
+//! use opentelemetry::api::trace::Tracer;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // export OTEL_SERVICE_NAME=my-service-name
@@ -87,7 +87,7 @@
 //!
 //! ```ignore
 //! // Note that this requires the `collector_client` feature.
-//! use opentelemetry::api::Tracer;
+//! use opentelemetry::api::trace::Tracer;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
@@ -113,7 +113,7 @@
 //! [`PipelineBuilder`]: struct.PipelineBuilder.html
 //!
 //! ```no_run
-//! use opentelemetry::api::{KeyValue, Tracer};
+//! use opentelemetry::api::{KeyValue, trace::Tracer};
 //! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -159,7 +159,7 @@ use async_trait::async_trait;
 #[cfg(feature = "collector_client")]
 use collector::CollectorAsyncClientHttp;
 use opentelemetry::{
-    api::{self, TracerProvider},
+    api::{self, trace::TracerProvider},
     exporter::trace,
     global, sdk,
 };
@@ -430,7 +430,7 @@ impl Into<jaeger::Tag> for api::KeyValue {
     }
 }
 
-impl Into<jaeger::Log> for api::Event {
+impl Into<jaeger::Log> for api::trace::Event {
     fn into(self) -> jaeger::Log {
         let timestamp = self
             .timestamp
@@ -479,7 +479,7 @@ impl Into<jaeger::Span> for &Arc<trace::SpanData> {
 }
 
 fn links_to_references(
-    links: &sdk::trace::EvictedQueue<api::Link>,
+    links: &sdk::trace::EvictedQueue<api::trace::Link>,
 ) -> Option<Vec<jaeger::SpanRef>> {
     if !links.is_empty() {
         let refs = links
@@ -546,7 +546,7 @@ fn build_span_tags(span_data: &Arc<trace::SpanData>) -> Option<Vec<jaeger::Tag>>
     }
 
     // Ensure error status is set
-    if span_data.status_code != api::StatusCode::OK && !user_overrides.error {
+    if span_data.status_code != api::trace::StatusCode::OK && !user_overrides.error {
         tags.push(api::Key::new(ERROR).bool(true).into())
     }
 
@@ -598,7 +598,9 @@ impl UserOverrides {
     }
 }
 
-fn events_to_logs(events: &sdk::trace::EvictedQueue<api::Event>) -> Option<Vec<jaeger::Log>> {
+fn events_to_logs(
+    events: &sdk::trace::EvictedQueue<api::trace::Event>,
+) -> Option<Vec<jaeger::Log>> {
     if events.is_empty() {
         None
     } else {

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -57,7 +57,7 @@
 //!
 //! ```no_run
 //! use opentelemetry::api::{KeyValue, Tracer};
-//! use opentelemetry::sdk::{trace, IdGenerator, Resource, Sampler};
+//! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //! use opentelemetry_otlp::{Compression, Credentials, Protocol};
 //! use std::time::Duration;
 //!
@@ -139,7 +139,7 @@ pub fn new_pipeline() -> OtlpPipelineBuilder {
 #[derive(Default, Debug)]
 pub struct OtlpPipelineBuilder {
     exporter_config: ExporterConfig,
-    trace_config: Option<sdk::Config>,
+    trace_config: Option<sdk::trace::Config>,
 }
 
 impl OtlpPipelineBuilder {
@@ -186,16 +186,16 @@ impl OtlpPipelineBuilder {
     }
 
     /// Set the trace provider configuration.
-    pub fn with_trace_config(mut self, trace_config: sdk::Config) -> Self {
+    pub fn with_trace_config(mut self, trace_config: sdk::trace::Config) -> Self {
         self.trace_config = Some(trace_config);
         self
     }
 
     /// Install the OTLP exporter pipeline with the recommended defaults.
-    pub fn install(mut self) -> Result<(sdk::Tracer, Uninstall), Box<dyn Error>> {
+    pub fn install(mut self) -> Result<(sdk::trace::Tracer, Uninstall), Box<dyn Error>> {
         let exporter = Exporter::new(self.exporter_config);
 
-        let mut provider_builder = sdk::TracerProvider::builder().with_exporter(exporter);
+        let mut provider_builder = sdk::trace::TracerProvider::builder().with_exporter(exporter);
         if let Some(config) = self.trace_config.take() {
             provider_builder = provider_builder.with_config(config);
         }

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -19,7 +19,7 @@
 //! telemetry:
 //!
 //! ```no_run
-//! use opentelemetry::api::Tracer;
+//! use opentelemetry::api::trace::Tracer;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let (tracer, _uninstall) = opentelemetry_otlp::new_pipeline().install()?;
@@ -56,7 +56,7 @@
 //! [`OtlpPipelineBuilder`]: struct.OtlpPipelineBuilder.html
 //!
 //! ```no_run
-//! use opentelemetry::api::{KeyValue, Tracer};
+//! use opentelemetry::api::{KeyValue, trace::Tracer};
 //! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //! use opentelemetry_otlp::{Compression, Credentials, Protocol};
 //! use std::time::Duration;
@@ -97,7 +97,7 @@
 //! ```
 #![deny(missing_docs, unreachable_pub, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
-use opentelemetry::{api::TracerProvider, global, sdk};
+use opentelemetry::{api::trace::TracerProvider, global, sdk};
 use std::collections::HashMap;
 use std::error::Error;
 use std::time::Duration;

--- a/opentelemetry-otlp/src/transform/common.rs
+++ b/opentelemetry-otlp/src/transform/common.rs
@@ -1,6 +1,6 @@
 use crate::proto::common::{AnyValue, ArrayValue, KeyValue};
 use opentelemetry::api::Value;
-use opentelemetry::sdk::EvictedHashMap;
+use opentelemetry::sdk::trace::EvictedHashMap;
 use protobuf::RepeatedField;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 

--- a/opentelemetry-otlp/src/transform/traces.rs
+++ b/opentelemetry-otlp/src/transform/traces.rs
@@ -4,7 +4,7 @@ use crate::proto::trace::{
     Status_StatusCode,
 };
 use crate::transform::common::{to_nanos, Attributes};
-use opentelemetry::api::{Link, SpanKind, StatusCode};
+use opentelemetry::api::trace::{Link, SpanKind, StatusCode};
 use opentelemetry::exporter::trace::SpanData;
 use protobuf::reflect::ProtobufValue;
 use protobuf::{RepeatedField, SingularPtrField};

--- a/opentelemetry-semantic-conventions/src/resource.rs
+++ b/opentelemetry-semantic-conventions/src/resource.rs
@@ -13,12 +13,12 @@
 //! use std::sync::Arc;
 //!
 //! let _tracer = opentelemetry::exporter::trace::stdout::new_pipeline()
-//!     .with_trace_config(sdk::Config {
+//!     .with_trace_config(sdk::trace::Config {
 //!         resource: Arc::new(sdk::Resource::new(vec![
 //!             semcov::resource::SERVICE_NAME.string("my-service"),
 //!             semcov::resource::SERVICE_NAMESPACE.string("my-namespace"),
 //!         ])),
-//!         ..sdk::Config::default()
+//!         ..sdk::trace::Config::default()
 //!     })
 //!     .install();
 //! ```

--- a/opentelemetry-semantic-conventions/src/trace.rs
+++ b/opentelemetry-semantic-conventions/src/trace.rs
@@ -8,7 +8,7 @@
 //! ## Usage
 //!
 //! ```rust
-//! use opentelemetry::api::Tracer;
+//! use opentelemetry::api::trace::Tracer;
 //! use opentelemetry::global;
 //! use opentelemetry_semantic_conventions as semcov;
 //!

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -17,7 +17,7 @@
 //! telemetry:
 //!
 //! ```no_run
-//! use opentelemetry::api::Tracer;
+//! use opentelemetry::api::trace::Tracer;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let (tracer, _uninstall) = opentelemetry_zipkin::new_pipeline().install()?;
@@ -54,7 +54,7 @@
 //! [`ZipkinPipelineBuilder`]: struct.ZipkinPipelineBuilder.html
 //!
 //! ```no_run
-//! use opentelemetry::api::{KeyValue, Tracer};
+//! use opentelemetry::api::{KeyValue, trace::Tracer};
 //! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -91,7 +91,7 @@ mod uploader;
 
 use async_trait::async_trait;
 use model::endpoint::Endpoint;
-use opentelemetry::{api::TracerProvider, exporter::trace, global, sdk};
+use opentelemetry::{api::trace::TracerProvider, exporter::trace, global, sdk};
 use reqwest::Url;
 use std::error::Error;
 use std::net::SocketAddr;

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -55,7 +55,7 @@
 //!
 //! ```no_run
 //! use opentelemetry::api::{KeyValue, Tracer};
-//! use opentelemetry::sdk::{trace, IdGenerator, Resource, Sampler};
+//! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let (tracer, _uninstall) = opentelemetry_zipkin::new_pipeline()
@@ -130,7 +130,7 @@ pub struct ZipkinPipelineBuilder {
     service_name: String,
     service_addr: Option<SocketAddr>,
     collector_endpoint: String,
-    trace_config: Option<sdk::Config>,
+    trace_config: Option<sdk::trace::Config>,
 }
 
 impl Default for ZipkinPipelineBuilder {
@@ -146,11 +146,11 @@ impl Default for ZipkinPipelineBuilder {
 
 impl ZipkinPipelineBuilder {
     /// Create `ExporterConfig` struct from current `ExporterConfigBuilder`
-    pub fn install(mut self) -> Result<(sdk::Tracer, Uninstall), Box<dyn Error>> {
+    pub fn install(mut self) -> Result<(sdk::trace::Tracer, Uninstall), Box<dyn Error>> {
         let endpoint = Endpoint::new(self.service_name, self.service_addr);
         let exporter = Exporter::new(endpoint, self.collector_endpoint.parse()?);
 
-        let mut provider_builder = sdk::TracerProvider::builder().with_exporter(exporter);
+        let mut provider_builder = sdk::trace::TracerProvider::builder().with_exporter(exporter);
         if let Some(config) = self.trace_config.take() {
             provider_builder = provider_builder.with_config(config);
         }
@@ -180,7 +180,7 @@ impl ZipkinPipelineBuilder {
     }
 
     /// Assign the SDK trace configuration.
-    pub fn with_trace_config(mut self, config: sdk::Config) -> Self {
+    pub fn with_trace_config(mut self, config: sdk::trace::Config) -> Self {
         self.trace_config = Some(config);
         self
     }

--- a/opentelemetry-zipkin/src/model/mod.rs
+++ b/opentelemetry-zipkin/src/model/mod.rs
@@ -15,8 +15,8 @@ const INSTRUMENTATION_LIBRARY_NAME: &str = "otel.library.name";
 /// Instrument Library version MUST be reported in Jaeger Span tags with the following key
 const INSTRUMENTATION_LIBRARY_VERSION: &str = "otel.library.version";
 
-/// Converts `api::Event` into an `annotation::Annotation`
-impl Into<annotation::Annotation> for api::Event {
+/// Converts `api::trace::Event` into an `annotation::Annotation`
+impl Into<annotation::Annotation> for api::trace::Event {
     fn into(self) -> annotation::Annotation {
         let timestamp = self
             .timestamp
@@ -32,36 +32,36 @@ impl Into<annotation::Annotation> for api::Event {
 }
 
 /// Converts StatusCode to str
-fn from_statuscode_to_str(status_code: api::StatusCode) -> &'static str {
+fn from_statuscode_to_str(status_code: api::trace::StatusCode) -> &'static str {
     match status_code {
-        api::StatusCode::OK => "OK",
-        api::StatusCode::Canceled => "CANCELLED",
-        api::StatusCode::Unknown => "UNKNOWN",
-        api::StatusCode::InvalidArgument => "INVALID_ARGUMENT",
-        api::StatusCode::DeadlineExceeded => "DEADLINE_EXCEEDED",
-        api::StatusCode::NotFound => "NOT_FOUND",
-        api::StatusCode::AlreadyExists => "ALREADY_EXISTS",
-        api::StatusCode::PermissionDenied => "PERMISSION_DENIED",
-        api::StatusCode::ResourceExhausted => "RESOURSE_EXHAUSTED",
-        api::StatusCode::FailedPrecondition => "FAILED_PRECONDITION",
-        api::StatusCode::Aborted => "ABORTED",
-        api::StatusCode::OutOfRange => "OUT_OF_RANGE",
-        api::StatusCode::Unimplemented => "UNINPLEMENTED",
-        api::StatusCode::Internal => "INTERNAL",
-        api::StatusCode::Unavailable => "UNAVAILABLE",
-        api::StatusCode::DataLoss => "DATA_LOSS",
-        api::StatusCode::Unauthenticated => "UNAUTHENTICATED",
+        api::trace::StatusCode::OK => "OK",
+        api::trace::StatusCode::Canceled => "CANCELLED",
+        api::trace::StatusCode::Unknown => "UNKNOWN",
+        api::trace::StatusCode::InvalidArgument => "INVALID_ARGUMENT",
+        api::trace::StatusCode::DeadlineExceeded => "DEADLINE_EXCEEDED",
+        api::trace::StatusCode::NotFound => "NOT_FOUND",
+        api::trace::StatusCode::AlreadyExists => "ALREADY_EXISTS",
+        api::trace::StatusCode::PermissionDenied => "PERMISSION_DENIED",
+        api::trace::StatusCode::ResourceExhausted => "RESOURSE_EXHAUSTED",
+        api::trace::StatusCode::FailedPrecondition => "FAILED_PRECONDITION",
+        api::trace::StatusCode::Aborted => "ABORTED",
+        api::trace::StatusCode::OutOfRange => "OUT_OF_RANGE",
+        api::trace::StatusCode::Unimplemented => "UNINPLEMENTED",
+        api::trace::StatusCode::Internal => "INTERNAL",
+        api::trace::StatusCode::Unavailable => "UNAVAILABLE",
+        api::trace::StatusCode::DataLoss => "DATA_LOSS",
+        api::trace::StatusCode::Unauthenticated => "UNAUTHENTICATED",
     }
 }
 
-/// Converts `api::SpanKind` into an `Option<span::Kind>`
-fn into_zipkin_span_kind(kind: api::SpanKind) -> Option<span::Kind> {
+/// Converts `api::trace::SpanKind` into an `Option<span::Kind>`
+fn into_zipkin_span_kind(kind: api::trace::SpanKind) -> Option<span::Kind> {
     match kind {
-        api::SpanKind::Client => Some(span::Kind::Client),
-        api::SpanKind::Server => Some(span::Kind::Server),
-        api::SpanKind::Producer => Some(span::Kind::Producer),
-        api::SpanKind::Consumer => Some(span::Kind::Consumer),
-        api::SpanKind::Internal => None,
+        api::trace::SpanKind::Client => Some(span::Kind::Client),
+        api::trace::SpanKind::Server => Some(span::Kind::Server),
+        api::trace::SpanKind::Producer => Some(span::Kind::Producer),
+        api::trace::SpanKind::Consumer => Some(span::Kind::Consumer),
+        api::trace::SpanKind::Internal => None,
     }
 }
 

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -17,7 +17,7 @@ use std::fmt::Debug;
 /// # Examples
 ///
 /// ```
-/// use opentelemetry::api::*;
+/// use opentelemetry::api::{*, trace::*};
 /// use opentelemetry::sdk;
 /// use std::collections::HashMap;
 ///
@@ -101,11 +101,12 @@ impl TextMapFormat for TextMapCompositePropagator {
 
 #[cfg(test)]
 mod tests {
-    use crate::api;
-    use crate::api::trace::span_context::TraceState;
     use crate::api::{
-        Context, Extractor, FieldIter, Injector, SpanContext, SpanId, TextMapCompositePropagator,
-        TextMapFormat, TraceContextExt, TraceContextPropagator, TraceId,
+        self,
+        trace::{
+            SpanContext, SpanId, TraceContextExt, TraceContextPropagator, TraceId, TraceState,
+        },
+        Context, Extractor, FieldIter, Injector, TextMapCompositePropagator, TextMapFormat,
     };
     use std::collections::HashMap;
     use std::str::FromStr;
@@ -178,9 +179,9 @@ mod tests {
     }
 
     #[derive(Debug)]
-    struct TestSpan(api::SpanContext);
+    struct TestSpan(api::trace::SpanContext);
 
-    impl api::Span for TestSpan {
+    impl api::trace::Span for TestSpan {
         fn add_event_with_timestamp(
             &self,
             _name: String,
@@ -188,14 +189,14 @@ mod tests {
             _attributes: Vec<api::KeyValue>,
         ) {
         }
-        fn span_context(&self) -> api::SpanContext {
+        fn span_context(&self) -> api::trace::SpanContext {
             self.0.clone()
         }
         fn is_recording(&self) -> bool {
             false
         }
         fn set_attribute(&self, _attribute: api::KeyValue) {}
-        fn set_status(&self, _code: api::StatusCode, _message: String) {}
+        fn set_status(&self, _code: api::trace::StatusCode, _message: String) {}
         fn update_name(&self, _new_name: String) {}
         fn end_with_timestamp(&self, _timestamp: std::time::SystemTime) {}
     }

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 ///
 /// ```
 /// use opentelemetry::api::{*, trace::*};
-/// use opentelemetry::sdk;
+/// use opentelemetry::sdk::trace as sdktrace;
 /// use std::collections::HashMap;
 ///
 /// // First create 1 or more propagators
@@ -35,7 +35,7 @@ use std::fmt::Debug;
 /// let mut injector = HashMap::new();
 ///
 /// // And a given span
-/// let example_span = sdk::trace::TracerProvider::default().get_tracer("example-component", None).start("span-name");
+/// let example_span = sdktrace::TracerProvider::default().get_tracer("example-component", None).start("span-name");
 ///
 /// // with the current context, call inject to add the headers
 /// composite_propagator.inject_context(&Context::current_with_span(example_span)

--- a/src/api/context/propagation/composite_propagator.rs
+++ b/src/api/context/propagation/composite_propagator.rs
@@ -35,7 +35,7 @@ use std::fmt::Debug;
 /// let mut injector = HashMap::new();
 ///
 /// // And a given span
-/// let example_span = sdk::TracerProvider::default().get_tracer("example-component", None).start("span-name");
+/// let example_span = sdk::trace::TracerProvider::default().get_tracer("example-component", None).start("span-name");
 ///
 /// // with the current context, call inject to add the headers
 /// composite_propagator.inject_context(&Context::current_with_span(example_span)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -32,22 +32,3 @@ pub use context::propagation::{
     text_propagator::TextMapFormat, Extractor, Injector,
 };
 pub use context::Context;
-
-#[cfg(feature = "trace")]
-pub use trace::{
-    context::TraceContextExt,
-    event::Event,
-    futures::FutureExt,
-    id_generator::IdGenerator,
-    link::Link,
-    noop::{NoopSpan, NoopSpanExporter, NoopTracer, NoopTracerProvider},
-    provider::TracerProvider,
-    span::{Span, SpanKind, StatusCode},
-    span_context::{
-        SpanContext, SpanId, TraceId, TraceState, TRACE_FLAG_DEBUG, TRACE_FLAG_DEFERRED,
-        TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
-    },
-    span_processor::SpanProcessor,
-    trace_context_propagator::TraceContextPropagator,
-    tracer::{SpanBuilder, Tracer},
-};

--- a/src/api/trace/context.rs
+++ b/src/api/trace/context.rs
@@ -26,12 +26,12 @@ pub trait TraceContextExt {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::{api, api::{Context, trace::{TracerProvider, TraceContextExt, Tracer}}, sdk};
+    /// use opentelemetry::{api, api::{Context, trace::{TracerProvider, TraceContextExt, Tracer}}, sdk::trace as sdktrace};
     ///
     /// // returns a reference to an empty span by default
     /// assert_eq!(Context::current().span().span_context(), api::trace::SpanContext::empty_context());
     ///
-    /// sdk::trace::TracerProvider::default().get_tracer("my-component", None).in_span("my-span", |cx| {
+    /// sdktrace::TracerProvider::default().get_tracer("my-component", None).in_span("my-span", |cx| {
     ///     // Returns a reference to the current span if set
     ///     assert_ne!(cx.span().span_context(), api::trace::SpanContext::empty_context());
     /// });

--- a/src/api/trace/context.rs
+++ b/src/api/trace/context.rs
@@ -31,7 +31,7 @@ pub trait TraceContextExt {
     /// // returns a reference to an empty span by default
     /// assert_eq!(Context::current().span().span_context(), api::SpanContext::empty_context());
     ///
-    /// sdk::TracerProvider::default().get_tracer("my-component", None).in_span("my-span", |cx| {
+    /// sdk::trace::TracerProvider::default().get_tracer("my-component", None).in_span("my-span", |cx| {
     ///     // Returns a reference to the current span if set
     ///     assert_ne!(cx.span().span_context(), api::SpanContext::empty_context());
     /// });

--- a/src/api/trace/context.rs
+++ b/src/api/trace/context.rs
@@ -2,23 +2,23 @@
 use crate::api;
 
 lazy_static::lazy_static! {
-    static ref NOOP_SPAN: api::NoopSpan = api::NoopSpan::new();
+    static ref NOOP_SPAN: api::trace::NoopSpan = api::trace::NoopSpan::new();
 }
 
-struct Span(Box<dyn api::Span + Send + Sync>);
-struct RemoteSpanContext(api::SpanContext);
+struct Span(Box<dyn api::trace::Span + Send + Sync>);
+struct RemoteSpanContext(api::trace::SpanContext);
 
 /// Methods for storing and retrieving trace data in a context.
 pub trait TraceContextExt {
     /// Returns a clone of the current context with the included span.
     ///
     /// This is useful for building tracers.
-    fn current_with_span<T: api::Span + Send + Sync>(span: T) -> Self;
+    fn current_with_span<T: api::trace::Span + Send + Sync>(span: T) -> Self;
 
     /// Returns a clone of this context with the included span.
     ///
     /// This is useful for building tracers.
-    fn with_span<T: api::Span + Send + Sync>(&self, span: T) -> Self;
+    fn with_span<T: api::trace::Span + Send + Sync>(&self, span: T) -> Self;
 
     /// Returns a reference to this context's span, or the default no-op span if
     /// none has been set.
@@ -26,40 +26,40 @@ pub trait TraceContextExt {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::{api, api::{Context, TracerProvider, TraceContextExt, Tracer}, sdk};
+    /// use opentelemetry::{api, api::{Context, trace::{TracerProvider, TraceContextExt, Tracer}}, sdk};
     ///
     /// // returns a reference to an empty span by default
-    /// assert_eq!(Context::current().span().span_context(), api::SpanContext::empty_context());
+    /// assert_eq!(Context::current().span().span_context(), api::trace::SpanContext::empty_context());
     ///
     /// sdk::trace::TracerProvider::default().get_tracer("my-component", None).in_span("my-span", |cx| {
     ///     // Returns a reference to the current span if set
-    ///     assert_ne!(cx.span().span_context(), api::SpanContext::empty_context());
+    ///     assert_ne!(cx.span().span_context(), api::trace::SpanContext::empty_context());
     /// });
     /// ```
-    fn span(&self) -> &dyn api::Span;
+    fn span(&self) -> &dyn api::trace::Span;
 
     /// Returns a copy of this context with the span context included.
     ///
     /// This is useful for building propagators.
-    fn with_remote_span_context(&self, span_context: api::SpanContext) -> Self;
+    fn with_remote_span_context(&self, span_context: api::trace::SpanContext) -> Self;
 
     /// Returns a reference to the remote span context data stored in this context,
     /// or none if no remote span context has been set.
     ///
     /// This is useful for building tracers.
-    fn remote_span_context(&self) -> Option<&api::SpanContext>;
+    fn remote_span_context(&self) -> Option<&api::trace::SpanContext>;
 }
 
 impl TraceContextExt for api::Context {
-    fn current_with_span<T: api::Span + Send + Sync>(span: T) -> Self {
+    fn current_with_span<T: api::trace::Span + Send + Sync>(span: T) -> Self {
         api::Context::current_with_value(Span(Box::new(span)))
     }
 
-    fn with_span<T: api::Span + Send + Sync>(&self, span: T) -> Self {
+    fn with_span<T: api::trace::Span + Send + Sync>(&self, span: T) -> Self {
         self.with_value(Span(Box::new(span)))
     }
 
-    fn span(&self) -> &dyn api::Span {
+    fn span(&self) -> &dyn api::trace::Span {
         if let Some(span) = self.get::<Span>() {
             span.0.as_ref()
         } else {
@@ -67,11 +67,11 @@ impl TraceContextExt for api::Context {
         }
     }
 
-    fn with_remote_span_context(&self, span_context: api::SpanContext) -> Self {
+    fn with_remote_span_context(&self, span_context: api::trace::SpanContext) -> Self {
         self.with_value(RemoteSpanContext(span_context))
     }
 
-    fn remote_span_context(&self) -> Option<&api::SpanContext> {
+    fn remote_span_context(&self) -> Option<&api::trace::SpanContext> {
         self.get::<RemoteSpanContext>()
             .map(|span_context| &span_context.0)
     }

--- a/src/api/trace/id_generator.rs
+++ b/src/api/trace/id_generator.rs
@@ -5,8 +5,8 @@ use std::fmt;
 /// Interface for generating IDs
 pub trait IdGenerator: Send + Sync + fmt::Debug {
     /// Generate a new `TraceId`
-    fn new_trace_id(&self) -> api::TraceId;
+    fn new_trace_id(&self) -> api::trace::TraceId;
 
     /// Generate a new `SpanId`
-    fn new_span_id(&self) -> api::SpanId;
+    fn new_span_id(&self) -> api::trace::SpanId;
 }

--- a/src/api/trace/link.rs
+++ b/src/api/trace/link.rs
@@ -8,13 +8,13 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Link {
-    span_context: api::SpanContext,
+    span_context: api::trace::SpanContext,
     attributes: Vec<api::KeyValue>,
 }
 
 impl Link {
     /// Create a new link
-    pub fn new(span_context: api::SpanContext, attributes: Vec<api::KeyValue>) -> Self {
+    pub fn new(span_context: api::trace::SpanContext, attributes: Vec<api::KeyValue>) -> Self {
         Link {
             span_context,
             attributes,
@@ -22,7 +22,7 @@ impl Link {
     }
 
     /// The span context of the linked span
-    pub fn span_context(&self) -> &api::SpanContext {
+    pub fn span_context(&self) -> &api::trace::SpanContext {
         &self.span_context
     }
 

--- a/src/api/trace/mod.rs
+++ b/src/api/trace/mod.rs
@@ -110,15 +110,33 @@
 //! Please review the W3C specification for details on the [Tracestate
 //! field](https://www.w3.org/TR/trace-context/#tracestate-field).
 //!
-pub mod context;
-pub mod event;
-pub mod futures;
-pub mod id_generator;
-pub mod link;
-pub mod noop;
-pub mod provider;
-pub mod span;
-pub mod span_context;
-pub mod span_processor;
-pub mod trace_context_propagator;
-pub mod tracer;
+mod context;
+mod event;
+mod futures;
+mod id_generator;
+mod link;
+mod noop;
+mod provider;
+mod span;
+mod span_context;
+mod span_processor;
+mod trace_context_propagator;
+mod tracer;
+
+pub use self::{
+    context::TraceContextExt,
+    event::Event,
+    futures::FutureExt,
+    id_generator::IdGenerator,
+    link::Link,
+    noop::{NoopSpan, NoopSpanExporter, NoopTracer, NoopTracerProvider},
+    provider::TracerProvider,
+    span::{Span, SpanKind, StatusCode},
+    span_context::{
+        SpanContext, SpanId, TraceId, TraceState, TRACE_FLAG_DEBUG, TRACE_FLAG_DEFERRED,
+        TRACE_FLAG_NOT_SAMPLED, TRACE_FLAG_SAMPLED,
+    },
+    span_processor::SpanProcessor,
+    trace_context_propagator::TraceContextPropagator,
+    tracer::{SpanBuilder, Tracer},
+};

--- a/src/api/trace/provider.rs
+++ b/src/api/trace/provider.rs
@@ -25,7 +25,7 @@ use std::fmt;
 /// An interface to create `Tracer` instances.
 pub trait TracerProvider: fmt::Debug + 'static {
     /// The `Tracer` type that this `TracerProvider` will return.
-    type Tracer: api::Tracer;
+    type Tracer: api::trace::Tracer;
 
     /// Creates a named tracer instance of `Self::Tracer`.
     /// If the name is an empty string then provider uses default name.

--- a/src/api/trace/span.rs
+++ b/src/api/trace/span.rs
@@ -87,7 +87,7 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
 
     /// Returns the `SpanContext` for the given `Span`. The returned value may be used even after
     /// the `Span is finished. The returned value MUST be the same for the entire `Span` lifetime.
-    fn span_context(&self) -> api::SpanContext;
+    fn span_context(&self) -> api::trace::SpanContext;
 
     /// Returns true if this `Span` is recording information like events with the `add_event`
     /// operation, attributes using `set_attributes`, status with `set_status`, etc.
@@ -127,7 +127,7 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     ///
     /// Only the value of the last call will be recorded, and implementations are free
     /// to ignore previous calls.
-    fn set_status(&self, code: api::StatusCode, message: String);
+    fn set_status(&self, code: api::trace::StatusCode, message: String);
 
     /// Updates the `Span`'s name. After this update, any sampling behavior based on the
     /// name will depend on the implementation.

--- a/src/api/trace/span_context.rs
+++ b/src/api/trace/span_context.rs
@@ -159,7 +159,7 @@ impl TraceState {
     /// use opentelemetry::api;
     ///
     /// let kvs = vec![("foo", "bar"), ("apple", "banana")];
-    /// let trace_state: Result<api::TraceState, ()> = api::TraceState::from_key_value(kvs);
+    /// let trace_state: Result<api::trace::TraceState, ()> = api::trace::TraceState::from_key_value(kvs);
     ///
     /// assert!(trace_state.is_ok());
     /// assert_eq!(trace_state.unwrap().header(), String::from("foo=bar,apple=banana"))

--- a/src/api/trace/tracer.rs
+++ b/src/api/trace/tracer.rs
@@ -25,7 +25,7 @@
 //! Spans can be created and nested manually:
 //!
 //! ```
-//! use opentelemetry::{global, api::{Span, Tracer}};
+//! use opentelemetry::{global, api::trace::{Span, Tracer}};
 //! let tracer = global::tracer("my-component");
 //!
 //! let parent = tracer.start("foo");
@@ -42,7 +42,7 @@
 //! Spans can also use the current thread's [`Context`] to track which span is active:
 //!
 //! ```
-//! use opentelemetry::{global, api::{Tracer, SpanKind}};
+//! use opentelemetry::{global, api::trace::{Tracer, SpanKind}};
 //! let tracer = global::tracer("my-component");
 //!
 //! // Create simple spans with `in_span`
@@ -74,7 +74,7 @@
 //! greater control over when the span is no longer considered active.
 //!
 //! ```
-//! use opentelemetry::{global, api::{Span, Tracer}};
+//! use opentelemetry::{global, api::trace::{Span, Tracer}};
 //! let tracer = global::tracer("my-component");
 //!
 //! let parent_span = tracer.start("foo");
@@ -103,7 +103,7 @@
 //! the following example _will not_ work:
 //!
 //! ```no_run
-//! # use opentelemetry::{global, api::Tracer};
+//! # use opentelemetry::{global, api::trace::Tracer};
 //! # let tracer = global::tracer("foo");
 //! # let span = tracer.start("foo-span");
 //! async {
@@ -124,7 +124,7 @@
 //!
 //! ```
 //! # async fn run() -> Result<(), ()> {
-//! use opentelemetry::api::{Context, FutureExt};
+//! use opentelemetry::api::{Context, trace::FutureExt};
 //! let cx = Context::current();
 //!
 //! let my_future = async {
@@ -148,7 +148,7 @@
 use crate::api::{
     self,
     context::{Context, ContextGuard},
-    TraceContextExt,
+    trace::TraceContextExt,
 };
 use crate::sdk;
 use std::fmt;
@@ -157,7 +157,7 @@ use std::time::SystemTime;
 /// Interface for constructing `Span`s.
 pub trait Tracer: fmt::Debug + 'static {
     /// The `Span` type used by this `Tracer`.
-    type Span: api::Span;
+    type Span: api::trace::Span;
 
     /// Returns a span with an invalid `SpanContext`. Used by functions that
     /// need to return a default span like `get_active_span` if no span is present.
@@ -239,7 +239,7 @@ pub trait Tracer: fmt::Debug + 'static {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::{global, api::{Span, Tracer, KeyValue}};
+    /// use opentelemetry::{global, api::{trace::{Span, Tracer}, KeyValue}};
     ///
     /// fn my_function() {
     ///     let tracer = global::tracer("my-component-a");
@@ -268,7 +268,7 @@ pub trait Tracer: fmt::Debug + 'static {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::{global, api::{Span, Tracer, KeyValue}};
+    /// use opentelemetry::{global, api::{trace::{Span, Tracer}, KeyValue}};
     ///
     /// fn my_function() {
     ///     // start an active span in one function
@@ -287,7 +287,7 @@ pub trait Tracer: fmt::Debug + 'static {
     /// ```
     fn get_active_span<F, T>(&self, f: F) -> T
     where
-        F: FnOnce(&dyn api::Span) -> T,
+        F: FnOnce(&dyn api::trace::Span) -> T,
         Self: Sized,
     {
         f(Context::current().span())
@@ -303,7 +303,7 @@ pub trait Tracer: fmt::Debug + 'static {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::{global, api::{Span, Tracer, KeyValue}};
+    /// use opentelemetry::{global, api::{trace::{Span, Tracer}, KeyValue}};
     ///
     /// fn my_function() {
     ///     // start an active span in one function
@@ -341,7 +341,7 @@ pub trait Tracer: fmt::Debug + 'static {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::{global, api::{Span, SpanKind, Tracer, KeyValue}};
+    /// use opentelemetry::{global, api::{trace::{Span, SpanKind, Tracer}, KeyValue}};
     ///
     /// fn my_function() {
     ///     let tracer = global::tracer("my-component");
@@ -377,7 +377,7 @@ pub trait Tracer: fmt::Debug + 'static {
 ///
 /// ```rust
 /// use opentelemetry::{
-///     api::{TracerProvider, SpanBuilder, SpanKind, Tracer},
+///     api::trace::{TracerProvider, SpanBuilder, SpanKind, Tracer},
 ///     global,
 /// };
 ///
@@ -399,13 +399,13 @@ pub trait Tracer: fmt::Debug + 'static {
 #[derive(Clone, Debug, Default)]
 pub struct SpanBuilder {
     /// Parent `SpanContext`
-    pub parent_context: Option<api::SpanContext>,
+    pub parent_context: Option<api::trace::SpanContext>,
     /// Trace id, useful for integrations with external tracing systems.
-    pub trace_id: Option<api::TraceId>,
+    pub trace_id: Option<api::trace::TraceId>,
     /// Span id, useful for integrations with external tracing systems.
-    pub span_id: Option<api::SpanId>,
+    pub span_id: Option<api::trace::SpanId>,
     /// Span kind
-    pub span_kind: Option<api::SpanKind>,
+    pub span_kind: Option<api::trace::SpanKind>,
     /// Span name
     pub name: String,
     /// Span start time
@@ -415,11 +415,11 @@ pub struct SpanBuilder {
     /// Span attributes
     pub attributes: Option<Vec<api::KeyValue>>,
     /// Span Message events
-    pub message_events: Option<Vec<api::Event>>,
+    pub message_events: Option<Vec<api::trace::Event>>,
     /// Span Links
-    pub links: Option<Vec<api::Link>>,
+    pub links: Option<Vec<api::trace::Link>>,
     /// Span status code
-    pub status_code: Option<api::StatusCode>,
+    pub status_code: Option<api::trace::StatusCode>,
     /// Span status message
     pub status_message: Option<String>,
     /// Sampling result
@@ -448,7 +448,7 @@ impl SpanBuilder {
     }
 
     /// Assign parent context
-    pub fn with_parent(self, parent_context: api::SpanContext) -> Self {
+    pub fn with_parent(self, parent_context: api::trace::SpanContext) -> Self {
         SpanBuilder {
             parent_context: Some(parent_context),
             ..self
@@ -456,7 +456,7 @@ impl SpanBuilder {
     }
 
     /// Specify trace id to use if no parent context exists
-    pub fn with_trace_id(self, trace_id: api::TraceId) -> Self {
+    pub fn with_trace_id(self, trace_id: api::trace::TraceId) -> Self {
         SpanBuilder {
             trace_id: Some(trace_id),
             ..self
@@ -464,7 +464,7 @@ impl SpanBuilder {
     }
 
     /// Assign span id
-    pub fn with_span_id(self, span_id: api::SpanId) -> Self {
+    pub fn with_span_id(self, span_id: api::trace::SpanId) -> Self {
         SpanBuilder {
             span_id: Some(span_id),
             ..self
@@ -472,7 +472,7 @@ impl SpanBuilder {
     }
 
     /// Assign span kind
-    pub fn with_kind(self, span_kind: api::SpanKind) -> Self {
+    pub fn with_kind(self, span_kind: api::trace::SpanKind) -> Self {
         SpanBuilder {
             span_kind: Some(span_kind),
             ..self
@@ -504,7 +504,7 @@ impl SpanBuilder {
     }
 
     /// Assign message events
-    pub fn with_message_events(self, message_events: Vec<api::Event>) -> Self {
+    pub fn with_message_events(self, message_events: Vec<api::trace::Event>) -> Self {
         SpanBuilder {
             message_events: Some(message_events),
             ..self
@@ -512,7 +512,7 @@ impl SpanBuilder {
     }
 
     /// Assign links
-    pub fn with_links(self, links: Vec<api::Link>) -> Self {
+    pub fn with_links(self, links: Vec<api::trace::Link>) -> Self {
         SpanBuilder {
             links: Some(links),
             ..self
@@ -520,7 +520,7 @@ impl SpanBuilder {
     }
 
     /// Assign status code
-    pub fn with_status_code(self, code: api::StatusCode) -> Self {
+    pub fn with_status_code(self, code: api::trace::StatusCode) -> Self {
         SpanBuilder {
             status_code: Some(code),
             ..self
@@ -544,7 +544,7 @@ impl SpanBuilder {
     }
 
     /// Builds a span with the given tracer from this configuration.
-    pub fn start<T: api::Tracer>(self, tracer: &T) -> T::Span {
+    pub fn start<T: api::trace::Tracer>(self, tracer: &T) -> T::Span {
         tracer.build(self)
     }
 }

--- a/src/api/trace/tracer.rs
+++ b/src/api/trace/tracer.rs
@@ -423,7 +423,7 @@ pub struct SpanBuilder {
     /// Span status message
     pub status_message: Option<String>,
     /// Sampling result
-    pub sampling_result: Option<sdk::SamplingResult>,
+    pub sampling_result: Option<sdk::trace::SamplingResult>,
 }
 
 /// SpanBuilder methods
@@ -536,7 +536,7 @@ impl SpanBuilder {
     }
 
     /// Assign sampling result
-    pub fn with_sampling_result(self, sampling_result: sdk::SamplingResult) -> Self {
+    pub fn with_sampling_result(self, sampling_result: sdk::trace::SamplingResult) -> Self {
         SpanBuilder {
             sampling_result: Some(sampling_result),
             ..self

--- a/src/experimental/api/context/propagation/base64_format.rs
+++ b/src/experimental/api/context/propagation/base64_format.rs
@@ -15,25 +15,25 @@ use base64::{decode, encode};
 /// representation.
 pub trait Base64Format {
     /// Serializes span context into a base64 encoded string
-    fn to_base64(&self, context: &api::SpanContext) -> String;
+    fn to_base64(&self, context: &api::trace::SpanContext) -> String;
 
     /// Deserialize a span context from a base64 encoded string
-    fn from_base64(&self, base64: &str) -> api::SpanContext;
+    fn from_base64(&self, base64: &str) -> api::trace::SpanContext;
 }
 
 impl<Format> Base64Format for Format
 where
     Format: BinaryFormat,
 {
-    fn to_base64(&self, context: &api::SpanContext) -> String {
+    fn to_base64(&self, context: &api::trace::SpanContext) -> String {
         encode(&self.to_bytes(context))
     }
 
-    fn from_base64(&self, base64: &str) -> api::SpanContext {
+    fn from_base64(&self, base64: &str) -> api::trace::SpanContext {
         if let Ok(bytes) = decode(base64.as_bytes()) {
             self.from_bytes(bytes)
         } else {
-            api::SpanContext::empty_context()
+            api::trace::SpanContext::empty_context()
         }
     }
 }
@@ -42,28 +42,28 @@ where
 mod tests {
     use super::super::binary_propagator::BinaryPropagator;
     use super::*;
-    use crate::api::trace::span_context::TraceState;
+    use crate::api::trace::TraceState;
 
     #[rustfmt::skip]
-    fn to_base64_data() -> Vec<(api::SpanContext, String)> {
+    fn to_base64_data() -> Vec<(api::trace::SpanContext, String)> {
         vec![
-            (api::SpanContext::new(
-                api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736),
-                api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true, TraceState::default()),
+            (api::trace::SpanContext::new(
+                api::trace::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736),
+                api::trace::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true, TraceState::default()),
                 "AABL+S81d7NNpqPOkp0ODkc2AQDwZ6oLqQK3AgE=".to_string()
             ),
-            (api::SpanContext::new(
-                api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736),
-                api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 0, true, TraceState::default()),
+            (api::trace::SpanContext::new(
+                api::trace::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736),
+                api::trace::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 0, true, TraceState::default()),
                 "AABL+S81d7NNpqPOkp0ODkc2AQDwZ6oLqQK3AgA=".to_string()
             ),
         ]
     }
 
     #[rustfmt::skip]
-    fn from_base64_data() -> Vec<(api::SpanContext, String)> {
+    fn from_base64_data() -> Vec<(api::trace::SpanContext, String)> {
         vec![
-            (api::SpanContext::empty_context(), "invalid base64 string".to_string())
+            (api::trace::SpanContext::empty_context(), "invalid base64 string".to_string())
         ]
     }
 

--- a/src/experimental/api/context/propagation/binary_propagator.rs
+++ b/src/experimental/api/context/propagation/binary_propagator.rs
@@ -6,17 +6,17 @@
 //! `BinaryFormat` MUST expose the APIs that serializes values into bytes,
 //! and deserializes values from bytes.
 use crate::api;
-use crate::api::trace::span_context::TraceState;
+use crate::api::trace::TraceState;
 use std::convert::TryInto;
 
 /// Used to serialize and deserialize `SpanContext`s to and from a binary
 /// representation.
 pub trait BinaryFormat {
     /// Serializes span context into a byte array and returns the array.
-    fn to_bytes(&self, context: &api::SpanContext) -> [u8; 29];
+    fn to_bytes(&self, context: &api::trace::SpanContext) -> [u8; 29];
 
     /// Deserializes a span context from a byte array.
-    fn from_bytes(&self, bytes: Vec<u8>) -> api::SpanContext;
+    fn from_bytes(&self, bytes: Vec<u8>) -> api::trace::SpanContext;
 }
 
 /// Extracts and injects `SpanContext`s from byte arrays.
@@ -32,7 +32,7 @@ impl BinaryPropagator {
 
 impl BinaryFormat for BinaryPropagator {
     /// Serializes span context into a byte array and returns the array.
-    fn to_bytes(&self, context: &api::SpanContext) -> [u8; 29] {
+    fn to_bytes(&self, context: &api::trace::SpanContext) -> [u8; 29] {
         let mut res = [0u8; 29];
         if !context.is_valid() {
             return res;
@@ -47,9 +47,9 @@ impl BinaryFormat for BinaryPropagator {
     }
 
     /// Deserializes a span context from a byte array.
-    fn from_bytes(&self, bytes: Vec<u8>) -> api::SpanContext {
+    fn from_bytes(&self, bytes: Vec<u8>) -> api::trace::SpanContext {
         if bytes.is_empty() {
-            return api::SpanContext::empty_context();
+            return api::trace::SpanContext::empty_context();
         }
         let trace_id: u128;
         let mut span_id = 0;
@@ -59,7 +59,7 @@ impl BinaryFormat for BinaryPropagator {
             trace_id = u128::from_be_bytes(b[1..17].try_into().unwrap());
             b = &b[17..];
         } else {
-            return api::SpanContext::empty_context();
+            return api::trace::SpanContext::empty_context();
         }
         if b.len() >= 9 && b[0] == 1 {
             span_id = u64::from_be_bytes(b[1..9].try_into().unwrap());
@@ -69,9 +69,9 @@ impl BinaryFormat for BinaryPropagator {
             trace_flags = b[1]
         }
 
-        let span_context = api::SpanContext::new(
-            api::TraceId::from_u128(trace_id),
-            api::SpanId::from_u64(span_id),
+        let span_context = api::trace::SpanContext::new(
+            api::trace::TraceId::from_u128(trace_id),
+            api::trace::SpanId::from_u64(span_id),
             trace_flags,
             true,
             // TODO traceparent and tracestate should both begin with a 0 byte, figure out how to differentiate
@@ -81,7 +81,7 @@ impl BinaryFormat for BinaryPropagator {
         if span_context.is_valid() {
             span_context
         } else {
-            api::SpanContext::empty_context()
+            api::trace::SpanContext::empty_context()
         }
     }
 }
@@ -89,71 +89,71 @@ impl BinaryFormat for BinaryPropagator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::trace::span_context::TraceState;
+    use crate::api::trace::TraceState;
 
     #[rustfmt::skip]
-    fn to_bytes_data() -> Vec<(api::SpanContext, [u8; 29])> {
+    fn to_bytes_data() -> Vec<(api::trace::SpanContext, [u8; 29])> {
         vec![
             // Context with sampled
-            (api::SpanContext::new(
-                api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736),
-                api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true, TraceState::default()), [
+            (api::trace::SpanContext::new(
+                api::trace::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736),
+                api::trace::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true, TraceState::default()), [
                 0x00, 0x00, 0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36,
                 0x01, 0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7,
                 0x02, 0x01,
             ]),
             // Context without sampled
-            (api::SpanContext::new(
-                api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736),
-                api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 0, true, TraceState::default()), [
+            (api::trace::SpanContext::new(
+                api::trace::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736),
+                api::trace::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 0, true, TraceState::default()), [
                 0x00, 0x00, 0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36,
                 0x01, 0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7,
                 0x02, 0x00,
             ]),
             // Invalid context
-            (api::SpanContext::empty_context(), [0u8; 29]),
+            (api::trace::SpanContext::empty_context(), [0u8; 29]),
         ]
     }
 
     #[rustfmt::skip]
-    fn from_bytes_data() -> Vec<(api::SpanContext, Vec<u8>)> {
+    fn from_bytes_data() -> Vec<(api::trace::SpanContext, Vec<u8>)> {
         vec![
             // Future version of the proto
-            (api::SpanContext::new(api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true, TraceState::default()), vec![
+            (api::trace::SpanContext::new(api::trace::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), api::trace::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true, TraceState::default()), vec![
                 0x02, 0x00, 0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36,
                 0x01, 0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7,
                 0x02, 0x01,
             ]),
             // current version with sampled
-            (api::SpanContext::new(api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true, TraceState::default()), vec![
+            (api::trace::SpanContext::new(api::trace::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), api::trace::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 1, true, TraceState::default()), vec![
                 0x02, 0x00, 0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36,
                 0x01, 0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7,
                 0x02, 0x01,
             ]),
             // valid context without option
-            (api::SpanContext::new(api::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), api::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 0, true, TraceState::default()), vec![
+            (api::trace::SpanContext::new(api::trace::TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), api::trace::SpanId::from_u64(0x00f0_67aa_0ba9_02b7), 0, true, TraceState::default()), vec![
                 0x00, 0x00, 0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36,
                 0x01, 0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7,
             ]),
             // zero trace id
-            (api::SpanContext::empty_context(), vec![
+            (api::trace::SpanContext::empty_context(), vec![
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                 0x02, 0x01,
             ]),
             // zero span id
-            (api::SpanContext::empty_context(), vec![
+            (api::trace::SpanContext::empty_context(), vec![
                 0x00, 0x00, 0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36,
                 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                 0x02, 0x01,
             ]),
             // wrong trace id field number
-            (api::SpanContext::empty_context(), vec![
+            (api::trace::SpanContext::empty_context(), vec![
                 0x00, 0x01, 0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36,
                 0x01, 0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7,
             ]),
             // short byte array
-            (api::SpanContext::empty_context(), vec![
+            (api::trace::SpanContext::empty_context(), vec![
                 0x00, 0x00, 0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d,
             ]),
         ]

--- a/src/exporter/trace/mod.rs
+++ b/src/exporter/trace/mod.rs
@@ -76,11 +76,11 @@ pub struct SpanData {
     /// Span end time
     pub end_time: SystemTime,
     /// Span attributes
-    pub attributes: sdk::EvictedHashMap,
+    pub attributes: sdk::trace::EvictedHashMap,
     /// Span Message events
-    pub message_events: sdk::EvictedQueue<api::Event>,
+    pub message_events: sdk::trace::EvictedQueue<api::Event>,
     /// Span Links
-    pub links: sdk::EvictedQueue<api::Link>,
+    pub links: sdk::trace::EvictedQueue<api::Link>,
     /// Span status code
     pub status_code: api::StatusCode,
     /// Span status message
@@ -120,9 +120,9 @@ mod tests {
         let end_time = SystemTime::now();
 
         let capacity = 3;
-        let attributes = sdk::EvictedHashMap::new(capacity);
-        let message_events = sdk::EvictedQueue::new(capacity);
-        let links = sdk::EvictedQueue::new(capacity);
+        let attributes = sdk::trace::EvictedHashMap::new(capacity);
+        let message_events = sdk::trace::EvictedQueue::new(capacity);
+        let links = sdk::trace::EvictedQueue::new(capacity);
 
         let status_code = api::StatusCode::OK;
         let status_message = String::new();

--- a/src/exporter/trace/mod.rs
+++ b/src/exporter/trace/mod.rs
@@ -64,11 +64,11 @@ pub trait SpanExporter: Send + Sync + std::fmt::Debug {
 #[derive(Clone, Debug, PartialEq)]
 pub struct SpanData {
     /// Exportable `SpanContext`
-    pub span_context: api::SpanContext,
+    pub span_context: api::trace::SpanContext,
     /// Span parent id
-    pub parent_span_id: api::SpanId,
+    pub parent_span_id: api::trace::SpanId,
     /// Span kind
-    pub span_kind: api::SpanKind,
+    pub span_kind: api::trace::SpanKind,
     /// Span name
     pub name: String,
     /// Span start time
@@ -78,11 +78,11 @@ pub struct SpanData {
     /// Span attributes
     pub attributes: sdk::trace::EvictedHashMap,
     /// Span Message events
-    pub message_events: sdk::trace::EvictedQueue<api::Event>,
+    pub message_events: sdk::trace::EvictedQueue<api::trace::Event>,
     /// Span Links
-    pub links: sdk::trace::EvictedQueue<api::Link>,
+    pub links: sdk::trace::EvictedQueue<api::trace::Link>,
     /// Span status code
-    pub status_code: api::StatusCode,
+    pub status_code: api::trace::StatusCode,
     /// Span status message
     pub status_message: String,
     /// Resource contains attributes representing an entity that produced this span.
@@ -96,7 +96,7 @@ pub struct SpanData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::trace::span_context::TraceState;
+    use crate::api::trace::TraceState;
 
     #[test]
     fn test_serialise() {
@@ -105,16 +105,16 @@ mod tests {
 
         let trace_flags = 0;
         let remote = false;
-        let span_context = api::SpanContext::new(
-            api::TraceId::from_u128(trace_id),
-            api::SpanId::from_u64(span_id),
+        let span_context = api::trace::SpanContext::new(
+            api::trace::TraceId::from_u128(trace_id),
+            api::trace::SpanId::from_u64(span_id),
             trace_flags,
             remote,
             TraceState::default(),
         );
 
         let parent_span_id = 1;
-        let span_kind = api::SpanKind::Client;
+        let span_kind = api::trace::SpanKind::Client;
         let name = "foo/bar baz 人?!".to_string();
         let start_time = SystemTime::now();
         let end_time = SystemTime::now();
@@ -124,13 +124,13 @@ mod tests {
         let message_events = sdk::trace::EvictedQueue::new(capacity);
         let links = sdk::trace::EvictedQueue::new(capacity);
 
-        let status_code = api::StatusCode::OK;
+        let status_code = api::trace::StatusCode::OK;
         let status_message = String::new();
         let resource = Arc::new(sdk::Resource::default());
 
         let span_data = SpanData {
             span_context,
-            parent_span_id: api::SpanId::from_u64(parent_span_id),
+            parent_span_id: api::trace::SpanId::from_u64(parent_span_id),
             span_kind,
             name,
             start_time,

--- a/src/exporter/trace/stdout.rs
+++ b/src/exporter/trace/stdout.rs
@@ -34,7 +34,7 @@ use std::sync::{Arc, Mutex};
 #[derive(Debug)]
 pub struct PipelineBuilder<W: Write> {
     pretty_print: bool,
-    trace_config: Option<sdk::Config>,
+    trace_config: Option<sdk::trace::Config>,
     writer: W,
 }
 
@@ -62,7 +62,7 @@ impl<W: Write> PipelineBuilder<W> {
     }
 
     /// Assign the SDK trace configuration.
-    pub fn with_trace_config(mut self, config: sdk::Config) -> Self {
+    pub fn with_trace_config(mut self, config: sdk::trace::Config) -> Self {
         self.trace_config = Some(config);
         self
     }
@@ -82,10 +82,10 @@ where
     W: Write + Debug + Send + 'static,
 {
     /// Install the stdout exporter pipeline with the recommended defaults.
-    pub fn install(mut self) -> (sdk::Tracer, Uninstall) {
+    pub fn install(mut self) -> (sdk::trace::Tracer, Uninstall) {
         let exporter = Exporter::new(self.writer, self.pretty_print);
 
-        let mut provider_builder = sdk::TracerProvider::builder().with_exporter(exporter);
+        let mut provider_builder = sdk::trace::TracerProvider::builder().with_exporter(exporter);
         if let Some(config) = self.trace_config.take() {
             provider_builder = provider_builder.with_config(config);
         }

--- a/src/exporter/trace/stdout.rs
+++ b/src/exporter/trace/stdout.rs
@@ -11,7 +11,7 @@
 //! # Examples
 //!
 //! ```no_run
-//! use opentelemetry::api::Tracer;
+//! use opentelemetry::api::trace::Tracer;
 //! use opentelemetry::exporter::trace::stdout;
 //!
 //! fn main() {
@@ -24,7 +24,7 @@
 //!     });
 //! }
 //! ```
-use crate::{api::TracerProvider, exporter::trace, global, sdk};
+use crate::{api::trace::TracerProvider, exporter::trace, global, sdk};
 use async_trait::async_trait;
 use std::fmt::Debug;
 use std::io::{self, stdout, Stdout, Write};

--- a/src/global/mod.rs
+++ b/src/global/mod.rs
@@ -11,12 +11,12 @@
 //! ## Usage
 //!
 //! ```rust
-//! use opentelemetry::api::{TracerProvider, Tracer};
+//! use opentelemetry::api::trace::{TracerProvider, Tracer};
 //! use opentelemetry::api::metrics::{Meter, MeterProvider};
 //! use opentelemetry::global;
 //!
 //! fn init_tracer() -> global::TracerProviderGuard {
-//!     let provider = opentelemetry::api::NoopTracerProvider::new();
+//!     let provider = opentelemetry::api::trace::NoopTracerProvider::new();
 //!
 //!     // Configure the global `TracerProvider` singleton when your app starts
 //!     // (there is a no-op default if this is not set by your application)

--- a/src/global/propagation.rs
+++ b/src/global/propagation.rs
@@ -3,9 +3,9 @@ use std::sync::RwLock;
 
 lazy_static::lazy_static! {
     /// The current global `TextMapFormat` propagator.
-    static ref GLOBAL_TEXT_MAP_PROPAGATOR: RwLock<Box<dyn api::TextMapFormat + Send + Sync>> = RwLock::new(Box::new(api::TextMapCompositePropagator::new(vec![Box::new(api::TraceContextPropagator::new()), Box::new(api::BaggagePropagator::new())])));
+    static ref GLOBAL_TEXT_MAP_PROPAGATOR: RwLock<Box<dyn api::TextMapFormat + Send + Sync>> = RwLock::new(Box::new(api::TextMapCompositePropagator::new(vec![Box::new(api::trace::TraceContextPropagator::new()), Box::new(api::BaggagePropagator::new())])));
     /// The global default `TextMapFormat` propagator.
-    static ref DEFAULT_TEXT_MAP_PROPAGATOR: api::TextMapCompositePropagator = api::TextMapCompositePropagator::new(vec![Box::new(api::TraceContextPropagator::new()), Box::new(api::BaggagePropagator::new())]);
+    static ref DEFAULT_TEXT_MAP_PROPAGATOR: api::TextMapCompositePropagator = api::TextMapCompositePropagator::new(vec![Box::new(api::trace::TraceContextPropagator::new()), Box::new(api::BaggagePropagator::new())]);
 }
 
 /// Sets the given [`TextMapFormat`] propagator as the current global propagator.
@@ -18,7 +18,7 @@ lazy_static::lazy_static! {
 /// use opentelemetry::{api, global};
 ///
 /// // create your text map propagator
-/// let propagator = api::TraceContextPropagator::new();
+/// let propagator = api::trace::TraceContextPropagator::new();
 ///
 /// // assign it as the global propagator
 /// global::set_text_map_propagator(propagator);
@@ -42,7 +42,7 @@ pub fn set_text_map_propagator<P: api::TextMapFormat + Send + Sync + 'static>(pr
 /// let example_carrier = HashMap::new();
 ///
 /// // create your text map propagator
-/// let tc_propagator = api::TraceContextPropagator::new();
+/// let tc_propagator = api::trace::TraceContextPropagator::new();
 /// global::set_text_map_propagator(tc_propagator);
 ///
 /// // use the global text map propagator to extract contexts

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -18,15 +18,3 @@ pub mod trace;
 pub use env::EnvResourceDetector;
 pub use instrumentation::InstrumentationLibrary;
 pub use resource::Resource;
-#[cfg(feature = "trace")]
-pub use trace::{
-    config::Config,
-    evicted_hash_map::EvictedHashMap,
-    evicted_queue::EvictedQueue,
-    id_generator::IdGenerator,
-    provider::{Builder, TracerProvider},
-    sampler::{Sampler, SamplingDecision, SamplingResult, ShouldSample},
-    span::Span,
-    span_processor::{BatchSpanProcessor, SimpleSpanProcessor},
-    tracer::Tracer,
-};

--- a/src/sdk/trace/config.rs
+++ b/src/sdk/trace/config.rs
@@ -16,7 +16,7 @@ pub struct Config {
     /// The sampler that the sdk should use
     pub default_sampler: Box<dyn sdk::trace::ShouldSample>,
     /// The id generator that the sdk should use
-    pub id_generator: Box<dyn api::IdGenerator>,
+    pub id_generator: Box<dyn api::trace::IdGenerator>,
     /// The max events that can be added to a `Span`.
     pub max_events_per_span: u32,
     /// The max attributes that can be added to a `Span`.
@@ -38,7 +38,10 @@ impl Config {
     }
 
     /// Specify the id generator to be used.
-    pub fn with_id_generator<T: api::IdGenerator + 'static>(mut self, id_generator: T) -> Self {
+    pub fn with_id_generator<T: api::trace::IdGenerator + 'static>(
+        mut self,
+        id_generator: T,
+    ) -> Self {
         self.id_generator = Box::new(id_generator);
         self
     }

--- a/src/sdk/trace/config.rs
+++ b/src/sdk/trace/config.rs
@@ -14,7 +14,7 @@ pub fn config() -> Config {
 #[derive(Debug)]
 pub struct Config {
     /// The sampler that the sdk should use
-    pub default_sampler: Box<dyn sdk::ShouldSample>,
+    pub default_sampler: Box<dyn sdk::trace::ShouldSample>,
     /// The id generator that the sdk should use
     pub id_generator: Box<dyn api::IdGenerator>,
     /// The max events that can be added to a `Span`.
@@ -29,7 +29,10 @@ pub struct Config {
 
 impl Config {
     /// Specify the default sampler to be used.
-    pub fn with_default_sampler<T: sdk::ShouldSample + 'static>(mut self, sampler: T) -> Self {
+    pub fn with_default_sampler<T: sdk::trace::ShouldSample + 'static>(
+        mut self,
+        sampler: T,
+    ) -> Self {
         self.default_sampler = Box::new(sampler);
         self
     }
@@ -69,8 +72,10 @@ impl Default for Config {
     /// Create default global sdk configuration.
     fn default() -> Self {
         Config {
-            default_sampler: Box::new(sdk::Sampler::ParentBased(Box::new(sdk::Sampler::AlwaysOn))),
-            id_generator: Box::new(sdk::IdGenerator::default()),
+            default_sampler: Box::new(sdk::trace::Sampler::ParentBased(Box::new(
+                sdk::trace::Sampler::AlwaysOn,
+            ))),
+            id_generator: Box::new(sdk::trace::IdGenerator::default()),
             max_events_per_span: 128,
             max_attributes_per_span: 32,
             max_links_per_span: 32,

--- a/src/sdk/trace/id_generator.rs
+++ b/src/sdk/trace/id_generator.rs
@@ -9,15 +9,15 @@ pub struct IdGenerator {
     _private: (),
 }
 
-impl api::IdGenerator for IdGenerator {
+impl api::trace::IdGenerator for IdGenerator {
     /// Generate new `TraceId` using thread local rng
-    fn new_trace_id(&self) -> api::TraceId {
-        CURRENT_RNG.with(|rng| api::TraceId::from_u128(rng.borrow_mut().gen()))
+    fn new_trace_id(&self) -> api::trace::TraceId {
+        CURRENT_RNG.with(|rng| api::trace::TraceId::from_u128(rng.borrow_mut().gen()))
     }
 
     /// Generate new `SpanId` using thread local rng
-    fn new_span_id(&self) -> api::SpanId {
-        CURRENT_RNG.with(|rng| api::SpanId::from_u64(rng.borrow_mut().gen()))
+    fn new_span_id(&self) -> api::trace::SpanId {
+        CURRENT_RNG.with(|rng| api::trace::SpanId::from_u64(rng.borrow_mut().gen()))
     }
 }
 

--- a/src/sdk/trace/mod.rs
+++ b/src/sdk/trace/mod.rs
@@ -6,14 +6,24 @@
 //! * The `Span` struct with is a mutable object storing information about the
 //! current operation execution.
 //! * The `TracerProvider` struct which configures and produces `Tracer`s.
-pub mod config;
-pub mod evicted_hash_map;
-pub mod evicted_queue;
-pub mod id_generator;
-pub mod provider;
-pub mod sampler;
-pub mod span;
-pub mod span_processor;
-pub mod tracer;
+mod config;
+mod evicted_hash_map;
+mod evicted_queue;
+mod id_generator;
+mod provider;
+mod sampler;
+mod span;
+mod span_processor;
+mod tracer;
 
-pub use config::config;
+pub use config::{config, Config};
+pub use evicted_hash_map::EvictedHashMap;
+pub use evicted_queue::EvictedQueue;
+pub use id_generator::IdGenerator;
+pub use provider::{Builder, TracerProvider};
+pub use sampler::{Sampler, SamplingDecision, SamplingResult, ShouldSample};
+pub use span::Span;
+pub use span_processor::{
+    BatchConfig, BatchSpanProcessor, BatchSpanProcessorBuilder, SimpleSpanProcessor,
+};
+pub use tracer::Tracer;

--- a/src/sdk/trace/provider.rs
+++ b/src/sdk/trace/provider.rs
@@ -19,7 +19,7 @@ const DEFAULT_COMPONENT_NAME: &str = "rust.opentelemetry.io/sdk/tracer";
 #[derive(Debug)]
 pub(crate) struct TracerProviderInner {
     processors: Vec<Box<dyn api::SpanProcessor>>,
-    config: sdk::Config,
+    config: sdk::trace::Config,
 }
 
 impl Drop for TracerProviderInner {
@@ -59,14 +59,14 @@ impl TracerProvider {
     }
 
     /// Config associated with this tracer
-    pub fn config(&self) -> &sdk::Config {
+    pub fn config(&self) -> &sdk::trace::Config {
         &self.inner.config
     }
 }
 
 impl api::TracerProvider for TracerProvider {
-    /// This implementation of `api::TracerProvider` produces `sdk::Tracer` instances.
-    type Tracer = sdk::Tracer;
+    /// This implementation of `api::TracerProvider` produces `sdk::trace::Tracer` instances.
+    type Tracer = sdk::trace::Tracer;
 
     /// Find or create `Tracer` instance by name.
     fn get_tracer(&self, name: &'static str, version: Option<&'static str>) -> Self::Tracer {
@@ -78,7 +78,7 @@ impl api::TracerProvider for TracerProvider {
         };
         let instrumentation_lib = sdk::InstrumentationLibrary::new(component_name, version);
 
-        sdk::Tracer::new(instrumentation_lib, Arc::downgrade(&self.inner))
+        sdk::trace::Tracer::new(instrumentation_lib, Arc::downgrade(&self.inner))
     }
 }
 
@@ -86,20 +86,22 @@ impl api::TracerProvider for TracerProvider {
 #[derive(Default, Debug)]
 pub struct Builder {
     processors: Vec<Box<dyn api::SpanProcessor>>,
-    config: sdk::Config,
+    config: sdk::trace::Config,
 }
 
 impl Builder {
     /// The `SpanExporter` that this provider should use.
     pub fn with_simple_exporter<T: SpanExporter + 'static>(self, exporter: T) -> Self {
         let mut processors = self.processors;
-        processors.push(Box::new(sdk::SimpleSpanProcessor::new(Box::new(exporter))));
+        processors.push(Box::new(sdk::trace::SimpleSpanProcessor::new(Box::new(
+            exporter,
+        ))));
 
         Builder { processors, ..self }
     }
 
     /// The `BatchProcessor` that this provider should use.
-    pub fn with_batch_exporter(self, processor: sdk::BatchSpanProcessor) -> Self {
+    pub fn with_batch_exporter(self, processor: sdk::trace::BatchSpanProcessor) -> Self {
         let mut processors = self.processors;
         processors.push(Box::new(processor));
 
@@ -109,7 +111,8 @@ impl Builder {
     /// Add a configured `SpanExporter`
     #[cfg(feature = "tokio")]
     pub fn with_exporter<T: SpanExporter + 'static>(self, exporter: T) -> Self {
-        let batch = sdk::BatchSpanProcessor::builder(exporter, tokio::spawn, tokio::time::interval);
+        let batch =
+            sdk::trace::BatchSpanProcessor::builder(exporter, tokio::spawn, tokio::time::interval);
         self.with_batch_exporter(batch.build())
     }
 
@@ -139,7 +142,7 @@ impl Builder {
     }
 
     /// The sdk `Config` that this provider will use.
-    pub fn with_config(self, config: sdk::Config) -> Self {
+    pub fn with_config(self, config: sdk::trace::Config) -> Self {
         Builder { config, ..self }
     }
 

--- a/src/sdk/trace/provider.rs
+++ b/src/sdk/trace/provider.rs
@@ -18,7 +18,7 @@ const DEFAULT_COMPONENT_NAME: &str = "rust.opentelemetry.io/sdk/tracer";
 /// TracerProvider inner type
 #[derive(Debug)]
 pub(crate) struct TracerProviderInner {
-    processors: Vec<Box<dyn api::SpanProcessor>>,
+    processors: Vec<Box<dyn api::trace::SpanProcessor>>,
     config: sdk::trace::Config,
 }
 
@@ -54,7 +54,7 @@ impl TracerProvider {
     }
 
     /// Span processors associated with this provider
-    pub fn span_processors(&self) -> &Vec<Box<dyn api::SpanProcessor>> {
+    pub fn span_processors(&self) -> &Vec<Box<dyn api::trace::SpanProcessor>> {
         &self.inner.processors
     }
 
@@ -64,8 +64,8 @@ impl TracerProvider {
     }
 }
 
-impl api::TracerProvider for TracerProvider {
-    /// This implementation of `api::TracerProvider` produces `sdk::trace::Tracer` instances.
+impl api::trace::TracerProvider for TracerProvider {
+    /// This implementation of `api::trace::TracerProvider` produces `sdk::trace::Tracer` instances.
     type Tracer = sdk::trace::Tracer;
 
     /// Find or create `Tracer` instance by name.
@@ -85,7 +85,7 @@ impl api::TracerProvider for TracerProvider {
 /// Builder for provider attributes.
 #[derive(Default, Debug)]
 pub struct Builder {
-    processors: Vec<Box<dyn api::SpanProcessor>>,
+    processors: Vec<Box<dyn api::trace::SpanProcessor>>,
     config: sdk::trace::Config,
 }
 
@@ -134,7 +134,7 @@ impl Builder {
     }
 
     /// The `SpanProcessor` that this provider should use.
-    pub fn with_span_processor<T: api::SpanProcessor + 'static>(self, processor: T) -> Self {
+    pub fn with_span_processor<T: api::trace::SpanProcessor + 'static>(self, processor: T) -> Self {
         let mut processors = self.processors;
         processors.push(Box::new(processor));
 

--- a/src/sdk/trace/sampler.rs
+++ b/src/sdk/trace/sampler.rs
@@ -38,7 +38,7 @@
 //! MUST NOT allow this combination.
 
 use crate::api;
-use crate::api::TraceState;
+use crate::api::trace::TraceState;
 
 /// The `ShouldSample` interface allows implementations to provide samplers
 /// which will return a sampling `SamplingResult` based on information that
@@ -48,12 +48,12 @@ pub trait ShouldSample: Send + Sync + std::fmt::Debug {
     #[allow(clippy::too_many_arguments)]
     fn should_sample(
         &self,
-        parent_context: Option<&api::SpanContext>,
-        trace_id: api::TraceId,
+        parent_context: Option<&api::trace::SpanContext>,
+        trace_id: api::trace::TraceId,
         name: &str,
-        span_kind: &api::SpanKind,
+        span_kind: &api::trace::SpanKind,
         attributes: &[api::KeyValue],
-        links: &[api::Link],
+        links: &[api::trace::Link],
     ) -> SamplingResult;
 }
 
@@ -98,12 +98,12 @@ pub enum Sampler {
 impl ShouldSample for Sampler {
     fn should_sample(
         &self,
-        parent_context: Option<&api::SpanContext>,
-        trace_id: api::TraceId,
+        parent_context: Option<&api::trace::SpanContext>,
+        trace_id: api::trace::TraceId,
         name: &str,
-        span_kind: &api::SpanKind,
+        span_kind: &api::trace::SpanKind,
         attributes: &[api::KeyValue],
-        links: &[api::Link],
+        links: &[api::trace::Link],
     ) -> SamplingResult {
         let decision = match self {
             // Always sample the trace
@@ -157,7 +157,7 @@ impl ShouldSample for Sampler {
 #[cfg(test)]
 mod tests {
     use crate::api;
-    use crate::api::trace::span_context::TraceState;
+    use crate::api::trace::TraceState;
     use crate::sdk::trace::{Sampler, SamplingDecision, ShouldSample};
     use rand::Rng;
 
@@ -216,13 +216,13 @@ mod tests {
             for _ in 0..total {
                 let parent_context = if parent {
                     let trace_flags = if sample_parent {
-                        api::TRACE_FLAG_SAMPLED
+                        api::trace::TRACE_FLAG_SAMPLED
                     } else {
                         0
                     };
-                    Some(api::SpanContext::new(
-                        api::TraceId::from_u128(1),
-                        api::SpanId::from_u64(1),
+                    Some(api::trace::SpanContext::new(
+                        api::trace::TraceId::from_u128(1),
+                        api::trace::SpanId::from_u64(1),
                         trace_flags,
                         false,
                         TraceState::default(),
@@ -230,13 +230,13 @@ mod tests {
                 } else {
                     None
                 };
-                let trace_id = api::TraceId::from_u128(rng.gen());
+                let trace_id = api::trace::TraceId::from_u128(rng.gen());
                 if sampler
                     .should_sample(
                         parent_context.as_ref(),
                         trace_id,
                         name,
-                        &api::SpanKind::Internal,
+                        &api::trace::SpanKind::Internal,
                         &[],
                         &[],
                     )

--- a/src/sdk/trace/sampler.rs
+++ b/src/sdk/trace/sampler.rs
@@ -158,7 +158,7 @@ impl ShouldSample for Sampler {
 mod tests {
     use crate::api;
     use crate::api::trace::span_context::TraceState;
-    use crate::sdk::{Sampler, SamplingDecision, ShouldSample};
+    use crate::sdk::trace::{Sampler, SamplingDecision, ShouldSample};
     use rand::Rng;
 
     #[rustfmt::skip]

--- a/src/sdk/trace/span.rs
+++ b/src/sdk/trace/span.rs
@@ -8,7 +8,7 @@
 //! start time is set to the current time on span creation. After the `Span` is created, it
 //! is possible to change its name, set its `Attributes`, and add `Links` and `Events`.
 //! These cannot be changed after the `Span`'s end time has been set.
-use crate::api::trace::span_context::TraceState;
+use crate::api::trace::TraceState;
 use crate::{api, exporter, sdk};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
@@ -16,7 +16,7 @@ use std::time::SystemTime;
 /// Single operation within a trace.
 #[derive(Clone, Debug)]
 pub struct Span {
-    id: api::SpanId,
+    id: api::trace::SpanId,
     inner: Arc<SpanInner>,
 }
 
@@ -29,7 +29,7 @@ struct SpanInner {
 
 impl Span {
     pub(crate) fn new(
-        id: api::SpanId,
+        id: api::trace::SpanId,
         data: Option<exporter::trace::SpanData>,
         tracer: sdk::trace::Tracer,
     ) -> Self {
@@ -65,7 +65,7 @@ impl Span {
     }
 }
 
-impl api::Span for Span {
+impl api::trace::Span for Span {
     /// Records events at a specific time in the context of a given `Span`.
     ///
     /// Note that the OpenTelemetry project documents certain ["standard event names and
@@ -79,17 +79,17 @@ impl api::Span for Span {
     ) {
         self.with_data_mut(|data| {
             data.message_events
-                .push_back(api::Event::new(name, timestamp, attributes))
+                .push_back(api::trace::Event::new(name, timestamp, attributes))
         });
     }
 
     /// Returns the `SpanContext` for the given `Span`.
-    fn span_context(&self) -> api::SpanContext {
+    fn span_context(&self) -> api::trace::SpanContext {
         self.with_data(|data| data.span_context.clone())
             .unwrap_or_else(|| {
-                api::SpanContext::new(
-                    api::TraceId::invalid(),
-                    api::SpanId::invalid(),
+                api::trace::SpanContext::new(
+                    api::trace::TraceId::invalid(),
+                    api::trace::SpanId::invalid(),
                     0,
                     false,
                     TraceState::default(),
@@ -116,7 +116,7 @@ impl api::Span for Span {
 
     /// Sets the status of the `Span`. If used, this will override the default `Span`
     /// status, which is `OK`.
-    fn set_status(&self, code: api::StatusCode, message: String) {
+    fn set_status(&self, code: api::trace::StatusCode, message: String) {
         self.with_data_mut(|data| {
             data.status_code = code;
             data.status_message = message

--- a/src/sdk/trace/span.rs
+++ b/src/sdk/trace/span.rs
@@ -24,14 +24,14 @@ pub struct Span {
 #[derive(Debug)]
 struct SpanInner {
     data: Option<Mutex<exporter::trace::SpanData>>,
-    tracer: sdk::Tracer,
+    tracer: sdk::trace::Tracer,
 }
 
 impl Span {
     pub(crate) fn new(
         id: api::SpanId,
         data: Option<exporter::trace::SpanData>,
-        tracer: sdk::Tracer,
+        tracer: sdk::trace::Tracer,
     ) -> Self {
         Span {
             id,

--- a/src/sdk/trace/span_processor.rs
+++ b/src/sdk/trace/span_processor.rs
@@ -41,7 +41,7 @@
 //! let exporter = api::NoopSpanExporter::new();
 //!
 //! // Then use the `with_simple_exporter` method to have the provider export when spans finish.
-//! let provider = sdk::TracerProvider::builder()
+//! let provider = sdk::trace::TracerProvider::builder()
 //!     .with_simple_exporter(exporter)
 //!     .build();
 //!
@@ -69,12 +69,12 @@
 //!     // Then build a batch processor. You can use whichever executor you have available, for
 //!     // example if you are using `async-std` instead of `tokio` you can replace the spawn and
 //!     // interval functions with `async_std::task::spawn` and `async_std::stream::interval`.
-//!     let batch = sdk::BatchSpanProcessor::builder(exporter, tokio::spawn, tokio::time::interval)
+//!     let batch = sdk::trace::BatchSpanProcessor::builder(exporter, tokio::spawn, tokio::time::interval)
 //!         .with_max_queue_size(4096)
 //!         .build();
 //!
 //!     // Then use the `with_batch_exporter` method to have the provider export spans in batches.
-//!     let provider = sdk::TracerProvider::builder()
+//!     let provider = sdk::trace::TracerProvider::builder()
 //!         .with_batch_exporter(batch)
 //!         .build();
 //!
@@ -411,7 +411,7 @@ mod tests {
         OTEL_BSP_MAX_EXPORT_BATCH_SIZE, OTEL_BSP_MAX_QUEUE_SIZE, OTEL_BSP_MAX_QUEUE_SIZE_DEFAULT,
         OTEL_BSP_SCHEDULE_DELAY_MILLIS, OTEL_BSP_SCHEDULE_DELAY_MILLIS_DEFAULT,
     };
-    use crate::sdk::BatchSpanProcessor;
+    use crate::sdk::trace::BatchSpanProcessor;
     use std::time;
 
     #[test]

--- a/src/sdk/trace/span_processor.rs
+++ b/src/sdk/trace/span_processor.rs
@@ -38,7 +38,7 @@
 //! use opentelemetry::{api, sdk, global};
 //!
 //! // Configure your preferred exporter
-//! let exporter = api::NoopSpanExporter::new();
+//! let exporter = api::trace::NoopSpanExporter::new();
 //!
 //! // Then use the `with_simple_exporter` method to have the provider export when spans finish.
 //! let provider = sdk::trace::TracerProvider::builder()
@@ -64,7 +64,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     // Configure your preferred exporter
-//!     let exporter = api::NoopSpanExporter::new();
+//!     let exporter = api::trace::NoopSpanExporter::new();
 //!
 //!     // Then build a batch processor. You can use whichever executor you have available, for
 //!     // example if you are using `async-std` instead of `tokio` you can replace the spawn and
@@ -127,7 +127,7 @@ impl SimpleSpanProcessor {
     }
 }
 
-impl api::SpanProcessor for SimpleSpanProcessor {
+impl api::trace::SpanProcessor for SimpleSpanProcessor {
     fn on_start(&self, _span: Arc<exporter::trace::SpanData>) {
         // Ignored
     }
@@ -158,7 +158,7 @@ impl fmt::Debug for BatchSpanProcessor {
     }
 }
 
-impl api::SpanProcessor for BatchSpanProcessor {
+impl api::trace::SpanProcessor for BatchSpanProcessor {
     fn on_start(&self, _span: Arc<exporter::trace::SpanData>) {
         // Ignored
     }

--- a/src/sdk/trace/span_processor.rs
+++ b/src/sdk/trace/span_processor.rs
@@ -35,13 +35,13 @@
 //! limiting, consider the batch processor instead.
 //!
 //! ```
-//! use opentelemetry::{api, sdk, global};
+//! use opentelemetry::{api::trace as apitrace, sdk::trace as sdktrace, global};
 //!
 //! // Configure your preferred exporter
-//! let exporter = api::trace::NoopSpanExporter::new();
+//! let exporter = apitrace::NoopSpanExporter::new();
 //!
 //! // Then use the `with_simple_exporter` method to have the provider export when spans finish.
-//! let provider = sdk::trace::TracerProvider::builder()
+//! let provider = sdktrace::TracerProvider::builder()
 //!     .with_simple_exporter(exporter)
 //!     .build();
 //!
@@ -58,23 +58,23 @@
 //!
 //! ```
 //! use futures::{stream};
-//! use opentelemetry::{api, sdk, global};
+//! use opentelemetry::{api::trace as apitrace, sdk::trace as sdktrace, global};
 //! use std::time::Duration;
 //!
 //! #[tokio::main]
 //! async fn main() {
 //!     // Configure your preferred exporter
-//!     let exporter = api::trace::NoopSpanExporter::new();
+//!     let exporter = apitrace::NoopSpanExporter::new();
 //!
 //!     // Then build a batch processor. You can use whichever executor you have available, for
 //!     // example if you are using `async-std` instead of `tokio` you can replace the spawn and
 //!     // interval functions with `async_std::task::spawn` and `async_std::stream::interval`.
-//!     let batch = sdk::trace::BatchSpanProcessor::builder(exporter, tokio::spawn, tokio::time::interval)
+//!     let batch = sdktrace::BatchSpanProcessor::builder(exporter, tokio::spawn, tokio::time::interval)
 //!         .with_max_queue_size(4096)
 //!         .build();
 //!
 //!     // Then use the `with_batch_exporter` method to have the provider export spans in batches.
-//!     let provider = sdk::trace::TracerProvider::builder()
+//!     let provider = sdktrace::TracerProvider::builder()
 //!         .with_batch_exporter(batch)
 //!         .build();
 //!

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -7,8 +7,8 @@
 //! and exposes methods for creating and activating new `Spans`.
 //!
 //! Docs: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#tracer
-use crate::api::trace::span_context::TraceState;
-use crate::api::TraceContextExt;
+use crate::api::trace::TraceContextExt;
+use crate::api::trace::TraceState;
 use crate::sdk;
 use crate::{api, api::context::Context, exporter};
 use std::fmt;
@@ -59,12 +59,12 @@ impl Tracer {
     #[allow(clippy::too_many_arguments)]
     fn make_sampling_decision(
         &self,
-        parent_context: Option<&api::SpanContext>,
-        trace_id: api::TraceId,
+        parent_context: Option<&api::trace::SpanContext>,
+        trace_id: api::trace::TraceId,
         name: &str,
-        span_kind: &api::SpanKind,
+        span_kind: &api::trace::SpanKind,
         attributes: &[api::KeyValue],
-        links: &[api::Link],
+        links: &[api::trace::Link],
     ) -> Option<(u8, Vec<api::KeyValue>, TraceState)> {
         let provider = self.provider()?;
         let sampler = &provider.config().default_sampler;
@@ -77,7 +77,7 @@ impl Tracer {
     fn process_sampling_result(
         &self,
         sampling_result: sdk::trace::SamplingResult,
-        parent_context: Option<&api::SpanContext>,
+        parent_context: Option<&api::trace::SpanContext>,
     ) -> Option<(u8, Vec<api::KeyValue>, TraceState)> {
         match sampling_result {
             sdk::trace::SamplingResult {
@@ -91,7 +91,7 @@ impl Tracer {
             } => {
                 let trace_flags = parent_context.map(|ctx| ctx.trace_flags()).unwrap_or(0);
                 Some((
-                    trace_flags & !api::TRACE_FLAG_SAMPLED,
+                    trace_flags & !api::trace::TRACE_FLAG_SAMPLED,
                     attributes,
                     trace_state,
                 ))
@@ -103,7 +103,7 @@ impl Tracer {
             } => {
                 let trace_flags = parent_context.map(|ctx| ctx.trace_flags()).unwrap_or(0);
                 Some((
-                    trace_flags | api::TRACE_FLAG_SAMPLED,
+                    trace_flags | api::trace::TRACE_FLAG_SAMPLED,
                     attributes,
                     trace_state,
                 ))
@@ -112,14 +112,14 @@ impl Tracer {
     }
 }
 
-impl api::Tracer for Tracer {
-    /// This implementation of `api::Tracer` produces `sdk::Span` instances.
+impl api::trace::Tracer for Tracer {
+    /// This implementation of `api::trace::Tracer` produces `sdk::Span` instances.
     type Span = sdk::trace::Span;
 
     /// Returns a span with an inactive `SpanContext`. Used by functions that
     /// need to return a default span like `get_active_span` if no span is present.
     fn invalid(&self) -> Self::Span {
-        sdk::trace::Span::new(api::SpanId::invalid(), None, self.clone())
+        sdk::trace::Span::new(api::trace::SpanId::invalid(), None, self.clone())
     }
 
     /// Starts a new `Span` in a given context.
@@ -138,8 +138,8 @@ impl api::Tracer for Tracer {
     /// Creates a span builder
     ///
     /// An ergonomic way for attributes to be configured before the `Span` is started.
-    fn span_builder(&self, name: &str) -> api::SpanBuilder {
-        api::SpanBuilder::from_name(name.to_string())
+    fn span_builder(&self, name: &str) -> api::trace::SpanBuilder {
+        api::trace::SpanBuilder::from_name(name.to_string())
     }
 
     /// Starts a span from a `SpanBuilder`.
@@ -149,10 +149,10 @@ impl api::Tracer for Tracer {
     /// trace. A span is said to be a _root span_ if it does not have a parent. Each
     /// trace includes a single root span, which is the shared ancestor of all other
     /// spans in the trace.
-    fn build_with_context(&self, mut builder: api::SpanBuilder, cx: &Context) -> Self::Span {
+    fn build_with_context(&self, mut builder: api::trace::SpanBuilder, cx: &Context) -> Self::Span {
         let provider = self.provider();
         if provider.is_none() {
-            return sdk::trace::Span::new(api::SpanId::invalid(), None, self.clone());
+            return sdk::trace::Span::new(api::trace::SpanId::invalid(), None, self.clone());
         }
 
         let provider = provider.unwrap();
@@ -162,7 +162,10 @@ impl api::Tracer for Tracer {
             .take()
             .unwrap_or_else(|| config.id_generator.new_span_id());
 
-        let span_kind = builder.span_kind.take().unwrap_or(api::SpanKind::Internal);
+        let span_kind = builder
+            .span_kind
+            .take()
+            .unwrap_or(api::trace::SpanKind::Internal);
         let mut attribute_options = builder.attributes.take().unwrap_or_else(Vec::new);
         let mut link_options = builder.links.take().unwrap_or_else(Vec::new);
 
@@ -190,7 +193,7 @@ impl api::Tracer for Tracer {
                     builder
                         .trace_id
                         .unwrap_or_else(|| config.id_generator.new_trace_id()),
-                    api::SpanId::invalid(),
+                    api::trace::SpanId::invalid(),
                     false,
                     0,
                 ));
@@ -239,12 +242,12 @@ impl api::Tracer for Tracer {
             if let Some(mut events) = builder.message_events {
                 message_events.append_vec(&mut events);
             }
-            let status_code = builder.status_code.unwrap_or(api::StatusCode::OK);
+            let status_code = builder.status_code.unwrap_or(api::trace::StatusCode::OK);
             let status_message = builder.status_message.unwrap_or_else(String::new);
             let resource = config.resource.clone();
 
             exporter::trace::SpanData {
-                span_context: api::SpanContext::new(
+                span_context: api::trace::SpanContext::new(
                     trace_id,
                     span_id,
                     trace_flags,
@@ -281,11 +284,16 @@ impl api::Tracer for Tracer {
 #[cfg(test)]
 mod tests {
     use crate::api::{
-        Context, KeyValue, Link, Span, SpanBuilder, SpanContext, SpanId, SpanKind, TraceId,
-        TraceState, Tracer, TracerProvider, TRACE_FLAG_SAMPLED,
+        trace::{
+            Link, Span, SpanBuilder, SpanContext, SpanId, SpanKind, TraceId, TraceState, Tracer,
+            TracerProvider, TRACE_FLAG_SAMPLED,
+        },
+        Context, KeyValue,
     };
-    use crate::sdk;
-    use crate::sdk::trace::{Config, SamplingDecision, SamplingResult, ShouldSample};
+    use crate::sdk::{
+        self,
+        trace::{Config, SamplingDecision, SamplingResult, ShouldSample},
+    };
 
     #[derive(Debug)]
     struct TestSampler {}


### PR DESCRIPTION
Resolves #254 Resolves #249 

* Moves trace exports from `api` and `sdk` to `api::trace` and `sdk::trace`
* Removes `metrics` from the default features