### PR TITLE
Adds Send + Sync to InstrumentCore (metrics)

### DIFF
--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -258,7 +258,7 @@ impl Meter {
     pub(crate) fn new_sync_instrument(
         &self,
         descriptor: Descriptor,
-    ) -> Result<Arc<dyn sdk_api::SyncInstrumentCore + Send + Sync>> {
+    ) -> Result<Arc<dyn sdk_api::SyncInstrumentCore>> {
         self.core.new_sync_instrument(descriptor)
     }
 
@@ -266,7 +266,7 @@ impl Meter {
         &self,
         descriptor: Descriptor,
         runner: AsyncRunner,
-    ) -> Result<Arc<dyn sdk_api::AsyncInstrumentCore + Send + Sync>> {
+    ) -> Result<Arc<dyn sdk_api::AsyncInstrumentCore>> {
         self.core.new_async_instrument(descriptor, runner)
     }
 }

--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -54,10 +54,7 @@ impl NoopMeterCore {
 }
 
 impl MeterCore for NoopMeterCore {
-    fn new_sync_instrument(
-        &self,
-        _descriptor: Descriptor,
-    ) -> Result<Arc<dyn SyncInstrumentCore + Send + Sync>> {
+    fn new_sync_instrument(&self, _descriptor: Descriptor) -> Result<Arc<dyn SyncInstrumentCore>> {
         Ok(Arc::new(NoopSyncInstrument::new()))
     }
 
@@ -65,7 +62,7 @@ impl MeterCore for NoopMeterCore {
         &self,
         _descriptor: Descriptor,
         _runner: AsyncRunner,
-    ) -> Result<Arc<dyn AsyncInstrumentCore + Send + Sync>> {
+    ) -> Result<Arc<dyn AsyncInstrumentCore>> {
         Ok(Arc::new(NoopAsyncInstrument::new()))
     }
 
@@ -99,7 +96,7 @@ impl InstrumentCore for NoopSyncInstrument {
 }
 
 impl SyncInstrumentCore for NoopSyncInstrument {
-    fn bind(&self, _labels: &'_ [KeyValue]) -> Arc<dyn SyncBoundInstrumentCore + Send + Sync> {
+    fn bind(&self, _labels: &'_ [KeyValue]) -> Arc<dyn SyncBoundInstrumentCore> {
         Arc::new(NoopBoundSyncInstrument::new())
     }
     fn record_one(&self, _number: Number, _labels: &'_ [KeyValue]) {

--- a/opentelemetry/src/metrics/registry.rs
+++ b/opentelemetry/src/metrics/registry.rs
@@ -161,5 +161,5 @@ impl From<&Descriptor> for UniqueInstrumentKey {
     }
 }
 
-type UniqueSyncInstrument = Arc<dyn SyncInstrumentCore + Send + Sync>;
-type UniqueAsyncInstrument = Arc<dyn AsyncInstrumentCore + Send + Sync>;
+type UniqueSyncInstrument = Arc<dyn SyncInstrumentCore>;
+type UniqueAsyncInstrument = Arc<dyn AsyncInstrumentCore>;

--- a/opentelemetry/src/metrics/sdk_api.rs
+++ b/opentelemetry/src/metrics/sdk_api.rs
@@ -16,31 +16,28 @@ pub trait MeterCore: fmt::Debug {
     );
 
     /// Create a new synchronous instrument implementation.
-    fn new_sync_instrument(
-        &self,
-        descriptor: Descriptor,
-    ) -> Result<Arc<dyn SyncInstrumentCore + Send + Sync>>;
+    fn new_sync_instrument(&self, descriptor: Descriptor) -> Result<Arc<dyn SyncInstrumentCore>>;
 
     /// Create a new asynchronous instrument implementation.
     fn new_async_instrument(
         &self,
         descriptor: Descriptor,
         runner: AsyncRunner,
-    ) -> Result<Arc<dyn AsyncInstrumentCore + Send + Sync>>;
+    ) -> Result<Arc<dyn AsyncInstrumentCore>>;
 }
 
 /// A common interface for synchronous and asynchronous instruments.
-pub trait InstrumentCore: fmt::Debug {
+pub trait InstrumentCore: fmt::Debug + Send + Sync {
     /// Description of the instrument's descriptor
     fn descriptor(&self) -> &Descriptor;
 }
 
 /// The implementation-level interface to a generic synchronous instrument
 /// (e.g., ValueRecorder and Counter instruments).
-pub trait SyncInstrumentCore: InstrumentCore + Send + Sync {
+pub trait SyncInstrumentCore: InstrumentCore {
     /// Creates an implementation-level bound instrument, binding a label set
     /// with this instrument implementation.
-    fn bind(&self, labels: &'_ [KeyValue]) -> Arc<dyn SyncBoundInstrumentCore + Send + Sync>;
+    fn bind(&self, labels: &'_ [KeyValue]) -> Arc<dyn SyncBoundInstrumentCore>;
 
     /// Capture a single synchronous metric event.
     fn record_one(&self, number: Number, labels: &'_ [KeyValue]);
@@ -57,7 +54,7 @@ pub trait SyncBoundInstrumentCore: fmt::Debug + Send + Sync {
 
 /// An implementation-level interface to an asynchronous instrument (e.g.,
 /// Observer instruments).
-pub trait AsyncInstrumentCore: InstrumentCore + Send + Sync {
+pub trait AsyncInstrumentCore: InstrumentCore {
     /// The underlying type as `Any` to support downcasting.
     fn as_any(&self) -> &dyn Any;
 }

--- a/opentelemetry/src/sdk/metrics/mod.rs
+++ b/opentelemetry/src/sdk/metrics/mod.rs
@@ -81,10 +81,7 @@ struct MapKey {
 struct AsyncInstrumentState {
     /// runners maintains the set of runners in the order they were
     /// registered.
-    runners: Vec<(
-        AsyncRunner,
-        Arc<dyn sdk_api::AsyncInstrumentCore + Send + Sync>,
-    )>,
+    runners: Vec<(AsyncRunner, Arc<dyn sdk_api::AsyncInstrumentCore>)>,
 }
 
 fn collect_async(labels: &[KeyValue], observations: &[Observation]) {
@@ -138,7 +135,7 @@ impl AccumulatorCore {
 
     fn register(
         &self,
-        instrument: Arc<dyn sdk_api::AsyncInstrumentCore + Send + Sync>,
+        instrument: Arc<dyn sdk_api::AsyncInstrumentCore>,
         runner: AsyncRunner,
     ) -> Result<()> {
         self.async_instruments
@@ -337,10 +334,7 @@ impl sdk_api::InstrumentCore for SyncInstrument {
 }
 
 impl sdk_api::SyncInstrumentCore for SyncInstrument {
-    fn bind(
-        &self,
-        labels: &'_ [KeyValue],
-    ) -> Arc<dyn sdk_api::SyncBoundInstrumentCore + Send + Sync> {
+    fn bind(&self, labels: &'_ [KeyValue]) -> Arc<dyn sdk_api::SyncBoundInstrumentCore> {
         self.acquire_handle(labels)
     }
     fn record_one(&self, number: Number, labels: &'_ [KeyValue]) {
@@ -514,7 +508,7 @@ impl sdk_api::MeterCore for Accumulator {
     fn new_sync_instrument(
         &self,
         descriptor: Descriptor,
-    ) -> Result<Arc<dyn sdk_api::SyncInstrumentCore + Send + Sync>> {
+    ) -> Result<Arc<dyn sdk_api::SyncInstrumentCore>> {
         Ok(Arc::new(SyncInstrument {
             instrument: Arc::new(Instrument {
                 descriptor,
@@ -547,7 +541,7 @@ impl sdk_api::MeterCore for Accumulator {
         &self,
         descriptor: Descriptor,
         runner: AsyncRunner,
-    ) -> Result<Arc<dyn sdk_api::AsyncInstrumentCore + Send + Sync>> {
+    ) -> Result<Arc<dyn sdk_api::AsyncInstrumentCore>> {
         let instrument = Arc::new(AsyncInstrument {
             instrument: Arc::new(Instrument {
                 descriptor,


### PR DESCRIPTION
- removes superfluous declarations on derived traits


as suggested: https://github.com/open-telemetry/opentelemetry-rust/pull/422#pullrequestreview-566880272