### PR TITLE
Fix parent based sampling in tracer

### DIFF
--- a/opentelemetry/src/api/trace/context.rs
+++ b/opentelemetry/src/api/trace/context.rs
@@ -42,6 +42,11 @@ pub trait TraceContextExt {
     /// ```
     fn span(&self) -> &dyn crate::trace::Span;
 
+    /// Used to see if a span has been marked as active
+    ///
+    /// This is useful for building tracers.
+    fn has_active_span(&self) -> bool;
+
     /// Returns a copy of this context with the span context included.
     ///
     /// This is useful for building propagators.
@@ -69,6 +74,10 @@ impl TraceContextExt for Context {
         } else {
             &*NOOP_SPAN
         }
+    }
+
+    fn has_active_span(&self) -> bool {
+        self.get::<Span>().is_some()
     }
 
     fn with_remote_span_context(&self, span_context: crate::trace::SpanContext) -> Self {

--- a/opentelemetry/src/api/trace/noop.rs
+++ b/opentelemetry/src/api/trace/noop.rs
@@ -150,12 +150,13 @@ impl trace::Tracer for NoopTracer {
             .parent_context
             .take()
             .or_else(|| {
-                Some(cx.span().span_context())
-                    .filter(|sc| sc.is_valid())
-                    .cloned()
+                if cx.has_active_span() {
+                    Some(cx.span().span_context().clone())
+                } else {
+                    None
+                }
             })
-            .or_else(|| cx.remote_span_context().filter(|sc| sc.is_valid()).cloned())
-            .filter(|cx| cx.is_valid());
+            .or_else(|| cx.remote_span_context().cloned());
         if let Some(span_context) = parent_span_context {
             trace::NoopSpan { span_context }
         } else {

--- a/opentelemetry/src/api/trace/span_context.rs
+++ b/opentelemetry/src/api/trace/span_context.rs
@@ -164,7 +164,7 @@ impl TraceState {
     /// assert!(trace_state.is_ok());
     /// assert_eq!(trace_state.unwrap().header(), String::from("foo=bar,apple=banana"))
     /// ```
-    #[allow(clippy::result_unit_err)]
+    #[allow(clippy::all)]
     pub fn from_key_value<T, K, V>(trace_state: T) -> Result<Self, ()>
     where
         T: IntoIterator<Item = (K, V)>,
@@ -210,7 +210,7 @@ impl TraceState {
     /// updated key/value is returned.
     ///
     /// ['spec']: https://www.w3.org/TR/trace-context/#list
-    #[allow(clippy::result_unit_err)]
+    #[allow(clippy::all)]
     pub fn insert(&self, key: String, value: String) -> Result<TraceState, ()> {
         if !TraceState::valid_key(key.as_str()) || !TraceState::valid_value(value.as_str()) {
             return Err(());
@@ -229,7 +229,7 @@ impl TraceState {
     /// with the removed entry is returned.
     ///
     /// ['spec']: https://www.w3.org/TR/trace-context/#list
-    #[allow(clippy::result_unit_err)]
+    #[allow(clippy::all)]
     pub fn delete(&self, key: String) -> Result<TraceState, ()> {
         if !TraceState::valid_key(key.as_str()) {
             return Err(());

--- a/opentelemetry/src/api/trace/span_context.rs
+++ b/opentelemetry/src/api/trace/span_context.rs
@@ -164,6 +164,7 @@ impl TraceState {
     /// assert!(trace_state.is_ok());
     /// assert_eq!(trace_state.unwrap().header(), String::from("foo=bar,apple=banana"))
     /// ```
+    #[allow(clippy::result_unit_err)]
     pub fn from_key_value<T, K, V>(trace_state: T) -> Result<Self, ()>
     where
         T: IntoIterator<Item = (K, V)>,
@@ -209,6 +210,7 @@ impl TraceState {
     /// updated key/value is returned.
     ///
     /// ['spec']: https://www.w3.org/TR/trace-context/#list
+    #[allow(clippy::result_unit_err)]
     pub fn insert(&self, key: String, value: String) -> Result<TraceState, ()> {
         if !TraceState::valid_key(key.as_str()) || !TraceState::valid_value(value.as_str()) {
             return Err(());
@@ -227,6 +229,7 @@ impl TraceState {
     /// with the removed entry is returned.
     ///
     /// ['spec']: https://www.w3.org/TR/trace-context/#list
+    #[allow(clippy::result_unit_err)]
     pub fn delete(&self, key: String) -> Result<TraceState, ()> {
         if !TraceState::valid_key(key.as_str()) {
             return Err(());

--- a/opentelemetry/src/sdk/metrics/aggregators/array.rs
+++ b/opentelemetry/src/sdk/metrics/aggregators/array.rs
@@ -205,7 +205,7 @@ impl Quantile for PointsData {
             return Err(MetricsError::NoDataCollected);
         }
 
-        if q < 0.0 || q > 1.0 {
+        if !(0.0..=1.0).contains(&q) {
             return Err(MetricsError::InvalidQuantile);
         }
 

--- a/opentelemetry/src/sdk/metrics/aggregators/ddsketch.rs
+++ b/opentelemetry/src/sdk/metrics/aggregators/ddsketch.rs
@@ -116,7 +116,7 @@ impl Distribution for DDSKetchAggregator {}
 
 impl Quantile for DDSKetchAggregator {
     fn quantile(&self, q: f64) -> Result<Number> {
-        if q < 0.0 || q > 1.0 {
+        if !(0.0..=1.0).contains(&q) {
             return Err(MetricsError::InvalidQuantile);
         }
         self.inner.read().map_err(From::from).and_then(|inner| {


### PR DESCRIPTION
Currently the sdk `Tracer` implementation will filter out invalid / dropped parent span contexts. This causes the parent based sampler to not function properly as it will then assume that child spans are roots.

This patch resolves this issue by adding a `has_active_span` method to the trace context extension, which allows the tracer to distinguish between invalid and unset parent contexts.

Fixes #351 