### PR TITLE
Rename core to common to match spec

### DIFF
--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -1,4 +1,3 @@
-//! OpenTelemetry shared core date types
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -230,9 +230,9 @@ mod context;
 
 pub use context::{Context, ContextGuard};
 
-mod core;
+mod common;
 
-pub use crate::core::{Array, Key, KeyValue, Value};
+pub use common::{Array, Key, KeyValue, Value};
 
 pub mod runtime;
 

--- a/opentelemetry/src/sdk/trace/span.rs
+++ b/opentelemetry/src/sdk/trace/span.rs
@@ -220,7 +220,7 @@ mod tests {
         DEFAULT_MAX_ATTRIBUTES_PER_EVENT, DEFAULT_MAX_ATTRIBUTES_PER_LINK,
     };
     use crate::trace::{Link, NoopSpanExporter, TraceFlags, TraceId, Tracer};
-    use crate::{core::KeyValue, trace::Span as _, trace::TracerProvider};
+    use crate::{trace::Span as _, trace::TracerProvider, KeyValue};
     use std::time::Duration;
 
     fn init() -> (sdk::trace::Tracer, SpanData) {


### PR DESCRIPTION
Nice to have the module names match the spec even if they are non-public.