### PR TITLE
Include all features for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ keywords = ["opentelemetry", "logging", "tracing", "metrics", "async"]
 license = "Apache-2.0"
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 async-std = { version = "1.6", features = ["unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -14,7 +14,8 @@ keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+all-features = true
 
 [features]
 default = []

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -15,6 +15,9 @@ keywords = ["opentelemetry", "jaeger", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 async-std = { version = "1.6", optional = true }
 async-trait = "0.1"

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -15,6 +15,9 @@ keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = ["reqwest-blocking-client"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry/reqwest"]


### PR DESCRIPTION
The documentation on docs.rs currently only includes default features. This leaves out the metrics feature.

This PR adds the following block to all `Cargo.toml` files that define features, which enables all features for the docs.rs build:

```toml
[package.metadata.docs.rs]
all-features = true
```

See docs about this: https://docs.rs/about/metadata

I ran `cargo doc --all-features` locally for all those projects to ensure the build works.