### PR TITLE
Add jaeger max packet size constraint

### DIFF
--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -167,7 +167,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         .with_agent_endpoint("localhost:6831")
         .with_service_name("my_app")
         .with_tags(vec![KeyValue::new("process_key", "process_value")])
-	.with_max_packet_size(65_000)
+        .with_max_packet_size(9_216)
         .with_trace_config(
             trace::config()
                 .with_default_sampler(Sampler::AlwaysOn)

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -167,6 +167,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         .with_agent_endpoint("localhost:6831")
         .with_service_name("my_app")
         .with_tags(vec![KeyValue::new("process_key", "process_value")])
+	.with_max_packet_size(65_000)
         .with_trace_config(
             trace::config()
                 .with_default_sampler(Sampler::AlwaysOn)

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -133,7 +133,7 @@
 //!         .with_agent_endpoint("localhost:6831")
 //!         .with_service_name("my_app")
 //!         .with_tags(vec![KeyValue::new("process_key", "process_value")])
-//!         .with_max_packet_size(65_000)
+//!         .with_max_packet_size(9_216)
 //!         .with_trace_config(
 //!             trace::config()
 //!                 .with_default_sampler(Sampler::AlwaysOn)

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -133,6 +133,7 @@
 //!         .with_agent_endpoint("localhost:6831")
 //!         .with_service_name("my_app")
 //!         .with_tags(vec![KeyValue::new("process_key", "process_value")])
+//!         .with_max_packet_size(65_000)
 //!         .with_trace_config(
 //!             trace::config()
 //!                 .with_default_sampler(Sampler::AlwaysOn)

--- a/opentelemetry/src/sdk/trace/provider.rs
+++ b/opentelemetry/src/sdk/trace/provider.rs
@@ -27,9 +27,7 @@ pub(crate) struct TracerProviderInner {
 impl Drop for TracerProviderInner {
     fn drop(&mut self) {
         for processor in &mut self.processors {
-            let result = processor.shutdown();
-
-            if let Err(err) = result {
+            if let Err(err) = processor.shutdown() {
                 global::handle_error(err);
             }
         }

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -126,10 +126,14 @@ impl SpanProcessor for SimpleSpanProcessor {
     }
 
     fn on_end(&self, span: SpanData) {
-        if let Ok(mut exporter) = self.exporter.lock() {
-            let _result = executor::block_on(exporter.export(vec![span]));
-        } else {
-            global::handle_error(TraceError::from("When export span with the SimpleSpanProcessor, the exporter's lock has been poisoned"));
+        let result = self
+            .exporter
+            .lock()
+            .map_err(|_| TraceError::Other("simple span processor mutex poisoned".into()))
+            .and_then(|mut exporter| executor::block_on(exporter.export(vec![span])));
+
+        if let Err(err) = result {
+            global::handle_error(err);
         }
     }
 
@@ -214,8 +218,18 @@ impl SpanProcessor for BatchSpanProcessor {
     }
 
     fn on_end(&self, span: SpanData) {
-        if let Ok(mut sender) = self.message_sender.lock() {
-            let _ = sender.try_send(BatchMessage::ExportSpan(span));
+        let result = self
+            .message_sender
+            .lock()
+            .map_err(|_| TraceError::Other("batch span processor mutex poisoned".into()))
+            .and_then(|mut sender| {
+                sender
+                    .try_send(BatchMessage::ExportSpan(span))
+                    .map_err(|err| TraceError::Other(err.into()))
+            });
+
+        if let Err(err) = result {
+            global::handle_error(err);
         }
     }
 
@@ -308,12 +322,16 @@ impl BatchSpanProcessor {
                                 spans.len().saturating_sub(config.max_export_batch_size),
                             );
 
-                            let _result = export_with_timeout(
+                            let result = export_with_timeout(
                                 config.max_export_timeout,
                                 exporter.as_mut(),
                                 &delay,
                                 batch,
                             ).await;
+
+                            if let Err(err) = result {
+                                global::handle_error(err);
+                            }
                         }
                     }
                     // Stream has terminated or processor is shutdown, return to finish execution.


### PR DESCRIPTION
Currently jaeger will silently ignore batches of spans where the resulting thrift payload packet sizes is over the max 65000
bytes. This patch brings the exporter in line with similar otel exporters by ensuring that the payload is less than the specified limit.

Resolves #441 