### PR TITLE
Switch Jaeger collectors to use http client trait.

### DIFF
--- a/opentelemetry-jaeger/CHANGELOG.md
+++ b/opentelemetry-jaeger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Master
+
+
+### Added
+- Allow user to use their own http clients or use 4 of the default implementation(`surf_collector_client`, `reqwest_collector_client`, `reqwest_blocking_collector_client`, `isahc_collector_client`). 
+
 ## v0.9.0
 
 ### Added

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -38,6 +38,7 @@ lazy_static = "1.4"
 
 [dev-dependencies]
 opentelemetry = { version = "0.10", default-features = false, features = ["trace", "testing"], path = "../opentelemetry" }
+futures = "0.3"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -35,6 +35,9 @@ wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4.18", optional = true }
 thiserror = "1.0"
 lazy_static = "1.4"
+reqwest = { version = "0.10", default-features = false, optional = true }
+headers = { version = "0.3.2", optional = true }
+surf = { version = "2.0", optional = true }
 
 [dev-dependencies]
 opentelemetry = { version = "0.10", default-features = false, features = ["trace", "testing"], path = "../opentelemetry" }
@@ -56,6 +59,10 @@ optional = true
 [features]
 default = []
 collector_client = ["http", "opentelemetry/http"]
+isahc_collector_client = ["isahc", "collector_client"]
+reqwest_blocking_collector_client = ["reqwest/blocking", "collector_client", "headers", "opentelemetry/reqwest"]
+reqwest_collector_client = ["reqwest", "collector_client", "headers", "opentelemetry/reqwest"]
+surf_collector_client = ["surf", "collector_client", "opentelemetry/surf"]
 wasm_collector_client = [
     "base64",
     "futures-util",

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -54,7 +54,7 @@ optional = true
 
 [features]
 default = []
-collector_client = ["isahc", "http"]
+collector_client = ["http", "opentelemetry/http"]
 wasm_collector_client = [
     "base64",
     "futures-util",

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -117,9 +117,15 @@ Then you can use the [`with_collector_endpoint`] method to specify the endpoint:
 [`with_collector_endpoint`]: https://docs.rs/opentelemetry-jaeger/latest/opentelemetry_jaeger/struct.PipelineBuilder.html#method.with_collector_endpoint
 
 ```rust
-// Note that this requires the `collector_client` feature.
-// We enabled the `isahc` feature for a default isahc http client.
-// You can also provide your own implementation via new_pipeline().with_http_client() method.
+// Note that this requires one of the following features enabled so that there is a default http client implementation
+// * surf_collector_client
+// * reqwest_collector_client
+// * reqwest_blocking_collector_client
+// * isahc_collector_client
+
+// You can also provide your own implementation by enable 
+// `collecor_client` and set it with 
+// new_pipeline().with_http_client() method.
 use opentelemetry::tracer;
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -109,7 +109,7 @@ example expects a Jaeger collector running on `http://localhost:14268`.
 
 ```toml
 [dependencies]
-opentelemetry-jaeger = { version = "..", features = ["collector_client"] }
+opentelemetry-jaeger = { version = "..", features = ["collector_client", "isahc"] }
 ```
 
 Then you can use the [`with_collector_endpoint`] method to specify the endpoint:
@@ -118,6 +118,8 @@ Then you can use the [`with_collector_endpoint`] method to specify the endpoint:
 
 ```rust
 // Note that this requires the `collector_client` feature.
+// We enabled the `isahc` feature for a default isahc http client.
+// You can also provide your own implementation via new_pipeline().with_http_client() method.
 use opentelemetry::tracer;
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -109,7 +109,7 @@ example expects a Jaeger collector running on `http://localhost:14268`.
 
 ```toml
 [dependencies]
-opentelemetry-jaeger = { version = "..", features = ["collector_client", "isahc"] }
+opentelemetry-jaeger = { version = "..", features = ["isahc_collector_client"] }
 ```
 
 Then you can use the [`with_collector_endpoint`] method to specify the endpoint:

--- a/opentelemetry-jaeger/src/exporter/collector.rs
+++ b/opentelemetry-jaeger/src/exporter/collector.rs
@@ -33,10 +33,7 @@ mod collector_client {
 
     impl CollectorAsyncClientHttp {
         /// Create a new HTTP collector client
-        pub(crate) fn new(
-            endpoint: Uri,
-            client: Box<dyn HttpClient>,
-        ) -> thrift::Result<Self> {
+        pub(crate) fn new(endpoint: Uri, client: Box<dyn HttpClient>) -> thrift::Result<Self> {
             let payload_size_estimate = AtomicUsize::new(512);
 
             Ok(CollectorAsyncClientHttp {
@@ -122,7 +119,7 @@ mod wasm_collector_client {
         pub(crate) fn submit_batch(
             &self,
             batch: jaeger::Batch,
-        ) -> impl Future<Output=thrift::Result<jaeger::BatchSubmitResponse>> + Send + 'static
+        ) -> impl Future<Output = thrift::Result<jaeger::BatchSubmitResponse>> + Send + 'static
         {
             self.build_request(batch)
                 .map(post_request)

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -685,8 +685,10 @@ pub enum Error {
     /// No http client provided.
     #[cfg(feature = "collector_client")]
     #[error(
-        "No http client provided. Please enable isahc feature to use a default isahc http \
-    client implementation, or use set_http_client method to provide one"
+        "No http client provided. Consider enable one of the `surf_collector_client`, \
+        `reqwest_collector_client`, `reqwest_blocking_collector_client`, `isahc_collector_client` \
+        feature to have a default implementation. Or use with_http_client method in pipeline to \
+        provide your own implementation."
     )]
     NoHttpClient,
     /// reqwest client errors

--- a/opentelemetry-jaeger/src/exporter/uploader.rs
+++ b/opentelemetry-jaeger/src/exporter/uploader.rs
@@ -25,7 +25,12 @@ impl BatchUploader {
                     .await
                     .map_err::<crate::Error, _>(Into::into)?;
             }
-            #[cfg(any(feature = "collector_client", feature = "wasm_collector_client"))]
+            #[cfg(feature = "collector_client")]
+            BatchUploader::Collector(collector) => {
+                // TODO Implement retry behaviour
+                collector.submit_batch(batch).await?;
+            }
+            #[cfg(all(not(feature = "collector_client"), feature = "wasm_collector_client"))]
             BatchUploader::Collector(collector) => {
                 // TODO Implement retry behaviour
                 collector

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -156,8 +156,10 @@
 //!
 //! The following crate feature flags are available:
 //!
-//! * `collector_client`: Export span data directly to a Jaeger collector using
-//!   isahc http client.
+//! * `collector_client`: Export span data directly to a Jaeger collector. User MUST provide the http client
+//!     to be used or enable `isahc` featue to use the default http client implementation.
+//!
+//! * `wasm_collector_client`: Enable collector in wasm.
 //!
 //! ## Supported Rust Versions
 //!

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -156,8 +156,15 @@
 //!
 //! The following crate feature flags are available:
 //!
-//! * `collector_client`: Export span data directly to a Jaeger collector. User MUST provide the http client
-//!     to be used or enable `isahc` featue to use the default http client implementation.
+//! * `collector_client`: Export span data directly to a Jaeger collector. User MUST provide the http client.
+//!
+//! * `surf_collector_client`: Export span data with Jaeger collector backed by a surf default http client.
+//!
+//! * `reqwest_collector_client`: Export span data with Jaeger collector backed by a reqwest http client.
+//!
+//! * `reqwest_blocking_collector_client`: Export span data with Jaeger collector backed by a reqwest blocking http client.
+//!
+//! * `isahc_collector_client`: Export span data with Jaeger collector backed by a isahc http client.
 //!
 //! * `wasm_collector_client`: Enable collector in wasm.
 //!

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -85,7 +85,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! opentelemetry-jaeger = { version = "..", features = ["collector_client"] }
+//! opentelemetry-jaeger = { version = "..", features = ["collector_client", "isahc"] }
 //! ```
 //!
 //! Then you can use the [`with_collector_endpoint`] method to specify the endpoint:
@@ -94,6 +94,8 @@
 //!
 //! ```ignore
 //! // Note that this requires the `collector_client` feature.
+//! // We enabled the `isahc` feature for a default isahc http client.
+//! // You can also provide your own implementation via new_pipeline().with_http_client() method.
 //! use opentelemetry::trace::{Tracer, TraceError};
 //!
 //! fn main() -> Result<(), TraceError> {

--- a/opentelemetry/src/sdk/export/trace/mod.rs
+++ b/opentelemetry/src/sdk/export/trace/mod.rs
@@ -1,6 +1,6 @@
 //! Trace exporters
 use crate::api::trace::TraceError;
-#[cfg(feature = "http")]
+#[cfg(all(feature = "http", any(feature = "surf", feature = "reqwest")))]
 use crate::sdk::export::ExportError;
 use crate::{
     sdk,

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -11,4 +11,24 @@ if rustup component add clippy; then
     `# Exit with a nonzero code if there are clippy warnings` \
     -Dwarnings \
     "$@"
+  cargo clippy --manifest-path=opentelemetry-jaeger/Cargo.toml --all-targets --features "surf_collector_client" --no-default-features -- \
+    `# Exit with a nonzero code if there are clippy warnings` \
+    -Dwarnings \
+    "$@"
+  cargo clippy --manifest-path=opentelemetry-jaeger/Cargo.toml --all-targets --features "isahc_collector_client" --no-default-features -- \
+    `# Exit with a nonzero code if there are clippy warnings` \
+    -Dwarnings \
+    "$@"
+  cargo clippy --manifest-path=opentelemetry-jaeger/Cargo.toml --all-targets --features "reqwest_blocking_collector_client" --no-default-features -- \
+    `# Exit with a nonzero code if there are clippy warnings` \
+    -Dwarnings \
+    "$@"
+  cargo clippy --manifest-path=opentelemetry-jaeger/Cargo.toml --all-targets --features "reqwest_collector_client" --no-default-features -- \
+    `# Exit with a nonzero code if there are clippy warnings` \
+    -Dwarnings \
+    "$@"
+  cargo clippy --manifest-path=opentelemetry-jaeger/Cargo.toml --all-targets --features "collector_client" --no-default-features -- \
+    `# Exit with a nonzero code if there are clippy warnings` \
+    -Dwarnings \
+    "$@"
 fi


### PR DESCRIPTION
closes #337 

Added 4 default collector http client implementations(`surf_collector_client`, `reqwest_collector_client`, `reqwest_blocking_collector_client`, `isahc_collector_client`). Note that with any of those enabled. The user can still override the http client setting with `with_http_client`

If the user chooses none of above. They will have to call `with_http_client` to set their own. Otherwise, it will throw a `No http client error`.

Upgrade Note:
- Change the feature from `collector_client` to `isahc_collector_client`. 
