### PR TITLE
otlp: mention service.name in kitchen sink cfg doc - closes #475

### DIFF
--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -131,7 +131,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
                 .with_max_events_per_span(64)
                 .with_max_attributes_per_span(16)
                 .with_max_events_per_span(16)
-                 with_resource(Resource::new(vec![KeyValue::new("service.name", "example")])),
+                 .with_resource(Resource::new(vec![KeyValue::new("service.name", "example")])),
         )
         .install()?;
 

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -131,7 +131,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
                 .with_max_events_per_span(64)
                 .with_max_attributes_per_span(16)
                 .with_max_events_per_span(16)
-                .with_resource(Resource::new(vec![KeyValue::new("key", "value")])),
+                 with_resource(Resource::new(vec![KeyValue::new("service.name", "example")])),
         )
         .install()?;
 

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -131,7 +131,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
                 .with_max_events_per_span(64)
                 .with_max_attributes_per_span(16)
                 .with_max_events_per_span(16)
-                 .with_resource(Resource::new(vec![KeyValue::new("service.name", "example")])),
+                .with_resource(Resource::new(vec![KeyValue::new("service.name", "example")])),
         )
         .install()?;
 

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -93,7 +93,7 @@
 //!                 .with_max_events_per_span(64)
 //!                 .with_max_attributes_per_span(16)
 //!                 .with_max_events_per_span(16)
-//!                 .with_resource(Resource::new(vec![KeyValue::new("key", "value")])),
+//!                 .with_resource(Resource::new(vec![KeyValue::new("service.name", "example")])),
 //!         )
 //!         .install()?;
 //!


### PR DESCRIPTION
adds a possibly slightly more useful key/value combination for docs.

it's probably a common thing to want to set, even if it's not a thing that otel cares about.
