### PR TITLE
Add non monotonic counter support to prometheus

### DIFF
--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     let value_recorder_two = meter.f64_value_recorder("ex.com.two").init();
 
-    let _correlations =
+    let _baggage =
         Context::current_with_baggage(vec![FOO_KEY.string("foo1"), BAR_KEY.string("bar1")])
             .attach();
 

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     let value_recorder_two = meter.f64_value_recorder("ex.com.two").init();
 
-    let _correlations =
+    let _baggage =
         Context::current_with_baggage(vec![FOO_KEY.string("foo1"), BAR_KEY.string("bar1")])
             .attach();
 

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -1,5 +1,8 @@
 use opentelemetry::sdk::Resource;
-use opentelemetry::{metrics::MeterProvider, KeyValue};
+use opentelemetry::{
+    metrics::{MeterProvider, ObserverResult},
+    KeyValue,
+};
 use opentelemetry_prometheus::PrometheusExporter;
 use prometheus::{Encoder, TextEncoder};
 
@@ -12,6 +15,7 @@ fn test_add() {
 
     let meter = exporter.provider().unwrap().meter("test");
 
+    let up_down_counter = meter.f64_up_down_counter("updowncounter").init();
     let counter = meter.f64_counter("counter").init();
     let value_recorder = meter.f64_value_recorder("value_recorder").init();
 
@@ -22,18 +26,32 @@ fn test_add() {
     counter.add(10.0, &labels);
     counter.add(5.3, &labels);
 
-    expected.push("counter{A=\"B\",C=\"D\",R=\"V\"} 15.3");
+    expected.push(r#"counter{A="B",C="D",R="V"} 15.3"#);
+
+    let cb_labels = labels.clone();
+    let _observer = meter
+        .i64_value_observer("intobserver", move |result: ObserverResult<i64>| {
+            result.observe(1, cb_labels.as_ref())
+        })
+        .init();
+
+    expected.push(r#"intobserver{A="B",C="D",R="V"} 1"#);
 
     value_recorder.record(-0.6, &labels);
     value_recorder.record(-0.4, &labels);
     value_recorder.record(0.6, &labels);
     value_recorder.record(20.0, &labels);
 
-    expected.push("value_recorder_bucket{A=\"B\",C=\"D\",R=\"V\",le=\"+Inf\"} 4");
-    expected.push("value_recorder_bucket{A=\"B\",C=\"D\",R=\"V\",le=\"-0.5\"} 1");
-    expected.push("value_recorder_bucket{A=\"B\",C=\"D\",R=\"V\",le=\"1\"} 3");
-    expected.push("value_recorder_count{A=\"B\",C=\"D\",R=\"V\"} 4");
-    expected.push("value_recorder_sum{A=\"B\",C=\"D\",R=\"V\"} 19.6");
+    expected.push(r#"value_recorder_bucket{A="B",C="D",R="V",le="+Inf"} 4"#);
+    expected.push(r#"value_recorder_bucket{A="B",C="D",R="V",le="-0.5"} 1"#);
+    expected.push(r#"value_recorder_bucket{A="B",C="D",R="V",le="1"} 3"#);
+    expected.push(r#"value_recorder_count{A="B",C="D",R="V"} 4"#);
+    expected.push(r#"value_recorder_sum{A="B",C="D",R="V"} 19.6"#);
+
+    up_down_counter.add(10.0, &labels);
+    up_down_counter.add(-3.2, &labels);
+
+    expected.push(r#"updowncounter{A="B",C="D",R="V"} 6.8"#);
 
     compare_export(&exporter, expected)
 }

--- a/opentelemetry/src/api/metrics/async_instrument.rs
+++ b/opentelemetry/src/api/metrics/async_instrument.rs
@@ -69,8 +69,8 @@ where
         }
     }
 
-    /// Observe captures a single integer value from the associated instrument
-    /// callback, with the given labels.
+    /// Observe captures a single value from the associated instrument callback,
+    /// with the given labels.
     pub fn observe(&self, value: T, labels: &[KeyValue]) {
         (self.f)(
             labels,

--- a/opentelemetry/src/api/metrics/kind.rs
+++ b/opentelemetry/src/api/metrics/kind.rs
@@ -51,13 +51,12 @@ impl InstrumentKind {
 
     /// Whether this kind of instrument groups its inputs (as opposed to adding).
     pub fn grouping(&self) -> bool {
-        matches!(
-            self,
-            InstrumentKind::Counter
-                | InstrumentKind::UpDownCounter
-                | InstrumentKind::SumObserver
-                | InstrumentKind::UpDownSumObserver
-        )
+        !self.adding()
+    }
+
+    /// Whether this kind of instrument exposes a non-decreasing sum.
+    pub fn monotonic(&self) -> bool {
+        matches!(self, InstrumentKind::Counter | InstrumentKind::SumObserver)
     }
 
     /// Whether this kind of instrument receives precomputed sums.

--- a/opentelemetry/src/api/mod.rs
+++ b/opentelemetry/src/api/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "metrics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 use crate::api::metrics::MetricsError;
+#[cfg(feature = "trace")]
+#[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 use crate::api::trace::TraceError;
 use std::sync::PoisonError;
 

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -21,7 +21,7 @@ pub fn handle_error<T: Into<Error>>(err: T) {
             #[cfg(feature = "trace")]
             #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
             Error::Trace(err) => eprintln!("OpenTelemetry trace error occurred {:?}", err),
-            Error::Other(err_msg) => println!("OpenTelemetry error occurred {}", err_msg),
+            Error::Other(err_msg) => eprintln!("OpenTelemetry error occurred {}", err_msg),
         },
     }
 }

--- a/opentelemetry/src/sdk/export/metrics/stdout.rs
+++ b/opentelemetry/src/sdk/export/metrics/stdout.rs
@@ -2,8 +2,8 @@
 use crate::global;
 use crate::sdk::{
     export::metrics::{
-        CheckpointSet, Count, ExportKind, ExportKindSelector, Exporter, LastValue, Max, Min,
-        Quantile, Sum,
+        CheckpointSet, Count, ExportKind, ExportKindFor, ExportKindSelector, Exporter, LastValue,
+        Max, Min, Quantile, Sum,
     },
     metrics::{
         aggregators::{
@@ -235,16 +235,16 @@ where
     }
 }
 
-impl<W> ExportKindSelector for StdoutExporter<W>
+impl<W> ExportKindFor for StdoutExporter<W>
 where
     W: fmt::Debug + io::Write,
 {
-    fn export_kind_for(&self, _descriptor: &Descriptor) -> ExportKind {
-        ExportKind::PassThrough
+    fn export_kind_for(&self, descriptor: &Descriptor) -> ExportKind {
+        ExportKindSelector::Stateless.export_kind_for(descriptor)
     }
 }
 
-/// A formatter for user-defined batch serilization.
+/// A formatter for user-defined batch serialization.
 pub struct Formatter(Box<dyn Fn(ExportBatch) -> Result<String> + Send + Sync>);
 impl fmt::Debug for Formatter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -361,7 +361,7 @@ where
         let (spawn, interval, exporter) = self.try_build()?;
         let mut push_builder = controllers::push(
             simple::Selector::Exact,
-            ExportKind::PassThrough,
+            ExportKindSelector::Stateless,
             exporter,
             spawn,
             interval,

--- a/opentelemetry/src/sdk/metrics/controllers/pull.rs
+++ b/opentelemetry/src/sdk/metrics/controllers/pull.rs
@@ -1,8 +1,6 @@
 use crate::metrics::{registry, Result};
 use crate::sdk::{
-    export::metrics::{
-        AggregatorSelector, CheckpointSet, Checkpointer, ExportKindSelector, Record,
-    },
+    export::metrics::{AggregatorSelector, CheckpointSet, Checkpointer, ExportKindFor, Record},
     metrics::{
         accumulator,
         processors::{self, BasicProcessor},
@@ -18,7 +16,7 @@ const DEFAULT_CACHE_DURATION: Duration = Duration::from_secs(10);
 /// Returns a builder for creating a `PullController` with the configured and options.
 pub fn pull(
     aggregator_selector: Box<dyn AggregatorSelector + Send + Sync>,
-    export_selector: Box<dyn ExportKindSelector + Send + Sync>,
+    export_selector: Box<dyn ExportKindFor + Send + Sync>,
 ) -> PullControllerBuilder {
     PullControllerBuilder::with_selectors(aggregator_selector, export_selector)
 }
@@ -65,7 +63,7 @@ impl PullController {
 impl CheckpointSet for PullController {
     fn try_for_each(
         &mut self,
-        export_selector: &dyn ExportKindSelector,
+        export_selector: &dyn ExportKindFor,
         f: &mut dyn FnMut(&Record<'_>) -> Result<()>,
     ) -> Result<()> {
         self.processor.lock().and_then(|mut locked_processor| {
@@ -83,7 +81,7 @@ pub struct PullControllerBuilder {
     aggregator_selector: Box<dyn AggregatorSelector + Send + Sync>,
 
     /// The export kind selector used by this controller
-    export_selector: Box<dyn ExportKindSelector + Send + Sync>,
+    export_selector: Box<dyn ExportKindFor + Send + Sync>,
 
     /// Resource is the OpenTelemetry resource associated with all Meters created by
     /// the controller.
@@ -107,7 +105,7 @@ impl PullControllerBuilder {
     /// Configure the sectors for this controller
     pub fn with_selectors(
         aggregator_selector: Box<dyn AggregatorSelector + Send + Sync>,
-        export_selector: Box<dyn ExportKindSelector + Send + Sync>,
+        export_selector: Box<dyn ExportKindFor + Send + Sync>,
     ) -> Self {
         PullControllerBuilder {
             aggregator_selector,

--- a/opentelemetry/src/sdk/metrics/controllers/push.rs
+++ b/opentelemetry/src/sdk/metrics/controllers/push.rs
@@ -1,7 +1,7 @@
 use crate::global;
 use crate::metrics::registry;
 use crate::sdk::{
-    export::metrics::{AggregatorSelector, Checkpointer, ExportKindSelector, Exporter},
+    export::metrics::{AggregatorSelector, Checkpointer, ExportKindFor, Exporter},
     metrics::{
         self,
         processors::{self, BasicProcessor},
@@ -28,7 +28,7 @@ pub fn push<AS, ES, E, SP, SO, I, IO>(
 ) -> PushControllerBuilder<SP, I>
 where
     AS: AggregatorSelector + Send + Sync + 'static,
-    ES: ExportKindSelector + Send + Sync + 'static,
+    ES: ExportKindFor + Send + Sync + 'static,
     E: Exporter + Send + Sync + 'static,
     SP: Fn(PushControllerWorker) -> SO,
     I: Fn(time::Duration) -> IO,
@@ -127,7 +127,7 @@ impl Drop for PushController {
 #[derive(Debug)]
 pub struct PushControllerBuilder<S, I> {
     aggregator_selector: Box<dyn AggregatorSelector + Send + Sync>,
-    export_selector: Box<dyn ExportKindSelector + Send + Sync>,
+    export_selector: Box<dyn ExportKindFor + Send + Sync>,
     exporter: Box<dyn Exporter + Send + Sync>,
     spawn: S,
     interval: I,

--- a/opentelemetry/src/sdk/metrics/processors/basic.rs
+++ b/opentelemetry/src/sdk/metrics/processors/basic.rs
@@ -1,7 +1,7 @@
 use crate::sdk::{
     export::metrics::{
         self, Accumulation, Aggregator, AggregatorSelector, CheckpointSet, Checkpointer,
-        ExportKind, ExportKindSelector, LockedProcessor, Processor, Record, Subtractor,
+        ExportKind, ExportKindFor, LockedProcessor, Processor, Record, Subtractor,
     },
     metrics::aggregators::SumAggregator,
     Resource,
@@ -19,7 +19,7 @@ use std::time::SystemTime;
 /// Create a new basic processor
 pub fn basic(
     aggregator_selector: Box<dyn AggregatorSelector + Send + Sync>,
-    export_selector: Box<dyn ExportKindSelector + Send + Sync>,
+    export_selector: Box<dyn ExportKindFor + Send + Sync>,
     memory: bool,
 ) -> BasicProcessor {
     BasicProcessor {
@@ -33,7 +33,7 @@ pub fn basic(
 #[derive(Debug)]
 pub struct BasicProcessor {
     aggregator_selector: Box<dyn AggregatorSelector + Send + Sync>,
-    export_selector: Box<dyn ExportKindSelector + Send + Sync>,
+    export_selector: Box<dyn ExportKindFor + Send + Sync>,
     state: Mutex<BasicProcessorState>,
 }
 
@@ -303,7 +303,7 @@ impl Default for BasicProcessorState {
 impl CheckpointSet for BasicProcessorState {
     fn try_for_each(
         &mut self,
-        exporter: &dyn ExportKindSelector,
+        exporter: &dyn ExportKindFor,
         f: &mut dyn FnMut(&Record<'_>) -> Result<()>,
     ) -> Result<()> {
         if self.started_collection != self.finished_collection {
@@ -323,17 +323,6 @@ impl CheckpointSet for BasicProcessorState {
             }
 
             match exporter.export_kind_for(&value.descriptor) {
-                ExportKind::PassThrough => {
-                    // No state is required, pass through the checkpointed value.
-                    agg = Some(&value.current);
-
-                    if instrument_kind.precomputed_sum() {
-                        start = self.process_start;
-                    } else {
-                        start = self.interval_start;
-                    }
-                }
-
                 ExportKind::Cumulative => {
                     // If stateful, the sum has been computed.  If stateless, the
                     // input was already cumulative. Either way, use the


### PR DESCRIPTION
* Export non-monotonic and last value instruments as prometheus gauges
* Replace `PassThrough` export kind with `Stateless` export kind selector, allowing support of both cumulative and delta export kinds.