### PR TITLE
metrics: remove extra instrument builders

### DIFF
--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -28,6 +28,17 @@ pub trait MeterProvider: fmt::Debug {
 
 /// Meter is the OpenTelemetry metric API, based on a sdk-defined `MeterCore`
 /// implementation and the `Meter` library name.
+///
+/// # Instruments
+///
+/// | **Name** | Instrument kind | Function(argument) | Default aggregation | Notes |
+/// | ----------------------- | ----- | --------- | ------------- | --- |
+/// | **Counter**             | Synchronous adding monotonic | Add(increment) | Sum | Per-request, part of a monotonic sum |
+/// | **UpDownCounter**       | Synchronous adding | Add(increment) | Sum | Per-request, part of a non-monotonic sum |
+/// | **ValueRecorder**       | Synchronous  | Record(value) | [TBD issue 636](https://github.com/open-telemetry/opentelemetry-specification/issues/636)  | Per-request, any grouping measurement |
+/// | **SumObserver**         | Asynchronous adding monotonic | Observe(sum) | Sum | Per-interval, reporting a monotonic sum |
+/// | **UpDownSumObserver**   | Asynchronous adding | Observe(sum) | Sum | Per-interval, reporting a non-monotonic sum |
+/// | **ValueObserver**       | Asynchronous | Observe(value) | LastValue  | Per-interval, any grouping measurement |
 #[derive(Debug)]
 pub struct Meter {
     instrumentation_library: InstrumentationLibrary,
@@ -50,14 +61,16 @@ impl Meter {
         }
     }
 
-    #[deprecated(note = "use instrumentation_library() instead")]
-    #[allow(dead_code)]
-    pub(crate) fn instrumentation_name(&self) -> &str {
-        self.instrumentation_library.name
-    }
-
     pub(crate) fn instrumentation_library(&self) -> InstrumentationLibrary {
         self.instrumentation_library
+    }
+
+    /// Creates a new integer `CounterBuilder` for `u64` values with the given name.
+    pub fn u64_counter<T>(&self, name: T) -> CounterBuilder<'_, u64>
+    where
+        T: Into<String>,
+    {
+        CounterBuilder::new(self, name.into(), NumberKind::U64)
     }
 
     /// Creates a new floating point `CounterBuilder` for `f64` values with the given name.
@@ -68,6 +81,14 @@ impl Meter {
         CounterBuilder::new(self, name.into(), NumberKind::F64)
     }
 
+    /// Creates a new integer `UpDownCounterBuilder` for an `i64` up down counter with the given name.
+    pub fn i64_up_down_counter<T>(&self, name: T) -> UpDownCounterBuilder<'_, i64>
+    where
+        T: Into<String>,
+    {
+        UpDownCounterBuilder::new(self, name.into(), NumberKind::I64)
+    }
+
     /// Creates a new floating point `UpDownCounterBuilder` for an `f64` up down counter with the given name.
     pub fn f64_up_down_counter<T>(&self, name: T) -> UpDownCounterBuilder<'_, f64>
     where
@@ -76,7 +97,23 @@ impl Meter {
         UpDownCounterBuilder::new(self, name.into(), NumberKind::F64)
     }
 
-    /// Creates a new floating point `ValueRecorderBuilder` for `f64` values with the given name.
+    /// Creates a new `ValueRecorderBuilder` for `i64` values with the given name.
+    pub fn i64_value_recorder<T>(&self, name: T) -> ValueRecorderBuilder<'_, i64>
+    where
+        T: Into<String>,
+    {
+        ValueRecorderBuilder::new(self, name.into(), NumberKind::I64)
+    }
+
+    /// Creates a new `ValueRecorderBuilder` for `u64` values with the given name.
+    pub fn u64_value_recorder<T>(&self, name: T) -> ValueRecorderBuilder<'_, u64>
+    where
+        T: Into<String>,
+    {
+        ValueRecorderBuilder::new(self, name.into(), NumberKind::U64)
+    }
+
+    /// Creates a new `ValueRecorderBuilder` for `f64` values with the given name.
     pub fn f64_value_recorder<T>(&self, name: T) -> ValueRecorderBuilder<'_, f64>
     where
         T: Into<String>,
@@ -84,7 +121,23 @@ impl Meter {
         ValueRecorderBuilder::new(self, name.into(), NumberKind::F64)
     }
 
-    /// Creates a new floating point `SumObserverBuilder` for `f64` values with the given name and callback.
+    /// Creates a new integer `SumObserverBuilder` for `u64` values with the given
+    /// name and callback
+    pub fn u64_sum_observer<T, F>(&self, name: T, callback: F) -> SumObserverBuilder<'_, u64>
+    where
+        T: Into<String>,
+        F: Fn(ObserverResult<u64>) + Send + Sync + 'static,
+    {
+        SumObserverBuilder::new(
+            self,
+            name.into(),
+            Some(AsyncRunner::U64(Box::new(callback))),
+            NumberKind::U64,
+        )
+    }
+
+    /// Creates a new floating point `SumObserverBuilder` for `f64` values with the
+    /// given name and callback
     pub fn f64_sum_observer<T, F>(&self, name: T, callback: F) -> SumObserverBuilder<'_, f64>
     where
         T: Into<String>,
@@ -98,77 +151,8 @@ impl Meter {
         )
     }
 
-    /// Creates a new floating point `UpDownSumObserverBuilder` for `f64` values with the given name and callback.
-    pub fn f64_up_down_sum_observer<T, F>(
-        &self,
-        name: T,
-        callback: F,
-    ) -> UpDownSumObserverBuilder<'_, f64>
-    where
-        T: Into<String>,
-        F: Fn(ObserverResult<f64>) + Send + Sync + 'static,
-    {
-        UpDownSumObserverBuilder::new(
-            self,
-            name.into(),
-            Some(AsyncRunner::F64(Box::new(callback))),
-            NumberKind::F64,
-        )
-    }
-
-    /// Creates a new floating point `ValueObserverBuilder` for `f64` values with the given name and callback.
-    pub fn f64_value_observer<T, F>(&self, name: T, callback: F) -> ValueObserverBuilder<'_, f64>
-    where
-        T: Into<String>,
-        F: Fn(ObserverResult<f64>) + Send + Sync + 'static,
-    {
-        ValueObserverBuilder::new(
-            self,
-            name.into(),
-            Some(AsyncRunner::F64(Box::new(callback))),
-            NumberKind::F64,
-        )
-    }
-
-    /// Creates a new integer `CounterBuilder` for `i64` values with the given name.
-    pub fn i64_counter<T>(&self, name: T) -> CounterBuilder<'_, i64>
-    where
-        T: Into<String>,
-    {
-        CounterBuilder::new(self, name.into(), NumberKind::I64)
-    }
-
-    /// Creates a new integer `UpDownCounterBuilder` for an `i64` up down counter with the given name.
-    pub fn i64_up_down_counter<T>(&self, name: T) -> UpDownCounterBuilder<'_, i64>
-    where
-        T: Into<String>,
-    {
-        UpDownCounterBuilder::new(self, name.into(), NumberKind::I64)
-    }
-
-    /// Creates a new integer `ValueRecorderBuilder` for `i64` values with the given name.
-    pub fn i64_value_recorder<T>(&self, name: T) -> ValueRecorderBuilder<'_, i64>
-    where
-        T: Into<String>,
-    {
-        ValueRecorderBuilder::new(self, name.into(), NumberKind::I64)
-    }
-
-    /// Creates a new integer `SumObserverBuilder` for `i64` values with the given name and callback.
-    pub fn i64_sum_observer<T, F>(&self, name: T, callback: F) -> SumObserverBuilder<'_, i64>
-    where
-        T: Into<String>,
-        F: Fn(ObserverResult<i64>) + Send + Sync + 'static,
-    {
-        SumObserverBuilder::new(
-            self,
-            name.into(),
-            Some(AsyncRunner::I64(Box::new(callback))),
-            NumberKind::I64,
-        )
-    }
-
-    /// Creates a new integer `UpDownSumObserverBuilder` for `i64` values with the given name and callback.
+    /// Creates a new integer `UpDownSumObserverBuilder` for `i64` values with the
+    /// given name and callback.
     pub fn i64_up_down_sum_observer<T, F>(
         &self,
         name: T,
@@ -186,7 +170,42 @@ impl Meter {
         )
     }
 
-    /// Creates a new integer `ValueObserverBuilder` for `i64` values with the given name and callback.
+    /// Creates a new floating point `UpDownSumObserverBuilder` for `f64` values
+    /// with the given name and callback
+    pub fn f64_up_down_sum_observer<T, F>(
+        &self,
+        name: T,
+        callback: F,
+    ) -> UpDownSumObserverBuilder<'_, f64>
+    where
+        T: Into<String>,
+        F: Fn(ObserverResult<f64>) + Send + Sync + 'static,
+    {
+        UpDownSumObserverBuilder::new(
+            self,
+            name.into(),
+            Some(AsyncRunner::F64(Box::new(callback))),
+            NumberKind::F64,
+        )
+    }
+
+    /// Creates a new integer `ValueObserverBuilder` for `u64` values with the given
+    /// name and callback
+    pub fn u64_value_observer<T, F>(&self, name: T, callback: F) -> ValueObserverBuilder<'_, u64>
+    where
+        T: Into<String>,
+        F: Fn(ObserverResult<u64>) + Send + Sync + 'static,
+    {
+        ValueObserverBuilder::new(
+            self,
+            name.into(),
+            Some(AsyncRunner::U64(Box::new(callback))),
+            NumberKind::U64,
+        )
+    }
+
+    /// Creates a new integer `ValueObserverBuilder` for `i64` values with the given
+    /// name and callback
     pub fn i64_value_observer<T, F>(&self, name: T, callback: F) -> ValueObserverBuilder<'_, i64>
     where
         T: Into<String>,
@@ -200,73 +219,18 @@ impl Meter {
         )
     }
 
-    /// Creates a new integer `CounterBuilder` for `u64` values with the given name.
-    pub fn u64_counter<T>(&self, name: T) -> CounterBuilder<'_, u64>
+    /// Creates a new floating point `ValueObserverBuilder` for `f64` values with
+    /// the given name and callback
+    pub fn f64_value_observer<T, F>(&self, name: T, callback: F) -> ValueObserverBuilder<'_, f64>
     where
         T: Into<String>,
-    {
-        CounterBuilder::new(self, name.into(), NumberKind::U64)
-    }
-
-    /// Creates a new integer `UpDownCounterBuilder` for an `u64` up down counter with the given name.
-    pub fn u64_up_down_counter<T>(&self, name: T) -> UpDownCounterBuilder<'_, u64>
-    where
-        T: Into<String>,
-    {
-        UpDownCounterBuilder::new(self, name.into(), NumberKind::U64)
-    }
-
-    /// Creates a new integer `ValueRecorderBuilder` for `u64` values with the given name.
-    pub fn u64_value_recorder<T>(&self, name: T) -> ValueRecorderBuilder<'_, u64>
-    where
-        T: Into<String>,
-    {
-        ValueRecorderBuilder::new(self, name.into(), NumberKind::U64)
-    }
-
-    /// Creates a new integer `SumObserverBuilder` for `u64` values with the given name and callback.
-    pub fn u64_sum_observer<T, F>(&self, name: T, callback: F) -> SumObserverBuilder<'_, u64>
-    where
-        T: Into<String>,
-        F: Fn(ObserverResult<u64>) + Send + Sync + 'static,
-    {
-        SumObserverBuilder::new(
-            self,
-            name.into(),
-            Some(AsyncRunner::U64(Box::new(callback))),
-            NumberKind::U64,
-        )
-    }
-
-    /// Creates a new integer `UpDownSumObserverBuilder` for `u64` values with the given name and callback.
-    pub fn u64_up_down_sum_observer<T, F>(
-        &self,
-        name: T,
-        callback: F,
-    ) -> UpDownSumObserverBuilder<'_, u64>
-    where
-        T: Into<String>,
-        F: Fn(ObserverResult<u64>) + Send + Sync + 'static,
-    {
-        UpDownSumObserverBuilder::new(
-            self,
-            name.into(),
-            Some(AsyncRunner::U64(Box::new(callback))),
-            NumberKind::U64,
-        )
-    }
-
-    /// Creates a new integer `ValueObserverBuilder` for `u64` values with the given name and callback.
-    pub fn u64_value_observer<T, F>(&self, name: T, callback: F) -> ValueObserverBuilder<'_, u64>
-    where
-        T: Into<String>,
-        F: Fn(ObserverResult<u64>) + Send + Sync + 'static,
+        F: Fn(ObserverResult<f64>) + Send + Sync + 'static,
     {
         ValueObserverBuilder::new(
             self,
             name.into(),
-            Some(AsyncRunner::U64(Box::new(callback))),
-            NumberKind::U64,
+            Some(AsyncRunner::F64(Box::new(callback))),
+            NumberKind::F64,
         )
     }
 

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -163,6 +163,8 @@ impl SpanProcessor for SimpleSpanProcessor {
 /// contexts.
 ///
 /// ```
+/// # #[cfg(feature="tokio")]
+/// # {
 /// use futures::{stream};
 /// use opentelemetry::{trace as apitrace, sdk::trace as sdktrace, global, util::tokio_interval_stream};
 /// use std::time::Duration;
@@ -187,6 +189,7 @@ impl SpanProcessor for SimpleSpanProcessor {
 ///     let guard = global::set_tracer_provider(provider);
 ///     # drop(guard)
 /// }
+/// # }
 /// ```
 ///
 /// [`SpanProcessor`]: ../../api/trace/span_processor/trait.SpanProcessor.html


### PR DESCRIPTION
This reverts some of the extra instruments introduced in #425. Specifically `Meter::u64_up_down_counter` and `Meter::u64_up_down_sum_observer` which are not necessary because of their type (e.g. a monotonically increasing  `up_down_counter` is simply a `counter`).