### PR TITLE
Rename message events to events

### DIFF
--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -102,7 +102,7 @@ pub(crate) mod tests {
         let mut attributes = sdk::trace::EvictedHashMap::new(capacity, capacity as usize);
         attributes.insert(Key::new("span.type").string("web"));
 
-        let message_events = sdk::trace::EvictedQueue::new(capacity);
+        let events = sdk::trace::EvictedQueue::new(capacity);
         let links = sdk::trace::EvictedQueue::new(capacity);
 
         trace::SpanData {
@@ -113,7 +113,7 @@ pub(crate) mod tests {
             start_time,
             end_time,
             attributes,
-            message_events,
+            events,
             links,
             status_code: StatusCode::Ok,
             status_message: "".into(),

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -521,7 +521,7 @@ fn convert_otel_span_into_jaeger_span(
             span.status_message.into_owned(),
             span.span_kind,
         )),
-        logs: events_to_logs(span.message_events),
+        logs: events_to_logs(span.events),
     }
 }
 

--- a/opentelemetry-otlp/src/transform/traces.rs
+++ b/opentelemetry-otlp/src/transform/traces.rs
@@ -95,9 +95,9 @@ mod tonic {
                         end_time_unix_nano: to_nanos(source_span.end_time),
                         dropped_attributes_count: source_span.attributes.dropped_count(),
                         attributes: Attributes::from(source_span.attributes).0,
-                        dropped_events_count: source_span.message_events.dropped_count(),
+                        dropped_events_count: source_span.events.dropped_count(),
                         events: source_span
-                            .message_events
+                            .events
                             .into_iter()
                             .map(|event| span::Event {
                                 time_unix_nano: to_nanos(event.timestamp),
@@ -224,9 +224,9 @@ mod prost {
                         end_time_unix_nano: to_nanos(source_span.end_time),
                         dropped_attributes_count: source_span.attributes.dropped_count(),
                         attributes: Attributes::from(source_span.attributes).0,
-                        dropped_events_count: source_span.message_events.dropped_count(),
+                        dropped_events_count: source_span.events.dropped_count(),
                         events: source_span
-                            .message_events
+                            .events
                             .into_iter()
                             .map(|event| span::Event {
                                 time_unix_nano: to_nanos(event.timestamp),
@@ -358,10 +358,10 @@ mod grpcio {
                             end_time_unix_nano: to_nanos(source_span.end_time),
                             dropped_attributes_count: source_span.attributes.dropped_count(),
                             attributes: Attributes::from(source_span.attributes).0,
-                            dropped_events_count: source_span.message_events.dropped_count(),
+                            dropped_events_count: source_span.events.dropped_count(),
                             events: RepeatedField::from_vec(
                                 source_span
-                                    .message_events
+                                    .events
                                     .into_iter()
                                     .map(|event| Span_Event {
                                         time_unix_nano: to_nanos(event.timestamp),

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -153,7 +153,7 @@ impl StackDriverExporter {
               .collect();
 
             let time_event = span
-              .message_events
+              .events
               .into_iter()
               .map(|event| TimeEvent {
                 time: Some(event.timestamp.into()),

--- a/opentelemetry-zipkin/src/exporter/model/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/model/mod.rs
@@ -104,13 +104,7 @@ pub(crate) fn into_zipkin_span(local_endpoint: Endpoint, span_data: trace::SpanD
                 .as_micros() as u64,
         )
         .local_endpoint(local_endpoint)
-        .annotations(
-            span_data
-                .message_events
-                .into_iter()
-                .map(Into::into)
-                .collect(),
-        )
+        .annotations(span_data.events.into_iter().map(Into::into).collect())
         .tags(tags)
         .build()
 }

--- a/opentelemetry-zipkin/src/exporter/model/span.rs
+++ b/opentelemetry-zipkin/src/exporter/model/span.rs
@@ -173,7 +173,7 @@ mod tests {
                 start_time: SystemTime::now(),
                 end_time: SystemTime::now(),
                 attributes: EvictedHashMap::new(20, 20),
-                message_events: EvictedQueue::new(20),
+                events: EvictedQueue::new(20),
                 links: EvictedQueue::new(20),
                 status_code,
                 status_message: status_msg.into(),

--- a/opentelemetry/src/sdk/export/trace/mod.rs
+++ b/opentelemetry/src/sdk/export/trace/mod.rs
@@ -72,8 +72,8 @@ pub struct SpanData {
     pub end_time: SystemTime,
     /// Span attributes
     pub attributes: sdk::trace::EvictedHashMap,
-    /// Span Message events
-    pub message_events: sdk::trace::EvictedQueue<Event>,
+    /// Span events
+    pub events: sdk::trace::EvictedQueue<Event>,
     /// Span Links
     pub links: sdk::trace::EvictedQueue<Link>,
     /// Span status code
@@ -116,7 +116,7 @@ mod tests {
 
         let capacity = 3;
         let attributes = sdk::trace::EvictedHashMap::new(capacity, 0);
-        let message_events = sdk::trace::EvictedQueue::new(capacity);
+        let events = sdk::trace::EvictedQueue::new(capacity);
         let links = sdk::trace::EvictedQueue::new(capacity);
 
         let status_code = StatusCode::Ok;
@@ -131,7 +131,7 @@ mod tests {
             start_time,
             end_time,
             attributes,
-            message_events,
+            events,
             links,
             status_code,
             status_message,

--- a/opentelemetry/src/sdk/trace/tracer.rs
+++ b/opentelemetry/src/sdk/trace/tracer.rs
@@ -255,7 +255,7 @@ impl crate::trace::Tracer for Tracer {
             name,
             start_time,
             end_time,
-            message_events,
+            events,
             status_code,
             status_message,
             ..
@@ -282,8 +282,8 @@ impl crate::trace::Tracer for Tracer {
             }
             let start_time = start_time.unwrap_or_else(crate::time::now);
             let end_time = end_time.unwrap_or(start_time);
-            let mut message_events_queue = EvictedQueue::new(span_limits.max_events_per_span);
-            if let Some(mut events) = message_events {
+            let mut events_queue = EvictedQueue::new(span_limits.max_events_per_span);
+            if let Some(mut events) = events {
                 let event_attributes_limit = span_limits.max_attributes_per_event as usize;
                 for event in events.iter_mut() {
                     let dropped_attributes_count = event
@@ -293,7 +293,7 @@ impl crate::trace::Tracer for Tracer {
                     event.attributes.truncate(event_attributes_limit);
                     event.dropped_attributes_count = dropped_attributes_count as u32;
                 }
-                message_events_queue.append_vec(&mut events);
+                events_queue.append_vec(&mut events);
             }
             let status_code = status_code.unwrap_or(StatusCode::Unset);
             let status_message = status_message.unwrap_or(Cow::Borrowed(""));
@@ -305,7 +305,7 @@ impl crate::trace::Tracer for Tracer {
                 start_time,
                 end_time,
                 attributes,
-                message_events: message_events_queue,
+                events: events_queue,
                 links,
                 status_code,
                 status_message,

--- a/opentelemetry/src/testing/trace.rs
+++ b/opentelemetry/src/testing/trace.rs
@@ -47,7 +47,7 @@ pub fn new_test_export_span_data() -> SpanData {
         start_time: crate::time::now(),
         end_time: crate::time::now(),
         attributes: EvictedHashMap::new(config.span_limits.max_attributes_per_span, 0),
-        message_events: EvictedQueue::new(config.span_limits.max_events_per_span),
+        events: EvictedQueue::new(config.span_limits.max_events_per_span),
         links: EvictedQueue::new(config.span_limits.max_links_per_span),
         status_code: StatusCode::Unset,
         status_message: "".into(),

--- a/opentelemetry/src/trace/tracer.rs
+++ b/opentelemetry/src/trace/tracer.rs
@@ -352,8 +352,8 @@ pub struct SpanBuilder {
     pub end_time: Option<SystemTime>,
     /// Span attributes
     pub attributes: Option<Vec<KeyValue>>,
-    /// Span Message events
-    pub message_events: Option<Vec<Event>>,
+    /// Span events
+    pub events: Option<Vec<Event>>,
     /// Span Links
     pub links: Option<Vec<Link>>,
     /// Span status code
@@ -385,7 +385,7 @@ impl SpanBuilder {
             start_time: None,
             end_time: None,
             attributes: None,
-            message_events: None,
+            events: None,
             links: None,
             status_code: None,
             status_message: None,
@@ -449,10 +449,10 @@ impl SpanBuilder {
         }
     }
 
-    /// Assign message events
-    pub fn with_message_events(self, message_events: Vec<Event>) -> Self {
+    /// Assign events
+    pub fn with_events(self, events: Vec<Event>) -> Self {
         SpanBuilder {
-            message_events: Some(message_events),
+            events: Some(events),
             ..self
         }
     }


### PR DESCRIPTION
Message events were a holdover from OpenCensus I believe.