### PR TITLE
fix: use InstrumentationLibrary in metrics.

### DIFF
--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -13,7 +13,7 @@ fn test_add() {
         .with_resource(Resource::new(vec![KeyValue::new("R", "V")]))
         .init();
 
-    let meter = exporter.provider().unwrap().meter("test");
+    let meter = exporter.provider().unwrap().meter("test", None);
 
     let up_down_counter = meter.f64_up_down_counter("updowncounter").init();
     let counter = meter.f64_counter("counter").init();

--- a/opentelemetry/benches/ddsketch.rs
+++ b/opentelemetry/benches/ddsketch.rs
@@ -28,7 +28,8 @@ fn ddsketch(data: Vec<f64>) {
         DDSKetchAggregator::new(&DDSketchConfig::new(0.001, 2048, 1e-9), NumberKind::F64);
     let descriptor = Descriptor::new(
         "test".to_string(),
-        "test".to_string(),
+        "test",
+        None,
         InstrumentKind::ValueRecorder,
         NumberKind::F64,
     );
@@ -53,7 +54,8 @@ fn array(data: Vec<f64>) {
     let aggregator = ArrayAggregator::default();
     let descriptor = Descriptor::new(
         "test".to_string(),
-        "test".to_string(),
+        "test",
+        None,
         InstrumentKind::ValueRecorder,
         NumberKind::F64,
     );

--- a/opentelemetry/benches/metric.rs
+++ b/opentelemetry/benches/metric.rs
@@ -131,7 +131,7 @@ impl Processor for BenchProcessor {
 fn build_meter() -> Meter {
     let processor = Arc::new(BenchProcessor::default());
     let core = accumulator(processor).build();
-    Meter::new("benches", Arc::new(core))
+    Meter::new("benches", None, Arc::new(core))
 }
 
 criterion_group!(benches, counters);

--- a/opentelemetry/src/api/metrics/config.rs
+++ b/opentelemetry/src/api/metrics/config.rs
@@ -1,3 +1,4 @@
+use crate::sdk::InstrumentationLibrary;
 use crate::Unit;
 
 /// Config contains some options for metrics of any kind.
@@ -5,31 +6,34 @@ use crate::Unit;
 pub struct InstrumentConfig {
     pub(crate) description: Option<String>,
     pub(crate) unit: Option<Unit>,
-    pub(crate) instrumentation_name: String,
-    pub(crate) instrumentation_version: Option<String>,
+    pub(crate) instrumentation_library: InstrumentationLibrary,
 }
 
 impl InstrumentConfig {
     /// Create a new config from instrumentation name
-    pub fn with_instrumentation_name(instrumentation_name: String) -> Self {
+    pub fn with_instrumentation_name(instrumentation_name: &'static str) -> Self {
         InstrumentConfig {
             description: None,
             unit: None,
-            instrumentation_name,
-            instrumentation_version: None,
+            instrumentation_library: InstrumentationLibrary {
+                name: instrumentation_name,
+                version: None,
+            },
         }
     }
 
-    /// Create a new config with instrumentation name and version
+    /// Create a new config with instrumentation name and optional version
     pub fn with_instrumentation(
-        instrumentation_name: String,
-        instrumentation_version: String,
+        instrumentation_name: &'static str,
+        instrumentation_version: Option<&'static str>,
     ) -> Self {
         InstrumentConfig {
             description: None,
             unit: None,
-            instrumentation_name,
-            instrumentation_version: Some(instrumentation_version),
+            instrumentation_library: InstrumentationLibrary {
+                name: instrumentation_name,
+                version: instrumentation_version,
+            },
         }
     }
 
@@ -44,12 +48,12 @@ impl InstrumentConfig {
     }
 
     /// Instrumentation name is the name given to the Meter that created this instrument.
-    pub fn instrumentation_name(&self) -> &String {
-        &self.instrumentation_name
+    pub fn instrumentation_name(&self) -> &'static str {
+        self.instrumentation_library.name
     }
 
     /// Instrumentation version returns the version of instrumentation
-    pub fn instrumentation_version(&self) -> Option<&String> {
-        self.instrumentation_version.as_ref()
+    pub fn instrumentation_version(&self) -> Option<&'static str> {
+        self.instrumentation_library.version
     }
 }

--- a/opentelemetry/src/api/metrics/counter.rs
+++ b/opentelemetry/src/api/metrics/counter.rs
@@ -69,7 +69,8 @@ impl<'a, T> CounterBuilder<'a, T> {
             meter,
             descriptor: Descriptor::new(
                 name,
-                meter.instrumentation_name().to_string(),
+                meter.instrumentation_library().name,
+                meter.instrumentation_library().version,
                 InstrumentKind::Counter,
                 number_kind,
             ),

--- a/opentelemetry/src/api/metrics/descriptor.rs
+++ b/opentelemetry/src/api/metrics/descriptor.rs
@@ -17,13 +17,15 @@ impl Descriptor {
     /// Create a new descriptor
     pub fn new(
         name: String,
-        instrumentation_name: String,
+        instrumentation_name: &'static str,
+        instrumentation_version: Option<&'static str>,
         instrument_kind: InstrumentKind,
         number_kind: NumberKind,
     ) -> Self {
         let mut hasher = FnvHasher::default();
         name.hash(&mut hasher);
         instrumentation_name.hash(&mut hasher);
+        instrumentation_version.hash(&mut hasher);
         instrument_kind.hash(&mut hasher);
         number_kind.hash(&mut hasher);
 
@@ -31,7 +33,10 @@ impl Descriptor {
             name,
             instrument_kind,
             number_kind,
-            config: InstrumentConfig::with_instrumentation_name(instrumentation_name),
+            config: InstrumentConfig::with_instrumentation(
+                instrumentation_name,
+                instrumentation_version,
+            ),
             attribute_hash: hasher.finish(),
         }
     }
@@ -68,8 +73,8 @@ impl Descriptor {
     }
 
     /// The name of the library that provided instrumentation for this instrument.
-    pub fn instrumentation_name(&self) -> &str {
-        self.config.instrumentation_name.as_str()
+    pub fn instrumentation_name(&self) -> &'static str {
+        self.config.instrumentation_name()
     }
 
     /// The pre-computed hash of the descriptor data

--- a/opentelemetry/src/api/metrics/noop.rs
+++ b/opentelemetry/src/api/metrics/noop.rs
@@ -18,7 +18,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 lazy_static::lazy_static! {
-    static ref NOOP_DESCRIPTOR: Descriptor = Descriptor::new(String::new(), "noop".to_string(), InstrumentKind::Counter, NumberKind::U64);
+    static ref NOOP_DESCRIPTOR: Descriptor = Descriptor::new(String::new(), "noop", None, InstrumentKind::Counter, NumberKind::U64);
 }
 
 /// A no-op instance of a `MetricProvider`
@@ -35,8 +35,8 @@ impl NoopMeterProvider {
 }
 
 impl MeterProvider for NoopMeterProvider {
-    fn meter(&self, name: &str) -> Meter {
-        Meter::new(name, Arc::new(NoopMeterCore::new()))
+    fn meter(&self, name: &'static str, version: Option<&'static str>) -> Meter {
+        Meter::new(name, version, Arc::new(NoopMeterCore::new()))
     }
 }
 

--- a/opentelemetry/src/api/metrics/observer.rs
+++ b/opentelemetry/src/api/metrics/observer.rs
@@ -56,7 +56,8 @@ impl<'a, T> SumObserverBuilder<'a, T> {
             meter,
             descriptor: Descriptor::new(
                 name,
-                meter.instrumentation_name().to_string(),
+                meter.instrumentation_library().name,
+                meter.instrumentation_library().version,
                 InstrumentKind::SumObserver,
                 number_kind,
             ),
@@ -142,7 +143,8 @@ impl<'a, T> UpDownSumObserverBuilder<'a, T> {
             meter,
             descriptor: Descriptor::new(
                 name,
-                meter.instrumentation_name().to_string(),
+                meter.instrumentation_library().name,
+                meter.instrumentation_library().version,
                 InstrumentKind::UpDownSumObserver,
                 number_kind,
             ),
@@ -227,7 +229,8 @@ impl<'a, T> ValueObserverBuilder<'a, T> {
             meter,
             descriptor: Descriptor::new(
                 name,
-                meter.instrumentation_name().to_string(),
+                meter.instrumentation_library().name,
+                meter.instrumentation_library().version,
                 InstrumentKind::ValueObserver,
                 number_kind,
             ),

--- a/opentelemetry/src/api/metrics/registry.rs
+++ b/opentelemetry/src/api/metrics/registry.rs
@@ -20,8 +20,8 @@ pub fn meter_provider(core: Arc<dyn MeterCore + Send + Sync>) -> RegistryMeterPr
 pub struct RegistryMeterProvider(Arc<dyn MeterCore + Send + Sync>);
 
 impl MeterProvider for RegistryMeterProvider {
-    fn meter(&self, name: &str) -> Meter {
-        Meter::new(name, self.0.clone())
+    fn meter(&self, name: &'static str, version: Option<&'static str>) -> Meter {
+        Meter::new(name, version, self.0.clone())
     }
 }
 

--- a/opentelemetry/src/api/metrics/up_down_counter.rs
+++ b/opentelemetry/src/api/metrics/up_down_counter.rs
@@ -69,7 +69,8 @@ impl<'a, T> UpDownCounterBuilder<'a, T> {
             meter,
             descriptor: Descriptor::new(
                 name,
-                meter.instrumentation_name().to_string(),
+                meter.instrumentation_library().name,
+                meter.instrumentation_library().version,
                 InstrumentKind::UpDownCounter,
                 number_kind,
             ),

--- a/opentelemetry/src/api/metrics/value_recorder.rs
+++ b/opentelemetry/src/api/metrics/value_recorder.rs
@@ -69,7 +69,8 @@ impl<'a, T> ValueRecorderBuilder<'a, T> {
             meter,
             descriptor: Descriptor::new(
                 name,
-                meter.instrumentation_name().to_string(),
+                meter.instrumentation_library().name,
+                meter.instrumentation_library().version,
                 InstrumentKind::ValueRecorder,
                 number_kind,
             ),

--- a/opentelemetry/src/global/metrics.rs
+++ b/opentelemetry/src/global/metrics.rs
@@ -16,8 +16,8 @@ pub struct GlobalMeterProvider {
 }
 
 impl MeterProvider for GlobalMeterProvider {
-    fn meter(&self, name: &str) -> Meter {
-        self.provider.meter(name)
+    fn meter(&self, name: &'static str, version: Option<&'static str>) -> Meter {
+        self.provider.meter(name, version)
     }
 }
 
@@ -67,6 +67,13 @@ pub fn meter_provider() -> GlobalMeterProvider {
 ///
 /// [`Meter`]: ../../api/metrics/meter/struct.Meter.html
 /// [`GlobalMeterProvider`]: struct.GlobalMeterProvider.html
-pub fn meter(name: &str) -> Meter {
-    meter_provider().meter(name)
+pub fn meter(name: &'static str) -> Meter {
+    meter_provider().meter(name, None)
+}
+
+/// Creates a [`Meter`] with the name and version.
+///
+/// [`Meter`]: ../../api/metrics/meter/struct.Meter.html
+pub fn meter_with_version(name: &'static str, version: &'static str) -> Meter {
+    meter_provider().meter(name, Some(version))
 }

--- a/opentelemetry/src/global/mod.rs
+++ b/opentelemetry/src/global/mod.rs
@@ -140,7 +140,9 @@ mod trace;
 pub use error_handler::{handle_error, set_error_handler};
 #[cfg(feature = "metrics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-pub use metrics::{meter, meter_provider, set_meter_provider, GlobalMeterProvider};
+pub use metrics::{
+    meter, meter_provider, meter_with_version, set_meter_provider, GlobalMeterProvider,
+};
 #[cfg(feature = "trace")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 pub use propagation::{get_text_map_propagator, set_text_map_propagator};

--- a/opentelemetry/src/sdk/metrics/aggregators/ddsketch.rs
+++ b/opentelemetry/src/sdk/metrics/aggregators/ddsketch.rs
@@ -811,7 +811,8 @@ mod tests {
         );
         let descriptor = Descriptor::new(
             "test".to_string(),
-            "test".to_string(),
+            "test",
+            None,
             InstrumentKind::ValueRecorder,
             kind.clone(),
         );
@@ -976,7 +977,8 @@ mod tests {
         );
         let descriptor = Descriptor::new(
             "test".to_string(),
-            "test".to_string(),
+            "test",
+            None,
             InstrumentKind::ValueRecorder,
             kind.clone(),
         );


### PR DESCRIPTION
Currently we don't use InstrumentationLibrary to store the instrumentation library information. This should help unify things a little bit. My only concern is whether there will be any cases that users cannot use static string as argument(need to fetch intrumentation information somewhere else). So far I haven't thought any, so leave it as it is for now. 