### PR TITLE
Expose the `Error` type to allow users to set custom error handlers

### DIFF
--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -23,7 +23,7 @@ pub enum Error {
     #[cfg(feature = "metrics")]
     #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
     #[error(transparent)]
-    /// Failed to export metrics.
+    /// An issue raised by the metrics module.
     Metric(#[from] MetricsError),
     #[error("{0}")]
     /// Other types of failures not covered by the variants above.

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -18,12 +18,15 @@ pub enum Error {
     #[cfg(feature = "trace")]
     #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
     #[error(transparent)]
+    /// Failed to export traces.
     Trace(#[from] TraceError),
     #[cfg(feature = "metrics")]
     #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
     #[error(transparent)]
+    /// Failed to export metrics.
     Metric(#[from] MetricsError),
     #[error("{0}")]
+    /// Other types of failures not covered by the variants above.
     Other(String),
 }
 

--- a/opentelemetry/src/global/mod.rs
+++ b/opentelemetry/src/global/mod.rs
@@ -144,7 +144,7 @@ mod propagation;
 #[cfg(feature = "trace")]
 mod trace;
 
-pub use error_handler::{handle_error, set_error_handler};
+pub use error_handler::{handle_error, set_error_handler, Error};
 #[cfg(feature = "metrics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 pub use metrics::{


### PR DESCRIPTION
Expose the `Error` type in the `global` module to allow users to define their own error handlers.  
This is currently impossible because `Error` is private and therefore users cannot provide a function that satisfies the constraints of `set_error_handler`.