### PR TITLE
Make timestamp parameter in end_with_timestamp optional

### DIFF
--- a/src/api/trace/noop.rs
+++ b/src/api/trace/noop.rs
@@ -103,7 +103,7 @@ impl trace::Span for NoopSpan {
     }
 
     /// Ignores `Span` endings
-    fn end_with_timestamp(&self, _timestamp: SystemTime) {
+    fn end_with_timestamp(&self, _timestamp: Option<SystemTime>) {
         // Ignored
     }
 }

--- a/src/api/trace/span.rs
+++ b/src/api/trace/span.rs
@@ -154,7 +154,7 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     ///
     /// This API MUST be non-blocking.
     fn end(&self) {
-        self.end_with_timestamp(SystemTime::now());
+        self.end_with_timestamp(Some(SystemTime::now()));
     }
 
     /// Finishes the `Span` with given timestamp
@@ -162,7 +162,7 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     /// For more details, refer to [`Span::end`]
     ///
     /// [`Span::end`]: trait.Span.html#method.end
-    fn end_with_timestamp(&self, timestamp: SystemTime);
+    fn end_with_timestamp(&self, timestamp: Option<SystemTime>);
 }
 
 /// `SpanKind` describes the relationship between the Span, its parents,

--- a/src/global/trace.rs
+++ b/src/global/trace.rs
@@ -61,7 +61,7 @@ impl trace::Span for BoxedSpan {
     }
 
     /// Finishes the span with given timestamp.
-    fn end_with_timestamp(&self, timestamp: SystemTime) {
+    fn end_with_timestamp(&self, timestamp: Option<SystemTime>) {
         self.0.end_with_timestamp(timestamp);
     }
 }

--- a/src/sdk/trace/span.rs
+++ b/src/sdk/trace/span.rs
@@ -135,9 +135,9 @@ impl crate::trace::Span for Span {
     }
 
     /// Finishes the span with given timestamp.
-    fn end_with_timestamp(&self, timestamp: SystemTime) {
+    fn end_with_timestamp(&self, timestamp: Option<SystemTime>) {
         self.with_data_mut(|data| {
-            data.end_time = timestamp;
+            data.end_time = timestamp.unwrap_or(SystemTime::now());
         });
     }
 }

--- a/src/testing/trace.rs
+++ b/src/testing/trace.rs
@@ -2,6 +2,7 @@ use crate::{
     trace::{Span, SpanContext, StatusCode},
     KeyValue,
 };
+use std::time::SystemTime;
 
 #[derive(Debug)]
 pub struct TestSpan(pub SpanContext);
@@ -10,7 +11,7 @@ impl Span for TestSpan {
     fn add_event_with_timestamp(
         &self,
         _name: String,
-        _timestamp: std::time::SystemTime,
+        _timestamp: SystemTime,
         _attributes: Vec<KeyValue>,
     ) {
     }
@@ -23,5 +24,5 @@ impl Span for TestSpan {
     fn set_attribute(&self, _attribute: KeyValue) {}
     fn set_status(&self, _code: StatusCode, _message: String) {}
     fn update_name(&self, _new_name: String) {}
-    fn end_with_timestamp(&self, _timestamp: std::time::SystemTime) {}
+    fn end_with_timestamp(&self, _timestamp: Option<SystemTime>) {}
 }


### PR DESCRIPTION
According to [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#end) the parameter should be optional and `end_with_timestamp` must use current timestamp as default value.
This PR suggests a possible implementation.
Library UX suffers a little, so I'm unsure what is better: spec compliance or shorter way to call a method.
