### PR TITLE
opentelemetry-http: return response from HttpClient

### DIFF
--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -38,5 +38,7 @@ lazy_static = "1.4"
 
 [dev-dependencies]
 base64 = "0.13"
+bytes = "1"
+futures-util = "0.3"
 isahc = "0.9"
 opentelemetry = { path = "../opentelemetry", features = ["trace", "testing"] }

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -12,7 +12,7 @@ use opentelemetry::sdk::export::trace;
 use opentelemetry::sdk::export::trace::SpanData;
 use opentelemetry::trace::TraceError;
 use opentelemetry::{global, sdk, trace::TracerProvider};
-use opentelemetry_http::HttpClient;
+use opentelemetry_http::{HttpClient, ResponseExt};
 
 /// Default Datadog collector endpoint
 const DEFAULT_AGENT_ENDPOINT: &str = "http://127.0.0.1:8126";
@@ -201,7 +201,8 @@ impl trace::SpanExporter for DatadogExporter {
             .header(DATADOG_TRACE_COUNT_HEADER, trace_count)
             .body(data)
             .map_err::<Error, _>(Into::into)?;
-        self.client.send(req).await
+        let _ = self.client.send(req).await?.error_for_status()?;
+        Ok(())
     }
 }
 

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -81,10 +81,14 @@
 //! use opentelemetry::{KeyValue, trace::Tracer};
 //! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
 //! use opentelemetry::sdk::export::trace::ExportResult;
-//! use opentelemetry_datadog::{new_pipeline, ApiVersion, Error};
 //! use opentelemetry::global::shutdown_tracer_provider;
-//! use opentelemetry_http::HttpClient;
+//! use opentelemetry_datadog::{new_pipeline, ApiVersion, Error};
+//! use opentelemetry_http::{HttpClient, HttpError};
 //! use async_trait::async_trait;
+//! use bytes::Bytes;
+//! use futures_util::io::AsyncReadExt as _;
+//! use http::{Request, Response};
+//! use std::convert::TryInto as _;
 //!
 //! // `reqwest` and `surf` are supported through features, if you prefer an
 //! // alternate http client you can add support by implementing `HttpClient` as
@@ -92,17 +96,20 @@
 //! #[derive(Debug)]
 //! struct IsahcClient(isahc::HttpClient);
 //!
+//! async fn body_to_bytes(mut body: isahc::Body) -> Result<Bytes, HttpError> {
+//!     let mut bytes = Vec::with_capacity(body.len().unwrap_or(0).try_into()?);
+//!     let _ = body.read_to_end(&mut bytes).await?;
+//!     Ok(bytes.into())
+//! }
+//!
 //! #[async_trait]
 //! impl HttpClient for IsahcClient {
-//!   async fn send(&self, request: http::Request<Vec<u8>>) -> ExportResult {
-//!     let result = self.0.send_async(request).await.map_err(|err| Error::Other(err.to_string()))?;
-//!
-//!     if result.status().is_success() {
-//!       Ok(())
-//!     } else {
-//!       Err(Error::Other(result.status().to_string()).into())
+//!     async fn send(&self, request: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
+//!         let response = self.0.send_async(request).await?;
+//!         Ok(Response::builder()
+//!             .status(response.status())
+//!             .body(body_to_bytes(response.into_body()).await?)?)
 //!     }
-//!   }
 //! }
 //!
 //! fn main() -> Result<(), opentelemetry::trace::TraceError> {

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -10,10 +10,11 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1.42"
-http = "0.2.2"
+async-trait = "0.1"
+bytes = "1"
+futures-util = { version = "0.3", default-features = false, features = ["io"] }
+http = "0.2"
 isahc = { version = "0.9", default-features = false, optional = true }
 opentelemetry = { version = "0.13", path = "../opentelemetry", features = ["trace"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking"], optional = true }
 surf = { version = "2.0", default-features = false, optional = true }
-thiserror = "1"

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -41,8 +41,9 @@ headers = { version = "0.3.2", optional = true }
 surf = { version = "2.0", optional = true }
 
 [dev-dependencies]
-opentelemetry = { version = "0.13", default-features = false, features = ["trace", "testing"], path = "../opentelemetry" }
+bytes = "1"
 futures = "0.3"
+opentelemetry = { version = "0.13", default-features = false, features = ["trace", "testing"], path = "../opentelemetry" }
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/opentelemetry-jaeger/src/exporter/collector.rs
+++ b/opentelemetry-jaeger/src/exporter/collector.rs
@@ -1,7 +1,7 @@
 //! # HTTP Jaeger Collector Client
 use http::Uri;
 #[cfg(feature = "collector_client")]
-use opentelemetry_http::HttpClient;
+use opentelemetry_http::{HttpClient, ResponseExt as _};
 use std::sync::atomic::AtomicUsize;
 
 /// `CollectorAsyncClientHttp` implements an async version of the
@@ -68,7 +68,8 @@ mod collector_client {
                 .expect("request should always be valid");
 
             // Send request to collector
-            self.client.send(req).await
+            let _ = self.client.send(req).await?.error_for_status()?;
+            Ok(())
         }
     }
 }

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -672,10 +672,9 @@ mod collector_client_tests {
 
     mod test_http_client {
         use async_trait::async_trait;
-        use http::Request;
-        use opentelemetry::sdk::export::trace::ExportResult;
-        use opentelemetry::trace::TraceError;
-        use opentelemetry_http::HttpClient;
+        use bytes::Bytes;
+        use http::{Request, Response};
+        use opentelemetry_http::{HttpClient, HttpError};
         use std::fmt::Debug;
 
         pub(crate) struct TestHttpClient;
@@ -688,8 +687,8 @@ mod collector_client_tests {
 
         #[async_trait]
         impl HttpClient for TestHttpClient {
-            async fn send(&self, _request: Request<Vec<u8>>) -> ExportResult {
-                Err(TraceError::from("wrong uri set in http client"))
+            async fn send(&self, _request: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
+                Err("wrong uri set in http client".into())
             }
         }
     }
@@ -707,7 +706,7 @@ mod collector_client_tests {
         });
         assert_eq!(
             format!("{:?}", res.err().unwrap()),
-            "Other(Custom(\"wrong uri set in http client\"))"
+            "Other(\"wrong uri set in http client\")"
         );
 
         Ok(())

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -40,5 +40,7 @@ surf = { version = "2.0", optional = true }
 thiserror = { version = "1.0"}
 
 [dev-dependencies]
+bytes = "1"
+futures-util = "0.3"
 isahc = "=0.9.6"
 opentelemetry = { version = "0.13", default-features = false, features = ["trace", "testing"], path = "../opentelemetry" }

--- a/opentelemetry-zipkin/src/exporter/uploader.rs
+++ b/opentelemetry-zipkin/src/exporter/uploader.rs
@@ -3,7 +3,7 @@ use crate::exporter::model::span::Span;
 use crate::exporter::Error;
 use http::{header::CONTENT_TYPE, Method, Request, Uri};
 use opentelemetry::sdk::export::trace::ExportResult;
-use opentelemetry_http::HttpClient;
+use opentelemetry_http::{HttpClient, ResponseExt};
 use std::fmt::Debug;
 
 #[derive(Debug)]
@@ -42,6 +42,7 @@ impl JsonV2Client {
             .header(CONTENT_TYPE, "application/json")
             .body(serde_json::to_vec(&spans).unwrap_or_default())
             .map_err::<Error, _>(Into::into)?;
-        self.client.send(req).await
+        let _ = self.client.send(req).await?.error_for_status()?;
+        Ok(())
     }
 }


### PR DESCRIPTION
Make the `HttpClient` trait in opentelemetry-http return a HTTP response instead of `()`. This enables exporters using this trait to implement retry behavior based on the result of the call.

The response currently contains the status code and response body. If needed we can also add the response headers later on.

The response body is typed as `bytes::Bytes`, which seems was the easiest to implement. `reqwest` returns `Bytes` and we can't easily get to the underlying bytes without copying. The other clients return a form of `[u8]`, which is easy to turn into `Bytes`.

The only error that can be returned from the `HttpClient` is because of connection issues, timeouts or possibly infinite redirects. I can create a custom error type instead of `Box<Error>` if that seems more appropriate.

My use case is the Azure Application Insights exporter. AppInsights may accept only some of the spans in a batch and not others because of rate limiting. To understand which ones went through we need to look at the status code and response body.