### PR TITLE
Rename remaining usage of default_sampler

### DIFF
--- a/opentelemetry/src/sdk/trace/config.rs
+++ b/opentelemetry/src/sdk/trace/config.rs
@@ -30,7 +30,7 @@ pub struct Config {
 }
 
 impl Config {
-    /// Specify the default sampler to be used.
+    /// Specify the sampler to be used.
     pub fn with_sampler<T: sdk::trace::ShouldSample + 'static>(mut self, sampler: T) -> Self {
         self.sampler = Box::new(sampler);
         self

--- a/opentelemetry/src/sdk/trace/config.rs
+++ b/opentelemetry/src/sdk/trace/config.rs
@@ -16,7 +16,7 @@ pub fn config() -> Config {
 #[derive(Debug)]
 pub struct Config {
     /// The sampler that the sdk should use
-    pub default_sampler: Box<dyn sdk::trace::ShouldSample>,
+    pub sampler: Box<dyn sdk::trace::ShouldSample>,
     /// The id generator that the sdk should use
     pub id_generator: Box<dyn IdGenerator>,
     /// The max events that can be added to a `Span`.
@@ -32,7 +32,7 @@ pub struct Config {
 impl Config {
     /// Specify the default sampler to be used.
     pub fn with_sampler<T: sdk::trace::ShouldSample + 'static>(mut self, sampler: T) -> Self {
-        self.default_sampler = Box::new(sampler);
+        self.sampler = Box::new(sampler);
         self
     }
 
@@ -71,7 +71,7 @@ impl Default for Config {
     /// Create default global sdk configuration.
     fn default() -> Self {
         let mut config = Config {
-            default_sampler: Box::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn))),
+            sampler: Box::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn))),
             id_generator: Box::new(sdk::trace::IdGenerator::default()),
             max_events_per_span: 128,
             max_attributes_per_span: 128,

--- a/opentelemetry/src/sdk/trace/tracer.rs
+++ b/opentelemetry/src/sdk/trace/tracer.rs
@@ -76,7 +76,7 @@ impl Tracer {
         links: &[Link],
         config: &Config,
     ) -> Option<(u8, Vec<KeyValue>, TraceState)> {
-        let sampling_result = config.default_sampler.should_sample(
+        let sampling_result = config.sampler.should_sample(
             Some(parent_cx),
             trace_id,
             name,


### PR DESCRIPTION
Fix last reference to default sampler left over from #482