### PR TITLE
Fix reqwest feature dependency for zipkin

### DIFF
--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 datadog = ["indexmap", "rmp", "async-trait"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry/reqwest"]
-reqwest-client = ["opentelemetry/reqwest"]
+reqwest-client = ["reqwest", "opentelemetry/reqwest"]
 surf-client = ["opentelemetry/surf"]
 
 [dependencies]

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["reqwest-blocking-client"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry/reqwest"]
-reqwest-client = ["opentelemetry/reqwest"]
+reqwest-client = ["reqwest", "opentelemetry/reqwest"]
 surf-client = ["opentelemetry/surf"]
 
 [dependencies]


### PR DESCRIPTION
Currently `opentelemetry-zipkin` will not compile with the non-blocking reqwest configuration as `reqwest` is not specified as a dependency.

Fixes #321