### PR TITLE
Add MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,16 @@ jobs:
     - uses: arduino/setup-protoc@v1
     - name: Lint
       run: ./scripts/lint.sh
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.42.0
+        components: clippy
+    - name: Run tests
+      run: cargo test --verbose --features base64_format,trace,metrics,serialize,binary_propagator,tokio,async-std,serde,http,tonic,reqwest -p opentelemetry -p opentelemetry-jaeger -p opentelemetry-zipkin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 all-features = true
 
 [dependencies]
-async-std = { version = "1.6", features = ["unstable"], optional = true }
+async-std = { version = "1.6", features = ["unstable"], default-features = false, optional = true  }
 async-trait = { version = "0.1", optional = true }
 base64 = { version = "0.13", optional = true }
 bincode = { version = "1.2", optional = true }
@@ -28,17 +28,17 @@ dashmap = { version = "4.0.0-rc6", optional = true }
 fnv = { version = "1.0", optional = true }
 futures = "0.3"
 lazy_static = "1.4"
-percent-encoding = "2.0"
+percent-encoding = { version = "2.0", optional = true }
 pin-project = { version = "0.4", optional = true }
-rand = { version = "0.7", optional = true }
-regex = "1.3.9"
+rand = { version = "0.7", default-features = false, optional = true }
+regex = { version = "1.3", default-features = false, features = ["std", "perf"], optional = true}
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 http = { version = "0.2", optional = true }
 thiserror = { version = "1.0", optional = true }
-tokio = { version = "0.2", features = ["rt-core", "blocking", "time", "stream"], optional = true }
-tonic = { version = "0.3", optional = true }
-reqwest = { version = "0.10", features = ["blocking"], optional = true }
-surf = { version = "2.0", optional = true }
+tokio = { version = "0.2", default-features = false, features = ["rt-core", "blocking", "time", "stream"], optional = true }
+tonic = { version = "0.3", default-features = false, optional = true }
+reqwest = { version = "0.10", default-features = false, features = ["blocking"], optional = true }
+surf = { version = "2.0", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = "0.3.1"
@@ -48,7 +48,7 @@ tokio = { version = "0.2", features = ["full"] }
 [features]
 default = ["trace"]
 base64_format = ["base64", "binary_propagator"]
-trace = ["rand", "pin-project", "async-trait"]
+trace = ["rand", "pin-project", "async-trait", "regex", "percent-encoding"]
 metrics = ["thiserror", "dashmap", "fnv"]
 serialize = ["serde", "bincode"]
 binary_propagator = []

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ OpenTelemetry provides a single set of APIs, libraries, agents, and collector
 services to capture distributed traces and metrics from your application. You
 can analyze them using [Prometheus], [Jaeger], and other observability tools.
 
+*Compiler support: [requires `rustc` 1.42+][msrv]*
+
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
+[msrv]: #supported-rust-versions
 
 ## Getting Started
 
@@ -33,6 +36,19 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 ```
 
 See the [examples](./examples) directory for different integration patterns.
+
+## Supported Rust Versions
+
+OpenTelemetry is built against the latest stable release. The minimum supported
+version is 1.42. The current OpenTelemetry version is not guaranteed to build
+on Rust versions earlier than the minimum supported version.
+
+The current stable Rust compiler and the three most recent minor versions
+before it will always be supported. For example, if the current stable compiler
+version is 1.45, the minimum supported version will not be increased past 1.42,
+three minor versions prior. Increasing the minimum supported compiler version
+is not considered a semver breaking change as long as doing so complies with
+this policy.
 
 ## Contributing
 

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -4,7 +4,10 @@ Collects OpenTelemetry spans and reports them to a given Jaeger `agent` or
 `collector` endpoint. See the [Jaeger Docs] for details about Jaeger and
 deployment information.
 
+*Compiler support: [requires `rustc` 1.42+][msrv]*
+
 [Jaeger Docs]: https://www.jaegertracing.io/docs/
+[msrv]: #supported-rust-versions
 
 ### Quickstart
 
@@ -145,3 +148,16 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     Ok(())
 }
 ```
+
+## Supported Rust Versions
+
+OpenTelemetry is built against the latest stable release. The minimum supported
+version is 1.42. The current OpenTelemetry version is not guaranteed to build
+on Rust versions earlier than the minimum supported version.
+
+The current stable Rust compiler and the three most recent minor versions
+before it will always be supported. For example, if the current stable compiler
+version is 1.45, the minimum supported version will not be increased past 1.42,
+three minor versions prior. Increasing the minimum supported compiler version
+is not considered a semver breaking change as long as doing so complies with
+this policy.

--- a/opentelemetry-jaeger/src/env.rs
+++ b/opentelemetry-jaeger/src/env.rs
@@ -39,18 +39,24 @@ pub(crate) fn assign_attrs(mut builder: PipelineBuilder) -> PipelineBuilder {
     }
 
     #[cfg(feature = "collector_client")]
-    if let Some(endpoint) = env::var(ENV_ENDPOINT).ok().filter(|var| !var.is_empty()) {
-        builder = builder.with_collector_endpoint(endpoint);
+    {
+        if let Some(endpoint) = env::var(ENV_ENDPOINT).ok().filter(|var| !var.is_empty()) {
+            builder = builder.with_collector_endpoint(endpoint);
+        }
     }
 
     #[cfg(feature = "collector_client")]
-    if let Some(user) = env::var(ENV_USER).ok().filter(|var| !var.is_empty()) {
-        builder = builder.with_collector_username(user);
+    {
+        if let Some(user) = env::var(ENV_USER).ok().filter(|var| !var.is_empty()) {
+            builder = builder.with_collector_username(user);
+        }
     }
 
     #[cfg(feature = "collector_client")]
-    if let Some(password) = env::var(ENV_PASSWORD).ok().filter(|var| !var.is_empty()) {
-        builder = builder.with_collector_password(password);
+    {
+        if let Some(password) = env::var(ENV_PASSWORD).ok().filter(|var| !var.is_empty()) {
+            builder = builder.with_collector_password(password);
+        }
     }
 
     builder

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -2,7 +2,10 @@
 //! `agent` or `collector` endpoint. See the [Jaeger Docs] for details
 //! about Jaeger and deployment information.
 //!
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
+//!
 //! [Jaeger Docs]: https://www.jaegertracing.io/docs/
+//! [msrv]: #supported-rust-versions
 //!
 //! ### Quickstart
 //!
@@ -140,6 +143,20 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! ## Supported Rust Versions
+//!
+//! OpenTelemetry is built against the latest stable release. The minimum
+//! supported version is 1.42. The current OpenTelemetry version is not
+//! guaranteed to build on Rust versions earlier than the minimum supported
+//! version.
+//!
+//! The current stable Rust compiler and the three most recent minor versions
+//! before it will always be supported. For example, if the current stable
+//! compiler version is 1.45, the minimum supported version will not be
+//! increased past 1.42, three minor versions prior. Increasing the minimum
+//! supported compiler version is not considered a semver breaking change as
+//! long as doing so complies with this policy.
 #![warn(
     future_incompatible,
     missing_debug_implementations,

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -36,4 +36,4 @@ reqwest = { version = "0.10", optional = true }
 surf = { version = "2.0", optional = true }
 
 [dev-dependencies]
-isahc = "0.9"
+isahc = "=0.9.6"

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -1,3 +1,138 @@
-# OpenTelemetry Zipkin 
+# OpenTelemetry Zipkin
 
-A Zipkin exporter implementation for OpenTelemetry Rust.
+Collects OpenTelemetry spans and reports them to a given Zipkin collector
+endpoint. See the [Zipkin Docs] for details and deployment information.
+
+*Compiler support: [requires `rustc` 1.42+][msrv]*
+
+[Zipkin Docs]: https://zipkin.io/
+[msrv]: #supported-rust-versions
+
+## Quickstart
+
+First make sure you have a running version of the zipkin process you want to
+send data to:
+
+```shell
+$ docker run -d -p 9411:9411 openzipkin/zipkin
+```
+
+Then install a new pipeline with the recommended defaults to start exporting
+telemetry:
+
+```rust
+use opentelemetry::api::trace::Tracer;
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let (tracer, _uninstall) = opentelemetry_zipkin::new_pipeline().install()?;
+
+    tracer.in_span("doing_work", |cx| {
+        // Traced app logic here...
+    });
+
+    Ok(())
+}
+```
+
+## Performance
+
+For optimal performance, a batch exporter is recommended as the simple exporter
+will export each span synchronously on drop. You can enable the [`tokio`] or
+[`async-std`] features to have a batch exporter configured for you automatically
+for either executor when you install the pipeline.
+
+```toml
+[dependencies]
+opentelemetry = { version = "*", features = ["tokio"] }
+opentelemetry-zipkin = { version = "*", features = ["reqwest-client"], default-features = false }
+```
+
+[`tokio`]: https://tokio.rs
+[`async-std`]: https://async.rs
+
+## Choosing an HTTP client
+
+The HTTP client that this exporter will use can be overridden using features or
+a manual implementation of the [`HttpClient`] trait. By default the
+`reqwest-blocking-client` feature is enabled which will use the `reqwest` crate.
+While this is compatible with both async and non-async projects, it is not
+optimal for high-performance async applications as it will block the executor
+thread. Consider using the `reqwest-client` (without blocking) or `surf-client`
+features if you are in the `tokio` or `async-std` ecosystems respectively, or
+select whichever client you prefer as shown below.
+
+Note that async http clients may require a specific async runtime to be
+available so be sure to match them appropriately.
+
+[`HttpClient`]: https://docs.rs/opentelemetry/0.9/opentelemetry/exporter/trace/trait.HttpClient.html
+
+## Kitchen Sink Full Configuration
+
+Example showing how to override all configuration options. See the
+[`ZipkinPipelineBuilder`] docs for details of each option.
+
+[`ZipkinPipelineBuilder`]: struct.ZipkinPipelineBuilder.html
+
+```rust
+use opentelemetry::api::{KeyValue, trace::Tracer};
+use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
+use opentelemetry::exporter::trace::{ExportResult, HttpClient};
+use async_trait::async_trait;
+use std::error::Error;
+
+// `reqwest` and `surf` are supported through features, if you prefer an
+// alternate http client you can add support by implementing `HttpClient` as
+// shown here.
+#[derive(Debug)]
+struct IsahcClient(isahc::HttpClient);
+
+#[async_trait]
+impl HttpClient for IsahcClient {
+  async fn send(&self, request: http::Request<Vec<u8>>) -> Result<ExportResult, Box<dyn Error + Send + Sync + 'static>> {
+    let result = self.0.send_async(request).await?;
+
+    if result.status().is_success() {
+      Ok(ExportResult::Success)
+    } else {
+      Ok(ExportResult::FailedNotRetryable)
+    }
+  }
+}
+
+fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let (tracer, _uninstall) = opentelemetry_zipkin::new_pipeline()
+        .with_http_client(IsahcClient(isahc::HttpClient::new()?))
+        .with_service_name("my_app")
+        .with_service_address("127.0.0.1:8080".parse()?)
+        .with_collector_endpoint("http://localhost:9411/api/v2/spans")
+        .with_trace_config(
+            trace::config()
+                .with_default_sampler(Sampler::AlwaysOn)
+                .with_id_generator(IdGenerator::default())
+                .with_max_events_per_span(64)
+                .with_max_attributes_per_span(16)
+                .with_max_events_per_span(16)
+                .with_resource(Resource::new(vec![KeyValue::new("key", "value")])),
+        )
+        .install()?;
+
+    tracer.in_span("doing_work", |cx| {
+        // Traced app logic here...
+    });
+
+    Ok(())
+}
+```
+
+## Supported Rust Versions
+
+OpenTelemetry is built against the latest stable release. The minimum supported
+version is 1.42. The current OpenTelemetry version is not guaranteed to build on
+Rust versions earlier than the minimum supported version.
+
+The current stable Rust compiler and the three most recent minor versions before
+it will always be supported. For example, if the current stable compiler version
+is 1.45, the minimum supported version will not be increased past 1.42, three
+minor versions prior. Increasing the minimum supported compiler version is not
+considered a semver breaking change as long as doing so complies with this
+policy.

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -1,8 +1,12 @@
-//! # OpenTelemetry Zipkin Exporter
+//! # OpenTelemetry Zipkin
 //!
 //! Collects OpenTelemetry spans and reports them to a given Zipkin collector
-//! endpoint. See the [Zipkin Docs](https://zipkin.io/) for details and
-//! deployment information.
+//! endpoint. See the [Zipkin Docs] for details and deployment information.
+//!
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
+//!
+//! [Zipkin Docs]: https://zipkin.io/
+//! [msrv]: #supported-rust-versions
 //!
 //! ## Quickstart
 //!
@@ -40,24 +44,28 @@
 //! ```toml
 //! [dependencies]
 //! opentelemetry = { version = "*", features = ["tokio"] }
-//! opentelemetry-zipkin = "*"
+//! opentelemetry-zipkin = { version = "*", features = ["reqwest-client"], default-features = false }
 //! ```
 //!
 //! [`tokio`]: https://tokio.rs
 //! [`async-std`]: https://async.rs
 //!
-//! ## Bring your own http clients
-//! Users can choose appropriate http clients to align with their runtime.
+//! ## Choosing an HTTP client
 //!
-//! Based on the feature enabled. The default http client will be different. If user doesn't specific
-//! features or enabled `reqwest-blocking-client` feature. The blocking reqwest http client will be used as
-//! default client. If `reqwest-client` feature is enabled. The async reqwest http client will be used. If
-//! `surf-client` feature is enabled. The surf http client will be used.
+//! The HTTP client that this exporter will use can be overridden using features
+//! or a manual implementation of the [`HttpClient`] trait. By default the
+//! `reqwest-blocking-client` feature is enabled which will use the `reqwest`
+//! crate. While this is compatible with both async and non-async projects, it
+//! is not optimal for high-performance async applications as it will block the
+//! executor thread. Consider using the `reqwest-client` (without blocking)
+//! or `surf-client` features if you are in the `tokio` or `async-std`
+//! ecosystems respectively, or select whichever client you prefer as shown
+//! below.
 //!
-//! Note that async http clients may need specific runtime otherwise it will panic. User should make
-//! sure the http client is running in appropriate runime.
+//! Note that async http clients may require a specific async runtime to be
+//! available so be sure to match them appropriately.
 //!
-//! Users can always use their own http clients by implementing `HttpClient` trait.
+//! [`HttpClient`]: https://docs.rs/opentelemetry/0.9/opentelemetry/exporter/trace/trait.HttpClient.html
 //!
 //! ## Kitchen Sink Full Configuration
 //!
@@ -69,8 +77,7 @@
 //! ```no_run
 //! use opentelemetry::api::{KeyValue, trace::Tracer};
 //! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
-//! use opentelemetry::exporter::trace::ExportResult;
-//! use opentelemetry::exporter::trace::HttpClient;
+//! use opentelemetry::exporter::trace::{ExportResult, HttpClient};
 //! use async_trait::async_trait;
 //! use std::error::Error;
 //!
@@ -117,6 +124,20 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! ## Supported Rust Versions
+//!
+//! OpenTelemetry is built against the latest stable release. The minimum
+//! supported version is 1.42. The current OpenTelemetry version is not
+//! guaranteed to build on Rust versions earlier than the minimum supported
+//! version.
+//!
+//! The current stable Rust compiler and the three most recent minor versions
+//! before it will always be supported. For example, if the current stable
+//! compiler version is 1.45, the minimum supported version will not be
+//! increased past 1.42, three minor versions prior. Increasing the minimum
+//! supported compiler version is not considered a semver breaking change as
+//! long as doing so complies with this policy.
 #![warn(
     future_incompatible,
     missing_debug_implementations,

--- a/src/api/metrics/number.rs
+++ b/src/api/metrics/number.rs
@@ -200,18 +200,18 @@ impl NumberKind {
     /// Returns the max value for each kind
     pub fn max(&self) -> Number {
         match self {
-            NumberKind::I64 => i64::MAX.into(),
-            NumberKind::F64 => f64::MAX.into(),
-            NumberKind::U64 => u64::MAX.into(),
+            NumberKind::I64 => std::i64::MAX.into(),
+            NumberKind::F64 => std::f64::MAX.into(),
+            NumberKind::U64 => std::u64::MAX.into(),
         }
     }
 
     /// Returns the min value for each kind
     pub fn min(&self) -> Number {
         match self {
-            NumberKind::I64 => i64::MIN.into(),
-            NumberKind::F64 => f64::MIN.into(),
-            NumberKind::U64 => u64::MIN.into(),
+            NumberKind::I64 => std::i64::MIN.into(),
+            NumberKind::F64 => std::f64::MIN.into(),
+            NumberKind::U64 => std::u64::MIN.into(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,11 @@
 //! services to capture distributed traces and metrics from your application. You
 //! can analyze them using [Prometheus], [Jaeger], and other observability tools.
 //!
+//! *Compiler support: [requires `rustc` 1.42+][msrv]*
+//!
 //! [Prometheus]: https://prometheus.io
 //! [Jaeger]: https://www.jaegertracing.io
+//! [msrv]: #supported-rust-versions
 //!
 //! ## Getting Started
 //!
@@ -26,6 +29,20 @@
 //!
 //! See the [examples](https://github.com/open-telemetry/opentelemetry-rust/tree/master/examples)
 //! directory for different integration patterns.
+//!
+//! ## Supported Rust Versions
+//!
+//! OpenTelemetry is built against the latest stable release. The minimum
+//! supported version is 1.42. The current OpenTelemetry version is not
+//! guaranteed to build on Rust versions earlier than the minimum supported
+//! version.
+//!
+//! The current stable Rust compiler and the three most recent minor versions
+//! before it will always be supported. For example, if the current stable
+//! compiler version is 1.45, the minimum supported version will not be
+//! increased past 1.42, three minor versions prior. Increasing the minimum
+//! supported compiler version is not considered a semver breaking change as
+//! long as doing so complies with this policy.
 #![recursion_limit = "256"]
 #![allow(clippy::needless_doctest_main)]
 #![warn(

--- a/src/sdk/metrics/aggregators/ddsketch.rs
+++ b/src/sdk/metrics/aggregators/ddsketch.rs
@@ -127,7 +127,7 @@ impl Quantile for DDSKetchAggregator {
                 return Ok(inner.min_value.clone());
             }
 
-            if (q - 1.0).abs() < f64::EPSILON {
+            if (q - 1.0).abs() < std::f64::EPSILON {
                 return Ok(inner.max_value.clone());
             }
 
@@ -239,7 +239,7 @@ impl Aggregator for DDSKetchAggregator {
                             }
 
 
-                            if (inner.gamma - other.gamma).abs() > f64::EPSILON {
+                            if (inner.gamma - other.gamma).abs() > std::f64::EPSILON {
                                 return Err(MetricsError::InconsistentAggregator(format!(
                                     "When merging two DDSKetchAggregators, their gamma must be the same. Expect max number of bins to be {:?}, but get {:?}", inner.gamma, other.gamma
                                 )));
@@ -1009,15 +1009,15 @@ mod tests {
         // assert sum, max, min and count
         assert!(
             (moved_ddsketch.max().unwrap().to_f64(&NumberKind::F64) - expected_max).abs()
-                < f64::EPSILON
+                < std::f64::EPSILON
         );
         assert!(
             (moved_ddsketch.min().unwrap().to_f64(&NumberKind::F64) - expected_min).abs()
-                < f64::EPSILON
+                < std::f64::EPSILON
         );
         assert!(
             (moved_ddsketch.sum().unwrap().to_f64(&NumberKind::F64) - expected_sum).abs()
-                < f64::EPSILON
+                < std::f64::EPSILON
         );
         assert_eq!(moved_ddsketch.count(), Ok(expected_count));
 
@@ -1030,7 +1030,7 @@ mod tests {
                     .to_f64(&NumberKind::F64)
                     - expected_iter.next().unwrap())
                 .abs()
-                    < f64::EPSILON
+                    < std::f64::EPSILON
             );
         }
     }


### PR DESCRIPTION
* Support rust 1.42.x for core crate and trace exporters (metrics exporters are still unstable and `protobuf` does not support 1.42)
* Make small inconsequential syntax changes to support backwards compatibility
* Ensure dependencies support 1.42 and remove unused default features
