### PR TITLE
chore: fix documentation

### DIFF
--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -28,3 +28,6 @@ lazy_static = "1.4"
 
 [dev-dependencies]
 opentelemetry = { path = "../opentelemetry", features = ["trace", "testing"] }
+opentelemetry-http = { path = "../opentelemetry-http" }
+hyper = { version = "0.14", features = ["full"] }
+tokio = { version = "1.0", features = ["full"] }

--- a/opentelemetry-aws/README.md
+++ b/opentelemetry-aws/README.md
@@ -27,6 +27,4 @@ to AWS's telemetry platform.
 
 Currently, this crate only supports `XRay` propagator. Contributions are welcome.
 
-## 
-
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry

--- a/opentelemetry-aws/src/lib.rs
+++ b/opentelemetry-aws/src/lib.rs
@@ -1,7 +1,37 @@
-//! # Opentelemetry AWS Integration
+//! This crate provides unofficial integration with AWS services.
 //!
-//! This crate provides integration with different telemetry platform.
-
+//! # Components
+//! As for now, the only components provided in this crate is AWS X-Ray propagator.
+//!
+//! ### AWS X-Ray Propagator
+//! This propagator helps propagate tracing information from upstream services to downstream services.
+//!
+//! ### Quick start
+//! ```rust, no_run
+//! use opentelemetry::global;
+//! use opentelemetry_aws::trace::XrayPropagator;
+//!
+//! use opentelemetry::{sdk::export::trace::stdout, trace::Tracer};
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//!     // Set the global propagator to X-Ray propagator
+//!     global::set_text_map_propagator(XrayPropagator::default());
+//!     let (tracer, _uninstall) = stdout::new_pipeline().install();
+//!
+//!     tracer.in_span("doing_work", |cx| {
+//!         // Send request to downstream services.
+//!         // Build request
+//!         global::get_text_map_propagator(|propagator| {
+//!             // Set X-Ray tracing header in request object `req`
+//!             propagator.inject_context(&cx, &mut HeaderInjector(req.headers_mut().unwrap()));
+//!             println!("Headers: {:?}", req.headers_ref());
+//!         })
+//!     });
+//!
+//!     Ok(())
+//! }
+//! ```
+//! A more detailed example can be found in [opentelemetry-rust](https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples/aws-xray) repo
 #[cfg(feature = "trace")]
 pub mod trace {
     use opentelemetry::{

--- a/opentelemetry-aws/src/lib.rs
+++ b/opentelemetry-aws/src/lib.rs
@@ -7,17 +7,19 @@
 //! This propagator helps propagate tracing information from upstream services to downstream services.
 //!
 //! ### Quick start
-//! ```rust, no_run
+//! ```no_run
 //! use opentelemetry::global;
 //! use opentelemetry_aws::trace::XrayPropagator;
-//!
 //! use opentelemetry::{sdk::export::trace::stdout, trace::Tracer};
+//! use opentelemetry_http::HeaderInjector;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! #[tokio::main]
+//! async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //!     // Set the global propagator to X-Ray propagator
 //!     global::set_text_map_propagator(XrayPropagator::default());
-//!     let (tracer, _uninstall) = stdout::new_pipeline().install();
+//!     let tracer = stdout::new_pipeline().install();
 //!
+//!     let mut req = hyper::Request::builder().uri("http://127.0.0.1:3000");
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Send request to downstream services.
 //!         // Build request

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -1,6 +1,6 @@
 //! # OpenTelemetry Datadog Exporter
 //!
-//! An OpenTelemetry exporter implementation
+//! An OpenTelemetry datadog exporter implementation
 //!
 //! See the [Datadog Docs](https://docs.datadoghq.com/agent/) for information on how to run the datadog-agent
 //!
@@ -14,10 +14,10 @@
 //! granular and might be used to identify a specific endpoint. In datadog, however, they
 //! are less granular - it is expected in Datadog that a service will have single
 //! primary span name that is the root of all traces within that service, with an additional piece of
-//! metadata called resource_name providing granularity - https://docs.datadoghq.com/tracing/guide/configuring-primary-operation/
+//! metadata called resource_name providing granularity. See [here](https://docs.datadoghq.com/tracing/guide/configuring-primary-operation/)
 //!
 //! The Datadog Golang API takes the approach of using a `resource.name` OpenTelemetry attribute to set the
-//! resource_name - https://github.com/DataDog/dd-trace-go/blob/ecb0b805ef25b00888a2fb62d465a5aa95e7301e/ddtrace/opentracer/tracer.go#L10
+//! resource_name. See [here](https://github.com/DataDog/dd-trace-go/blob/ecb0b805ef25b00888a2fb62d465a5aa95e7301e/ddtrace/opentracer/tracer.go#L10)
 //!
 //! Unfortunately, this breaks compatibility with other OpenTelemetry exporters which expect
 //! a more granular operation name - as per the OpenTracing specification.
@@ -29,7 +29,7 @@
 //! Datadog additionally has a span_type string that alters the rendering of the spans in the web UI.
 //! This can be set as the `span.type` OpenTelemetry span attribute.
 //!
-//! For standard values see here - https://github.com/DataDog/dd-trace-go/blob/ecb0b805ef25b00888a2fb62d465a5aa95e7301e/ddtrace/ext/app_types.go#L31
+//! For standard values see [here](https://github.com/DataDog/dd-trace-go/blob/ecb0b805ef25b00888a2fb62d465a5aa95e7301e/ddtrace/ext/app_types.go#L31)
 //!
 //! ## Performance
 //!
@@ -45,7 +45,8 @@
 //! ```
 //!
 //! [`rt-tokio`]: https://tokio.rs
-//! [`async-std`]: https://async.rs
+//! [`rt-tokio-current-thread`]: https://tokio.rs
+//! [`rt-async-std`]: https://async.rs
 //!
 
 //! ## Bring your own http client

--- a/opentelemetry-prometheus/examples/hyper.rs
+++ b/opentelemetry-prometheus/examples/hyper.rs
@@ -27,23 +27,23 @@ async fn serve_req(
 ) -> Result<Response<Body>, hyper::Error> {
     let request_start = SystemTime::now();
 
+    state.http_counter.add(1);
+    state
+        .http_req_histogram
+        .record(request_start.elapsed().map_or(0.0, |d| d.as_secs_f64()));
+
     let mut buffer = vec![];
     let encoder = TextEncoder::new();
     let metric_families = state.exporter.registry().gather();
+    let _test = metric_families.len();
     encoder.encode(&metric_families, &mut buffer).unwrap();
 
-    state.http_counter.add(1);
     state.http_body_gauge.record(buffer.len() as u64);
-
     let response = Response::builder()
         .status(200)
         .header(CONTENT_TYPE, encoder.format_type())
         .body(Body::from(buffer))
         .unwrap();
-
-    state
-        .http_req_histogram
-        .record(request_start.elapsed().map_or(0.0, |d| d.as_secs_f64()));
 
     Ok(response)
 }

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -37,6 +37,8 @@ use opentelemetry::{sdk::export::trace::stdout, trace::Tracer};
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     // Create a new instrumentation pipeline
+    // Please note that if _uninstall is dropped. 
+    // So does the tracer provider. As a result you may get no spans.
     let (tracer, _uninstall) = stdout::new_pipeline().install();
 
     tracer.in_span("doing_work", |cx| {
@@ -69,8 +71,9 @@ In particular, the following crates are likely to be of interest:
   metrics information to [`Prometheus`].
 - [`opentelemetry-zipkin`] provides a pipeline and exporter for sending trace
   information to [`Zipkin`].
-- [`opentelemetry-contrib`] provides additional exporters to vendors like
-  [`Datadog`].
+- [`opentelemetry-contrib`] provides additional exporters and propagators that are experimental.
+- [`opentelemetry-datadog`] provides additional exporters to [`Datadog`].
+- [`opentelemetry-aws`] provides unofficial propagators for AWS X-ray.  
 - [`opentelemetry-semantic-conventions`] provides standard names and semantic
   otel conventions.
 
@@ -101,6 +104,8 @@ above, please let us know! We'd love to add your project to the list!
 [`Zipkin`]: https://zipkin.io
 [`opentelemetry-contrib`]: https://crates.io/crates/opentelemetry-contrib
 [`Datadog`]: https://www.datadoghq.com
+[`opentelemetry-datadog`]: https://crates.io/crates/opentelemetry-datadog
+[`opentelemetry-aws`]: https://crates.io/crates/opentelemetry-aws
 [`opentelemetry-semantic-conventions`]: https://crates.io/crates/opentelemetry-semantic-conventions
 
 [`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry

--- a/opentelemetry/src/global/mod.rs
+++ b/opentelemetry/src/global/mod.rs
@@ -134,6 +134,7 @@
 //!
 //! [installing a metrics pipeline]: crate::sdk::export::metrics::stdout::StdoutExporterBuilder::try_init
 //! [`MeterProvider`]: crate::metrics::MeterProvider
+//! [`set_meter_provider`]: crate::global::set_meter_provider
 
 mod error_handler;
 #[cfg(feature = "metrics")]

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -93,8 +93,9 @@
 //!   metrics information to [`Prometheus`].
 //! - [`opentelemetry-zipkin`] provides a pipeline and exporter for sending
 //!   trace information to [`Zipkin`].
-//! - [`opentelemetry-contrib`] provides additional exporters to vendors like
-//!   [`Datadog`].
+//! - [`opentelemetry-datadog`] provides additional exporters to [`Datadog`].
+//! - [`opentelemetry-aws`] provides unofficial propagators for AWS X-ray.
+//! - [`opentelemetry-contrib`] provides additional exporters and propagators that are experimental.
 //! - [`opentelemetry-semantic-conventions`] provides standard names and
 //!   semantic otel conventions.
 //!
@@ -119,12 +120,15 @@
 //! [`opentelemetry-jaeger`]: https://crates.io/crates/opentelemetry-jaeger
 //! [`Jaeger`]: https://www.jaegertracing.io
 //! [`opentelemetry-otlp`]: https://crates.io/crates/opentelemetry-otlp
+//! [`opentelemetry-http`]: https://crates.io/crates/opentelemetry-http
 //! [`opentelemetry-prometheus`]: https://crates.io/crates/opentelemetry-prometheus
+//! [`opentelemetry-aws`]: https://crates.io/crates/opentelemetry-aws
 //! [`Prometheus`]: https://prometheus.io
 //! [`opentelemetry-zipkin`]: https://crates.io/crates/opentelemetry-zipkin
-//! [http]: https://crates.io/crates/http
+//! [`http`]: https://crates.io/crates/http
 //! [`Zipkin`]: https://zipkin.io
 //! [`opentelemetry-contrib`]: https://crates.io/crates/opentelemetry-contrib
+//! [`opentelemetry-datadog`]: https://crates.io/crates/opentelemetry-datadog
 //! [`Datadog`]: https://www.datadoghq.com
 //! [`opentelemetry-semantic-conventions`]: https://crates.io/crates/opentelemetry-semantic-conventions
 //!


### PR DESCRIPTION
Also notice that we never publish `opentelemetry-datadog` and `opentelemetry-aws` crates. 