### PR TITLE
Remove tracer provider guard.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         override: true
     - name: Run tests
       run: cargo --version &&
-        cargo test --verbose --manifest-path=opentelemetry/Cargo.toml --features trace,metrics,serialize,tokio-support,serde,testing &&
+        cargo test --verbose --manifest-path=opentelemetry/Cargo.toml --features trace,metrics,serialize,rt-tokio,serde,testing &&
         cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml &&
         cargo test --manifest-path=opentelemetry-zipkin/Cargo.toml
   coverage:

--- a/README.md
+++ b/README.md
@@ -37,10 +37,7 @@ use opentelemetry::{sdk::export::trace::stdout, trace::Tracer};
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     // Create a new instrumentation pipeline
-    // Note: uninstalling the tracer happens when the _uninstall
-    // variable is dropped. Assigning it to _ will immediately
-    // drop it and uninstall the tracer
-    let (tracer, _uninstall) = stdout::new_pipeline().install();
+    let tracer = stdout::new_pipeline().install();
 
     tracer.in_span("doing_work", |cx| {
         // Traced app logic here...

--- a/examples/actix-http/Cargo.toml
+++ b/examples/actix-http/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-opentelemetry = { path = "../../opentelemetry", features = ["tokio-support"] }
+opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio"] }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["reqwest_collector_client", "tokio"] }
 thrift = "0.13"
 futures = "0.3"

--- a/examples/actix-http/src/main.rs
+++ b/examples/actix-http/src/main.rs
@@ -8,7 +8,7 @@ use opentelemetry::{
     Key,
 };
 
-fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), TraceError> {
+fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
     opentelemetry_jaeger::new_pipeline()
         .with_collector_endpoint("http://127.0.0.1:14268/api/traces")
         .with_service_name("trace-http-demo")
@@ -27,7 +27,7 @@ async fn index() -> &'static str {
 async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "debug");
     env_logger::init();
-    let (tracer, _uninstall) = init_tracer().expect("Failed to initialise tracer.");
+    let tracer = init_tracer().expect("Failed to initialise tracer.");
 
     HttpServer::new(move || {
         let tracer = tracer.clone();

--- a/examples/actix-udp/src/main.rs
+++ b/examples/actix-udp/src/main.rs
@@ -8,7 +8,7 @@ use opentelemetry::{
     Key,
 };
 
-fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), TraceError> {
+fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
     opentelemetry_jaeger::new_pipeline()
         .with_agent_endpoint("localhost:6831")
         .with_service_name("trace-udp-demo")
@@ -27,7 +27,7 @@ async fn index() -> &'static str {
 async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "debug");
     env_logger::init();
-    let _uninstall = init_tracer().expect("Failed to initialise tracer.");
+    let _tracer = init_tracer().expect("Failed to initialise tracer.");
 
     HttpServer::new(|| {
         App::new()

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 futures = "0.3"
 thrift = "0.13"
 tokio = { version = "1.0", features = ["full"] }
-opentelemetry = { path = "../../opentelemetry", features = ["tokio-support"] }
+opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio"] }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["tokio"] }

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -53,7 +53,7 @@ async fn run(addr: &SocketAddr) -> io::Result<usize> {
     write(&mut stream).with_context(cx).await
 }
 
-fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), TraceError> {
+fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("trace-demo")
         .install()
@@ -61,7 +61,7 @@ fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_jaeger::Uninstall), 
 
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let (tracer, _uninstall) = init_tracer()?;
+    let tracer = init_tracer()?;
     let addr = "127.0.0.1:6142".parse()?;
     let addr2 = "127.0.0.1:6143".parse()?;
     let span = tracer.start("root");

--- a/examples/aws-xray/src/client.rs
+++ b/examples/aws-xray/src/client.rs
@@ -9,7 +9,7 @@ use opentelemetry::{
 use opentelemetry_aws::XrayPropagator;
 use opentelemetry_http::HeaderInjector;
 
-fn init_tracer() -> (sdktrace::Tracer, stdout::Uninstall) {
+fn init_tracer() -> sdktrace::Tracer {
     global::set_text_map_propagator(XrayPropagator::new());
 
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
@@ -26,7 +26,7 @@ fn init_tracer() -> (sdktrace::Tracer, stdout::Uninstall) {
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let (_tracer, _guard) = init_tracer();
+    let _tracer = init_tracer();
 
     let client = Client::new();
     let span = global::tracer("example/client").start("say hello");

--- a/examples/aws-xray/src/server.rs
+++ b/examples/aws-xray/src/server.rs
@@ -30,7 +30,7 @@ async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     ))
 }
 
-fn init_tracer() -> (sdktrace::Tracer, stdout::Uninstall) {
+fn init_tracer() -> sdktrace::Tracer {
     global::set_text_map_propagator(XrayPropagator::new());
 
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
@@ -47,7 +47,7 @@ fn init_tracer() -> (sdktrace::Tracer, stdout::Uninstall) {
 
 #[tokio::main]
 async fn main() {
-    let _guard = init_tracer();
+    let _tracer = init_tracer();
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 
     let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });

--- a/examples/basic-otlp/Cargo.toml
+++ b/examples/basic-otlp/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3"
 lazy_static = "1.4"
-opentelemetry = { path = "../../opentelemetry", features = ["tokio-support", "metrics", "serialize"] }
+opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio", "metrics", "serialize"] }
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic", "metrics"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -1,6 +1,6 @@
 use futures::stream::Stream;
 use futures::StreamExt;
-use opentelemetry::global::shut_down_provider;
+use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::sdk::metrics::{selectors, PushController};
 use opentelemetry::trace::TraceError;
 use opentelemetry::{
@@ -103,7 +103,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // wait for 1 minutes so that we could see metrics being pushed via OTLP every 10 seconds.
     tokio::time::sleep(Duration::from_secs(60)).await;
 
-    shut_down_provider();
+    shutdown_tracer_provider();
 
     Ok(())
 }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3"
 lazy_static = "1.4"
-opentelemetry = { path = "../../opentelemetry", features = ["serialize", "tokio-support", "metrics"] }
+opentelemetry = { path = "../../opentelemetry", features = ["serialize", "rt-tokio", "metrics"] }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["tokio"] }
 serde_json = "1.0"
 thrift = "0.13"

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,6 +1,6 @@
 use futures::stream::{Stream, StreamExt};
 use opentelemetry::global;
-use opentelemetry::global::shut_down_provider;
+use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::sdk::{metrics::PushController, trace as sdktrace};
 use opentelemetry::trace::TraceError;
 use opentelemetry::{
@@ -99,7 +99,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         });
     });
 
-    shut_down_provider(); // sending remaining spans.
+    shutdown_tracer_provider(); // sending remaining spans.
 
     Ok(())
 }

--- a/examples/datadog/src/main.rs
+++ b/examples/datadog/src/main.rs
@@ -1,4 +1,5 @@
 use opentelemetry::global;
+use opentelemetry::global::shut_down_provider;
 use opentelemetry::{
     trace::{Span, TraceContextExt, Tracer},
     Key,
@@ -17,7 +18,7 @@ fn bar() {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let (tracer, _uninstall) = new_pipeline()
+    let tracer = new_pipeline()
         .with_service_name("trace-demo")
         .with_version(ApiVersion::Version05)
         .install()?;
@@ -33,6 +34,8 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         bar();
         thread::sleep(Duration::from_millis(6));
     });
+
+    shut_down_provider();
 
     Ok(())
 }

--- a/examples/datadog/src/main.rs
+++ b/examples/datadog/src/main.rs
@@ -1,5 +1,5 @@
 use opentelemetry::global;
-use opentelemetry::global::shut_down_provider;
+use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::{
     trace::{Span, TraceContextExt, Tracer},
     Key,
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         thread::sleep(Duration::from_millis(6));
     });
 
-    shut_down_provider();
+    shutdown_tracer_provider();
 
     Ok(())
 }

--- a/examples/external-otlp-grpcio-async-std/src/main.rs
+++ b/examples/external-otlp-grpcio-async-std/src/main.rs
@@ -31,7 +31,7 @@ use std::{
 const ENDPOINT: &str = "OTLP_GRPCIO_ENDPOINT";
 const HEADER_PREFIX: &str = "OTLP_GRPCIO_";
 
-fn init_tracer() -> Result<(sdktrace::Tracer, opentelemetry_otlp::Uninstall), TraceError> {
+fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
     let endpoint = var(ENDPOINT).unwrap_or_else(|_| {
         panic!(
             "You must specify and endpoint to connect to with the variable {:?}.",
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         _ => {}
     };
     env_logger::init();
-    let _guard = init_tracer()?;
+    let _ = init_tracer()?;
 
     let tracer = global::tracer("ex.com/basic");
 

--- a/examples/external-otlp-tonic-tokio/Cargo.toml
+++ b/examples/external-otlp-tonic-tokio/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3"
 opentelemetry = { path = "../../opentelemetry", features = [
-    "tokio-support",
+    "rt-tokio",
     "metrics",
     "serialize"
 ] }

--- a/examples/external-otlp-tonic-tokio/src/main.rs
+++ b/examples/external-otlp-tonic-tokio/src/main.rs
@@ -19,7 +19,7 @@ use tonic::{
 };
 use url::Url;
 
-use opentelemetry::global::shut_down_provider;
+use opentelemetry::global::shutdown_tracer_provider;
 use std::{env::vars, str::FromStr, time::Duration};
 use std::{
     env::{remove_var, var},
@@ -96,7 +96,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // wait for 1 minutes so that we could see metrics being pushed via OTLP every 10 seconds.
     tokio::time::sleep(Duration::from_secs(60)).await;
 
-    shut_down_provider();
+    shutdown_tracer_provider();
 
     Ok(())
 }

--- a/examples/grpc/src/client.rs
+++ b/examples/grpc/src/client.rs
@@ -1,6 +1,7 @@
 use hello_world::greeter_client::GreeterClient;
 use hello_world::HelloRequest;
 use opentelemetry::global;
+use opentelemetry::global::shut_down_provider;
 use opentelemetry::sdk::propagation::TraceContextPropagator;
 use opentelemetry::trace::TraceError;
 use opentelemetry::{
@@ -26,7 +27,7 @@ pub mod hello_world {
     tonic::include_proto!("helloworld");
 }
 
-fn tracing_init() -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall), TraceError> {
+fn tracing_init() -> Result<impl Tracer, TraceError> {
     global::set_text_map_propagator(TraceContextPropagator::new());
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("grpc-client")
@@ -35,7 +36,7 @@ fn tracing_init() -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall), Trac
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let (tracer, _uninstall) = tracing_init()?;
+    let tracer = tracing_init()?;
     let mut client = GreeterClient::connect("http://[::1]:50051").await?;
     let span = tracer.start("client-request");
     let cx = Context::current_with_span(span);
@@ -53,5 +54,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
         "response-received".to_string(),
         vec![KeyValue::new("response", format!("{:?}", response))],
     );
+
+    shut_down_provider();
+
     Ok(())
 }

--- a/examples/grpc/src/client.rs
+++ b/examples/grpc/src/client.rs
@@ -1,7 +1,7 @@
 use hello_world::greeter_client::GreeterClient;
 use hello_world::HelloRequest;
 use opentelemetry::global;
-use opentelemetry::global::shut_down_provider;
+use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::sdk::propagation::TraceContextPropagator;
 use opentelemetry::trace::TraceError;
 use opentelemetry::{
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
         vec![KeyValue::new("response", format!("{:?}", response))],
     );
 
-    shut_down_provider();
+    shutdown_tracer_provider();
 
     Ok(())
 }

--- a/examples/grpc/src/server.rs
+++ b/examples/grpc/src/server.rs
@@ -59,7 +59,7 @@ impl Greeter for MyGreeter {
     }
 }
 
-fn tracing_init() -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall), TraceError> {
+fn tracing_init() -> Result<impl Tracer, TraceError> {
     global::set_text_map_propagator(TraceContextPropagator::new());
     opentelemetry_jaeger::new_pipeline()
         .with_service_name("grpc-server")
@@ -68,7 +68,7 @@ fn tracing_init() -> Result<(impl Tracer, opentelemetry_jaeger::Uninstall), Trac
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let _uninstall = tracing_init()?;
+    let _tracer = tracing_init()?;
     let addr = "[::1]:50051".parse()?;
     let greeter = MyGreeter::default();
 

--- a/examples/http/src/client.rs
+++ b/examples/http/src/client.rs
@@ -11,7 +11,7 @@ use opentelemetry::{
 };
 use opentelemetry_http::HeaderInjector;
 
-fn init_tracer() -> (impl Tracer, stdout::Uninstall) {
+fn init_tracer() -> impl Tracer {
     global::set_text_map_propagator(TraceContextPropagator::new());
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
@@ -23,7 +23,7 @@ fn init_tracer() -> (impl Tracer, stdout::Uninstall) {
 
 #[tokio::main]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let _guard = init_tracer();
+    let _tracer = init_tracer();
 
     let client = Client::new();
     let span = global::tracer("example/client").start("say hello");

--- a/examples/http/src/server.rs
+++ b/examples/http/src/server.rs
@@ -22,7 +22,7 @@ async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     Ok(Response::new("Hello, World!".into()))
 }
 
-fn init_tracer() -> (impl Tracer, stdout::Uninstall) {
+fn init_tracer() -> impl Tracer {
     global::set_text_map_propagator(TraceContextPropagator::new());
 
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
@@ -35,7 +35,7 @@ fn init_tracer() -> (impl Tracer, stdout::Uninstall) {
 
 #[tokio::main]
 async fn main() {
-    let _guard = init_tracer();
+    let _tracer = init_tracer();
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 
     let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });

--- a/examples/stdout.rs
+++ b/examples/stdout.rs
@@ -8,7 +8,7 @@ fn main() {
     // Install stdout exporter pipeline to be able to retrieve collected spans.
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
-    let (tracer, _uninstall) = stdout::new_pipeline()
+    let tracer = stdout::new_pipeline()
         .with_trace_config(trace::config().with_default_sampler(Sampler::AlwaysOn))
         .install();
 

--- a/examples/zipkin/src/main.rs
+++ b/examples/zipkin/src/main.rs
@@ -1,5 +1,5 @@
 use opentelemetry::global;
-use opentelemetry::global::shut_down_provider;
+use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::trace::{Span, Tracer};
 use std::thread;
 use std::time::Duration;
@@ -22,6 +22,6 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         thread::sleep(Duration::from_millis(6));
     });
 
-    shut_down_provider();
+    shutdown_tracer_provider();
     Ok(())
 }

--- a/examples/zipkin/src/main.rs
+++ b/examples/zipkin/src/main.rs
@@ -1,4 +1,5 @@
 use opentelemetry::global;
+use opentelemetry::global::shut_down_provider;
 use opentelemetry::trace::{Span, Tracer};
 use std::thread;
 use std::time::Duration;
@@ -11,7 +12,7 @@ fn bar() {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let (tracer, _uninstall) = opentelemetry_zipkin::new_pipeline()
+    let tracer = opentelemetry_zipkin::new_pipeline()
         .with_service_name("trace-demo")
         .install()?;
 
@@ -21,5 +22,6 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         thread::sleep(Duration::from_millis(6));
     });
 
+    shut_down_provider();
     Ok(())
 }

--- a/opentelemetry-datadog/README.md
+++ b/opentelemetry-datadog/README.md
@@ -67,7 +67,7 @@ to [`Datadog`].
  }
 
  fn main() -> Result<(), opentelemetry::trace::TraceError> {
-     let (tracer, _uninstall) = new_pipeline()
+     let tracer = new_pipeline()
          .with_service_name("my_app")
          .with_version(ApiVersion::Version05)
          .with_agent_endpoint("http://localhost:8126")
@@ -81,6 +81,8 @@ to [`Datadog`].
      tracer.in_span("doing_work", |cx| {
          // Traced app logic here...
      });
+     
+     opentelemetry::global::shut_down_provider();
 
      Ok(())
  }

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -95,7 +95,7 @@ impl Default for DatadogPipelineBuilder {
 
 impl DatadogPipelineBuilder {
     /// Create `ExporterConfig` struct from current `ExporterConfigBuilder`
-    pub fn install(mut self) -> Result<(sdk::trace::Tracer, Uninstall), TraceError> {
+    pub fn install(mut self) -> Result<sdk::trace::Tracer, TraceError> {
         if let Some(client) = self.client {
             let endpoint = self.agent_endpoint + self.version.path();
             let exporter = DatadogExporter::new(
@@ -112,8 +112,8 @@ impl DatadogPipelineBuilder {
             let provider = provider_builder.build();
             let tracer =
                 provider.get_tracer("opentelemetry-datadog", Some(env!("CARGO_PKG_VERSION")));
-            let provider_guard = global::set_tracer_provider(provider);
-            Ok((tracer, Uninstall(provider_guard)))
+            let _ = global::set_tracer_provider(provider);
+            Ok(tracer)
         } else {
             Err(Error::NoHttpClient.into())
         }
@@ -179,11 +179,6 @@ impl trace::SpanExporter for DatadogExporter {
         self.client.send(req).await
     }
 }
-
-/// Uninstalls the Datadog pipeline on drop
-#[must_use]
-#[derive(Debug)]
-pub struct Uninstall(global::TracerProviderGuard);
 
 #[cfg(test)]
 mod tests {

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -74,7 +74,7 @@
 //! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //! use opentelemetry::sdk::export::trace::ExportResult;
 //! use opentelemetry_datadog::{new_pipeline, ApiVersion, Error};
-//! use opentelemetry::global::shut_down_provider;
+//! use opentelemetry::global::shutdown_tracer_provider;
 //! use opentelemetry_http::HttpClient;
 //! use async_trait::async_trait;
 //!
@@ -113,7 +113,7 @@
 //!         // Traced app logic here...
 //!     });
 //!
-//!     shut_down_provider(); // sending remaining spans before exit
+//!     shutdown_tracer_provider(); // sending remaining spans before exit
 //!
 //!     Ok(())
 //! }

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -35,16 +35,16 @@
 //!
 //! For optimal performance, a batch exporter is recommended as the simple
 //! exporter will export each span synchronously on drop. You can enable the
-//! [`tokio-support`] or [`async-std`] features to have a batch exporter configured for
+//! [`rt-tokio`], [`rt-tokio-current-thread`] or [`rt-async-std`] features to have a batch exporter configured for
 //! you automatically for either executor when you install the pipeline.
 //!
 //! ```toml
 //! [dependencies]
-//! opentelemetry = { version = "*", features = ["tokio-support"] }
+//! opentelemetry = { version = "*", features = ["rt-tokio"] }
 //! opentelemetry-datadog = "*"
 //! ```
 //!
-//! [`tokio-support`]: https://tokio.rs
+//! [`rt-tokio`]: https://tokio.rs
 //! [`async-std`]: https://async.rs
 //!
 

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -74,6 +74,7 @@
 //! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //! use opentelemetry::sdk::export::trace::ExportResult;
 //! use opentelemetry_datadog::{new_pipeline, ApiVersion, Error};
+//! use opentelemetry::global::shut_down_provider;
 //! use opentelemetry_http::HttpClient;
 //! use async_trait::async_trait;
 //!
@@ -97,7 +98,7 @@
 //! }
 //!
 //! fn main() -> Result<(), opentelemetry::trace::TraceError> {
-//!     let (tracer, _uninstall) = new_pipeline()
+//!     let tracer = new_pipeline()
 //!         .with_service_name("my_app")
 //!         .with_version(ApiVersion::Version05)
 //!         .with_agent_endpoint("http://localhost:8126")
@@ -111,6 +112,8 @@
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...
 //!     });
+//!
+//!     shut_down_provider(); // sending remaining spans before exit
 //!
 //!     Ok(())
 //! }

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -47,11 +47,13 @@ use opentelemetry::trace::Tracer;
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
-    let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline().install()?;
+    let tracer = opentelemetry_jaeger::new_pipeline().install()?;
 
     tracer.in_span("doing_work", |cx| {
         // Traced app logic here...
     });
+    
+    global::shut_down_provider(); // sending remaining spans
 
     Ok(())
 }
@@ -111,7 +113,7 @@ Then you can use the [`with_collector_endpoint`] method to specify the endpoint:
 use opentelemetry::trace::Tracer;
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
+    let tracer = opentelemetry_jaeger::new_pipeline()
         .with_collector_endpoint("http://localhost:14268/api/traces")
         // optionally set username and password as well.
         .with_collector_username("username")
@@ -121,6 +123,8 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     tracer.in_span("doing_work", |cx| {
         // Traced app logic here...
     });
+
+    opentelemetry::global::shut_down_provider(); // sending remaining spans
 
     Ok(())
 }
@@ -144,7 +148,7 @@ use opentelemetry::KeyValue;
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
-    let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
+    let tracer = opentelemetry_jaeger::new_pipeline()
         .with_agent_endpoint("localhost:6831")
         .with_service_name("my_app")
         .with_tags(vec![KeyValue::new("process_key", "process_value")])
@@ -163,7 +167,9 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     tracer.in_span("doing_work", |cx| {
         // Traced app logic here...
     });
-
+    
+    global::shut_down_provider(); // sending remaining spans
+    
     Ok(())
 }
 ```

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -64,18 +64,19 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 ## Performance
 
 For optimal performance, a batch exporter is recommended as the simple exporter
-will export each span synchronously on drop. You can enable the [`tokio-support`] or
-[`async-std`] features to have a batch exporter configured for you automatically
+will export each span synchronously on drop. You can enable the [`rt-tokio`], [`rt-tokio-current-thread`] or
+[`rt-async-std`] features to have a batch exporter configured for you automatically
 for either executor when you install the pipeline.
 
 ```toml
 [dependencies]
-opentelemetry = { version = "*", features = ["tokio-support"] }
+opentelemetry = { version = "*", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "*", features = ["tokio"] }
 ```
 
-[`tokio-support`]: https://tokio.rs
-[`async-std`]: https://async.rs
+[`rt-tokio`]: https://tokio.rs
+[`rt-tokio-current-thread`]: https://tokio.rs
+[`rt-async-std`]: https://async.rs
 
 ### Jaeger Exporter From Environment Variables
 

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -63,11 +63,6 @@ pub fn new_pipeline() -> PipelineBuilder {
     PipelineBuilder::default()
 }
 
-/// Guard that uninstalls the Jaeger trace pipeline when dropped
-#[must_use]
-#[derive(Debug)]
-pub struct Uninstall(global::TracerProviderGuard);
-
 /// Jaeger span exporter
 #[derive(Debug)]
 pub struct Exporter {
@@ -262,14 +257,14 @@ impl PipelineBuilder {
     }
 
     /// Install a Jaeger pipeline with the recommended defaults.
-    pub fn install(self) -> Result<(sdk::trace::Tracer, Uninstall), TraceError> {
+    pub fn install(self) -> Result<sdk::trace::Tracer, TraceError> {
         let tracer_provider = self.build()?;
         let tracer =
             tracer_provider.get_tracer("opentelemetry-jaeger", Some(env!("CARGO_PKG_VERSION")));
 
-        let provider_guard = global::set_tracer_provider(tracer_provider);
+        let _ = global::set_tracer_provider(tracer_provider);
 
-        Ok((tracer, Uninstall(provider_guard)))
+        Ok(tracer)
     }
 
     /// Build a configured `sdk::trace::TracerProvider` with the recommended defaults.

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -25,11 +25,13 @@
 //!
 //! fn main() -> Result<(), opentelemetry::trace::TraceError> {
 //!     global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
-//!     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline().install()?;
+//!     let tracer = opentelemetry_jaeger::new_pipeline().install()?;
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...
 //!     });
+//!
+//!     global::shut_down_provider(); // export remaining spans
 //!
 //!     Ok(())
 //! }
@@ -81,7 +83,7 @@
 //! use opentelemetry::trace::{Tracer, TraceError};
 //!
 //! fn main() -> Result<(), TraceError> {
-//!     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
+//!     let tracer = opentelemetry_jaeger::new_pipeline()
 //!         .with_collector_endpoint("http://localhost:14268/api/traces")
 //!         // optionally set username and password as well.
 //!         .with_collector_username("username")
@@ -110,7 +112,7 @@
 //!
 //! fn main() -> Result<(), TraceError> {
 //!     global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
-//!     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
+//!     let tracer = opentelemetry_jaeger::new_pipeline()
 //!         .with_agent_endpoint("localhost:6831")
 //!         .with_service_name("my_app")
 //!         .with_tags(vec![KeyValue::new("process_key", "process_value")])
@@ -129,6 +131,8 @@
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...
 //!     });
+//!
+//!     global::shut_down_provider(); // export remaining spans
 //!
 //!     Ok(())
 //! }
@@ -570,5 +574,5 @@ mod propagator {
     }
 }
 
-pub use exporter::{new_pipeline, Error, Exporter, PipelineBuilder, Process, Uninstall};
+pub use exporter::{new_pipeline, Error, Exporter, PipelineBuilder, Process};
 pub use propagator::Propagator;

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -46,7 +46,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! opentelemetry = { version = "*", features = ["tokio-support"] }
+//! opentelemetry = { version = "*", features = ["rt-tokio"] }
 //! opentelemetry-jaeger = { version = "*", features = ["tokio"] }
 //! ```
 //!

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -31,7 +31,7 @@
 //!         // Traced app logic here...
 //!     });
 //!
-//!     global::shut_down_provider(); // export remaining spans
+//!     global::shutdown_tracer_provider(); // export remaining spans
 //!
 //!     Ok(())
 //! }
@@ -132,7 +132,7 @@
 //!         // Traced app logic here...
 //!     });
 //!
-//!     global::shut_down_provider(); // export remaining spans
+//!     global::shutdown_tracer_provider(); // export remaining spans
 //!
 //!     Ok(())
 //! }

--- a/opentelemetry-otlp/tests/smoke.rs
+++ b/opentelemetry-otlp/tests/smoke.rs
@@ -1,4 +1,5 @@
 use futures::StreamExt;
+use opentelemetry::global::shut_down_provider;
 use opentelemetry::trace::{Span, SpanKind, Tracer};
 use opentelemetry_otlp::proto::collector::trace::v1::{
     trace_service_server::{TraceService, TraceServiceServer},
@@ -66,7 +67,7 @@ async fn smoke_tracer() {
 
     {
         println!("Installing tracer...");
-        let (tracer, _uninstall) = opentelemetry_otlp::new_pipeline()
+        let tracer = opentelemetry_otlp::new_pipeline()
             .with_endpoint(format!("http://{}", addr))
             .install()
             .expect("failed to install");
@@ -78,6 +79,8 @@ async fn smoke_tracer() {
             .start(&tracer);
         span.add_event("my-test-event".into(), vec![]);
         span.end();
+
+        shut_down_provider();
     }
 
     println!("Waiting for request...");

--- a/opentelemetry-otlp/tests/smoke.rs
+++ b/opentelemetry-otlp/tests/smoke.rs
@@ -1,5 +1,5 @@
 use futures::StreamExt;
-use opentelemetry::global::shut_down_provider;
+use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::trace::{Span, SpanKind, Tracer};
 use opentelemetry_otlp::proto::collector::trace::v1::{
     trace_service_server::{TraceService, TraceServiceServer},
@@ -80,7 +80,7 @@ async fn smoke_tracer() {
         span.add_event("my-test-event".into(), vec![]);
         span.end();
 
-        shut_down_provider();
+        shutdown_tracer_provider();
     }
 
     println!("Waiting for request...");

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -62,17 +62,17 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 ## Performance
 
 For optimal performance, a batch exporter is recommended as the simple exporter
-will export each span synchronously on drop. You can enable the [`tokio-support`] or
+will export each span synchronously on drop. You can enable the [`rt-tokio`], [`rt-tokio-current-thread`] or
 [`async-std`] features to have a batch exporter configured for you automatically
 for either executor when you install the pipeline.
 
 ```toml
 [dependencies]
-opentelemetry = { version = "*", features = ["tokio-support"] }
+opentelemetry = { version = "*", features = ["rt-tokio"] }
 opentelemetry-zipkin = { version = "*", features = ["reqwest-client"], default-features = false }
 ```
 
-[`tokio-support`]: https://tokio.rs
+[`rt-tokio`]: https://tokio.rs
 [`async-std`]: https://async.rs
 
 ## Choosing an HTTP client

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -47,11 +47,13 @@ use opentelemetry::global;
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     global::set_text_map_propagator(opentelemetry_zipkin::Propagator::new());
-    let (tracer, _uninstall) = opentelemetry_zipkin::new_pipeline().install()?;
+    let tracer = opentelemetry_zipkin::new_pipeline().install()?;
 
     tracer.in_span("doing_work", |cx| {
         // Traced app logic here...
     });
+    
+    global::shut_down_provider();
 
     Ok(())
 }
@@ -125,7 +127,7 @@ impl HttpClient for IsahcClient {
 
 fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     global::set_text_map_propagator(opentelemetry_zipkin::Propagator::new());
-    let (tracer, _uninstall) = opentelemetry_zipkin::new_pipeline()
+    let tracer = opentelemetry_zipkin::new_pipeline()
         .with_http_client(IsahcClient(isahc::HttpClient::new()?))
         .with_service_name("my_app")
         .with_service_address("127.0.0.1:8080".parse()?)
@@ -144,6 +146,8 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     tracer.in_span("doing_work", |cx| {
         // Traced app logic here...
     });
+    
+    global::shut_down_provider();
 
     Ok(())
 }

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -83,7 +83,7 @@ impl Default for ZipkinPipelineBuilder {
 
 impl ZipkinPipelineBuilder {
     /// Create `ExporterConfig` struct from current `ExporterConfigBuilder`
-    pub fn install(mut self) -> Result<(sdk::trace::Tracer, Uninstall), TraceError> {
+    pub fn install(mut self) -> Result<sdk::trace::Tracer, TraceError> {
         if let Some(client) = self.client {
             let endpoint = Endpoint::new(self.service_name, self.service_addr);
             let exporter = Exporter::new(
@@ -102,9 +102,9 @@ impl ZipkinPipelineBuilder {
             let provider = provider_builder.build();
             let tracer =
                 provider.get_tracer("opentelemetry-zipkin", Some(env!("CARGO_PKG_VERSION")));
-            let provider_guard = global::set_tracer_provider(provider);
+            let _ = global::set_tracer_provider(provider);
 
-            Ok((tracer, Uninstall(provider_guard)))
+            Ok(tracer)
         } else {
             Err(Error::NoHttpClient.into())
         }
@@ -153,11 +153,6 @@ impl trace::SpanExporter for Exporter {
         self.uploader.upload(zipkin_spans).await
     }
 }
-
-/// Uninstalls the Zipkin pipeline on drop.
-#[must_use]
-#[derive(Debug)]
-pub struct Uninstall(global::TracerProviderGuard);
 
 /// Wrap type for errors from opentelemetry zipkin
 #[derive(thiserror::Error, Debug)]

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -32,7 +32,7 @@
 //!         // Traced app logic here...
 //!     });
 //!
-//!     global::shut_down_provider(); // sending remaining spans
+//!     global::shutdown_tracer_provider(); // sending remaining spans
 //!
 //!     Ok(())
 //! }
@@ -128,7 +128,7 @@
 //!         // Traced app logic here...
 //!     });
 //!
-//!     global::shut_down_provider(); // sending remaining spans
+//!     global::shutdown_tracer_provider(); // sending remaining spans
 //!
 //!     Ok(())
 //! }

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -42,16 +42,16 @@
 //!
 //! For optimal performance, a batch exporter is recommended as the simple
 //! exporter will export each span synchronously on drop. You can enable the
-//! [`tokio-support`] or [`async-std`] features to have a batch exporter configured for
+//! [`rt-tokio`], [`rt-tokio-current-thread`] or [`async-std`] features to have a batch exporter configured for
 //! you automatically for either executor when you install the pipeline.
 //!
 //! ```toml
 //! [dependencies]
-//! opentelemetry = { version = "*", features = ["tokio-support"] }
+//! opentelemetry = { version = "*", features = ["rt-tokio"] }
 //! opentelemetry-zipkin = { version = "*", features = ["reqwest-client"], default-features = false }
 //! ```
 //!
-//! [`tokio-support`]: https://tokio.rs
+//! [`rt-tokio`]: https://tokio.rs
 //! [`async-std`]: https://async.rs
 //!
 //! ## Choosing an HTTP client

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -26,11 +26,13 @@
 //!
 //! fn main() -> Result<(), TraceError> {
 //!     global::set_text_map_propagator(opentelemetry_zipkin::Propagator::new());
-//!     let (tracer, _uninstall) = opentelemetry_zipkin::new_pipeline().install()?;
+//!     let tracer = opentelemetry_zipkin::new_pipeline().install()?;
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...
 //!     });
+//!
+//!     global::shut_down_provider(); // sending remaining spans
 //!
 //!     Ok(())
 //! }
@@ -106,7 +108,7 @@
 //!
 //! fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 //!     global::set_text_map_propagator(opentelemetry_zipkin::Propagator::new());
-//!     let (tracer, _uninstall) = opentelemetry_zipkin::new_pipeline()
+//!     let tracer = opentelemetry_zipkin::new_pipeline()
 //!         .with_http_client(IsahcClient(isahc::HttpClient::new()?))
 //!         .with_service_name("my_app")
 //!         .with_service_address("127.0.0.1:8080".parse()?)
@@ -125,6 +127,8 @@
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...
 //!     });
+//!
+//!     global::shut_down_provider(); // sending remaining spans
 //!
 //!     Ok(())
 //! }
@@ -173,5 +177,5 @@ extern crate typed_builder;
 mod exporter;
 mod propagator;
 
-pub use exporter::{new_pipeline, Error, Exporter, Uninstall, ZipkinPipelineBuilder};
+pub use exporter::{new_pipeline, Error, Exporter, ZipkinPipelineBuilder};
 pub use propagator::{B3Encoding, Propagator};

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -34,8 +34,6 @@ serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 thiserror = "1"
 tokio = { version = "1.0", default-features = false, features = ["rt", "time"], optional = true }
 tokio-stream = { version = "0.1", optional = true }
-reqwest = { version = "0.11", default-features = false, features = ["blocking"], optional = true }
-surf = { version = "2.0", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -50,9 +50,10 @@ default = ["trace"]
 trace = ["rand", "pin-project", "async-trait", "percent-encoding"]
 metrics = ["dashmap", "fnv"]
 serialize = ["serde"]
-testing = ["trace", "metrics", "tokio-support", "tokio/full"]
-tokio-support = ["tokio", "tokio-stream"]
-tokio-rt-current-thread = ["tokio", "tokio-stream"]
+testing = ["trace", "metrics", "rt-tokio", "tokio/full"]
+rt-tokio = ["tokio", "tokio-stream"]
+rt-tokio-current-thread = ["tokio", "tokio-stream"]
+rt-async-std = ["async-std"]
 
 [[bench]]
 name = "trace"

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -54,6 +54,7 @@ metrics = ["dashmap", "fnv"]
 serialize = ["serde"]
 testing = ["trace", "metrics", "tokio-support", "tokio/full"]
 tokio-support = ["tokio", "tokio-stream"]
+tokio-rt-current-thread = ["tokio", "tokio-stream"]
 
 [[bench]]
 name = "trace"

--- a/opentelemetry/src/global/mod.rs
+++ b/opentelemetry/src/global/mod.rs
@@ -155,6 +155,6 @@ pub use propagation::{get_text_map_propagator, set_text_map_propagator};
 #[cfg(feature = "trace")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 pub use trace::{
-    set_tracer_provider, shut_down_provider, tracer, tracer_provider, tracer_with_version,
+    set_tracer_provider, shutdown_tracer_provider, tracer, tracer_provider, tracer_with_version,
     BoxedSpan, BoxedTracer, GenericTracer, GenericTracerProvider, GlobalTracerProvider,
 };

--- a/opentelemetry/src/global/mod.rs
+++ b/opentelemetry/src/global/mod.rs
@@ -21,12 +21,12 @@
 //! use opentelemetry::trace::{Tracer, NoopTracerProvider};
 //! use opentelemetry::global;
 //!
-//! fn init_tracer() -> global::TracerProviderGuard {
+//! fn init_tracer() {
 //!     let provider = NoopTracerProvider::new();
 //!
 //!     // Configure the global `TracerProvider` singleton when your app starts
 //!     // (there is a no-op default if this is not set by your application)
-//!     global::set_tracer_provider(provider)
+//!     let _ = global::set_tracer_provider(provider);
 //! }
 //!
 //! fn do_something_tracked() {
@@ -39,7 +39,7 @@
 //! }
 //!
 //! // in main or other app start
-//! let _guard = init_tracer();
+//! let _ = init_tracer();
 //! do_something_tracked();
 //! # }
 //! ```
@@ -155,6 +155,6 @@ pub use propagation::{get_text_map_propagator, set_text_map_propagator};
 #[cfg(feature = "trace")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 pub use trace::{
-    set_tracer_provider, tracer, tracer_provider, tracer_with_version, BoxedSpan, BoxedTracer,
-    GenericTracer, GenericTracerProvider, GlobalTracerProvider, TracerProviderGuard,
+    set_tracer_provider, shut_down_provider, tracer, tracer_provider, tracer_with_version,
+    BoxedSpan, BoxedTracer, GenericTracer, GenericTracerProvider, GlobalTracerProvider,
 };

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -381,10 +381,10 @@ mod tests {
     #[test]
     #[ignore]
     fn test_set_tracer_provider() {
-        let _guard = set_tracer_provider(TestTracerProvider::new("global one"));
+        let _ = set_tracer_provider(TestTracerProvider::new("global one"));
 
         {
-            let _guard = set_tracer_provider(TestTracerProvider::new("inner one"));
+            let _ = set_tracer_provider(TestTracerProvider::new("inner one"));
             assert!(format!("{:?}", tracer_provider()).contains("inner one"));
         }
 
@@ -394,7 +394,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_set_tracer_provider_in_another_thread() {
-        let _guard = set_tracer_provider(TestTracerProvider::new("global one"));
+        let _ = set_tracer_provider(TestTracerProvider::new("global one"));
 
         let handle = thread::spawn(move || {
             assert!(format!("{:?}", tracer_provider()).contains("global one"));
@@ -409,7 +409,7 @@ mod tests {
     #[ignore]
     fn test_set_tracer_provider_in_another_function() {
         let setup = || {
-            let _guard = set_tracer_provider(TestTracerProvider::new("global one"));
+            let _ = set_tracer_provider(TestTracerProvider::new("global one"));
             assert!(format!("{:?}", tracer_provider()).contains("global one"))
         };
 

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -276,7 +276,7 @@ where
 
 /// Shut down the current tracer provider. This will invoke shut_down method on all span processors.
 /// span processors should export remaining spans before return
-pub fn shut_down_provider() {
+pub fn shutdown_tracer_provider() {
     let mut tracer_provider = GLOBAL_TRACER_PROVIDER
         .write()
         .expect("GLOBAL_TRACER_PROVIDER RwLock poisoned");
@@ -462,7 +462,7 @@ mod tests {
 
             tracer.in_span("test", |_cx| {});
 
-            shut_down_provider();
+            shutdown_tracer_provider();
 
             assert!(assert_writer.len() > 0);
         }
@@ -495,7 +495,7 @@ mod tests {
         #[ignore]
         async fn test_set_provider_single_thread_tokio_shutdown() {
             let _ = test_set_provider_in_tokio().await;
-            // shut_down_provider(); Will block forever
+            // shutdown_tracer_provider(); Will block forever
         }
 
         // Test if the multiple thread tokio runtime could exit successfully when not force flushing spans
@@ -511,7 +511,7 @@ mod tests {
         #[ignore]
         async fn test_set_provider_multiple_thread_tokio_shutdown() {
             let assert_writer = test_set_provider_in_tokio().await;
-            shut_down_provider();
+            shutdown_tracer_provider();
             assert!(assert_writer.len() > 0);
         }
 

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -294,12 +294,12 @@ pub fn shutdown_tracer_provider() {
 mod tests {
     use super::*;
     use crate::trace::NoopTracer;
-    #[cfg(any(feature = "tokio-support", feature = "tokio-rt-current-thread"))]
+    #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
     use crate::trace::Tracer;
     use std::fmt::Debug;
-    #[cfg(any(feature = "tokio-support", feature = "tokio-rt-current-thread"))]
+    #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
     use std::io::Write;
-    #[cfg(any(feature = "tokio-support", feature = "tokio-rt-current-thread"))]
+    #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
     use std::sync::Mutex;
     use std::thread;
     use std::thread::sleep;
@@ -308,7 +308,7 @@ mod tests {
     macro_rules! cfg_tokio {
         ($($item:item)*) => {
             $(
-                #[cfg(any(feature = "tokio-support", feature = "tokio-rt-current-thread"))]
+                #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
                 $item
             )*
         }
@@ -488,7 +488,7 @@ mod tests {
     // Test if the multiple thread tokio runtime could exit successfully when not force flushing spans
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[ignore]
-    #[cfg(feature = "tokio-support")]
+    #[cfg(feature = "rt-tokio")]
     async fn test_set_provider_multiple_thread_tokio() {
         let assert_writer = test_set_provider_in_tokio().await;
         assert_eq!(assert_writer.len(), 0);
@@ -497,7 +497,7 @@ mod tests {
     // Test if the multiple thread tokio runtime could exit successfully when force flushing spans
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[ignore]
-    #[cfg(feature = "tokio-support")]
+    #[cfg(feature = "rt-tokio")]
     async fn test_set_provider_multiple_thread_tokio_shutdown() {
         let assert_writer = test_set_provider_in_tokio().await;
         shutdown_tracer_provider();
@@ -508,7 +508,7 @@ mod tests {
     // Expected to see the spans being exported to buffer
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "tokio-rt-current-thread")]
+    #[cfg(feature = "rt-tokio-current-thread")]
     async fn test_set_provider_single_thread_tokio_with_simple_processor() {
         let assert_writer = AssertWriter::new();
         let _ = set_tracer_provider(build_tracer_provider(false, assert_writer.clone()));
@@ -524,7 +524,7 @@ mod tests {
     // Test if the single thread tokio runtime could exit successfully when not force flushing spans
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "tokio-rt-current-thread")]
+    #[cfg(feature = "rt-tokio-current-thread")]
     async fn test_set_provider_single_thread_tokio() {
         let assert_writer = test_set_provider_in_tokio().await;
         assert_eq!(assert_writer.len(), 0)
@@ -533,7 +533,7 @@ mod tests {
     // Test if the single thread tokio runtime could exit successfully when force flushing spans.
     #[tokio::test]
     #[ignore]
-    #[cfg(feature = "tokio-rt-current-thread")]
+    #[cfg(feature = "rt-tokio-current-thread")]
     async fn test_set_provider_single_thread_tokio_shutdown() {
         let assert_writer = test_set_provider_in_tokio().await;
         shutdown_tracer_provider();

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -262,17 +262,6 @@ pub fn tracer_with_version(name: &'static str, version: &'static str) -> BoxedTr
 #[derive(Debug)]
 pub struct TracerProviderGuard(Option<GlobalTracerProvider>);
 
-impl Drop for TracerProviderGuard {
-    fn drop(&mut self) {
-        // if let Some(previous) = self.0.take() {
-        //     let mut global_provider = GLOBAL_TRACER_PROVIDER
-        //         .write()
-        //         .expect("GLOBAL_TRACER_PROVIDER RwLock poisoned");
-        //     *global_provider = previous;
-        // }
-    }
-}
-
 /// Sets the given [`TracerProvider`] instance as the current global provider.
 ///
 /// [`TracerProvider`]: ../api/trace/provider/trait.TracerProvider.html
@@ -441,7 +430,7 @@ mod tests {
     #[ignore]
     fn test_set_two_provider_in_two_thread() {
         let (sender, recv) = std::sync::mpsc::channel();
-        let (sender1, sender2) = (sender.clone(), sender.clone());
+        let (sender1, sender2) = (sender.clone(), sender);
         let _handle1 = thread::spawn(move || {
             sleep(Duration::from_secs(1));
             let _guard = set_tracer_provider(TestTracerProvider::new("thread 1"));

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -47,12 +47,30 @@
 //! via the following flags:
 //!
 //! * `tokio-support`: Spawn telemetry tasks using [tokio]'s multi-thread runtime.
-//! * `tokio-rt-current-thread`: Spawn telemetry tasks in a separate thread so that the main thread won't be blocked.
+//! * `tokio-rt-current-thread`: Spawn telemetry tasks on a separate runtime so that the main runtime won't be blocked.
 //! * `async-std`: Spawn telemetry tasks using [async-std]'s runtime.
 //!
 //! [tokio]: https://crates.io/crates/tokio
 //! [async-std]: https://crates.io/crates/async-std
 //! [serde]: https://crates.io/crates/serde
+//!
+//! ## Working with runtimes
+//!
+//! Opentelemetry API & SDK supports different runtimes. Usually, when working with async runtime. To
+//! improve the performance, we recommend to use batch span processors where the spans will be sent in
+//! batch, reducing the number of requests and resource needed.
+//!
+//! Batch span processors need to run a background task to collect and send spans. Different runtime
+//! needs different ways to handle the background task.
+//!
+//! ### Tokio
+//!
+//! Tokio currently offers two different schedulers. One is `current_thread_scheduler`, the other is
+//! `multiple_thread_scheduler`. Both of them default to use batch span processors to install span exporters.
+//!
+//! But for `current_thread_scheduler`. It can cause the program to hang forever if we schedule the backgroud
+//! task with other tasks in the same runtime. Thus, users should enable `tokio-rt-current-thread` feature
+//! to ask the background task be scheduled on a different runtime on a different thread.
 //!
 //! ## Related Crates
 //!

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -46,9 +46,9 @@
 //! Support for recording and exporting telemetry asynchronously can be added
 //! via the following flags:
 //!
-//! * `tokio-support`: Spawn telemetry tasks using [tokio]'s multi-thread runtime.
-//! * `tokio-rt-current-thread`: Spawn telemetry tasks on a separate runtime so that the main runtime won't be blocked.
-//! * `async-std`: Spawn telemetry tasks using [async-std]'s runtime.
+//! * `rt-tokio`: Spawn telemetry tasks using [tokio]'s multi-thread runtime.
+//! * `rt-tokio-current-thread`: Spawn telemetry tasks on a separate runtime so that the main runtime won't be blocked.
+//! * `rt-async-std`: Spawn telemetry tasks using [async-std]'s runtime.
 //!
 //! [tokio]: https://crates.io/crates/tokio
 //! [async-std]: https://crates.io/crates/async-std
@@ -69,7 +69,7 @@
 //! `multiple_thread_scheduler`. Both of them default to use batch span processors to install span exporters.
 //!
 //! But for `current_thread_scheduler`. It can cause the program to hang forever if we schedule the backgroud
-//! task with other tasks in the same runtime. Thus, users should enable `tokio-rt-current-thread` feature
+//! task with other tasks in the same runtime. Thus, users should enable `rt-tokio-current-thread` feature
 //! to ask the background task be scheduled on a different runtime on a different thread.
 //!
 //! ## Related Crates
@@ -178,9 +178,11 @@ pub mod testing;
 pub mod baggage;
 
 mod context;
+
 pub use context::{Context, ContextGuard};
 
 mod core;
+
 pub use crate::core::{Array, Key, KeyValue, Unit, Value};
 
 pub mod util;

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -15,15 +15,17 @@
 //! ```no_run
 //! # #[cfg(feature = "trace")]
 //! # {
-//! use opentelemetry::{sdk::export::trace::stdout, trace::Tracer};
+//! use opentelemetry::{sdk::export::trace::stdout, trace::Tracer, global};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //!     // Create a new instrumentation pipeline
-//!     let (tracer, _uninstall) = stdout::new_pipeline().install();
+//!     let tracer = stdout::new_pipeline().install();
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...
 //!     });
+//!
+//!     global::shut_down_provider(); // sending remaining spans
 //!
 //!     Ok(())
 //! }

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -44,22 +44,13 @@
 //! Support for recording and exporting telemetry asynchronously can be added
 //! via the following flags:
 //!
-//! * `tokio-support`: Spawn telemetry tasks using [tokio]'s runtime.
+//! * `tokio-support`: Spawn telemetry tasks using [tokio]'s multi-thread runtime.
+//! * `tokio-rt-current-thread`: Spawn telemetry tasks in a separate thread so that the main thread won't be blocked.
 //! * `async-std`: Spawn telemetry tasks using [async-std]'s runtime.
-//!
-//! Finally the following flags can be used by exporter authors:
-//!
-//! * `reqwest`: Implementation of [`HttpClient`] for [reqwest].
-//! * `surf`: Implementation of [`HttpClient`] for [surf]`.
 //!
 //! [tokio]: https://crates.io/crates/tokio
 //! [async-std]: https://crates.io/crates/async-std
 //! [serde]: https://crates.io/crates/serde
-//! [http]: https://crates.io/crates/http
-//! [tonic]: https://crates.io/crates/tonic
-//! [`HttpClient`]: crate::sdk::export::trace::HttpClient
-//! [reqwest]: https://crates.io/crates/reqwest
-//! [surf]: https://crates.io/crates/surf
 //!
 //! ## Related Crates
 //!
@@ -72,6 +63,8 @@
 //!
 //! In particular, the following crates are likely to be of interest:
 //!
+//! - [`opentelemetry-http`] provides a pipeline and exporter for sending
+//!   trace information to [`http`].
 //! - [`opentelemetry-jaeger`] provides a pipeline and exporter for sending
 //!   trace information to [`Jaeger`].
 //! - [`opentelemetry-otlp`] exporter for sending trace and metric data in the
@@ -109,6 +102,7 @@
 //! [`opentelemetry-prometheus`]: https://crates.io/crates/opentelemetry-prometheus
 //! [`Prometheus`]: https://prometheus.io
 //! [`opentelemetry-zipkin`]: https://crates.io/crates/opentelemetry-zipkin
+//! [http]: https://crates.io/crates/http
 //! [`Zipkin`]: https://zipkin.io
 //! [`opentelemetry-contrib`]: https://crates.io/crates/opentelemetry-contrib
 //! [`Datadog`]: https://www.datadoghq.com

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -56,9 +56,9 @@
 //!
 //! ## Working with runtimes
 //!
-//! Opentelemetry API & SDK supports different runtimes. Usually, when working with async runtime. To
-//! improve the performance, we recommend to use batch span processors where the spans will be sent in
-//! batch, reducing the number of requests and resource needed.
+//! Opentelemetry API & SDK supports different runtimes. When working with async runtime, we recommend
+//! to use batch span processors where the spans will be sent in batch, reducing the number of requests
+//! and resource needed.
 //!
 //! Batch span processors need to run a background task to collect and send spans. Different runtime
 //! needs different ways to handle the background task.

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -25,7 +25,7 @@
 //!         // Traced app logic here...
 //!     });
 //!
-//!     global::shut_down_provider(); // sending remaining spans
+//!     global::shutdown_tracer_provider(); // sending remaining spans
 //!
 //!     Ok(())
 //! }

--- a/opentelemetry/src/sdk/export/trace/stdout.rs
+++ b/opentelemetry/src/sdk/export/trace/stdout.rs
@@ -13,7 +13,7 @@
 //! ```no_run
 //! use opentelemetry::trace::Tracer;
 //! use opentelemetry::sdk::export::trace::stdout;
-//! use opentelemetry::global::shut_down_provider;
+//! use opentelemetry::global::shutdown_tracer_provider;
 //!
 //! fn main() {
 //!     let tracer = stdout::new_pipeline()
@@ -24,7 +24,7 @@
 //!         // Traced app logic here...
 //!     });
 //!
-//!     shut_down_provider(); // sending remaining spans
+//!     shutdown_tracer_provider(); // sending remaining spans
 //! }
 //! ```
 use crate::{

--- a/opentelemetry/src/sdk/trace/provider.rs
+++ b/opentelemetry/src/sdk/trace/provider.rs
@@ -13,16 +13,16 @@ use crate::{
     sdk::{self, export::trace::SpanExporter, trace::SpanProcessor},
 };
 #[cfg(all(
-    feature = "tokio-rt-current-thread",
-    not(feature = "tokio-support"),
-    not(feature = "async-std")
+    feature = "rt-tokio-current-thread",
+    not(feature = "rt-tokio"),
+    not(feature = "rt-async-std")
 ))]
 use futures::future::BoxFuture;
 use std::sync::Arc;
 #[cfg(all(
-    feature = "tokio-rt-current-thread",
-    not(feature = "tokio-support"),
-    not(feature = "async-std")
+    feature = "rt-tokio-current-thread",
+    not(feature = "rt-tokio"),
+    not(feature = "rt-async-std")
 ))]
 use std::thread;
 
@@ -125,8 +125,8 @@ impl Builder {
     }
 
     /// Add a configured `SpanExporter`
-    #[cfg(feature = "tokio-support")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tokio-support")))]
+    #[cfg(feature = "rt-tokio")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rt-tokio")))]
     pub fn with_exporter<T: SpanExporter + 'static>(self, exporter: T) -> Self {
         let batch = sdk::trace::BatchSpanProcessor::builder(
             exporter,
@@ -139,11 +139,11 @@ impl Builder {
 
     /// Add a configured `SpanExporter`
     #[cfg(all(
-        feature = "tokio-rt-current-thread",
-        not(feature = "tokio-support"),
-        not(feature = "async-std")
+        feature = "rt-tokio-current-thread",
+        not(feature = "rt-tokio"),
+        not(feature = "rt-async-std")
     ))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tokio-rt-current-thread")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rt-tokio-current-thread")))]
     pub fn with_exporter<T: SpanExporter + 'static>(self, exporter: T) -> Self {
         // We cannot force push tracing in current thread tokio scheduler because
         // we rely on BatchSpanProcessor to export spans in a background task, meanwhile we need to
@@ -171,11 +171,11 @@ impl Builder {
 
     /// Add a configured `SpanExporter`
     #[cfg(all(
-        feature = "async-std",
-        not(feature = "tokio-support"),
-        not(feature = "tokio-rt-current-thread")
+        feature = "rt-async-std",
+        not(feature = "rt-tokio"),
+        not(feature = "rt-tokio-current-thread")
     ))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "async-std")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rt-async-std")))]
     pub fn with_exporter<T: SpanExporter + 'static>(self, exporter: T) -> Self {
         let batch = sdk::trace::BatchSpanProcessor::builder(
             exporter,
@@ -188,9 +188,9 @@ impl Builder {
 
     /// Add a configured `SpanExporter`
     #[cfg(all(
-        not(feature = "async-std"),
-        not(feature = "tokio-support"),
-        not(feature = "tokio-rt-current-thread")
+        not(feature = "rt-async-std"),
+        not(feature = "rt-tokio"),
+        not(feature = "rt-tokio-current-thread")
     ))]
     pub fn with_exporter<T: SpanExporter + 'static>(self, exporter: T) -> Self {
         self.with_simple_exporter(exporter)

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -718,20 +718,20 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "async-std")]
+    #[cfg(feature = "rt-async-std")]
     fn test_timeout_async_std_timeout() {
         async_std::task::block_on(timeout_test_std_async(true));
     }
 
     #[test]
-    #[cfg(feature = "async-std")]
+    #[cfg(feature = "rt-async-std")]
     fn test_timeout_async_std_not_timeout() {
         async_std::task::block_on(timeout_test_std_async(false));
     }
 
     // If the time_out is true, then the result suppose to ended with timeout.
     // otherwise the exporter should be able to export within time out duration.
-    #[cfg(feature = "async-std")]
+    #[cfg(feature = "rt-async-std")]
     async fn timeout_test_std_async(time_out: bool) {
         let config = BatchConfig {
             max_export_timeout: Duration::from_millis(if time_out { 5 } else { 60 }),

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -101,8 +101,7 @@ pub trait SpanProcessor: Send + Sync + std::fmt::Debug {
 ///     .with_simple_exporter(exporter)
 ///     .build();
 ///
-/// let guard = global::set_tracer_provider(provider);
-/// # drop(guard)
+/// let previous_provider = global::set_tracer_provider(provider);
 /// ```
 ///
 /// [`SpanProcessor`]: ../../api/trace/span_processor/trait.SpanProcessor.html

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -1,6 +1,6 @@
 //! # OpenTelemetry Tracing API.
 //!
-//! The tracing API consist of a few main traits:
+//! The tracing API consists of a few main traits:
 //!
 //! * The `Tracer` trait which describes all tracing operations.
 //! * The `Span` trait with is a mutable object storing information about the

--- a/opentelemetry/src/util.rs
+++ b/opentelemetry/src/util.rs
@@ -1,7 +1,7 @@
 //! Internal utilities
 
 /// Helper which wraps `tokio::time::interval` and makes it return a stream
-#[cfg(any(test, feature = "tokio-support", feature = "tokio-rt-current-thread"))]
+#[cfg(any(test, feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
 pub fn tokio_interval_stream(
     period: std::time::Duration,
 ) -> tokio_stream::wrappers::IntervalStream {

--- a/opentelemetry/src/util.rs
+++ b/opentelemetry/src/util.rs
@@ -1,7 +1,7 @@
 //! Internal utilities
 
 /// Helper which wraps `tokio::time::interval` and makes it return a stream
-#[cfg(any(test, feature = "tokio-support"))]
+#[cfg(any(test, feature = "tokio-support", feature = "tokio-rt-current-thread"))]
 pub fn tokio_interval_stream(
     period: std::time::Duration,
 ) -> tokio_stream::wrappers::IntervalStream {

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,6 +7,14 @@ if rustup component add clippy; then
     `# Exit with a nonzero code if there are clippy warnings` \
     -Dwarnings \
     "$@"
+  cargo clippy --manifest-path=opentelemetry/Cargo.toml --all-targets --features "trace,tokio-rt-current-thread" --no-default-features -- \
+    `# Exit with a nonzero code if there are clippy warnings` \
+    -Dwarnings \
+    "$@"
+  cargo clippy --manifest-path=opentelemetry/Cargo.toml --all-targets --features "trace,async-std" --no-default-features -- \
+    `# Exit with a nonzero code if there are clippy warnings` \
+    -Dwarnings \
+    "$@"
   cargo clippy --manifest-path=opentelemetry-otlp/Cargo.toml --all-targets --features "grpc-sys" --no-default-features -- \
     `# Exit with a nonzero code if there are clippy warnings` \
     -Dwarnings \

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,11 +7,11 @@ if rustup component add clippy; then
     `# Exit with a nonzero code if there are clippy warnings` \
     -Dwarnings \
     "$@"
-  cargo clippy --manifest-path=opentelemetry/Cargo.toml --all-targets --features "trace,tokio-support" --no-default-features -- \
+  cargo clippy --manifest-path=opentelemetry/Cargo.toml --all-targets --features "trace,rt-tokio" --no-default-features -- \
     `# Exit with a nonzero code if there are clippy warnings` \
     -Dwarnings \
     "$@"
-  cargo clippy --manifest-path=opentelemetry/Cargo.toml --all-targets --features "trace,tokio-rt-current-thread" --no-default-features -- \
+  cargo clippy --manifest-path=opentelemetry/Cargo.toml --all-targets --features "trace,rt-tokio-current-thread" --no-default-features -- \
     `# Exit with a nonzero code if there are clippy warnings` \
     -Dwarnings \
     "$@"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,6 +7,10 @@ if rustup component add clippy; then
     `# Exit with a nonzero code if there are clippy warnings` \
     -Dwarnings \
     "$@"
+  cargo clippy --manifest-path=opentelemetry/Cargo.toml --all-targets --features "trace,tokio-support" --no-default-features -- \
+    `# Exit with a nonzero code if there are clippy warnings` \
+    -Dwarnings \
+    "$@"
   cargo clippy --manifest-path=opentelemetry/Cargo.toml --all-targets --features "trace,tokio-rt-current-thread" --no-default-features -- \
     `# Exit with a nonzero code if there are clippy warnings` \
     -Dwarnings \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,7 @@ cargo test --all "$@"
 cargo test --manifest-path=opentelemetry/Cargo.toml --no-default-features
 # Run global tracer provider test in single thread
 cargo test --manifest-path=opentelemetry/Cargo.toml --features=tokio-support -- --ignored --test-threads=1
+cargo test --manifest-path=opentelemetry/Cargo.toml --features=tokio-rt-current-thread -- --ignored --test-threads=1
 cargo test --manifest-path=opentelemetry/Cargo.toml --all-features
 cargo test --manifest-path=opentelemetry-contrib/Cargo.toml --all-features
 cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --all-features

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,8 +7,8 @@ cargo test --all "$@"
 # See https://github.com/rust-lang/cargo/issues/5364
 cargo test --manifest-path=opentelemetry/Cargo.toml --no-default-features
 # Run global tracer provider test in single thread
-cargo test --manifest-path=opentelemetry/Cargo.toml --features=tokio-support -- --ignored --test-threads=1
-cargo test --manifest-path=opentelemetry/Cargo.toml --features=tokio-rt-current-thread -- --ignored --test-threads=1
+cargo test --manifest-path=opentelemetry/Cargo.toml --features=rt-tokio -- --ignored --test-threads=1
+cargo test --manifest-path=opentelemetry/Cargo.toml --features=rt-tokio-current-thread -- --ignored --test-threads=1
 cargo test --manifest-path=opentelemetry/Cargo.toml --all-features
 cargo test --manifest-path=opentelemetry-contrib/Cargo.toml --all-features
 cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --all-features

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,6 +6,8 @@ cargo test --all "$@"
 
 # See https://github.com/rust-lang/cargo/issues/5364
 cargo test --manifest-path=opentelemetry/Cargo.toml --no-default-features
+# Run global tracer provider test in single thread
+cargo test --manifest-path=opentelemetry/Cargo.toml --features=tokio-support -- --ignored --test-threads=1
 cargo test --manifest-path=opentelemetry/Cargo.toml --all-features
 cargo test --manifest-path=opentelemetry-contrib/Cargo.toml --all-features
 cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --all-features


### PR DESCRIPTION
Resolve #427 
Resolve #364 

## Problem statement

The problem we have is how to allow users to send remaining spans before exits. The current approach works for multiple thread tokio runtime, but not really working for the current thread tokio runtime.

Also currently we allow the users to use multiple tracer providers throughout the application, which I believe is not a common situation. Most people should have one global tracer provider.

## Proposed solution

We currently have the `set_tracer_provider` function to set the tracer provider. It currently will return a guard, the drop of the guard will trigger the shutdown of the tracer provider. 

the function instead of returning the guard, we return the replaced tracer provider. If users need to use multiple tracer providers. They can manage those tracer providers on their own.

In order to shut down tracer provider properly. We could have a `shut_down_provider` function that will block in place until the current tracer provider shuts down. The problem then becomes that how do we spawn the background task so that it will not block forever when shuts down.

### Different situations

The objective is if users `shut_down_provider` before exit, the remaining spans in `BatchSpanProcessor` would sending all remaining spans. If not, then all remaining spans in it will be dropped.

Tried a few different set up to see if we can do it. 

| Runtime | How to spawn worker task in `BatchProcessor` | Call `shut_down_provider` before exit? | Result | 
| -----------|----------------|------------------|------|
| Single thread tokio | `tokio::spawn` | no | exit successfully | 
| Multiple thread tokio | `tokio::spawn` | no | exit successfully | 
| Single thread tokio | `tokio::spawn` | yes | hang forever |
| Multiple thread tokio | `tokio::spawn` | yes | send spans and exit |
| Single thread tokio | spawn_blocking | no | hang forever | 
| Multiple thread tokio | spawn_blocking | no | hang forever | 
| Single thread tokio | spawn_blocking | yes | send spans and exit  |
| Multiple thread tokio | spawn_blocking | yes | send spans and exit |

\* spawn_blocking = `|fut| tokio::spawn_blocking(|| futures::executor::block_on(fut))`

So my theory on why `opentelemetry` hang forever when using the single thread tokio:

when `shutdown` `BatchSpanProcessor`. We need to wait for the worker task to finish. But by blocking here, we prevent the worker task from being polled. If we don't block and wait here. When the `shutdown` finishes, the runtime will go ahead and drop the worker task, so we can't guarantee the spans in `BatchSpanProcessor` can be sent.
https://github.com/open-telemetry/opentelemetry-rust/blob/f06f38b5c33ed28c5eda1459b3efa0ff8c67e961/opentelemetry/src/sdk/trace/span_processor.rs#L232-L240

I have been proking around and tried random stuff on it but none of them seem to work. So would love some advice here as I believe some of you might have more experience on how tokio works.

### Final solution
- `set_tracer_provider` function should return the replaced tracer provider.
- `shut_down_tracer_provider` function will be used to shut down the tracer provider.
- `tokio::spawn` will be used to spawn background tasks in BatchProcessor if the runtime has multiple threads.
- If tokio runtime only have one thread. We will create a new thread and a new runtime to spawn background tasks.