### PR TITLE
Update Semantic Conventions

### DIFF
--- a/opentelemetry-semantic-conventions/.gitignore
+++ b/opentelemetry-semantic-conventions/.gitignore
@@ -1,0 +1,1 @@
+opentelemetry-specification/

--- a/opentelemetry-semantic-conventions/scripts/generate-consts-from-spec.sh
+++ b/opentelemetry-semantic-conventions/scripts/generate-consts-from-spec.sh
@@ -1,64 +1,45 @@
 #!/bin/bash
-# Semantic conventions are currently defined in Markdown files in the
-# specification repository. This script downloads these files and attempts to
-# find the attributes and their documentation. It then prints Rust code with
-# constants for these attributes to stdout.
-#
-# This helps you get started but doesn't do all the things. You will need to the
-# following manually:
-# - This prints some attributes multiple times, because it mistakes examples for
-#   attribute definitions. Remove those.
-# - In some cases the description isn't parsed properly. In those cases you will
-#   need to copy it manually.
-# - Hard wrap description text, so it fits the code style of this repo.
-# - Add URLs for links in the documentation.
+set -euo pipefail
 
-set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRATE_DIR="${SCRIPT_DIR}/../"
 
-md_to_rs() {
-	while read line; do
-		# Regex explanation:
-		# Find markdown tables (lines starting with "|") and take the first 2 columns
-		# - The 1st column is the attribute name consisting of a-z0-9._
-		# - The 2nd column is (usually) the type
-		# - The 3rd column is (usually) the description
-		if [[ "$line" =~ ^\|\ \[?\`?([a-z0-9._]+)\`?\]?(:?\([^|]+\))?\ +\|\ ([^|]+)\ +\|\ ([^|]+) ]]; then
-			name="${BASH_REMATCH[1]}"
-			const_name=$(echo "$name" | tr a-z A-Z | sed "s/\\./_/g")
-			doc="${BASH_REMATCH[4]}"
-			echo ""
-			echo "/// $doc"
-			echo "pub const $const_name: Key = Key::from_static_str(\"$name\");"
-		fi
-	done <<<"$1"
-}
+# freeze the spec version and generator version to make generation reproducible
+SPEC_VERSION=v1.1.0
+SEMCOVGEN_VERSION=0.2.1
 
-md_url_to_rs() {
-	md_to_rs "$(curl -sSf "https://raw.githubusercontent.com/open-telemetry/opentelemetry-specification/master/specification/$1")"
-}
+cd "$CRATE_DIR"
 
-case "$1" in
-	"resource")
-		md_url_to_rs "resource/semantic_conventions/README.md"
-		md_url_to_rs "resource/semantic_conventions/cloud.md"
-		md_url_to_rs "resource/semantic_conventions/container.md"
-		md_url_to_rs "resource/semantic_conventions/deployment_environment.md"
-		md_url_to_rs "resource/semantic_conventions/faas.md"
-		md_url_to_rs "resource/semantic_conventions/host.md"
-		md_url_to_rs "resource/semantic_conventions/k8s.md"
-		md_url_to_rs "resource/semantic_conventions/os.md"
-		md_url_to_rs "resource/semantic_conventions/process.md"
-		;;
-	"trace")
-		md_url_to_rs "trace/semantic_conventions/database.md"
-		md_url_to_rs "trace/semantic_conventions/exceptions.md"
-		md_url_to_rs "trace/semantic_conventions/faas.md"
-		md_url_to_rs "trace/semantic_conventions/http.md"
-		md_url_to_rs "trace/semantic_conventions/messaging.md"
-		md_url_to_rs "trace/semantic_conventions/rpc.md"
-		md_url_to_rs "trace/semantic_conventions/span-general.md"
-		;;
-	*)
-		echo "Usage: $0 <resource|trace>"
-		;;
-esac
+rm -rf opentelemetry-specification || true
+mkdir opentelemetry-specification
+cd opentelemetry-specification
+
+git init
+git remote add origin https://github.com/open-telemetry/opentelemetry-specification.git
+git fetch origin "$SPEC_VERSION"
+git reset --hard FETCH_HEAD
+cd "$CRATE_DIR"
+
+docker run --rm \
+	-v "${CRATE_DIR}/opentelemetry-specification/semantic_conventions/trace:/source" \
+	-v "${CRATE_DIR}/scripts/templates:/templates" \
+	-v "${CRATE_DIR}/src:/output" \
+	otel/semconvgen:$SEMCOVGEN_VERSION \
+	--yaml-root /source \
+	code \
+	--template /templates/semantic_attributes.rs.j2 \
+	--output /output/trace.rs \
+	--parameters conventions=trace
+
+docker run --rm \
+	-v "${CRATE_DIR}/opentelemetry-specification/semantic_conventions/resource:/source" \
+	-v "${CRATE_DIR}/scripts/templates:/templates" \
+	-v "${CRATE_DIR}/src:/output" \
+	otel/semconvgen:$SEMCOVGEN_VERSION \
+	--yaml-root /source \
+	code \
+	--template /templates/semantic_attributes.rs.j2 \
+	--output /output/resource.rs \
+	--parameters conventions=resource
+
+cargo fmt

--- a/opentelemetry-semantic-conventions/scripts/templates/header_resource.rs
+++ b/opentelemetry-semantic-conventions/scripts/templates/header_resource.rs
@@ -1,0 +1,20 @@
+//! # Resource Semantic Conventions
+//!
+//! The [resource semantic conventions] define a set of standardized attributes
+//! to be used in `Resource`s.
+//!
+//! [resource semantic conventions]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions
+//!
+//! ## Usage
+//!
+//! ```rust,no_run
+//! use opentelemetry::sdk;
+//! use opentelemetry_semantic_conventions as semcov;
+//!
+//! let _tracer = opentelemetry::sdk::export::trace::stdout::new_pipeline()
+//!     .with_trace_config(sdk::trace::config().with_resource(sdk::Resource::new(vec![
+//!         semcov::resource::SERVICE_NAME.string("my-service"),
+//!         semcov::resource::SERVICE_NAMESPACE.string("my-namespace"),
+//!     ])))
+//!     .install_simple();
+//! ```

--- a/opentelemetry-semantic-conventions/scripts/templates/header_trace.rs
+++ b/opentelemetry-semantic-conventions/scripts/templates/header_trace.rs
@@ -1,0 +1,22 @@
+//! # Trace Semantic Conventions
+//!
+//! The [trace semantic conventions] define a set of standardized attributes to
+//! be used in `Span`s.
+//!
+//! [trace semantic conventions]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use opentelemetry::{global, trace::Tracer as _};
+//! use opentelemetry_semantic_conventions as semcov;
+//!
+//! let tracer = global::tracer("my-component");
+//! let _span = tracer
+//!     .span_builder("span-name")
+//!     .with_attributes(vec![
+//!         semcov::trace::NET_PEER_IP.string("10.0.0.1"),
+//!         semcov::trace::NET_PEER_PORT.i64(80),
+//!     ])
+//!     .start(&tracer);
+//! ```

--- a/opentelemetry-semantic-conventions/scripts/templates/semantic_attributes.rs.j2
+++ b/opentelemetry-semantic-conventions/scripts/templates/semantic_attributes.rs.j2
@@ -1,0 +1,29 @@
+// DO NOT EDIT, this is an auto-generated file
+//
+// If you want to update the file:
+// - Edit the template at scripts{{template}}
+// - Run the script at scripts/generate-consts-from-spec.sh
+
+{% include 'header_' + conventions + '.rs' %}
+
+use opentelemetry::Key;
+
+{%- for attribute in attributes | unique(attribute="fqn") %}
+
+/// {% filter escape %}{{attribute.brief | to_doc_brief}}.{% endfilter %}
+{%- if attribute.note %}
+///
+{%- for line in attribute.note.split('\n') %}
+/// {% filter escape %}{{line}}{% endfilter %}
+{%- endfor %}
+{%- endif %}
+{%- if attribute.examples %}
+///
+/// # Examples
+///
+{%- for example in attribute.examples %}
+/// - {% filter escape %}{{example}}{% endfilter %}
+{%- endfor %}
+{%- endif %}
+pub const {{attribute.fqn | to_const_name}}: Key = Key::from_static_str("{{attribute.fqn}}");
+{%- endfor %}

--- a/opentelemetry-semantic-conventions/src/resource.rs
+++ b/opentelemetry-semantic-conventions/src/resource.rs
@@ -1,3 +1,9 @@
+// DO NOT EDIT, this is an auto-generated file
+//
+// If you want to update the file:
+// - Edit the template at scripts/templates/semantic_attributes.rs.j2
+// - Run the script at scripts/generate-consts-from-spec.sh
+
 //! # Resource Semantic Conventions
 //!
 //! The [resource semantic conventions] define a set of standardized attributes
@@ -21,247 +27,526 @@
 
 use opentelemetry::Key;
 
+/// Name of the cloud provider.
+///
+/// # Examples
+///
+/// - gcp
+pub const CLOUD_PROVIDER: Key = Key::from_static_str("cloud.provider");
+
+/// The cloud account ID the resource is assigned to.
+///
+/// # Examples
+///
+/// - 111111111111
+/// - opentelemetry
+pub const CLOUD_ACCOUNT_ID: Key = Key::from_static_str("cloud.account.id");
+
+/// The geographical region the resource is running. Refer to your provider&#39;s docs to see the available regions, for example [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), or [Google Cloud regions](https://cloud.google.com/about/locations).
+///
+/// # Examples
+///
+/// - us-central1
+/// - us-east-1
+pub const CLOUD_REGION: Key = Key::from_static_str("cloud.region");
+
+/// Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
+///
+/// Availability zones are called &#34;zones&#34; on Google Cloud.
+///
+/// # Examples
+///
+/// - us-east-1c
+pub const CLOUD_AVAILABILITY_ZONE: Key = Key::from_static_str("cloud.availability_zone");
+
+/// The cloud infrastructure resource in use.
+///
+/// The prefix of the service SHOULD match the one specified in `cloud.provider`.
+///
+/// # Examples
+///
+/// - aws_ec2
+/// - azure_vm
+/// - gcp_compute_engine
+pub const CLOUD_INFRASTRUCTURE_SERVICE: Key = Key::from_static_str("cloud.infrastructure_service");
+
+/// The Amazon Resource Name (ARN) of an [ECS container instance](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html).
+///
+/// # Examples
+///
+/// - arn:aws:ecs:us-west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9
+pub const AWS_ECS_CONTAINER_ARN: Key = Key::from_static_str("aws.ecs.container.arn");
+
+/// The ARN of an [ECS cluster](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html).
+///
+/// # Examples
+///
+/// - arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster
+pub const AWS_ECS_CLUSTER_ARN: Key = Key::from_static_str("aws.ecs.cluster.arn");
+
+/// The [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html) for an ECS task.
+///
+/// # Examples
+///
+/// - ec2
+/// - fargate
+pub const AWS_ECS_LAUNCHTYPE: Key = Key::from_static_str("aws.ecs.launchtype");
+
+/// The ARN of an [ECS task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html).
+///
+/// # Examples
+///
+/// - arn:aws:ecs:us-west-1:123456789123:task/10838bed-421f-43ef-870a-f43feacbbb5b
+pub const AWS_ECS_TASK_ARN: Key = Key::from_static_str("aws.ecs.task.arn");
+
+/// The task definition family this task definition is a member of.
+///
+/// # Examples
+///
+/// - opentelemetry-family
+pub const AWS_ECS_TASK_FAMILY: Key = Key::from_static_str("aws.ecs.task.family");
+
+/// The ARN of an EKS cluster.
+///
+/// # Examples
+///
+/// - arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster
+pub const AWS_EKS_CLUSTER_ARN: Key = Key::from_static_str("aws.eks.cluster.arn");
+
+/// The name(s) of the AWS log group(s) an application is writing to.
+///
+/// Multiple log groups must be supported for cases like multi-container applications, where a single application has sidecar containers, and each write to their own log group.
+///
+/// # Examples
+///
+/// - /aws/lambda/my-function
+/// - opentelemetry-service
+pub const AWS_LOG_GROUP_NAMES: Key = Key::from_static_str("aws.log.group.names");
+
+/// The Amazon Resource Name(s) (ARN) of the AWS log group(s).
+///
+/// See the [log group ARN format documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format).
+///
+/// # Examples
+///
+/// - arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*
+pub const AWS_LOG_GROUP_ARNS: Key = Key::from_static_str("aws.log.group.arns");
+
+/// The name(s) of the AWS log stream(s) an application is writing to.
+///
+/// # Examples
+///
+/// - logs/main/10838bed-421f-43ef-870a-f43feacbbb5b
+pub const AWS_LOG_STREAM_NAMES: Key = Key::from_static_str("aws.log.stream.names");
+
+/// The ARN(s) of the AWS log stream(s).
+///
+/// See the [log stream ARN format documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format). One log group can contain several log streams, so these ARNs necessarily identify both a log group and a log stream.
+///
+/// # Examples
+///
+/// - arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:log-stream:logs/main/10838bed-421f-43ef-870a-f43feacbbb5b
+pub const AWS_LOG_STREAM_ARNS: Key = Key::from_static_str("aws.log.stream.arns");
+
+/// Container name.
+///
+/// # Examples
+///
+/// - opentelemetry-autoconf
+pub const CONTAINER_NAME: Key = Key::from_static_str("container.name");
+
+/// Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated.
+///
+/// # Examples
+///
+/// - a3bf90e006b2
+pub const CONTAINER_ID: Key = Key::from_static_str("container.id");
+
+/// The container runtime managing this container.
+///
+/// # Examples
+///
+/// - docker
+/// - containerd
+/// - rkt
+pub const CONTAINER_RUNTIME: Key = Key::from_static_str("container.runtime");
+
+/// Name of the image the container was built on.
+///
+/// # Examples
+///
+/// - gcr.io/opentelemetry/operator
+pub const CONTAINER_IMAGE_NAME: Key = Key::from_static_str("container.image.name");
+
+/// Container image tag.
+///
+/// # Examples
+///
+/// - 0.1
+pub const CONTAINER_IMAGE_TAG: Key = Key::from_static_str("container.image.tag");
+
+/// Name of the [deployment environment](https://en.wikipedia.org/wiki/Deployment_environment) (aka deployment tier).
+///
+/// # Examples
+///
+/// - staging
+/// - production
+pub const DEPLOYMENT_ENVIRONMENT: Key = Key::from_static_str("deployment.environment");
+
+/// The name of the function being executed.
+///
+/// # Examples
+///
+/// - my-function
+pub const FAAS_NAME: Key = Key::from_static_str("faas.name");
+
+/// The unique ID of the function being executed.
+///
+/// For example, in AWS Lambda this field corresponds to the [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) value, in GCP to the URI of the resource, and in Azure to the [FunctionDirectory](https://github.com/Azure/azure-functions-host/wiki/Retrieving-information-about-the-currently-running-function) field.
+///
+/// # Examples
+///
+/// - arn:aws:lambda:us-west-2:123456789012:function:my-function
+pub const FAAS_ID: Key = Key::from_static_str("faas.id");
+
+/// The version string of the function being executed as defined in [Version Attributes](../../resource/semantic_conventions/README.md#version-attributes).
+///
+/// # Examples
+///
+/// - 2.0.0
+pub const FAAS_VERSION: Key = Key::from_static_str("faas.version");
+
+/// The execution environment ID as a string.
+///
+/// # Examples
+///
+/// - my-function:instance-0001
+pub const FAAS_INSTANCE: Key = Key::from_static_str("faas.instance");
+
+/// The amount of memory available to the serverless function in MiB.
+///
+/// It&#39;s recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information.
+///
+/// # Examples
+///
+/// - 128
+pub const FAAS_MAX_MEMORY: Key = Key::from_static_str("faas.max_memory");
+
+/// Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider.
+///
+/// # Examples
+///
+/// - opentelemetry-test
+pub const HOST_ID: Key = Key::from_static_str("host.id");
+
+/// Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user.
+///
+/// # Examples
+///
+/// - opentelemetry-test
+pub const HOST_NAME: Key = Key::from_static_str("host.name");
+
+/// Type of host. For Cloud, this must be the machine type.
+///
+/// # Examples
+///
+/// - n1-standard-1
+pub const HOST_TYPE: Key = Key::from_static_str("host.type");
+
+/// The CPU architecture the host system is running on.
+pub const HOST_ARCH: Key = Key::from_static_str("host.arch");
+
+/// Name of the VM image or OS install the host was instantiated from.
+///
+/// # Examples
+///
+/// - infra-ami-eks-worker-node-7d4ec78312
+/// - CentOS-8-x86_64-1905
+pub const HOST_IMAGE_NAME: Key = Key::from_static_str("host.image.name");
+
+/// VM image ID. For Cloud, this value is from the provider.
+///
+/// # Examples
+///
+/// - ami-07b06b442921831e5
+pub const HOST_IMAGE_ID: Key = Key::from_static_str("host.image.id");
+
+/// The version string of the VM image as defined in [Version Attributes](README.md#version-attributes).
+///
+/// # Examples
+///
+/// - 0.1
+pub const HOST_IMAGE_VERSION: Key = Key::from_static_str("host.image.version");
+
+/// The name of the cluster.
+///
+/// # Examples
+///
+/// - opentelemetry-cluster
+pub const K8S_CLUSTER_NAME: Key = Key::from_static_str("k8s.cluster.name");
+
+/// The name of the Node.
+///
+/// # Examples
+///
+/// - node-1
+pub const K8S_NODE_NAME: Key = Key::from_static_str("k8s.node.name");
+
+/// The UID of the Node.
+///
+/// # Examples
+///
+/// - 1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2
+pub const K8S_NODE_UID: Key = Key::from_static_str("k8s.node.uid");
+
+/// The name of the namespace that the pod is running in.
+///
+/// # Examples
+///
+/// - default
+pub const K8S_NAMESPACE_NAME: Key = Key::from_static_str("k8s.namespace.name");
+
+/// The UID of the Pod.
+///
+/// # Examples
+///
+/// - 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+pub const K8S_POD_UID: Key = Key::from_static_str("k8s.pod.uid");
+
+/// The name of the Pod.
+///
+/// # Examples
+///
+/// - opentelemetry-pod-autoconf
+pub const K8S_POD_NAME: Key = Key::from_static_str("k8s.pod.name");
+
+/// The name of the Container in a Pod template.
+///
+/// # Examples
+///
+/// - redis
+pub const K8S_CONTAINER_NAME: Key = Key::from_static_str("k8s.container.name");
+
+/// The UID of the ReplicaSet.
+///
+/// # Examples
+///
+/// - 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+pub const K8S_REPLICASET_UID: Key = Key::from_static_str("k8s.replicaset.uid");
+
+/// The name of the ReplicaSet.
+///
+/// # Examples
+///
+/// - opentelemetry
+pub const K8S_REPLICASET_NAME: Key = Key::from_static_str("k8s.replicaset.name");
+
+/// The UID of the Deployment.
+///
+/// # Examples
+///
+/// - 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+pub const K8S_DEPLOYMENT_UID: Key = Key::from_static_str("k8s.deployment.uid");
+
+/// The name of the Deployment.
+///
+/// # Examples
+///
+/// - opentelemetry
+pub const K8S_DEPLOYMENT_NAME: Key = Key::from_static_str("k8s.deployment.name");
+
+/// The UID of the StatefulSet.
+///
+/// # Examples
+///
+/// - 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+pub const K8S_STATEFULSET_UID: Key = Key::from_static_str("k8s.statefulset.uid");
+
+/// The name of the StatefulSet.
+///
+/// # Examples
+///
+/// - opentelemetry
+pub const K8S_STATEFULSET_NAME: Key = Key::from_static_str("k8s.statefulset.name");
+
+/// The UID of the DaemonSet.
+///
+/// # Examples
+///
+/// - 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+pub const K8S_DAEMONSET_UID: Key = Key::from_static_str("k8s.daemonset.uid");
+
+/// The name of the DaemonSet.
+///
+/// # Examples
+///
+/// - opentelemetry
+pub const K8S_DAEMONSET_NAME: Key = Key::from_static_str("k8s.daemonset.name");
+
+/// The UID of the Job.
+///
+/// # Examples
+///
+/// - 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+pub const K8S_JOB_UID: Key = Key::from_static_str("k8s.job.uid");
+
+/// The name of the Job.
+///
+/// # Examples
+///
+/// - opentelemetry
+pub const K8S_JOB_NAME: Key = Key::from_static_str("k8s.job.name");
+
+/// The UID of the CronJob.
+///
+/// # Examples
+///
+/// - 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+pub const K8S_CRONJOB_UID: Key = Key::from_static_str("k8s.cronjob.uid");
+
+/// The name of the CronJob.
+///
+/// # Examples
+///
+/// - opentelemetry
+pub const K8S_CRONJOB_NAME: Key = Key::from_static_str("k8s.cronjob.name");
+
+/// The operating system type.
+pub const OS_TYPE: Key = Key::from_static_str("os.type");
+
+/// Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands.
+///
+/// # Examples
+///
+/// - Microsoft Windows [Version 10.0.18363.778]
+/// - Ubuntu 18.04.1 LTS
+pub const OS_DESCRIPTION: Key = Key::from_static_str("os.description");
+
+/// Process identifier (PID).
+///
+/// # Examples
+///
+/// - 1234
+pub const PROCESS_PID: Key = Key::from_static_str("process.pid");
+
+/// The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`.
+///
+/// # Examples
+///
+/// - otelcol
+pub const PROCESS_EXECUTABLE_NAME: Key = Key::from_static_str("process.executable.name");
+
+/// The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`.
+///
+/// # Examples
+///
+/// - /usr/bin/cmd/otelcol
+pub const PROCESS_EXECUTABLE_PATH: Key = Key::from_static_str("process.executable.path");
+
+/// The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`.
+///
+/// # Examples
+///
+/// - cmd/otelcol
+pub const PROCESS_COMMAND: Key = Key::from_static_str("process.command");
+
+/// The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead.
+///
+/// # Examples
+///
+/// - C:\cmd\otecol --config=&#34;my directory\config.yaml&#34;
+pub const PROCESS_COMMAND_LINE: Key = Key::from_static_str("process.command_line");
+
+/// All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`.
+///
+/// # Examples
+///
+/// - cmd/otecol
+/// - --config=config.yaml
+pub const PROCESS_COMMAND_ARGS: Key = Key::from_static_str("process.command_args");
+
+/// The username of the user that owns the process.
+///
+/// # Examples
+///
+/// - root
+pub const PROCESS_OWNER: Key = Key::from_static_str("process.owner");
+
+/// The name of the runtime of this process. For compiled native binaries, this SHOULD be the name of the compiler.
+///
+/// # Examples
+///
+/// - OpenJDK Runtime Environment
+pub const PROCESS_RUNTIME_NAME: Key = Key::from_static_str("process.runtime.name");
+
+/// The version of the runtime of this process, as returned by the runtime without modification.
+///
+/// # Examples
+///
+/// - 14.0.2
+pub const PROCESS_RUNTIME_VERSION: Key = Key::from_static_str("process.runtime.version");
+
+/// An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment.
+///
+/// # Examples
+///
+/// - Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0
+pub const PROCESS_RUNTIME_DESCRIPTION: Key = Key::from_static_str("process.runtime.description");
+
 /// Logical name of the service.
 ///
-/// MUST be the same for all instances of horizontally scaled services.
+/// MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md#process), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
+///
+/// # Examples
+///
+/// - shoppingcart
 pub const SERVICE_NAME: Key = Key::from_static_str("service.name");
 
 /// A namespace for `service.name`.
 ///
-/// A string value having a meaning that helps to distinguish a group of
-/// services, for example the team name that owns a group of services.
-/// `service.name` is expected to be unique within the same namespace.
+/// A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
 ///
-/// If `service.namespace` is not specified in the Resource then `service.name`
-/// is expected to be unique for all services that have no explicit namespace
-/// defined (so the empty/unspecified namespace is simply one more valid
-/// namespace). Zero-length namespace string is assumed equal to unspecified
-/// namespace.
+/// # Examples
+///
+/// - Shop
 pub const SERVICE_NAMESPACE: Key = Key::from_static_str("service.namespace");
 
 /// The string ID of the service instance.
 ///
-/// MUST be unique for each instance of the same
-/// `service.namespace,service.name` pair (in other words
-/// `service.namespace,service.name,service.id` triplet MUST be globally
-/// unique).
+/// MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations).
 ///
-/// The ID helps to distinguish instances of the same service that exist at the
-/// same time (e.g. instances of a horizontally scaled service). It is
-/// preferable for the ID to be persistent and stay the same for the lifetime of
-/// the service instance, however it is acceptable that the ID is ephemeral and
-/// changes during important lifetime events for the service (e.g. service
-/// restarts).
+/// # Examples
 ///
-/// If the service has no inherent unique ID that can be used as the value of
-/// this attribute it is recommended to generate a random Version 1 or Version 4
-/// RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version
-/// 5, see RFC 4122 for more recommendations).
+/// - 627cc493-f310-47de-96bd-71410b7dec09
 pub const SERVICE_INSTANCE_ID: Key = Key::from_static_str("service.instance.id");
 
 /// The version string of the service API or implementation.
+///
+/// # Examples
+///
+/// - 2.0.0
 pub const SERVICE_VERSION: Key = Key::from_static_str("service.version");
 
 /// The name of the telemetry SDK as defined above.
+///
+/// # Examples
+///
+/// - opentelemetry
 pub const TELEMETRY_SDK_NAME: Key = Key::from_static_str("telemetry.sdk.name");
 
 /// The language of the telemetry SDK.
 pub const TELEMETRY_SDK_LANGUAGE: Key = Key::from_static_str("telemetry.sdk.language");
 
 /// The version string of the telemetry SDK.
+///
+/// # Examples
+///
+/// - 1.2.3
 pub const TELEMETRY_SDK_VERSION: Key = Key::from_static_str("telemetry.sdk.version");
 
 /// The version string of the auto instrumentation agent, if used.
+///
+/// # Examples
+///
+/// - 1.2.3
 pub const TELEMETRY_AUTO_VERSION: Key = Key::from_static_str("telemetry.auto.version");
-
-/// Name of the cloud provider.
-///
-/// Example values are aws, azure, gcp.
-pub const CLOUD_PROVIDER: Key = Key::from_static_str("cloud.provider");
-
-/// The cloud account ID used to identify different entities.
-pub const CLOUD_ACCOUNT_ID: Key = Key::from_static_str("cloud.account.id");
-
-/// A specific geographical location where different entities can run.
-pub const CLOUD_REGION: Key = Key::from_static_str("cloud.region");
-
-/// Zones are a sub set of the region connected through low-latency links.
-///
-/// In AWS, this is called availability-zone.
-pub const CLOUD_ZONE: Key = Key::from_static_str("cloud.zone");
-
-/// Container name.
-pub const CONTAINER_NAME: Key = Key::from_static_str("container.name");
-
-/// Container id. Usually a UUID, as for example used to [identify Docker
-/// containers]. The UUID might be abbreviated.
-///
-/// [identify Docker containers]: https://docs.docker.com/engine/reference/run/#container-identification
-pub const CONTAINER_ID: Key = Key::from_static_str("container.id");
-
-/// Name of the image the container was built on.
-pub const CONTAINER_IMAGE_NAME: Key = Key::from_static_str("container.image.name");
-
-/// Container image tag.
-pub const CONTAINER_IMAGE_TAG: Key = Key::from_static_str("container.image.tag");
-
-/// Name of the [deployment environment] (aka deployment tier).
-///
-/// [deployment environment]: https://en.wikipedia.org/wiki/Deployment_environment
-pub const DEPLOYMENT_ENVIRONMENT: Key = Key::from_static_str("deployment.environment");
-
-/// The name of the function being executed.
-pub const FAAS_NAME: Key = Key::from_static_str("faas.name");
-
-/// The unique ID of the function being executed.
-///
-/// For example, in AWS Lambda this field corresponds to the [ARN] value, in GCP
-/// to the URI of the resource, and in Azure to the [FunctionDirectory] field.
-///
-/// [ARN]: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
-/// [FunctionDirectory]: https://github.com/Azure/azure-functions-host/wiki/Retrieving-information-about-the-currently-running-function
-pub const FAAS_ID: Key = Key::from_static_str("faas.id");
-
-/// The version string of the function being executed as defined in [Version
-/// Attributes].
-///
-/// [Version Attributes]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions#version-attributes
-pub const FAAS_VERSION: Key = Key::from_static_str("faas.version");
-
-/// The execution environment ID as a string.
-pub const FAAS_INSTANCE: Key = Key::from_static_str("faas.instance");
-
-/// Unique host ID.
-///
-/// For Cloud, this must be the instance_id assigned by the cloud provider.
-pub const HOST_ID: Key = Key::from_static_str("host.id");
-
-/// Name of the host.
-///
-/// On Unix systems, it may contain what the `hostname` command returns, or the
-/// fully qualified hostname, or another name specified by the user.
-pub const HOST_NAME: Key = Key::from_static_str("host.name");
-
-/// Type of host.
-///
-/// For Cloud, this must be the machine type.
-pub const HOST_TYPE: Key = Key::from_static_str("host.type");
-
-/// Name of the VM image or OS install the host was instantiated from.
-pub const HOST_IMAGE_NAME: Key = Key::from_static_str("host.image.name");
-
-/// VM image ID.
-///
-/// For Cloud, this value is from the provider.
-pub const HOST_IMAGE_ID: Key = Key::from_static_str("host.image.id");
-
-/// The version string of the VM image as defined in [Version Attributes].
-///
-/// [Version Attributes]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions#version-attributes
-pub const HOST_IMAGE_VERSION: Key = Key::from_static_str("host.image.version");
-
-/// The name of the cluster.
-pub const K8S_CLUSTER_NAME: Key = Key::from_static_str("k8s.cluster.name");
-
-/// The name of the namespace that the pod is running in.
-pub const K8S_NAMESPACE_NAME: Key = Key::from_static_str("k8s.namespace.name");
-
-/// The UID of the Pod.
-pub const K8S_POD_UID: Key = Key::from_static_str("k8s.pod.uid");
-
-/// The name of the Pod.
-pub const K8S_POD_NAME: Key = Key::from_static_str("k8s.pod.name");
-
-/// The name of the Container in a Pod template.
-pub const K8S_CONTAINER_NAME: Key = Key::from_static_str("k8s.container.name");
-
-/// The UID of the ReplicaSet.
-pub const K8S_REPLICASET_UID: Key = Key::from_static_str("k8s.replicaset.uid");
-
-/// The name of the ReplicaSet.
-pub const K8S_REPLICASET_NAME: Key = Key::from_static_str("k8s.replicaset.name");
-
-/// The UID of the Deployment.
-pub const K8S_DEPLOYMENT_UID: Key = Key::from_static_str("k8s.deployment.uid");
-
-/// The name of the Deployment.
-pub const K8S_DEPLOYMENT_NAME: Key = Key::from_static_str("k8s.deployment.name");
-
-/// The UID of the StatefulSet.
-pub const K8S_STATEFULSET_UID: Key = Key::from_static_str("k8s.statefulset.uid");
-
-/// The name of the StatefulSet.
-pub const K8S_STATEFULSET_NAME: Key = Key::from_static_str("k8s.statefulset.name");
-
-/// The UID of the DaemonSet.
-pub const K8S_DAEMONSET_UID: Key = Key::from_static_str("k8s.daemonset.uid");
-
-/// The name of the DaemonSet.
-pub const K8S_DAEMONSET_NAME: Key = Key::from_static_str("k8s.daemonset.name");
-
-/// The UID of the Job.
-pub const K8S_JOB_UID: Key = Key::from_static_str("k8s.job.uid");
-
-/// The name of the Job.
-pub const K8S_JOB_NAME: Key = Key::from_static_str("k8s.job.name");
-
-/// The UID of the CronJob.
-pub const K8S_CRONJOB_UID: Key = Key::from_static_str("k8s.cronjob.uid");
-
-/// The name of the CronJob.
-pub const K8S_CRONJOB_NAME: Key = Key::from_static_str("k8s.cronjob.name");
-
-/// The operating system type.
-pub const OS_TYPE: Key = Key::from_static_str("os.type");
-
-/// Human readable (not intended to be parsed) OS version information, like e.g.
-/// reported by `ver` or `lsb_release -a` commands.
-pub const OS_DESCRIPTION: Key = Key::from_static_str("os.description");
-
-/// Process identifier (PID).
-pub const PROCESS_PID: Key = Key::from_static_str("process.pid");
-
-/// The name of the process executable.
-///
-/// On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On
-/// Windows, can be set to the base name of `GetProcessImageFileNameW`.
-pub const PROCESS_EXECUTABLE_NAME: Key = Key::from_static_str("process.executable.name");
-
-/// The full path to the process executable.
-///
-/// On Linux based systems, can be set to the target of `proc/[pid]/exe`. On
-/// Windows, can be set to the result of `GetProcessImageFileNameW`.
-pub const PROCESS_EXECUTABLE_PATH: Key = Key::from_static_str("process.executable.path");
-
-/// The command used to launch the process (i.e. the command name).
-///
-/// On Linux based systems, can be set to the zeroth string in
-/// `proc/[pid]/cmdline`. On Windows, can be set to the first parameter
-/// extracted from `GetCommandLineW`.
-pub const PROCESS_COMMAND: Key = Key::from_static_str("process.command");
-
-/// The full command used to launch the process.
-///
-/// The value can be either a list of strings representing the ordered list of
-/// arguments, or a single string representing the full command.
-///
-/// On Linux based systems, can be set to the list of null-delimited strings
-/// extracted from `proc/[pid]/cmdline`. On Windows, can be set to the result of
-/// `GetCommandLineW`.
-pub const PROCESS_COMMAND_LINE: Key = Key::from_static_str("process.command_line");
-
-/// The username of the user that owns the process.
-pub const PROCESS_OWNER: Key = Key::from_static_str("process.owner");
-
-/// The name of the runtime of this process.
-///
-/// For compiled native binaries, this SHOULD be the name of the compiler.
-pub const PROCESS_RUNTIME_NAME: Key = Key::from_static_str("process.runtime.name");
-
-/// The version of the runtime of this process, as returned by the runtime
-/// without modification.
-pub const PROCESS_RUNTIME_VERSION: Key = Key::from_static_str("process.runtime.version");
-
-/// An additional description about the runtime of the process, for example a
-/// specific vendor customization of the runtime environment.
-pub const PROCESS_RUNTIME_DESCRIPTION: Key = Key::from_static_str("process.runtime.description");

--- a/opentelemetry-semantic-conventions/src/trace.rs
+++ b/opentelemetry-semantic-conventions/src/trace.rs
@@ -1,3 +1,9 @@
+// DO NOT EDIT, this is an auto-generated file
+//
+// If you want to update the file:
+// - Edit the template at scripts/templates/semantic_attributes.rs.j2
+// - Run the script at scripts/generate-consts-from-spec.sh
+
 //! # Trace Semantic Conventions
 //!
 //! The [trace semantic conventions] define a set of standardized attributes to
@@ -8,8 +14,7 @@
 //! ## Usage
 //!
 //! ```rust
-//! use opentelemetry::trace::Tracer;
-//! use opentelemetry::global;
+//! use opentelemetry::{global, trace::Tracer as _};
 //! use opentelemetry_semantic_conventions as semcov;
 //!
 //! let tracer = global::tracer("my-component");
@@ -24,421 +29,662 @@
 
 use opentelemetry::Key;
 
-/// An identifier for the database management system (DBMS) product being used.
+/// An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers.
 pub const DB_SYSTEM: Key = Key::from_static_str("db.system");
 
-/// The connection string used to connect to the database.
+/// The connection string used to connect to the database. It is recommended to remove embedded credentials.
 ///
-/// It is recommended to remove embedded credentials.
+/// # Examples
+///
+/// - Server=(localdb)\v11.0;Integrated Security=true;
 pub const DB_CONNECTION_STRING: Key = Key::from_static_str("db.connection_string");
 
 /// Username for accessing the database.
+///
+/// # Examples
+///
+/// - readonly_user
+/// - reporting_user
 pub const DB_USER: Key = Key::from_static_str("db.user");
 
-/// Remote address of the peer (dotted decimal for IPv4 or [RFC5952] for IPv6)
+/// The fully-qualified class name of the [Java Database Connectivity (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to connect.
 ///
-/// [RFC5952]: https://tools.ietf.org/html/rfc5952
-pub const NET_PEER_IP: Key = Key::from_static_str("net.peer.ip");
-
-/// Remote hostname or similar.
-pub const NET_PEER_NAME: Key = Key::from_static_str("net.peer.name");
-
-/// Remote port number.
-pub const NET_PEER_PORT: Key = Key::from_static_str("net.peer.port");
-
-/// Transport protocol used.
-pub const NET_TRANSPORT: Key = Key::from_static_str("net.transport");
-
-/// The fully-qualified class name of the [Java Database Connectivity (JDBC)]
-/// driver used to connect.
+/// # Examples
 ///
-/// [Java Database Connectivity (JDBC)]: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
+/// - org.postgresql.Driver
+/// - com.microsoft.sqlserver.jdbc.SQLServerDriver
 pub const DB_JDBC_DRIVER_CLASSNAME: Key = Key::from_static_str("db.jdbc.driver_classname");
 
-/// The Microsoft SQL Server [instance name]) connecting to.
+/// If no [tech-specific attribute](#call-level-attributes-for-specific-technologies) is defined, this attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails).
 ///
-/// This name is used to determine the port of a named instance. If setting a
-/// `db.mssql.instance_name`, `net.peer.port` is no longer required (but still
-/// recommended if non-standard).
+/// In some SQL databases, the database name to be used is called &#34;schema name&#34;.
 ///
-/// [instance name]: https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15
-pub const DB_MSSQL_INSTANCE_NAME: Key = Key::from_static_str("db.mssql.instance_name");
-
-/// If no [tech-specific attribute] is defined, this attribute is used to report
-/// the name of the database being accessed.
+/// # Examples
 ///
-/// For commands that switch the database, this should be set to the target
-/// database (even if the command fails).
-///
-/// In some SQL databases, the database name to be used is called "schema name".
-///
-/// [tech-specific attribute]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md#call-level-attributes-for-specific-technologies
+/// - customers
+/// - main
 pub const DB_NAME: Key = Key::from_static_str("db.name");
 
 /// The database statement being executed.
 ///
 /// The value may be sanitized to exclude sensitive information.
+///
+/// # Examples
+///
+/// - SELECT * FROM wuser_table
+/// - SET mykey &#34;WuValue&#34;
 pub const DB_STATEMENT: Key = Key::from_static_str("db.statement");
 
-/// The name of the operation being executed.
+/// The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`, or the SQL keyword.
 ///
-/// e.g. the [MongoDB command name] such as `findAndModify`.
+/// When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
 ///
-/// While it would semantically make sense to set this, e.g., to a SQL keyword
-/// like `SELECT` or `INSERT`, it is not recommended to attempt any client-side
-/// parsing of `db.statement` just to get this property (the back end can do
-/// that if required).
+/// # Examples
 ///
-/// [MongoDB command name]: https://docs.mongodb.com/manual/reference/command/#database-operations
+/// - findAndModify
+/// - HMSET
+/// - SELECT
 pub const DB_OPERATION: Key = Key::from_static_str("db.operation");
 
-/// The name of the keyspace being accessed.
+/// Remote hostname or similar, see note below.
 ///
-/// To be used instead of the generic `db.name` attribute.
+/// # Examples
+///
+/// - example.com
+pub const NET_PEER_NAME: Key = Key::from_static_str("net.peer.name");
+
+/// Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6).
+///
+/// # Examples
+///
+/// - 127.0.0.1
+pub const NET_PEER_IP: Key = Key::from_static_str("net.peer.ip");
+
+/// Remote port number.
+///
+/// # Examples
+///
+/// - 80
+/// - 8080
+/// - 443
+pub const NET_PEER_PORT: Key = Key::from_static_str("net.peer.port");
+
+/// Transport protocol used. See note below.
+///
+/// # Examples
+///
+/// - IP.TCP
+pub const NET_TRANSPORT: Key = Key::from_static_str("net.transport");
+
+/// The Microsoft SQL Server [instance name](https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15) connecting to. This name is used to determine the port of a named instance.
+///
+/// If setting a `db.mssql.instance_name`, `net.peer.port` is no longer required (but still recommended if non-standard).
+///
+/// # Examples
+///
+/// - MSSQLSERVER
+pub const DB_MSSQL_INSTANCE_NAME: Key = Key::from_static_str("db.mssql.instance_name");
+
+/// The name of the keyspace being accessed. To be used instead of the generic `db.name` attribute.
+///
+/// # Examples
+///
+/// - mykeyspace
 pub const DB_CASSANDRA_KEYSPACE: Key = Key::from_static_str("db.cassandra.keyspace");
 
-/// The [HBase namespace] being accessed.
+/// The fetch size used for paging, i.e. how many rows will be returned at once.
 ///
-/// To be used instead of the generic `db.name` attribute.
+/// # Examples
 ///
-/// [HBase namespace]: https://hbase.apache.org/book.html#_namespace
+/// - 5000
+pub const DB_CASSANDRA_PAGE_SIZE: Key = Key::from_static_str("db.cassandra.page_size");
+
+/// The consistency level of the query. Based on consistency values from [CQL](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html).
+pub const DB_CASSANDRA_CONSISTENCY_LEVEL: Key =
+    Key::from_static_str("db.cassandra.consistency_level");
+
+/// The name of the primary table that the operation is acting upon, including the schema name (if applicable).
+///
+/// This mirrors the db.sql.table attribute but references cassandra rather than sql. It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+///
+/// # Examples
+///
+/// - mytable
+pub const DB_CASSANDRA_TABLE: Key = Key::from_static_str("db.cassandra.table");
+
+/// Whether or not the query is idempotent.
+pub const DB_CASSANDRA_IDEMPOTENCE: Key = Key::from_static_str("db.cassandra.idempotence");
+
+/// The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
+///
+/// # Examples
+///
+/// - 0
+/// - 2
+pub const DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT: Key =
+    Key::from_static_str("db.cassandra.speculative_execution_count");
+
+/// The ID of the coordinating node for a query.
+///
+/// # Examples
+///
+/// - be13faa2-8574-4d71-926d-27f16cf8a7af
+pub const DB_CASSANDRA_COORDINATOR_ID: Key = Key::from_static_str("db.cassandra.coordinator.id");
+
+/// The data center of the coordinating node for a query.
+///
+/// # Examples
+///
+/// - us-west-2
+pub const DB_CASSANDRA_COORDINATOR_DC: Key = Key::from_static_str("db.cassandra.coordinator.dc");
+
+/// The [HBase namespace](https://hbase.apache.org/book.html#_namespace) being accessed. To be used instead of the generic `db.name` attribute.
+///
+/// # Examples
+///
+/// - default
 pub const DB_HBASE_NAMESPACE: Key = Key::from_static_str("db.hbase.namespace");
 
-/// The index of the database being accessed as used in the [`SELECT` command],
-/// provided as an integer.
+/// The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` attribute.
 ///
-/// To be used instead of the generic `db.name` attribute.
+/// # Examples
 ///
-/// [`SELECT` command]: https://redis.io/commands/select
+/// - 0
+/// - 1
+/// - 15
 pub const DB_REDIS_DATABASE_INDEX: Key = Key::from_static_str("db.redis.database_index");
 
 /// The collection being accessed within the database stated in `db.name`.
+///
+/// # Examples
+///
+/// - customers
+/// - products
 pub const DB_MONGODB_COLLECTION: Key = Key::from_static_str("db.mongodb.collection");
 
-/// The type of the exception (its fully-qualified class name, if applicable).
+/// The name of the primary table that the operation is acting upon, including the schema name (if applicable).
 ///
-/// The dynamic type of the exception should be preferred over the static type
-/// in languages that support it.
+/// It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+///
+/// # Examples
+///
+/// - public.users
+/// - customers
+pub const DB_SQL_TABLE: Key = Key::from_static_str("db.sql.table");
+
+/// The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
+///
+/// # Examples
+///
+/// - java.net.ConnectException
+/// - OSError
 pub const EXCEPTION_TYPE: Key = Key::from_static_str("exception.type");
 
 /// The exception message.
+///
+/// # Examples
+///
+/// - Division by zero
+/// - Can&#39;t convert &#39;int&#39; object to str implicitly
 pub const EXCEPTION_MESSAGE: Key = Key::from_static_str("exception.message");
 
-/// A stacktrace as a string in the natural representation for the language
-/// runtime.
+/// A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
 ///
-/// The representation is to be determined and documented by each language SIG.
+/// # Examples
+///
+/// - Exception in thread &#34;main&#34; java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
 pub const EXCEPTION_STACKTRACE: Key = Key::from_static_str("exception.stacktrace");
 
-/// SHOULD be set to true if the exception event is recorded at a point where it
-/// is known that the exception is escaping the scope of the span.
+/// SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.
 ///
-/// An exception is considered to have escaped (or left) the scope of a span, if
-/// that span is ended while the exception is still logically "in flight". This
-/// may be actually "in flight" in some languages (e.g. if the exception is
-/// passed to a Context manager's `__exit__` method in Python) but will usually
-/// be caught at the point of recording the exception in most languages.
+/// An exception is considered to have escaped (or left) the scope of a span,
+/// if that span is ended while the exception is still logically &#34;in flight&#34;.
+/// This may be actually &#34;in flight&#34; in some languages (e.g. if the exception
+/// is passed to a Context manager&#39;s `__exit__` method in Python) but will
+/// usually be caught at the point of recording the exception in most languages.
 ///
-/// It is usually not possible to determine at the point where an exception is
-/// thrown whether it will escape the scope of a span. However, it is trivial to
-/// know that an exception will escape, if one checks for an active exception
-/// just before ending the span, as done in the [example
-/// above](#exception-end-example).
+/// It is usually not possible to determine at the point where an exception is thrown
+/// whether it will escape the scope of a span.
+/// However, it is trivial to know that an exception
+/// will escape, if one checks for an active exception just before ending the span,
+/// as done in the [example above](#exception-end-example).
 ///
-/// It follows that an exception may still escape the scope of the span even if
-/// the `exception.escaped` attribute was not set or set to false, since the
-/// event might have been recorded at a time where it was not clear whether the
-/// exception will escape.
+/// It follows that an exception may still escape the scope of the span
+/// even if the `exception.escaped` attribute was not set or set to false,
+/// since the event might have been recorded at a time where it was not
+/// clear whether the exception will escape.
 pub const EXCEPTION_ESCAPED: Key = Key::from_static_str("exception.escaped");
 
 /// Type of the trigger on which the function is executed.
-///
-/// It SHOULD be one of the following strings: "datasource", "http", "pubsub",
-/// "timer", or "other".
 pub const FAAS_TRIGGER: Key = Key::from_static_str("faas.trigger");
 
-/// String containing the execution id of the function.
+/// The execution ID of the current function execution.
 ///
-/// E.g. `af9d5aa4-a685-4c5f-a22b-444f80b3cc28`
+/// # Examples
+///
+/// - af9d5aa4-a685-4c5f-a22b-444f80b3cc28
 pub const FAAS_EXECUTION: Key = Key::from_static_str("faas.execution");
 
-/// Indicates that the serverless function is executed for the first time (aka
-/// cold start).
-pub const FAAS_COLDSTART: Key = Key::from_static_str("faas.coldstart");
-
-/// The name of the invoked function.
-pub const FAAS_INVOKED_NAME: Key = Key::from_static_str("faas.invoked_name");
-
-/// The cloud provider of the invoked function.
-pub const FAAS_INVOKED_PROVIDER: Key = Key::from_static_str("faas.invoked_provider");
-
-/// The cloud region of the invoked function.
-pub const FAAS_INVOKED_REGION: Key = Key::from_static_str("faas.invoked_region");
-
-/// The name of the source on which the operation was performed.
+/// The name of the source on which the triggering operation was performed. For example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name.
 ///
-/// For example, in Cloud Storage or S3 corresponds to the bucket name, and in
-/// Cosmos DB to the database name.
+/// # Examples
+///
+/// - myBucketName
+/// - myDbName
 pub const FAAS_DOCUMENT_COLLECTION: Key = Key::from_static_str("faas.document.collection");
 
 /// Describes the type of the operation that was performed on the data.
-///
-/// It SHOULD be one of the following strings: "insert", "edit", "delete".
 pub const FAAS_DOCUMENT_OPERATION: Key = Key::from_static_str("faas.document.operation");
 
-/// A string containing the time when the data was accessed in the [ISO 8601]
-/// format expressed in [UTC].
+/// A string containing the time when the data was accessed in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime).
 ///
-/// E.g. `"2020-01-23T13:47:06Z"`
+/// # Examples
 ///
-/// [ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
-/// [UTC]: https://www.w3.org/TR/NOTE-datetime
+/// - 2020-01-23T13:47:06Z
 pub const FAAS_DOCUMENT_TIME: Key = Key::from_static_str("faas.document.time");
 
-/// The document name/table subjected to the operation.
+/// The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name.
 ///
-/// For example, in Cloud Storage or S3 is the name of the file, and in Cosmos
-/// DB the table name.
+/// # Examples
+///
+/// - myFile.txt
+/// - myTableName
 pub const FAAS_DOCUMENT_NAME: Key = Key::from_static_str("faas.document.name");
 
-/// A string containing the function invocation time in the [ISO 8601] format
-/// expressed in [UTC].
-///
-/// E.g. `"2020-01-23T13:47:06Z"`
-///
-/// [ISO 8601]: https://www.iso.org/iso-8601-date-and-time-format.html
-/// [UTC]: https://www.w3.org/TR/NOTE-datetime
-pub const FAAS_TIME: Key = Key::from_static_str("faas.time");
-
-/// A string containing the schedule period as [Cron Expression].
-///
-/// E.g. `"0/5 * * * ? *"`
-///
-/// [Cron Expression]: https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm
-pub const FAAS_CRON: Key = Key::from_static_str("faas.cron");
-
 /// HTTP request method.
+///
+/// # Examples
+///
+/// - GET
+/// - POST
+/// - HEAD
 pub const HTTP_METHOD: Key = Key::from_static_str("http.method");
 
-/// Full HTTP request URL in the form
-/// `scheme://host[:port]/path?query[#fragment]`.
+/// Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`. Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
 ///
-/// Usually the fragment is not transmitted over HTTP, but if it is known, it
-/// should be included nevertheless.
+/// `http.url` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute&#39;s value should be `https://www.example.com/`.
+///
+/// # Examples
+///
+/// - https://www.foo.bar/search?q=OpenTelemetry#SemConv
 pub const HTTP_URL: Key = Key::from_static_str("http.url");
 
 /// The full request target as passed in a HTTP request line or equivalent.
+///
+/// # Examples
+///
+/// - /path/12314/?q=ddds#123
 pub const HTTP_TARGET: Key = Key::from_static_str("http.target");
 
-/// The value of the [HTTP host header].
+/// The value of the [HTTP host header](https://tools.ietf.org/html/rfc7230#section-5.4). When the header is empty or not present, this attribute should be the same.
 ///
-/// When the header is empty or not present, this attribute should be the same.
+/// # Examples
 ///
-/// [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4
+/// - www.example.org
 pub const HTTP_HOST: Key = Key::from_static_str("http.host");
 
 /// The URI scheme identifying the used protocol.
+///
+/// # Examples
+///
+/// - http
+/// - https
 pub const HTTP_SCHEME: Key = Key::from_static_str("http.scheme");
 
 /// [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).
+///
+/// # Examples
+///
+/// - 200
 pub const HTTP_STATUS_CODE: Key = Key::from_static_str("http.status_code");
 
 /// Kind of HTTP protocol used.
 ///
-/// If net.transport is not specified, it can be assumed to be IP.TCP except if
-/// http.flavor is QUIC, in which case IP.UDP is assumed.
+/// If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 ///
-/// http.flavor` MUST be one of the following or, if none of the listed values
-/// apply, a custom value:
+/// # Examples
 ///
-/// | Value  | Description |
-/// |---|---|
-/// | `1.0` | HTTP 1.0 |
-/// | `1.1` | HTTP 1.1 |
-/// | `2.0` | HTTP 2 |
-/// | `SPDY` | SPDY protocol. |
-/// | `QUIC` | QUIC protocol. |
+/// - 1.0
 pub const HTTP_FLAVOR: Key = Key::from_static_str("http.flavor");
 
-/// Value of the [HTTP User-Agent] header sent by the client.
+/// Value of the [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the client.
 ///
-/// [HTTP User-Agent]: https://tools.ietf.org/html/rfc7231#section-5.5.3
+/// # Examples
+///
+/// - CERN-LineMode/2.15 libwww/2.17b3
 pub const HTTP_USER_AGENT: Key = Key::from_static_str("http.user_agent");
 
-/// The size of the request payload body in bytes.
+/// The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size.
 ///
-/// This is the number of bytes transferred excluding headers and is often, but
-/// not always, present as the [Content-Length] header. For requests using
-/// transport encoding, this should be the compressed size.
+/// # Examples
 ///
-/// [Content-Length]: https://tools.ietf.org/html/rfc7230#section-3.3.2
+/// - 3495
 pub const HTTP_REQUEST_CONTENT_LENGTH: Key = Key::from_static_str("http.request_content_length");
 
-/// The size of the uncompressed request payload body after transport decoding.
+/// The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used.
 ///
-/// Not set if transport encoding not used.
+/// # Examples
+///
+/// - 5493
 pub const HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED: Key =
     Key::from_static_str("http.request_content_length_uncompressed");
 
-/// The size of the response payload body in bytes.
+/// The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size.
 ///
-/// This is the number of bytes transferred excluding headers and is often, but
-/// not always, present as the [Content-Length] header. For requests using
-/// transport encoding, this should be the compressed size.
+/// # Examples
 ///
-/// [Content-Length]: https://tools.ietf.org/html/rfc7230#section-3.3.2
+/// - 3495
 pub const HTTP_RESPONSE_CONTENT_LENGTH: Key = Key::from_static_str("http.response_content_length");
 
-/// The size of the uncompressed response payload body after transport decoding.
+/// The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used.
 ///
-/// Not set if transport encoding not used.
+/// # Examples
+///
+/// - 5493
 pub const HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED: Key =
     Key::from_static_str("http.response_content_length_uncompressed");
 
-/// The primary server name of the matched virtual host.
+/// The primary server name of the matched virtual host. This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set ( `net.host.name` should be used instead).
 ///
-/// This should be obtained via configuration. If no such configuration can be
-/// obtained, this attribute MUST NOT be set ( `net.host.name` should be used
-/// instead).
+/// `http.url` is usually not readily available on the server side but would have to be assembled in a cumbersome and sometimes lossy process from other information (see e.g. open-telemetry/opentelemetry-python/pull/148). It is thus preferred to supply the raw data that is available.
 ///
-/// `http.url` is usually not readily available on the server side but would have
-/// to be assembled in a cumbersome and sometimes lossy process from other
-/// information (see e.g. open-telemetry/opentelemetry-python/pull/148). It is
-/// thus preferred to supply the raw data that is available.
+/// # Examples
+///
+/// - example.com
 pub const HTTP_SERVER_NAME: Key = Key::from_static_str("http.server_name");
 
 /// The matched route (path template).
+///
+/// # Examples
+///
+/// - /users/:userID?
 pub const HTTP_ROUTE: Key = Key::from_static_str("http.route");
 
-/// The IP address of the original client behind all proxies, if known (e.g.
-/// from [X-Forwarded-For]).
+/// The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)).
 ///
-/// This is not necessarily the same as `net.peer.ip`, which would identify the
-/// network-level peer, which may be a proxy.
+/// This is not necessarily the same as `net.peer.ip`, which would identify the network-level peer, which may be a proxy.
 ///
-/// [X-Forwarded-For]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+/// # Examples
+///
+/// - 83.164.160.102
 pub const HTTP_CLIENT_IP: Key = Key::from_static_str("http.client_ip");
 
+/// Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.
+///
+/// # Examples
+///
+/// - 192.168.0.1
+pub const NET_HOST_IP: Key = Key::from_static_str("net.host.ip");
+
+/// Like `net.peer.port` but for the host port.
+///
+/// # Examples
+///
+/// - 35555
+pub const NET_HOST_PORT: Key = Key::from_static_str("net.host.port");
+
+/// Local hostname or similar, see note below.
+///
+/// # Examples
+///
+/// - localhost
+pub const NET_HOST_NAME: Key = Key::from_static_str("net.host.name");
+
 /// A string identifying the messaging system.
+///
+/// # Examples
+///
+/// - kafka
+/// - rabbitmq
+/// - activemq
 pub const MESSAGING_SYSTEM: Key = Key::from_static_str("messaging.system");
 
-/// The message destination name.
+/// The message destination name. This might be equal to the span name but is required nevertheless.
 ///
-/// This might be equal to the span name but is required nevertheless.
+/// # Examples
+///
+/// - MyQueue
+/// - MyTopic
 pub const MESSAGING_DESTINATION: Key = Key::from_static_str("messaging.destination");
 
-/// The kind of message destination
+/// The kind of message destination.
 pub const MESSAGING_DESTINATION_KIND: Key = Key::from_static_str("messaging.destination_kind");
 
 /// A boolean that is true if the message destination is temporary.
 pub const MESSAGING_TEMP_DESTINATION: Key = Key::from_static_str("messaging.temp_destination");
 
 /// The name of the transport protocol.
+///
+/// # Examples
+///
+/// - AMQP
+/// - MQTT
 pub const MESSAGING_PROTOCOL: Key = Key::from_static_str("messaging.protocol");
 
 /// The version of the transport protocol.
+///
+/// # Examples
+///
+/// - 0.9.1
 pub const MESSAGING_PROTOCOL_VERSION: Key = Key::from_static_str("messaging.protocol_version");
 
 /// Connection string.
+///
+/// # Examples
+///
+/// - tibjmsnaming://localhost:7222
+/// - https://queue.amazonaws.com/80398EXAMPLE/MyQueue
 pub const MESSAGING_URL: Key = Key::from_static_str("messaging.url");
 
-/// A value used by the messaging system as an identifier for the message,
-/// represented as a string.
+/// A value used by the messaging system as an identifier for the message, represented as a string.
+///
+/// # Examples
+///
+/// - 452a7c7c7c7048c2f887f61572b18fc2
 pub const MESSAGING_MESSAGE_ID: Key = Key::from_static_str("messaging.message_id");
 
-/// The [conversation ID] identifying the conversation to which the message
-/// belongs, represented as a string.
+/// The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called &#34;Correlation ID&#34;.
 ///
-/// Sometimes called "Correlation ID".
+/// # Examples
 ///
-/// [conversation ID]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/messaging.md#conversations
+/// - MyConversationId
 pub const MESSAGING_CONVERSATION_ID: Key = Key::from_static_str("messaging.conversation_id");
 
-/// The (uncompressed) size of the message payload in bytes.
+/// The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
 ///
-/// Also use this attribute if it is unknown whether the compressed or
-/// uncompressed payload size is reported.
+/// # Examples
+///
+/// - 2738
 pub const MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES: Key =
     Key::from_static_str("messaging.message_payload_size_bytes");
 
 /// The compressed size of the message payload in bytes.
+///
+/// # Examples
+///
+/// - 2048
 pub const MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES: Key =
     Key::from_static_str("messaging.message_payload_compressed_size_bytes");
 
-/// A string identifying the kind of message consumption as defined in the
-/// [Operation names] section above.
+/// A string containing the function invocation time in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime).
 ///
-/// If the operation is "send", this attribute MUST NOT be set, since the
-/// operation can be inferred from the span kind in that case.
+/// # Examples
 ///
-/// [Operation names]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/messaging.md#operation-names
-pub const MESSAGING_OPERATION: Key = Key::from_static_str("messaging.operation");
+/// - 2020-01-23T13:47:06Z
+pub const FAAS_TIME: Key = Key::from_static_str("faas.time");
 
-/// A string identifying the remoting system.
-pub const RPC_SYSTEM: Key = Key::from_static_str("rpc.system");
-
-/// The full name of the service being called, including its package name, if
-/// applicable.
-pub const RPC_SERVICE: Key = Key::from_static_str("rpc.service");
-
-/// The name of the method being called, must be equal to the $method part in
-/// the span name.
-pub const RPC_METHOD: Key = Key::from_static_str("rpc.method");
-
-/// Like `net.peer.ip` but for the host IP.
+/// A string containing the schedule period as [Cron Expression](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm).
 ///
-/// Useful in case of a multi-IP host.
-pub const NET_HOST_IP: Key = Key::from_static_str("net.host.ip");
-
-/// Like `net.peer.port` but for the host port.
-pub const NET_HOST_PORT: Key = Key::from_static_str("net.host.port");
-
-/// Local hostname or similar
-pub const NET_HOST_NAME: Key = Key::from_static_str("net.host.name");
-
-/// The [`service.name`] of the remote service.
+/// # Examples
 ///
-/// SHOULD be equal to the actual `service.name` resource attribute of the
-/// remote service if any.
+/// - 0/5 * * * ? *
+pub const FAAS_CRON: Key = Key::from_static_str("faas.cron");
+
+/// A boolean that is true if the serverless function is executed for the first time (aka cold-start).
+pub const FAAS_COLDSTART: Key = Key::from_static_str("faas.coldstart");
+
+/// The name of the invoked function.
 ///
-/// [`service.name`]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/README.md#service
+/// SHOULD be equal to the `faas.name` resource attribute of the invoked function.
+///
+/// # Examples
+///
+/// - my-function
+pub const FAAS_INVOKED_NAME: Key = Key::from_static_str("faas.invoked_name");
+
+/// The cloud provider of the invoked function.
+///
+/// SHOULD be equal to the `cloud.provider` resource attribute of the invoked function.
+///
+/// # Examples
+///
+/// - aws
+pub const FAAS_INVOKED_PROVIDER: Key = Key::from_static_str("faas.invoked_provider");
+
+/// The cloud region of the invoked function.
+///
+/// SHOULD be equal to the `cloud.region` resource attribute of the invoked function.
+///
+/// # Examples
+///
+/// - eu-central-1
+pub const FAAS_INVOKED_REGION: Key = Key::from_static_str("faas.invoked_region");
+
+/// The [`service.name`](../../resource/semantic_conventions/README.md#service) of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any.
+///
+/// # Examples
+///
+/// - AuthTokenCache
 pub const PEER_SERVICE: Key = Key::from_static_str("peer.service");
 
-/// Username or client_id extracted from the access token or [Authorization]
-/// header in the inbound request from outside the system.
+/// Username or client_id extracted from the access token or [Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) header in the inbound request from outside the system.
 ///
-/// [Authorization]: https://tools.ietf.org/html/rfc7235#section-4.2
+/// # Examples
+///
+/// - username
 pub const ENDUSER_ID: Key = Key::from_static_str("enduser.id");
 
-/// Actual/assumed role the client is making the request under extracted from
-/// token or application security context.
+/// Actual/assumed role the client is making the request under extracted from token or application security context.
+///
+/// # Examples
+///
+/// - admin
 pub const ENDUSER_ROLE: Key = Key::from_static_str("enduser.role");
 
-/// Scopes or granted authorities the client currently possesses extracted from
-/// token or application security context.
+/// Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an [OAuth 2.0 Access Token](https://tools.ietf.org/html/rfc6749#section-3.3) or an attribute value in a [SAML 2.0 Assertion](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html).
 ///
-/// The value would come from the scope associated with an [OAuth 2.0 Access
-/// Token] or an attribute value in a [SAML 2.0 Assertion].
+/// # Examples
 ///
-/// [OAuth 2.0 Access Token]: https://tools.ietf.org/html/rfc6749#section-3.3
-/// [SAML 2.0 Assertion]: http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html
+/// - read:message, write:files
 pub const ENDUSER_SCOPE: Key = Key::from_static_str("enduser.scope");
 
-/// The method or function name, or equivalent (usually rightmost part of the
-/// code unit's name).
+/// Current &#34;managed&#34; thread ID (as opposed to OS thread ID).
+///
+/// # Examples
+///
+/// - 42
+pub const THREAD_ID: Key = Key::from_static_str("thread.id");
+
+/// Current thread name.
+///
+/// # Examples
+///
+/// - main
+pub const THREAD_NAME: Key = Key::from_static_str("thread.name");
+
+/// The method or function name, or equivalent (usually rightmost part of the code unit&#39;s name).
+///
+/// # Examples
+///
+/// - serveRequest
 pub const CODE_FUNCTION: Key = Key::from_static_str("code.function");
 
-/// The "namespace" within which `code.function` is defined.
+/// The &#34;namespace&#34; within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit.
 ///
-/// Usually the qualified class or module name, such that `code.namespace` +
-/// some separator + `code.function` form a unique identifier for the code unit.
+/// # Examples
+///
+/// - com.example.MyHttpService
 pub const CODE_NAMESPACE: Key = Key::from_static_str("code.namespace");
 
-/// The source code file name that identifies the code unit as uniquely as
-/// possible (preferably an absolute file path).
+/// The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).
+///
+/// # Examples
+///
+/// - /usr/local/MyApplication/content_root/app/index.php
 pub const CODE_FILEPATH: Key = Key::from_static_str("code.filepath");
 
-/// The line number in `code.filepath` best representing the operation.
+/// The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
 ///
-/// It SHOULD point within the code unit named in `code.function`.
+/// # Examples
+///
+/// - 42
 pub const CODE_LINENO: Key = Key::from_static_str("code.lineno");
+
+/// A string identifying the kind of message consumption as defined in the [Operation names](#operation-names) section above. If the operation is &#34;send&#34;, this attribute MUST NOT be set, since the operation can be inferred from the span kind in that case.
+pub const MESSAGING_OPERATION: Key = Key::from_static_str("messaging.operation");
+
+/// Message keys in Kafka are used for grouping alike messages to ensure they&#39;re processed on the same partition. They differ from `messaging.message_id` in that they&#39;re not unique. If the key is `null`, the attribute MUST NOT be set.
+///
+/// If the key type is not string, it&#39;s string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don&#39;t include its value.
+///
+/// # Examples
+///
+/// - myKey
+pub const MESSAGING_KAFKA_MESSAGE_KEY: Key = Key::from_static_str("messaging.kafka.message_key");
+
+/// Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
+///
+/// # Examples
+///
+/// - my-group
+pub const MESSAGING_KAFKA_CONSUMER_GROUP: Key =
+    Key::from_static_str("messaging.kafka.consumer_group");
+
+/// Client Id for the Consumer or Producer that is handling the message.
+///
+/// # Examples
+///
+/// - client-5
+pub const MESSAGING_KAFKA_CLIENT_ID: Key = Key::from_static_str("messaging.kafka.client_id");
+
+/// Partition the message is sent to.
+///
+/// # Examples
+///
+/// - 2
+pub const MESSAGING_KAFKA_PARTITION: Key = Key::from_static_str("messaging.kafka.partition");
+
+/// A boolean that is true if the message is a tombstone.
+pub const MESSAGING_KAFKA_TOMBSTONE: Key = Key::from_static_str("messaging.kafka.tombstone");
+
+/// A string identifying the remoting system.
+///
+/// # Examples
+///
+/// - grpc
+/// - java_rmi
+/// - wcf
+pub const RPC_SYSTEM: Key = Key::from_static_str("rpc.system");
+
+/// The full name of the service being called, including its package name, if applicable.
+///
+/// # Examples
+///
+/// - myservice.EchoService
+pub const RPC_SERVICE: Key = Key::from_static_str("rpc.service");
+
+/// The name of the method being called, must be equal to the $method part in the span name.
+///
+/// # Examples
+///
+/// - exampleMethod
+pub const RPC_METHOD: Key = Key::from_static_str("rpc.method");
+
+/// The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request.
+///
+/// # Examples
+///
+/// - 0
+/// - 1
+/// - 16
+pub const RPC_GRPC_STATUS_CODE: Key = Key::from_static_str("rpc.grpc.status_code");


### PR DESCRIPTION
Semantic conventions were a bit outdated. They also exist as YAML files now and there is a code generation tool. This PR:

- Changes the generation script to use the `otel/semconvgen` Docker image and the semantic conventions YAML files.
- Updates the `const`s based on version v1.1.0 of the spec.

This means we loose the manual changes we made to some of the constants. Possibly the most notable one is the Rust backtrace example. But using the generation tool is so much easier that I think it's worth it.

Let me now what you think.