### PR TITLE
metrics: implement batch observer

### DIFF
--- a/opentelemetry/src/metrics/async_instrument.rs
+++ b/opentelemetry/src/metrics/async_instrument.rs
@@ -140,13 +140,13 @@ impl AsyncRunner {
     /// implementation can be used for batch runners.)
     pub fn run(
         &self,
-        instrument: Option<Arc<dyn sdk_api::AsyncInstrumentCore>>,
+        instrument: &Option<Arc<dyn sdk_api::AsyncInstrumentCore>>,
         f: fn(&[KeyValue], &[Observation]),
     ) {
         match (instrument, self) {
-            (Some(i), AsyncRunner::F64(run)) => run(ObserverResult::new(i, f)),
-            (Some(i), AsyncRunner::I64(run)) => run(ObserverResult::new(i, f)),
-            (Some(i), AsyncRunner::U64(run)) => run(ObserverResult::new(i, f)),
+            (Some(i), AsyncRunner::F64(run)) => run(ObserverResult::new(i.clone(), f)),
+            (Some(i), AsyncRunner::I64(run)) => run(ObserverResult::new(i.clone(), f)),
+            (Some(i), AsyncRunner::U64(run)) => run(ObserverResult::new(i.clone(), f)),
             (None, AsyncRunner::Batch(run)) => run(BatchObserverResult::new(f)),
             _ => global::handle_error(MetricsError::Other(
                 "Invalid async runner / instrument pair".into(),

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -20,7 +20,7 @@ mod up_down_counter;
 mod value_recorder;
 
 use crate::sdk::export::ExportError;
-pub use async_instrument::{AsyncRunner, BatchObserverCallback, Observation, ObserverResult};
+pub use async_instrument::{AsyncRunner, BatchObserverResult, Observation, ObserverResult};
 pub use config::InstrumentConfig;
 pub use counter::{BoundCounter, Counter, CounterBuilder};
 pub use descriptor::Descriptor;

--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -61,7 +61,7 @@ impl MeterCore for NoopMeterCore {
     fn new_async_instrument(
         &self,
         _descriptor: Descriptor,
-        _runner: AsyncRunner,
+        _runner: Option<AsyncRunner>,
     ) -> Result<Arc<dyn AsyncInstrumentCore>> {
         Ok(Arc::new(NoopAsyncInstrument::new()))
     }
@@ -73,6 +73,10 @@ impl MeterCore for NoopMeterCore {
         _measurements: Vec<Measurement>,
     ) {
         // Ignored
+    }
+
+    fn new_batch_observer(&self, _runner: AsyncRunner) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/opentelemetry/src/metrics/observer.rs
+++ b/opentelemetry/src/metrics/observer.rs
@@ -8,12 +8,67 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct BatchObserver<'a> {
     meter: &'a Meter,
-    runner: AsyncRunner,
 }
 
 impl<'a> BatchObserver<'a> {
-    pub(crate) fn new(meter: &'a Meter, runner: AsyncRunner) -> Self {
-        BatchObserver { meter, runner }
+    pub(crate) fn new(meter: &'a Meter) -> Self {
+        BatchObserver { meter }
+    }
+
+    /// Creates a new integer `SumObserverBuilder` for `u64` values with the given name.
+    pub fn u64_sum_observer<T>(&self, name: T) -> SumObserverBuilder<'_, u64>
+    where
+        T: Into<String>,
+    {
+        SumObserverBuilder::new(self.meter, name.into(), None, NumberKind::U64)
+    }
+
+    /// Creates a new floating point `SumObserverBuilder` for `f64` values with the given name.
+    pub fn f64_sum_observer<T>(&self, name: T) -> SumObserverBuilder<'_, f64>
+    where
+        T: Into<String>,
+    {
+        SumObserverBuilder::new(self.meter, name.into(), None, NumberKind::F64)
+    }
+
+    /// Creates a new integer `UpDownSumObserverBuilder` for `i64` values with the given name.
+    pub fn i64_up_down_sum_observer<T>(&self, name: T) -> UpDownSumObserverBuilder<'_, i64>
+    where
+        T: Into<String>,
+    {
+        UpDownSumObserverBuilder::new(self.meter, name.into(), None, NumberKind::I64)
+    }
+
+    /// Creates a new floating point `UpDownSumObserverBuilder` for `f64` values with the given name.
+    pub fn f64_up_down_sum_observer<T>(&self, name: T) -> UpDownSumObserverBuilder<'_, f64>
+    where
+        T: Into<String>,
+    {
+        UpDownSumObserverBuilder::new(self.meter, name.into(), None, NumberKind::F64)
+    }
+
+    /// Creates a new integer `ValueObserverBuilder` for `u64` values with the given name.
+    pub fn u64_value_observer<T>(&self, name: T) -> ValueObserverBuilder<'_, u64>
+    where
+        T: Into<String>,
+    {
+        ValueObserverBuilder::new(self.meter, name.into(), None, NumberKind::U64)
+    }
+
+    /// Creates a new integer `ValueObserverBuilder` for `i64` values with the given name.
+    pub fn i64_value_observer<T>(&self, name: T) -> ValueObserverBuilder<'_, i64>
+    where
+        T: Into<String>,
+    {
+        ValueObserverBuilder::new(self.meter, name.into(), None, NumberKind::I64)
+    }
+
+    /// Creates a new floating point `ValueObserverBuilder` for `f64` values with the given name.
+    pub fn f64_value_observer<T>(&self, name: T) -> ValueObserverBuilder<'_, f64>
+    where
+        T: Into<String>,
+    {
+        ValueObserverBuilder::new(self.meter, name.into(), None, NumberKind::F64)
     }
 }
 
@@ -41,7 +96,7 @@ where
 pub struct SumObserverBuilder<'a, T> {
     meter: &'a Meter,
     descriptor: Descriptor,
-    runner: AsyncRunner,
+    runner: Option<AsyncRunner>,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -49,7 +104,7 @@ impl<'a, T> SumObserverBuilder<'a, T> {
     pub(crate) fn new(
         meter: &'a Meter,
         name: String,
-        runner: AsyncRunner,
+        runner: Option<AsyncRunner>,
         number_kind: NumberKind,
     ) -> Self {
         SumObserverBuilder {
@@ -128,7 +183,7 @@ where
 pub struct UpDownSumObserverBuilder<'a, T> {
     meter: &'a Meter,
     descriptor: Descriptor,
-    runner: AsyncRunner,
+    runner: Option<AsyncRunner>,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -136,7 +191,7 @@ impl<'a, T> UpDownSumObserverBuilder<'a, T> {
     pub(crate) fn new(
         meter: &'a Meter,
         name: String,
-        runner: AsyncRunner,
+        runner: Option<AsyncRunner>,
         number_kind: NumberKind,
     ) -> Self {
         UpDownSumObserverBuilder {
@@ -214,7 +269,7 @@ where
 pub struct ValueObserverBuilder<'a, T> {
     meter: &'a Meter,
     descriptor: Descriptor,
-    runner: AsyncRunner,
+    runner: Option<AsyncRunner>,
     _marker: std::marker::PhantomData<T>,
 }
 
@@ -222,7 +277,7 @@ impl<'a, T> ValueObserverBuilder<'a, T> {
     pub(crate) fn new(
         meter: &'a Meter,
         name: String,
-        runner: AsyncRunner,
+        runner: Option<AsyncRunner>,
         number_kind: NumberKind,
     ) -> Self {
         ValueObserverBuilder {

--- a/opentelemetry/src/metrics/registry.rs
+++ b/opentelemetry/src/metrics/registry.rs
@@ -76,7 +76,7 @@ impl MeterCore for UniqueInstrumentMeterCore {
     fn new_async_instrument(
         &self,
         descriptor: Descriptor,
-        runner: AsyncRunner,
+        runner: Option<AsyncRunner>,
     ) -> super::Result<UniqueAsyncInstrument> {
         self.async_state
             .lock()
@@ -95,6 +95,10 @@ impl MeterCore for UniqueInstrumentMeterCore {
                     }
                 })
             })
+    }
+
+    fn new_batch_observer(&self, runner: AsyncRunner) -> Result<()> {
+        self.inner.new_batch_observer(runner)
     }
 }
 

--- a/opentelemetry/src/metrics/sdk_api.rs
+++ b/opentelemetry/src/metrics/sdk_api.rs
@@ -19,11 +19,16 @@ pub trait MeterCore: fmt::Debug {
     fn new_sync_instrument(&self, descriptor: Descriptor) -> Result<Arc<dyn SyncInstrumentCore>>;
 
     /// Create a new asynchronous instrument implementation.
+    ///
+    /// Runner is `None` if used in batch as the batch runner is registered separately.
     fn new_async_instrument(
         &self,
         descriptor: Descriptor,
-        runner: AsyncRunner,
+        runner: Option<AsyncRunner>,
     ) -> Result<Arc<dyn AsyncInstrumentCore>>;
+
+    /// Register a batch observer
+    fn new_batch_observer(&self, runner: AsyncRunner) -> Result<()>;
 }
 
 /// A common interface for synchronous and asynchronous instruments.


### PR DESCRIPTION
This patch adds an implementation of the metrics batch observer. The API is not identical to the example in [the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/api.md#batch-observer) as it is inconvenient to register metrics after they are moved into the observer callback in rust. Instead the `Meter::batch_observer` method accepts a closure in which instruments can be registered before being moved into the callback.

```rust
meter.batch_observer(|batch| {
    let inst = batch.u64_sum_observer("example").init();

    move |result| {
        result.observe(&[KeyValue::new("a", "1")], inst.observation(42)]);
    }
});
```