### PR TITLE
Change ExportResult to std::result::Result

### DIFF
--- a/opentelemetry-jaeger/src/uploader.rs
+++ b/opentelemetry-jaeger/src/uploader.rs
@@ -18,19 +18,16 @@ impl BatchUploader {
     /// Emit a jaeger batch for the given uploader
     pub(crate) async fn upload(&self, batch: jaeger::Batch) -> trace::ExportResult {
         match self {
-            BatchUploader::Agent(client) => match client.emit_batch(batch).await {
-                Ok(_) => trace::ExportResult::Success,
-                // TODO determine if the error is retryable
-                Err(_) => trace::ExportResult::FailedNotRetryable,
-            },
+            BatchUploader::Agent(client) => {
+                // TODO Implement retry behaviour
+                client.emit_batch(batch).await?;
+            }
             #[cfg(feature = "collector_client")]
             BatchUploader::Collector(collector) => {
-                match collector.submit_batch(batch).await {
-                    Ok(_) => trace::ExportResult::Success,
-                    // TODO determine if the error is retryable
-                    Err(_) => trace::ExportResult::FailedNotRetryable,
-                }
+                // TODO Implement retry behaviour
+                collector.submit_batch(batch).await?;
             }
-        }
+        };
+        Ok(())
     }
 }

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -109,13 +109,13 @@ struct IsahcClient(isahc::HttpClient);
 
 #[async_trait]
 impl HttpClient for IsahcClient {
-  async fn send(&self, request: http::Request<Vec<u8>>) -> Result<ExportResult, Box<dyn Error + Send + Sync + 'static>> {
+  async fn send(&self, request: http::Request<Vec<u8>>) -> ExportResult {
     let result = self.0.send_async(request).await?;
 
     if result.status().is_success() {
-      Ok(ExportResult::Success)
+      Ok(())
     } else {
-      Ok(ExportResult::FailedNotRetryable)
+      Err(result.status().as_str().into())
     }
   }
 }

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -89,13 +89,13 @@
 //!
 //! #[async_trait]
 //! impl HttpClient for IsahcClient {
-//!   async fn send(&self, request: http::Request<Vec<u8>>) -> Result<ExportResult, Box<dyn Error + Send + Sync + 'static>> {
+//!   async fn send(&self, request: http::Request<Vec<u8>>) -> ExportResult {
 //!     let result = self.0.send_async(request).await?;
 //!
 //!     if result.status().is_success() {
-//!       Ok(ExportResult::Success)
+//!       Ok(())
 //!     } else {
-//!       Ok(ExportResult::FailedNotRetryable)
+//!       Err(result.status().as_str().into())
 //!     }
 //!   }
 //! }

--- a/opentelemetry-zipkin/src/uploader.rs
+++ b/opentelemetry-zipkin/src/uploader.rs
@@ -21,10 +21,7 @@ impl Uploader {
     /// Upload spans to Zipkin
     pub(crate) async fn upload(&self, spans: Vec<Span>) -> ExportResult {
         match self {
-            Uploader::Http(client) => client
-                .upload(spans)
-                .await
-                .unwrap_or(ExportResult::FailedNotRetryable),
+            Uploader::Http(client) => client.upload(spans).await,
         }
     }
 }
@@ -36,10 +33,7 @@ pub(crate) struct JsonV2Client {
 }
 
 impl JsonV2Client {
-    async fn upload(
-        &self,
-        spans: Vec<Span>,
-    ) -> Result<ExportResult, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    async fn upload(&self, spans: Vec<Span>) -> ExportResult {
         let req = Request::builder()
             .method(Method::POST)
             .uri(self.collector_endpoint.clone())

--- a/opentelemetry/src/api/trace/noop.rs
+++ b/opentelemetry/src/api/trace/noop.rs
@@ -182,7 +182,7 @@ impl NoopSpanExporter {
 #[async_trait]
 impl SpanExporter for NoopSpanExporter {
     async fn export(&self, _batch: Vec<SpanData>) -> ExportResult {
-        ExportResult::Success
+        Ok(())
     }
 }
 

--- a/opentelemetry/src/exporter/trace/stdout.rs
+++ b/opentelemetry/src/exporter/trace/stdout.rs
@@ -129,28 +129,19 @@ where
 {
     /// Export spans to stdout
     async fn export(&self, batch: Vec<SpanData>) -> ExportResult {
-        let writer = self
+        let mut writer = self
             .writer
             .lock()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()));
-        let result = writer.and_then(|mut w| {
-            for span in batch {
-                if self.pretty_print {
-                    w.write_all(format!("{:#?}\n", span).as_bytes())?;
-                } else {
-                    w.write_all(format!("{:?}\n", span).as_bytes())?;
-                }
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        for span in batch {
+            if self.pretty_print {
+                writer.write_all(format!("{:#?}\n", span).as_bytes())?;
+            } else {
+                writer.write_all(format!("{:?}\n", span).as_bytes())?;
             }
-
-            Ok(())
-        });
-
-        if result.is_ok() {
-            ExportResult::Success
-        } else {
-            // FIXME: determine retryable io::Error types
-            ExportResult::FailedNotRetryable
         }
+
+        Ok(())
     }
 }
 

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -110,7 +110,8 @@ impl SpanProcessor for SimpleSpanProcessor {
     }
 
     fn on_end(&self, span: SpanData) {
-        executor::block_on(self.exporter.export(vec![span]));
+        // TODO: Surface error through global error handler
+        let _result = executor::block_on(self.exporter.export(vec![span]));
     }
 
     fn shutdown(&mut self) {
@@ -239,7 +240,9 @@ impl BatchSpanProcessor {
                             let batch = spans.split_off(
                                 spans.len().saturating_sub(config.max_export_batch_size),
                             );
-                            exporter.export(batch).await;
+
+                            // TODO: Surface error through global error handler
+                            let _result = exporter.export(batch).await;
                         }
                     }
                     // Stream has terminated or processor is shutdown, return to finish execution.
@@ -248,7 +251,9 @@ impl BatchSpanProcessor {
                             let batch = spans.split_off(
                                 spans.len().saturating_sub(config.max_export_batch_size),
                             );
-                            exporter.export(batch).await;
+
+                            // TODO: Surface error through global error handler
+                            let _result = exporter.export(batch).await;
                         }
                         exporter.shutdown();
                         break;


### PR DESCRIPTION
The spec changed and ExportResult no longer includes the hint about error being retriable. Since it now only distinguishes between success and error, it makes sense to use Rust's standard Result type.

Closes #331 