### PR TITLE
adding otlp http transport, using proto binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "examples/basic",
     "examples/basic-otlp",
     "examples/basic-otlp-with-selector",
+    "examples/basic-otlp-http",
     "examples/datadog",
     "examples/external-otlp-tonic-tokio",
     "examples/grpc",

--- a/examples/basic-otlp-http/Cargo.toml
+++ b/examples/basic-otlp-http/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "basic-otlp-http"
+version = "0.1.0"
+authors = ["rdan <dan.rusei@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio", "metrics", "serialize"] }
+opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["http-proto", "reqwest-client"] }
+tokio = { version = "1.0", features = ["full"] }

--- a/examples/basic-otlp-http/Dockerfile
+++ b/examples/basic-otlp-http/Dockerfile
@@ -1,0 +1,6 @@
+FROM rust:1.51
+COPY . /usr/src/basic-otlp-http/
+WORKDIR /usr/src/basic-otlp-http/
+RUN cargo build --release
+RUN cargo install --path .
+CMD ["/usr/local/cargo/bin/basic-otlp-http"]

--- a/examples/basic-otlp-http/README.md
+++ b/examples/basic-otlp-http/README.md
@@ -1,0 +1,24 @@
+* The application send data directly to a Collector (port 55681)
+* Run the application locally, to run as a docker container you have to change the relative paths from the `Cargo.toml`
+* The Collector then sends the data to the appropriate backend, in this case JAEGER
+
+This demo uses `docker-compose` and by default runs against the `otel/opentelemetry-collector-dev:latest` image.
+
+```shell
+docker-compose up
+or
+docker-compose up -d
+```
+
+In another terminal run the application `cargo run`
+
+Use the browser to see the trace:
+- Jaeger at http://0.0.0.0:16686
+
+Tear it down:
+
+```shell
+docker-compose down
+```
+
+

--- a/examples/basic-otlp-http/docker-compose.yaml
+++ b/examples/basic-otlp-http/docker-compose.yaml
@@ -1,0 +1,37 @@
+version: "2"
+services:
+
+  # Jaeger
+  jaeger-all-in-one:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "16686:16686"
+      - "14268"
+      - "14250"
+
+  # Collector
+  otel-collector:
+    image: otel/opentelemetry-collector-dev:latest
+    command: ["--config=/etc/otel-collector-config.yaml", "${OTELCOL_ARGS}"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "1888:1888"   # pprof extension
+      - "13133:13133" # health_check extension
+      - "4317"        # OTLP gRPC receiver
+      - "55681:55681" # OTLP HTTP receiver
+      - "55670:55679" # zpages extension
+    depends_on:
+      - jaeger-all-in-one
+
+
+  # metrics-rust:
+  #   build:
+  #     dockerfile: $PWD/Dockerfile
+  #     context: ./basic-otlp-http
+  #   environment:
+  #     - OTLP_TONIC_ENDPOINT=otel-collector:4317
+  #   depends_on:
+  #     - otel-collector
+
+

--- a/examples/basic-otlp-http/otel-collector-config.yaml
+++ b/examples/basic-otlp-http/otel-collector-config.yaml
@@ -1,0 +1,35 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+      grpc:
+
+exporters:
+  logging:
+    loglevel: debug
+
+  jaeger:
+    endpoint: jaeger-all-in-one:14250
+    insecure: true
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, jaeger]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]

--- a/examples/basic-otlp-http/src/main.rs
+++ b/examples/basic-otlp-http/src/main.rs
@@ -1,0 +1,48 @@
+use opentelemetry::trace::TraceError;
+use opentelemetry::{global, sdk::trace as sdktrace};
+use opentelemetry::{
+    trace::{TraceContextExt, Tracer},
+    Key,
+};
+use std::error::Error;
+use std::time::Duration;
+
+fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
+    opentelemetry_otlp::new_pipeline()
+        .with_endpoint("http://localhost:55681/v1/traces")
+        .with_http()
+        .install_batch(opentelemetry::runtime::Tokio)
+}
+
+const LEMONS_KEY: Key = Key::from_static_str("ex.com/lemons");
+const ANOTHER_KEY: Key = Key::from_static_str("ex.com/another");
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let _ = init_tracer()?;
+
+    let tracer = global::tracer("ex.com/basic");
+
+    tracer.in_span("operation", |cx| {
+        let span = cx.span();
+        span.add_event(
+            "Nice operation!".to_string(),
+            vec![Key::new("bogons").i64(100)],
+        );
+        span.set_attribute(ANOTHER_KEY.string("yes"));
+
+        tracer.in_span("Sub operation...", |cx| {
+            let span = cx.span();
+            span.set_attribute(LEMONS_KEY.string("five"));
+
+            span.add_event("Sub span event".to_string(), vec![]);
+        });
+    });
+
+    // wait for 1 minutes so that we could see metrics being pushed via OTLP every 10 seconds.
+    tokio::time::sleep(Duration::from_secs(60)).await;
+
+    global::shutdown_tracer_provider();
+
+    Ok(())
+}

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -44,6 +44,10 @@ protobuf = { version = "2.18", optional = true }
 thiserror = "1.0"
 tonic = { version = "0.4", optional = true }
 tokio = { version = "1.0", features = ["full"], optional = true }
+opentelemetry-http = { version = "0.2", path = "../opentelemetry-http", optional = true }
+reqwest = { version = "0.11", optional = true, default-features = false }
+surf = { version = "2.0", optional = true }
+http = "0.2"
 
 [dev-dependencies]
 chrono = "0.4"
@@ -64,5 +68,12 @@ openssl = ["grpcio/openssl"]
 openssl-vendored = ["grpcio/openssl-vendored"]
 integration-testing = ["tonic", "tonic-build", "prost", "tokio/full", "opentelemetry/trace"]
 
+http-proto = ["prost-build", "prost", "opentelemetry-http"]
+reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
+reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
+reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
+surf-client = ["surf", "opentelemetry-http/surf"]
+
 [build-dependencies]
 tonic-build = { version = "0.4", optional = true }
+prost-build = {version = "0.7", optional = true }

--- a/opentelemetry-otlp/build.rs
+++ b/opentelemetry-otlp/build.rs
@@ -3,12 +3,22 @@
 //
 // Grpc related files used by grpcio are maintained at src/proto/grpcio. tests/grpc_build.rs makes
 // sure they are up to date.
+#[cfg(any(feature = "tonic", feature = "http-proto"))]
+use std::path::PathBuf;
+
 fn main() {
     #[cfg(feature = "tonic")]
+    {
+        let out_dir = PathBuf::from(
+            std::env::var("OUT_DIR").expect("OUT_DIR should be set by cargo but can't find"),
+        )
+        .join("tonic");
+        std::fs::create_dir_all(out_dir.clone()).expect("cannot create output dir");
         tonic_build::configure()
         .build_server(std::env::var_os("CARGO_FEATURE_INTEGRATION_TESTING").is_some())
         .build_client(true)
         .format(false)
+        .out_dir(out_dir)
         .compile(
             &[
                 "src/proto/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto",
@@ -22,4 +32,29 @@ fn main() {
             &["src/proto/opentelemetry-proto"],
         )
         .expect("Error generating protobuf");
+    }
+
+    #[cfg(feature = "http-proto")]
+    {
+        let out_dir = PathBuf::from(
+            std::env::var("OUT_DIR").expect("OUT_DIR should be set by cargo but can't find"),
+        )
+        .join("prost");
+        std::fs::create_dir_all(out_dir.clone()).expect("cannot create output dir");
+        prost_build::Config::new()
+            .out_dir(out_dir)
+            .compile_protos(
+            &[
+                "src/proto/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto",
+                "src/proto/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto",
+                "src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace.proto",
+                "src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace_config.proto",
+                "src/proto/opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.proto",
+                "src/proto/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto",
+                "src/proto/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
+            ],
+            &["src/proto/opentelemetry-proto"],
+            )
+        .expect("Error generating protobuf");
+    }
 }

--- a/opentelemetry-otlp/src/proto.rs
+++ b/opentelemetry-otlp/src/proto.rs
@@ -2,13 +2,13 @@
 pub mod collector {
     pub mod metrics {
         pub mod v1 {
-            tonic::include_proto!("opentelemetry.proto.collector.metrics.v1");
+            include!(concat!(env!("OUT_DIR"), "/tonic", "/opentelemetry.proto.collector.metrics.v1.rs"));
         }
     }
 
     pub mod trace {
         pub mod v1 {
-            tonic::include_proto!("opentelemetry.proto.collector.trace.v1");
+            include!(concat!(env!("OUT_DIR"), "/tonic", "/opentelemetry.proto.collector.trace.v1.rs"));
         }
     }
 }
@@ -16,28 +16,69 @@ pub mod collector {
 #[cfg(feature = "tonic")]
 pub mod common {
     pub mod v1 {
-        tonic::include_proto!("opentelemetry.proto.common.v1");
+        include!(concat!(env!("OUT_DIR"), "/tonic", "/opentelemetry.proto.common.v1.rs"));
     }
 }
 
 #[cfg(feature = "tonic")]
 pub mod metrics {
     pub mod v1 {
-        tonic::include_proto!("opentelemetry.proto.metrics.v1");
+        include!(concat!(env!("OUT_DIR"), "/tonic", "/opentelemetry.proto.metrics.v1.rs"));
     }
 }
 
 #[cfg(feature = "tonic")]
 pub mod resource {
     pub mod v1 {
-        tonic::include_proto!("opentelemetry.proto.resource.v1");
+        include!(concat!(env!("OUT_DIR"), "/tonic", "/opentelemetry.proto.resource.v1.rs"));
     }
 }
 
 #[cfg(feature = "tonic")]
 pub mod trace {
     pub mod v1 {
-        tonic::include_proto!("opentelemetry.proto.trace.v1");
+        include!(concat!(env!("OUT_DIR"), "/tonic", "/opentelemetry.proto.trace.v1.rs"));
+    }
+}
+
+#[cfg(feature="http-proto")]
+pub mod prost {
+    pub mod collector {
+        pub mod metrics {
+            pub mod v1 {
+                include!(concat!(env!("OUT_DIR"), "/prost", "/opentelemetry.proto.collector.metrics.v1.rs"));
+            }
+        }
+
+        pub mod trace {
+            pub mod v1 {
+                include!(concat!(env!("OUT_DIR"), "/prost", "/opentelemetry.proto.collector.trace.v1.rs"));
+            }
+        }
+    }
+
+    pub mod common {
+        pub mod v1 {
+                include!(concat!(env!("OUT_DIR"), "/prost", "/opentelemetry.proto.common.v1.rs"));
+        }
+    }
+
+    pub mod metrics {
+        pub mod v1 {
+                include!(concat!(env!("OUT_DIR"), "/prost", "/opentelemetry.proto.metrics.v1.rs"));
+        }
+    }
+
+    pub mod resource {
+        pub mod v1 {
+                include!(concat!(env!("OUT_DIR"), "/prost", "/opentelemetry.proto.resource.v1.rs"));
+        }
+    }
+
+    pub mod trace {
+        pub mod v1 {
+                include!(concat!(env!("OUT_DIR"), "/prost", "/opentelemetry.proto.trace.v1.rs"));
+        }
     }
 }
 

--- a/opentelemetry-otlp/src/transform/traces.rs
+++ b/opentelemetry-otlp/src/transform/traces.rs
@@ -131,6 +131,135 @@ mod tonic {
     }
 }
 
+#[cfg(feature = "http-proto")]
+mod prost {
+    use super::*;
+    use crate::proto::prost::resource::v1::Resource;
+    use crate::proto::prost::trace::v1::{
+        span, status, InstrumentationLibrarySpans, ResourceSpans, Span, Status,
+    };
+    use crate::transform::common::prost::Attributes;
+
+    impl From<SpanKind> for span::SpanKind {
+        fn from(span_kind: SpanKind) -> Self {
+            match span_kind {
+                SpanKind::Client => span::SpanKind::Client,
+                SpanKind::Consumer => span::SpanKind::Consumer,
+                SpanKind::Internal => span::SpanKind::Internal,
+                SpanKind::Producer => span::SpanKind::Producer,
+                SpanKind::Server => span::SpanKind::Server,
+            }
+        }
+    }
+
+    impl From<StatusCode> for status::StatusCode {
+        fn from(status_code: StatusCode) -> Self {
+            match status_code {
+                StatusCode::Ok => status::StatusCode::Ok,
+                StatusCode::Unset => status::StatusCode::Unset,
+                StatusCode::Error => status::StatusCode::Error,
+            }
+        }
+    }
+
+    impl From<Link> for span::Link {
+        fn from(link: Link) -> Self {
+            span::Link {
+                trace_id: link
+                    .span_context()
+                    .trace_id()
+                    .to_u128()
+                    .to_be_bytes()
+                    .to_vec(),
+                span_id: link
+                    .span_context()
+                    .span_id()
+                    .to_u64()
+                    .to_be_bytes()
+                    .to_vec(),
+                trace_state: link.span_context().trace_state().header(),
+                attributes: Attributes::from(link.attributes().clone()).0,
+                dropped_attributes_count: 0,
+            }
+        }
+    }
+
+    impl From<SpanData> for ResourceSpans {
+        fn from(source_span: SpanData) -> Self {
+            let span_kind: span::SpanKind = source_span.span_kind.into();
+            ResourceSpans {
+                resource: Some(Resource {
+                    attributes: resource_attributes(
+                        source_span.resource.as_ref().map(AsRef::as_ref),
+                    )
+                    .0,
+                    dropped_attributes_count: 0,
+                }),
+                instrumentation_library_spans: vec![InstrumentationLibrarySpans {
+                    instrumentation_library: Default::default(),
+                    spans: vec![Span {
+                        trace_id: source_span
+                            .span_context
+                            .trace_id()
+                            .to_u128()
+                            .to_be_bytes()
+                            .to_vec(),
+                        span_id: source_span
+                            .span_context
+                            .span_id()
+                            .to_u64()
+                            .to_be_bytes()
+                            .to_vec(),
+                        trace_state: source_span.span_context.trace_state().header(),
+                        parent_span_id: {
+                            if source_span.parent_span_id.to_u64() > 0 {
+                                source_span.parent_span_id.to_u64().to_be_bytes().to_vec()
+                            } else {
+                                vec![]
+                            }
+                        },
+                        name: source_span.name.into_owned(),
+                        kind: span_kind as i32,
+                        start_time_unix_nano: to_nanos(source_span.start_time),
+                        end_time_unix_nano: to_nanos(source_span.end_time),
+                        dropped_attributes_count: source_span.attributes.dropped_count(),
+                        attributes: Attributes::from(source_span.attributes).0,
+                        dropped_events_count: source_span.message_events.dropped_count(),
+                        events: source_span
+                            .message_events
+                            .into_iter()
+                            .map(|event| span::Event {
+                                time_unix_nano: to_nanos(event.timestamp),
+                                name: event.name.into(),
+                                attributes: Attributes::from(event.attributes).0,
+                                dropped_attributes_count: 0,
+                            })
+                            .collect(),
+                        dropped_links_count: source_span.links.dropped_count(),
+                        links: source_span.links.into_iter().map(Into::into).collect(),
+                        status: Some(Status {
+                            code: status::StatusCode::from(source_span.status_code).into(),
+                            message: source_span.status_message.into_owned(),
+                            ..Default::default()
+                        }),
+                    }],
+                }],
+            }
+        }
+    }
+
+    fn resource_attributes(resource: Option<&sdk::Resource>) -> Attributes {
+        resource
+            .map(|res| {
+                res.iter()
+                    .map(|(k, v)| opentelemetry::KeyValue::new(k.clone(), v.clone()))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+            .into()
+    }
+}
+
 #[cfg(feature = "grpc-sys")]
 mod grpcio {
     use super::*;

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -22,6 +22,11 @@ if rustup component add clippy; then
   cargo_feature opentelemetry-otlp "trace,grpc-sys"
   cargo_feature opentelemetry-otlp "trace,grpc-sys,openssl"
   cargo_feature opentelemetry-otlp "trace,grpc-sys,openssl-vendored"
+  cargo_feature opentelemetry-otlp "http-proto"
+  cargo_feature opentelemetry-otlp "http-proto, reqwest-blocking-client"
+  cargo_feature opentelemetry-otlp "http-proto, reqwest-client"
+  cargo_feature opentelemetry-otlp "http-proto, reqwest-rustls"
+  cargo_feature opentelemetry-otlp "http-proto, surf-client"
 
   cargo_feature opentelemetry-jaeger "surf_collector_client"
   cargo_feature opentelemetry-jaeger "isahc_collector_client"


### PR DESCRIPTION
this commit fixes #477 
This PR implements the OTLP/HTTP that  uses HTTP POST requests to send telemetry data from clients to servers.
OTLP/HTTP uses Protobuf payloads encoded either in binary format or in JSON format, ths PR addresses only the binary format.
The Protobuf schema of the messages is the same for OTLP/HTTP and OTLP/gRPC. 

This is the first iteration, looking forward for your feedback.