### PR TITLE
Send owned span data to exporters

### DIFF
--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -8,4 +8,4 @@ futures = "0.3"
 thrift = "0.13"
 tokio = { version = "0.2", features = ["full"] }
 opentelemetry = { path = "../../", features = ["tokio"] }
-opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }
+opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["tokio"] }

--- a/opentelemetry-contrib/src/datadog/mod.rs
+++ b/opentelemetry-contrib/src/datadog/mod.rs
@@ -90,7 +90,6 @@ use opentelemetry::{api::trace::TracerProvider, exporter::trace, global, sdk};
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Url;
 use std::error::Error;
-use std::sync::Arc;
 
 /// Default Datadog collector endpoint
 const DEFAULT_AGENT_ENDPOINT: &str = "http://127.0.0.1:8126";
@@ -194,7 +193,7 @@ impl DatadogPipelineBuilder {
 #[async_trait]
 impl trace::SpanExporter for DatadogExporter {
     /// Export spans to datadog-agent
-    async fn export(&self, batch: &[Arc<trace::SpanData>]) -> trace::ExportResult {
+    async fn export(&self, batch: Vec<trace::SpanData>) -> trace::ExportResult {
         let data = match self.version.encode(&self.service_name, batch) {
             Ok(data) => data,
             Err(_) => return trace::ExportResult::FailedNotRetryable,

--- a/opentelemetry-contrib/src/datadog/model/mod.rs
+++ b/opentelemetry-contrib/src/datadog/model/mod.rs
@@ -1,6 +1,5 @@
 use opentelemetry::exporter::trace;
 use std::fmt;
-use std::sync::Arc;
 
 mod v03;
 mod v05;
@@ -53,7 +52,7 @@ impl ApiVersion {
     pub(crate) fn encode(
         self,
         service_name: &str,
-        spans: &[Arc<trace::SpanData>],
+        spans: Vec<trace::SpanData>,
     ) -> Result<Vec<u8>, Error> {
         match self {
             Self::Version03 => v03::encode(service_name, spans),
@@ -68,9 +67,10 @@ mod tests {
     use opentelemetry::api::Key;
     use opentelemetry::sdk::InstrumentationLibrary;
     use opentelemetry::{api, sdk};
+    use std::sync::Arc;
     use std::time::{Duration, SystemTime};
 
-    fn get_spans() -> Vec<Arc<trace::SpanData>> {
+    fn get_spans() -> Vec<trace::SpanData> {
         let parent_span_id = 1;
         let trace_id = 7;
         let span_id = 99;
@@ -109,13 +109,13 @@ mod tests {
             instrumentation_lib: InstrumentationLibrary::new("component", None),
         };
 
-        vec![Arc::new(span_data)]
+        vec![span_data]
     }
 
     #[test]
     fn test_encode_v03() -> Result<(), Box<dyn std::error::Error>> {
         let spans = get_spans();
-        let encoded = base64::encode(ApiVersion::Version03.encode("service_name", &spans)?);
+        let encoded = base64::encode(ApiVersion::Version03.encode("service_name", spans)?);
 
         assert_eq!(encoded.as_str(), "kZGLpHR5cGWjd2Vip3NlcnZpY2Wsc2VydmljZV9uYW1lpG5hbWWpY29tcG9uZW50qHJlc291cmNlqHJlc291cmNlqHRyYWNlX2lkzwAAAAAAAAAHp3NwYW5faWTPAAAAAAAAAGOpcGFyZW50X2lkzwAAAAAAAAABpXN0YXJ00wAAAAAAAAAAqGR1cmF0aW9u0wAAAAA7msoApWVycm9y0gAAAACkbWV0YYGpc3Bhbi50eXBlo3dlYg==");
 
@@ -125,7 +125,7 @@ mod tests {
     #[test]
     fn test_encode_v05() -> Result<(), Box<dyn std::error::Error>> {
         let spans = get_spans();
-        let encoded = base64::encode(ApiVersion::Version05.encode("service_name", &spans)?);
+        let encoded = base64::encode(ApiVersion::Version05.encode("service_name", spans)?);
 
         assert_eq!(encoded.as_str(), "kpWsc2VydmljZV9uYW1lo3dlYqljb21wb25lbnSocmVzb3VyY2Wpc3Bhbi50eXBlkZGczgAAAADOAAAAAs4AAAADzwAAAAAAAAAHzwAAAAAAAABjzwAAAAAAAAAB0wAAAAAAAAAA0wAAAAA7msoA0gAAAACBzgAAAATOAAAAAYDOAAAAAQ==");
 

--- a/opentelemetry-contrib/src/datadog/model/v03.rs
+++ b/opentelemetry-contrib/src/datadog/model/v03.rs
@@ -1,14 +1,13 @@
 use crate::datadog::model::Error;
 use opentelemetry::api::{Key, Value};
 use opentelemetry::exporter::trace;
-use std::sync::Arc;
 use std::time::SystemTime;
 
-pub(crate) fn encode(service_name: &str, spans: &[Arc<trace::SpanData>]) -> Result<Vec<u8>, Error> {
+pub(crate) fn encode(service_name: &str, spans: Vec<trace::SpanData>) -> Result<Vec<u8>, Error> {
     let mut encoded = Vec::new();
     rmp::encode::write_array_len(&mut encoded, spans.len() as u32)?;
 
-    for span in spans.iter() {
+    for span in spans.into_iter() {
         // API supports but doesn't mandate grouping spans with the same trace ID
         rmp::encode::write_array_len(&mut encoded, 1)?;
 
@@ -59,7 +58,7 @@ pub(crate) fn encode(service_name: &str, spans: &[Arc<trace::SpanData>]) -> Resu
         rmp::encode::write_i64(&mut encoded, duration)?;
 
         rmp::encode::write_str(&mut encoded, "error")?;
-        rmp::encode::write_i32(&mut encoded, span.status_code.clone() as i32)?;
+        rmp::encode::write_i32(&mut encoded, span.status_code as i32)?;
 
         rmp::encode::write_str(&mut encoded, "meta")?;
         rmp::encode::write_map_len(&mut encoded, span.attributes.len() as u32)?;

--- a/opentelemetry-contrib/src/datadog/model/v05.rs
+++ b/opentelemetry-contrib/src/datadog/model/v05.rs
@@ -2,7 +2,6 @@ use crate::datadog::intern::StringInterner;
 use crate::datadog::model::Error;
 use opentelemetry::api::{Key, Value};
 use opentelemetry::exporter::trace;
-use std::sync::Arc;
 use std::time::SystemTime;
 
 // Protocol documentation sourced from https://github.com/DataDog/datadog-agent/blob/c076ea9a1ffbde4c76d35343dbc32aecbbf99cb9/pkg/trace/api/version.go
@@ -50,7 +49,7 @@ use std::time::SystemTime;
 //
 // 		The dictionary in this case would be []string{""}, having only the empty string at index 0.
 //
-pub(crate) fn encode(service_name: &str, spans: &[Arc<trace::SpanData>]) -> Result<Vec<u8>, Error> {
+pub(crate) fn encode(service_name: &str, spans: Vec<trace::SpanData>) -> Result<Vec<u8>, Error> {
     let mut interner = StringInterner::new();
     let mut encoded_spans = encode_spans(&mut interner, service_name, spans)?;
 
@@ -70,14 +69,14 @@ pub(crate) fn encode(service_name: &str, spans: &[Arc<trace::SpanData>]) -> Resu
 fn encode_spans(
     interner: &mut StringInterner,
     service_name: &str,
-    spans: &[Arc<trace::SpanData>],
+    spans: Vec<trace::SpanData>,
 ) -> Result<Vec<u8>, Error> {
     let mut encoded = Vec::new();
     rmp::encode::write_array_len(&mut encoded, spans.len() as u32)?;
 
     let service_interned = interner.intern(&service_name);
 
-    for span in spans.iter() {
+    for span in spans.into_iter() {
         // API supports but doesn't mandate grouping spans with the same trace ID
         rmp::encode::write_array_len(&mut encoded, 1)?;
 
@@ -109,7 +108,7 @@ fn encode_spans(
         rmp::encode::write_u64(&mut encoded, span.parent_span_id.to_u64())?;
         rmp::encode::write_i64(&mut encoded, start)?;
         rmp::encode::write_i64(&mut encoded, duration)?;
-        rmp::encode::write_i32(&mut encoded, span.status_code.clone() as i32)?;
+        rmp::encode::write_i32(&mut encoded, span.status_code as i32)?;
         rmp::encode::write_map_len(&mut encoded, span.attributes.len() as u32)?;
         for (key, value) in span.attributes.iter() {
             let value_string: String = value.into();

--- a/opentelemetry-jaeger/src/thrift/agent.rs
+++ b/opentelemetry-jaeger/src/thrift/agent.rs
@@ -303,4 +303,3 @@ impl AgentEmitBatchArgs {
     o_prot.write_struct_end()
   }
 }
-

--- a/opentelemetry-jaeger/src/transport/buffer.rs
+++ b/opentelemetry-jaeger/src/transport/buffer.rs
@@ -30,6 +30,7 @@ impl io::Read for TBufferChannel {
         unreachable!("jaeger protocol never reads")
     }
 }
+
 impl io::Write for TBufferChannel {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if let Ok(mut inner) = self.inner.lock() {

--- a/opentelemetry-jaeger/src/transport/buffer.rs
+++ b/opentelemetry-jaeger/src/transport/buffer.rs
@@ -1,0 +1,53 @@
+use std::io;
+use std::sync::{Arc, Mutex};
+use thrift::transport::{ReadHalf, TIoChannel, WriteHalf};
+
+/// Custom TBufferChannel that can be dynamically grown and split off of.
+#[derive(Debug, Clone)]
+pub(crate) struct TBufferChannel {
+    inner: Arc<Mutex<Vec<u8>>>,
+}
+
+impl TBufferChannel {
+    /// Create a new buffer channel with the given initial capacity
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        TBufferChannel {
+            inner: Arc::new(Mutex::new(Vec::with_capacity(capacity))),
+        }
+    }
+
+    /// Take the accumulated bytes from the buffer, leaving capacity unchanged.
+    pub(crate) fn take_bytes(&mut self) -> Vec<u8> {
+        self.inner
+            .lock()
+            .map(|mut write| write.split_off(0))
+            .unwrap_or_default()
+    }
+}
+
+impl io::Read for TBufferChannel {
+    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+        unreachable!("jaeger protocol never reads")
+    }
+}
+impl io::Write for TBufferChannel {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.extend_from_slice(buf);
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl TIoChannel for TBufferChannel {
+    fn split(self) -> thrift::Result<(ReadHalf<Self>, WriteHalf<Self>)>
+    where
+        Self: Sized,
+    {
+        Ok((ReadHalf::new(self.clone()), WriteHalf::new(self)))
+    }
+}

--- a/opentelemetry-jaeger/src/transport/mod.rs
+++ b/opentelemetry-jaeger/src/transport/mod.rs
@@ -1,4 +1,6 @@
 //! Additional Thrift transport implementations
+mod buffer;
 mod noop;
 
+pub(crate) use buffer::TBufferChannel;
 pub(crate) use noop::TNoopChannel;

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -147,9 +147,9 @@ impl Exporter {
 
 #[async_trait]
 impl SpanExporter for Exporter {
-    async fn export(&self, batch: &[Arc<SpanData>]) -> ExportResult {
+    async fn export(&self, batch: Vec<SpanData>) -> ExportResult {
         let request = ExportTraceServiceRequest {
-            resource_spans: RepeatedField::from_vec(batch.iter().map(|span| span.into()).collect()),
+            resource_spans: RepeatedField::from_vec(batch.into_iter().map(Into::into).collect()),
             unknown_fields: Default::default(),
             cached_size: Default::default(),
         };

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -95,7 +95,6 @@ use opentelemetry::{api::trace::TracerProvider, exporter::trace, global, sdk};
 use reqwest::Url;
 use std::error::Error;
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 /// Default Zipkin collector endpoint
 const DEFAULT_COLLECTOR_ENDPOINT: &str = "http://127.0.0.1:9411/api/v2/spans";
@@ -189,9 +188,9 @@ impl ZipkinPipelineBuilder {
 #[async_trait]
 impl trace::SpanExporter for Exporter {
     /// Export spans to Zipkin collector.
-    async fn export(&self, batch: &[Arc<trace::SpanData>]) -> trace::ExportResult {
+    async fn export(&self, batch: Vec<trace::SpanData>) -> trace::ExportResult {
         let zipkin_spans = batch
-            .iter()
+            .into_iter()
             .map(|span| model::into_zipkin_span(self.local_endpoint.clone(), span))
             .collect();
 

--- a/src/api/trace/noop.rs
+++ b/src/api/trace/noop.rs
@@ -5,9 +5,11 @@
 //! to have minimal resource utilization and runtime impact.
 use crate::api::trace::TraceContextExt;
 use crate::api::trace::TraceState;
-use crate::{api, exporter};
+use crate::{
+    api,
+    exporter::trace::{ExportResult, SpanData, SpanExporter},
+};
 use async_trait::async_trait;
-use std::sync::Arc;
 use std::time::SystemTime;
 
 /// A no-op instance of a `TracerProvider`.
@@ -178,12 +180,9 @@ impl NoopSpanExporter {
 }
 
 #[async_trait]
-impl exporter::trace::SpanExporter for NoopSpanExporter {
-    async fn export(
-        &self,
-        _batch: &[Arc<exporter::trace::SpanData>],
-    ) -> exporter::trace::ExportResult {
-        exporter::trace::ExportResult::Success
+impl SpanExporter for NoopSpanExporter {
+    async fn export(&self, _batch: Vec<SpanData>) -> ExportResult {
+        ExportResult::Success
     }
 }
 

--- a/src/api/trace/span_processor.rs
+++ b/src/api/trace/span_processor.rs
@@ -34,15 +34,14 @@
 //! [`is_recording`]: ../span/trait.Span.html#method.is_recording
 //! [`TracerProvider`]: ../provider/trait.TracerProvider.html
 
-use crate::exporter;
-use std::sync::Arc;
+use crate::exporter::trace::SpanData;
 
 /// `SpanProcessor`s allow finished spans to be processed.
 pub trait SpanProcessor: Send + Sync + std::fmt::Debug {
     /// `on_start` method is invoked when a `Span` is started.
-    fn on_start(&self, span: Arc<exporter::trace::SpanData>);
+    fn on_start(&self, span: &SpanData);
     /// `on_end` method is invoked when a `Span` is ended.
-    fn on_end(&self, span: Arc<exporter::trace::SpanData>);
+    fn on_end(&self, span: SpanData);
     /// Shutdown is invoked when SDK shuts down. Use this call to cleanup any
     /// processor data. No calls to `on_start` and `on_end` method is invoked
     /// after `shutdown` call is made.

--- a/src/exporter/trace/mod.rs
+++ b/src/exporter/trace/mod.rs
@@ -43,7 +43,7 @@ pub trait SpanExporter: Send + Sync + std::fmt::Debug {
     ///
     /// This function must not block indefinitely, there must be a reasonable
     /// upper limit after which the call must time out with an error result.
-    async fn export(&self, batch: &[Arc<SpanData>]) -> ExportResult;
+    async fn export(&self, batch: Vec<SpanData>) -> ExportResult;
 
     /// Shuts down the exporter. Called when SDK is shut down. This is an
     /// opportunity for exporter to do any cleanup required.

--- a/src/sdk/trace/evicted_queue.rs
+++ b/src/sdk/trace/evicted_queue.rs
@@ -54,6 +54,11 @@ impl<T> EvictedQueue<T> {
     pub fn len(&self) -> usize {
         self.queue.len()
     }
+
+    /// Count of dropped attributes
+    pub fn dropped_count(&self) -> u32 {
+        self.dropped_count
+    }
 }
 
 impl<T> IntoIterator for EvictedQueue<T> {

--- a/src/sdk/trace/span.rs
+++ b/src/sdk/trace/span.rs
@@ -154,9 +154,9 @@ impl Drop for SpanInner {
                             data.end_time = SystemTime::now();
                         }
                     }
-                    let last_processor_idx = provider.span_processors().len().saturating_sub(1);
-                    for (idx, processor) in provider.span_processors().iter().enumerate() {
-                        let span_data = if idx == last_processor_idx {
+                    let mut processors = provider.span_processors().iter().peekable();
+                    while let Some(processor) = processors.next() {
+                        let span_data = if processors.peek().is_none() {
                             // last loop or single processor/exporter, move data
                             span_data.take()
                         } else {

--- a/src/sdk/trace/span.rs
+++ b/src/sdk/trace/span.rs
@@ -23,7 +23,7 @@ pub struct Span {
 /// Inner data, processed and exported on drop
 #[derive(Debug)]
 struct SpanInner {
-    data: Option<Mutex<exporter::trace::SpanData>>,
+    data: Option<Mutex<Option<exporter::trace::SpanData>>>,
     tracer: sdk::trace::Tracer,
 }
 
@@ -36,7 +36,7 @@ impl Span {
         Span {
             id,
             inner: Arc::new(SpanInner {
-                data: data.map(Mutex::new),
+                data: data.map(|data| Mutex::new(Some(data))),
                 tracer,
             }),
         }
@@ -47,10 +47,12 @@ impl Span {
     where
         F: FnOnce(&exporter::trace::SpanData) -> T,
     {
-        self.inner
-            .data
-            .as_ref()
-            .and_then(|inner| inner.lock().ok().map(|span_data| f(&span_data)))
+        self.inner.data.as_ref().and_then(|inner| {
+            inner
+                .lock()
+                .ok()
+                .and_then(|span_data| span_data.as_ref().map(f))
+        })
     }
 
     /// Operate on mutable reference to span inner
@@ -58,10 +60,12 @@ impl Span {
     where
         F: FnOnce(&mut exporter::trace::SpanData) -> T,
     {
-        self.inner
-            .data
-            .as_ref()
-            .and_then(|inner| inner.lock().ok().map(|mut span_data| f(&mut span_data)))
+        self.inner.data.as_ref().and_then(|inner| {
+            inner
+                .lock()
+                .ok()
+                .and_then(|mut span_data| span_data.as_mut().map(f))
+        })
     }
 }
 
@@ -142,14 +146,27 @@ impl Drop for SpanInner {
     /// Report span on inner drop
     fn drop(&mut self) {
         if let Some(data) = self.data.take() {
-            if let Ok(mut inner) = data.lock() {
-                if inner.end_time == inner.start_time {
-                    inner.end_time = SystemTime::now();
-                }
-                let exportable_span = Arc::new(inner.clone());
+            if let Ok(mut span_data) = data.lock().map(|mut data| data.take()) {
                 if let Some(provider) = self.tracer.provider() {
-                    for processor in provider.span_processors() {
-                        processor.on_end(exportable_span.clone())
+                    // Set end time if unset or invalid
+                    if let Some(data) = span_data.as_mut() {
+                        if data.end_time <= data.start_time {
+                            data.end_time = SystemTime::now();
+                        }
+                    }
+                    let last_processor_idx = provider.span_processors().len().saturating_sub(1);
+                    for (idx, processor) in provider.span_processors().iter().enumerate() {
+                        let span_data = if idx == last_processor_idx {
+                            // last loop or single processor/exporter, move data
+                            span_data.take()
+                        } else {
+                            // clone so each exporter gets owned data
+                            span_data.clone()
+                        };
+
+                        if let Some(span_data) = span_data {
+                            processor.on_end(span_data);
+                        }
                     }
                 }
             }

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -12,7 +12,7 @@ use crate::api::trace::TraceState;
 use crate::sdk;
 use crate::{api, api::context::Context, exporter};
 use std::fmt;
-use std::sync::{Arc, Weak};
+use std::sync::Weak;
 use std::time::SystemTime;
 
 /// `Tracer` implementation to create and manage spans
@@ -271,9 +271,8 @@ impl api::trace::Tracer for Tracer {
 
         // Call `on_start` for all processors
         if let Some(inner) = inner.as_ref().cloned() {
-            let inner_data = Arc::new(inner);
             for processor in provider.span_processors() {
-                processor.on_start(inner_data.clone())
+                processor.on_start(&inner)
             }
         }
 


### PR DESCRIPTION
As most exporters copy the majority of the exported span data, switch API to send owned data to exporters.

The export method now becomes:

```diff
- async fn export(&self, batch: &[Arc<trace::SpanData>]) -> trace::ExportResult
+ async fn export(&self, batch: Vec<trace::SpanData>) -> trace::ExportResult 
```

Additional small tweaks / bug fixes encountered during the refactor:

* Add missing `tokio` feature to async example's jaeger dependency
* Switch to custom `TBufferChannel` impl in jaeger exporter because the default buffer size is fixed and unknown at compile time.
* add trace_state impl to otlp exporter
* Expose dropped count on `EvictedQueue` and add to otlp exporter