### PR TITLE
Return span context ref

### DIFF
--- a/opentelemetry/src/api/trace/context.rs
+++ b/opentelemetry/src/api/trace/context.rs
@@ -33,11 +33,11 @@ pub trait TraceContextExt {
     /// };
     ///
     /// // returns a reference to an empty span by default
-    /// assert_eq!(Context::current().span().span_context(), SpanContext::empty_context());
+    /// assert_eq!(Context::current().span().span_context(), &SpanContext::empty_context());
     ///
     /// sdktrace::TracerProvider::default().get_tracer("my-component", None).in_span("my-span", |cx| {
     ///     // Returns a reference to the current span if set
-    ///     assert_ne!(cx.span().span_context(), SpanContext::empty_context());
+    ///     assert_ne!(cx.span().span_context(), &SpanContext::empty_context());
     /// });
     /// ```
     fn span(&self) -> &dyn crate::trace::Span;

--- a/opentelemetry/src/api/trace/span.rs
+++ b/opentelemetry/src/api/trace/span.rs
@@ -87,7 +87,7 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
 
     /// Returns the `SpanContext` for the given `Span`. The returned value may be used even after
     /// the `Span is finished. The returned value MUST be the same for the entire `Span` lifetime.
-    fn span_context(&self) -> SpanContext;
+    fn span_context(&self) -> &SpanContext;
 
     /// Returns true if this `Span` is recording information like events with the `add_event`
     /// operation, attributes using `set_attributes`, status with `set_status`, etc.

--- a/opentelemetry/src/api/trace/span_processor.rs
+++ b/opentelemetry/src/api/trace/span_processor.rs
@@ -35,11 +35,12 @@
 //! [`TracerProvider`]: ../provider/trait.TracerProvider.html
 
 use crate::exporter::trace::SpanData;
+use crate::{trace::Span, Context};
 
 /// `SpanProcessor`s allow finished spans to be processed.
 pub trait SpanProcessor: Send + Sync + std::fmt::Debug {
     /// `on_start` method is invoked when a `Span` is started.
-    fn on_start(&self, span: &SpanData);
+    fn on_start(&self, span: &dyn Span, cx: &Context);
     /// `on_end` method is invoked when a `Span` is ended.
     fn on_end(&self, span: SpanData);
     /// Shutdown is invoked when SDK shuts down. Use this call to cleanup any

--- a/opentelemetry/src/api/trace/tracer.rs
+++ b/opentelemetry/src/api/trace/tracer.rs
@@ -41,7 +41,7 @@ use std::time::SystemTime;
 ///
 /// let parent = tracer.start("foo");
 /// let child = tracer.span_builder("bar")
-///     .with_parent(parent.span_context())
+///     .with_parent(parent.span_context().clone())
 ///     .start(&tracer);
 ///
 /// // ...

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -30,7 +30,7 @@ impl trace::Span for BoxedSpan {
     }
 
     /// Returns the `SpanContext` for the given `Span`.
-    fn span_context(&self) -> trace::SpanContext {
+    fn span_context(&self) -> &trace::SpanContext {
         self.0.span_context()
     }
 

--- a/opentelemetry/src/sdk/propagation/aws.rs
+++ b/opentelemetry/src/sdk/propagation/aws.rs
@@ -107,7 +107,7 @@ impl XrayPropagator {
 
 impl TextMapPropagator for XrayPropagator {
     fn inject_context(&self, cx: &Context, injector: &mut dyn Injector) {
-        let span_context: SpanContext = cx.span().span_context();
+        let span_context = cx.span().span_context();
         if span_context.is_valid() {
             let xray_trace_id: XrayTraceId = span_context.trace_id().into();
 

--- a/opentelemetry/src/sdk/trace/span.rs
+++ b/opentelemetry/src/sdk/trace/span.rs
@@ -200,7 +200,7 @@ fn build_export_data(
         status_code: data.status_code,
         status_message: data.status_message,
         resource: data.resource,
-        instrumentation_lib: tracer.instrumentation_library().clone(),
+        instrumentation_lib: *tracer.instrumentation_library(),
     }
 }
 

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -1,6 +1,7 @@
 use crate::{
     exporter::trace::{SpanData, SpanExporter},
-    trace::SpanProcessor,
+    trace::{Span, SpanProcessor},
+    Context,
 };
 use futures::{channel::mpsc, executor, future::BoxFuture, Future, FutureExt, Stream, StreamExt};
 use std::fmt;
@@ -57,7 +58,7 @@ impl SimpleSpanProcessor {
 }
 
 impl SpanProcessor for SimpleSpanProcessor {
-    fn on_start(&self, _span: &SpanData) {
+    fn on_start(&self, _span: &dyn Span, _cx: &Context) {
         // Ignored
     }
 
@@ -126,7 +127,7 @@ impl fmt::Debug for BatchSpanProcessor {
 }
 
 impl SpanProcessor for BatchSpanProcessor {
-    fn on_start(&self, _span: &SpanData) {
+    fn on_start(&self, _span: &dyn Span, _cx: &Context) {
         // Ignored
     }
 

--- a/opentelemetry/src/testing/trace.rs
+++ b/opentelemetry/src/testing/trace.rs
@@ -14,8 +14,8 @@ impl Span for TestSpan {
         _attributes: Vec<KeyValue>,
     ) {
     }
-    fn span_context(&self) -> SpanContext {
-        self.0.clone()
+    fn span_context(&self) -> &SpanContext {
+        &self.0
     }
     fn is_recording(&self) -> bool {
         false


### PR DESCRIPTION
Currently the `Span` trait in the API has its `span_context` method return an owned `SpanContext`. In order to be more consistent with the rest of the APIs, this patch updates the trait to instead return a reference, and moves the `SpanContext` data outside of the mutex in the SDK to implement the trait. This also allows #265 to be implemented
without having to lock.

Additionally the spec now states that the `on_start` method for `SpanProcessor`s must be passed a span and the parent context so those are updated as well.
