### PR TITLE
feat: allow users to bring their own tonic channel.

### DIFF
--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -346,9 +346,9 @@ impl TonicPipelineBuilder {
         self
     }
 
-    /// Use `channel` as tonic's transports channel.
+    /// Use `channel` as tonic's transport channel.
     /// this will override tls config and should only be used
-    /// when working with non-HTTP transport.
+    /// when working with non-HTTP transports.
     ///
     /// Users MUST make sure the [`ExporterConfig::timeout`] is
     /// the same as the channel's timeout.

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -346,7 +346,7 @@ impl TonicPipelineBuilder {
         self
     }
 
-    /// Use `channel` as tonic's transport channel.
+    /// Use `channel` as tonic's transports channel.
     /// this will override tls config and should only be used
     /// when working with non-HTTP transport.
     ///

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -295,6 +295,7 @@ impl OtlpPipelineBuilder {
             exporter_config: self.exporter_config,
             trace_config: self.trace_config,
             tonic_config: TonicConfig::default(),
+            channel: None,
         }
     }
 
@@ -327,6 +328,7 @@ pub struct TonicPipelineBuilder {
     exporter_config: ExporterConfig,
     tonic_config: TonicConfig,
     trace_config: Option<sdk::trace::Config>,
+    channel: Option<tonic::transport::Channel>,
 }
 
 #[cfg(feature = "tonic")]
@@ -344,6 +346,19 @@ impl TonicPipelineBuilder {
         self
     }
 
+    /// Use `channel` as tonic's transport channel.
+    /// this will override tls config and should only be used
+    /// when working with non-HTTP transport.
+    ///
+    /// Users MUST make sure the [`ExporterConfig::timeout`] is
+    /// the same as the channel's timeout.
+    ///
+    /// [`ExporterConfig::timeout`]: crate::span::ExporterConfig::timeout
+    pub fn with_channel(mut self, channel: tonic::transport::Channel) -> Self {
+        self.channel = Some(channel);
+        self
+    }
+
     /// Install a trace exporter using [tonic] as grpc layer and a simple span processor.
     ///
     /// Returns a [`Tracer`] with the name `opentelemetry-otlp` and current crate version.
@@ -353,7 +368,12 @@ impl TonicPipelineBuilder {
     /// [`Tracer`]: opentelemetry::trace::Tracer
     /// [tonic]: https://github.com/hyperium/tonic
     pub fn install_simple(self) -> Result<sdk::trace::Tracer, TraceError> {
-        let exporter = TraceExporter::new_tonic(self.exporter_config, self.tonic_config)?;
+        let exporter = match self.channel {
+            Some(channel) => {
+                TraceExporter::from_tonic_channel(self.exporter_config, self.tonic_config, channel)
+            }
+            None => TraceExporter::new_tonic(self.exporter_config, self.tonic_config),
+        }?;
         Ok(build_simple_with_exporter(exporter, self.trace_config))
     }
 
@@ -367,7 +387,12 @@ impl TonicPipelineBuilder {
     /// [`Tracer`]: opentelemetry::trace::Tracer
     /// [tonic]: https://github.com/hyperium/tonic
     pub fn install_batch<R: Runtime>(self, runtime: R) -> Result<sdk::trace::Tracer, TraceError> {
-        let exporter = TraceExporter::new_tonic(self.exporter_config, self.tonic_config)?;
+        let exporter = match self.channel {
+            Some(channel) => {
+                TraceExporter::from_tonic_channel(self.exporter_config, self.tonic_config, channel)
+            }
+            None => TraceExporter::new_tonic(self.exporter_config, self.tonic_config),
+        }?;
         Ok(build_batch_with_exporter(
             exporter,
             self.trace_config,

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -206,16 +206,16 @@ impl Debug for TraceExporter {
 }
 
 impl TraceExporter {
-    /// Builds a new span exporter with the given configuration
+    /// Builds a new span exporter with the given configuration.
     #[cfg(feature = "tonic")]
     pub fn new_tonic(
         config: ExporterConfig,
         tonic_config: TonicConfig,
     ) -> Result<Self, crate::Error> {
-        let endpoint = TonicChannel::from_shared(config.endpoint)?;
+        let endpoint = TonicChannel::from_shared(config.endpoint.clone())?;
 
         #[cfg(feature = "tls")]
-        let channel = match tonic_config.tls_config {
+        let channel = match tonic_config.tls_config.clone() {
             Some(tls_config) => endpoint.tls_config(tls_config)?,
             None => endpoint,
         }
@@ -225,6 +225,22 @@ impl TraceExporter {
         #[cfg(not(feature = "tls"))]
         let channel = endpoint.timeout(config.timeout).connect_lazy()?;
 
+        TraceExporter::from_tonic_channel(config, tonic_config, channel)
+    }
+
+    /// Builds a new span exporter with given tonic channel.
+    ///
+    /// This allows users to bring their own custom channel like UDS.
+    /// However, users MUST make sure the [`ExporterConfig::timeout`] is
+    /// the same as the channel's timeout.
+    ///
+    /// [`ExporterConfig::timeout`]: crate::span::ExporterConfig::timeout
+    #[cfg(feature = "tonic")]
+    pub fn from_tonic_channel(
+        config: ExporterConfig,
+        tonic_config: TonicConfig,
+        channel: tonic::transport::Channel,
+    ) -> Result<Self, crate::Error> {
         let client = match tonic_config.metadata.to_owned() {
             None => TonicTraceServiceClient::new(channel),
             Some(metadata) => {

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -215,8 +215,8 @@ impl TraceExporter {
         let endpoint = TonicChannel::from_shared(config.endpoint.clone())?;
 
         #[cfg(feature = "tls")]
-        let channel = match tonic_config.tls_config.clone() {
-            Some(tls_config) => endpoint.tls_config(tls_config)?,
+        let channel = match tonic_config.tls_config.as_ref() {
+            Some(tls_config) => endpoint.tls_config(tls_config.clone())?,
             None => endpoint,
         }
         .timeout(config.timeout)


### PR DESCRIPTION
Sometimes users want to use custom channel like UDS. Added a `from_tonic_channel` function to allow users to bring the custom channel.

fixes #486