### PR TITLE
fix: HistogramAggregator returns sum when asked for count

### DIFF
--- a/opentelemetry/src/sdk/metrics/aggregators/histogram.rs
+++ b/opentelemetry/src/sdk/metrics/aggregators/histogram.rs
@@ -64,7 +64,7 @@ impl Count for HistogramAggregator {
         self.inner
             .read()
             .map_err(From::from)
-            .map(|inner| inner.state.sum.load().to_u64(&NumberKind::U64))
+            .map(|inner| inner.state.count.load().to_u64(&NumberKind::U64))
     }
 }
 


### PR DESCRIPTION
Find this bug when testing the otlp metric exporter. We still might need to add more tests around metrics. But I think this should fix the problem.