### PR TITLE
Add expend_attributes method

### DIFF
--- a/opentelemetry/benches/trace.rs
+++ b/opentelemetry/benches/trace.rs
@@ -111,8 +111,8 @@ fn set_attribute_in_batch(c: &mut Criterion, tracer: &sdktrace::Tracer) {
     }
     group.bench_function("insert in batch", |b| {
         b.iter(|| {
-            let span = Box::new(tracer.start("span1"));
-            span.extend_attributes(attributes.clone().into_iter());
+            let span = tracer.start("span1");
+            span.extend_attributes(attributes.clone());
         })
     });
     group.bench_function("insert one by one", |b| {

--- a/opentelemetry/src/api/trace/span.rs
+++ b/opentelemetry/src/api/trace/span.rs
@@ -124,7 +124,7 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
 
     /// An API to set multiple `Attribute`s. This function works similar to `set_attribute` but can
     /// add multiple attributes at once. For more details, refer to `set_attribute`.
-    fn extend_attributes(&self, attributes: Vec<KeyValue>){
+    fn extend_attributes(&self, attributes: Vec<KeyValue>) {
         attributes.into_iter().for_each(|attr| {
             self.set_attribute(attr);
         });

--- a/opentelemetry/src/api/trace/span.rs
+++ b/opentelemetry/src/api/trace/span.rs
@@ -122,13 +122,10 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     /// that have prescribed semantic meanings.
     fn set_attribute(&self, attribute: KeyValue);
 
-    /// An API to set multiple `Attribute`. This function works similar with `set_attribute` but can
+    /// An API to set multiple `Attribute`s. This function works similar to `set_attribute` but can
     /// add multiple attributes at once. For more details, refer to `set_attribute`.
-    fn extend_attributes(&self, attributes: impl Iterator<Item = KeyValue>)
-    where
-        Self: Sized,
-    {
-        attributes.for_each(|attr| {
+    fn extend_attributes(&self, attributes: Vec<KeyValue>){
+        attributes.into_iter().for_each(|attr| {
             self.set_attribute(attr);
         });
     }
@@ -174,76 +171,6 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     ///
     /// [`Span::end`]: trait.Span.html#method.end
     fn end_with_timestamp(&self, timestamp: SystemTime);
-}
-
-impl Span for Box<dyn Span + Send + Sync> {
-    fn add_event_with_timestamp(
-        &self,
-        name: String,
-        timestamp: SystemTime,
-        attributes: Vec<KeyValue>,
-    ) {
-        (**self).add_event_with_timestamp(name, timestamp, attributes);
-    }
-
-    fn span_context(&self) -> &SpanContext {
-        (**self).span_context()
-    }
-
-    fn is_recording(&self) -> bool {
-        (**self).is_recording()
-    }
-
-    fn set_attribute(&self, attribute: KeyValue) {
-        (**self).set_attribute(attribute)
-    }
-
-    fn set_status(&self, code: StatusCode, message: String) {
-        (**self).set_status(code, message)
-    }
-
-    fn update_name(&self, new_name: String) {
-        (**self).update_name(new_name)
-    }
-
-    fn end_with_timestamp(&self, timestamp: SystemTime) {
-        (**self).end_with_timestamp(timestamp)
-    }
-}
-
-impl Span for &'static dyn Span {
-    fn add_event_with_timestamp(
-        &self,
-        name: String,
-        timestamp: SystemTime,
-        attributes: Vec<KeyValue>,
-    ) {
-        (*self).add_event_with_timestamp(name, timestamp, attributes);
-    }
-
-    fn span_context(&self) -> &SpanContext {
-        (*self).span_context()
-    }
-
-    fn is_recording(&self) -> bool {
-        (*self).is_recording()
-    }
-
-    fn set_attribute(&self, attribute: KeyValue) {
-        (*self).set_attribute(attribute)
-    }
-
-    fn set_status(&self, code: StatusCode, message: String) {
-        (*self).set_status(code, message)
-    }
-
-    fn update_name(&self, new_name: String) {
-        (*self).update_name(new_name)
-    }
-
-    fn end_with_timestamp(&self, timestamp: SystemTime) {
-        (*self).end_with_timestamp(timestamp)
-    }
 }
 
 /// `SpanKind` describes the relationship between the Span, its parents,

--- a/opentelemetry/src/api/trace/span.rs
+++ b/opentelemetry/src/api/trace/span.rs
@@ -122,6 +122,17 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     /// that have prescribed semantic meanings.
     fn set_attribute(&self, attribute: KeyValue);
 
+    /// An API to set multiple `Attribute`. This function works similar with `set_attribute` but can
+    /// add multiple attributes at once. For more details, refer to `set_attribute`.
+    fn extend_attributes(&self, attributes: impl Iterator<Item = KeyValue>)
+    where
+        Self: Sized,
+    {
+        attributes.for_each(|attr| {
+            self.set_attribute(attr);
+        });
+    }
+
     /// Sets the status of the `Span`. If used, this will override the default `Span`
     /// status, which is `OK`.
     ///
@@ -163,6 +174,76 @@ pub trait Span: fmt::Debug + 'static + Send + Sync {
     ///
     /// [`Span::end`]: trait.Span.html#method.end
     fn end_with_timestamp(&self, timestamp: SystemTime);
+}
+
+impl Span for Box<dyn Span + Send + Sync> {
+    fn add_event_with_timestamp(
+        &self,
+        name: String,
+        timestamp: SystemTime,
+        attributes: Vec<KeyValue>,
+    ) {
+        (**self).add_event_with_timestamp(name, timestamp, attributes);
+    }
+
+    fn span_context(&self) -> &SpanContext {
+        (**self).span_context()
+    }
+
+    fn is_recording(&self) -> bool {
+        (**self).is_recording()
+    }
+
+    fn set_attribute(&self, attribute: KeyValue) {
+        (**self).set_attribute(attribute)
+    }
+
+    fn set_status(&self, code: StatusCode, message: String) {
+        (**self).set_status(code, message)
+    }
+
+    fn update_name(&self, new_name: String) {
+        (**self).update_name(new_name)
+    }
+
+    fn end_with_timestamp(&self, timestamp: SystemTime) {
+        (**self).end_with_timestamp(timestamp)
+    }
+}
+
+impl Span for &'static dyn Span {
+    fn add_event_with_timestamp(
+        &self,
+        name: String,
+        timestamp: SystemTime,
+        attributes: Vec<KeyValue>,
+    ) {
+        (*self).add_event_with_timestamp(name, timestamp, attributes);
+    }
+
+    fn span_context(&self) -> &SpanContext {
+        (*self).span_context()
+    }
+
+    fn is_recording(&self) -> bool {
+        (*self).is_recording()
+    }
+
+    fn set_attribute(&self, attribute: KeyValue) {
+        (*self).set_attribute(attribute)
+    }
+
+    fn set_status(&self, code: StatusCode, message: String) {
+        (*self).set_status(code, message)
+    }
+
+    fn update_name(&self, new_name: String) {
+        (*self).update_name(new_name)
+    }
+
+    fn end_with_timestamp(&self, timestamp: SystemTime) {
+        (*self).end_with_timestamp(timestamp)
+    }
 }
 
 /// `SpanKind` describes the relationship between the Span, its parents,

--- a/opentelemetry/src/sdk/trace/span.rs
+++ b/opentelemetry/src/sdk/trace/span.rs
@@ -128,6 +128,16 @@ impl crate::trace::Span for Span {
         });
     }
 
+    /// An API to set multiple `Attribute`. This function works similar with `set_attribute` but can
+    /// add multiple attributes at once. For more details, refer to `set_attribute`.
+    fn extend_attributes(&self, attributes: impl Iterator<Item = KeyValue>) {
+        self.with_data(|data| {
+            attributes.for_each(|attr| {
+                data.attributes.insert(attr);
+            });
+        });
+    }
+
     /// Sets the status of the `Span`. If used, this will override the default `Span`
     /// status, which is `Unset`.
     fn set_status(&self, code: StatusCode, message: String) {

--- a/opentelemetry/src/sdk/trace/span.rs
+++ b/opentelemetry/src/sdk/trace/span.rs
@@ -70,8 +70,8 @@ impl Span {
 
     /// Operate on a mutable reference to span data
     fn with_data<T, F>(&self, f: F) -> Option<T>
-        where
-            F: FnOnce(&mut SpanData) -> T,
+    where
+        F: FnOnce(&mut SpanData) -> T,
     {
         self.inner.data.as_ref().and_then(|inner| {
             inner
@@ -365,17 +365,17 @@ mod tests {
     }
 
     #[test]
-    fn extend_attributes(){
+    fn extend_attributes() {
         let span = create_span();
         let attributes = vec![
             KeyValue::new("k2", "v1"),
             KeyValue::new("k3", "v2"),
-            KeyValue::new("k1","v3"),
+            KeyValue::new("k1", "v3"),
         ];
         span.extend_attributes(attributes.clone());
-        span.with_data(|data|{
-            for kv in attributes{
-                if let Some(val) = data.attributes.get(&kv.key){
+        span.with_data(|data| {
+            for kv in attributes {
+                if let Some(val) = data.attributes.get(&kv.key) {
                     assert_eq!(*val, kv.value);
                 } else {
                     panic!("no such attribute");


### PR DESCRIPTION
Part of #338 
Did a POC on generic iterator of KeyValue. One problem is since we are using `dyn Span` in `global` module. We cannot really have a function with generic argument in `Span` trait. Hacked it around a little bit based on [this post](https://internals.rust-lang.org/t/generic-methods-over-object-safe-traits/6774). But still feel like we might need to use Vec in the end.

Benchmarked the speed of inserting 1000 key value pairs in one thread. Looks promising, should be more difference if running in multiple threads.
```
set attributes in batch/insert in batch                                                                            
                        time:   [60.776 us 60.903 us 61.047 us]
                        change: [-4.5324% -3.8952% -2.7253%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
set attributes in batch/insert one by one                                                                            
                        time:   [73.007 us 73.119 us 73.279 us]
                        change: [-3.7832% -3.5073% -3.2366%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)

```