### PR TITLE
fix: allow users to use custom export kind selector.

### DIFF
--- a/examples/basic-otlp-with-selector/README.md
+++ b/examples/basic-otlp-with-selector/README.md
@@ -1,4 +1,7 @@
-# Basic OpenTelemetry Example
+# Basic OTLP exporter Example
 
-This example shows basic span and metric usage, and exports to the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) via OTLP with a custom metric aggregator selector.
+This example shows how to configure OTLP metrics exporter to use custom aggregator selectors and custom export kind selectors.
+
+## Prerequisite
+You should first start a `opentelemetry-collector` on localhost using the default configuration. 
 

--- a/examples/basic-otlp/README.md
+++ b/examples/basic-otlp/README.md
@@ -1,4 +1,6 @@
-# Basic OpenTelemetry Example
+# Basic OTLP exporter Example
 
 This example shows basic span and metric usage, and exports to the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) via OTLP.
 
+## Prerequisite
+You should first start a `opentelemetry-collector` on localhost using the default configuration. 

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -169,10 +169,24 @@ where
     }
 
     /// Build with export kind selector
-    pub fn with_export_kind(self, export_selector: ES) -> Self {
+    pub fn with_export_kind<E>(
+        self,
+        export_selector: E,
+    ) -> OtlpMetricPipelineBuilder<AS, E, SP, SO, I, IO>
+    where
+        E: ExportKindFor + Send + Sync + Clone + 'static,
+    {
         OtlpMetricPipelineBuilder {
+            aggregator_selector: self.aggregator_selector,
             export_selector,
-            ..self
+            spawn: self.spawn,
+            interval: self.interval,
+            export_config: self.export_config,
+            tonic_config: self.tonic_config,
+            resource: self.resource,
+            stateful: self.stateful,
+            period: self.period,
+            timeout: self.timeout,
         }
     }
 


### PR DESCRIPTION
Follow up on #497, which allows users to bring their own aggregator selector.

Also updated the name of examples.