### PR TITLE
Use current span for SDK-less context propagation

### DIFF
--- a/opentelemetry/src/trace/noop.rs
+++ b/opentelemetry/src/trace/noop.rs
@@ -6,7 +6,7 @@
 use crate::{
     sdk::export::trace::{ExportResult, SpanData, SpanExporter},
     trace,
-    trace::{TraceContextExt, TraceState},
+    trace::{SpanBuilder, TraceContextExt, TraceState},
     Context, KeyValue,
 };
 use async_trait::async_trait;
@@ -131,14 +131,12 @@ impl trace::Tracer for NoopTracer {
 
     /// Starts a new `NoopSpan` with a given context.
     ///
-    /// If the context contains a valid span context, it is propagated.
+    /// If the context contains a valid span, it's span context is propagated.
     fn start_with_context<T>(&self, name: T, cx: Context) -> Self::Span
     where
         T: Into<std::borrow::Cow<'static, str>>,
     {
-        let mut builder = self.span_builder(name);
-        builder.parent_context = Some(cx);
-        self.build(builder)
+        self.build(SpanBuilder::from_name_with_context(name, cx))
     }
 
     /// Starts a `SpanBuilder`.
@@ -151,13 +149,16 @@ impl trace::Tracer for NoopTracer {
 
     /// Builds a `NoopSpan` from a `SpanBuilder`.
     ///
-    /// If the span builder or context contains a valid span context, it is propagated.
-    fn build(&self, mut builder: trace::SpanBuilder) -> Self::Span {
-        match builder.parent_context.take() {
-            Some(cx) if cx.has_active_span() => trace::NoopSpan {
+    /// If the span builder or the context's current span contains a valid span context, it is
+    /// propagated.
+    fn build(&self, builder: trace::SpanBuilder) -> Self::Span {
+        let cx = builder.parent_context;
+        if cx.has_active_span() {
+            trace::NoopSpan {
                 span_context: cx.span().span_context().clone(),
-            },
-            _ => self.invalid(),
+            }
+        } else {
+            self.invalid()
         }
     }
 }
@@ -212,13 +213,13 @@ mod tests {
         let tracer = NoopTracer::new();
         let builder = tracer
             .span_builder("foo")
-            .with_parent_context(Context::current_with_span(TestSpan(valid_span_context())));
+            .with_parent_context(Context::new().with_span(TestSpan(valid_span_context())));
         let span = tracer.build(builder);
         assert!(span.span_context().is_valid());
     }
 
     #[test]
-    fn noop_tracer_propagates_valid_span_context_from_span() {
+    fn noop_tracer_propagates_valid_span_context_from_explicitly_specified_context() {
         let tracer = NoopTracer::new();
         let cx = Context::new().with_span(NoopSpan {
             span_context: valid_span_context(),

--- a/opentelemetry/src/trace/tracer.rs
+++ b/opentelemetry/src/trace/tracer.rs
@@ -337,7 +337,7 @@ pub trait Tracer: fmt::Debug + 'static {
 #[derive(Clone, Debug, Default)]
 pub struct SpanBuilder {
     /// Parent `Context`
-    pub parent_context: Option<Context>,
+    pub parent_context: Context,
     /// Trace id, useful for integrations with external tracing systems.
     pub trace_id: Option<TraceId>,
     /// Span id, useful for integrations with external tracing systems.
@@ -368,8 +368,16 @@ pub struct SpanBuilder {
 impl SpanBuilder {
     /// Create a new span builder from a span name
     pub fn from_name<T: Into<Cow<'static, str>>>(name: T) -> Self {
+        Self::from_name_with_context(name, Context::current())
+    }
+
+    /// Create a new span builder from a span name with the specified context
+    pub(crate) fn from_name_with_context<T: Into<Cow<'static, str>>>(
+        name: T,
+        parent_context: Context,
+    ) -> Self {
         SpanBuilder {
-            parent_context: None,
+            parent_context,
             trace_id: None,
             span_id: None,
             span_kind: None,
@@ -388,7 +396,7 @@ impl SpanBuilder {
     /// Assign parent context
     pub fn with_parent_context(self, parent_context: Context) -> Self {
         SpanBuilder {
-            parent_context: Some(parent_context),
+            parent_context,
             ..self
         }
     }


### PR DESCRIPTION
In the absence of an SDK the API should not record spans anymore but it should propagate the span context. In our case absence of an SDK means we're using the `NoopTracer`.

See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#behavior-of-the-api-in-the-absence-of-an-installed-sdk

There are different ways to create new spans and they provide different ways of specifying the parent context:

- `Tracer::start`: uses `Context::current()`
- `Tracer::build`: uses the context from the span builder or falls back to the current context. BUT we did not have this fallback in the `NoopTracer`.
- `Tracer::start_with_context`: uses the specified context

This changes the `SpanBuilder` to make its `parent_context` non-optional. That way the current context fallback is done on
`SpanBuilder` creation. Tracer implementations just need to read the `parent_context` from the span builder.

---

- I hope I understood the spec correctly here 🙂 
- I'm not entirely sure if this is the best way to do it. Happy to take suggestions.