### PR TITLE
use log crate for structured logging

### DIFF
--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -27,6 +27,7 @@ dashmap = { version = "4.0.1", optional = true }
 fnv = { version = "1.0", optional = true }
 futures = "0.3"
 lazy_static = "1.4"
+log = "0.4.14"
 percent-encoding = { version = "2.0", optional = true }
 pin-project = { version = "1.0.2", optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -1,3 +1,4 @@
+use log::error;
 use std::sync::PoisonError;
 use std::sync::RwLock;
 
@@ -44,11 +45,11 @@ pub fn handle_error<T: Into<Error>>(err: T) {
         _ => match err.into() {
             #[cfg(feature = "metrics")]
             #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-            Error::Metric(err) => eprintln!("OpenTelemetry metrics error occurred {:?}", err),
+            Error::Metric(err) => error!("OpenTelemetry metrics error occurred {:?}", err),
             #[cfg(feature = "trace")]
             #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
-            Error::Trace(err) => eprintln!("OpenTelemetry trace error occurred {:?}", err),
-            Error::Other(err_msg) => eprintln!("OpenTelemetry error occurred {}", err_msg),
+            Error::Trace(err) => error!("OpenTelemetry trace error occurred {:?}", err),
+            Error::Other(err_msg) => error!("OpenTelemetry error occurred {}", err_msg),
         },
     }
 }


### PR DESCRIPTION
Currently the errors are simply printed out to the console via `eprintln!`. This PR integrates [rust-lang/log](https://github.com/rust-lang/log) to enable applications using structured logging to also consume the log and/or any error level/target filtering

```
2021-04-15T10:50:05.439886+02:00 - ERROR [opentelemetry::global::error_handler] OpenTelemetry trace error occurred ExportFailed(ThriftAgentError(TransportError { kind: NotOpen, message: "connection refused" }))      foo=1 bar=2 
```

```
{"level":"ERROR","message":"OpenTelemetry trace error occurred ExportFailed(ThriftAgentError(TransportError { kind: NotOpen, message: \"connection refused\" }))","messageMetadata":"","foo":"1","bar":"2","target":"opentelemetry::global::error_handler","timestamp":"2021-04-15T10:50:56.968634+02:00"}
```