### PR TITLE
Improve performance of EvictedHashMap

### DIFF
--- a/opentelemetry-contrib/src/datadog/model/mod.rs
+++ b/opentelemetry-contrib/src/datadog/model/mod.rs
@@ -90,7 +90,7 @@ mod tests {
         let end_time = start_time.checked_add(Duration::from_secs(1)).unwrap();
 
         let capacity = 3;
-        let mut attributes = sdk::trace::EvictedHashMap::new(capacity);
+        let mut attributes = sdk::trace::EvictedHashMap::new(capacity, capacity as usize);
         attributes.insert(Key::new("span.type").string("web"));
 
         let message_events = sdk::trace::EvictedQueue::new(capacity);

--- a/opentelemetry/benches/trace.rs
+++ b/opentelemetry/benches/trace.rs
@@ -89,8 +89,8 @@ const MAP_KEYS: [Key; 20] = [
 ];
 
 fn insert_keys(mut map: sdktrace::EvictedHashMap, n: usize) {
-    for idx in 0..n {
-        map.insert(KeyValue::new(MAP_KEYS[idx].clone(), idx as i64));
+    for (idx, key) in MAP_KEYS.iter().enumerate().take(n) {
+        map.insert(KeyValue::new(key.clone(), idx as i64));
     }
 }
 

--- a/opentelemetry/benches/trace.rs
+++ b/opentelemetry/benches/trace.rs
@@ -2,10 +2,25 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::{
     sdk::trace as sdktrace,
     trace::{Span, Tracer, TracerProvider},
-    Key,
+    Key, KeyValue,
 };
 
 fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("EvictedHashMap");
+    group.bench_function("insert 1", |b| {
+        b.iter(|| insert_keys(sdktrace::EvictedHashMap::new(32, 1), 1))
+    });
+    group.bench_function("insert 5", |b| {
+        b.iter(|| insert_keys(sdktrace::EvictedHashMap::new(32, 5), 5))
+    });
+    group.bench_function("insert 10", |b| {
+        b.iter(|| insert_keys(sdktrace::EvictedHashMap::new(32, 10), 10))
+    });
+    group.bench_function("insert 20", |b| {
+        b.iter(|| insert_keys(sdktrace::EvictedHashMap::new(32, 20), 20))
+    });
+    group.finish();
+
     trace_benchmark_group(c, "start-end-span", |tracer| tracer.start("foo").end());
 
     trace_benchmark_group(c, "start-end-span-4-attrs", |tracer| {
@@ -48,6 +63,35 @@ fn criterion_benchmark(c: &mut Criterion) {
         span.set_attribute(Key::new("key15").f64(123.456));
         span.end();
     });
+}
+
+const MAP_KEYS: [Key; 20] = [
+    Key::from_static_str("key1"),
+    Key::from_static_str("key2"),
+    Key::from_static_str("key3"),
+    Key::from_static_str("key4"),
+    Key::from_static_str("key5"),
+    Key::from_static_str("key6"),
+    Key::from_static_str("key7"),
+    Key::from_static_str("key8"),
+    Key::from_static_str("key9"),
+    Key::from_static_str("key10"),
+    Key::from_static_str("key11"),
+    Key::from_static_str("key12"),
+    Key::from_static_str("key13"),
+    Key::from_static_str("key14"),
+    Key::from_static_str("key15"),
+    Key::from_static_str("key16"),
+    Key::from_static_str("key17"),
+    Key::from_static_str("key18"),
+    Key::from_static_str("key19"),
+    Key::from_static_str("key20"),
+];
+
+fn insert_keys(mut map: sdktrace::EvictedHashMap, n: usize) {
+    for idx in 0..n {
+        map.insert(KeyValue::new(MAP_KEYS[idx].clone(), idx as i64));
+    }
 }
 
 fn trace_benchmark_group<F: Fn(&sdktrace::Tracer)>(c: &mut Criterion, name: &str, f: F) {

--- a/opentelemetry/src/exporter/trace/mod.rs
+++ b/opentelemetry/src/exporter/trace/mod.rs
@@ -200,7 +200,7 @@ mod tests {
         let end_time = SystemTime::now();
 
         let capacity = 3;
-        let attributes = sdk::trace::EvictedHashMap::new(capacity);
+        let attributes = sdk::trace::EvictedHashMap::new(capacity, 0);
         let message_events = sdk::trace::EvictedQueue::new(capacity);
         let links = sdk::trace::EvictedQueue::new(capacity);
 

--- a/opentelemetry/src/sdk/trace/evicted_queue.rs
+++ b/opentelemetry/src/sdk/trace/evicted_queue.rs
@@ -16,7 +16,7 @@ pub struct EvictedQueue<T> {
 }
 
 impl<T> EvictedQueue<T> {
-    /// Create a new `EvictedQueue` with a given capacity.
+    /// Create a new `EvictedQueue` with a given max length.
     pub fn new(max_len: u32) -> Self {
         EvictedQueue {
             queue: None,

--- a/opentelemetry/src/sdk/trace/evicted_queue.rs
+++ b/opentelemetry/src/sdk/trace/evicted_queue.rs
@@ -10,17 +10,17 @@ use std::collections::VecDeque;
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct EvictedQueue<T> {
-    queue: VecDeque<T>,
-    capacity: u32,
+    queue: Option<VecDeque<T>>,
+    max_len: u32,
     dropped_count: u32,
 }
 
 impl<T> EvictedQueue<T> {
     /// Create a new `EvictedQueue` with a given capacity.
-    pub fn new(capacity: u32) -> Self {
+    pub fn new(max_len: u32) -> Self {
         EvictedQueue {
-            queue: Default::default(),
-            capacity,
+            queue: None,
+            max_len,
             dropped_count: 0,
         }
     }
@@ -28,11 +28,12 @@ impl<T> EvictedQueue<T> {
     /// Push a new element to the back of the queue, dropping and
     /// recording dropped count if over capacity.
     pub(crate) fn push_back(&mut self, value: T) {
-        if self.queue.len() as u32 == self.capacity {
-            self.queue.pop_front();
+        let queue = self.queue.get_or_insert_with(Default::default);
+        if queue.len() as u32 == self.max_len {
+            queue.pop_front();
             self.dropped_count += 1;
         }
-        self.queue.push_back(value);
+        queue.push_back(value);
     }
 
     /// Moves all the elements of other into self, leaving other empty.
@@ -42,17 +43,17 @@ impl<T> EvictedQueue<T> {
 
     /// Returns `true` if the `EvictedQueue` is empty.
     pub fn is_empty(&self) -> bool {
-        self.queue.is_empty()
+        self.queue.as_ref().map_or(true, |queue| queue.is_empty())
     }
 
     /// Returns a front-to-back iterator.
-    pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, T> {
-        self.queue.iter()
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter(self.queue.as_ref().map(|queue| queue.iter()))
     }
 
     /// Returns the number of elements in the `EvictedQueue`.
     pub fn len(&self) -> usize {
-        self.queue.len()
+        self.queue.as_ref().map_or(0, |queue| queue.len())
     }
 
     /// Count of dropped attributes
@@ -61,32 +62,36 @@ impl<T> EvictedQueue<T> {
     }
 }
 
+/// An owned iterator over the entries of a `EvictedQueue`.
+#[derive(Debug)]
+pub struct IntoIter<T>(Option<std::collections::vec_deque::IntoIter<T>>);
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.as_mut().and_then(|iter| iter.next())
+    }
+}
+
 impl<T> IntoIterator for EvictedQueue<T> {
     type Item = T;
-    type IntoIter = std::collections::vec_deque::IntoIter<T>;
+    type IntoIter = IntoIter<T>;
 
-    /// Consumes the `EvictedQueue` into a front-to-back iterator yielding elements by
-    /// value.
     fn into_iter(self) -> Self::IntoIter {
-        self.queue.into_iter()
+        IntoIter(self.queue.map(|queue| queue.into_iter()))
     }
 }
 
-impl<'a, T> IntoIterator for &'a EvictedQueue<T> {
+/// An iterator over the entries of an `EvictedQueue`.
+#[derive(Debug)]
+pub struct Iter<'a, T>(Option<std::collections::vec_deque::Iter<'a, T>>);
+
+impl<'a, T: 'static> Iterator for Iter<'a, T> {
     type Item = &'a T;
-    type IntoIter = std::collections::vec_deque::Iter<'a, T>;
 
-    fn into_iter(self) -> Self::IntoIter {
-        self.queue.iter()
-    }
-}
-
-impl<'a, T> IntoIterator for &'a mut EvictedQueue<T> {
-    type Item = &'a mut T;
-    type IntoIter = std::collections::vec_deque::IterMut<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.queue.iter_mut()
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.as_mut().and_then(|iter| iter.next())
     }
 }
 
@@ -112,6 +117,9 @@ mod tests {
 
         assert_eq!(queue.dropped_count, 1);
         assert_eq!(queue.len(), capacity as usize);
-        assert_eq!(queue.queue, (1..=capacity).collect::<VecDeque<_>>());
+        assert_eq!(
+            queue.queue.unwrap(),
+            (1..=capacity).collect::<VecDeque<_>>()
+        );
     }
 }

--- a/opentelemetry/src/sdk/trace/span.rs
+++ b/opentelemetry/src/sdk/trace/span.rs
@@ -220,7 +220,7 @@ mod tests {
             name: "opentelemetry".to_string(),
             start_time: SystemTime::now(),
             end_time: SystemTime::now(),
-            attributes: sdk::trace::EvictedHashMap::new(config.max_attributes_per_span),
+            attributes: sdk::trace::EvictedHashMap::new(config.max_attributes_per_span, 0),
             message_events: sdk::trace::EvictedQueue::new(config.max_events_per_span),
             links: sdk::trace::EvictedQueue::new(config.max_links_per_span),
             status_code: StatusCode::Unset,

--- a/opentelemetry/src/sdk/trace/tracer.rs
+++ b/opentelemetry/src/sdk/trace/tracer.rs
@@ -212,10 +212,7 @@ impl crate::trace::Tracer for Tracer {
                 &builder.name,
                 &span_kind,
                 &attribute_options,
-                link_options
-                    .as_ref()
-                    .map(|links| links.as_slice())
-                    .unwrap_or(&[]),
+                link_options.as_deref().unwrap_or(&[]),
             )
         } else {
             // has parent that is local: use parent if sampled, or don't record.


### PR DESCRIPTION
A large portion of tracing time is typically spent processing span attributes. This patch improves performance of inserting additional span attributes at creation time by optimizing the backing evicted hash map data structure.

Changes:

* Use `entry` api on insert to avoid hashing keys twice
* Specify an initial attribute capacity when building a span to avoid growing backing hashmap capacity repeatedly
* Avoid allocating and appending extra links vec if unused
* (non-perf) add new type for `Iter` and `IntoIter` to avoid std hashmap in public api

Benchmark changes:

```
EvictedHashMap/insert 1 time:   [210.50 ns 212.56 ns 215.01 ns]
                        change: [-6.6266% -4.9711% -3.3843%] (p = 0.00 < 0.05)
                        Performance has improved.
EvictedHashMap/insert 5 time:   [828.72 ns 836.35 ns 843.99 ns]
                        change: [-21.606% -20.885% -20.169%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
EvictedHashMap/insert 10
                        time:   [1.5435 us 1.5517 us 1.5604 us]
                        change: [-26.554% -26.207% -25.837%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
EvictedHashMap/insert 20
                        time:   [2.9865 us 2.9960 us 3.0070 us]
                        change: [-28.683% -27.587% -26.707%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```