### PR TITLE
Add opentelemetry.io docs

### DIFF
--- a/website_docs/_index.md
+++ b/website_docs/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Rust"
+weight: 26
+description: >
+  A language-specific implementation of OpenTelemetry in Rust.
+---
+
+This is the OpenTelemetry for Rust documentation. OpenTelemetry is an
+observability framework -- an API, SDK, and tools that are designed to aid in
+the generation and collection of application telemetry data such as metrics,
+logs, and traces. This documentation is designed to help you understand how to
+get started using OpenTelemetry for Rust.
+
+# Status and Releases
+
+The current status of the major functional components for OpenTelemetry Rust is
+as follows:
+
+| Tracing | Metrics | Logging |
+| ------- | ------- | ------- |
+| Beta    | Alpha   | Not Yet Implemented |
+
+The current release can be found [here](https://github.com/open-telemetry/opentelemetry-rust/releases)
+
+# Further Reading
+
+- [docs.rs](https://docs.rs/opentelemetry)
+- [Examples](https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples)
+- [Contrib](https://github.com/open-telemetry/opentelemetry-rust#ecosystem)


### PR DESCRIPTION
Per open-telemetry/opentelemetry.io#472, we're mirroring the docs content on the website to each SIG. When a release occurs and these docs are updated, please make an issue or PR mirroring them to their appropriate location in the website repo (https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/rust).