### PR TITLE
Fix datadog example

### DIFF
--- a/examples/datadog/Cargo.toml
+++ b/examples/datadog/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 
 [dependencies]
 opentelemetry = { path = "../../opentelemetry" }
-opentelemetry-contrib = { path = "../../opentelemetry-contrib", features = ["datadog"] }
+opentelemetry-contrib = { path = "../../opentelemetry-contrib", features = ["datadog", "reqwest-blocking-client"] }


### PR DESCRIPTION
Currently the Datadog example will panic at runtime as there are no exporter http clients configured