### PR TITLE
opentelemetry-datadog: document panic in `new_pipeline`

### DIFF
--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -49,6 +49,12 @@ impl DatadogExporter {
 }
 
 /// Create a new Datadog exporter pipeline builder.
+///
+/// # Panic
+///
+/// If the `reqwest-client` or `reqwest-blocking-client` features are
+/// enabled, this function will panic if the tokio runtime is not
+/// running.
 pub fn new_pipeline() -> DatadogPipelineBuilder {
     DatadogPipelineBuilder::default()
 }


### PR DESCRIPTION
This is already documented at the crate level, but it isn't clear
_where_ the panic can occur. This makes it more explicit.

Edit: Thanks a lot for this crate it is awesome :)
Edit2: I find the CLA thing pretty invasive. Do I really have to give my address to contribute code?!