### PR TITLE
Fix single threaded runtime tokio feature bug

### DIFF
--- a/examples/actix-http/Cargo.toml
+++ b/examples/actix-http/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-opentelemetry = { path = "../../" }
-opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["collector_client"] }
+opentelemetry = { path = "../../", features = ["tokio"] }
+opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["collector_client", "tokio"] }
 thrift = "0.13"
 futures = "0.3"
 actix-web = "3"

--- a/src/sdk/trace/span_processor.rs
+++ b/src/sdk/trace/span_processor.rs
@@ -174,11 +174,13 @@ impl api::trace::SpanProcessor for BatchSpanProcessor {
 
     fn shutdown(&mut self) {
         if let Ok(mut sender) = self.message_sender.lock() {
-            let _ = sender.try_send(BatchMessage::Shutdown);
-        }
-
-        if let Some(worker_handle) = self.worker_handle.take() {
-            futures::executor::block_on(worker_handle)
+            // Send shutdown message to worker future
+            if sender.try_send(BatchMessage::Shutdown).is_ok() {
+                if let Some(worker_handle) = self.worker_handle.take() {
+                    // Wait for future to shut down if sending was successful
+                    futures::executor::block_on(worker_handle)
+                }
+            }
         }
     }
 }

--- a/src/sdk/trace/span_processor.rs
+++ b/src/sdk/trace/span_processor.rs
@@ -177,7 +177,7 @@ impl api::trace::SpanProcessor for BatchSpanProcessor {
             // Send shutdown message to worker future
             if sender.try_send(BatchMessage::Shutdown).is_ok() {
                 if let Some(worker_handle) = self.worker_handle.take() {
-                    // Wait for future to shut down if sending was successful
+                    // Block waiting for worker to shut down if sending was successful
                     futures::executor::block_on(worker_handle)
                 }
             }


### PR DESCRIPTION
* Add `tokio` feature to actix example which uses the single threaded tokio runtime
* switch from `tokio::spawn` back to `|fut| tokio::task::spawn_blocking(|| futures::executor::block_on(fut))` to fix the processor shutdown bug in single threaded runtimes
* Fix `async-std` import (we should add more tests that exercise the full feature matrix)
* Only block waiting on the pan processor future if sending shutdown was successful.

Fixes #277