### PR TITLE
feat(otlp): add openssl feature flags for grpcio

### DIFF
--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -27,6 +27,10 @@ grpcio = "0.6"
 opentelemetry = { version = "0.10", default-features = false, features = ["trace"], path = "../opentelemetry" }
 protobuf = "2.18"
 
+[features]
+openssl = ["grpcio/openssl"]
+openssl-vendored = ["grpcio/openssl-vendored"]
+
 [build-dependencies]
 protobuf-codegen = "2.16"
 protoc-grpcio = "2.0"

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -120,3 +120,16 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     Ok(())
 }
 ```
+
+## Feature flags
+
+By default `opentelemetry-otlp` uses `boringssl` for grpc crypto. You can switch
+this to use `openssl` by enabling the `openssl` feature:
+
+```toml
+[dependencies]
+opentelemetry-otlp = { version = "*", features = ["openssl"] }
+```
+
+If you would like to use a vendored `openssl` version, use the `openssl-vendored` feature.
+For more info, see https://github.com/tikv/grpc-rs#feature-openssl-and-openssl-vendored.

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -95,6 +95,18 @@
 //!     Ok(())
 //! }
 //! ```
+//! ## Feature flags
+//! 
+//! By default `opentelemetry-otlp` uses `boringssl` for grpc crypto. You can switch
+//! this to use `openssl` by enabling the `openssl` feature:
+//! 
+//! ```toml
+//! [dependencies]
+//! opentelemetry-otlp = { version = "*", features = ["openssl"] }
+//! ```
+//! 
+//! If you would like to use a vendored `openssl` version, use the `openssl-vendored` feature.
+//! For more info, see https://github.com/tikv/grpc-rs#feature-openssl-and-openssl-vendored.
 #![warn(
     future_incompatible,
     missing_debug_implementations,

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -96,15 +96,15 @@
 //! }
 //! ```
 //! ## Feature flags
-//! 
+//!
 //! By default `opentelemetry-otlp` uses `boringssl` for grpc crypto. You can switch
 //! this to use `openssl` by enabling the `openssl` feature:
-//! 
+//!
 //! ```toml
 //! [dependencies]
 //! opentelemetry-otlp = { version = "*", features = ["openssl"] }
 //! ```
-//! 
+//!
 //! If you would like to use a vendored `openssl` version, use the `openssl-vendored` feature.
 //! For more info, see https://github.com/tikv/grpc-rs#feature-openssl-and-openssl-vendored.
 #![warn(


### PR DESCRIPTION
`grpcio` has an `openssl` and `openssl-vendored` feature to use `openssl` instead of `boringssl`. This PR exposes these features through an `openssl` and `openssl-vendored` feature﻿ in `opentelemetry-otlp`.
