### PR TITLE
[trace] Move mark_as_active_span and get_active_span into context

### DIFF
--- a/src/api/trace/mod.rs
+++ b/src/api/trace/mod.rs
@@ -123,7 +123,7 @@ mod span_processor;
 mod tracer;
 
 pub use self::{
-    context::TraceContextExt,
+    context::{get_active_span, mark_span_as_active, TraceContextExt},
     event::Event,
     futures::FutureExt,
     id_generator::IdGenerator,

--- a/src/api/trace/tracer.rs
+++ b/src/api/trace/tracer.rs
@@ -115,7 +115,7 @@ use std::time::SystemTime;
 /// the following example _will not_ work:
 ///
 /// ```no_run
-/// # use opentelemetry::{global, trace::{Tracer, mark_span_as_active}};///
+/// # use opentelemetry::{global, trace::{Tracer, mark_span_as_active}};
 /// # let tracer = global::tracer("foo");
 /// # let span = tracer.start("foo-span");
 /// async {

--- a/src/api/trace/tracer.rs
+++ b/src/api/trace/tracer.rs
@@ -3,7 +3,7 @@ use crate::{
     trace::{
         Event, Link, Span, SpanContext, SpanId, SpanKind, StatusCode, TraceContextExt, TraceId,
     },
-    Context, ContextGuard, KeyValue,
+    Context, KeyValue,
 };
 use std::fmt;
 use std::time::SystemTime;
@@ -86,15 +86,15 @@ use std::time::SystemTime;
 /// greater control over when the span is no longer considered active.
 ///
 /// ```
-/// use opentelemetry::{global, trace::{Span, Tracer}};
+/// use opentelemetry::{global, trace::{Span, Tracer, mark_span_as_active}};
 /// let tracer = global::tracer("my-component");
 ///
 /// let parent_span = tracer.start("foo");
-/// let parent_active = tracer.mark_span_as_active(parent_span);
+/// let parent_active = mark_span_as_active(parent_span);
 ///
 /// {
 ///     let child = tracer.start("bar");
-///     let _child_active = tracer.mark_span_as_active(child);
+///     let _child_active = mark_span_as_active(child);
 ///
 ///     // do work in the context of the child span...
 ///
@@ -115,12 +115,12 @@ use std::time::SystemTime;
 /// the following example _will not_ work:
 ///
 /// ```no_run
-/// # use opentelemetry::{global, trace::Tracer};
+/// # use opentelemetry::{global, trace::{Tracer, mark_span_as_active}};///
 /// # let tracer = global::tracer("foo");
 /// # let span = tracer.start("foo-span");
 /// async {
 ///     // Does not work
-///     let _g = tracer.mark_span_as_active(span);
+///     let _g = mark_span_as_active(span);
 ///     // ...
 /// };
 /// ```
@@ -230,71 +230,6 @@ pub trait Tracer: fmt::Debug + 'static {
     /// Create a span from a `SpanBuilder`
     fn build_with_context(&self, builder: SpanBuilder, cx: &Context) -> Self::Span;
 
-    /// Mark a given `Span` as active.
-    ///
-    /// The `Tracer` MUST provide a way to update its active `Span`, and MAY provide convenience
-    /// methods to manage a `Span`'s lifetime and the scope in which a `Span` is active. When an
-    /// active `Span` is made inactive, the previously-active `Span` SHOULD be made active. A `Span`
-    /// maybe finished (i.e. have a non-null end time) but still be active. A `Span` may be active
-    /// on one thread after it has been made inactive on another.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use opentelemetry::{global, trace::{Span, Tracer}, KeyValue};
-    ///
-    /// fn my_function() {
-    ///     let tracer = global::tracer("my-component-a");
-    ///     // start an active span in one function
-    ///     let span = tracer.start("span-name");
-    ///     let _guard = tracer.mark_span_as_active(span);
-    ///     // anything happening in functions we call can still access the active span...
-    ///     my_other_function();
-    /// }
-    ///
-    /// fn my_other_function() {
-    ///     // call methods on the current span from
-    ///     global::tracer("my-component-b").get_active_span(|span| {
-    ///         span.add_event("An event!".to_string(), vec![KeyValue::new("happened", true)]);
-    ///     });
-    /// }
-    /// ```
-    #[must_use = "Dropping the guard detaches the context."]
-    fn mark_span_as_active(&self, span: Self::Span) -> ContextGuard {
-        let cx = Context::current_with_span(span);
-        cx.attach()
-    }
-
-    /// Executes a closure with a reference to this thread's current span.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use opentelemetry::{global, trace::{Span, Tracer}, KeyValue};
-    ///
-    /// fn my_function() {
-    ///     // start an active span in one function
-    ///     global::tracer("my-component").in_span("span-name", |_cx| {
-    ///         // anything happening in functions we call can still access the active span...
-    ///         my_other_function();
-    ///     })
-    /// }
-    ///
-    /// fn my_other_function() {
-    ///     // call methods on the current span from
-    ///     global::tracer("my-component").get_active_span(|span| {
-    ///         span.add_event("An event!".to_string(), vec![KeyValue::new("happened", true)]);
-    ///     })
-    /// }
-    /// ```
-    fn get_active_span<F, T>(&self, f: F) -> T
-    where
-        F: FnOnce(&dyn Span) -> T,
-        Self: Sized,
-    {
-        f(Context::current().span())
-    }
-
     /// Start a new span and execute the given closure with reference to the span's
     /// context.
     ///
@@ -305,7 +240,7 @@ pub trait Tracer: fmt::Debug + 'static {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::{global, trace::{Span, Tracer}, KeyValue};
+    /// use opentelemetry::{global, trace::{Span, Tracer, get_active_span}, KeyValue};
     ///
     /// fn my_function() {
     ///     // start an active span in one function
@@ -317,7 +252,7 @@ pub trait Tracer: fmt::Debug + 'static {
     ///
     /// fn my_other_function() {
     ///     // call methods on the current span from
-    ///     global::tracer("my-component").get_active_span(|span| {
+    ///     get_active_span(|span| {
     ///         span.add_event("An event!".to_string(), vec![KeyValue::new("happened", true)]);
     ///     })
     /// }
@@ -343,7 +278,7 @@ pub trait Tracer: fmt::Debug + 'static {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::{global, trace::{Span, SpanKind, Tracer}, KeyValue};
+    /// use opentelemetry::{global, trace::{Span, SpanKind, Tracer, get_active_span}, KeyValue};
     ///
     /// fn my_function() {
     ///     let tracer = global::tracer("my-component");
@@ -358,7 +293,7 @@ pub trait Tracer: fmt::Debug + 'static {
     ///
     /// fn my_other_function() {
     ///     // call methods on the current span from
-    ///     global::tracer("my-component").get_active_span(|span| {
+    ///     get_active_span(|span| {
     ///         span.add_event("An event!".to_string(), vec![KeyValue::new("happened", true)]);
     ///     })
     /// }


### PR DESCRIPTION
Resolve #273 
Spec gives a few choices on where those two functions should be put. Since Rust is not an OOP language. We should just expose the functions in trace module. Leave those two functions in context since they are delegations of context operations.

I feel like `TraceContextExt` is more consistent with rust world so I didn't really rename it into `TracingContextUtilities`. But could definitely make the change if we think `TracingContextUtilities` is more intutive.

