### PR TITLE
Add with_unit method for metrics API

### DIFF
--- a/opentelemetry/src/metrics/counter.rs
+++ b/opentelemetry/src/metrics/counter.rs
@@ -86,7 +86,7 @@ impl<'a, T> CounterBuilder<'a, T> {
 
     /// Set the unit for this counter.
     pub fn with_unit(mut self, unit: Unit) -> Self {
-        self.descriptor.set_unit(unit);
+        self.descriptor.config.unit = Some(unit);
         self
     }
 

--- a/opentelemetry/src/metrics/counter.rs
+++ b/opentelemetry/src/metrics/counter.rs
@@ -3,7 +3,7 @@ use crate::{
         sync_instrument::{SyncBoundInstrument, SyncInstrument},
         Descriptor, InstrumentKind, Measurement, Meter, Number, NumberKind, Result,
     },
-    KeyValue,
+    KeyValue, Unit,
 };
 use std::marker;
 
@@ -81,6 +81,12 @@ impl<'a, T> CounterBuilder<'a, T> {
     /// Set the description for this counter
     pub fn with_description<S: Into<String>>(mut self, description: S) -> Self {
         self.descriptor.set_description(description.into());
+        self
+    }
+
+    /// Set the unit for this counter.
+    pub fn with_unit(mut self, unit: Unit) -> Self {
+        self.descriptor.set_unit(unit);
         self
     }
 

--- a/opentelemetry/src/metrics/descriptor.rs
+++ b/opentelemetry/src/metrics/descriptor.rs
@@ -1,6 +1,5 @@
 use crate::metrics::{InstrumentConfig, InstrumentKind, NumberKind};
 use crate::sdk::InstrumentationLibrary;
-use crate::Unit;
 use fnv::FnvHasher;
 use std::hash::{Hash, Hasher};
 
@@ -11,7 +10,7 @@ pub struct Descriptor {
     name: String,
     instrument_kind: InstrumentKind,
     number_kind: NumberKind,
-    config: InstrumentConfig,
+    pub(crate) config: InstrumentConfig,
     attribute_hash: u64,
 }
 
@@ -72,11 +71,6 @@ impl Descriptor {
     /// Unit describes the units of the metric instrument.
     pub fn unit(&self) -> Option<&str> {
         self.config.unit.as_ref().map(|unit| unit.as_ref())
-    }
-
-    /// Assign a new unit.
-    pub fn set_unit(&mut self, unit: Unit) {
-        self.config.unit = Some(unit);
     }
 
     /// The name of the library that provided instrumentation for this instrument.

--- a/opentelemetry/src/metrics/descriptor.rs
+++ b/opentelemetry/src/metrics/descriptor.rs
@@ -1,5 +1,6 @@
 use crate::metrics::{InstrumentConfig, InstrumentKind, NumberKind};
 use crate::sdk::InstrumentationLibrary;
+use crate::Unit;
 use fnv::FnvHasher;
 use std::hash::{Hash, Hasher};
 
@@ -71,6 +72,11 @@ impl Descriptor {
     /// Unit describes the units of the metric instrument.
     pub fn unit(&self) -> Option<&str> {
         self.config.unit.as_ref().map(|unit| unit.as_ref())
+    }
+
+    /// Assign a new unit.
+    pub fn set_unit(&mut self, unit: Unit) {
+        self.config.unit = Some(unit);
     }
 
     /// The name of the library that provided instrumentation for this instrument.

--- a/opentelemetry/src/metrics/observer.rs
+++ b/opentelemetry/src/metrics/observer.rs
@@ -75,7 +75,7 @@ impl<'a, T> SumObserverBuilder<'a, T> {
 
     /// Set the unit for this `SumObserver`.
     pub fn with_unit(mut self, unit: Unit) -> Self {
-        self.descriptor.set_unit(unit);
+        self.descriptor.config.unit = Some(unit);
         self
     }
 
@@ -168,7 +168,7 @@ impl<'a, T> UpDownSumObserverBuilder<'a, T> {
 
     /// Set the unit for this `UpDownSumObserver`.
     pub fn with_unit(mut self, unit: Unit) -> Self {
-        self.descriptor.set_unit(unit);
+        self.descriptor.config.unit = Some(unit);
         self
     }
 
@@ -259,7 +259,7 @@ impl<'a, T> ValueObserverBuilder<'a, T> {
 
     /// Set the unit for this `ValueObserver`.
     pub fn with_unit(mut self, unit: Unit) -> Self {
-        self.descriptor.set_unit(unit);
+        self.descriptor.config.unit = Some(unit);
         self
     }
 

--- a/opentelemetry/src/metrics/observer.rs
+++ b/opentelemetry/src/metrics/observer.rs
@@ -2,6 +2,7 @@ use crate::metrics::{
     sdk_api, AsyncRunner, Descriptor, InstrumentKind, Meter, Number, NumberKind, Observation,
     Result,
 };
+use crate::Unit;
 use std::sync::Arc;
 
 /// An Observer callback that can report observations for multiple instruments.
@@ -69,6 +70,12 @@ impl<'a, T> SumObserverBuilder<'a, T> {
     /// Set the description of this `SumObserver`
     pub fn with_description<S: Into<String>>(mut self, description: S) -> Self {
         self.descriptor.set_description(description.into());
+        self
+    }
+
+    /// Set the unit for this `SumObserver`.
+    pub fn with_unit(mut self, unit: Unit) -> Self {
+        self.descriptor.set_unit(unit);
         self
     }
 
@@ -159,6 +166,12 @@ impl<'a, T> UpDownSumObserverBuilder<'a, T> {
         self
     }
 
+    /// Set the unit for this `UpDownSumObserver`.
+    pub fn with_unit(mut self, unit: Unit) -> Self {
+        self.descriptor.set_unit(unit);
+        self
+    }
+
     /// Create a `UpDownSumObserver` from this configuration.
     pub fn try_init(self) -> Result<UpDownSumObserver<T>> {
         let instrument = self
@@ -241,6 +254,12 @@ impl<'a, T> ValueObserverBuilder<'a, T> {
     /// Set the description of this `ValueObserver`
     pub fn with_description<S: Into<String>>(mut self, description: S) -> Self {
         self.descriptor.set_description(description.into());
+        self
+    }
+
+    /// Set the unit for this `ValueObserver`.
+    pub fn with_unit(mut self, unit: Unit) -> Self {
+        self.descriptor.set_unit(unit);
         self
     }
 

--- a/opentelemetry/src/metrics/up_down_counter.rs
+++ b/opentelemetry/src/metrics/up_down_counter.rs
@@ -86,7 +86,7 @@ impl<'a, T> UpDownCounterBuilder<'a, T> {
 
     /// Set the unit for this counter.
     pub fn with_unit(mut self, unit: Unit) -> Self {
-        self.descriptor.set_unit(unit);
+        self.descriptor.config.unit = Some(unit);
         self
     }
 

--- a/opentelemetry/src/metrics/up_down_counter.rs
+++ b/opentelemetry/src/metrics/up_down_counter.rs
@@ -3,7 +3,7 @@ use crate::{
         sync_instrument::{SyncBoundInstrument, SyncInstrument},
         Descriptor, InstrumentKind, Measurement, Meter, Number, NumberKind, Result,
     },
-    KeyValue,
+    KeyValue, Unit,
 };
 use std::marker;
 
@@ -81,6 +81,12 @@ impl<'a, T> UpDownCounterBuilder<'a, T> {
     /// Set the description for this counter
     pub fn with_description<S: Into<String>>(mut self, description: S) -> Self {
         self.descriptor.set_description(description.into());
+        self
+    }
+
+    /// Set the unit for this counter.
+    pub fn with_unit(mut self, unit: Unit) -> Self {
+        self.descriptor.set_unit(unit);
         self
     }
 

--- a/opentelemetry/src/metrics/value_recorder.rs
+++ b/opentelemetry/src/metrics/value_recorder.rs
@@ -3,6 +3,7 @@ use crate::metrics::{
     Descriptor, InstrumentKind, Measurement, Meter, Number, NumberKind, Result,
 };
 use crate::KeyValue;
+use crate::Unit;
 use std::marker;
 
 /// ValueRecorder is a metric that records per-request non-additive values.
@@ -81,6 +82,12 @@ impl<'a, T> ValueRecorderBuilder<'a, T> {
     /// Set the description for this `ValueRecorder`
     pub fn with_description<S: Into<String>>(mut self, description: S) -> Self {
         self.descriptor.set_description(description.into());
+        self
+    }
+
+    /// Set the unit for this `ValueRecorder`.
+    pub fn with_unit(mut self, unit: Unit) -> Self {
+        self.descriptor.set_unit(unit);
         self
     }
 

--- a/opentelemetry/src/metrics/value_recorder.rs
+++ b/opentelemetry/src/metrics/value_recorder.rs
@@ -87,7 +87,7 @@ impl<'a, T> ValueRecorderBuilder<'a, T> {
 
     /// Set the unit for this `ValueRecorder`.
     pub fn with_unit(mut self, unit: Unit) -> Self {
-        self.descriptor.set_unit(unit);
+        self.descriptor.config.unit = Some(unit);
         self
     }
 


### PR DESCRIPTION
Add `with_unit` method to `CounterBuilder`, `SumObserverBuilder`,
`UpDownSumObserverBuilder`, `ValueObserverBuilder` structs.

Add `set_unit` method to `Descriptor` struct.

For #276