### PR TITLE
fix: otlp docs cannot compile.

### DIFF
--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -25,6 +25,11 @@ name = "smoke"
 path = "tests/smoke.rs"
 required-features = ["integration-testing"]
 
+[[test]]
+name = "grpc_build"
+path = "tests/grpc_build.rs"
+required-features = ["grpc-sys"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
@@ -43,6 +48,8 @@ tokio = { version = "1.0", features = ["full"], optional = true }
 [dev-dependencies]
 chrono = "0.4"
 tokio-stream = { version = "0.1", features = ["net"] }
+protobuf-codegen = { version = "2.16"}
+protoc-grpcio = { version = "2.0"}
 
 [features]
 trace = ["opentelemetry/trace"]
@@ -52,12 +59,10 @@ default = ["tonic", "tonic-build", "prost", "tokio"]
 tls = ["tonic/tls"]
 tls-roots = ["tls", "tonic/tls-roots"]
 
-grpc-sys = ["grpcio", "protobuf", "protobuf-codegen", "protoc-grpcio"]
+grpc-sys = ["grpcio", "protobuf"]
 openssl = ["grpcio/openssl"]
 openssl-vendored = ["grpcio/openssl-vendored"]
 integration-testing = ["tonic", "tonic-build", "prost", "tokio/full", "opentelemetry/trace"]
 
 [build-dependencies]
-protobuf-codegen = { version = "2.16", optional = true }
-protoc-grpcio = { version = "2.0", optional = true }
 tonic-build = { version = "0.4", optional = true }

--- a/opentelemetry-otlp/build.rs
+++ b/opentelemetry-otlp/build.rs
@@ -1,12 +1,8 @@
-#[cfg(feature = "grpc-sys")]
-extern crate protoc_grpcio;
-
-#[cfg(feature = "grpc-sys")]
-use protobuf_codegen::Customize;
-
-#[cfg(feature = "grpc-sys")]
-use protoc_grpcio::compile_grpc_protos;
-
+// Grpc related files used by tonic are generated here. Those files re-generate for each build
+// so it's up to date.
+//
+// Grpc related files used by grpcio are maintained at src/proto/grpcio. tests/grpc_build.rs makes
+// sure they are up to date.
 fn main() {
     #[cfg(feature = "tonic")]
         tonic_build::configure()
@@ -26,29 +22,4 @@ fn main() {
             &["src/proto/opentelemetry-proto"],
         )
         .expect("Error generating protobuf");
-
-    #[cfg(feature = "grpc-sys")]
-    {
-        let result = compile_grpc_protos(
-                &[
-                    "src/proto/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto",
-                    "src/proto/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto",
-                    "src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace.proto",
-                    "src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace_config.proto",
-                    "src/proto/opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.proto",
-                    "src/proto/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto",
-                    "src/proto/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
-                ],
-                &["src/proto/opentelemetry-proto/"],
-                "src/proto/grpcio",
-                Some(Customize {
-                    expose_fields: Some(true),
-                    serde_derive: Some(true),
-                    ..Default::default()
-                }),
-            );
-        if let Err(err) = result {
-            println!("cargo:warning=Error generating protobuf: {:?}", err);
-        }
-    }
 }

--- a/opentelemetry-otlp/build.rs
+++ b/opentelemetry-otlp/build.rs
@@ -28,23 +28,27 @@ fn main() {
         .expect("Error generating protobuf");
 
     #[cfg(feature = "grpc-sys")]
-        compile_grpc_protos(
-        &[
-            "src/proto/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto",
-            "src/proto/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto",
-            "src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace.proto",
-            "src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace_config.proto",
-            "src/proto/opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.proto",
-            "src/proto/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto",
-            "src/proto/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
-        ],
-        &["src/proto/opentelemetry-proto/"],
-        "src/proto/grpcio",
-        Some(Customize {
-            expose_fields: Some(true),
-            serde_derive: Some(true),
-            ..Default::default()
-        }),
-    )
-        .expect("Error generating protobuf");
+        {
+            let result = compile_grpc_protos(
+                &[
+                    "src/proto/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto",
+                    "src/proto/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto",
+                    "src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace.proto",
+                    "src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace_config.proto",
+                    "src/proto/opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.proto",
+                    "src/proto/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto",
+                    "src/proto/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
+                ],
+                &["src/proto/opentelemetry-proto/"],
+                "src/proto/grpcio",
+                Some(Customize {
+                    expose_fields: Some(true),
+                    serde_derive: Some(true),
+                    ..Default::default()
+                }),
+            );
+            if let Err(err) = result {
+                println!("cargo:warning=Error generating protobuf: {:?}", err);
+            }
+        }
 }

--- a/opentelemetry-otlp/build.rs
+++ b/opentelemetry-otlp/build.rs
@@ -28,8 +28,8 @@ fn main() {
         .expect("Error generating protobuf");
 
     #[cfg(feature = "grpc-sys")]
-        {
-            let result = compile_grpc_protos(
+    {
+        let result = compile_grpc_protos(
                 &[
                     "src/proto/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto",
                     "src/proto/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto",
@@ -47,8 +47,8 @@ fn main() {
                     ..Default::default()
                 }),
             );
-            if let Err(err) = result {
-                println!("cargo:warning=Error generating protobuf: {:?}", err);
-            }
+        if let Err(err) = result {
+            println!("cargo:warning=Error generating protobuf: {:?}", err);
         }
+    }
 }

--- a/opentelemetry-otlp/tests/grpc_build.rs
+++ b/opentelemetry-otlp/tests/grpc_build.rs
@@ -1,0 +1,55 @@
+use protobuf_codegen::Customize;
+use protoc_grpcio::compile_grpc_protos;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+// This test helps to keep files generated and used by grpcio update to date.
+// If the test fails, it means the generated files has been changed. Please commit the change
+// and rerun test. It should pass at the second time.
+#[test]
+fn build_grpc() {
+    let before_build = build_content_map();
+    compile_grpc_protos(
+        &[
+            "src/proto/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto",
+            "src/proto/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto",
+            "src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace.proto",
+            "src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace_config.proto",
+            "src/proto/opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.proto",
+            "src/proto/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto",
+            "src/proto/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
+        ],
+        &["src/proto/opentelemetry-proto/"],
+        "src/proto/grpcio",
+        Some(Customize {
+            expose_fields: Some(true),
+            serde_derive: Some(true),
+            ..Default::default()
+        }),
+    )
+        .expect("Error generating protobuf");
+    let after_build = build_content_map();
+    // we cannot use assert_eq! here because it will print both maps when they don't match, which makes
+    // the error message unreadable.
+    assert!(
+        before_build == after_build,
+        "generated file has changed, please commit the change file and rerun the test"
+    );
+}
+
+fn build_content_map() -> HashMap<PathBuf, String> {
+    let mut map = HashMap::new();
+    let dict =
+        std::fs::read_dir("src/proto/grpcio").expect("cannot open dict of generated grpc files");
+    for entry in dict {
+        if let Ok(entry) = entry {
+            map.insert(
+                entry.path(),
+                std::fs::read_to_string(entry.path()).unwrap_or_else(|_| {
+                    panic!("cannot read from file {}", entry.path().to_string_lossy())
+                }),
+            );
+        }
+    }
+    map
+}


### PR DESCRIPTION
The bug was introduced since we are compiling grpc files using both tonic and grpcio.

The build logs say:
 thread 'main' panicked at 'Error generating protobuf: Os { code: 30, kind: Other, message: "Read-only file system" }

But we already have compiled files in `proto/grpcio`. Thus ignore this error and print a warning message.

fix #496 