### PR TITLE
Remove #[must_use] from set_tracer_provider

### DIFF
--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -252,6 +252,9 @@ pub fn tracer_with_version(name: &'static str, version: &'static str) -> BoxedTr
 
 /// Sets the given [`TracerProvider`] instance as the current global provider.
 ///
+/// It returns the [`TracerProvider`] instance that was previously mounted as global provider
+/// (e.g. [`NoopTracerProvider`] if a provider had not been set before).
+///
 /// [`TracerProvider`]: crate::trace::TracerProvider
 pub fn set_tracer_provider<P, T, S>(new_provider: P) -> GlobalTracerProvider
 where

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -253,7 +253,6 @@ pub fn tracer_with_version(name: &'static str, version: &'static str) -> BoxedTr
 /// Sets the given [`TracerProvider`] instance as the current global provider.
 ///
 /// [`TracerProvider`]: crate::trace::TracerProvider
-#[must_use]
 pub fn set_tracer_provider<P, T, S>(new_provider: P) -> GlobalTracerProvider
 where
     S: trace::Span + Send + Sync,


### PR DESCRIPTION
I believe `#[must_use]` here is a legacy leftover from the previous version of `opentelemetry`, where `set_tracer_provider` returned a guard.
I have updated the documentation as well to clarify what is being returned.