### PR TITLE
Move hyper prometheus example into something runnable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "examples/external-otlp-tonic-tokio",
     "examples/grpc",
     "examples/http",
+    "examples/hyper-prometheus",
     "examples/tracing-grpc",
     "examples/zipkin",
     "examples/multiple-span-processors"

--- a/examples/hyper-prometheus/Cargo.toml
+++ b/examples/hyper-prometheus/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hyper-prometheus"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio"] }
+opentelemetry-prometheus = { path = "../../opentelemetry-prometheus" }
+prometheus = "0.12"
+lazy_static = "1.4"
+hyper = { version = "0.14", features = ["full"] }
+tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
This change moves the hyper-prometheus example out of the opentelemetry-prometheus, and into the global examples folder.

This is the only example located in a subpackage, making it harder to find.
That example also wasn't executable, making it harder to experiment on. By making the folder a part of the workspace, we can now run `cargo run` on it and see the behavior.

I've also changed the behavior a little bit to return the metrics only on the `/metrics` path, which is the usually expected behavior from a Prometheus exporter.