### PR TITLE
Store parent context in span builder

### DIFF
--- a/examples/aws-xray/src/server.rs
+++ b/examples/aws-xray/src/server.rs
@@ -20,7 +20,7 @@ async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
         .to_str()
         .unwrap();
 
-    let span = global::tracer("example/server").start_from_context("hello", &parent_context);
+    let span = global::tracer("example/server").start_with_context("hello", parent_context);
     span.add_event(format!("Handling - {}", x_amzn_trace_id), Vec::new());
 
     Ok(Response::new(

--- a/examples/grpc/src/server.rs
+++ b/examples/grpc/src/server.rs
@@ -25,7 +25,7 @@ impl Greeter for MyGreeter {
         request: Request<HelloRequest>, // Accept request of type HelloRequest
     ) -> Result<Response<HelloReply>, Status> {
         let parent_cx = global::get_text_map_propagator(|prop| prop.extract(request.metadata()));
-        let span = global::tracer("greeter").start_from_context("Processing reply", &parent_cx);
+        let span = global::tracer("greeter").start_with_context("Processing reply", parent_cx);
         span.set_attribute(KeyValue::new("request", format!("{:?}", request)));
 
         // Return an instance of type HelloReply

--- a/examples/http/src/server.rs
+++ b/examples/http/src/server.rs
@@ -13,7 +13,7 @@ use std::{convert::Infallible, net::SocketAddr};
 
 async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     let parent_cx = global::get_text_map_propagator(|propagator| propagator.extract(req.headers()));
-    let span = global::tracer("example/server").start_from_context("hello", &parent_cx);
+    let span = global::tracer("example/server").start_with_context("hello", parent_cx);
     span.add_event("handling this...".to_string(), Vec::new());
 
     Ok(Response::new("Hello, World!".into()))

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -92,7 +92,7 @@ impl trace::Tracer for BoxedTracer {
     /// trace. A span is said to be a _root span_ if it does not have a parent. Each
     /// trace includes a single root span, which is the shared ancestor of all other
     /// spans in the trace.
-    fn start_from_context(&self, name: &str, cx: &Context) -> Self::Span {
+    fn start_with_context(&self, name: &str, cx: Context) -> Self::Span {
         BoxedSpan(self.0.start_with_context_boxed(name, cx))
     }
 
@@ -104,8 +104,8 @@ impl trace::Tracer for BoxedTracer {
     }
 
     /// Create a span from a `SpanBuilder`
-    fn build_with_context(&self, builder: trace::SpanBuilder, cx: &Context) -> Self::Span {
-        BoxedSpan(self.0.build_with_context_boxed(builder, cx))
+    fn build(&self, builder: trace::SpanBuilder) -> Self::Span {
+        BoxedSpan(self.0.build_boxed(builder))
     }
 }
 
@@ -120,11 +120,11 @@ pub trait GenericTracer: fmt::Debug + 'static {
 
     /// Returns a trait object so the underlying implementation can be swapped
     /// out at runtime.
-    fn start_with_context_boxed(&self, name: &str, cx: &Context) -> Box<DynSpan>;
+    fn start_with_context_boxed(&self, name: &str, cx: Context) -> Box<DynSpan>;
 
     /// Returns a trait object so the underlying implementation can be swapped
     /// out at runtime.
-    fn build_with_context_boxed(&self, builder: trace::SpanBuilder, cx: &Context) -> Box<DynSpan>;
+    fn build_boxed(&self, builder: trace::SpanBuilder) -> Box<DynSpan>;
 }
 
 impl<S, T> GenericTracer for T
@@ -139,14 +139,14 @@ where
 
     /// Returns a trait object so the underlying implementation can be swapped
     /// out at runtime.
-    fn start_with_context_boxed(&self, name: &str, cx: &Context) -> Box<DynSpan> {
-        Box::new(self.start_from_context(name, cx))
+    fn start_with_context_boxed(&self, name: &str, cx: Context) -> Box<DynSpan> {
+        Box::new(self.start_with_context(name, cx))
     }
 
     /// Returns a trait object so the underlying implementation can be swapped
     /// out at runtime.
-    fn build_with_context_boxed(&self, builder: trace::SpanBuilder, cx: &Context) -> Box<DynSpan> {
-        Box::new(self.build_with_context(builder, cx))
+    fn build_boxed(&self, builder: trace::SpanBuilder) -> Box<DynSpan> {
+        Box::new(self.build(builder))
     }
 }
 

--- a/opentelemetry/src/sdk/trace/sampler.rs
+++ b/opentelemetry/src/sdk/trace/sampler.rs
@@ -113,19 +113,21 @@ impl ShouldSample for Sampler {
             // Never sample the trace
             Sampler::AlwaysOff => SamplingDecision::Drop,
             // The parent decision if sampled; otherwise the decision of delegate_sampler
-            Sampler::ParentBased(delegate_sampler) => parent_context.map_or(
-                delegate_sampler
-                    .should_sample(parent_context, trace_id, name, span_kind, attributes, links)
-                    .decision,
-                |ctx| {
-                    let parent_span_context = ctx.span().span_context();
-                    if parent_span_context.is_sampled() {
-                        SamplingDecision::RecordAndSample
-                    } else {
-                        SamplingDecision::Drop
-                    }
-                },
-            ),
+            Sampler::ParentBased(delegate_sampler) => {
+                parent_context.filter(|cx| cx.has_active_span()).map_or(
+                    delegate_sampler
+                        .should_sample(parent_context, trace_id, name, span_kind, attributes, links)
+                        .decision,
+                    |ctx| {
+                        let parent_span_context = ctx.span().span_context();
+                        if parent_span_context.is_sampled() {
+                            SamplingDecision::RecordAndSample
+                        } else {
+                            SamplingDecision::Drop
+                        }
+                    },
+                )
+            }
             // Probabilistically sample the trace.
             Sampler::TraceIdRatioBased(prob) => {
                 if *prob >= 1.0 {
@@ -269,5 +271,21 @@ mod tests {
                 tolerance
             );
         }
+    }
+
+    #[test]
+    fn filter_parent_sampler_for_active_spans() {
+        let sampler = Sampler::ParentBased(Box::new(Sampler::AlwaysOn));
+        let cx = Context::current_with_value("some_value");
+        let result = sampler.should_sample(
+            Some(&cx),
+            TraceId::from_u128(1),
+            "should sample",
+            &SpanKind::Internal,
+            &[],
+            &[],
+        );
+
+        assert_eq!(result.decision, SamplingDecision::RecordAndSample);
     }
 }

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -695,10 +695,8 @@ mod tests {
         D: Fn(time::Duration) -> DS + 'static + Send + Sync,
         DS: Future<Output = ()> + Send + Sync + 'static,
     {
-        async fn export(&mut self, batch: Vec<SpanData>) -> ExportResult {
-            println!("Accepting {} spans", batch.len());
+        async fn export(&mut self, _batch: Vec<SpanData>) -> ExportResult {
             (self.delay_fn)(self.delay_for).await;
-            println!("Finish exporting, return result from exporter");
             Ok(())
         }
     }


### PR DESCRIPTION
The span builder currently holds a parent `SpanContext`, and `Context` information is passed separately when starting a span directly or via a builder. This poses a few problems, first you can assign a context which contains an active span _as well as_ a builder with a parent span context, which can lead to confusion, and secondly we have to construct a wrapper context when sampling even in cases when the passed in context already contains an active span.

This patch resolves this by changing the span builder's parent context to instead store a `Context` directly. This allows the builder methods to have a single context to look at when searching for parent span contexts, and allows the wrapper context to only be created for sampling when it is facilitating a remote parent.