### PR TITLE
Corrects span StatusCode ordering

### DIFF
--- a/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
@@ -130,7 +130,7 @@ mod tests {
         let spans = get_spans();
         let encoded = base64::encode(ApiVersion::Version03.encode("service_name", spans)?);
 
-        assert_eq!(encoded.as_str(), "kZGLpHR5cGWjd2Vip3NlcnZpY2Wsc2VydmljZV9uYW1lpG5hbWWpY29tcG9uZW50qHJlc291cmNlqHJlc291cmNlqHRyYWNlX2lkzwAAAAAAAAAHp3NwYW5faWTPAAAAAAAAAGOpcGFyZW50X2lkzwAAAAAAAAABpXN0YXJ00wAAAAAAAAAAqGR1cmF0aW9u0wAAAAA7msoApWVycm9y0gAAAACkbWV0YYGpc3Bhbi50eXBlo3dlYg==");
+        assert_eq!(encoded.as_str(), "kZGLpHR5cGWjd2Vip3NlcnZpY2Wsc2VydmljZV9uYW1lpG5hbWWpY29tcG9uZW50qHJlc291cmNlqHJlc291cmNlqHRyYWNlX2lkzwAAAAAAAAAHp3NwYW5faWTPAAAAAAAAAGOpcGFyZW50X2lkzwAAAAAAAAABpXN0YXJ00wAAAAAAAAAAqGR1cmF0aW9u0wAAAAA7msoApWVycm9y0gAAAAGkbWV0YYGpc3Bhbi50eXBlo3dlYg==");
 
         Ok(())
     }
@@ -140,7 +140,7 @@ mod tests {
         let spans = get_spans();
         let encoded = base64::encode(ApiVersion::Version05.encode("service_name", spans)?);
 
-        assert_eq!(encoded.as_str(), "kpWsc2VydmljZV9uYW1lo3dlYqljb21wb25lbnSocmVzb3VyY2Wpc3Bhbi50eXBlkZGczgAAAADOAAAAAs4AAAADzwAAAAAAAAAHzwAAAAAAAABjzwAAAAAAAAAB0wAAAAAAAAAA0wAAAAA7msoA0gAAAACBzgAAAATOAAAAAYDOAAAAAQ==");
+        assert_eq!(encoded.as_str(), "kpWsc2VydmljZV9uYW1lo3dlYqljb21wb25lbnSocmVzb3VyY2Wpc3Bhbi50eXBlkZGczgAAAADOAAAAAs4AAAADzwAAAAAAAAAHzwAAAAAAAABjzwAAAAAAAAAB0wAAAAAAAAAA0wAAAAA7msoA0gAAAAGBzgAAAATOAAAAAYDOAAAAAQ==");
 
         Ok(())
     }

--- a/opentelemetry/src/api/trace/span.rs
+++ b/opentelemetry/src/api/trace/span.rs
@@ -243,10 +243,10 @@ impl fmt::Display for SpanKind {
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum StatusCode {
-    /// OK is returned on success.
-    Ok = 0,
     /// The default status.
-    Unset = 1,
+    Unset = 0,
+    /// OK is returned on success.
+    Ok = 1,
     /// The operation contains an error.
     Error = 2,
 }


### PR DESCRIPTION
When using `opentelemetry` and `opentelemetry-contrib` to report traces to Datadog, I noticed that all spans are marked as errors by default. I was able to correct this by manually calling `span.set_status(StatusCode::Ok, ...)`, but I have since learned that the expectation (which the docs support) is that the default should be `Ok` instead.

This change updates the ordering to make `Ok` the default, and updates tests in the Datadog encoder to reflect this change.