### PR TITLE
Rename trace config with_default_sampler to with_sampler

### DIFF
--- a/examples/aws-xray/src/client.rs
+++ b/examples/aws-xray/src/client.rs
@@ -18,7 +18,7 @@ fn init_tracer() -> sdktrace::Tracer {
     stdout::new_pipeline()
         .with_trace_config(
             sdktrace::config()
-                .with_default_sampler(sdktrace::Sampler::AlwaysOn)
+                .with_sampler(sdktrace::Sampler::AlwaysOn)
                 .with_id_generator(sdktrace::XrayIdGenerator::default()),
         )
         .install()

--- a/examples/aws-xray/src/server.rs
+++ b/examples/aws-xray/src/server.rs
@@ -39,7 +39,7 @@ fn init_tracer() -> sdktrace::Tracer {
     stdout::new_pipeline()
         .with_trace_config(
             sdktrace::config()
-                .with_default_sampler(sdktrace::Sampler::AlwaysOn)
+                .with_sampler(sdktrace::Sampler::AlwaysOn)
                 .with_id_generator(sdktrace::XrayIdGenerator::default()),
         )
         .install()

--- a/examples/http/src/client.rs
+++ b/examples/http/src/client.rs
@@ -17,7 +17,7 @@ fn init_tracer() -> impl Tracer {
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
     stdout::new_pipeline()
-        .with_trace_config(trace::config().with_default_sampler(Sampler::AlwaysOn))
+        .with_trace_config(trace::config().with_sampler(Sampler::AlwaysOn))
         .install()
 }
 

--- a/examples/http/src/server.rs
+++ b/examples/http/src/server.rs
@@ -29,7 +29,7 @@ fn init_tracer() -> impl Tracer {
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
     stdout::new_pipeline()
-        .with_trace_config(trace::config().with_default_sampler(Sampler::AlwaysOn))
+        .with_trace_config(trace::config().with_sampler(Sampler::AlwaysOn))
         .install()
 }
 

--- a/examples/stdout.rs
+++ b/examples/stdout.rs
@@ -9,7 +9,7 @@ fn main() {
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
     // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
     let tracer = stdout::new_pipeline()
-        .with_trace_config(trace::config().with_default_sampler(Sampler::AlwaysOn))
+        .with_trace_config(trace::config().with_sampler(Sampler::AlwaysOn))
         .install();
 
     tracer.in_span("operation", |_cx| {});

--- a/opentelemetry-datadog/README.md
+++ b/opentelemetry-datadog/README.md
@@ -73,7 +73,7 @@ to [`Datadog`].
          .with_agent_endpoint("http://localhost:8126")
          .with_trace_config(
              trace::config()
-                 .with_default_sampler(Sampler::AlwaysOn)
+                 .with_sampler(Sampler::AlwaysOn)
                  .with_id_generator(IdGenerator::default())
          )
          .install()?;

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -105,7 +105,7 @@
 //!         .with_agent_endpoint("http://localhost:8126")
 //!         .with_trace_config(
 //!             trace::config()
-//!                 .with_default_sampler(Sampler::AlwaysOn)
+//!                 .with_sampler(Sampler::AlwaysOn)
 //!                 .with_id_generator(IdGenerator::default())
 //!         )
 //!         .install()?;

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -156,7 +156,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         .with_max_packet_size(9_216)
         .with_trace_config(
             trace::config()
-                .with_default_sampler(Sampler::AlwaysOn)
+                .with_sampler(Sampler::AlwaysOn)
                 .with_id_generator(IdGenerator::default())
                 .with_max_events_per_span(64)
                 .with_max_attributes_per_span(16)

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -118,7 +118,7 @@
 //!         .with_max_packet_size(9_216)
 //!         .with_trace_config(
 //!             trace::config()
-//!                 .with_default_sampler(Sampler::AlwaysOn)
+//!                 .with_sampler(Sampler::AlwaysOn)
 //!                 .with_id_generator(IdGenerator::default())
 //!                 .with_max_events_per_span(64)
 //!                 .with_max_attributes_per_span(16)

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -123,7 +123,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         .with_timeout(Duration::from_secs(3))
         .with_trace_config(
             trace::config()
-                .with_default_sampler(Sampler::AlwaysOn)
+                .with_sampler(Sampler::AlwaysOn)
                 .with_id_generator(IdGenerator::default())
                 .with_max_events_per_span(64)
                 .with_max_attributes_per_span(16)

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -94,7 +94,7 @@
 //!         .with_timeout(Duration::from_secs(3))
 //!         .with_trace_config(
 //!             trace::config()
-//!                 .with_default_sampler(Sampler::AlwaysOn)
+//!                 .with_sampler(Sampler::AlwaysOn)
 //!                 .with_id_generator(IdGenerator::default())
 //!                 .with_max_events_per_span(64)
 //!                 .with_max_attributes_per_span(16)

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -134,7 +134,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .with_collector_endpoint("http://localhost:9411/api/v2/spans")
         .with_trace_config(
             trace::config()
-                .with_default_sampler(Sampler::AlwaysOn)
+                .with_sampler(Sampler::AlwaysOn)
                 .with_id_generator(IdGenerator::default())
                 .with_max_events_per_span(64)
                 .with_max_attributes_per_span(16)

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -114,7 +114,7 @@
 //!         .with_collector_endpoint("http://localhost:9411/api/v2/spans")
 //!         .with_trace_config(
 //!             trace::config()
-//!                 .with_default_sampler(Sampler::AlwaysOn)
+//!                 .with_sampler(Sampler::AlwaysOn)
 //!                 .with_id_generator(IdGenerator::default())
 //!                 .with_max_events_per_span(64)
 //!                 .with_max_attributes_per_span(16)

--- a/opentelemetry/src/sdk/trace/config.rs
+++ b/opentelemetry/src/sdk/trace/config.rs
@@ -31,10 +31,7 @@ pub struct Config {
 
 impl Config {
     /// Specify the default sampler to be used.
-    pub fn with_default_sampler<T: sdk::trace::ShouldSample + 'static>(
-        mut self,
-        sampler: T,
-    ) -> Self {
+    pub fn with_sampler<T: sdk::trace::ShouldSample + 'static>(mut self, sampler: T) -> Self {
         self.default_sampler = Box::new(sampler);
         self
     }

--- a/opentelemetry/src/sdk/trace/tracer.rs
+++ b/opentelemetry/src/sdk/trace/tracer.rs
@@ -346,7 +346,7 @@ mod tests {
     fn allow_sampler_to_change_trace_state() {
         // Setup
         let sampler = TestSampler {};
-        let config = Config::default().with_default_sampler(sampler);
+        let config = Config::default().with_sampler(sampler);
         let tracer_provider = sdk::trace::TracerProvider::builder()
             .with_config(config)
             .build();
@@ -373,7 +373,7 @@ mod tests {
     #[test]
     fn drop_parent_based_children() {
         let sampler = Sampler::ParentBased(Box::new(Sampler::AlwaysOn));
-        let config = Config::default().with_default_sampler(sampler);
+        let config = Config::default().with_sampler(sampler);
         let tracer_provider = sdk::trace::TracerProvider::builder()
             .with_config(config)
             .build();
@@ -388,7 +388,7 @@ mod tests {
     #[test]
     fn uses_current_context_for_builders_if_unset() {
         let sampler = Sampler::ParentBased(Box::new(Sampler::AlwaysOn));
-        let config = Config::default().with_default_sampler(sampler);
+        let config = Config::default().with_sampler(sampler);
         let tracer_provider = sdk::trace::TracerProvider::builder()
             .with_config(config)
             .build();


### PR DESCRIPTION
This is a holdover from when non-default samplers were planned and can be updated to be less confusing.