### PR TITLE
fix: with_collector_endpoint is error prune.

### DIFF
--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -128,7 +128,7 @@ impl trace::SpanExporter for Exporter {
 pub struct PipelineBuilder {
     agent_endpoint: Vec<net::SocketAddr>,
     #[cfg(any(feature = "collector_client", feature = "wasm_collector_client"))]
-    collector_endpoint: Option<http::Uri>,
+    collector_endpoint: Option<Result<http::Uri, http::uri::InvalidUri>>,
     #[cfg(any(feature = "collector_client", feature = "wasm_collector_client"))]
     collector_username: Option<String>,
     #[cfg(any(feature = "collector_client", feature = "wasm_collector_client"))]
@@ -205,9 +205,12 @@ impl PipelineBuilder {
     pub fn with_collector_endpoint<T>(self, collector_endpoint: T) -> Self
     where
         http::Uri: core::convert::TryFrom<T>,
+        <http::Uri as core::convert::TryFrom<T>>::Error: Into<http::uri::InvalidUri>,
     {
         PipelineBuilder {
-            collector_endpoint: core::convert::TryFrom::try_from(collector_endpoint).ok(),
+            collector_endpoint: Some(
+                core::convert::TryFrom::try_from(collector_endpoint).map_err(Into::into),
+            ),
             ..self
         }
     }
@@ -313,7 +316,11 @@ impl PipelineBuilder {
 
     #[cfg(feature = "collector_client")]
     fn init_uploader(self) -> Result<(Process, uploader::BatchUploader), TraceError> {
-        if let Some(collector_endpoint) = self.collector_endpoint {
+        if let Some(collector_endpoint) = self
+            .collector_endpoint
+            .transpose()
+            .map_err::<Error, _>(Into::into)?
+        {
             #[cfg(all(
                 not(feature = "isahc_collector_client"),
                 not(feature = "surf_collector_client"),
@@ -401,7 +408,11 @@ impl PipelineBuilder {
 
     #[cfg(all(feature = "wasm_collector_client", not(feature = "collector_client")))]
     fn init_uploader(self) -> Result<(Process, uploader::BatchUploader), TraceError> {
-        if let Some(collector_endpoint) = self.collector_endpoint {
+        if let Some(collector_endpoint) = self
+            .collector_endpoint
+            .transpose()
+            .map_err::<Error, _>(Into::into)?
+        {
             let collector = CollectorAsyncClientHttp::new(
                 collector_endpoint,
                 self.collector_username,
@@ -717,6 +728,11 @@ pub enum Error {
         feature = "reqwest_blocking_collector_client"
     ))]
     ReqwestClientError(#[from] reqwest::Error),
+
+    /// invalid collector uri is provided.
+    #[error("collector uri is invalid, {0}")]
+    #[cfg(any(feature = "collector_client", feature = "wasm_collector_client"))]
+    InvalidUri(#[from] http::uri::InvalidUri),
 }
 
 impl ExportError for Error {
@@ -772,6 +788,30 @@ mod collector_client_tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    #[cfg(any(
+        feature = "isahc_collector_client",
+        feature = "surf_collector_client",
+        feature = "reqwest_collector_client",
+        feature = "reqwest_blocking_collector_client"
+    ))]
+    fn test_set_collector_endpoint() {
+        let invalid_uri = new_pipeline()
+            .with_collector_endpoint("127.0.0.1:14268/api/traces")
+            .init_uploader();
+        assert!(invalid_uri.is_err());
+        assert_eq!(
+            format!("{:?}", invalid_uri.err().unwrap()),
+            "ExportFailed(InvalidUri(InvalidUri(InvalidFormat)))"
+        );
+
+        let valid_uri = new_pipeline()
+            .with_collector_endpoint("http://127.0.0.1:14268/api/traces")
+            .init_uploader();
+
+        assert!(valid_uri.is_ok());
     }
 }
 


### PR DESCRIPTION
Fix #426.

Now we will store the result of try_from function until we init the uploader. If the result is error, we wrap it into TraceError and return.