### PR TITLE
Change SpanExporter::export &self to &mut self 

### DIFF
--- a/opentelemetry-contrib/src/trace/exporter/datadog/mod.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/mod.rs
@@ -278,7 +278,7 @@ impl DatadogPipelineBuilder {
 #[async_trait]
 impl trace::SpanExporter for DatadogExporter {
     /// Export spans to datadog-agent
-    async fn export(&self, batch: Vec<SpanData>) -> trace::ExportResult {
+    async fn export(&mut self, batch: Vec<SpanData>) -> trace::ExportResult {
         let data = self.version.encode(&self.service_name, batch)?;
         let req = Request::builder()
             .method(Method::POST)

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -258,7 +258,7 @@ impl Into<jaeger::Process> for Process {
 #[async_trait]
 impl trace::SpanExporter for Exporter {
     /// Export spans to Jaeger
-    async fn export(&self, batch: Vec<trace::SpanData>) -> trace::ExportResult {
+    async fn export(&mut self, batch: Vec<trace::SpanData>) -> trace::ExportResult {
         let mut jaeger_spans: Vec<jaeger::Span> = Vec::with_capacity(batch.len());
         let mut process = self.process.clone();
 

--- a/opentelemetry-jaeger/src/uploader.rs
+++ b/opentelemetry-jaeger/src/uploader.rs
@@ -16,7 +16,7 @@ pub(crate) enum BatchUploader {
 
 impl BatchUploader {
     /// Emit a jaeger batch for the given uploader
-    pub(crate) async fn upload(&self, batch: jaeger::Batch) -> trace::ExportResult {
+    pub(crate) async fn upload(&mut self, batch: jaeger::Batch) -> trace::ExportResult {
         match self {
             BatchUploader::Agent(client) => {
                 // TODO Implement retry behaviour

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -146,7 +146,7 @@ impl Exporter {
 
 #[async_trait]
 impl SpanExporter for Exporter {
-    async fn export(&self, batch: Vec<SpanData>) -> ExportResult {
+    async fn export(&mut self, batch: Vec<SpanData>) -> ExportResult {
         let request = ExportTraceServiceRequest {
             resource_spans: RepeatedField::from_vec(batch.into_iter().map(Into::into).collect()),
             unknown_fields: Default::default(),

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -309,7 +309,7 @@ impl ZipkinPipelineBuilder {
 #[async_trait]
 impl trace::SpanExporter for Exporter {
     /// Export spans to Zipkin collector.
-    async fn export(&self, batch: Vec<trace::SpanData>) -> trace::ExportResult {
+    async fn export(&mut self, batch: Vec<trace::SpanData>) -> trace::ExportResult {
         let zipkin_spans = batch
             .into_iter()
             .map(|span| model::into_zipkin_span(self.local_endpoint.clone(), span))

--- a/opentelemetry/src/api/trace/noop.rs
+++ b/opentelemetry/src/api/trace/noop.rs
@@ -181,7 +181,7 @@ impl NoopSpanExporter {
 
 #[async_trait]
 impl SpanExporter for NoopSpanExporter {
-    async fn export(&self, _batch: Vec<SpanData>) -> ExportResult {
+    async fn export(&mut self, _batch: Vec<SpanData>) -> ExportResult {
         Ok(())
     }
 }

--- a/opentelemetry/src/exporter/trace/mod.rs
+++ b/opentelemetry/src/exporter/trace/mod.rs
@@ -50,8 +50,8 @@ pub trait SpanExporter: Send + Debug {
     /// not allowed and should return an error.
     ///
     /// This function should not block indefinitely (e.g. if it attempts to
-    /// flush the data and the destination is unavailable). Language library
-    /// authors can decide if they want to make the shutdown timeout
+    /// flush the data and the destination is unavailable). SDK authors
+    /// can decide if they want to make the shutdown timeout
     /// configurable.
     fn shutdown(&mut self) {}
 }

--- a/opentelemetry/src/exporter/trace/mod.rs
+++ b/opentelemetry/src/exporter/trace/mod.rs
@@ -23,45 +23,43 @@ pub type ExportResult = Result<(), Box<dyn std::error::Error + Send + Sync + 'st
 /// implement so that they can be plugged into OpenTelemetry SDK and support
 /// sending of telemetry data.
 ///
-/// The goals of the interface are:
-///
-/// - Minimize burden of implementation for protocol-dependent telemetry
-///  exporters. The protocol exporter is expected to be primarily a simple
-/// telemetry data encoder and transmitter.
-/// - Allow implementing helpers as composable components that use the same
-/// chainable Exporter interface. SDK authors are encouraged to implement common
-/// functionality such as queuing, batching, tagging, etc. as helpers. This
-/// functionality will be applicable regardless of what protocol exporter is used.
+/// The goal of the interface is to minimize burden of implementation for
+/// protocol-dependent telemetry exporters. The protocol exporter is expected to
+/// be primarily a simple telemetry data encoder and transmitter.
 #[async_trait]
-pub trait SpanExporter: Send + Sync + std::fmt::Debug {
-    /// Exports a batch of telemetry data. Protocol exporters that will implement
-    /// this function are typically expected to serialize and transmit the data
-    /// to the destination.
+pub trait SpanExporter: Send + Sync + Debug {
+    /// Exports a batch of readable spans. Protocol exporters that will
+    /// implement this function are typically expected to serialize and transmit
+    /// the data to the destination.
     ///
     /// This function will never be called concurrently for the same exporter
     /// instance. It can be called again only after the current call returns.
     ///
     /// This function must not block indefinitely, there must be a reasonable
     /// upper limit after which the call must time out with an error result.
-    async fn export(&self, batch: Vec<SpanData>) -> ExportResult;
+    ///
+    /// Any retry logic that is required by the exporter is the responsibility
+    /// of the exporter.
+    async fn export(&mut self, batch: Vec<SpanData>) -> ExportResult;
 
     /// Shuts down the exporter. Called when SDK is shut down. This is an
     /// opportunity for exporter to do any cleanup required.
     ///
-    /// `shutdown` should be called only once for each Exporter instance. After
-    /// the call to `shutdown`, subsequent calls to `SpanExport` are not allowed
-    /// and should return an error.
+    /// This function should be called only once for each `SpanExporter`
+    /// instance. After the call to `shutdown`, subsequent calls to `export` are
+    /// not allowed and should return an error.
     ///
-    /// Shutdown should not block indefinitely (e.g. if it attempts to flush the
-    /// data and the destination is unavailable). SDK authors can
-    /// decide if they want to make the shutdown timeout to be configurable.
+    /// This function should not block indefinitely (e.g. if it attempts to
+    /// flush the data and the destination is unavailable). Language library
+    /// authors can decide if they want to make the shutdown timeout
+    /// configurable.
     fn shutdown(&mut self) {}
 }
 
 /// A minimal interface necessary for export spans over HTTP.
 ///
-/// Users sometime choose http clients that relay on certain runtime. This trait allows users to bring
-/// their choice of http clients.
+/// Users sometime choose http clients that relay on certain runtime. This trait
+/// allows users to bring their choice of http clients.
 #[cfg(feature = "http")]
 #[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 #[async_trait]

--- a/opentelemetry/src/exporter/trace/mod.rs
+++ b/opentelemetry/src/exporter/trace/mod.rs
@@ -27,7 +27,7 @@ pub type ExportResult = Result<(), Box<dyn std::error::Error + Send + Sync + 'st
 /// protocol-dependent telemetry exporters. The protocol exporter is expected to
 /// be primarily a simple telemetry data encoder and transmitter.
 #[async_trait]
-pub trait SpanExporter: Send + Sync + Debug {
+pub trait SpanExporter: Send + Debug {
     /// Exports a batch of readable spans. Protocol exporters that will
     /// implement this function are typically expected to serialize and transmit
     /// the data to the destination.

--- a/opentelemetry/src/exporter/trace/stdout.rs
+++ b/opentelemetry/src/exporter/trace/stdout.rs
@@ -128,7 +128,7 @@ where
     W: Write + Debug + Send + 'static,
 {
     /// Export spans to stdout
-    async fn export(&self, batch: Vec<SpanData>) -> ExportResult {
+    async fn export(&mut self, batch: Vec<SpanData>) -> ExportResult {
         let mut writer = self
             .writer
             .lock()

--- a/opentelemetry/src/testing/trace.rs
+++ b/opentelemetry/src/testing/trace.rs
@@ -1,7 +1,15 @@
 use crate::{
-    trace::{Span, SpanContext, StatusCode},
+    exporter::trace::{self as exporter, ExportResult, SpanExporter},
+    sdk::{
+        trace::{Config, EvictedHashMap, EvictedQueue},
+        InstrumentationLibrary,
+    },
+    trace::{Span, SpanContext, SpanId, SpanKind, StatusCode},
     KeyValue,
 };
+use async_trait::async_trait;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::time::SystemTime;
 
 #[derive(Debug)]
 pub struct TestSpan(pub SpanContext);
@@ -24,4 +32,53 @@ impl Span for TestSpan {
     fn set_status(&self, _code: StatusCode, _message: String) {}
     fn update_name(&self, _new_name: String) {}
     fn end_with_timestamp(&self, _timestamp: std::time::SystemTime) {}
+}
+
+pub fn new_test_export_span_data() -> exporter::SpanData {
+    let config = Config::default();
+    exporter::SpanData {
+        span_context: SpanContext::empty_context(),
+        parent_span_id: SpanId::from_u64(0),
+        span_kind: SpanKind::Internal,
+        name: "opentelemetry".to_string(),
+        start_time: SystemTime::now(),
+        end_time: SystemTime::now(),
+        attributes: EvictedHashMap::new(config.max_attributes_per_span, 0),
+        message_events: EvictedQueue::new(config.max_events_per_span),
+        links: EvictedQueue::new(config.max_links_per_span),
+        status_code: StatusCode::Unset,
+        status_message: "".to_string(),
+        resource: config.resource,
+        instrumentation_lib: InstrumentationLibrary::default(),
+    }
+}
+
+#[derive(Debug)]
+pub struct TestSpanExporter {
+    tx_export: Sender<exporter::SpanData>,
+    tx_shutdown: Sender<()>,
+}
+
+#[async_trait]
+impl SpanExporter for TestSpanExporter {
+    async fn export(&mut self, batch: Vec<exporter::SpanData>) -> ExportResult {
+        for span_data in batch {
+            self.tx_export.send(span_data)?;
+        }
+        Ok(())
+    }
+
+    fn shutdown(&mut self) {
+        self.tx_shutdown.send(()).unwrap();
+    }
+}
+
+pub fn new_test_exporter() -> (TestSpanExporter, Receiver<exporter::SpanData>, Receiver<()>) {
+    let (tx_export, rx_export) = channel();
+    let (tx_shutdown, rx_shutdown) = channel();
+    let exporter = TestSpanExporter {
+        tx_export,
+        tx_shutdown,
+    };
+    (exporter, rx_export, rx_shutdown)
 }


### PR DESCRIPTION
This is a proposal. I think it would make sense to change `&self` in the `SpanExporter::export` function to a `&mut self`. The spec says 

> Export() will never be called concurrently for the same exporter instance. Export() can be called again only after the current call returns.

This change would enforce the restriction at compile time, which is nice.

While doing this change I noticed that the `SimpleSpanProcessor` doesn't adhere to this. It calls `export` in `on_end` without any checks and `on_end` can be called from multiple threads concurrently. I changed it to use a Mutex for now.

As a second step I removed the `Sync` requirement for `SpanExporter`. We can now do this without any problems, because both of it's functions take a `&mut self`. This means the stdout exporter no longer needs an internal Mutex. I'm not entirely sure about this change, though. Is it possible for the spec to have a non-breaking change, that would require us to add `Sync` back (which would be a breaking change)?
