### PR TITLE
bump prometheus dependency

### DIFF
--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 opentelemetry = { version = "0.12", path = "../opentelemetry", default-features = false, features = ["metrics"] }
-prometheus = "0.11"
+prometheus = "0.12"
 protobuf = "2.14"
 
 [dev-dependencies]


### PR DESCRIPTION
This is a bump to the latest version of the prometheus library.

```
# Changelog

## 0.12.0

 - Improvement: Fix format string in panic!() calls (#391)

 - Improvement: Replace regex with memchr (#385)

 - Improvement: Update reqwest requirement from ^0.10 to ^0.11 (#379)
```
https://github.com/tikv/rust-prometheus/compare/v0.11.0...v0.12.0