### PR TITLE
Lint: fix issues with unnecessary wraps

### DIFF
--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -192,7 +192,7 @@ mod tests {
     use crate::exporter::model::tests::get_span;
 
     #[test]
-    fn test_out_of_order_group() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_out_of_order_group() {
         let batch = vec![get_span(1, 1, 1), get_span(2, 2, 2), get_span(1, 1, 3)];
         let expected = vec![
             vec![get_span(1, 1, 1), get_span(1, 1, 3)],
@@ -204,7 +204,5 @@ mod tests {
         traces.sort_by_key(|t| t[0].span_context.trace_id().to_u128());
 
         assert_eq!(traces, expected);
-
-        Ok(())
     }
 }

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -782,7 +782,7 @@ mod tests {
     }
 
     #[test]
-    fn test_set_status() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_set_status() {
         for (status_code, error_msg, status_tag_val, msg_tag_val) in get_error_tag_test_data() {
             let tags = build_span_tags(
                 EvictedHashMap::new(20, 20),
@@ -803,6 +803,5 @@ mod tests {
                 assert_tag_not_contains(tags.clone(), OTEL_STATUS_DESCRIPTION);
             }
         }
-        Ok(())
     }
 }

--- a/opentelemetry-otlp/src/transform/metrics.rs
+++ b/opentelemetry-otlp/src/transform/metrics.rs
@@ -731,7 +731,7 @@ mod tests {
         }
 
         #[test]
-        fn test_sink() -> Result<(), MetricsError> {
+        fn test_sink() {
             let test_data: Vec<(ResourceWrapper, InstrumentationLibrary, Metric)> = vec![
                 (
                     vec![("runtime", "tokio")],
@@ -826,8 +826,6 @@ mod tests {
             for (expect, actual) in expect.into_iter().zip(actual.into_iter()) {
                 assert_resource_metrics(expect, actual);
             }
-
-            Ok(())
         }
     }
 }

--- a/opentelemetry-zipkin/src/exporter/model/span.rs
+++ b/opentelemetry-zipkin/src/exporter/model/span.rs
@@ -156,7 +156,7 @@ mod tests {
     }
 
     #[test]
-    fn test_set_status() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_set_status() {
         for (status_code, status_msg, status_tag_val, status_msg_tag_val) in
             get_set_status_test_data()
         {
@@ -188,7 +188,5 @@ mod tests {
                 assert_tag_contains(tags, OTEL_ERROR_DESCRIPTION, status_msg_tag_val);
             };
         }
-
-        Ok(())
     }
 }


### PR DESCRIPTION
Remove `Result` from return types in tests of `opentelemetry-datadog`,
`opentelemetry-jaeger`, `opentelemetry-otlp`, `opentelemetry-zipkin`.

Reference: https://github.com/rust-lang/rust-clippy/pull/6070