### PR TITLE
Allow batch span processor to export data as soon as a batch is filled

### DIFF
--- a/opentelemetry/src/runtime.rs
+++ b/opentelemetry/src/runtime.rs
@@ -17,7 +17,7 @@ use std::{future::Future, time::Duration};
 pub trait Runtime: Clone + Send + Sync + 'static {
     /// A future stream, which returns items in a previously specified interval. The item type is
     /// not important.
-    type Interval: Stream + Send + Unpin;
+    type Interval: Stream + Send;
 
     /// A future, which resolves after a previously specified amount of time. The output type is
     /// not important.

--- a/opentelemetry/src/runtime.rs
+++ b/opentelemetry/src/runtime.rs
@@ -17,7 +17,7 @@ use std::{future::Future, time::Duration};
 pub trait Runtime: Clone + Send + Sync + 'static {
     /// A future stream, which returns items in a previously specified interval. The item type is
     /// not important.
-    type Interval: Stream + Send;
+    type Interval: Stream + Send + Unpin;
 
     /// A future, which resolves after a previously specified amount of time. The output type is
     /// not important.

--- a/opentelemetry/src/testing/mod.rs
+++ b/opentelemetry/src/testing/mod.rs
@@ -1,1 +1,4 @@
+//! Utilities to help unit tests and integration tests
+//!
+
 pub mod trace;

--- a/opentelemetry/src/testing/trace.rs
+++ b/opentelemetry/src/testing/trace.rs
@@ -90,18 +90,16 @@ pub fn new_test_exporter() -> (TestSpanExporter, Receiver<SpanData>, Receiver<()
 
 #[derive(Debug)]
 pub struct TokioSpanExporter {
-    tx_export: tokio::sync::mpsc::UnboundedSender<SpanData>,
+    tx_export: tokio::sync::mpsc::UnboundedSender<Vec<SpanData>>,
     tx_shutdown: tokio::sync::mpsc::UnboundedSender<()>,
 }
 
 #[async_trait]
 impl SpanExporter for TokioSpanExporter {
     async fn export(&mut self, batch: Vec<SpanData>) -> ExportResult {
-        for span_data in batch {
-            self.tx_export
-                .send(span_data)
-                .map_err::<TestExportError, _>(Into::into)?;
-        }
+        self.tx_export
+            .send(batch)
+            .map_err::<TestExportError, _>(Into::into)?;
         Ok(())
     }
 
@@ -112,7 +110,7 @@ impl SpanExporter for TokioSpanExporter {
 
 pub fn new_tokio_test_exporter() -> (
     TokioSpanExporter,
-    tokio::sync::mpsc::UnboundedReceiver<SpanData>,
+    tokio::sync::mpsc::UnboundedReceiver<Vec<SpanData>>,
     tokio::sync::mpsc::UnboundedReceiver<()>,
 ) {
     let (tx_export, rx_export) = tokio::sync::mpsc::unbounded_channel();


### PR DESCRIPTION
resolves #468 

## Problem

When generating spans at a high speed, users often experience span loss because the buffer reaches max size. Currently, the solution is to encourage users to use a larger buffer size and a shorter delay. This PR proposes a new export mode within the batch span processor. This allows the batch span processor to export spans as soon as the batch is filled. 

## Proposed solution

We spawn two tasks to handle the exports of spans. One is `collect task`, which collects spans and determines whether it's time to export it. The other is `export task`, which exports a batch of spans. 

The `collect task` should be non-blocking unless the message it received is shutdown or force push. When a span sent to `collect task`, it will push the span into the buffer. `collect task` will send a batch to `export task` in two cases, one is when the batch's size reaches the `max_export_size`, the other is when pre-defined `scheduled_delay` reaches. `collect task` will restart the `schedule_delay` timer after each export.

The `export task` polls batches of spans from the channel between it and `collect task`. The channel between them serves as a temporary buffer for the exporter. The channel length is `max_queue_size`. Note that the element of this channel is `Vec<SpanData>`. Thus, the buffer can hold `max_queue_size * batch_size` spans.

Note that even in this mode, users can still experience span loss if the spans are generating faster than the exporter can handle. Specifically, the `collect task` will drop spans if the channel between it and `export task` has been filled.


<details>
  <summary>Diagram</summary>

  ```
                  ┌─────────────────────────┐
                  │      User tasks         │
                  │                         │
                  └─────────┬───────────────┘
                            │
                            │ Export spans
                            │
┌───────────────────────────┼─────────────────────────────────────────────────────────────────────┐
│                           │                                                                     │
│  Batch span processor     │                                                                     │
│                           │                                                                     │
│                        ┌──┼──────────────────────────────────────────────────────────────┐      │
│                        │  │ Collect task                                                 │      │
│                        │  │                                                              │      │
│                        │ ┌▼──────────────┐                    ┌───────────────┐          │      │
│                        │ │ Buffer        │                    │  Delay timer  │          │      │
│                        │ └─────┬─────────┘                    └──────┬─────▲──┘          │      │
│                        │       │                                     │     │             │      │
│                        │       │                                     │     │             │      │
│                        │       │    Buffer filled or timer hit       │     │ Reset timer │      │
│                        │       └─────────────────┬───────────────────┘     │             │      │
│                        │                         │                         │             │      │
│                        │  ┌──────────────────────┴─────────────────────────┘             │      │
│                        │  │                                                              │      │
│                        └──┼──────────────────────────────────────────────────────────────┘      │
│                           │                                                                     │
│                           │  Push a batch of spans                                              │
│                           │                                                                     │
│                           │       ┌────────────────────────┐                                    │
│                           └───────►  Export queue          ├────┐                               │
│                                   └────────────────────────┘    │                               │
│                                                                 │                               │
│                                           Poll a batch of spans │                               │
│                                                                 │                               │
│                                               ┌─────────────────▼──────┐                        │
│                                               │   Export task          │                        │
│                                               │                        │                        │
│                                               └─────────────────┬──────┘                        │
│                                                                 │                               │
│                                                                 │ Export                        │
│                                                                 │                               │
└─────────────────────────────────────────────────────────────────┼───────────────────────────────┘
                                                                  │
                                                                  │
                                                                  
   ```
</details>

## Open questions
1. How do we handle communication failure between tasks?
2. How do we decide the length of the channel between `collect task` and `export task`?