### PR TITLE
Fix warnings based on updated clippy

### DIFF
--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -50,8 +50,8 @@ fn compare_export(exporter: &PrometheusExporter, mut expected: Vec<&'static str>
         .filter(|line| !line.starts_with('#') && !line.is_empty())
         .collect::<Vec<_>>();
 
-    metrics_only.sort();
-    expected.sort();
+    metrics_only.sort_unstable();
+    expected.sort_unstable();
 
     assert_eq!(expected.join("\n"), metrics_only.join("\n"))
 }

--- a/src/api/metrics/kind.rs
+++ b/src/api/metrics/kind.rs
@@ -27,12 +27,10 @@ pub enum InstrumentKind {
 impl InstrumentKind {
     /// Whether this is a synchronous kind of instrument.
     pub fn synchronous(&self) -> bool {
-        match self {
+        matches! (self,
             InstrumentKind::Counter
             | InstrumentKind::UpDownCounter
-            | InstrumentKind::ValueRecorder => true,
-            _ => false,
-        }
+            | InstrumentKind::ValueRecorder)
     }
 
     /// Whether this is a synchronous kind of instrument.
@@ -42,24 +40,20 @@ impl InstrumentKind {
 
     /// Whether this kind of instrument adds its inputs (as opposed to grouping).
     pub fn adding(&self) -> bool {
-        match self {
+        matches!(self,
             InstrumentKind::Counter
             | InstrumentKind::UpDownCounter
             | InstrumentKind::SumObserver
-            | InstrumentKind::UpDownSumObserver => true,
-            _ => false,
-        }
+            | InstrumentKind::UpDownSumObserver)
     }
 
     /// Whether this kind of instrument groups its inputs (as opposed to adding).
     pub fn grouping(&self) -> bool {
-        match self {
+        matches!(self,
             InstrumentKind::Counter
             | InstrumentKind::UpDownCounter
             | InstrumentKind::SumObserver
-            | InstrumentKind::UpDownSumObserver => true,
-            _ => false,
-        }
+            | InstrumentKind::UpDownSumObserver)
     }
 
     /// Whether this kind of instrument receives precomputed sums.

--- a/src/sdk/metrics/aggregators/ddsketch.rs
+++ b/src/sdk/metrics/aggregators/ddsketch.rs
@@ -558,8 +558,8 @@ impl Store {
             } else {
                 // bins length is equal to max number of bins
                 self.bins.drain(0..(min_key - self.min_key) as usize);
-                for _ in self.max_key - min_key + 1..self.max_num_bins {
-                    self.bins.push(0);
+                if self.max_num_bins > self.max_key - min_key + 1 {
+                    self.bins.resize(self.bins.len() + (self.max_num_bins - (self.max_key - min_key + 1)) as usize, 0)
                 }
             }
             self.max_key = key;
@@ -1025,7 +1025,7 @@ mod tests {
                     .unwrap()
                     .to_f64(&NumberKind::F64)
                     - expected_iter.next().unwrap())
-                .abs()
+                    .abs()
                     < f64::EPSILON
             );
         }


### PR DESCRIPTION
Rust recently released the new version, which includes some new warnings. This PR fixed those warnings