### PR TITLE
Allow metrics instruments to be cloned

### DIFF
--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -202,7 +202,7 @@ impl ExporterBuilder {
 ///
 /// This exporter supports Prometheus pulls, as such it does not
 /// implement the export.Exporter interface.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PrometheusExporter {
     registry: prometheus::Registry,
     controller: Arc<Mutex<PullController>>,

--- a/src/api/metrics/counter.rs
+++ b/src/api/metrics/counter.rs
@@ -8,7 +8,7 @@ use crate::api::{
 use std::marker;
 
 /// A metric that accumulates values.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Counter<T>(SyncInstrument<T>);
 
 impl<T> Counter<T>
@@ -38,7 +38,7 @@ where
 }
 
 /// BoundCounter is a bound instrument for counters.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BoundCounter<'a, T> {
     labels: &'a [KeyValue],
     bound_instrument: SyncBoundInstrument<T>,

--- a/src/api/metrics/sdk_api.rs
+++ b/src/api/metrics/sdk_api.rs
@@ -37,7 +37,7 @@ pub trait InstrumentCore: fmt::Debug {
 
 /// The implementation-level interface to a generic synchronous instrument
 /// (e.g., ValueRecorder and Counter instruments).
-pub trait SyncInstrumentCore: InstrumentCore {
+pub trait SyncInstrumentCore: InstrumentCore + Send + Sync {
     /// Creates an implementation-level bound instrument, binding a label set
     /// with this instrument implementation.
     fn bind<'a>(&self, labels: &'a [KeyValue]) -> Arc<dyn SyncBoundInstrumentCore + Send + Sync>;

--- a/src/api/metrics/sync_instrument.rs
+++ b/src/api/metrics/sync_instrument.rs
@@ -37,7 +37,7 @@ impl Measurement {
 }
 
 /// Wrapper around a sdk-implemented sync instrument for a given type
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct SyncInstrument<T> {
     instrument: Arc<dyn sdk_api::SyncInstrumentCore>,
     _marker: marker::PhantomData<T>,
@@ -73,7 +73,7 @@ impl<T> SyncInstrument<T> {
 }
 
 /// Wrapper around a sdk-implemented sync bound instrument
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct SyncBoundInstrument<T> {
     bound_instrument: Arc<dyn sdk_api::SyncBoundInstrumentCore>,
     _marker: marker::PhantomData<T>,

--- a/src/api/metrics/up_down_counter.rs
+++ b/src/api/metrics/up_down_counter.rs
@@ -8,7 +8,7 @@ use crate::api::{
 use std::marker;
 
 /// A metric instrument that sums non-monotonic values.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct UpDownCounter<T>(SyncInstrument<T>);
 
 impl<T> UpDownCounter<T>
@@ -38,7 +38,7 @@ where
 }
 
 /// BoundUpDownCounter is a bound instrument for counters.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BoundUpDownCounter<'a, T> {
     labels: &'a [KeyValue],
     bound_instrument: SyncBoundInstrument<T>,

--- a/src/api/metrics/value_recorder.rs
+++ b/src/api/metrics/value_recorder.rs
@@ -6,7 +6,7 @@ use crate::api::KeyValue;
 use std::marker;
 
 /// ValueRecorder is a metric that records per-request non-additive values.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ValueRecorder<T>(SyncInstrument<T>);
 
 impl<T> ValueRecorder<T>
@@ -38,7 +38,7 @@ where
 /// non-additive values.
 ///
 /// It inherits the Unbind function from syncBoundInstrument.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BoundValueRecorder<'a, T> {
     labels: &'a [KeyValue],
     bound_instrument: SyncBoundInstrument<T>,


### PR DESCRIPTION
Allow metrics to be cloned and synchronized (e.g. for use in actix-web workers)