### PR TITLE
fix: Counter adds the delta from last collection.

### DIFF
--- a/opentelemetry/src/sdk/metrics/processors/basic.rs
+++ b/opentelemetry/src/sdk/metrics/processors/basic.rs
@@ -215,9 +215,10 @@ impl Checkpointer for BasicLockedProcessor<'_> {
                 // If this processor does not require memory, stale, stateless
                 // entries can be removed. This implies that they were not updated
                 // over the previous full collection interval.
-                if stale && stateless && has_memory {
+                if stale && stateless && !has_memory {
                     return false;
                 }
+                return true;
             }
 
             // Update Aggregator state to support exporting either a


### PR DESCRIPTION
Fix #394 

During each collection interval. The processor will maintain two places to store the values. `cumulative` and `current`. `current` won't get clear until the next time instrument gets updated. So if the instrument hasn't updated since the last collection. We should skip any change made to the `cumulative` part.