### PR TITLE
[datadog] group exported spans by trace_id

### DIFF
--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 base64_format = ["base64", "binary_propagator"]
 binary_propagator = []
-datadog = ["indexmap", "rmp", "async-trait", "thiserror", "opentelemetry-http"]
+datadog = ["indexmap", "rmp", "async-trait", "thiserror", "opentelemetry-http", "itertools"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 surf-client = ["surf", "opentelemetry-http/surf"]
@@ -40,6 +40,7 @@ surf = { version = "2.0", optional = true }
 http = "0.2"
 base64 = { version = "0.13", optional = true }
 thiserror = { version = "1.0", optional = true }
+itertools = { version = "0.10", optional = true }
 
 [dev-dependencies]
 base64 = "0.13"

--- a/opentelemetry-contrib/src/trace/exporter/datadog/mod.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/mod.rs
@@ -274,15 +274,20 @@ impl DatadogPipelineBuilder {
     }
 }
 
+fn group_into_traces(spans: Vec<SpanData>) -> Vec<Vec<SpanData>> {
+    spans
+        .into_iter()
+        .into_group_map_by(|span_data| span_data.span_context.trace_id())
+        .into_iter()
+        .map(|(_, trace)| trace)
+        .collect()
+}
+
 #[async_trait]
 impl trace::SpanExporter for DatadogExporter {
     /// Export spans to datadog-agent
     async fn export(&mut self, batch: Vec<SpanData>) -> trace::ExportResult {
-        let traces: Vec<Vec<SpanData>> = batch.into_iter()
-            .into_group_map_by(|span_data| span_data.span_context.trace_id())
-            .into_iter()
-            .map(|(_, trace)| trace)
-            .collect();
+        let traces: Vec<Vec<SpanData>> = group_into_traces(batch);
         let trace_count = traces.len();
         let data = self.version.encode(&self.service_name, traces)?;
         let req = Request::builder()
@@ -300,3 +305,27 @@ impl trace::SpanExporter for DatadogExporter {
 #[must_use]
 #[derive(Debug)]
 pub struct Uninstall(global::TracerProviderGuard);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::trace::exporter::datadog::model::tests::get_span;
+
+    #[test]
+    fn test_out_of_order_group() -> Result<(), Box<dyn std::error::Error>> {
+        let batch = vec![get_span(1, 1, 1), get_span(2, 2, 2), get_span(1, 1, 3)];
+        let expected = vec![
+            vec![get_span(1, 1, 1), get_span(1, 1, 3)],
+            vec![get_span(2, 2, 2)],
+        ];
+
+        let mut traces = group_into_traces(batch);
+        // We need to sort the output in order to compare, but this is not required by the Datadog agent
+        traces.sort_by_key(|t| t[0].span_context.trace_id().to_u128());
+
+        assert_eq!(traces, expected);
+
+        Ok(())
+    }
+}

--- a/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
@@ -62,11 +62,11 @@ impl ApiVersion {
     pub(crate) fn encode(
         self,
         service_name: &str,
-        spans: Vec<trace::SpanData>,
+        traces: Vec<Vec<trace::SpanData>>,
     ) -> Result<Vec<u8>, Error> {
         match self {
-            Self::Version03 => v03::encode(service_name, spans),
-            Self::Version05 => v05::encode(service_name, spans),
+            Self::Version03 => v03::encode(service_name, traces),
+            Self::Version05 => v05::encode(service_name, traces),
         }
     }
 }
@@ -83,7 +83,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::{Duration, SystemTime};
 
-    fn get_spans() -> Vec<trace::SpanData> {
+    fn get_traces() -> Vec<Vec<trace::SpanData>> {
         let parent_span_id = 1;
         let trace_id = 7;
         let span_id = 99;
@@ -122,13 +122,13 @@ mod tests {
             instrumentation_lib: InstrumentationLibrary::new("component", None),
         };
 
-        vec![span_data]
+        vec![vec![span_data]]
     }
 
     #[test]
     fn test_encode_v03() -> Result<(), Box<dyn std::error::Error>> {
-        let spans = get_spans();
-        let encoded = base64::encode(ApiVersion::Version03.encode("service_name", spans)?);
+        let traces = get_traces();
+        let encoded = base64::encode(ApiVersion::Version03.encode("service_name", traces)?);
 
         assert_eq!(encoded.as_str(), "kZGLpHR5cGWjd2Vip3NlcnZpY2Wsc2VydmljZV9uYW1lpG5hbWWpY29tcG9uZW50qHJlc291cmNlqHJlc291cmNlqHRyYWNlX2lkzwAAAAAAAAAHp3NwYW5faWTPAAAAAAAAAGOpcGFyZW50X2lkzwAAAAAAAAABpXN0YXJ00wAAAAAAAAAAqGR1cmF0aW9u0wAAAAA7msoApWVycm9y0gAAAAGkbWV0YYGpc3Bhbi50eXBlo3dlYg==");
 
@@ -137,8 +137,8 @@ mod tests {
 
     #[test]
     fn test_encode_v05() -> Result<(), Box<dyn std::error::Error>> {
-        let spans = get_spans();
-        let encoded = base64::encode(ApiVersion::Version05.encode("service_name", spans)?);
+        let traces = get_traces();
+        let encoded = base64::encode(ApiVersion::Version05.encode("service_name", traces)?);
 
         assert_eq!(encoded.as_str(), "kpWsc2VydmljZV9uYW1lo3dlYqljb21wb25lbnSocmVzb3VyY2Wpc3Bhbi50eXBlkZGczgAAAADOAAAAAs4AAAADzwAAAAAAAAAHzwAAAAAAAABjzwAAAAAAAAAB0wAAAAAAAAAA0wAAAAA7msoA0gAAAAGBzgAAAATOAAAAAYDOAAAAAQ==");
 

--- a/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/model/mod.rs
@@ -72,7 +72,7 @@ impl ApiVersion {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use opentelemetry::sdk;
     use opentelemetry::sdk::InstrumentationLibrary;
@@ -84,10 +84,10 @@ mod tests {
     use std::time::{Duration, SystemTime};
 
     fn get_traces() -> Vec<Vec<trace::SpanData>> {
-        let parent_span_id = 1;
-        let trace_id = 7;
-        let span_id = 99;
+        vec![vec![get_span(7, 1, 99)]]
+    }
 
+    pub(crate) fn get_span(trace_id: u128, parent_span_id: u64, span_id: u64) -> trace::SpanData {
         let span_context = SpanContext::new(
             TraceId::from_u128(trace_id),
             SpanId::from_u64(span_id),
@@ -106,7 +106,7 @@ mod tests {
         let message_events = sdk::trace::EvictedQueue::new(capacity);
         let links = sdk::trace::EvictedQueue::new(capacity);
 
-        let span_data = trace::SpanData {
+        trace::SpanData {
             span_context,
             parent_span_id: SpanId::from_u64(parent_span_id),
             span_kind: SpanKind::Client,
@@ -120,9 +120,7 @@ mod tests {
             status_message: String::new(),
             resource: Arc::new(sdk::Resource::default()),
             instrumentation_lib: InstrumentationLibrary::new("component", None),
-        };
-
-        vec![vec![span_data]]
+        }
     }
 
     #[test]

--- a/opentelemetry-contrib/src/trace/exporter/datadog/model/v03.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/model/v03.rs
@@ -3,7 +3,10 @@ use opentelemetry::sdk::export::trace;
 use opentelemetry::{Key, Value};
 use std::time::SystemTime;
 
-pub(crate) fn encode(service_name: &str, traces: Vec<Vec<trace::SpanData>>) -> Result<Vec<u8>, Error> {
+pub(crate) fn encode(
+    service_name: &str,
+    traces: Vec<Vec<trace::SpanData>>,
+) -> Result<Vec<u8>, Error> {
     let mut encoded = Vec::new();
     rmp::encode::write_array_len(&mut encoded, traces.len() as u32)?;
 

--- a/opentelemetry-contrib/src/trace/exporter/datadog/model/v03.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/model/v03.rs
@@ -3,68 +3,69 @@ use opentelemetry::sdk::export::trace;
 use opentelemetry::{Key, Value};
 use std::time::SystemTime;
 
-pub(crate) fn encode(service_name: &str, spans: Vec<trace::SpanData>) -> Result<Vec<u8>, Error> {
+pub(crate) fn encode(service_name: &str, traces: Vec<Vec<trace::SpanData>>) -> Result<Vec<u8>, Error> {
     let mut encoded = Vec::new();
-    rmp::encode::write_array_len(&mut encoded, spans.len() as u32)?;
+    rmp::encode::write_array_len(&mut encoded, traces.len() as u32)?;
 
-    for span in spans.into_iter() {
-        // API supports but doesn't mandate grouping spans with the same trace ID
-        rmp::encode::write_array_len(&mut encoded, 1)?;
+    for trace in traces.into_iter() {
+        rmp::encode::write_array_len(&mut encoded, trace.len() as u32)?;
 
-        // Safe until the year 2262 when Datadog will need to change their API
-        let start = span
-            .start_time
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as i64;
+        for span in trace.into_iter() {
+            // Safe until the year 2262 when Datadog will need to change their API
+            let start = span
+                .start_time
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as i64;
 
-        let duration = span
-            .end_time
-            .duration_since(span.start_time)
-            .map(|x| x.as_nanos() as i64)
-            .unwrap_or(0);
+            let duration = span
+                .end_time
+                .duration_since(span.start_time)
+                .map(|x| x.as_nanos() as i64)
+                .unwrap_or(0);
 
-        if let Some(Value::String(s)) = span.attributes.get(&Key::new("span.type")) {
-            rmp::encode::write_map_len(&mut encoded, 11)?;
-            rmp::encode::write_str(&mut encoded, "type")?;
-            rmp::encode::write_str(&mut encoded, s.as_ref())?;
-        } else {
-            rmp::encode::write_map_len(&mut encoded, 10)?;
-        }
+            if let Some(Value::String(s)) = span.attributes.get(&Key::new("span.type")) {
+                rmp::encode::write_map_len(&mut encoded, 11)?;
+                rmp::encode::write_str(&mut encoded, "type")?;
+                rmp::encode::write_str(&mut encoded, s.as_ref())?;
+            } else {
+                rmp::encode::write_map_len(&mut encoded, 10)?;
+            }
 
-        // Datadog span name is OpenTelemetry component name - see module docs for more information
-        rmp::encode::write_str(&mut encoded, "service")?;
-        rmp::encode::write_str(&mut encoded, service_name)?;
+            // Datadog span name is OpenTelemetry component name - see module docs for more information
+            rmp::encode::write_str(&mut encoded, "service")?;
+            rmp::encode::write_str(&mut encoded, service_name)?;
 
-        rmp::encode::write_str(&mut encoded, "name")?;
-        rmp::encode::write_str(&mut encoded, span.instrumentation_lib.name)?;
+            rmp::encode::write_str(&mut encoded, "name")?;
+            rmp::encode::write_str(&mut encoded, span.instrumentation_lib.name)?;
 
-        rmp::encode::write_str(&mut encoded, "resource")?;
-        rmp::encode::write_str(&mut encoded, &span.name)?;
+            rmp::encode::write_str(&mut encoded, "resource")?;
+            rmp::encode::write_str(&mut encoded, &span.name)?;
 
-        rmp::encode::write_str(&mut encoded, "trace_id")?;
-        rmp::encode::write_u64(&mut encoded, span.span_context.trace_id().to_u128() as u64)?;
+            rmp::encode::write_str(&mut encoded, "trace_id")?;
+            rmp::encode::write_u64(&mut encoded, span.span_context.trace_id().to_u128() as u64)?;
 
-        rmp::encode::write_str(&mut encoded, "span_id")?;
-        rmp::encode::write_u64(&mut encoded, span.span_context.span_id().to_u64())?;
+            rmp::encode::write_str(&mut encoded, "span_id")?;
+            rmp::encode::write_u64(&mut encoded, span.span_context.span_id().to_u64())?;
 
-        rmp::encode::write_str(&mut encoded, "parent_id")?;
-        rmp::encode::write_u64(&mut encoded, span.parent_span_id.to_u64())?;
+            rmp::encode::write_str(&mut encoded, "parent_id")?;
+            rmp::encode::write_u64(&mut encoded, span.parent_span_id.to_u64())?;
 
-        rmp::encode::write_str(&mut encoded, "start")?;
-        rmp::encode::write_i64(&mut encoded, start)?;
+            rmp::encode::write_str(&mut encoded, "start")?;
+            rmp::encode::write_i64(&mut encoded, start)?;
 
-        rmp::encode::write_str(&mut encoded, "duration")?;
-        rmp::encode::write_i64(&mut encoded, duration)?;
+            rmp::encode::write_str(&mut encoded, "duration")?;
+            rmp::encode::write_i64(&mut encoded, duration)?;
 
-        rmp::encode::write_str(&mut encoded, "error")?;
-        rmp::encode::write_i32(&mut encoded, span.status_code as i32)?;
+            rmp::encode::write_str(&mut encoded, "error")?;
+            rmp::encode::write_i32(&mut encoded, span.status_code as i32)?;
 
-        rmp::encode::write_str(&mut encoded, "meta")?;
-        rmp::encode::write_map_len(&mut encoded, span.attributes.len() as u32)?;
-        for (key, value) in span.attributes.iter() {
-            rmp::encode::write_str(&mut encoded, key.as_str())?;
-            rmp::encode::write_str(&mut encoded, value.as_str().as_ref())?;
+            rmp::encode::write_str(&mut encoded, "meta")?;
+            rmp::encode::write_map_len(&mut encoded, span.attributes.len() as u32)?;
+            for (key, value) in span.attributes.iter() {
+                rmp::encode::write_str(&mut encoded, key.as_str())?;
+                rmp::encode::write_str(&mut encoded, value.as_str().as_ref())?;
+            }
         }
     }
 

--- a/opentelemetry-contrib/src/trace/exporter/datadog/model/v05.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/model/v05.rs
@@ -49,7 +49,10 @@ use std::time::SystemTime;
 //
 // 		The dictionary in this case would be []string{""}, having only the empty string at index 0.
 //
-pub(crate) fn encode(service_name: &str, traces: Vec<Vec<trace::SpanData>>) -> Result<Vec<u8>, Error> {
+pub(crate) fn encode(
+    service_name: &str,
+    traces: Vec<Vec<trace::SpanData>>,
+) -> Result<Vec<u8>, Error> {
     let mut interner = StringInterner::new();
     let mut encoded_traces = encode_traces(&mut interner, service_name, traces)?;
 

--- a/opentelemetry-contrib/src/trace/exporter/datadog/model/v05.rs
+++ b/opentelemetry-contrib/src/trace/exporter/datadog/model/v05.rs
@@ -49,9 +49,9 @@ use std::time::SystemTime;
 //
 // 		The dictionary in this case would be []string{""}, having only the empty string at index 0.
 //
-pub(crate) fn encode(service_name: &str, spans: Vec<trace::SpanData>) -> Result<Vec<u8>, Error> {
+pub(crate) fn encode(service_name: &str, traces: Vec<Vec<trace::SpanData>>) -> Result<Vec<u8>, Error> {
     let mut interner = StringInterner::new();
-    let mut encoded_spans = encode_spans(&mut interner, service_name, spans)?;
+    let mut encoded_traces = encode_traces(&mut interner, service_name, traces)?;
 
     let mut payload = Vec::new();
     rmp::encode::write_array_len(&mut payload, 2)?;
@@ -61,61 +61,62 @@ pub(crate) fn encode(service_name: &str, spans: Vec<trace::SpanData>) -> Result<
         rmp::encode::write_str(&mut payload, data)?;
     }
 
-    payload.append(&mut encoded_spans);
+    payload.append(&mut encoded_traces);
 
     Ok(payload)
 }
 
-fn encode_spans(
+fn encode_traces(
     interner: &mut StringInterner,
     service_name: &str,
-    spans: Vec<trace::SpanData>,
+    traces: Vec<Vec<trace::SpanData>>,
 ) -> Result<Vec<u8>, Error> {
     let mut encoded = Vec::new();
-    rmp::encode::write_array_len(&mut encoded, spans.len() as u32)?;
+    rmp::encode::write_array_len(&mut encoded, traces.len() as u32)?;
 
     let service_interned = interner.intern(&service_name);
 
-    for span in spans.into_iter() {
-        // API supports but doesn't mandate grouping spans with the same trace ID
-        rmp::encode::write_array_len(&mut encoded, 1)?;
+    for trace in traces.into_iter() {
+        rmp::encode::write_array_len(&mut encoded, trace.len() as u32)?;
 
-        // Safe until the year 2262 when Datadog will need to change their API
-        let start = span
-            .start_time
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as i64;
+        for span in trace.into_iter() {
+            // Safe until the year 2262 when Datadog will need to change their API
+            let start = span
+                .start_time
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as i64;
 
-        let duration = span
-            .end_time
-            .duration_since(span.start_time)
-            .map(|x| x.as_nanos() as i64)
-            .unwrap_or(0);
+            let duration = span
+                .end_time
+                .duration_since(span.start_time)
+                .map(|x| x.as_nanos() as i64)
+                .unwrap_or(0);
 
-        let span_type = match span.attributes.get(&Key::new("span.type")) {
-            Some(Value::String(s)) => interner.intern(s.as_ref()),
-            _ => interner.intern(""),
-        };
+            let span_type = match span.attributes.get(&Key::new("span.type")) {
+                Some(Value::String(s)) => interner.intern(s.as_ref()),
+                _ => interner.intern(""),
+            };
 
-        // Datadog span name is OpenTelemetry component name - see module docs for more information
-        rmp::encode::write_array_len(&mut encoded, 12)?;
-        rmp::encode::write_u32(&mut encoded, service_interned)?;
-        rmp::encode::write_u32(&mut encoded, interner.intern(span.instrumentation_lib.name))?;
-        rmp::encode::write_u32(&mut encoded, interner.intern(&span.name))?;
-        rmp::encode::write_u64(&mut encoded, span.span_context.trace_id().to_u128() as u64)?;
-        rmp::encode::write_u64(&mut encoded, span.span_context.span_id().to_u64())?;
-        rmp::encode::write_u64(&mut encoded, span.parent_span_id.to_u64())?;
-        rmp::encode::write_i64(&mut encoded, start)?;
-        rmp::encode::write_i64(&mut encoded, duration)?;
-        rmp::encode::write_i32(&mut encoded, span.status_code as i32)?;
-        rmp::encode::write_map_len(&mut encoded, span.attributes.len() as u32)?;
-        for (key, value) in span.attributes.iter() {
-            rmp::encode::write_u32(&mut encoded, interner.intern(key.as_str()))?;
-            rmp::encode::write_u32(&mut encoded, interner.intern(value.as_str().as_ref()))?;
+            // Datadog span name is OpenTelemetry component name - see module docs for more information
+            rmp::encode::write_array_len(&mut encoded, 12)?;
+            rmp::encode::write_u32(&mut encoded, service_interned)?;
+            rmp::encode::write_u32(&mut encoded, interner.intern(span.instrumentation_lib.name))?;
+            rmp::encode::write_u32(&mut encoded, interner.intern(&span.name))?;
+            rmp::encode::write_u64(&mut encoded, span.span_context.trace_id().to_u128() as u64)?;
+            rmp::encode::write_u64(&mut encoded, span.span_context.span_id().to_u64())?;
+            rmp::encode::write_u64(&mut encoded, span.parent_span_id.to_u64())?;
+            rmp::encode::write_i64(&mut encoded, start)?;
+            rmp::encode::write_i64(&mut encoded, duration)?;
+            rmp::encode::write_i32(&mut encoded, span.status_code as i32)?;
+            rmp::encode::write_map_len(&mut encoded, span.attributes.len() as u32)?;
+            for (key, value) in span.attributes.iter() {
+                rmp::encode::write_u32(&mut encoded, interner.intern(key.as_str()))?;
+                rmp::encode::write_u32(&mut encoded, interner.intern(value.as_str().as_ref()))?;
+            }
+            rmp::encode::write_map_len(&mut encoded, 0)?;
+            rmp::encode::write_u32(&mut encoded, span_type)?;
         }
-        rmp::encode::write_map_len(&mut encoded, 0)?;
-        rmp::encode::write_u32(&mut encoded, span_type)?;
     }
 
     Ok(encoded)


### PR DESCRIPTION
While not technically required, not doing this causes issues with the datadog-trace-agent rate limits, and will lead to dropped spans when the span trace exceeds the agent-configured trace rate limit.

This also set the X-Datadog-Trace-Count header which is used by the agent to enforce this rate limit quickly, to report to the exporter that the rate limit was exceeded, and to update internal metrics for tracking trace reporting statistics  https://github.com/DataDog/datadog-agent/blob/master/pkg/trace/api/api.go#L442

TODO: 
- [x] Add some tests that actually test this grouping beyond more than one span in the export