### PR TITLE
Fix zipkin and datadog surf client features

### DIFF
--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 datadog = ["indexmap", "rmp", "async-trait"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry/reqwest"]
-surf-client = ["opentelemetry/surf"]
+surf-client = ["surf", "opentelemetry/surf"]
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -23,7 +23,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["reqwest-blocking-client"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry/reqwest"]
-surf-client = ["opentelemetry/surf"]
+surf-client = ["surf", "opentelemetry/surf"]
 
 [dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
Currently these features do not include the required `surf` dependency