### PR TITLE
fix(otlp): propagate Resource from Span to proto

### DIFF
--- a/opentelemetry-otlp/src/transform/traces.rs
+++ b/opentelemetry-otlp/src/transform/traces.rs
@@ -56,9 +56,16 @@ impl From<Link> for Span_Link {
 
 impl From<SpanData> for ResourceSpans {
     fn from(source_span: SpanData) -> Self {
+        let resource_attributes: Attributes = source_span
+            .resource
+            .clone()
+            .iter()
+            .map(|(k, v)| opentelemetry::KeyValue::new(k.clone(), v.clone()))
+            .collect::<Vec<_>>()
+            .into();
         ResourceSpans {
             resource: SingularPtrField::from(Some(Resource {
-                attributes: Default::default(),
+                attributes: resource_attributes.0,
                 dropped_attributes_count: 0,
                 ..Default::default()
             })),

--- a/opentelemetry-otlp/src/transform/traces.rs
+++ b/opentelemetry-otlp/src/transform/traces.rs
@@ -58,7 +58,6 @@ impl From<SpanData> for ResourceSpans {
     fn from(source_span: SpanData) -> Self {
         let resource_attributes: Attributes = source_span
             .resource
-            .clone()
             .iter()
             .map(|(k, v)| opentelemetry::KeyValue::new(k.clone(), v.clone()))
             .collect::<Vec<_>>()


### PR DESCRIPTION
Previously `with_resource` had no effect, because the keys were not being propagated into the ResourceSpan.﻿
