### PR TITLE
Switch to Cow for event names

### DIFF
--- a/opentelemetry-otlp/src/transform/traces.rs
+++ b/opentelemetry-otlp/src/transform/traces.rs
@@ -172,7 +172,7 @@ impl From<SpanData> for ResourceSpans {
                         .into_iter()
                         .map(|event| span::Event {
                             time_unix_nano: to_nanos(event.timestamp),
-                            name: event.name,
+                            name: event.name.into(),
                             attributes: Attributes::from(event.attributes).0,
                             dropped_attributes_count: 0,
                         })
@@ -234,7 +234,7 @@ impl From<SpanData> for ResourceSpans {
                                 .into_iter()
                                 .map(|event| Span_Event {
                                     time_unix_nano: to_nanos(event.timestamp),
-                                    name: event.name,
+                                    name: event.name.into(),
                                     attributes: Attributes::from(event.attributes).0,
                                     dropped_attributes_count: 0,
                                     ..Default::default()

--- a/opentelemetry-zipkin/src/exporter/model/annotation.rs
+++ b/opentelemetry-zipkin/src/exporter/model/annotation.rs
@@ -25,7 +25,7 @@ impl From<Event> for Annotation {
 
         Annotation::builder()
             .timestamp(timestamp)
-            .value(event.name)
+            .value(event.name.into())
             .build()
     }
 }

--- a/opentelemetry/src/sdk/trace/tracer.rs
+++ b/opentelemetry/src/sdk/trace/tracer.rs
@@ -276,7 +276,7 @@ impl crate::trace::Tracer for Tracer {
             SpanData {
                 parent_span_id,
                 span_kind,
-                name: builder.name,
+                name: builder.name.into(),
                 start_time,
                 end_time,
                 attributes,

--- a/opentelemetry/src/trace/event.rs
+++ b/opentelemetry/src/trace/event.rs
@@ -3,6 +3,7 @@
 use crate::KeyValue;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::time::SystemTime;
 
 /// A `Span` has the ability to add events. Events have a time associated
@@ -11,7 +12,7 @@ use std::time::SystemTime;
 #[derive(Clone, Debug, PartialEq)]
 pub struct Event {
     /// Event name
-    pub name: String,
+    pub name: Cow<'static, str>,
     /// Event timestamp
     pub timestamp: SystemTime,
     /// Event attributes
@@ -20,18 +21,22 @@ pub struct Event {
 
 impl Event {
     /// Create new `Event`
-    pub fn new(name: String, timestamp: SystemTime, attributes: Vec<KeyValue>) -> Self {
+    pub fn new<T: Into<Cow<'static, str>>>(
+        name: T,
+        timestamp: SystemTime,
+        attributes: Vec<KeyValue>,
+    ) -> Self {
         Event {
-            name,
+            name: name.into(),
             timestamp,
             attributes,
         }
     }
 
     /// Create new `Event` with a given name.
-    pub fn with_name(name: String) -> Self {
+    pub fn with_name<T: Into<Cow<'static, str>>>(name: T) -> Self {
         Event {
-            name,
+            name: name.into(),
             timestamp: crate::time::now(),
             attributes: Vec::new(),
         }

--- a/opentelemetry/src/trace/tracer.rs
+++ b/opentelemetry/src/trace/tracer.rs
@@ -3,6 +3,7 @@ use crate::{
     trace::{Event, Link, Span, SpanId, SpanKind, StatusCode, TraceContextExt, TraceId},
     Context, KeyValue,
 };
+use std::borrow::Cow;
 use std::fmt;
 use std::time::SystemTime;
 
@@ -316,7 +317,7 @@ pub trait Tracer: fmt::Debug + 'static {
 ///
 /// // The builder can be used to create a span directly with the tracer
 /// let _span = tracer.build(SpanBuilder {
-///     name: "example-span-name".to_string(),
+///     name: "example-span-name".into(),
 ///     span_kind: Some(SpanKind::Server),
 ///     ..Default::default()
 /// });
@@ -338,7 +339,7 @@ pub struct SpanBuilder {
     /// Span kind
     pub span_kind: Option<SpanKind>,
     /// Span name
-    pub name: String,
+    pub name: Cow<'static, str>,
     /// Span start time
     pub start_time: Option<SystemTime>,
     /// Span end time
@@ -360,13 +361,13 @@ pub struct SpanBuilder {
 /// SpanBuilder methods
 impl SpanBuilder {
     /// Create a new span builder from a span name
-    pub fn from_name(name: String) -> Self {
+    pub fn from_name<T: Into<Cow<'static, str>>>(name: T) -> Self {
         SpanBuilder {
             parent_context: None,
             trace_id: None,
             span_id: None,
             span_kind: None,
-            name,
+            name: name.into(),
             start_time: None,
             end_time: None,
             attributes: None,


### PR DESCRIPTION
Avoid additional unnecessary allocations when working with static event names.