### PR TITLE
[exporter] Allow user choose whether to export instrumentation library

### DIFF
--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -307,7 +307,7 @@ impl PipelineBuilder {
     }
 
     /// Config whether to export information of instrumentation library.
-    pub fn export_instrumentation_library(self, export: bool) -> Self {
+    pub fn with_instrumentation_library_tags(self, export: bool) -> Self {
         PipelineBuilder {
             export_instrument_library: export,
             ..self
@@ -497,12 +497,6 @@ fn links_to_references(
         Some(refs)
     } else {
         None
-    }
-}
-
-impl Into<jaeger::Span> for trace::SpanData {
-    fn into(self) -> jaeger::Span {
-        convert_otel_span_into_jaeger_span(self, true)
     }
 }
 

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -195,6 +195,8 @@ pub struct Uninstall(global::TracerProviderGuard);
 #[derive(Debug)]
 pub struct Exporter {
     process: jaeger::Process,
+    /// Whether or not to export instrumentation information.
+    export_instrumentation_lib: bool,
     uploader: uploader::BatchUploader,
 }
 
@@ -233,7 +235,10 @@ impl trace::SpanExporter for Exporter {
                     }
                 }
             }
-            jaeger_spans.push(span.into());
+            jaeger_spans.push(convert_otel_span_into_jaeger_span(
+                span,
+                self.export_instrumentation_lib,
+            ));
         }
 
         self.uploader
@@ -252,6 +257,7 @@ pub struct PipelineBuilder {
     collector_username: Option<String>,
     #[cfg(feature = "collector_client")]
     collector_password: Option<String>,
+    export_instrument_library: bool,
     process: Process,
     config: Option<sdk::trace::Config>,
 }
@@ -267,6 +273,7 @@ impl Default for PipelineBuilder {
             collector_username: None,
             #[cfg(feature = "collector_client")]
             collector_password: None,
+            export_instrument_library: true,
             process: Process {
                 service_name: DEFAULT_SERVICE_NAME.to_string(),
                 tags: Vec::new(),
@@ -295,6 +302,14 @@ impl PipelineBuilder {
                 .map(|addrs| addrs.collect())
                 .unwrap_or_default(),
 
+            ..self
+        }
+    }
+
+    /// Config whether to export information of instrumentation library.
+    pub fn export_instrumentation_library(self, export: bool) -> Self {
+        PipelineBuilder {
+            export_instrument_library: export,
             ..self
         }
     }
@@ -384,10 +399,12 @@ impl PipelineBuilder {
     ///
     /// This is useful if you are manually constructing a pipeline.
     pub fn init_exporter(self) -> Result<Exporter, Box<dyn Error + Send + Sync + 'static>> {
+        let export_instrumentation_lib = self.export_instrument_library;
         let (process, uploader) = self.init_uploader()?;
 
         Ok(Exporter {
             process: process.into(),
+            export_instrumentation_lib,
             uploader,
         })
     }
@@ -455,42 +472,6 @@ impl Into<jaeger::Log> for api::trace::Event {
     }
 }
 
-impl Into<jaeger::Span> for trace::SpanData {
-    /// Convert spans to jaeger thrift span for exporting.
-    fn into(self) -> jaeger::Span {
-        let trace_id = self.span_reference.trace_id().to_u128();
-        let trace_id_high = (trace_id >> 64) as i64;
-        let trace_id_low = trace_id as i64;
-        jaeger::Span {
-            trace_id_low,
-            trace_id_high,
-            span_id: self.span_reference.span_id().to_u64() as i64,
-            parent_span_id: self.parent_span_id.to_u64() as i64,
-            operation_name: self.name,
-            references: links_to_references(self.links),
-            flags: self.span_reference.trace_flags() as i32,
-            start_time: self
-                .start_time
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap_or_else(|_| Duration::from_secs(0))
-                .as_micros() as i64,
-            duration: self
-                .end_time
-                .duration_since(self.start_time)
-                .unwrap_or_else(|_| Duration::from_secs(0))
-                .as_micros() as i64,
-            tags: build_span_tags(
-                self.attributes,
-                self.instrumentation_lib,
-                self.status_code,
-                self.status_message,
-                self.span_kind,
-            ),
-            logs: events_to_logs(self.message_events),
-        }
-    }
-}
-
 fn links_to_references(
     links: sdk::trace::EvictedQueue<api::trace::Link>,
 ) -> Option<Vec<jaeger::SpanRef>> {
@@ -519,6 +500,53 @@ fn links_to_references(
     }
 }
 
+impl Into<jaeger::Span> for trace::SpanData {
+    fn into(self) -> jaeger::Span {
+        convert_otel_span_into_jaeger_span(self, true)
+    }
+}
+
+/// Convert spans to jaeger thrift span for exporting.
+fn convert_otel_span_into_jaeger_span(
+    span: trace::SpanData,
+    export_instrument_lib: bool,
+) -> jaeger::Span {
+    let trace_id = span.span_reference.trace_id().to_u128();
+    let trace_id_high = (trace_id >> 64) as i64;
+    let trace_id_low = trace_id as i64;
+    jaeger::Span {
+        trace_id_low,
+        trace_id_high,
+        span_id: span.span_reference.span_id().to_u64() as i64,
+        parent_span_id: span.parent_span_id.to_u64() as i64,
+        operation_name: span.name,
+        references: links_to_references(span.links),
+        flags: span.span_reference.trace_flags() as i32,
+        start_time: span
+            .start_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_else(|_| Duration::from_secs(0))
+            .as_micros() as i64,
+        duration: span
+            .end_time
+            .duration_since(span.start_time)
+            .unwrap_or_else(|_| Duration::from_secs(0))
+            .as_micros() as i64,
+        tags: build_span_tags(
+            span.attributes,
+            if export_instrument_lib {
+                Some(span.instrumentation_lib)
+            } else {
+                None
+            },
+            span.status_code,
+            span.status_message,
+            span.span_kind,
+        ),
+        logs: events_to_logs(span.message_events),
+    }
+}
+
 fn build_process_tags(
     span_data: &trace::SpanData,
 ) -> Option<impl Iterator<Item = jaeger::Tag> + '_> {
@@ -536,7 +564,7 @@ fn build_process_tags(
 
 fn build_span_tags(
     attrs: sdk::trace::EvictedHashMap,
-    instrumentation_lib: sdk::InstrumentationLibrary,
+    instrumentation_lib: Option<sdk::InstrumentationLibrary>,
     status_code: api::trace::StatusCode,
     status_message: String,
     kind: api::trace::SpanKind,
@@ -551,10 +579,14 @@ fn build_span_tags(
         })
         .collect::<Vec<_>>();
 
-    // Set instrument library tags
-    tags.push(api::KeyValue::new(INSTRUMENTATION_LIBRARY_NAME, instrumentation_lib.name).into());
-    if let Some(version) = instrumentation_lib.version {
-        tags.push(api::KeyValue::new(INSTRUMENTATION_LIBRARY_VERSION, version).into())
+    if let Some(instrumentation_lib) = instrumentation_lib {
+        // Set instrument library tags
+        tags.push(
+            api::KeyValue::new(INSTRUMENTATION_LIBRARY_NAME, instrumentation_lib.name).into(),
+        );
+        if let Some(version) = instrumentation_lib.version {
+            tags.push(api::KeyValue::new(INSTRUMENTATION_LIBRARY_VERSION, version).into())
+        }
     }
 
     // Ensure error status is set


### PR DESCRIPTION
Sometimes it's too much overhead for users to export every instrumentation library of every span. Follow up on #243