### PR TITLE
Revisit error handling in trace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         override: true
     - name: Run tests
       run: cargo --version &&
-        cargo test --verbose --manifest-path=opentelemetry/Cargo.toml --features trace,metrics,serialize,tokio,async-std,serde,http,tonic,reqwest &&
+        cargo test --verbose --manifest-path=opentelemetry/Cargo.toml --features trace,metrics,serialize,tokio,serde,http,tonic,reqwest &&
         cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml &&
         cargo test --manifest-path=opentelemetry-zipkin/Cargo.toml
   meta:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         override: true
     - name: Run tests
       run: cargo --version &&
-        cargo test --verbose --manifest-path=opentelemetry/Cargo.toml --features trace,metrics,serialize,tokio,serde,http,tonic,reqwest &&
+        cargo test --verbose --manifest-path=opentelemetry/Cargo.toml --features trace,metrics,serialize,tokio,async-std,serde,http,tonic,reqwest &&
         cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml &&
         cargo test --manifest-path=opentelemetry-zipkin/Cargo.toml
   meta:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,13 @@ patterns in the spec.
 For a deeper discussion, see:
 https://github.com/open-telemetry/opentelemetry-specification/issues/165
 
+### Error Handling
+Currently, the Opentelemetry Rust SDK has two ways to handle errors. In the situation where errors are not allowed to return. One should call global error handler to process the errors. Otherwise, one should return the errors. 
+
+The Opentelemetry Rust SDK comes with an error type `openetelemetry::Error`. For different function, one error has been defined. All error returned by trace module MUST be wrapped in `opentelemetry::api::trace::TraceError`. All errors returned by metrics module MUST be wrapped in `opentelemetry::api::trace::MetricsError`. 
+
+For users that want to implement their own exporters. It's RECOMMENDED to wrap all errors from the exporter into a crate-level error type, and implement `ExporterError` trait.  
+
 ## Style Guide
 
 * Run `cargo clippy --all` - this will catch common mistakes and improve

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ https://github.com/open-telemetry/opentelemetry-specification/issues/165
 ### Error Handling
 Currently, the Opentelemetry Rust SDK has two ways to handle errors. In the situation where errors are not allowed to return. One should call global error handler to process the errors. Otherwise, one should return the errors. 
 
-The Opentelemetry Rust SDK comes with an error type `openetelemetry::Error`. For different function, one error has been defined. All error returned by trace module MUST be wrapped in `opentelemetry::api::trace::TraceError`. All errors returned by metrics module MUST be wrapped in `opentelemetry::api::trace::MetricsError`. 
+The Opentelemetry Rust SDK comes with an error type `openetelemetry::Error`. For different function, one error has been defined. All error returned by trace module MUST be wrapped in `opentelemetry::trace::TraceError`. All errors returned by metrics module MUST be wrapped in `opentelemetry::metrics::MetricsError`. 
 
 For users that want to implement their own exporters. It's RECOMMENDED to wrap all errors from the exporter into a crate-level error type, and implement `ExporterError` trait.  
 

--- a/examples/actix-http/src/main.rs
+++ b/examples/actix-http/src/main.rs
@@ -1,17 +1,14 @@
 use actix_service::Service;
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpServer};
+use opentelemetry::trace::TraceError;
 use opentelemetry::{global, sdk::trace as sdktrace};
 use opentelemetry::{
     trace::{FutureExt, TraceContextExt, Tracer},
     Key,
 };
-use opentelemetry::trace::TraceError;
 
-fn init_tracer() -> Result<
-    (sdktrace::Tracer, opentelemetry_jaeger::Uninstall),
-    TraceError
-> {
+fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), TraceError> {
     opentelemetry_jaeger::new_pipeline()
         .with_collector_endpoint("http://127.0.0.1:14268/api/traces")
         .with_service_name("trace-http-demo")

--- a/examples/actix-http/src/main.rs
+++ b/examples/actix-http/src/main.rs
@@ -6,11 +6,11 @@ use opentelemetry::{
     trace::{FutureExt, TraceContextExt, Tracer},
     Key,
 };
-use std::error::Error;
+use opentelemetry::trace::TraceError;
 
 fn init_tracer() -> Result<
     (sdktrace::Tracer, opentelemetry_jaeger::Uninstall),
-    Box<dyn Error + Send + Sync + 'static>,
+    TraceError
 > {
     opentelemetry_jaeger::new_pipeline()
         .with_collector_endpoint("http://127.0.0.1:14268/api/traces")

--- a/examples/actix-udp/src/main.rs
+++ b/examples/actix-udp/src/main.rs
@@ -6,11 +6,11 @@ use opentelemetry::{
     trace::{FutureExt, TraceContextExt, Tracer},
     Key,
 };
-use std::error::Error;
+use opentelemetry::trace::TraceError;
 
 fn init_tracer() -> Result<
     (sdktrace::Tracer, opentelemetry_jaeger::Uninstall),
-    Box<dyn Error + Send + Sync + 'static>,
+    TraceError
 > {
     opentelemetry_jaeger::new_pipeline()
         .with_agent_endpoint("localhost:6831")

--- a/examples/actix-udp/src/main.rs
+++ b/examples/actix-udp/src/main.rs
@@ -1,17 +1,14 @@
 use actix_service::Service;
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpServer};
+use opentelemetry::trace::TraceError;
 use opentelemetry::{global, sdk::trace as sdktrace};
 use opentelemetry::{
     trace::{FutureExt, TraceContextExt, Tracer},
     Key,
 };
-use opentelemetry::trace::TraceError;
 
-fn init_tracer() -> Result<
-    (sdktrace::Tracer, opentelemetry_jaeger::Uninstall),
-    TraceError
-> {
+fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), TraceError> {
     opentelemetry_jaeger::new_pipeline()
         .with_agent_endpoint("localhost:6831")
         .with_service_name("trace-udp-demo")

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -17,6 +17,7 @@
 //!     cargo run --example async_fn
 //!
 //! [`hello_world`]: https://github.com/tokio-rs/tokio/blob/132e9f1da5965530b63554d7a1c59824c3de4e30/tokio/examples/hello_world.rs
+use opentelemetry::trace::TraceError;
 use opentelemetry::{
     global,
     sdk::trace as sdktrace,
@@ -26,7 +27,6 @@ use opentelemetry::{
 use std::{error::Error, io, net::SocketAddr};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
-use opentelemetry::trace::TraceError;
 
 async fn connect(addr: &SocketAddr) -> io::Result<TcpStream> {
     let tracer = global::tracer("connector");
@@ -53,10 +53,7 @@ async fn run(addr: &SocketAddr) -> io::Result<usize> {
     write(&mut stream).with_context(cx).await
 }
 
-fn init_tracer() -> Result<
-    (sdktrace::Tracer, opentelemetry_jaeger::Uninstall),
-    TraceError
-> {
+fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), TraceError> {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("trace-demo")
         .install()

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -26,6 +26,7 @@ use opentelemetry::{
 use std::{error::Error, io, net::SocketAddr};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
+use opentelemetry::trace::TraceError;
 
 async fn connect(addr: &SocketAddr) -> io::Result<TcpStream> {
     let tracer = global::tracer("connector");
@@ -54,7 +55,7 @@ async fn run(addr: &SocketAddr) -> io::Result<usize> {
 
 fn init_tracer() -> Result<
     (sdktrace::Tracer, opentelemetry_jaeger::Uninstall),
-    Box<dyn Error + Send + Sync + 'static>,
+    TraceError
 > {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("trace-demo")

--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -11,14 +11,13 @@ use opentelemetry::{global, sdk::trace as sdktrace};
 use std::error::Error;
 use std::time::Duration;
 
-fn init_tracer(
-) -> Result<(sdktrace::Tracer, opentelemetry_otlp::Uninstall), Box<dyn Error + Send + Sync + 'static>>
+fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_otlp::Uninstall), Box<dyn Error + Send + Sync + 'static>>
 {
-    opentelemetry_otlp::new_pipeline().install()
+    opentelemetry_otlp::new_pipeline().install().map_err::<Box<dyn Error + Send + Sync + 'static>, _>(|err| Box::new(err))
 }
 
 // Skip first immediate tick from tokio, not needed for async_std.
-fn delayed_interval(duration: Duration) -> impl Stream<Item = tokio::time::Instant> {
+fn delayed_interval(duration: Duration) -> impl Stream<Item=tokio::time::Instant> {
     tokio::time::interval(duration).skip(1)
 }
 

--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -10,13 +10,13 @@ use opentelemetry::{
 use opentelemetry::{global, sdk::trace as sdktrace};
 use std::error::Error;
 use std::time::Duration;
+use opentelemetry::trace::TraceError;
 
 fn init_tracer(
-) -> Result<(sdktrace::Tracer, opentelemetry_otlp::Uninstall), Box<dyn Error + Send + Sync + 'static>>
+) -> Result<(sdktrace::Tracer, opentelemetry_otlp::Uninstall), TraceError>
 {
     opentelemetry_otlp::new_pipeline()
         .install()
-        .map_err::<Box<dyn Error + Send + Sync + 'static>, _>(|err| Box::new(err))
 }
 
 // Skip first immediate tick from tokio, not needed for async_std.

--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -1,6 +1,7 @@
 use futures::stream::{Stream, StreamExt};
 use opentelemetry::exporter;
 use opentelemetry::sdk::metrics::PushController;
+use opentelemetry::trace::TraceError;
 use opentelemetry::{
     baggage::BaggageExt,
     metrics::{self, MetricsError, ObserverResult},
@@ -10,13 +11,9 @@ use opentelemetry::{
 use opentelemetry::{global, sdk::trace as sdktrace};
 use std::error::Error;
 use std::time::Duration;
-use opentelemetry::trace::TraceError;
 
-fn init_tracer(
-) -> Result<(sdktrace::Tracer, opentelemetry_otlp::Uninstall), TraceError>
-{
-    opentelemetry_otlp::new_pipeline()
-        .install()
+fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_otlp::Uninstall), TraceError> {
+    opentelemetry_otlp::new_pipeline().install()
 }
 
 // Skip first immediate tick from tokio, not needed for async_std.

--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -11,13 +11,16 @@ use opentelemetry::{global, sdk::trace as sdktrace};
 use std::error::Error;
 use std::time::Duration;
 
-fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_otlp::Uninstall), Box<dyn Error + Send + Sync + 'static>>
+fn init_tracer(
+) -> Result<(sdktrace::Tracer, opentelemetry_otlp::Uninstall), Box<dyn Error + Send + Sync + 'static>>
 {
-    opentelemetry_otlp::new_pipeline().install().map_err::<Box<dyn Error + Send + Sync + 'static>, _>(|err| Box::new(err))
+    opentelemetry_otlp::new_pipeline()
+        .install()
+        .map_err::<Box<dyn Error + Send + Sync + 'static>, _>(|err| Box::new(err))
 }
 
 // Skip first immediate tick from tokio, not needed for async_std.
-fn delayed_interval(duration: Duration) -> impl Stream<Item=tokio::time::Instant> {
+fn delayed_interval(duration: Duration) -> impl Stream<Item = tokio::time::Instant> {
     tokio::time::interval(duration).skip(1)
 }
 

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -2,6 +2,7 @@ use futures::stream::{Stream, StreamExt};
 use opentelemetry::exporter;
 use opentelemetry::global;
 use opentelemetry::sdk::{metrics::PushController, trace as sdktrace};
+use opentelemetry::trace::TraceError;
 use opentelemetry::{
     baggage::BaggageExt,
     metrics::{self, MetricsError, ObserverResult},
@@ -10,12 +11,8 @@ use opentelemetry::{
 };
 use std::error::Error;
 use std::time::Duration;
-use opentelemetry::trace::TraceError;
 
-fn init_tracer() -> Result<
-    (sdktrace::Tracer, opentelemetry_jaeger::Uninstall),
-    TraceError,
-> {
+fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), TraceError> {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("trace-demo")
         .with_tags(vec![

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -10,10 +10,11 @@ use opentelemetry::{
 };
 use std::error::Error;
 use std::time::Duration;
+use opentelemetry::trace::TraceError;
 
 fn init_tracer() -> Result<
     (sdktrace::Tracer, opentelemetry_jaeger::Uninstall),
-    Box<dyn Error + Send + Sync + 'static>,
+    TraceError,
 > {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("trace-demo")

--- a/examples/grpc/src/client.rs
+++ b/examples/grpc/src/client.rs
@@ -2,19 +2,17 @@ use hello_world::greeter_client::GreeterClient;
 use hello_world::HelloRequest;
 use opentelemetry::global;
 use opentelemetry::sdk::propagation::TraceContextPropagator;
+use opentelemetry::trace::TraceError;
 use opentelemetry::{
     trace::{TraceContextExt, Tracer},
     Context, KeyValue,
 };
-use opentelemetry::trace::TraceError;
 
 pub mod hello_world {
     tonic::include_proto!("helloworld");
 }
 
-fn tracing_init(
-) -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall),TraceError>
-{
+fn tracing_init() -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall), TraceError> {
     global::set_text_map_propagator(TraceContextPropagator::new());
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("grpc-client")

--- a/examples/grpc/src/client.rs
+++ b/examples/grpc/src/client.rs
@@ -6,14 +6,14 @@ use opentelemetry::{
     trace::{TraceContextExt, Tracer},
     Context, KeyValue,
 };
-use std::error::Error;
+use opentelemetry::trace::TraceError;
 
 pub mod hello_world {
     tonic::include_proto!("helloworld");
 }
 
 fn tracing_init(
-) -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error + Send + Sync + 'static>>
+) -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall),TraceError>
 {
     global::set_text_map_propagator(TraceContextPropagator::new());
     opentelemetry_jaeger::new_pipeline()

--- a/examples/grpc/src/server.rs
+++ b/examples/grpc/src/server.rs
@@ -9,6 +9,7 @@ use opentelemetry::{
     KeyValue,
 };
 use std::error::Error;
+use opentelemetry::trace::TraceError;
 
 pub mod hello_world {
     tonic::include_proto!("helloworld"); // The string specified here must match the proto package name.
@@ -37,7 +38,7 @@ impl Greeter for MyGreeter {
 }
 
 fn tracing_init(
-) -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall), Box<dyn Error + Send + Sync + 'static>>
+) -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall), TraceError>
 {
     global::set_text_map_propagator(TraceContextPropagator::new());
     opentelemetry_jaeger::new_pipeline()

--- a/examples/grpc/src/server.rs
+++ b/examples/grpc/src/server.rs
@@ -4,12 +4,12 @@ use hello_world::greeter_server::{Greeter, GreeterServer};
 use hello_world::{HelloReply, HelloRequest};
 use opentelemetry::global;
 use opentelemetry::sdk::propagation::TraceContextPropagator;
+use opentelemetry::trace::TraceError;
 use opentelemetry::{
     trace::{Span, Tracer},
     KeyValue,
 };
 use std::error::Error;
-use opentelemetry::trace::TraceError;
 
 pub mod hello_world {
     tonic::include_proto!("helloworld"); // The string specified here must match the proto package name.
@@ -37,9 +37,7 @@ impl Greeter for MyGreeter {
     }
 }
 
-fn tracing_init(
-) -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall), TraceError>
-{
+fn tracing_init() -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall), TraceError> {
     global::set_text_map_propagator(TraceContextPropagator::new());
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("grpc-server")

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 base64_format = ["base64", "binary_propagator"]
 binary_propagator = []
-datadog = ["indexmap", "rmp", "async-trait"]
+datadog = ["indexmap", "rmp", "async-trait", "thiserror"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry/reqwest"]
 surf-client = ["surf", "opentelemetry/surf"]
@@ -37,6 +37,7 @@ reqwest = { version = "0.10", optional = true }
 surf = { version = "2.0", optional = true }
 http = "0.2"
 base64 = { version = "0.13", optional = true }
+thiserror = { version = "1.0", optional = true }
 
 [dev-dependencies]
 base64 = "0.13"

--- a/opentelemetry-contrib/src/trace/exporter/datadog/mod.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/mod.rs
@@ -129,8 +129,8 @@ use async_trait::async_trait;
 use http::{Method, Request, Uri};
 use opentelemetry::exporter::trace;
 use opentelemetry::exporter::trace::{HttpClient, SpanData};
-use opentelemetry::{global, sdk, trace::TracerProvider};
 use opentelemetry::trace::TraceError;
+use opentelemetry::{global, sdk, trace::TracerProvider};
 
 /// Default Datadog collector endpoint
 const DEFAULT_AGENT_ENDPOINT: &str = "http://127.0.0.1:8126";
@@ -211,9 +211,7 @@ impl Default for DatadogPipelineBuilder {
 
 impl DatadogPipelineBuilder {
     /// Create `ExporterConfig` struct from current `ExporterConfigBuilder`
-    pub fn install(
-        mut self,
-    ) -> Result<(sdk::trace::Tracer, Uninstall), TraceError> {
+    pub fn install(mut self) -> Result<(sdk::trace::Tracer, Uninstall), TraceError> {
         if let Some(client) = self.client {
             let endpoint = self.agent_endpoint + self.version.path();
             let exporter = DatadogExporter::new(
@@ -280,7 +278,8 @@ impl trace::SpanExporter for DatadogExporter {
             .method(Method::POST)
             .uri(self.request_url.clone())
             .header(http::header::CONTENT_TYPE, self.version.content_type())
-            .body(data).map_err::<Error, _>(Into::into)?;
+            .body(data)
+            .map_err::<Error, _>(Into::into)?;
         self.client.send(req).await
     }
 }

--- a/opentelemetry-contrib/src/trace/exporter/datadog/mod.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/mod.rs
@@ -76,7 +76,7 @@
 //! use opentelemetry::exporter::trace::HttpClient;
 //! use opentelemetry_contrib::trace::exporter::datadog::{new_pipeline, ApiVersion};
 //! use async_trait::async_trait;
-//! use std::error::Error;
+//! use opentelemetry_contrib::trace::exporter::datadog::Error;
 //!
 //! // `reqwest` and `surf` are supported through features, if you prefer an
 //! // alternate http client you can add support by implementing `HttpClient` as
@@ -87,12 +87,12 @@
 //! #[async_trait]
 //! impl HttpClient for IsahcClient {
 //!   async fn send(&self, request: http::Request<Vec<u8>>) -> ExportResult {
-//!     let result = self.0.send_async(request).await?;
+//!     let result = self.0.send_async(request).await.map_err(|err| Error::Other(err.to_string()))?;
 //!
 //!     if result.status().is_success() {
 //!       Ok(())
 //!     } else {
-//!       Err(result.status().as_str().into())
+//!       Err(Error::Other(result.status().to_string()).into())
 //!     }
 //!   }
 //! }
@@ -123,6 +123,7 @@ mod intern;
 mod model;
 
 pub use model::ApiVersion;
+pub use model::Error;
 
 use async_trait::async_trait;
 use http::{Method, Request, Uri};
@@ -130,7 +131,6 @@ use opentelemetry::exporter::trace;
 use opentelemetry::exporter::trace::{HttpClient, SpanData};
 use opentelemetry::{global, sdk, trace::TracerProvider};
 use opentelemetry::trace::TraceError;
-use crate::trace::exporter::datadog::model::Error;
 
 /// Default Datadog collector endpoint
 const DEFAULT_AGENT_ENDPOINT: &str = "http://127.0.0.1:8126";

--- a/opentelemetry-contrib/src/trace/exporter/datadog/mod.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/mod.rs
@@ -98,7 +98,7 @@
 //! }
 //!
 //! fn main() -> Result<(), opentelemetry::trace::TraceError> {
-//! let (tracer, _uninstall) = new_pipeline()
+//!     let (tracer, _uninstall) = new_pipeline()
 //!         .with_service_name("my_app")
 //!         .with_version(ApiVersion::Version05)
 //!         .with_agent_endpoint("http://localhost:8126")

--- a/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
@@ -6,12 +6,19 @@ use http::uri::InvalidUri;
 mod v03;
 mod v05;
 
+/// Wrap type for errors from opentelemetry datadog exporter
 #[derive(Debug)]
-pub(crate) enum Error {
+pub enum Error {
+    /// Message pack error
     MessagePackError,
+    /// No http client founded. User should provide one or enbale features
     NoHttpClient,
+    /// Http requests failed with following errors
     RequestError(http::Error),
-    InvalidUri(http::uri::InvalidUri)
+    /// The Uri was invalid.
+    InvalidUri(http::uri::InvalidUri),
+    /// Other errors
+    Other(String),
 }
 
 impl std::error::Error for Error {}
@@ -29,17 +36,18 @@ impl fmt::Display for Error {
             Error::NoHttpClient => write!(f, "http client must be set, users can enable reqwest or surf feature to use http client implementation within create"),
             Error::RequestError(err) => write!(f, "{}", err),
             Error::InvalidUri(err) => write!(f, "{}", err),
+            Error::Other(msg) => write!(f, "{}", msg)
         }
     }
 }
 
-impl From<http::uri::InvalidUri> for Error{
+impl From<http::uri::InvalidUri> for Error {
     fn from(err: InvalidUri) -> Self {
         Error::InvalidUri(err)
     }
 }
 
-impl From<http::Error> for Error{
+impl From<http::Error> for Error {
     fn from(err: http::Error) -> Self {
         Error::RequestError(err)
     }

--- a/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
@@ -1,7 +1,7 @@
-use opentelemetry::exporter::trace;
-use std::fmt;
-use opentelemetry::exporter::trace::ExportError;
 use http::uri::InvalidUri;
+use opentelemetry::exporter::trace;
+use opentelemetry::exporter::trace::ExportError;
+use std::fmt;
 
 mod v03;
 mod v05;
@@ -52,7 +52,6 @@ impl From<http::Error> for Error {
         Error::RequestError(err)
     }
 }
-
 
 impl From<rmp::encode::ValueWriteError> for Error {
     fn from(_: rmp::encode::ValueWriteError) -> Self {

--- a/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
@@ -1,5 +1,4 @@
-use opentelemetry::exporter::trace;
-use opentelemetry::exporter::trace::ExportError;
+use opentelemetry::exporter::{trace, ExportError};
 
 mod v03;
 mod v05;

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -27,6 +27,7 @@ isahc = { version = "0.9", default-features = false, optional = true }
 opentelemetry = { version = "0.10", default-features = false, features = ["trace"], path = "../opentelemetry" }
 thrift = "0.13"
 tokio = { version = "0.2", features = ["udp", "sync"], optional = true }
+thiserror = "1.0"
 
 [features]
 default = []

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -165,17 +165,17 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 #![warn(
-future_incompatible,
-missing_debug_implementations,
-missing_docs,
-nonstandard_style,
-rust_2018_idioms,
-unreachable_pub,
-unused
+    future_incompatible,
+    missing_debug_implementations,
+    missing_docs,
+    nonstandard_style,
+    rust_2018_idioms,
+    unreachable_pub,
+    unused
 )]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
 #![doc(
-html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/master/assets/logo.svg"
+    html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/master/assets/logo.svg"
 )]
 #![cfg_attr(test, deny(warnings))]
 
@@ -194,6 +194,7 @@ use agent::AgentAsyncClientUDP;
 use async_trait::async_trait;
 #[cfg(feature = "collector_client")]
 use collector::CollectorAsyncClientHttp;
+use opentelemetry::exporter::trace::ExportError;
 use opentelemetry::{
     exporter::trace,
     global, sdk,
@@ -205,7 +206,6 @@ use std::{
     time::{Duration, SystemTime},
 };
 use uploader::BatchUploader;
-use opentelemetry::exporter::trace::ExportError;
 
 /// Default service name if no service is configured.
 const DEFAULT_SERVICE_NAME: &str = "OpenTelemetry";
@@ -357,8 +357,8 @@ impl PipelineBuilder {
     #[cfg(feature = "collector_client")]
     #[cfg_attr(docsrs, doc(cfg(feature = "collector_client")))]
     pub fn with_collector_endpoint<T>(self, collector_endpoint: T) -> Self
-        where
-            http::Uri: core::convert::TryFrom<T>,
+    where
+        http::Uri: core::convert::TryFrom<T>,
     {
         PipelineBuilder {
             collector_endpoint: core::convert::TryFrom::try_from(collector_endpoint).ok(),
@@ -393,7 +393,7 @@ impl PipelineBuilder {
     }
 
     /// Assign the process service tags.
-    pub fn with_tags<T: IntoIterator<Item=KeyValue>>(mut self, tags: T) -> Self {
+    pub fn with_tags<T: IntoIterator<Item = KeyValue>>(mut self, tags: T) -> Self {
         self.process.tags = tags.into_iter().collect();
         self
     }
@@ -409,7 +409,8 @@ impl PipelineBuilder {
     /// Install a Jaeger pipeline with the recommended defaults.
     pub fn install(
         self,
-    ) -> Result<(sdk::trace::Tracer, Uninstall), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    ) -> Result<(sdk::trace::Tracer, Uninstall), Box<dyn std::error::Error + Send + Sync + 'static>>
+    {
         let tracer_provider = self.build()?;
         let tracer =
             tracer_provider.get_tracer("opentelemetry-jaeger", Some(env!("CARGO_PKG_VERSION")));
@@ -422,7 +423,8 @@ impl PipelineBuilder {
     /// Build a configured `sdk::trace::TracerProvider` with the recommended defaults.
     pub fn build(
         mut self,
-    ) -> Result<sdk::trace::TracerProvider, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    ) -> Result<sdk::trace::TracerProvider, Box<dyn std::error::Error + Send + Sync + 'static>>
+    {
         let config = self.config.take();
         let exporter = self.init_exporter()?;
 
@@ -438,7 +440,9 @@ impl PipelineBuilder {
     /// Initialize a new exporter.
     ///
     /// This is useful if you are manually constructing a pipeline.
-    pub fn init_exporter(self) -> Result<Exporter, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    pub fn init_exporter(
+        self,
+    ) -> Result<Exporter, Box<dyn std::error::Error + Send + Sync + 'static>> {
         let export_instrumentation_lib = self.export_instrument_library;
         let (process, uploader) = self.init_uploader()?;
 
@@ -460,7 +464,10 @@ impl PipelineBuilder {
     #[cfg(feature = "collector_client")]
     fn init_uploader(
         self,
-    ) -> Result<(Process, uploader::BatchUploader), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    ) -> Result<
+        (Process, uploader::BatchUploader),
+        Box<dyn std::error::Error + Send + Sync + 'static>,
+    > {
         if let Some(collector_endpoint) = self.collector_endpoint {
             let collector = CollectorAsyncClientHttp::new(
                 collector_endpoint,
@@ -587,7 +594,7 @@ fn convert_otel_span_into_jaeger_span(
 
 fn build_process_tags(
     span_data: &trace::SpanData,
-) -> Option<impl Iterator<Item=jaeger::Tag> + '_> {
+) -> Option<impl Iterator<Item = jaeger::Tag> + '_> {
     if span_data.resource.is_empty() {
         None
     } else {
@@ -683,7 +690,7 @@ fn events_to_logs(events: sdk::trace::EvictedQueue<Event>) -> Option<Vec<jaeger:
 pub enum Error {
     /// Error from thrift agents.
     #[error("thrift agent failed with {0}")]
-    ThriftAgentError(#[from] ::thrift::Error)
+    ThriftAgentError(#[from] ::thrift::Error),
 }
 
 impl ExportError for Error {

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -428,10 +428,7 @@ impl PipelineBuilder {
     }
 
     /// Build a configured `sdk::trace::TracerProvider` with the recommended defaults.
-    pub fn build(
-        mut self,
-    ) -> Result<sdk::trace::TracerProvider, Box<dyn std::error::Error + Send + Sync + 'static>>
-    {
+    pub fn build(mut self) -> Result<sdk::trace::TracerProvider, TraceError> {
         let config = self.config.take();
         let exporter = self.init_exporter()?;
 

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -206,6 +206,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use uploader::BatchUploader;
+use opentelemetry::trace::TraceError;
 
 /// Default service name if no service is configured.
 const DEFAULT_SERVICE_NAME: &str = "OpenTelemetry";
@@ -409,7 +410,7 @@ impl PipelineBuilder {
     /// Install a Jaeger pipeline with the recommended defaults.
     pub fn install(
         self,
-    ) -> Result<(sdk::trace::Tracer, Uninstall), Box<dyn std::error::Error + Send + Sync + 'static>>
+    ) -> Result<(sdk::trace::Tracer, Uninstall), TraceError>
     {
         let tracer_provider = self.build()?;
         let tracer =

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -22,7 +22,7 @@
 //! ```no_run
 //! use opentelemetry::trace::Tracer;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! fn main() -> Result<(), opentelemetry::trace::TraceError> {
 //!     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline().install()?;
 //!
 //!     tracer.in_span("doing_work", |cx| {
@@ -59,9 +59,9 @@
 //! [jaeger variables spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md#jaeger-exporter
 //!
 //! ```no_run
-//! use opentelemetry::trace::Tracer;
+//! use opentelemetry::trace::{Tracer, TraceError};
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! fn main() -> Result<(), TraceError> {
 //!     // export OTEL_SERVICE_NAME=my-service-name
 //!     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline().from_env().install()?;
 //!
@@ -90,9 +90,9 @@
 //!
 //! ```ignore
 //! // Note that this requires the `collector_client` feature.
-//! use opentelemetry::trace::Tracer;
+//! use opentelemetry::trace::{Tracer, TraceError};
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! fn main() -> Result<(), TraceError> {
 //!     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
 //!         .with_collector_endpoint("http://localhost:14268/api/traces")
 //!         // optionally set username and password as well.
@@ -116,10 +116,10 @@
 //! [`PipelineBuilder`]: struct.PipelineBuilder.html
 //!
 //! ```no_run
-//! use opentelemetry::{KeyValue, trace::Tracer};
+//! use opentelemetry::{KeyValue, trace::{Tracer, TraceError}};
 //! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! fn main() -> Result<(), TraceError> {
 //!     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
 //!         .from_env()
 //!         .with_agent_endpoint("localhost:6831")
@@ -444,9 +444,7 @@ impl PipelineBuilder {
     /// Initialize a new exporter.
     ///
     /// This is useful if you are manually constructing a pipeline.
-    pub fn init_exporter(
-        self,
-    ) -> Result<Exporter, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    pub fn init_exporter(self) -> Result<Exporter, TraceError> {
         let export_instrumentation_lib = self.export_instrument_library;
         let (process, uploader) = self.init_uploader()?;
 
@@ -458,30 +456,25 @@ impl PipelineBuilder {
     }
 
     #[cfg(not(any(feature = "collector_client", feature = "wasm_collector_client")))]
-    fn init_uploader(
-        self,
-    ) -> Result<(Process, BatchUploader), Box<dyn std::error::Error + Send + Sync + 'static>> {
-        let agent = AgentAsyncClientUDP::new(self.agent_endpoint.as_slice())?;
+    fn init_uploader(self) -> Result<(Process, BatchUploader), TraceError> {
+        let agent = AgentAsyncClientUDP::new(self.agent_endpoint.as_slice())
+            .map_err::<Error, _>(Into::into)?;
         Ok((self.process, BatchUploader::Agent(agent)))
     }
 
     #[cfg(any(feature = "collector_client", feature = "wasm_collector_client"))]
-    fn init_uploader(
-        self,
-    ) -> Result<
-        (Process, uploader::BatchUploader),
-        Box<dyn std::error::Error + Send + Sync + 'static>,
-    > {
+    fn init_uploader(self) -> Result<(Process, uploader::BatchUploader), TraceError> {
         if let Some(collector_endpoint) = self.collector_endpoint {
             let collector = CollectorAsyncClientHttp::new(
                 collector_endpoint,
                 self.collector_username,
                 self.collector_password,
-            )?;
+            )
+            .map_err::<Error, _>(Into::into)?;
             Ok((self.process, uploader::BatchUploader::Collector(collector)))
         } else {
             let endpoint = self.agent_endpoint.as_slice();
-            let agent = AgentAsyncClientUDP::new(endpoint)?;
+            let agent = AgentAsyncClientUDP::new(endpoint).map_err::<Error, _>(Into::into)?;
             Ok((self.process, BatchUploader::Agent(agent)))
         }
     }

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -194,7 +194,8 @@ use agent::AgentAsyncClientUDP;
 use async_trait::async_trait;
 #[cfg(any(feature = "collector_client", feature = "wasm_collector_client"))]
 use collector::CollectorAsyncClientHttp;
-use opentelemetry::exporter::trace::ExportError;
+use opentelemetry::exporter::ExportError;
+use opentelemetry::trace::TraceError;
 use opentelemetry::{
     exporter::trace,
     global, sdk,
@@ -206,7 +207,6 @@ use std::{
     time::{Duration, SystemTime},
 };
 use uploader::BatchUploader;
-use opentelemetry::trace::TraceError;
 
 /// Default service name if no service is configured.
 const DEFAULT_SERVICE_NAME: &str = "OpenTelemetry";
@@ -417,10 +417,7 @@ impl PipelineBuilder {
     }
 
     /// Install a Jaeger pipeline with the recommended defaults.
-    pub fn install(
-        self,
-    ) -> Result<(sdk::trace::Tracer, Uninstall), TraceError>
-    {
+    pub fn install(self) -> Result<(sdk::trace::Tracer, Uninstall), TraceError> {
         let tracer_provider = self.build()?;
         let tracer =
             tracer_provider.get_tracer("opentelemetry-jaeger", Some(env!("CARGO_PKG_VERSION")));

--- a/opentelemetry-jaeger/src/uploader.rs
+++ b/opentelemetry-jaeger/src/uploader.rs
@@ -20,14 +20,14 @@ impl BatchUploader {
         match self {
             BatchUploader::Agent(client) => {
                 // TODO Implement retry behaviour
-                client.emit_batch(batch).await?;
+                client.emit_batch(batch).await.map_err::<crate::Error, _>(Into::into)?;
             }
             #[cfg(feature = "collector_client")]
             BatchUploader::Collector(collector) => {
                 // TODO Implement retry behaviour
-                collector.submit_batch(batch).await?;
+                collector.submit_batch(batch).await.map_err::<crate::Error, _>(Into::into)?;
             }
-        };
+        }
         Ok(())
     }
 }

--- a/opentelemetry-jaeger/src/uploader.rs
+++ b/opentelemetry-jaeger/src/uploader.rs
@@ -20,12 +20,18 @@ impl BatchUploader {
         match self {
             BatchUploader::Agent(client) => {
                 // TODO Implement retry behaviour
-                client.emit_batch(batch).await.map_err::<crate::Error, _>(Into::into)?;
+                client
+                    .emit_batch(batch)
+                    .await
+                    .map_err::<crate::Error, _>(Into::into)?;
             }
             #[cfg(feature = "collector_client")]
             BatchUploader::Collector(collector) => {
                 // TODO Implement retry behaviour
-                collector.submit_batch(batch).await.map_err::<crate::Error, _>(Into::into)?;
+                collector
+                    .submit_batch(batch)
+                    .await
+                    .map_err::<crate::Error, _>(Into::into)?;
             }
         }
         Ok(())

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -26,6 +26,7 @@ futures = "0.3"
 grpcio = "0.6"
 opentelemetry = { version = "0.10", default-features = false, features = ["trace"], path = "../opentelemetry" }
 protobuf = "2.18"
+thiserror = "1.0"
 
 [features]
 openssl = ["grpcio/openssl"]

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -131,8 +131,8 @@ mod span;
 mod transform;
 
 pub use crate::span::{Compression, Credentials, Exporter, ExporterConfig, Protocol};
-use opentelemetry::trace::TraceError;
 use opentelemetry::exporter::trace::ExportError;
+use opentelemetry::trace::TraceError;
 
 /// Create a new pipeline builder with the recommended configuration.
 ///
@@ -216,9 +216,7 @@ impl OtlpPipelineBuilder {
     }
 
     /// Install the OTLP exporter pipeline with the recommended defaults.
-    pub fn install(
-        mut self,
-    ) -> Result<(sdk::trace::Tracer, Uninstall), TraceError> {
+    pub fn install(mut self) -> Result<(sdk::trace::Tracer, Uninstall), TraceError> {
         let exporter = Exporter::new(self.exporter_config);
 
         let mut provider_builder = sdk::trace::TracerProvider::builder().with_exporter(exporter);
@@ -239,15 +237,15 @@ pub struct Uninstall(global::TracerProviderGuard);
 
 /// Wrap type for errors from opentelemetry otel
 #[derive(thiserror::Error, Debug)]
-pub enum Error{
+pub enum Error {
     // FIXME: wait until https://github.com/open-telemetry/opentelemetry-rust/pull/352 merged
     /// Error from grpcio module
     #[error("grpcio error {0}")]
-    Grpcio(#[from] grpcio::Error)
+    Grpcio(#[from] grpcio::Error),
 }
 
 impl ExportError for Error {
-    fn exporter_name(&self) -> &'static str{
+    fn exporter_name(&self) -> &'static str {
         "otel"
     }
 }

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -131,7 +131,7 @@ mod span;
 mod transform;
 
 pub use crate::span::{Compression, Credentials, Exporter, ExporterConfig, Protocol};
-use opentelemetry::exporter::trace::ExportError;
+use opentelemetry::exporter::ExportError;
 use opentelemetry::trace::TraceError;
 
 /// Create a new pipeline builder with the recommended configuration.

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -246,6 +246,6 @@ pub enum Error {
 
 impl ExportError for Error {
     fn exporter_name(&self) -> &'static str {
-        "otel"
+        "otlp"
     }
 }

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -167,9 +167,9 @@ impl SpanExporter for Exporter {
 
         let receiver = self
             .trace_exporter
-            .export_async_opt(&request, call_options).map_err::<crate::Error, _>(Into::into)?;
+            .export_async_opt(&request, call_options)
+            .map_err::<crate::Error, _>(Into::into)?;
         receiver.await.map_err::<crate::Error, _>(Into::into)?;
         Ok(())
     }
 }
-

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -167,8 +167,9 @@ impl SpanExporter for Exporter {
 
         let receiver = self
             .trace_exporter
-            .export_async_opt(&request, call_options)?;
-        receiver.await?;
+            .export_async_opt(&request, call_options).map_err::<crate::Error, _>(Into::into)?;
+        receiver.await.map_err::<crate::Error, _>(Into::into)?;
         Ok(())
     }
 }
+

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -35,6 +35,7 @@ lazy_static = "1.4"
 http = "0.2"
 reqwest = { version = "0.10", optional = true }
 surf = { version = "2.0", optional = true }
+thiserror = { version = "1.0"}
 
 [dev-dependencies]
 isahc = "=0.9.6"

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -90,12 +90,12 @@
 //! #[async_trait]
 //! impl HttpClient for IsahcClient {
 //!   async fn send(&self, request: http::Request<Vec<u8>>) -> ExportResult {
-//!     let result = self.0.send_async(request).await?;
+//!     let result = self.0.send_async(request).await.map_err(|err| opentelemetry_zipkin::Error::Other(err.to_string()))?;
 //!
 //!     if result.status().is_success() {
 //!       Ok(())
 //!     } else {
-//!       Err(result.status().as_str().into())
+//!       Err(opentelemetry_zipkin::Error::Other(result.status().to_string()).into())
 //!     }
 //!   }
 //! }

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -148,17 +148,17 @@
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
 #![warn(
-    future_incompatible,
-    missing_debug_implementations,
-    missing_docs,
-    nonstandard_style,
-    rust_2018_idioms,
-    unreachable_pub,
-    unused
+future_incompatible,
+missing_debug_implementations,
+missing_docs,
+nonstandard_style,
+rust_2018_idioms,
+unreachable_pub,
+unused
 )]
 #![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/master/assets/logo.svg"
+html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/master/assets/logo.svg"
 )]
 #![cfg_attr(test, deny(warnings))]
 
@@ -171,11 +171,10 @@ mod uploader;
 use async_trait::async_trait;
 use http::Uri;
 use model::endpoint::Endpoint;
-use opentelemetry::exporter::trace::HttpClient;
+use opentelemetry::exporter::trace::{HttpClient, ExportError};
 use opentelemetry::{exporter::trace, global, sdk, trace::TracerProvider};
-use std::error::Error;
-use std::io;
 use std::net::SocketAddr;
+use opentelemetry::trace::TraceError;
 
 /// Default Zipkin collector endpoint
 const DEFAULT_COLLECTOR_ENDPOINT: &str = "http://127.0.0.1:9411/api/v2/spans";
@@ -220,21 +219,21 @@ impl Default for ZipkinPipelineBuilder {
             #[cfg(feature = "reqwest-blocking-client")]
             client: Some(Box::new(reqwest::blocking::Client::new())),
             #[cfg(all(
-                not(feature = "reqwest-blocking-client"),
-                not(feature = "surf-client"),
-                feature = "reqwest-client"
+            not(feature = "reqwest-blocking-client"),
+            not(feature = "surf-client"),
+            feature = "reqwest-client"
             ))]
             client: Some(Box::new(reqwest::Client::new())),
             #[cfg(all(
-                not(feature = "reqwest-client"),
-                not(feature = "reqwest-blocking-client"),
-                feature = "surf-client"
+            not(feature = "reqwest-client"),
+            not(feature = "reqwest-blocking-client"),
+            feature = "surf-client"
             ))]
             client: Some(Box::new(surf::Client::new())),
             #[cfg(all(
-                not(feature = "reqwest-client"),
-                not(feature = "surf-client"),
-                not(feature = "reqwest-blocking-client")
+            not(feature = "reqwest-client"),
+            not(feature = "surf-client"),
+            not(feature = "reqwest-blocking-client")
             ))]
             client: None,
 
@@ -250,10 +249,10 @@ impl ZipkinPipelineBuilder {
     /// Create `ExporterConfig` struct from current `ExporterConfigBuilder`
     pub fn install(
         mut self,
-    ) -> Result<(sdk::trace::Tracer, Uninstall), Box<dyn Error + Send + Sync + 'static>> {
+    ) -> Result<(sdk::trace::Tracer, Uninstall), TraceError> {
         if let Some(client) = self.client {
             let endpoint = Endpoint::new(self.service_name, self.service_addr);
-            let exporter = Exporter::new(endpoint, client, self.collector_endpoint.parse()?);
+            let exporter = Exporter::new(endpoint, client, self.collector_endpoint.parse().map_err::<Error, _>(Into::into)?);
 
             let mut provider_builder =
                 sdk::trace::TracerProvider::builder().with_exporter(exporter);
@@ -267,11 +266,7 @@ impl ZipkinPipelineBuilder {
 
             Ok((tracer, Uninstall(provider_guard)))
         } else {
-            Err(Box::new(io::Error::new(
-                io::ErrorKind::Other,
-                "http client must be set, users can enable reqwest or surf feature to use http \
-                    client implementation within create",
-            )))
+            Err(Error::NoHttpClient.into())
         }
     }
 
@@ -322,3 +317,30 @@ impl trace::SpanExporter for Exporter {
 /// Uninstalls the Zipkin pipeline on drop.
 #[derive(Debug)]
 pub struct Uninstall(global::TracerProviderGuard);
+
+/// Wrap type for errors from opentelemetry zipkin
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// No http client implementation found. User should provide one or enable features.
+    #[error("http client must be set, users can enable reqwest or surf feature to use http client implementation within create")]
+    NoHttpClient,
+
+    /// Http requests failed
+    #[error("http request failed with {0}")]
+    RequestFailed(#[from] http::Error),
+
+    /// The uri provided is invalid
+    #[error("invalid uri")]
+    InvalidUri(#[from] http::uri::InvalidUri),
+
+    /// Other errors
+    #[error("export error: {0}")]
+    Other(String),
+}
+
+impl ExportError for Error {
+    fn exporter_name(&self) -> &'static str {
+        "zipkin"
+    }
+}

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -171,9 +171,14 @@ mod uploader;
 use async_trait::async_trait;
 use http::Uri;
 use model::endpoint::Endpoint;
-use opentelemetry::exporter::trace::{ExportError, HttpClient};
-use opentelemetry::trace::TraceError;
-use opentelemetry::{exporter::trace, global, sdk, trace::TracerProvider};
+use opentelemetry::{
+    exporter::{
+        trace::{self, HttpClient},
+        ExportError,
+    },
+    global, sdk,
+    trace::{TraceError, TracerProvider},
+};
 use std::net::SocketAddr;
 
 /// Default Zipkin collector endpoint

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -21,9 +21,9 @@
 //! telemetry:
 //!
 //! ```no_run
-//! use opentelemetry::trace::Tracer;
+//! use opentelemetry::trace::{Tracer, TraceError};
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! fn main() -> Result<(), TraceError> {
 //!     let (tracer, _uninstall) = opentelemetry_zipkin::new_pipeline().install()?;
 //!
 //!     tracer.in_span("doing_work", |cx| {

--- a/opentelemetry-zipkin/src/uploader.rs
+++ b/opentelemetry-zipkin/src/uploader.rs
@@ -1,9 +1,9 @@
 //! # Zipkin Span Exporter
 use crate::model::span::Span;
+use crate::Error;
 use http::{header::CONTENT_TYPE, Method, Request, Uri};
 use opentelemetry::exporter::trace::{ExportResult, HttpClient};
 use std::fmt::Debug;
-use crate::Error;
 
 #[derive(Debug)]
 pub(crate) enum Uploader {
@@ -39,7 +39,8 @@ impl JsonV2Client {
             .method(Method::POST)
             .uri(self.collector_endpoint.clone())
             .header(CONTENT_TYPE, "application/json")
-            .body(serde_json::to_vec(&spans).unwrap_or_default()).map_err::<Error, _>(Into::into)?;
+            .body(serde_json::to_vec(&spans).unwrap_or_default())
+            .map_err::<Error, _>(Into::into)?;
         self.client.send(req).await
     }
 }

--- a/opentelemetry-zipkin/src/uploader.rs
+++ b/opentelemetry-zipkin/src/uploader.rs
@@ -3,6 +3,7 @@ use crate::model::span::Span;
 use http::{header::CONTENT_TYPE, Method, Request, Uri};
 use opentelemetry::exporter::trace::{ExportResult, HttpClient};
 use std::fmt::Debug;
+use crate::Error;
 
 #[derive(Debug)]
 pub(crate) enum Uploader {
@@ -38,7 +39,7 @@ impl JsonV2Client {
             .method(Method::POST)
             .uri(self.collector_endpoint.clone())
             .header(CONTENT_TYPE, "application/json")
-            .body(serde_json::to_vec(&spans).unwrap_or_default())?;
+            .body(serde_json::to_vec(&spans).unwrap_or_default()).map_err::<Error, _>(Into::into)?;
         self.client.send(req).await
     }
 }

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -22,7 +22,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-std = { version = "1.6", features = ["unstable"], default-features = false, optional = true }
-async-io = { version = "~1.2.0", optional = true }
 async-trait = { version = "0.1", optional = true }
 bincode = { version = "1.2", optional = true }
 dashmap = { version = "4.0.0-rc6", optional = true }
@@ -48,7 +47,6 @@ js-sys = "0.3"
 criterion = "0.3.1"
 rand_distr = "0.3.0"
 tokio = { version = "0.2", features = ["full"] }
-async-std = { version = "1.6", features = ["unstable"] }
 
 [features]
 default = ["trace"]

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -22,6 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-std = { version = "1.6", features = ["unstable"], default-features = false, optional = true }
+async-io = { version = "~1.2.0", optional = true }
 async-trait = { version = "0.1", optional = true }
 bincode = { version = "1.2", optional = true }
 dashmap = { version = "4.0.0-rc6", optional = true }

--- a/opentelemetry/src/api/metrics/mod.rs
+++ b/opentelemetry/src/api/metrics/mod.rs
@@ -19,6 +19,7 @@ mod sync_instrument;
 mod up_down_counter;
 mod value_recorder;
 
+use crate::exporter::ExportError;
 pub use async_instrument::{AsyncRunner, BatchObserverCallback, Observation, ObserverResult};
 pub use config::InstrumentConfig;
 pub use counter::{BoundCounter, Counter, CounterBuilder};
@@ -38,7 +39,7 @@ pub use value_recorder::{BoundValueRecorder, ValueRecorder, ValueRecorderBuilder
 pub type Result<T> = result::Result<T, MetricsError>;
 
 /// Errors returned by the metrics API.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum MetricsError {
     /// Other errors not covered by specific cases.
@@ -68,6 +69,15 @@ pub enum MetricsError {
     /// Errors when aggregator cannot subtract
     #[error("Aggregator does not subtract")]
     NoSubtraction,
+    /// Fail to export metrics
+    #[error("Export metrics failed with {0}")]
+    ExportErr(Box<dyn ExportError>),
+}
+
+impl<T: ExportError> From<T> for MetricsError {
+    fn from(err: T) -> Self {
+        MetricsError::ExportErr(Box::new(err))
+    }
 }
 
 impl<T> From<PoisonError<T>> for MetricsError {

--- a/opentelemetry/src/api/mod.rs
+++ b/opentelemetry/src/api/mod.rs
@@ -30,12 +30,16 @@ pub enum OpenTelemetryError {
     Other(String),
 }
 
+#[cfg(feature = "trace")]
+#[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 impl From<TraceError> for OpenTelemetryError {
     fn from(err: TraceError) -> Self {
         OpenTelemetryError::TraceErr(err)
     }
 }
 
+#[cfg(feature = "metrics")]
+#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 impl From<MetricsError> for OpenTelemetryError {
     fn from(err: MetricsError) -> Self {
         OpenTelemetryError::MetricErr(err)

--- a/opentelemetry/src/api/mod.rs
+++ b/opentelemetry/src/api/mod.rs
@@ -19,35 +19,23 @@ pub mod propagation;
 pub mod trace;
 
 /// Wrapper for error from both tracing and metrics part of open telemetry.
-#[derive(Debug)]
-pub enum OpenTelemetryError {
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
     #[cfg(feature = "trace")]
     #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
-    TraceErr(TraceError),
+    #[error(transparent)]
+    Trace(#[from] TraceError),
     #[cfg(feature = "metrics")]
     #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-    MetricErr(MetricsError),
+    #[error(transparent)]
+    Metric(#[from] MetricsError),
+    #[error("{0}")]
     Other(String),
 }
 
-#[cfg(feature = "trace")]
-#[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
-impl From<TraceError> for OpenTelemetryError {
-    fn from(err: TraceError) -> Self {
-        OpenTelemetryError::TraceErr(err)
-    }
-}
-
-#[cfg(feature = "metrics")]
-#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-impl From<MetricsError> for OpenTelemetryError {
-    fn from(err: MetricsError) -> Self {
-        OpenTelemetryError::MetricErr(err)
-    }
-}
-
-impl<T> From<PoisonError<T>> for OpenTelemetryError {
+impl<T> From<PoisonError<T>> for Error {
     fn from(err: PoisonError<T>) -> Self {
-        OpenTelemetryError::Other(err.to_string())
+        Error::Other(err.to_string())
     }
 }

--- a/opentelemetry/src/api/mod.rs
+++ b/opentelemetry/src/api/mod.rs
@@ -1,7 +1,7 @@
-use crate::api::trace::TraceError;
 #[cfg(feature = "metrics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 use crate::api::metrics::MetricsError;
+use crate::api::trace::TraceError;
 use std::sync::PoisonError;
 
 pub mod baggage;

--- a/opentelemetry/src/api/mod.rs
+++ b/opentelemetry/src/api/mod.rs
@@ -1,3 +1,9 @@
+use crate::api::trace::TraceError;
+#[cfg(feature = "metrics")]
+#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
+use crate::api::metrics::MetricsError;
+use std::sync::PoisonError;
+
 pub mod baggage;
 pub(crate) mod context;
 pub(crate) mod core;
@@ -11,3 +17,33 @@ pub mod propagation;
 #[cfg(feature = "trace")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 pub mod trace;
+
+/// Wrapper for error from both tracing and metrics part of open telemetry.
+#[derive(Debug)]
+pub enum OpenTelemetryError {
+    #[cfg(feature = "trace")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
+    TraceErr(TraceError),
+    #[cfg(feature = "metrics")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
+    MetricErr(MetricsError),
+    Other(String),
+}
+
+impl From<TraceError> for OpenTelemetryError {
+    fn from(err: TraceError) -> Self {
+        OpenTelemetryError::TraceErr(err)
+    }
+}
+
+impl From<MetricsError> for OpenTelemetryError {
+    fn from(err: MetricsError) -> Self {
+        OpenTelemetryError::MetricErr(err)
+    }
+}
+
+impl<T> From<PoisonError<T>> for OpenTelemetryError {
+    fn from(err: PoisonError<T>) -> Self {
+        OpenTelemetryError::Other(err.to_string())
+    }
+}

--- a/opentelemetry/src/api/trace/mod.rs
+++ b/opentelemetry/src/api/trace/mod.rs
@@ -139,8 +139,8 @@ pub use self::{
     },
     tracer::{SpanBuilder, Tracer},
 };
-use std::time;
 use crate::exporter::trace::ExportError;
+use std::time;
 
 /// Describe the result of operations in tracing API.
 pub type TraceResult<T> = Result<T, TraceError>;
@@ -167,7 +167,9 @@ pub enum TraceError {
 }
 
 impl<T> From<T> for TraceError
-    where T: ExportError {
+where
+    T: ExportError,
+{
     fn from(err: T) -> Self {
         TraceError::ExportFailed(Box::new(err))
     }

--- a/opentelemetry/src/exporter/mod.rs
+++ b/opentelemetry/src/exporter/mod.rs
@@ -14,3 +14,9 @@ pub mod metrics;
 #[cfg(feature = "trace")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 pub mod trace;
+
+/// Marker trait for errors returned by exporters
+pub trait ExportError: std::error::Error + Send + Sync + 'static {
+    /// The name of exporter that returned this error
+    fn exporter_name(&self) -> &'static str;
+}

--- a/opentelemetry/src/exporter/trace/mod.rs
+++ b/opentelemetry/src/exporter/trace/mod.rs
@@ -1,4 +1,5 @@
 //! Trace exporters
+use crate::api::trace::TraceError;
 use crate::{
     sdk,
     trace::{Event, Link, SpanContext, SpanId, SpanKind, StatusCode},
@@ -13,7 +14,6 @@ use std::convert::TryInto;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::SystemTime;
-use crate::api::trace::TraceError;
 
 pub mod stdout;
 

--- a/opentelemetry/src/exporter/trace/mod.rs
+++ b/opentelemetry/src/exporter/trace/mod.rs
@@ -1,5 +1,6 @@
 //! Trace exporters
 use crate::api::trace::TraceError;
+use crate::exporter::ExportError;
 use crate::{
     sdk,
     trace::{Event, Link, SpanContext, SpanId, SpanKind, StatusCode},
@@ -21,14 +22,6 @@ pub mod stdout;
 
 /// Describes the result of an export.
 pub type ExportResult = Result<(), TraceError>;
-
-/// Marker trait for errors returned by exporters
-pub trait ExportError: std::error::Error + Send + Sync + 'static {
-    /// The name of exporter that returned this error
-    fn exporter_name(&self) -> &'static str {
-        "N/A"
-    }
-}
 
 /// `SpanExporter` defines the interface that protocol-specific exporters must
 /// implement so that they can be plugged into OpenTelemetry SDK and support
@@ -102,7 +95,11 @@ impl std::error::Error for HttpClientError {}
 
 #[cfg(feature = "http")]
 #[cfg_attr(docsrs, doc(cfg(feature = "http")))]
-impl ExportError for HttpClientError {}
+impl ExportError for HttpClientError {
+    fn exporter_name(&self) -> &'static str {
+        "http client"
+    }
+}
 
 #[cfg(feature = "http")]
 #[cfg_attr(docsrs, doc(cfg(feature = "http")))]

--- a/opentelemetry/src/exporter/trace/stdout.rs
+++ b/opentelemetry/src/exporter/trace/stdout.rs
@@ -31,8 +31,8 @@ use crate::{
     trace::TracerProvider,
 };
 use async_trait::async_trait;
-use std::fmt::{Debug, Display, Formatter};
 use std::io::{stdout, Stdout, Write};
+use std::fmt::Debug;
 
 /// Pipeline builder
 #[derive(Debug)]
@@ -150,22 +150,9 @@ where
 pub struct Uninstall(global::TracerProviderGuard);
 
 /// Stdout exporter's error
-#[derive(Debug)]
-struct Error(std::io::Error);
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0.to_string().as_str())
-    }
-}
-
-impl std::error::Error for Error {}
-
-impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Self {
-        Error(err)
-    }
-}
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+struct Error(#[from] std::io::Error);
 
 impl ExportError for Error {
     fn exporter_name(&self) -> &'static str {

--- a/opentelemetry/src/exporter/trace/stdout.rs
+++ b/opentelemetry/src/exporter/trace/stdout.rs
@@ -24,15 +24,17 @@
 //!     });
 //! }
 //! ```
-use crate::exporter::trace::ExportError;
 use crate::{
-    exporter::trace::{ExportResult, SpanData, SpanExporter},
+    exporter::{
+        trace::{ExportResult, SpanData, SpanExporter},
+        ExportError,
+    },
     global, sdk,
     trace::TracerProvider,
 };
 use async_trait::async_trait;
-use std::io::{stdout, Stdout, Write};
 use std::fmt::Debug;
+use std::io::{stdout, Stdout, Write};
 
 /// Pipeline builder
 #[derive(Debug)]

--- a/opentelemetry/src/exporter/trace/stdout.rs
+++ b/opentelemetry/src/exporter/trace/stdout.rs
@@ -24,16 +24,16 @@
 //!     });
 //! }
 //! ```
+use crate::exporter::trace::ExportError;
 use crate::{
     exporter::trace::{ExportResult, SpanData, SpanExporter},
     global, sdk,
     trace::TracerProvider,
 };
 use async_trait::async_trait;
+use serde::export::Formatter;
 use std::fmt::{Debug, Display};
 use std::io::{stdout, Stdout, Write};
-use crate::exporter::trace::ExportError;
-use serde::export::Formatter;
 
 /// Pipeline builder
 #[derive(Debug)]
@@ -83,8 +83,8 @@ impl<W: Write> PipelineBuilder<W> {
 }
 
 impl<W> PipelineBuilder<W>
-    where
-        W: Write + Debug + Send + 'static,
+where
+    W: Write + Debug + Send + 'static,
 {
     /// Install the stdout exporter pipeline with the recommended defaults.
     pub fn install(mut self) -> (sdk::trace::Tracer, Uninstall) {
@@ -125,16 +125,20 @@ impl<W: Write> Exporter<W> {
 
 #[async_trait]
 impl<W> SpanExporter for Exporter<W>
-    where
-        W: Write + Debug + Send + 'static,
+where
+    W: Write + Debug + Send + 'static,
 {
     /// Export spans to stdout
     async fn export(&mut self, batch: Vec<SpanData>) -> ExportResult {
         for span in batch {
             if self.pretty_print {
-                self.writer.write_all(format!("{:#?}\n", span).as_bytes()).map_err(|err| Error::from(err))?;
+                self.writer
+                    .write_all(format!("{:#?}\n", span).as_bytes())
+                    .map_err(|err| Error::from(err))?;
             } else {
-                self.writer.write_all(format!("{:?}\n", span).as_bytes()).map_err(|err| Error::from(err))?;
+                self.writer
+                    .write_all(format!("{:?}\n", span).as_bytes())
+                    .map_err(|err| Error::from(err))?;
             }
         }
 
@@ -169,4 +173,3 @@ impl ExportError for Error {
         "stdout"
     }
 }
-

--- a/opentelemetry/src/exporter/trace/stdout.rs
+++ b/opentelemetry/src/exporter/trace/stdout.rs
@@ -31,8 +31,7 @@ use crate::{
     trace::TracerProvider,
 };
 use async_trait::async_trait;
-use serde::export::Formatter;
-use std::fmt::{Debug, Display};
+use std::fmt::{Debug, Display, Formatter};
 use std::io::{stdout, Stdout, Write};
 
 /// Pipeline builder
@@ -134,11 +133,11 @@ where
             if self.pretty_print {
                 self.writer
                     .write_all(format!("{:#?}\n", span).as_bytes())
-                    .map_err(|err| Error::from(err))?;
+                    .map_err::<Error, _>(Into::into)?;
             } else {
                 self.writer
                     .write_all(format!("{:?}\n", span).as_bytes())
-                    .map_err(|err| Error::from(err))?;
+                    .map_err::<Error, _>(Into::into)?;
             }
         }
 

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -1,5 +1,5 @@
-use std::sync::RwLock;
 use crate::api::OpenTelemetryError;
+use std::sync::RwLock;
 
 lazy_static::lazy_static! {
     /// The global error handler.
@@ -15,17 +15,23 @@ pub fn handle_error<T: Into<OpenTelemetryError>>(err: T) {
     match GLOBAL_ERROR_HANDLER.read() {
         Ok(handler) if handler.is_some() => (handler.as_ref().unwrap().0)(err.into()),
         _ => match err.into() {
-            OpenTelemetryError::MetricErr(err) => eprintln!("OpenTelemetry metrics error occurred {:?}", err),
-            OpenTelemetryError::TraceErr(err) => eprintln!("OpenTelemetry trace error occurred {:?}", err),
-            OpenTelemetryError::Other(err_msg) => println!("OpenTelemetry error occurred {}", err_msg)
-        }
+            OpenTelemetryError::MetricErr(err) => {
+                eprintln!("OpenTelemetry metrics error occurred {:?}", err)
+            }
+            OpenTelemetryError::TraceErr(err) => {
+                eprintln!("OpenTelemetry trace error occurred {:?}", err)
+            }
+            OpenTelemetryError::Other(err_msg) => {
+                println!("OpenTelemetry error occurred {}", err_msg)
+            }
+        },
     }
 }
 
 /// Set global error handler.
 pub fn set_error_handler<F>(f: F) -> std::result::Result<(), OpenTelemetryError>
-    where
-        F: Fn(OpenTelemetryError) + Send + Sync + 'static,
+where
+    F: Fn(OpenTelemetryError) + Send + Sync + 'static,
 {
     GLOBAL_ERROR_HANDLER
         .write()

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -1,4 +1,4 @@
-use crate::api::OpenTelemetryError;
+use crate::api::Error;
 use std::sync::RwLock;
 
 lazy_static::lazy_static! {
@@ -6,26 +6,26 @@ lazy_static::lazy_static! {
     static ref GLOBAL_ERROR_HANDLER: RwLock<Option<ErrorHandler>> = RwLock::new(None);
 }
 
-struct ErrorHandler(Box<dyn Fn(OpenTelemetryError) + Send + Sync>);
+struct ErrorHandler(Box<dyn Fn(Error) + Send + Sync>);
 
 /// Handle error using the globally configured error handler.
 ///
 /// Writes to stderr if unset.
-pub fn handle_error<T: Into<OpenTelemetryError>>(err: T) {
+pub fn handle_error<T: Into<Error>>(err: T) {
     match GLOBAL_ERROR_HANDLER.read() {
         Ok(handler) if handler.is_some() => (handler.as_ref().unwrap().0)(err.into()),
         _ => match err.into() {
             #[cfg(feature = "metrics")]
             #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-            OpenTelemetryError::MetricErr(err) => {
+            Error::Metric(err) => {
                 eprintln!("OpenTelemetry metrics error occurred {:?}", err)
             }
             #[cfg(feature = "trace")]
             #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
-            OpenTelemetryError::TraceErr(err) => {
+            Error::Trace(err) => {
                 eprintln!("OpenTelemetry trace error occurred {:?}", err)
             }
-            OpenTelemetryError::Other(err_msg) => {
+            Error::Other(err_msg) => {
                 println!("OpenTelemetry error occurred {}", err_msg)
             }
         },
@@ -33,9 +33,9 @@ pub fn handle_error<T: Into<OpenTelemetryError>>(err: T) {
 }
 
 /// Set global error handler.
-pub fn set_error_handler<F>(f: F) -> std::result::Result<(), OpenTelemetryError>
+pub fn set_error_handler<F>(f: F) -> std::result::Result<(), Error>
 where
-    F: Fn(OpenTelemetryError) + Send + Sync + 'static,
+    F: Fn(Error) + Send + Sync + 'static,
 {
     GLOBAL_ERROR_HANDLER
         .write()

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -1,27 +1,31 @@
-use crate::metrics::{MetricsError, Result};
 use std::sync::RwLock;
+use crate::api::OpenTelemetryError;
 
 lazy_static::lazy_static! {
     /// The global error handler.
     static ref GLOBAL_ERROR_HANDLER: RwLock<Option<ErrorHandler>> = RwLock::new(None);
 }
 
-struct ErrorHandler(Box<dyn Fn(MetricsError) + Send + Sync>);
+struct ErrorHandler(Box<dyn Fn(OpenTelemetryError) + Send + Sync>);
 
 /// Handle error using the globally configured error handler.
 ///
 /// Writes to stderr if unset.
-pub fn handle_error(err: MetricsError) {
+pub fn handle_error<T: Into<OpenTelemetryError>>(err: T) {
     match GLOBAL_ERROR_HANDLER.read() {
-        Ok(handler) if handler.is_some() => (handler.as_ref().unwrap().0)(err),
-        _ => eprintln!("OpenTelemetry metrics error occurred {:?}", err),
+        Ok(handler) if handler.is_some() => (handler.as_ref().unwrap().0)(err.into()),
+        _ => match err.into() {
+            OpenTelemetryError::MetricErr(err) => eprintln!("OpenTelemetry metrics error occurred {:?}", err),
+            OpenTelemetryError::TraceErr(err) => eprintln!("OpenTelemetry trace error occurred {:?}", err),
+            OpenTelemetryError::Other(err_msg) => println!("OpenTelemetry error occurred {}", err_msg)
+        }
     }
 }
 
 /// Set global error handler.
-pub fn set_error_handler<F>(f: F) -> Result<()>
-where
-    F: Fn(MetricsError) + Send + Sync + 'static,
+pub fn set_error_handler<F>(f: F) -> std::result::Result<(), OpenTelemetryError>
+    where
+        F: Fn(OpenTelemetryError) + Send + Sync + 'static,
 {
     GLOBAL_ERROR_HANDLER
         .write()

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -15,9 +15,13 @@ pub fn handle_error<T: Into<OpenTelemetryError>>(err: T) {
     match GLOBAL_ERROR_HANDLER.read() {
         Ok(handler) if handler.is_some() => (handler.as_ref().unwrap().0)(err.into()),
         _ => match err.into() {
+            #[cfg(feature = "metrics")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
             OpenTelemetryError::MetricErr(err) => {
                 eprintln!("OpenTelemetry metrics error occurred {:?}", err)
             }
+            #[cfg(feature = "trace")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
             OpenTelemetryError::TraceErr(err) => {
                 eprintln!("OpenTelemetry trace error occurred {:?}", err)
             }

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -17,17 +17,11 @@ pub fn handle_error<T: Into<Error>>(err: T) {
         _ => match err.into() {
             #[cfg(feature = "metrics")]
             #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-            Error::Metric(err) => {
-                eprintln!("OpenTelemetry metrics error occurred {:?}", err)
-            }
+            Error::Metric(err) => eprintln!("OpenTelemetry metrics error occurred {:?}", err),
             #[cfg(feature = "trace")]
             #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
-            Error::Trace(err) => {
-                eprintln!("OpenTelemetry trace error occurred {:?}", err)
-            }
-            Error::Other(err_msg) => {
-                println!("OpenTelemetry error occurred {}", err_msg)
-            }
+            Error::Trace(err) => eprintln!("OpenTelemetry trace error occurred {:?}", err),
+            Error::Other(err_msg) => println!("OpenTelemetry error occurred {}", err_msg),
         },
     }
 }

--- a/opentelemetry/src/global/mod.rs
+++ b/opentelemetry/src/global/mod.rs
@@ -129,7 +129,6 @@
 //! [installing a metrics pipeline]: crate::exporter::metrics::stdout::StdoutExporterBuilder::try_init
 //! [`MeterProvider`]: crate::metrics::MeterProvider
 
-#[cfg(feature = "metrics")]
 mod error_handler;
 #[cfg(feature = "metrics")]
 mod metrics;
@@ -138,8 +137,6 @@ mod propagation;
 #[cfg(feature = "trace")]
 mod trace;
 
-#[cfg(feature = "metrics")]
-#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 pub use error_handler::{handle_error, set_error_handler};
 #[cfg(feature = "metrics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]

--- a/opentelemetry/src/sdk/metrics/aggregators/ddsketch.rs
+++ b/opentelemetry/src/sdk/metrics/aggregators/ddsketch.rs
@@ -1019,7 +1019,7 @@ mod tests {
             (moved_ddsketch.sum().unwrap().to_f64(&NumberKind::F64) - expected_sum).abs()
                 < std::f64::EPSILON
         );
-        assert_eq!(moved_ddsketch.count(), Ok(expected_count));
+        assert_eq!(moved_ddsketch.count().unwrap(), expected_count);
 
         // assert can generate same result
         for q in test_quantiles() {

--- a/opentelemetry/src/sdk/metrics/processors/basic.rs
+++ b/opentelemetry/src/sdk/metrics/processors/basic.rs
@@ -367,7 +367,7 @@ impl CheckpointSet for BasicProcessorState {
                 start,
                 self.interval_end,
             ));
-            if res == Err(MetricsError::NoDataCollected) {
+            if let Err(MetricsError::NoDataCollected) = res {
                 Ok(())
             } else {
                 res

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -291,8 +291,7 @@ impl BatchSpanProcessor {
                                     exporter.as_mut(),
                                     &delay,
                                     batch,
-                                )
-                                    .await,
+                                ).await,
                             );
                         }
                         let send_result = ch.send(results);

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -567,7 +567,6 @@ mod tests {
     use std::time;
     use std::time::Duration;
 
-    use async_std::prelude::*;
     use async_trait::async_trait;
 
     use crate::exporter::trace::{stdout, ExportResult, SpanData, SpanExporter};
@@ -576,6 +575,8 @@ mod tests {
     use crate::testing::trace::{
         new_test_export_span_data, new_test_exporter, new_tokio_test_exporter,
     };
+
+    use futures::Future;
 
     use super::{
         BatchSpanProcessor, SimpleSpanProcessor, SpanProcessor, OTEL_BSP_MAX_EXPORT_BATCH_SIZE,
@@ -726,17 +727,20 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "async-std")]
     fn test_timeout_async_std_timeout() {
         async_std::task::block_on(timeout_test_std_async(true));
     }
 
     #[test]
+    #[cfg(feature = "async-std")]
     fn test_timeout_async_std_not_timeout() {
         async_std::task::block_on(timeout_test_std_async(false));
     }
 
     // If the time_out is true, then the result suppose to ended with timeout.
     // otherwise the exporter should be able to export within time out duration.
+    #[cfg(feature = "async-std")]
     async fn timeout_test_std_async(time_out: bool) {
         let mut config = BatchConfig::default();
         config.max_export_timeout = time::Duration::from_millis(if time_out { 5 } else { 60 });

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -296,7 +296,7 @@ impl BatchSpanProcessor {
                             );
                         }
                         let send_result = ch.send(results);
-                        if let Err(_) = send_result {
+                        if send_result.is_err() {
                             global::handle_error(TraceError::Other("fail to send the export response from worker handle in BatchProcessor".to_string()))
                         }
                     }
@@ -336,7 +336,7 @@ impl BatchSpanProcessor {
                         }
                         exporter.shutdown();
                         let send_result = ch.send(results);
-                        if let Err(_) = send_result {
+                        if send_result.is_err() {
                             global::handle_error(TraceError::Other("fail to send the export response from worker handle in BatchProcessor".to_string()))
                         }
                         break;

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -33,18 +33,20 @@
 //!
 //! [`is_recording`]: ../span/trait.Span.html#method.is_recording
 //! [`TracerProvider`]: ../provider/trait.TracerProvider.html
-use crate::api::trace::TraceError;
+use std::{fmt, str::FromStr, sync::Mutex, time};
+
+use futures::{
+    channel::mpsc, channel::oneshot, executor, future::BoxFuture, future::Either, pin_mut, Future,
+    FutureExt, Stream, StreamExt,
+};
+
+use crate::api::trace::{TraceError, TraceResult};
 use crate::exporter::trace::ExportTimedOutError;
 use crate::sdk::trace::Span;
 use crate::{
     exporter::trace::{ExportResult, SpanData, SpanExporter},
     Context,
 };
-use futures::{
-    channel::mpsc, channel::oneshot, executor, future::BoxFuture, future::Either, pin_mut, Future,
-    FutureExt, Stream, StreamExt,
-};
-use std::{fmt, str::FromStr, sync::Mutex, time};
 
 /// Delay interval between two consecutive exports, default to be 5000.
 const OTEL_BSP_SCHEDULE_DELAY_MILLIS: &str = "OTEL_BSP_SCHEDULE_DELAY_MILLIS";
@@ -76,10 +78,10 @@ pub trait SpanProcessor: Send + Sync + std::fmt::Debug {
     /// API, therefore it should not block or throw an exception.
     fn on_end(&self, span: SpanData);
     /// Force the spans lying in the cache to be exported.
-    fn force_flush(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>;
+    fn force_flush(&self) -> TraceResult<()>;
     /// Shuts down the processor. Called when SDK is shut down. This is an
     /// opportunity for processors to do any cleanup required.
-    fn shutdown(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>;
+    fn shutdown(&mut self) -> TraceResult<()>;
 }
 
 /// A [`SpanProcessor`] that exports synchronously when spans are finished.
@@ -130,12 +132,12 @@ impl SpanProcessor for SimpleSpanProcessor {
         }
     }
 
-    fn force_flush(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    fn force_flush(&self) -> TraceResult<()> {
         // Ignored since all spans in Simple Processor will be exported as they ended.
         Ok(())
     }
 
-    fn shutdown(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    fn shutdown(&mut self) -> TraceResult<()> {
         if let Ok(mut exporter) = self.exporter.lock() {
             exporter.shutdown();
             Ok(())
@@ -143,8 +145,7 @@ impl SpanProcessor for SimpleSpanProcessor {
             Err(TraceError::Other(
                 "When shutting down the SimpleSpanProcessor, the exporter's lock has been poisoned"
                     .into(),
-            )
-            .into())
+            ))
         }
     }
 }
@@ -214,26 +215,24 @@ impl SpanProcessor for BatchSpanProcessor {
         }
     }
 
-    fn force_flush(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    fn force_flush(&self) -> TraceResult<()> {
         let mut sender = self.message_sender.lock().map_err(|_| TraceError::Other("When force flushing the BatchSpanProcessor, the message sender's lock has been poisoned".into()))?;
         let (res_sender, res_receiver) = oneshot::channel::<Vec<ExportResult>>();
-        sender.try_send(BatchMessage::Flush(Some(res_sender)))?;
+        sender
+            .try_send(BatchMessage::Flush(Some(res_sender)))
+            .map_err(|err| Box::new(err))?;
         for result in futures::executor::block_on(res_receiver)? {
-            if result.is_err() {
-                return result;
-            }
+            result?;
         }
         Ok(())
     }
 
-    fn shutdown(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    fn shutdown(&mut self) -> TraceResult<()> {
         let mut sender = self.message_sender.lock().map_err(|_| TraceError::Other("When shutting down the BatchSpanProcessor, the message sender's lock has been poisoned".into()))?;
         let (res_sender, res_receiver) = oneshot::channel::<Vec<ExportResult>>();
         sender.try_send(BatchMessage::Shutdown(res_sender))?;
         for result in futures::executor::block_on(res_receiver)? {
-            if result.is_err() {
-                return result;
-            }
+            result?;
         }
         Ok(())
     }
@@ -565,22 +564,25 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        BatchSpanProcessor, SimpleSpanProcessor, SpanProcessor, OTEL_BSP_MAX_EXPORT_BATCH_SIZE,
-        OTEL_BSP_MAX_QUEUE_SIZE, OTEL_BSP_MAX_QUEUE_SIZE_DEFAULT, OTEL_BSP_SCHEDULE_DELAY_MILLIS,
-        OTEL_BSP_SCHEDULE_DELAY_MILLIS_DEFAULT,
-    };
+    use std::fmt::Debug;
+    use std::time;
+    use std::time::Duration;
+
+    use async_std::prelude::*;
+    use async_trait::async_trait;
+
     use crate::exporter::trace::{stdout, ExportResult, SpanData, SpanExporter};
     use crate::sdk::trace::span_processor::OTEL_BSP_EXPORT_TIMEOUT_MILLIS;
     use crate::sdk::trace::BatchConfig;
     use crate::testing::trace::{
         new_test_export_span_data, new_test_exporter, new_tokio_test_exporter,
     };
-    use async_std::prelude::*;
-    use async_trait::async_trait;
-    use std::fmt::Debug;
-    use std::time;
-    use std::time::Duration;
+
+    use super::{
+        BatchSpanProcessor, SimpleSpanProcessor, SpanProcessor, OTEL_BSP_MAX_EXPORT_BATCH_SIZE,
+        OTEL_BSP_MAX_QUEUE_SIZE, OTEL_BSP_MAX_QUEUE_SIZE_DEFAULT, OTEL_BSP_SCHEDULE_DELAY_MILLIS,
+        OTEL_BSP_SCHEDULE_DELAY_MILLIS_DEFAULT,
+    };
 
     #[test]
     fn simple_span_processor_on_end_calls_export() {

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -219,8 +219,7 @@ impl SpanProcessor for BatchSpanProcessor {
     fn force_flush(&self) -> TraceResult<()> {
         let mut sender = self.message_sender.lock().map_err(|_| TraceError::Other("When force flushing the BatchSpanProcessor, the message sender's lock has been poisoned".into()))?;
         let (res_sender, res_receiver) = oneshot::channel::<Vec<ExportResult>>();
-        sender
-            .try_send(BatchMessage::Flush(Some(res_sender)))?;
+        sender.try_send(BatchMessage::Flush(Some(res_sender)))?;
         for result in futures::executor::block_on(res_receiver)? {
             result?;
         }
@@ -253,13 +252,13 @@ impl BatchSpanProcessor {
         delay: D,
         config: BatchConfig,
     ) -> Self
-        where
-            S: Fn(BoxFuture<'static, ()>) -> SH,
-            SH: Future<Output=SO> + Send + Sync + 'static,
-            I: Fn(time::Duration) -> IS,
-            IS: Stream<Item=ISI> + Send + 'static,
-            D: (Fn(time::Duration) -> DS) + Send + Sync + 'static,
-            DS: Future<Output=()> + 'static + Send + Sync,
+    where
+        S: Fn(BoxFuture<'static, ()>) -> SH,
+        SH: Future<Output = SO> + Send + Sync + 'static,
+        I: Fn(time::Duration) -> IS,
+        IS: Stream<Item = ISI> + Send + 'static,
+        D: (Fn(time::Duration) -> DS) + Send + Sync + 'static,
+        DS: Future<Output = ()> + 'static + Send + Sync,
     {
         let (message_sender, message_receiver) = mpsc::channel(config.max_queue_size);
         let ticker = interval(config.scheduled_delay).map(|_| BatchMessage::Flush(None));
@@ -360,13 +359,13 @@ impl BatchSpanProcessor {
         delay: D,
         interval: I,
     ) -> BatchSpanProcessorBuilder<E, S, I, D>
-        where
-            E: SpanExporter,
-            S: Fn(BoxFuture<'static, ()>) -> SH,
-            SH: Future<Output=SO> + Send + Sync + 'static,
-            I: Fn(time::Duration) -> IO,
-            D: (Fn(time::Duration) -> DS) + Send + Sync + 'static,
-            DS: Future<Output=()> + 'static + Send + Sync,
+    where
+        E: SpanExporter,
+        S: Fn(BoxFuture<'static, ()>) -> SH,
+        SH: Future<Output = SO> + Send + Sync + 'static,
+        I: Fn(time::Duration) -> IO,
+        D: (Fn(time::Duration) -> DS) + Send + Sync + 'static,
+        DS: Future<Output = ()> + 'static + Send + Sync,
     {
         BatchSpanProcessorBuilder {
             exporter,
@@ -390,13 +389,13 @@ impl BatchSpanProcessor {
         interval: I,
         delay: D,
     ) -> BatchSpanProcessorBuilder<E, S, I, D>
-        where
-            E: SpanExporter,
-            S: Fn(BoxFuture<'static, ()>) -> SH,
-            SH: Future<Output=SO> + Send + Sync + 'static,
-            I: Fn(time::Duration) -> IO,
-            D: (Fn(time::Duration) -> DS) + Send + Sync + 'static,
-            DS: Future<Output=()> + 'static + Send + Sync,
+    where
+        E: SpanExporter,
+        S: Fn(BoxFuture<'static, ()>) -> SH,
+        SH: Future<Output = SO> + Send + Sync + 'static,
+        I: Fn(time::Duration) -> IO,
+        D: (Fn(time::Duration) -> DS) + Send + Sync + 'static,
+        DS: Future<Output = ()> + 'static + Send + Sync,
     {
         let mut config = BatchConfig::default();
         let schedule_delay = std::env::var(OTEL_BSP_SCHEDULE_DELAY_MILLIS)
@@ -447,10 +446,10 @@ async fn export_with_timeout<D, DS, E>(
     delay: &D,
     batch: Vec<SpanData>,
 ) -> ExportResult
-    where
-        D: (Fn(time::Duration) -> DS) + Send + Sync + 'static,
-        DS: Future<Output=()> + 'static + Send + Sync,
-        E: SpanExporter + ?Sized,
+where
+    D: (Fn(time::Duration) -> DS) + Send + Sync + 'static,
+    DS: Future<Output = ()> + 'static + Send + Sync,
+    E: SpanExporter + ?Sized,
 {
     let export = exporter.export(batch);
     let timeout = delay(time_out);
@@ -507,14 +506,14 @@ pub struct BatchSpanProcessorBuilder<E, S, I, D> {
 }
 
 impl<E, S, SH, SO, I, IS, ISI, D, DS> BatchSpanProcessorBuilder<E, S, I, D>
-    where
-        E: SpanExporter + 'static,
-        S: Fn(BoxFuture<'static, ()>) -> SH,
-        SH: Future<Output=SO> + Send + Sync + 'static,
-        I: Fn(time::Duration) -> IS,
-        IS: Stream<Item=ISI> + Send + 'static,
-        D: (Fn(time::Duration) -> DS) + Send + Sync + 'static,
-        DS: Future<Output=()> + 'static + Send + Sync,
+where
+    E: SpanExporter + 'static,
+    S: Fn(BoxFuture<'static, ()>) -> SH,
+    SH: Future<Output = SO> + Send + Sync + 'static,
+    I: Fn(time::Duration) -> IS,
+    IS: Stream<Item = ISI> + Send + 'static,
+    D: (Fn(time::Duration) -> DS) + Send + Sync + 'static,
+    DS: Future<Output = ()> + 'static + Send + Sync,
 {
     /// Set max queue size for batches
     pub fn with_max_queue_size(self, size: usize) -> Self {
@@ -684,9 +683,9 @@ mod tests {
     }
 
     impl<D, DS> Debug for BlockingExporter<D>
-        where
-            D: Fn(time::Duration) -> DS + 'static + Send + Sync,
-            DS: Future<Output=()> + Send + Sync + 'static,
+    where
+        D: Fn(time::Duration) -> DS + 'static + Send + Sync,
+        DS: Future<Output = ()> + Send + Sync + 'static,
     {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.write_str("blocking exporter for testing")
@@ -695,9 +694,9 @@ mod tests {
 
     #[async_trait]
     impl<D, DS> SpanExporter for BlockingExporter<D>
-        where
-            D: Fn(time::Duration) -> DS + 'static + Send + Sync,
-            DS: Future<Output=()> + Send + Sync + 'static,
+    where
+        D: Fn(time::Duration) -> DS + 'static + Send + Sync,
+        DS: Future<Output = ()> + Send + Sync + 'static,
     {
         async fn export(&mut self, batch: Vec<SpanData>) -> ExportResult {
             println!("Accepting {} spans", batch.len());

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -310,8 +310,7 @@ impl BatchSpanProcessor {
                                 exporter.as_mut(),
                                 &delay,
                                 batch,
-                            )
-                                .await;
+                            ).await;
                         }
                     }
                     // Stream has terminated or processor is shutdown, return to finish execution.
@@ -329,8 +328,7 @@ impl BatchSpanProcessor {
                                     exporter.as_mut(),
                                     &delay,
                                     batch,
-                                )
-                                    .await,
+                                ).await,
                             );
                         }
                         exporter.shutdown();
@@ -342,8 +340,7 @@ impl BatchSpanProcessor {
                     }
                 }
             }
-        }))
-            .map(|_| ());
+        })).map(|_| ());
 
         // Return batch processor with link to worker
         BatchSpanProcessor {

--- a/opentelemetry/src/testing/trace.rs
+++ b/opentelemetry/src/testing/trace.rs
@@ -1,6 +1,8 @@
-use crate::exporter::trace::{ExportError, SpanData};
 use crate::{
-    exporter::trace::{self as exporter, ExportResult, SpanExporter},
+    exporter::{
+        trace::{self as exporter, ExportResult, SpanData, SpanExporter},
+        ExportError,
+    },
     sdk::{
         trace::{Config, EvictedHashMap, EvictedQueue},
         InstrumentationLibrary,

--- a/opentelemetry/src/testing/trace.rs
+++ b/opentelemetry/src/testing/trace.rs
@@ -1,4 +1,4 @@
-use crate::exporter::trace::{SpanData, ExportError};
+use crate::exporter::trace::{ExportError, SpanData};
 use crate::{
     exporter::trace::{self as exporter, ExportResult, SpanExporter},
     sdk::{
@@ -9,10 +9,10 @@ use crate::{
     KeyValue,
 };
 use async_trait::async_trait;
+use serde::export::Formatter;
+use std::fmt::Display;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::time::SystemTime;
-use std::fmt::Display;
-use serde::export::Formatter;
 
 #[derive(Debug)]
 pub struct TestSpan(pub SpanContext);
@@ -23,7 +23,8 @@ impl Span for TestSpan {
         _name: String,
         _timestamp: std::time::SystemTime,
         _attributes: Vec<KeyValue>,
-    ) {}
+    ) {
+    }
     fn span_context(&self) -> &SpanContext {
         &self.0
     }
@@ -65,7 +66,9 @@ pub struct TestSpanExporter {
 impl SpanExporter for TestSpanExporter {
     async fn export(&mut self, batch: Vec<exporter::SpanData>) -> ExportResult {
         for span_data in batch {
-            self.tx_export.send(span_data).map_err::<TestExportError, _>(Into::into)?;
+            self.tx_export
+                .send(span_data)
+                .map_err::<TestExportError, _>(Into::into)?;
         }
         Ok(())
     }
@@ -95,7 +98,9 @@ pub struct TokioSpanExporter {
 impl SpanExporter for TokioSpanExporter {
     async fn export(&mut self, batch: Vec<SpanData>) -> ExportResult {
         for span_data in batch {
-            self.tx_export.send(span_data).map_err::<TestExportError, _>(Into::into)?;
+            self.tx_export
+                .send(span_data)
+                .map_err::<TestExportError, _>(Into::into)?;
         }
         Ok(())
     }

--- a/opentelemetry/src/testing/trace.rs
+++ b/opentelemetry/src/testing/trace.rs
@@ -9,8 +9,7 @@ use crate::{
     KeyValue,
 };
 use async_trait::async_trait;
-use serde::export::Formatter;
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::time::SystemTime;
 


### PR DESCRIPTION
#### Current approaches
Currently, most of the errors in `trace` have been returned via `Box<dyn std::error::Error + Send + Sync + 'static>`. This approach gives users good flexibility to return basically any errors. But it totally depends on user to return meaningful messages in errors to help end user to understand the issue. 

#### Proposed approaches
As discussed in #286, we decided to use `thiserror` library wide to allow multiple level of errors throughout the whole process to send span. 

1. We define a `TraceError` enum to represent any possible errors from `trace` module. It provides some predefined variantion, and we should add more variantions as needed. It also provides two generic variantions `Other` and `Boxed`. `Other` could hold any string and `Boxed` could hold any `Box<dyn std::error::Error + Send + Sync + 'static>`. It allows the user to adapt their currently implementation easily. 

2. We define a `ExporterError` trait, which contains one method to return the name of the exporter. Exporter implementations are engouraged to define their own Error type and implement ExporterError. This allow any exporter implementations to pass their custom errors back to SDK. This should also help narrow down which exporter causes the error when errors being returned.

3. Change function signature to return `TraceError` or `ExporterError` when possible. And use global error handler to handle the rest of errors



