### PR TITLE
fix: otel-otlp will try to create another tokio runtime inside one if async feature was not enabled.

### DIFF
--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -45,13 +45,15 @@ chrono = "0.4"
 tokio-stream = { version = "0.1", features = ["net"] }
 
 [features]
-async = ["default"]
 trace = ["opentelemetry/trace"]
 metrics = ["opentelemetry/metrics", "default"]
+
 default = ["tonic", "tonic-build", "prost", "tokio"]
-grpc-sys = ["grpcio", "protobuf", "protobuf-codegen", "protoc-grpcio"]
+tonic-sync = ["default"]
 tls = ["tonic/tls"]
 tls-roots = ["tls", "tonic/tls-roots"]
+
+grpc-sys = ["grpcio", "protobuf", "protobuf-codegen", "protoc-grpcio"]
 openssl = ["grpcio/openssl"]
 openssl-vendored = ["grpcio/openssl-vendored"]
 integration-testing = ["tonic", "tonic-build", "prost", "tokio/full", "opentelemetry/trace"]

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -49,7 +49,6 @@ trace = ["opentelemetry/trace"]
 metrics = ["opentelemetry/metrics", "default"]
 
 default = ["tonic", "tonic-build", "prost", "tokio"]
-tonic-sync = ["default"]
 tls = ["tonic/tls"]
 tls-roots = ["tls", "tonic/tls-roots"]
 

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -47,7 +47,7 @@ tokio-stream = { version = "0.1", features = ["net"] }
 [features]
 async = ["default"]
 trace = ["opentelemetry/trace"]
-metrics = ["opentelemetry/metrics"]
+metrics = ["opentelemetry/metrics", "default"]
 default = ["tonic", "tonic-build", "prost", "tokio"]
 grpc-sys = ["grpcio", "protobuf", "protobuf-codegen", "protoc-grpcio"]
 tls = ["tonic/tls"]

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -60,21 +60,6 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 }
 ```
 
-## Tonic vs Grpcio
-
-Multiple gRPC transport layers are available. [`tonic`](https://crates.io/crates/tonic) is the default gRPC transport 
-layer and is enabled by default. [`grpcio`](https://crates.io/crates/grpcio) is optional.
-
-| gRPC transport layer | [hyperium/tonic](https://github.com/hyperium/tonic) | [tikv/grpc-rs](https://github.com/tikv/grpc-rs) |
-|---|---|---|
-| Feature | --features=default | --features=grpc-sys |
-| gRPC library | [`tonic`](https://crates.io/crates/tonic) | [`grpcio`](https://crates.io/crates/grpcio) |
-| Transport | [hyperium/hyper](https://github.com/hyperium/hyper) (Rust) | [grpc/grpc](https://github.com/grpc/grpc) (C++ binding) |
-| TLS support | yes | yes |
-| TLS library | rustls | OpenSSL |
-| TLS optional | yes | yes |
-| Supported .proto generator | [`prost`](https://crates.io/crates/prost) | [`prost`](https://crates.io/crates/prost), [`protobuf`](https://crates.io/crates/protobuf) |
-
 ## Performance
 
 For optimal performance, a batch exporter is recommended as the simple
@@ -118,7 +103,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"[binary data]"));
 
     let (tracer, _uninstall) = opentelemetry_otlp::new_pipeline()
-        .with_endpoint("localhost:4317")
+        .with_endpoint("http://localhost:4317")
         .with_protocol(Protocol::Grpc)
         .with_timeout(Duration::from_secs(3))
         .with_trace_config(
@@ -145,3 +130,18 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     Ok(())
 }
 ```
+
+# Grpc libraries comparison
+
+Multiple gRPC transport layers are available. [`tonic`](https://crates.io/crates/tonic) is the default gRPC transport
+layer and is enabled by default. [`grpcio`](https://crates.io/crates/grpcio) is optional.
+
+| gRPC transport layer | [hyperium/tonic](https://github.com/hyperium/tonic) | [tikv/grpc-rs](https://github.com/tikv/grpc-rs) |
+|---|---|---|
+| Feature | --features=default | --features=grpc-sys |
+| gRPC library | [`tonic`](https://crates.io/crates/tonic) | [`grpcio`](https://crates.io/crates/grpcio) |
+| Transport | [hyperium/hyper](https://github.com/hyperium/hyper) (Rust) | [grpc/grpc](https://github.com/grpc/grpc) (C++ binding) |
+| TLS support | yes | yes |
+| TLS library | rustls | OpenSSL |
+| TLS optional | yes | yes |
+| Supported .proto generator | [`prost`](https://crates.io/crates/prost) | [`prost`](https://crates.io/crates/prost), [`protobuf`](https://crates.io/crates/protobuf) |

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -338,6 +338,8 @@ impl TonicPipelineBuilder {
     ///
     /// Returns a [`Tracer`] with the name `opentelemetry-otlp` and current crate version.
     ///
+    /// `install` will panic if not called within a tokio runtime
+    ///
     /// [`Tracer`]: opentelemetry::trace::Tracer
     /// [tonic]: https://github.com/hyperium/tonic
     pub fn install(self) -> Result<sdk::trace::Tracer, TraceError> {

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -148,7 +148,6 @@ mod proto;
 pub mod proto;
 
 #[cfg(feature = "metrics")]
-#[allow(warnings)]
 mod metric;
 mod span;
 mod transform;
@@ -408,6 +407,11 @@ pub enum Error {
     #[cfg(feature = "grpc-sys")]
     #[error("grpcio error {0}")]
     Grpcio(#[from] grpcio::Error),
+
+    /// The lock in exporters has been poisoned.
+    #[cfg(feature = "metrics")]
+    #[error("the lock of the {0} has been poisoned")]
+    PoisonedLock(&'static str)
 }
 
 impl ExportError for Error {

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -1,10 +1,13 @@
 //! The OTLP Exporter supports exporting trace and metric data in the OTLP
-//! format to the OpenTelemetry collector. The OpenTelemetry Collector offers a
-//! vendor-agnostic implementation on how to receive, process, and export
-//! telemetry data. In addition, it removes the need to run, operate, and
-//! maintain multiple agents/collectors in order to support open-source
-//! telemetry data formats (e.g. Jaeger, Prometheus, etc.) sending to multiple
-//! open-source or commercial back-ends.
+//! format to the OpenTelemetry collector or other compatible backend. The
+//! OpenTelemetry Collector offers a vendor-agnostic implementation on how
+//! to receive, process, and export telemetry data. In addition, it removes
+//! the need to run, operate, and maintain multiple agents/collectors in
+//! order to support open-source telemetry data formats (e.g. Jaeger,
+//! Prometheus, etc.) sending to multiple open-source or commercial back-ends.
+//!
+//! Currently, this crate only support sending tracing data or metrics in OTLP
+//! via grpc. Support for sending data via HTTP will be added in the future.
 //!
 //! ## Quickstart
 //!
@@ -34,18 +37,6 @@
 //! }
 //! ```
 //!
-//! ## Tonic vs Grpcio
-//!
-//! | Project | [hyperium/tonic](https://github.com/hyperium/tonic) | [tikv/grpc-rs](https://github.com/tikv/grpc-rs) |
-//! |---|---|---|
-//! | Feature name | --features=default | --features=grpc-sys |
-//! | gRPC library | [`tonic`](https://crates.io/crates/tonic) | [`grpcio`](https://crates.io/crates/grpcio) |
-//! | Transport | [hyperium/hyper](https://github.com/hyperium/hyper) (Rust) | [grpc/grpc](https://github.com/grpc/grpc) (C++ binding) |
-//! | TLS support | yes | yes |
-//! | TLS optional | yes | yes |
-//! | TLS library | rustls | OpenSSL |
-//! | Supported .proto generator | [`prost`](https://crates.io/crates/prost) | [`prost`](https://crates.io/crates/prost), [`protobuf`](https://crates.io/crates/protobuf) |
-//!
 //! ## Performance
 //!
 //! For optimal performance, a batch exporter is recommended as the simple
@@ -67,12 +58,14 @@
 //! Example showing how to override all configuration options. See the
 //! [`OtlpPipelineBuilder`] docs for details of each option.
 //!
-//! There are two types of configurations. The first is common configurations that is used by both
-//! tonic and grpcio. The other is configuration that only works with tonic or grpcio.
+//! There are two types of configurations. The first is common configurations
+//! that is used by both tonic and grpcio. The other is configuration that only
+//! works with tonic or grpcio.
 //!
-//! The [`OtlpPipelineBuilder`] will first config the configurations that shared by both grpc layers.
-//! Then users can choose their grpc layer by `with_tonic` or `with_grpcio` functions. User can then
-//! config anything that only works with specific grpc layers.
+//! The [`OtlpPipelineBuilder`] will first config the configurations that shared
+//! by both grpc layers. Then users can choose their grpc layer by [`with_tonic`]
+//! or [`with_grpcio`] functions. User can then config anything that only works
+//! with specific grpc layers.
 //!
 //! ```no_run
 //! use opentelemetry::{KeyValue, trace::Tracer};
@@ -89,7 +82,7 @@
 //!     map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"[binary data]"));
 //!
 //!     let tracer = opentelemetry_otlp::new_pipeline()
-//!         .with_endpoint("localhost:4317")
+//!         .with_endpoint("http://localhost:4317")
 //!         .with_protocol(Protocol::Grpc)
 //!         .with_timeout(Duration::from_secs(3))
 //!         .with_trace_config(
@@ -112,6 +105,25 @@
 //!     Ok(())
 //! }
 //! ```
+//! [`with_tonic`]: crate::OtlpPipelineBuilder::with_tonic
+//! [`with_grpcio`]: crate::OtlpPipelineBuilder::with_grpcio
+//!
+//!
+//! # Grpc libraries comparison
+//!
+//! The table below provides a short comparison between `grpcio` and `tonic`, two
+//! of the most popular grpc libraries in Rust. Users can choose between them when
+//! working with otlp with grpc as transport layer.
+//!
+//! | Project | [hyperium/tonic](https://github.com/hyperium/tonic) | [tikv/grpc-rs](https://github.com/tikv/grpc-rs) |
+//! |---|---|---|
+//! | Feature name | --features=default | --features=grpc-sys |
+//! | gRPC library | [`tonic`](https://crates.io/crates/tonic) | [`grpcio`](https://crates.io/crates/grpcio) |
+//! | Transport | [hyperium/hyper](https://github.com/hyperium/hyper) (Rust) | [grpc/grpc](https://github.com/grpc/grpc) (C++ binding) |
+//! | TLS support | yes | yes |
+//! | TLS optional | yes | yes |
+//! | TLS library | rustls | OpenSSL |
+//! | Supported .proto generator | [`prost`](https://crates.io/crates/prost) | [`prost`](https://crates.io/crates/prost), [`protobuf`](https://crates.io/crates/protobuf) |
 #![warn(
     future_incompatible,
     missing_debug_implementations,
@@ -204,7 +216,7 @@ pub fn new_pipeline() -> OtlpPipelineBuilder {
     OtlpPipelineBuilder::default()
 }
 
-/// Recommended configuration for an Otlp exporter pipeline.
+/// Recommended configuration for an OTLP exporter pipeline.
 ///
 /// ## Examples
 ///
@@ -288,9 +300,17 @@ impl OtlpPipelineBuilder {
     }
 }
 
-/// Tonic trace exporter builder.
+/// Build a trace exporter that uses [tonic] as grpc layer and opentelemetry protocol.
 ///
-/// User can get the `TonicPipelineBuilder` by calling `with_tonic` function in `OtlpPipelineBuilder`
+/// It provides methods to config tonic. The methods can be chained. The exporter can be built by calling
+/// [`install`]
+///
+/// `TonicPipelineBuilder` can be constructed by calling [`with_tonic`] function in [`OtlpPipelineBuilder`]
+///
+/// [`with_tonic`]: crate::OtlpPipelineBuilder::with_tonic
+/// [`OtlpPipelineBuilder`]: crate::OtlpPipelineBuilder
+/// [`install`]: crate::TonicPipelineBuilder::install
+/// [tonic]: https://github.com/hyperium/tonic
 #[derive(Default, Debug)]
 #[cfg(feature = "tonic")]
 pub struct TonicPipelineBuilder {
@@ -314,16 +334,29 @@ impl TonicPipelineBuilder {
         self
     }
 
-    /// Install a trace exporter using tonic
+    /// Install a trace exporter using [tonic] as grpc layer.
+    ///
+    /// Returns a [`Tracer`] with the name `opentelemetry-otlp` and current crate version.
+    ///
+    /// [`Tracer`]: opentelemetry::trace::Tracer
+    /// [tonic]: https://github.com/hyperium/tonic
     pub fn install(self) -> Result<sdk::trace::Tracer, TraceError> {
         let exporter = TraceExporter::new_tonic(self.exporter_config, self.tonic_config)?;
         Ok(build_with_exporter(exporter, self.trace_config))
     }
 }
 
-/// Grpc trace exporter builder.
+/// Build a trace exporter that uses [grpcio] as grpc layer and opentelemetry protocol.
 ///
-/// User can get the `GrpcioPipelineBuilder` by calling `with_grpcio` function in `OtlpPipelineBuilder`
+/// It provides methods to config grpcio. The methods can be chained. The exporter can be built by calling
+/// [`install`].
+///
+/// `GrpcioPipelineBuilder` can be constructed by calling [`with_grpcio`] function in [`OtlpPipelineBuilder`].
+///
+/// [`with_grpcio`]: crate::OtlpPipelineBuilder::with_grpcio
+/// [`OtlpPipelineBuilder`]: crate::OtlpPipelineBuilder
+/// [`install`]: crate::GrpcioPipelineBuilder::install
+/// [grpcio]: https://github.com/tikv/grpc-rs
 #[derive(Default, Debug)]
 #[cfg(feature = "grpc-sys")]
 pub struct GrpcioPipelineBuilder {
@@ -340,7 +373,7 @@ impl GrpcioPipelineBuilder {
         self
     }
 
-    /// Set Additional headers to send to the collector.
+    /// Set additional headers to send to the collector.
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.grpcio_config.headers = Some(headers);
         self
@@ -364,7 +397,12 @@ impl GrpcioPipelineBuilder {
         self
     }
 
-    /// Install a trace exporter using grpcio
+    /// Install a trace exporter using [grpcio] as grpc layer.
+    ///
+    /// Returns a [`Tracer`] with the name `opentelemetry-otlp` and current crate version.
+    ///
+    /// [`Tracer`]: opentelemetry::trace::Tracer
+    /// [grpcio]: https://github.com/tikv/grpc-rs
     pub fn install(self) -> Result<sdk::trace::Tracer, TraceError> {
         let exporter = TraceExporter::new_grpcio(self.exporter_config, self.grpcio_config);
         Ok(build_with_exporter(exporter, self.trace_config))
@@ -411,7 +449,7 @@ pub enum Error {
     /// The lock in exporters has been poisoned.
     #[cfg(feature = "metrics")]
     #[error("the lock of the {0} has been poisoned")]
-    PoisonedLock(&'static str)
+    PoisonedLock(&'static str),
 }
 
 impl ExportError for Error {
@@ -420,7 +458,7 @@ impl ExportError for Error {
     }
 }
 
-/// The communication protocol to use when sending data.
+/// The communication protocol to use when exporting data.
 #[derive(Clone, Copy, Debug)]
 pub enum Protocol {
     /// GRPC protocol

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -9,14 +9,11 @@ use crate::proto::collector::metrics::v1::{
     metrics_service_client::MetricsServiceClient, ExportMetricsServiceRequest,
 };
 use crate::transform::{record_to_metric, sink, CheckpointedMetrics};
-use crate::{ExporterConfig, TonicConfig};
-use futures::{SinkExt, Stream, StreamExt, TryFutureExt};
-use opentelemetry::labels::Iter;
+use crate::{ExporterConfig, Error};
+use futures::Stream;
 use opentelemetry::metrics::{Descriptor, Result};
 use opentelemetry::sdk::export::metrics::{AggregatorSelector, ExportKindSelector};
-use opentelemetry::sdk::export::ExportError;
 use opentelemetry::sdk::metrics::{PushController, PushControllerWorker};
-use opentelemetry::sdk::resource::IntoIter;
 use opentelemetry::sdk::{
     export::metrics::{CheckpointSet, ExportKind, ExportKindFor, Exporter},
     metrics::selectors,
@@ -33,6 +30,10 @@ use tonic::transport::Channel;
 #[cfg(feature = "tonic")]
 use tonic::Request;
 
+/// Return a pipeline to build OTLP metrics exporter.
+///
+/// Note that currently the OTLP metrics exporter only supports tonic as it's grpc layer and tokio as
+/// runtime.
 pub fn new_metrics_pipeline<SP, SO, I, IO>(
     spawn: SP,
     interval: I,
@@ -55,6 +56,11 @@ where
     }
 }
 
+/// Pipeline to build OTLP metrics exporter
+///
+/// Note that currently the OTLP metrics exporter only supports tonic as it's grpc layer and tokio as
+/// runtime.
+#[derive(Debug)]
 pub struct OtlpMetricPipelineBuilder<AS, ES, SP, SO, I, IO>
 where
     AS: AggregatorSelector + Send + Sync + 'static,
@@ -84,7 +90,7 @@ where
 {
     /// Build with resource key value pairs.
     pub fn with_resource<T: IntoIterator<Item = R>, R: Into<KeyValue>>(
-        mut self,
+        self,
         resource: T,
     ) -> Self {
         OtlpMetricPipelineBuilder {
@@ -94,7 +100,7 @@ where
     }
 
     /// Build with export configuration
-    pub fn with_export_config(mut self, export_config: ExporterConfig) -> Self {
+    pub fn with_export_config(self, export_config: ExporterConfig) -> Self {
         OtlpMetricPipelineBuilder {
             export_config: Some(export_config),
             ..self
@@ -110,7 +116,7 @@ where
     }
 
     /// Build with the aggregator selector
-    pub fn with_aggregator_selector(mut self, aggregator_selector: AS) -> Self {
+    pub fn with_aggregator_selector(self, aggregator_selector: AS) -> Self {
         OtlpMetricPipelineBuilder {
             aggregator_selector,
             ..self
@@ -118,12 +124,12 @@ where
     }
 
     /// Build with spawn function
-    pub fn with_spawn(mut self, spawn: SP) -> Self {
+    pub fn with_spawn(self, spawn: SP) -> Self {
         OtlpMetricPipelineBuilder { spawn, ..self }
     }
 
     /// Build with timeout
-    pub fn with_timeout(mut self, timeout: time::Duration) -> Self {
+    pub fn with_timeout(self, timeout: time::Duration) -> Self {
         OtlpMetricPipelineBuilder {
             timeout: Some(timeout),
             ..self
@@ -131,7 +137,7 @@ where
     }
 
     /// Build with period, your metrics will be exported with this period
-    pub fn with_period(mut self, period: time::Duration) -> Self {
+    pub fn with_period(self, period: time::Duration) -> Self {
         OtlpMetricPipelineBuilder {
             period: Some(period),
             ..self
@@ -139,7 +145,7 @@ where
     }
 
     /// Build a stateful push controller or not
-    pub fn with_stateful(mut self, stateful: bool) -> Self {
+    pub fn with_stateful(self, stateful: bool) -> Self {
         OtlpMetricPipelineBuilder {
             stateful: Some(stateful),
             ..self
@@ -147,12 +153,12 @@ where
     }
 
     /// Build with interval function
-    pub fn with_interval(mut self, interval: I) -> Self {
+    pub fn with_interval(self, interval: I) -> Self {
         OtlpMetricPipelineBuilder { interval, ..self }
     }
 
     /// Build with export kind selector
-    pub fn with_export_kind(mut self, export_selector: ES) -> Self {
+    pub fn with_export_kind(self, export_selector: ES) -> Self {
         OtlpMetricPipelineBuilder {
             export_selector,
             ..self
@@ -180,6 +186,12 @@ where
         }
         if let Some(resource) = self.resource {
             builder = builder.with_resource(resource);
+        }
+        if let Some(stateful) = self.stateful{
+            builder = builder.with_stateful(stateful);
+        }
+        if let Some(timeout) = self.timeout{
+            builder = builder.with_timeout(timeout)
         }
         let controller = builder.build();
         global::set_meter_provider(controller.provider());
@@ -216,6 +228,7 @@ impl ExportKindFor for MetricsExporter {
 }
 
 impl MetricsExporter {
+    /// Create a new OTLP metrics exporter.
     #[cfg(feature = "tonic")]
     pub fn new<T: ExportKindFor + Send + Sync + 'static>(
         config: ExporterConfig,
@@ -270,7 +283,7 @@ impl MetricsExporter {
                         break;
                     }
                     ExportMsg::Export(req) => {
-                        client.to_owned().export(req).await;
+                        let _ = client.to_owned().export(req).await;
                     }
                 }
             }
@@ -305,17 +318,19 @@ impl Exporter for MetricsExporter {
             }
         })?;
         let request = Request::new(sink(resource_metrics));
-        self.sender.lock().map(|mut sender| {
-            sender.try_send(ExportMsg::Export(request));
-        });
+        self.sender.lock().map(|sender| {
+            let _ = sender.try_send(ExportMsg::Export(request));
+        }).map_err(|_| {
+            Error::PoisonedLock("otlp metric exporter's tonic sender")
+        })?;
         Ok(())
     }
 }
 
 impl Drop for MetricsExporter {
     fn drop(&mut self) {
-        self.sender.lock().map(|mut sender| {
-            sender.try_send(ExportMsg::Shutdown);
+        let _ = self.sender.lock().map(| sender| {
+            let _ = sender.try_send(ExportMsg::Shutdown);
         });
     }
 }

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -51,7 +51,7 @@ use std::time::Duration;
 /// Exporter that sends data in OTLP format.
 pub enum TraceExporter {
     #[cfg(feature = "tonic")]
-    /// Trace Exporter using tonic as grpc layer
+    /// Trace Exporter using tonic as grpc layer.
     Tonic {
         /// Duration of timeout when sending spans to backend.
         timeout: Duration,
@@ -59,9 +59,6 @@ pub enum TraceExporter {
         metadata: Option<MetadataMap>,
         /// The Grpc trace exporter
         trace_exporter: TonicTraceServiceClient<TonicChannel>,
-        /// If the application don't have a runtime(`tonic-sync` feature is enabled). Use this runtime
-        /// to use tonic.
-        runtime: Option<tokio::runtime::Runtime>,
     },
     #[cfg(feature = "grpc-sys")]
     /// Trace Exporter using grpcio as grpc layer
@@ -100,13 +97,6 @@ pub struct TonicConfig {
     /// TLS settings for the collector endpoint.
     #[cfg(feature = "tls")]
     pub tls_config: Option<ClientTlsConfig>,
-
-    /// Optional runtime when the trace exporter is not run in an async environment.
-    /// If not provided, exporter will build a tokio current thread runtime and use it.
-    ///
-    /// This is needed because the tonic is run on top of the tokio.
-    #[cfg(feature = "tonic-sync")]
-    pub runtime: Option<tokio::runtime::Runtime>,
 }
 
 #[cfg(feature = "tonic")]
@@ -116,8 +106,6 @@ impl Default for TonicConfig {
             #[cfg(feature = "tls")]
             tls_config: None,
             metadata: None,
-            #[cfg(feature = "tonic-sync")]
-            runtime: None,
         }
     }
 }
@@ -261,15 +249,6 @@ impl TraceExporter {
             timeout: config.timeout,
             metadata: tonic_config.metadata,
             trace_exporter: client,
-            #[cfg(feature = "tonic-sync")]
-            runtime: Some(tonic_config.runtime.unwrap_or_else(|| {
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .unwrap()
-            })),
-            #[cfg(not(feature = "tonic-sync"))]
-            runtime: None,
         })
     }
 
@@ -344,28 +323,16 @@ impl SpanExporter for TraceExporter {
             }
 
             #[cfg(feature = "tonic")]
-            TraceExporter::Tonic {
-                trace_exporter,
-                runtime,
-                ..
-            } => {
+            TraceExporter::Tonic { trace_exporter, .. } => {
                 let request = Request::new(TonicRequest {
                     resource_spans: batch.into_iter().map(Into::into).collect(),
                 });
 
-                match runtime {
-                    Some(rt) => {
-                        rt.block_on(trace_exporter.to_owned().export(request))
-                            .map_err::<crate::Error, _>(Into::into)?;
-                    }
-                    None => {
-                        trace_exporter
-                            .to_owned()
-                            .export(request)
-                            .await
-                            .map_err::<crate::Error, _>(Into::into)?;
-                    }
-                }
+                trace_exporter
+                    .to_owned()
+                    .export(request)
+                    .await
+                    .map_err::<crate::Error, _>(Into::into)?;
 
                 Ok(())
             }

--- a/opentelemetry/src/sdk/metrics/controllers/push.rs
+++ b/opentelemetry/src/sdk/metrics/controllers/push.rs
@@ -26,12 +26,12 @@ pub fn push<AS, ES, E, SP, SO, I, IO>(
     spawn: SP,
     interval: I,
 ) -> PushControllerBuilder<SP, I>
-    where
-        AS: AggregatorSelector + Send + Sync + 'static,
-        ES: ExportKindFor + Send + Sync + 'static,
-        E: Exporter + Send + Sync + 'static,
-        SP: Fn(PushControllerWorker) -> SO,
-        I: Fn(time::Duration) -> IO,
+where
+    AS: AggregatorSelector + Send + Sync + 'static,
+    ES: ExportKindFor + Send + Sync + 'static,
+    E: Exporter + Send + Sync + 'static,
+    SP: Fn(PushControllerWorker) -> SO,
+    I: Fn(time::Duration) -> IO,
 {
     PushControllerBuilder {
         aggregator_selector: Box::new(aggregator_selector),
@@ -63,7 +63,7 @@ enum PushMessage {
 /// passed in executor.
 #[allow(missing_debug_implementations)]
 pub struct PushControllerWorker {
-    messages: Pin<Box<dyn Stream<Item=PushMessage> + Send>>,
+    messages: Pin<Box<dyn Stream<Item = PushMessage> + Send>>,
     accumulator: Accumulator,
     processor: Arc<BasicProcessor>,
     exporter: Box<dyn Exporter + Send + Sync>,
@@ -137,10 +137,10 @@ pub struct PushControllerBuilder<S, I> {
 }
 
 impl<S, SO, I, IS, ISI> PushControllerBuilder<S, I>
-    where
-        S: Fn(PushControllerWorker) -> SO,
-        I: Fn(time::Duration) -> IS,
-        IS: Stream<Item=ISI> + Send + 'static,
+where
+    S: Fn(PushControllerWorker) -> SO,
+    I: Fn(time::Duration) -> IS,
+    IS: Stream<Item = ISI> + Send + 'static,
 {
     /// Configure the statefulness of this controller.
     pub fn with_stateful(self, stateful: bool) -> Self {

--- a/opentelemetry/src/sdk/metrics/controllers/push.rs
+++ b/opentelemetry/src/sdk/metrics/controllers/push.rs
@@ -26,12 +26,12 @@ pub fn push<AS, ES, E, SP, SO, I, IO>(
     spawn: SP,
     interval: I,
 ) -> PushControllerBuilder<SP, I>
-where
-    AS: AggregatorSelector + Send + Sync + 'static,
-    ES: ExportKindFor + Send + Sync + 'static,
-    E: Exporter + Send + Sync + 'static,
-    SP: Fn(PushControllerWorker) -> SO,
-    I: Fn(time::Duration) -> IO,
+    where
+        AS: AggregatorSelector + Send + Sync + 'static,
+        ES: ExportKindFor + Send + Sync + 'static,
+        E: Exporter + Send + Sync + 'static,
+        SP: Fn(PushControllerWorker) -> SO,
+        I: Fn(time::Duration) -> IO,
 {
     PushControllerBuilder {
         aggregator_selector: Box::new(aggregator_selector),
@@ -63,7 +63,7 @@ enum PushMessage {
 /// passed in executor.
 #[allow(missing_debug_implementations)]
 pub struct PushControllerWorker {
-    messages: Pin<Box<dyn Stream<Item = PushMessage> + Send>>,
+    messages: Pin<Box<dyn Stream<Item=PushMessage> + Send>>,
     accumulator: Accumulator,
     processor: Arc<BasicProcessor>,
     exporter: Box<dyn Exporter + Send + Sync>,
@@ -137,10 +137,10 @@ pub struct PushControllerBuilder<S, I> {
 }
 
 impl<S, SO, I, IS, ISI> PushControllerBuilder<S, I>
-where
-    S: Fn(PushControllerWorker) -> SO,
-    I: Fn(time::Duration) -> IS,
-    IS: Stream<Item = ISI> + Send + 'static,
+    where
+        S: Fn(PushControllerWorker) -> SO,
+        I: Fn(time::Duration) -> IS,
+        IS: Stream<Item=ISI> + Send + 'static,
 {
     /// Configure the statefulness of this controller.
     pub fn with_stateful(self, stateful: bool) -> Self {
@@ -162,6 +162,14 @@ where
     pub fn with_resource(self, resource: Resource) -> Self {
         PushControllerBuilder {
             resource: Some(resource),
+            ..self
+        }
+    }
+
+    /// Config the timeout of one request.
+    pub fn with_timeout(self, duration: time::Duration) -> Self {
+        PushControllerBuilder {
+            timeout: Some(duration),
             ..self
         }
     }


### PR DESCRIPTION
- The bug was introduced in #467. I believe the async feature was there to spin up a tokio runtime if the exporter was not already in one. It's mostly because the tonic cannot work without a tokio runtime.
- Renamed the async feature to be less confusing.
- Cleaned up all the clippy problems in the metrics module and add some links into the doc.
- Add a with_timeout method in `opentelemetry/sdk/metrics/controller/push.rs` push controller to config the timeout of each push.