### PR TITLE
Update semantic conventions

### DIFF
--- a/opentelemetry-semantic-conventions/scripts/generate-consts-from-spec.sh
+++ b/opentelemetry-semantic-conventions/scripts/generate-consts-from-spec.sh
@@ -20,7 +20,8 @@ md_to_rs() {
 		# Regex explanation:
 		# Find markdown tables (lines starting with "|") and take the first 2 columns
 		# - The 1st column is the attribute name consisting of a-z0-9._
-		# - The 2nd column is the description
+		# - The 2nd column is (usually) the type
+		# - The 3rd column is (usually) the description
 		if [[ "$line" =~ ^\|\ \[?\`?([a-z0-9._]+)\`?\]?(:?\([^|]+\))?\ +\|\ ([^|]+)\ +\|\ ([^|]+) ]]; then
 			name="${BASH_REMATCH[1]}"
 			const_name=$(echo "$name" | tr a-z A-Z | sed "s/\\./_/g")

--- a/opentelemetry-semantic-conventions/scripts/generate-consts-from-spec.sh
+++ b/opentelemetry-semantic-conventions/scripts/generate-consts-from-spec.sh
@@ -21,10 +21,10 @@ md_to_rs() {
 		# Find markdown tables (lines starting with "|") and take the first 2 columns
 		# - The 1st column is the attribute name consisting of a-z0-9._
 		# - The 2nd column is the description
-		if [[ "$line" =~ ^\|\ \`?([a-z0-9._]+)\`?\ +\|\ ([^|]+) ]]; then
+		if [[ "$line" =~ ^\|\ \[?\`?([a-z0-9._]+)\`?\]?(:?\([^|]+\))?\ +\|\ ([^|]+)\ +\|\ ([^|]+) ]]; then
 			name="${BASH_REMATCH[1]}"
 			const_name=$(echo "$name" | tr a-z A-Z | sed "s/\\./_/g")
-			doc="${BASH_REMATCH[2]}"
+			doc="${BASH_REMATCH[4]}"
 			echo ""
 			echo "/// $doc"
 			echo "pub const $const_name: Key = Key::from_static_str(\"$name\");"
@@ -41,6 +41,7 @@ case "$1" in
 		md_url_to_rs "resource/semantic_conventions/README.md"
 		md_url_to_rs "resource/semantic_conventions/cloud.md"
 		md_url_to_rs "resource/semantic_conventions/container.md"
+		md_url_to_rs "resource/semantic_conventions/deployment_environment.md"
 		md_url_to_rs "resource/semantic_conventions/faas.md"
 		md_url_to_rs "resource/semantic_conventions/host.md"
 		md_url_to_rs "resource/semantic_conventions/k8s.md"
@@ -48,13 +49,13 @@ case "$1" in
 		md_url_to_rs "resource/semantic_conventions/process.md"
 		;;
 	"trace")
-		md_url_to_rs "trace/semantic_conventions/span-general.md"
 		md_url_to_rs "trace/semantic_conventions/database.md"
 		md_url_to_rs "trace/semantic_conventions/exceptions.md"
 		md_url_to_rs "trace/semantic_conventions/faas.md"
 		md_url_to_rs "trace/semantic_conventions/http.md"
 		md_url_to_rs "trace/semantic_conventions/messaging.md"
 		md_url_to_rs "trace/semantic_conventions/rpc.md"
+		md_url_to_rs "trace/semantic_conventions/span-general.md"
 		;;
 	*)
 		echo "Usage: $0 <resource|trace>"

--- a/opentelemetry-semantic-conventions/src/resource.rs
+++ b/opentelemetry-semantic-conventions/src/resource.rs
@@ -34,8 +34,7 @@ pub const SERVICE_NAME: Key = Key::from_static_str("service.name");
 ///
 /// A string value having a meaning that helps to distinguish a group of
 /// services, for example the team name that owns a group of services.
-/// `service.name` is expected to be unique within the same namespace. The field
-/// is optional.
+/// `service.name` is expected to be unique within the same namespace.
 ///
 /// If `service.namespace` is not specified in the Resource then `service.name`
 /// is expected to be unique for all services that have no explicit namespace
@@ -48,8 +47,8 @@ pub const SERVICE_NAMESPACE: Key = Key::from_static_str("service.namespace");
 ///
 /// MUST be unique for each instance of the same
 /// `service.namespace,service.name` pair (in other words
-/// `service.namespace,service.name,service.instance.id` triplet MUST be
-/// globally unique).
+/// `service.namespace,service.name,service.id` triplet MUST be globally
+/// unique).
 ///
 /// The ID helps to distinguish instances of the same service that exist at the
 /// same time (e.g. instances of a horizontally scaled service). It is
@@ -64,29 +63,19 @@ pub const SERVICE_NAMESPACE: Key = Key::from_static_str("service.namespace");
 /// 5, see RFC 4122 for more recommendations).
 pub const SERVICE_INSTANCE_ID: Key = Key::from_static_str("service.instance.id");
 
-/// The version string of the service API or implementation as defined in
-/// [Version Attributes].
-///
-/// [Version Attributes]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions#version-attributes
+/// The version string of the service API or implementation.
 pub const SERVICE_VERSION: Key = Key::from_static_str("service.version");
 
 /// The name of the telemetry SDK as defined above.
 pub const TELEMETRY_SDK_NAME: Key = Key::from_static_str("telemetry.sdk.name");
 
 /// The language of the telemetry SDK.
-/// One of the following values MUST be used, if one applies: "cpp", "dotnet",
-/// "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs"
 pub const TELEMETRY_SDK_LANGUAGE: Key = Key::from_static_str("telemetry.sdk.language");
 
-/// The version string of the telemetry SDK as defined in [Version Attributes].
-///
-/// [Version Attributes]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions#version-attributes
+/// The version string of the telemetry SDK.
 pub const TELEMETRY_SDK_VERSION: Key = Key::from_static_str("telemetry.sdk.version");
 
-/// The version string of the auto instrumentation agent, if used, as defined in
-/// [Version Attributes].
-///
-/// [Version Attributes]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions#version-attributes
+/// The version string of the auto instrumentation agent, if used.
 pub const TELEMETRY_AUTO_VERSION: Key = Key::from_static_str("telemetry.auto.version");
 
 /// Name of the cloud provider.
@@ -94,14 +83,15 @@ pub const TELEMETRY_AUTO_VERSION: Key = Key::from_static_str("telemetry.auto.ver
 /// Example values are aws, azure, gcp.
 pub const CLOUD_PROVIDER: Key = Key::from_static_str("cloud.provider");
 
-/// The cloud account id used to identify different entities.
+/// The cloud account ID used to identify different entities.
 pub const CLOUD_ACCOUNT_ID: Key = Key::from_static_str("cloud.account.id");
 
-/// A specific geographical location where different entities can run
+/// A specific geographical location where different entities can run.
 pub const CLOUD_REGION: Key = Key::from_static_str("cloud.region");
 
 /// Zones are a sub set of the region connected through low-latency links.
-/// In aws it is called availability-zone.
+///
+/// In AWS, this is called availability-zone.
 pub const CLOUD_ZONE: Key = Key::from_static_str("cloud.zone");
 
 /// Container name.
@@ -119,10 +109,15 @@ pub const CONTAINER_IMAGE_NAME: Key = Key::from_static_str("container.image.name
 /// Container image tag.
 pub const CONTAINER_IMAGE_TAG: Key = Key::from_static_str("container.image.tag");
 
+/// Name of the [deployment environment] (aka deployment tier).
+///
+/// [deployment environment]: https://en.wikipedia.org/wiki/Deployment_environment
+pub const DEPLOYMENT_ENVIRONMENT: Key = Key::from_static_str("deployment.environment");
+
 /// The name of the function being executed.
 pub const FAAS_NAME: Key = Key::from_static_str("faas.name");
 
-/// The unique name of the function being executed.
+/// The unique ID of the function being executed.
 ///
 /// For example, in AWS Lambda this field corresponds to the [ARN] value, in GCP
 /// to the URI of the resource, and in Azure to the [FunctionDirectory] field.
@@ -132,7 +127,7 @@ pub const FAAS_NAME: Key = Key::from_static_str("faas.name");
 pub const FAAS_ID: Key = Key::from_static_str("faas.id");
 
 /// The version string of the function being executed as defined in [Version
-/// Attributes]
+/// Attributes].
 ///
 /// [Version Attributes]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions#version-attributes
 pub const FAAS_VERSION: Key = Key::from_static_str("faas.version");
@@ -140,26 +135,28 @@ pub const FAAS_VERSION: Key = Key::from_static_str("faas.version");
 /// The execution environment ID as a string.
 pub const FAAS_INSTANCE: Key = Key::from_static_str("faas.instance");
 
-/// Hostname of the host.
+/// Unique host ID.
 ///
-/// It contains what the `hostname` command returns on the host machine.
-pub const HOST_HOSTNAME: Key = Key::from_static_str("host.hostname");
-
-/// Unique host id.
-///
-/// For Cloud this must be the instance_id assigned by the cloud provider
+/// For Cloud, this must be the instance_id assigned by the cloud provider.
 pub const HOST_ID: Key = Key::from_static_str("host.id");
 
 /// Name of the host.
 ///
-/// It may contain what `hostname` returns on Unix systems, the fully qualified,
-/// or a name specified by the user.
+/// On Unix systems, it may contain what the `hostname` command returns, or the
+/// fully qualified hostname, or another name specified by the user.
 pub const HOST_NAME: Key = Key::from_static_str("host.name");
+
+/// Type of host.
+///
+/// For Cloud, this must be the machine type.
+pub const HOST_TYPE: Key = Key::from_static_str("host.type");
 
 /// Name of the VM image or OS install the host was instantiated from.
 pub const HOST_IMAGE_NAME: Key = Key::from_static_str("host.image.name");
 
-/// VM image id. For Cloud, this value is from the provider.
+/// VM image ID.
+///
+/// For Cloud, this value is from the provider.
 pub const HOST_IMAGE_ID: Key = Key::from_static_str("host.image.id");
 
 /// The version string of the VM image as defined in [Version Attributes].
@@ -173,7 +170,7 @@ pub const K8S_CLUSTER_NAME: Key = Key::from_static_str("k8s.cluster.name");
 /// The name of the namespace that the pod is running in.
 pub const K8S_NAMESPACE_NAME: Key = Key::from_static_str("k8s.namespace.name");
 
-/// The uid of the Pod.
+/// The UID of the Pod.
 pub const K8S_POD_UID: Key = Key::from_static_str("k8s.pod.uid");
 
 /// The name of the Pod.
@@ -182,37 +179,37 @@ pub const K8S_POD_NAME: Key = Key::from_static_str("k8s.pod.name");
 /// The name of the Container in a Pod template.
 pub const K8S_CONTAINER_NAME: Key = Key::from_static_str("k8s.container.name");
 
-/// The uid of the ReplicaSet.
+/// The UID of the ReplicaSet.
 pub const K8S_REPLICASET_UID: Key = Key::from_static_str("k8s.replicaset.uid");
 
 /// The name of the ReplicaSet.
 pub const K8S_REPLICASET_NAME: Key = Key::from_static_str("k8s.replicaset.name");
 
-/// The uid of the Deployment.
+/// The UID of the Deployment.
 pub const K8S_DEPLOYMENT_UID: Key = Key::from_static_str("k8s.deployment.uid");
 
 /// The name of the Deployment.
 pub const K8S_DEPLOYMENT_NAME: Key = Key::from_static_str("k8s.deployment.name");
 
-/// The uid of the StatefulSet.
+/// The UID of the StatefulSet.
 pub const K8S_STATEFULSET_UID: Key = Key::from_static_str("k8s.statefulset.uid");
 
 /// The name of the StatefulSet.
 pub const K8S_STATEFULSET_NAME: Key = Key::from_static_str("k8s.statefulset.name");
 
-/// The uid of the DaemonSet.
+/// The UID of the DaemonSet.
 pub const K8S_DAEMONSET_UID: Key = Key::from_static_str("k8s.daemonset.uid");
 
 /// The name of the DaemonSet.
 pub const K8S_DAEMONSET_NAME: Key = Key::from_static_str("k8s.daemonset.name");
 
-/// The uid of the Job.
+/// The UID of the Job.
 pub const K8S_JOB_UID: Key = Key::from_static_str("k8s.job.uid");
 
 /// The name of the Job.
 pub const K8S_JOB_NAME: Key = Key::from_static_str("k8s.job.name");
 
-/// The uid of the CronJob.
+/// The UID of the CronJob.
 pub const K8S_CRONJOB_UID: Key = Key::from_static_str("k8s.cronjob.uid");
 
 /// The name of the CronJob.
@@ -228,27 +225,47 @@ pub const OS_DESCRIPTION: Key = Key::from_static_str("os.description");
 /// Process identifier (PID).
 pub const PROCESS_PID: Key = Key::from_static_str("process.pid");
 
-/// The name of the process executable. On Linux based systems, can be set to
-/// the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name
-/// of `GetProcessImageFileNameW`.
+/// The name of the process executable.
+///
+/// On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On
+/// Windows, can be set to the base name of `GetProcessImageFileNameW`.
 pub const PROCESS_EXECUTABLE_NAME: Key = Key::from_static_str("process.executable.name");
 
-/// The full path to the process executable. On Linux based systems, can be set
-/// to the target of `proc/[pid]/exe`. On Windows, can be set to the result of
-/// `GetProcessImageFileNameW`.
+/// The full path to the process executable.
+///
+/// On Linux based systems, can be set to the target of `proc/[pid]/exe`. On
+/// Windows, can be set to the result of `GetProcessImageFileNameW`.
 pub const PROCESS_EXECUTABLE_PATH: Key = Key::from_static_str("process.executable.path");
 
-/// The command used to launch the process (i.e. the command name). On Linux
-/// based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On
-/// Windows, can be set to the first parameter extracted from `GetCommandLineW`.
+/// The command used to launch the process (i.e. the command name).
+///
+/// On Linux based systems, can be set to the zeroth string in
+/// `proc/[pid]/cmdline`. On Windows, can be set to the first parameter
+/// extracted from `GetCommandLineW`.
 pub const PROCESS_COMMAND: Key = Key::from_static_str("process.command");
 
-/// The full command used to launch the process. The value can be either a list
-/// of strings representing the ordered list of arguments, or a single string
-/// representing the full command. On Linux based systems, can be set to the
-/// list of null-delimited strings extracted from `proc/[pid]/cmdline`. On
-/// Windows, can be set to the result of `GetCommandLineW`.
+/// The full command used to launch the process.
+///
+/// The value can be either a list of strings representing the ordered list of
+/// arguments, or a single string representing the full command.
+///
+/// On Linux based systems, can be set to the list of null-delimited strings
+/// extracted from `proc/[pid]/cmdline`. On Windows, can be set to the result of
+/// `GetCommandLineW`.
 pub const PROCESS_COMMAND_LINE: Key = Key::from_static_str("process.command_line");
 
 /// The username of the user that owns the process.
 pub const PROCESS_OWNER: Key = Key::from_static_str("process.owner");
+
+/// The name of the runtime of this process.
+///
+/// For compiled native binaries, this SHOULD be the name of the compiler.
+pub const PROCESS_RUNTIME_NAME: Key = Key::from_static_str("process.runtime.name");
+
+/// The version of the runtime of this process, as returned by the runtime
+/// without modification.
+pub const PROCESS_RUNTIME_VERSION: Key = Key::from_static_str("process.runtime.version");
+
+/// An additional description about the runtime of the process, for example a
+/// specific vendor customization of the runtime environment.
+pub const PROCESS_RUNTIME_DESCRIPTION: Key = Key::from_static_str("process.runtime.description");

--- a/opentelemetry-semantic-conventions/src/trace.rs
+++ b/opentelemetry-semantic-conventions/src/trace.rs
@@ -24,31 +24,384 @@
 
 use opentelemetry::api::Key;
 
-/// Transport protocol used.
-pub const NET_TRANSPORT: Key = Key::from_static_str("net.transport");
+/// An identifier for the database management system (DBMS) product being used.
+pub const DB_SYSTEM: Key = Key::from_static_str("db.system");
+
+/// The connection string used to connect to the database.
+///
+/// It is recommended to remove embedded credentials.
+pub const DB_CONNECTION_STRING: Key = Key::from_static_str("db.connection_string");
+
+/// Username for accessing the database.
+pub const DB_USER: Key = Key::from_static_str("db.user");
 
 /// Remote address of the peer (dotted decimal for IPv4 or [RFC5952] for IPv6)
 ///
 /// [RFC5952]: https://tools.ietf.org/html/rfc5952
 pub const NET_PEER_IP: Key = Key::from_static_str("net.peer.ip");
 
-/// Remote port number as an integer. E.g., `80`.
-pub const NET_PEER_PORT: Key = Key::from_static_str("net.peer.port");
-
-/// Remote hostname or similar.                          
+/// Remote hostname or similar.
 pub const NET_PEER_NAME: Key = Key::from_static_str("net.peer.name");
 
-/// Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.        
+/// Remote port number.
+pub const NET_PEER_PORT: Key = Key::from_static_str("net.peer.port");
+
+/// Transport protocol used.
+pub const NET_TRANSPORT: Key = Key::from_static_str("net.transport");
+
+/// The fully-qualified class name of the [Java Database Connectivity (JDBC)]
+/// driver used to connect.
+///
+/// [Java Database Connectivity (JDBC)]: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
+pub const DB_JDBC_DRIVER_CLASSNAME: Key = Key::from_static_str("db.jdbc.driver_classname");
+
+/// The Microsoft SQL Server [instance name]) connecting to.
+///
+/// This name is used to determine the port of a named instance. If setting a
+/// `db.mssql.instance_name`, `net.peer.port` is no longer required (but still
+/// recommended if non-standard).
+///
+/// [instance name]: https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15
+pub const DB_MSSQL_INSTANCE_NAME: Key = Key::from_static_str("db.mssql.instance_name");
+
+/// If no [tech-specific attribute] is defined, this attribute is used to report
+/// the name of the database being accessed.
+///
+/// For commands that switch the database, this should be set to the target
+/// database (even if the command fails).
+///
+/// In some SQL databases, the database name to be used is called "schema name".
+///
+/// [tech-specific attribute]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md#call-level-attributes-for-specific-technologies
+pub const DB_NAME: Key = Key::from_static_str("db.name");
+
+/// The database statement being executed.
+///
+/// The value may be sanitized to exclude sensitive information.
+pub const DB_STATEMENT: Key = Key::from_static_str("db.statement");
+
+/// The name of the operation being executed.
+///
+/// e.g. the [MongoDB command name] such as `findAndModify`.
+///
+/// While it would semantically make sense to set this, e.g., to a SQL keyword
+/// like `SELECT` or `INSERT`, it is not recommended to attempt any client-side
+/// parsing of `db.statement` just to get this property (the back end can do
+/// that if required).
+///
+/// [MongoDB command name]: https://docs.mongodb.com/manual/reference/command/#database-operations
+pub const DB_OPERATION: Key = Key::from_static_str("db.operation");
+
+/// The name of the keyspace being accessed.
+///
+/// To be used instead of the generic `db.name` attribute.
+pub const DB_CASSANDRA_KEYSPACE: Key = Key::from_static_str("db.cassandra.keyspace");
+
+/// The [HBase namespace] being accessed.
+///
+/// To be used instead of the generic `db.name` attribute.
+///
+/// [HBase namespace]: https://hbase.apache.org/book.html#_namespace
+pub const DB_HBASE_NAMESPACE: Key = Key::from_static_str("db.hbase.namespace");
+
+/// The index of the database being accessed as used in the [`SELECT` command],
+/// provided as an integer.
+///
+/// To be used instead of the generic `db.name` attribute.
+///
+/// [`SELECT` command]: https://redis.io/commands/select
+pub const DB_REDIS_DATABASE_INDEX: Key = Key::from_static_str("db.redis.database_index");
+
+/// The collection being accessed within the database stated in `db.name`.
+pub const DB_MONGODB_COLLECTION: Key = Key::from_static_str("db.mongodb.collection");
+
+/// The type of the exception (its fully-qualified class name, if applicable).
+///
+/// The dynamic type of the exception should be preferred over the static type
+/// in languages that support it.
+pub const EXCEPTION_TYPE: Key = Key::from_static_str("exception.type");
+
+/// The exception message.
+pub const EXCEPTION_MESSAGE: Key = Key::from_static_str("exception.message");
+
+/// A stacktrace as a string in the natural representation for the language
+/// runtime.
+///
+/// The representation is to be determined and documented by each language SIG.
+pub const EXCEPTION_STACKTRACE: Key = Key::from_static_str("exception.stacktrace");
+
+/// SHOULD be set to true if the exception event is recorded at a point where it
+/// is known that the exception is escaping the scope of the span.
+///
+/// An exception is considered to have escaped (or left) the scope of a span, if
+/// that span is ended while the exception is still logically "in flight". This
+/// may be actually "in flight" in some languages (e.g. if the exception is
+/// passed to a Context manager's `__exit__` method in Python) but will usually
+/// be caught at the point of recording the exception in most languages.
+///
+/// It is usually not possible to determine at the point where an exception is
+/// thrown whether it will escape the scope of a span. However, it is trivial to
+/// know that an exception will escape, if one checks for an active exception
+/// just before ending the span, as done in the [example
+/// above](#exception-end-example).
+///
+/// It follows that an exception may still escape the scope of the span even if
+/// the `exception.escaped` attribute was not set or set to false, since the
+/// event might have been recorded at a time where it was not clear whether the
+/// exception will escape.
+pub const EXCEPTION_ESCAPED: Key = Key::from_static_str("exception.escaped");
+
+/// Type of the trigger on which the function is executed.
+///
+/// It SHOULD be one of the following strings: "datasource", "http", "pubsub",
+/// "timer", or "other".
+pub const FAAS_TRIGGER: Key = Key::from_static_str("faas.trigger");
+
+/// String containing the execution id of the function.
+///
+/// E.g. `af9d5aa4-a685-4c5f-a22b-444f80b3cc28`
+pub const FAAS_EXECUTION: Key = Key::from_static_str("faas.execution");
+
+/// Indicates that the serverless function is executed for the first time (aka
+/// cold start).
+pub const FAAS_COLDSTART: Key = Key::from_static_str("faas.coldstart");
+
+/// The name of the invoked function.
+pub const FAAS_INVOKED_NAME: Key = Key::from_static_str("faas.invoked_name");
+
+/// The cloud provider of the invoked function.
+pub const FAAS_INVOKED_PROVIDER: Key = Key::from_static_str("faas.invoked_provider");
+
+/// The cloud region of the invoked function.
+pub const FAAS_INVOKED_REGION: Key = Key::from_static_str("faas.invoked_region");
+
+/// The name of the source on which the operation was performed.
+///
+/// For example, in Cloud Storage or S3 corresponds to the bucket name, and in
+/// Cosmos DB to the database name.
+pub const FAAS_DOCUMENT_COLLECTION: Key = Key::from_static_str("faas.document.collection");
+
+/// Describes the type of the operation that was performed on the data.
+///
+/// It SHOULD be one of the following strings: "insert", "edit", "delete".
+pub const FAAS_DOCUMENT_OPERATION: Key = Key::from_static_str("faas.document.operation");
+
+/// A string containing the time when the data was accessed in the [ISO 8601]
+/// format expressed in [UTC].
+///
+/// E.g. `"2020-01-23T13:47:06Z"`
+///
+/// [ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
+/// [UTC]: https://www.w3.org/TR/NOTE-datetime
+pub const FAAS_DOCUMENT_TIME: Key = Key::from_static_str("faas.document.time");
+
+/// The document name/table subjected to the operation.
+///
+/// For example, in Cloud Storage or S3 is the name of the file, and in Cosmos
+/// DB the table name.
+pub const FAAS_DOCUMENT_NAME: Key = Key::from_static_str("faas.document.name");
+
+/// A string containing the function invocation time in the [ISO 8601] format
+/// expressed in [UTC].
+///
+/// E.g. `"2020-01-23T13:47:06Z"`
+///
+/// [ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
+/// [UTC]: https://www.w3.org/TR/NOTE-datetime
+pub const FAAS_TIME: Key = Key::from_static_str("faas.time");
+
+/// A string containing the schedule period as [Cron Expression].
+///
+/// E.g. `"0/5 * * * ? *"`
+///
+/// [Cron Expression]: https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm
+pub const FAAS_CRON: Key = Key::from_static_str("faas.cron");
+
+/// HTTP request method.
+pub const HTTP_METHOD: Key = Key::from_static_str("http.method");
+
+/// Full HTTP request URL in the form
+/// `scheme://host[:port]/path?query[#fragment]`.
+///
+/// Usually the fragment is not transmitted over HTTP, but if it is known, it
+/// should be included nevertheless.
+pub const HTTP_URL: Key = Key::from_static_str("http.url");
+
+/// The full request target as passed in a HTTP request line or equivalent.
+pub const HTTP_TARGET: Key = Key::from_static_str("http.target");
+
+/// The value of the [HTTP host header].
+///
+/// When the header is empty or not present, this attribute should be the same.
+///
+/// [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4
+pub const HTTP_HOST: Key = Key::from_static_str("http.host");
+
+/// The URI scheme identifying the used protocol.
+pub const HTTP_SCHEME: Key = Key::from_static_str("http.scheme");
+
+/// [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).
+pub const HTTP_STATUS_CODE: Key = Key::from_static_str("http.status_code");
+
+/// Kind of HTTP protocol used.
+///
+/// If net.transport is not specified, it can be assumed to be IP.TCP except if
+/// http.flavor is QUIC, in which case IP.UDP is assumed.
+///
+/// http.flavor` MUST be one of the following or, if none of the listed values
+/// apply, a custom value:
+///
+/// | Value  | Description |
+/// |---|---|
+/// | `1.0` | HTTP 1.0 |
+/// | `1.1` | HTTP 1.1 |
+/// | `2.0` | HTTP 2 |
+/// | `SPDY` | SPDY protocol. |
+/// | `QUIC` | QUIC protocol. |
+pub const HTTP_FLAVOR: Key = Key::from_static_str("http.flavor");
+
+/// Value of the [HTTP User-Agent] header sent by the client.
+///
+/// [HTTP User-Agent]: https://tools.ietf.org/html/rfc7231#section-5.5.3
+pub const HTTP_USER_AGENT: Key = Key::from_static_str("http.user_agent");
+
+/// The size of the request payload body in bytes.
+///
+/// This is the number of bytes transferred excluding headers and is often, but
+/// not always, present as the [Content-Length] header. For requests using
+/// transport encoding, this should be the compressed size.
+///
+/// [Content-Length]: https://tools.ietf.org/html/rfc7230#section-3.3.2
+pub const HTTP_REQUEST_CONTENT_LENGTH: Key = Key::from_static_str("http.request_content_length");
+
+/// The size of the uncompressed request payload body after transport decoding.
+///
+/// Not set if transport encoding not used.
+pub const HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED: Key =
+    Key::from_static_str("http.request_content_length_uncompressed");
+
+/// The size of the response payload body in bytes.
+///
+/// This is the number of bytes transferred excluding headers and is often, but
+/// not always, present as the [Content-Length] header. For requests using
+/// transport encoding, this should be the compressed size.
+///
+/// [Content-Length]: https://tools.ietf.org/html/rfc7230#section-3.3.2
+pub const HTTP_RESPONSE_CONTENT_LENGTH: Key = Key::from_static_str("http.response_content_length");
+
+/// The size of the uncompressed response payload body after transport decoding.
+///
+/// Not set if transport encoding not used.
+pub const HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED: Key =
+    Key::from_static_str("http.response_content_length_uncompressed");
+
+/// The primary server name of the matched virtual host.
+///
+/// This should be obtained via configuration. If no such configuration can be
+/// obtained, this attribute MUST NOT be set ( `net.host.name` should be used
+/// instead).
+///
+/// `http.url` is usually not readily available on the server side but would have
+/// to be assembled in a cumbersome and sometimes lossy process from other
+/// information (see e.g. open-telemetry/opentelemetry-python/pull/148). It is
+/// thus preferred to supply the raw data that is available.
+pub const HTTP_SERVER_NAME: Key = Key::from_static_str("http.server_name");
+
+/// The matched route (path template).
+pub const HTTP_ROUTE: Key = Key::from_static_str("http.route");
+
+/// The IP address of the original client behind all proxies, if known (e.g.
+/// from [X-Forwarded-For]).
+///
+/// This is not necessarily the same as `net.peer.ip`, which would identify the
+/// network-level peer, which may be a proxy.
+///
+/// [X-Forwarded-For]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+pub const HTTP_CLIENT_IP: Key = Key::from_static_str("http.client_ip");
+
+/// A string identifying the messaging system.
+pub const MESSAGING_SYSTEM: Key = Key::from_static_str("messaging.system");
+
+/// The message destination name.
+///
+/// This might be equal to the span name but is required nevertheless.
+pub const MESSAGING_DESTINATION: Key = Key::from_static_str("messaging.destination");
+
+/// The kind of message destination
+pub const MESSAGING_DESTINATION_KIND: Key = Key::from_static_str("messaging.destination_kind");
+
+/// A boolean that is true if the message destination is temporary.
+pub const MESSAGING_TEMP_DESTINATION: Key = Key::from_static_str("messaging.temp_destination");
+
+/// The name of the transport protocol.
+pub const MESSAGING_PROTOCOL: Key = Key::from_static_str("messaging.protocol");
+
+/// The version of the transport protocol.
+pub const MESSAGING_PROTOCOL_VERSION: Key = Key::from_static_str("messaging.protocol_version");
+
+/// Connection string.
+pub const MESSAGING_URL: Key = Key::from_static_str("messaging.url");
+
+/// A value used by the messaging system as an identifier for the message,
+/// represented as a string.
+pub const MESSAGING_MESSAGE_ID: Key = Key::from_static_str("messaging.message_id");
+
+/// The [conversation ID] identifying the conversation to which the message
+/// belongs, represented as a string.
+///
+/// Sometimes called "Correlation ID".
+///
+/// [conversation ID]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/messaging.md#conversations
+pub const MESSAGING_CONVERSATION_ID: Key = Key::from_static_str("messaging.conversation_id");
+
+/// The (uncompressed) size of the message payload in bytes.
+///
+/// Also use this attribute if it is unknown whether the compressed or
+/// uncompressed payload size is reported.
+pub const MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES: Key =
+    Key::from_static_str("messaging.message_payload_size_bytes");
+
+/// The compressed size of the message payload in bytes.
+pub const MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES: Key =
+    Key::from_static_str("messaging.message_payload_compressed_size_bytes");
+
+/// A string identifying the kind of message consumption as defined in the
+/// [Operation names] section above.
+///
+/// If the operation is "send", this attribute MUST NOT be set, since the
+/// operation can be inferred from the span kind in that case.
+///
+/// [Operation names]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/messaging.md#operation-names
+pub const MESSAGING_OPERATION: Key = Key::from_static_str("messaging.operation");
+
+/// A string identifying the remoting system.
+pub const RPC_SYSTEM: Key = Key::from_static_str("rpc.system");
+
+/// The full name of the service being called, including its package name, if
+/// applicable.
+pub const RPC_SERVICE: Key = Key::from_static_str("rpc.service");
+
+/// The name of the method being called, must be equal to the $method part in
+/// the span name.
+pub const RPC_METHOD: Key = Key::from_static_str("rpc.method");
+
+/// Like `net.peer.ip` but for the host IP.
+///
+/// Useful in case of a multi-IP host.
 pub const NET_HOST_IP: Key = Key::from_static_str("net.host.ip");
 
-/// Like `net.peer.port` but for the host port.                                       
+/// Like `net.peer.port` but for the host port.
 pub const NET_HOST_PORT: Key = Key::from_static_str("net.host.port");
 
-/// Local hostname or similar.
+/// Local hostname or similar
 pub const NET_HOST_NAME: Key = Key::from_static_str("net.host.name");
 
-/// The `service.name` of the remote service. SHOULD be equal to the actual
-/// `service.name` resource attribute of the remote service if any.
+/// The [`service.name`] of the remote service.
+///
+/// SHOULD be equal to the actual `service.name` resource attribute of the
+/// remote service if any.
+///
+/// [`service.name`]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/README.md#service
 pub const PEER_SERVICE: Key = Key::from_static_str("peer.service");
 
 /// Username or client_id extracted from the access token or [Authorization]
@@ -62,293 +415,30 @@ pub const ENDUSER_ID: Key = Key::from_static_str("enduser.id");
 pub const ENDUSER_ROLE: Key = Key::from_static_str("enduser.role");
 
 /// Scopes or granted authorities the client currently possesses extracted from
-/// token or application security context. The value would come from the scope
-/// associated with an [OAuth 2.0 Access Token] or an attribute value in a [SAML
-/// 2.0 Assertion].
+/// token or application security context.
+///
+/// The value would come from the scope associated with an [OAuth 2.0 Access
+/// Token] or an attribute value in a [SAML 2.0 Assertion].
 ///
 /// [OAuth 2.0 Access Token]: https://tools.ietf.org/html/rfc6749#section-3.3
 /// [SAML 2.0 Assertion]: http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html
 pub const ENDUSER_SCOPE: Key = Key::from_static_str("enduser.scope");
 
-/// Current "managed" thread ID (as opposed to OS thread ID). E.g. `42`
-pub const THREAD_ID: Key = Key::from_static_str("thread.id");
+/// The method or function name, or equivalent (usually rightmost part of the
+/// code unit's name).
+pub const CODE_FUNCTION: Key = Key::from_static_str("code.function");
 
-/// Current thread name. E.g. `main`                                   
-pub const THREAD_NAME: Key = Key::from_static_str("thread.name");
-
-/// An identifier for the database management system (DBMS) product being used.
-/// See [semantic conventions] page for a list of well-known identifiers.
+/// The "namespace" within which `code.function` is defined.
 ///
-/// [semantic conventions page]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md#notes-and-well-known-identifiers-for-dbsystem
-pub const DB_SYSTEM: Key = Key::from_static_str("db.system");
+/// Usually the qualified class or module name, such that `code.namespace` +
+/// some separator + `code.function` form a unique identifier for the code unit.
+pub const CODE_NAMESPACE: Key = Key::from_static_str("code.namespace");
 
-/// Username for accessing the database, e.g., `"readonly_user"` or `"reporting_user"`
-pub const DB_USER: Key = Key::from_static_str("db.user");
+/// The source code file name that identifies the code unit as uniquely as
+/// possible (preferably an absolute file path).
+pub const CODE_FILEPATH: Key = Key::from_static_str("code.filepath");
 
-/// The [instance name] connecting to. This name is used to determine the port of
-/// a named instance.
+/// The line number in `code.filepath` best representing the operation.
 ///
-/// [instance name]: https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15
-pub const DB_MSSQL_INSTANCE_NAME: Key = Key::from_static_str("db.mssql.instance_name");
-
-/// The fully-qualified class name of the [Java Database Connectivity (JDBC)]
-/// driver used to connect, e.g., `"org.postgresql.Driver"` or
-///` "com.microsoft.sqlserver.jdbc.SQLServerDriver"`.
-///
-/// [Java Database Connectivity (JDBC)]: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
-pub const DB_JDBC_DRIVER_CLASSNAME: Key = Key::from_static_str("db.jdbc.driver_classname");
-
-/// If no tech-specific attribute is defined in the list below, this attribute
-/// is used to report the name of the database being accessed. For commands that
-/// switch the database, this should be set to the target database (even if the
-/// command fails).
-pub const DB_NAME: Key = Key::from_static_str("db.name");
-
-/// The database statement being executed. Note that the value may be sanitized
-/// to exclude sensitive information. E.g., for `db.system="other_sql"`,
-/// `"SELECT * FROM wuser_table"`; for `db.system="redis"`, `"SET mykey
-/// 'WuValue'"`.
-pub const DB_STATEMENT: Key = Key::from_static_str("db.statement");
-
-/// The name of the operation being executed, e.g. the [MongoDB command name]
-/// such as `findAndModify`. While it would semantically make sense to set this,
-/// e.g., to an SQL keyword like `SELECT` or `INSERT`, it is *not* recommended
-/// to attempt any client-side parsing of `db.statement` just to get this
-/// property (the back end can do that if required).
-///
-/// [MongoDB command name]: https://docs.mongodb.com/manual/reference/command/#database-operations
-pub const DB_OPERATION: Key = Key::from_static_str("db.operation");
-
-/// The name of the keyspace being accessed. To be used instead of the generic
-/// `db.name` attribute.
-pub const DB_CASSANDRA_KEYSPACE: Key = Key::from_static_str("db.cassandra.keyspace");
-
-/// The HBase namespace being accessed. To be used instead of the generic
-/// `db.name` attribute.
-pub const DB_HBASE_NAMESPACE: Key = Key::from_static_str("db.hbase.namespace");
-
-/// The index of the database being accessed as used in the `SELECT` command,
-/// provided as an integer. To be used instead of the generic `db.name` attribute.
-pub const DB_REDIS_DATABASE_INDEX: Key = Key::from_static_str("db.redis.database_index");
-
-/// The collection being accessed within the database stated in `db.name`.
-pub const DB_MONGODB_COLLECTION: Key = Key::from_static_str("db.mongodb.collection");
-
-/// The type of the exception (its fully-qualified class name, if applicable).
-/// The dynamic type of the exception should be preferred over the static type
-/// in languages that support it. E.g. "java.net.ConnectException", "OSError"
-pub const EXCEPTION_TYPE: Key = Key::from_static_str("exception.type");
-
-/// The exception message. E.g. `"Division by zero"`, `"Can't convert 'int'
-/// object to str implicitly"`
-pub const EXCEPTION_MESSAGE: Key = Key::from_static_str("exception.message");
-
-/// A stacktrace as a string in the natural representation for the language
-/// runtime. The representation is to be determined and documented by each
-/// language SIG. E.g.:
-///
-/// ```text
-/// stack backtrace:
-///    0: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
-///    1: core::fmt::write
-///    2: std::io::Write::write_fmt
-///    3: std::panicking::default_hook::{{closure}}
-///    4: std::panicking::default_hook
-///    5: std::panicking::rust_panic_with_hook
-///    6: std::panicking::begin_panic
-///    7: test::main
-///    8: std::rt::lang_start::{{closure}}
-///    9: std::rt::lang_start_internal
-///   10: std::rt::lang_start
-///   11: main
-/// ```
-pub const EXCEPTION_STACKTRACE: Key = Key::from_static_str("exception.stacktrace");
-
-/// Type of the trigger on which the function is executed.
-///
-/// It SHOULD be one of the following strings: "datasource", "http", "pubsub",
-/// "timer", or "other".
-pub const FAAS_TRIGGER: Key = Key::from_static_str("faas.trigger");
-
-/// String containing the execution id of the function. E.g.
-/// `af9d5aa4-a685-4c5f-a22b-444f80b3cc28`
-pub const FAAS_EXECUTION: Key = Key::from_static_str("faas.execution");
-
-/// A boolean indicating that the serverless function is executed for the first
-/// time (aka cold start).
-pub const FAAS_COLDSTART: Key = Key::from_static_str("faas.coldstart");
-
-/// The name of the source on which the operation was performed. For example, in
-/// Cloud Storage or S3 corresponds to the bucket name, and in Cosmos DB to the
-/// database name.
-pub const FAAS_DOCUMENT_COLLECTION: Key = Key::from_static_str("faas.document.collection");
-
-/// Describes the type of the operation that was performed on the data.
-///
-/// It SHOULD be one of the following strings: "insert", "edit", "delete".
-pub const FAAS_DOCUMENT_OPERATION: Key = Key::from_static_str("faas.document.operation");
-
-/// A string containing the time when the data was accessed in the [ISO 8601]
-/// format expressed in [UTC]. E.g. `"2020-01-23T13:47:06Z"`
-///
-/// [ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
-/// [UTC]: https://www.w3.org/TR/NOTE-datetime
-pub const FAAS_DOCUMENT_TIME: Key = Key::from_static_str("faas.document.time");
-
-/// The document name/table subjected to the operation.
-///
-/// For example, in Cloud Storage or S3 is the name of the file, and in Cosmos
-/// DB the table name.
-pub const FAAS_DOCUMENT_NAME: Key = Key::from_static_str("faas.document.name");
-
-/// A string containing the function invocation time in the [ISO 8601] format
-/// expressed in [UTC]. E.g. `"2020-01-23T13:47:06Z"`
-///
-/// [ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
-/// [UTC]: https://www.w3.org/TR/NOTE-datetime
-pub const FAAS_TIME: Key = Key::from_static_str("faas.time");
-
-/// A string containing the schedule period as [Cron Expression]. E.g. `"0/5 * * * ? *"`
-///
-/// [Cron Expression]: https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm
-pub const FAAS_CRON: Key = Key::from_static_str("faas.cron");
-
-/// HTTP request method. E.g. `"GET"`.
-pub const HTTP_METHOD: Key = Key::from_static_str("http.method");
-
-/// Full HTTP request URL in the form
-/// `scheme://host[:port]/path?query[#fragment]`. Usually the fragment is not
-/// transmitted over HTTP, but if it is known, it should be included
-/// nevertheless.
-pub const HTTP_URL: Key = Key::from_static_str("http.url");
-
-/// The full request target as passed in a [HTTP request line] or equivalent,
-/// e.g. `"/path/12314/?q=ddds#123"`.
-///
-/// [HTTP request line]: https://tools.ietf.org/html/rfc7230#section-3.1.1
-pub const HTTP_TARGET: Key = Key::from_static_str("http.target");
-
-/// The value of the [HTTP host header]. When the header is empty or not
-/// present, this attribute should be the same.
-///
-/// [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4
-pub const HTTP_HOST: Key = Key::from_static_str("http.host");
-
-/// The URI scheme identifying the used protocol: `"http"` or `"https"`
-pub const HTTP_SCHEME: Key = Key::from_static_str("http.scheme");
-
-/// [HTTP response status code]. E.g. `200` (integer)
-///
-/// [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
-pub const HTTP_STATUS_CODE: Key = Key::from_static_str("http.status_code");
-
-/// [HTTP reason phrase]. E.g. `"OK"`
-///
-/// [HTTP reason phrase]: https://tools.ietf.org/html/rfc7230#section-3.1.2
-pub const HTTP_STATUS_TEXT: Key = Key::from_static_str("http.status_text");
-
-/// Kind of HTTP protocol used: `"1.0"`, `"1.1"`, `"2"`, `"SPDY"` or `"QUIC"`.
-pub const HTTP_FLAVOR: Key = Key::from_static_str("http.flavor");
-
-/// Value of the HTTP [User-Agent] header sent by the client.
-///
-/// [User-Agent]: https://tools.ietf.org/html/rfc7231#section-5.5.3
-pub const HTTP_USER_AGENT: Key = Key::from_static_str("http.user_agent");
-
-/// The size of the request payload body in bytes. This is the number of bytes
-/// transferred excluding headers and is often, but not always, present as the
-/// [Content-Length] header. For requests using transport encoding, this should
-/// be the compressed size.
-///
-/// [Content-Length]: https://tools.ietf.org/html/rfc7230#section-3.3.2
-pub const HTTP_REQUEST_CONTENT_LENGTH: Key = Key::from_static_str("http.request_content_length");
-
-/// The size of the uncompressed request payload body after transport decoding.
-/// Not set if transport encoding not used.
-pub const HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED: Key =
-    Key::from_static_str("http.request_content_length_uncompressed");
-
-/// The size of the response payload body in bytes. This is the number of bytes
-/// transferred excluding headers and is often, but not always, present as the
-/// [Content-Length] header. For requests using transport encoding, this
-/// should be the compressed size.
-///
-/// [Content-Length]: https://tools.ietf.org/html/rfc7230#section-3.3.2
-pub const HTTP_RESPONSE_CONTENT_LENGTH: Key = Key::from_static_str("http.response_content_length");
-
-/// The size of the uncompressed response payload body after transport decoding.
-/// Not set if transport encoding not used.
-pub const HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED: Key =
-    Key::from_static_str("http.response_content_length_uncompressed");
-
-/// The primary server name of the matched virtual host. This should be obtained
-/// via configuration. If no such configuration can be obtained, this attribute
-/// MUST NOT be set (`net.host.name` should be used instead).
-pub const HTTP_SERVER_NAME: Key = Key::from_static_str("http.server_name");
-
-/// The matched route (path template). E.g. `"/users/:userID?"`.
-pub const HTTP_ROUTE: Key = Key::from_static_str("http.route");
-
-/// The IP address of the original client behind all proxies, if known (e.g.
-/// from [X-Forwarded-For]). Note that this is not necessarily the same as
-/// `net.peer.ip`, which would identify the network-level peer, which may be a
-/// proxy.
-///
-/// [X-Forwarded-For]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
-pub const HTTP_CLIENT_IP: Key = Key::from_static_str("http.client_ip");
-
-/// A string identifying the messaging system such as `kafka`, `rabbitmq` or `activemq`.
-pub const MESSAGING_SYSTEM: Key = Key::from_static_str("messaging.system");
-
-/// The message destination name, e.g. `MyQueue` or `MyTopic`. This might be
-/// equal to the span name but is required nevertheless.
-pub const MESSAGING_DESTINATION: Key = Key::from_static_str("messaging.destination");
-
-/// The kind of message destination: Either `queue` or `topic`.
-pub const MESSAGING_DESTINATION_KIND: Key = Key::from_static_str("messaging.destination_kind");
-
-/// The name of the transport protocol such as `AMQP` or `MQTT`.
-pub const MESSAGING_PROTOCOL: Key = Key::from_static_str("messaging.protocol");
-
-/// The version of the transport protocol such as `0.9.1`.
-pub const MESSAGING_PROTOCOL_VERSION: Key = Key::from_static_str("messaging.protocol_version");
-
-/// Connection string such as `tibjmsnaming://localhost:7222` or
-/// `https://queue.amazonaws.com/80398EXAMPLE/MyQueue`.
-pub const MESSAGING_URL: Key = Key::from_static_str("messaging.url");
-
-/// A value used by the messaging system as an identifier for the message,
-/// represented as a string.
-pub const MESSAGING_MESSAGE_ID: Key = Key::from_static_str("messaging.message_id");
-
-/// The conversation ID identifying the conversation to which the message
-/// belongs, represented as a string. Sometimes called "Correlation ID".
-pub const MESSAGING_CONVERSATION_ID: Key = Key::from_static_str("messaging.conversation_id");
-
-/// The (uncompressed) size of the message payload in bytes. Also use this
-/// attribute if it is unknown whether the compressed or uncompressed payload
-/// size is reported.
-pub const MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES: Key =
-    Key::from_static_str("messaging.message_payload_size_bytes");
-
-/// The compressed size of the message payload in bytes.
-pub const MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES: Key =
-    Key::from_static_str("messaging.message_payload_compressed_size_bytes");
-
-/// A string identifying the kind of message consumption as defined in the
-/// Operation names section above. Only `"receive"` and `"process"` are used for
-/// this attribute. If the operation is `"send"`, this attribute MUST NOT be
-/// set, since the operation can be inferred from the span kind in that case.
-pub const MESSAGING_OPERATION: Key = Key::from_static_str("messaging.operation");
-
-/// A string identifying the remoting system, e.g., `"grpc"`, `"java_rmi"` or
-/// `"wcf"`.      
-pub const RPC_SYSTEM: Key = Key::from_static_str("rpc.system");
-
-/// The full name of the service being called, including its package name, if
-/// applicable.   
-pub const RPC_SERVICE: Key = Key::from_static_str("rpc.service");
-
-/// The name of the method being called, must be equal to the $method part in
-/// the span name.
-pub const RPC_METHOD: Key = Key::from_static_str("rpc.method");
+/// It SHOULD point within the code unit named in `code.function`.
+pub const CODE_LINENO: Key = Key::from_static_str("code.lineno");


### PR DESCRIPTION
The regex is not a little more complicated as the semantic conventions can now have links, as and typically have a `type` as the second column.