### PR TITLE
small performance boost for `Resource.get`

### DIFF
--- a/opentelemetry/src/sdk/resource/mod.rs
+++ b/opentelemetry/src/sdk/resource/mod.rs
@@ -138,7 +138,7 @@ impl Resource {
 
     /// Retrieve the value from resource associate with given key.
     pub fn get(&self, key: Key) -> Option<Value> {
-        self.attrs.get(&key).map(|x| x.clone())
+        self.attrs.get(&key).cloned()
     }
 
     /// Encoded labels

--- a/opentelemetry/src/sdk/resource/mod.rs
+++ b/opentelemetry/src/sdk/resource/mod.rs
@@ -138,9 +138,7 @@ impl Resource {
 
     /// Retrieve the value from resource associate with given key.
     pub fn get(&self, key: Key) -> Option<Value> {
-        self.iter()
-            .find(|(k, _v)| **k == key)
-            .map(|(_k, v)| v.clone())
+        self.attrs.get(&key).map(|x| x.clone())
     }
 
     /// Encoded labels


### PR DESCRIPTION
Since `Resource`'s attrs is already a btreemap, no need to iterate to lookup.
Also here is another question regarding #384: it seems this has been partially resolved by recent PRs which add resource_detectors. However if the user provided a `trace_config` created with `with_resource` which doesn't contains a `service.name` entry, the final span will still don't have a `service.name` resource attribute. Does this behavior expected and conform to the spec?