### PR TITLE
Export missing global types

### DIFF
--- a/src/global/mod.rs
+++ b/src/global/mod.rs
@@ -56,14 +56,14 @@
 //! The generic interface is provided by the [`GlobalProvider`] struct which
 //! can be accessed anywhere via [`tracer_provider`] and allows applications to
 //! use the [`BoxedTracer`] and [`BoxedSpan`] instances that implement
-//! [`Tracer`] and [`Span`]. They wrap a boxed dyn [`GenericProvider`],
+//! [`Tracer`] and [`Span`]. They wrap a boxed dyn [`GenericTracerProvider`],
 //! [`GenericTracer`], and [`Span`] respectively allowing the underlying
 //! implementation to be set at runtime.
 //!
 //! [`TracerProvider`]: ../api/trace/provider/trait.TracerProvider.html
 //! [`Tracer`]: ../api/trace/tracer/trait.Tracer.html
 //! [`Span`]: ../api/trace/span/trait.Span.html
-//! [`GenericProvider`]: trait.GenericProvider.html
+//! [`GenericTracerProvider`]: trait.GenericTracerProvider.html
 //! [`GenericTracer`]: trait.GenericTracer.html
 //! [`GlobalProvider`]: struct.GlobalProvider.html
 //! [`BoxedTracer`]: struct.BoxedTracer.html
@@ -85,13 +85,13 @@ mod trace;
 pub use error_handler::{handle_error, set_error_handler};
 #[cfg(feature = "metrics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-pub use metrics::{meter, meter_provider, set_meter_provider};
+pub use metrics::{meter, meter_provider, set_meter_provider, GlobalMeterProvider};
 #[cfg(feature = "trace")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 pub use propagation::{get_text_map_propagator, set_text_map_propagator};
 #[cfg(feature = "trace")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 pub use trace::{
-    set_tracer_provider, tracer, tracer_provider, tracer_with_version, GenericProvider,
-    TracerProviderGuard,
+    set_tracer_provider, tracer, tracer_provider, tracer_with_version, BoxedSpan, BoxedTracer,
+    GenericTracer, GenericTracerProvider, GlobalTracerProvider, TracerProviderGuard,
 };

--- a/src/global/trace.rs
+++ b/src/global/trace.rs
@@ -155,7 +155,7 @@ where
 ///
 /// [`TracerProvider`]: ../api/trace/provider/trait.TracerProvider.html
 /// [`GlobalProvider`]: struct.GlobalProvider.html
-pub trait GenericProvider: fmt::Debug + 'static {
+pub trait GenericTracerProvider: fmt::Debug + 'static {
     /// Creates a named tracer instance that is a trait object through the underlying `TracerProvider`.
     fn get_tracer_boxed(
         &self,
@@ -164,7 +164,7 @@ pub trait GenericProvider: fmt::Debug + 'static {
     ) -> Box<dyn GenericTracer + Send + Sync>;
 }
 
-impl<S, T, P> GenericProvider for P
+impl<S, T, P> GenericTracerProvider for P
 where
     S: trace::Span + Send + Sync,
     T: trace::Tracer<Span = S> + Send + Sync,
@@ -188,7 +188,7 @@ where
 /// [`BoxedTracer`]: struct.BoxedTracer.html
 #[derive(Clone, Debug)]
 pub struct GlobalTracerProvider {
-    provider: Arc<dyn GenericProvider + Send + Sync>,
+    provider: Arc<dyn GenericTracerProvider + Send + Sync>,
 }
 
 impl GlobalTracerProvider {


### PR DESCRIPTION
Rename `GenericProvider` to `GenericTracerProvider` and export missing global types