### PR TITLE
Update grpcio version and add the coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
 [![Documentation](https://docs.rs/opentelemetry/badge.svg)](https://docs.rs/opentelemetry)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
-[![codecov](https://codecov.io/gh/TommyCpp/opentelemetry-rust/branch/master/graph/badge.svg?token=5OYQK2KY8Z)](https://codecov.io/gh/TommyCpp/opentelemetry-rust)
+[![codecov](https://codecov.io/gh/open-telemetry/opentelemetry-rust/branch/main/graph/badge.svg)](https://codecov.io/gh/open-telemetry/opentelemetry-rust)
 [![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
 
 [Website](https://opentelemetry.io/) |

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
 [![Documentation](https://docs.rs/opentelemetry/badge.svg)](https://docs.rs/opentelemetry)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
+[![codecov](https://codecov.io/gh/TommyCpp/opentelemetry-rust/branch/master/graph/badge.svg?token=5OYQK2KY8Z)](https://codecov.io/gh/TommyCpp/opentelemetry-rust)
 [![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
 
 [Website](https://opentelemetry.io/) |

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -37,7 +37,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-trait = "0.1"
 futures = "0.3"
-grpcio = { version = "0.7", optional = true }
+grpcio = { version = "0.8", optional = true }
 opentelemetry = { version = "0.14", default-features = false, features = ["trace"], path = "../opentelemetry" }
 prost = { version = "0.7", optional = true }
 protobuf = { version = "2.18", optional = true }


### PR DESCRIPTION
fix #554 
fix #553 

We probably need to work on adding some tests around the jaeger exporter. I think the metrics' tests can be delayed after tracing GA.