### PR TITLE
fix(datadog): status_code must be 0 or 1

### DIFF
--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -127,7 +127,7 @@ pub(crate) mod tests {
         let traces = get_traces();
         let encoded = base64::encode(ApiVersion::Version03.encode("service_name", traces)?);
 
-        assert_eq!(encoded.as_str(), "kZGLpHR5cGWjd2Vip3NlcnZpY2Wsc2VydmljZV9uYW1lpG5hbWWpY29tcG9uZW50qHJlc291cmNlqHJlc291cmNlqHRyYWNlX2lkzwAAAAAAAAAHp3NwYW5faWTPAAAAAAAAAGOpcGFyZW50X2lkzwAAAAAAAAABpXN0YXJ00wAAAAAAAAAAqGR1cmF0aW9u0wAAAAA7msoApWVycm9y0gAAAAGkbWV0YYGpc3Bhbi50eXBlo3dlYg==");
+        assert_eq!(encoded.as_str(), "kZGLpHR5cGWjd2Vip3NlcnZpY2Wsc2VydmljZV9uYW1lpG5hbWWpY29tcG9uZW50qHJlc291cmNlqHJlc291cmNlqHRyYWNlX2lkzwAAAAAAAAAHp3NwYW5faWTPAAAAAAAAAGOpcGFyZW50X2lkzwAAAAAAAAABpXN0YXJ00wAAAAAAAAAAqGR1cmF0aW9u0wAAAAA7msoApWVycm9y0gAAAACkbWV0YYGpc3Bhbi50eXBlo3dlYg==");
 
         Ok(())
     }
@@ -137,7 +137,7 @@ pub(crate) mod tests {
         let traces = get_traces();
         let encoded = base64::encode(ApiVersion::Version05.encode("service_name", traces)?);
 
-        assert_eq!(encoded.as_str(), "kpWsc2VydmljZV9uYW1lo3dlYqljb21wb25lbnSocmVzb3VyY2Wpc3Bhbi50eXBlkZGczgAAAADOAAAAAs4AAAADzwAAAAAAAAAHzwAAAAAAAABjzwAAAAAAAAAB0wAAAAAAAAAA0wAAAAA7msoA0gAAAAGBzgAAAATOAAAAAYDOAAAAAQ==");
+        assert_eq!(encoded.as_str(), "kpWsc2VydmljZV9uYW1lo3dlYqljb21wb25lbnSocmVzb3VyY2Wpc3Bhbi50eXBlkZGczgAAAADOAAAAAs4AAAADzwAAAAAAAAAHzwAAAAAAAABjzwAAAAAAAAAB0wAAAAAAAAAA0wAAAAA7msoA0gAAAACBzgAAAATOAAAAAYDOAAAAAQ==");
 
         Ok(())
     }

--- a/opentelemetry-datadog/src/exporter/model/v03.rs
+++ b/opentelemetry-datadog/src/exporter/model/v03.rs
@@ -1,5 +1,6 @@
 use crate::exporter::model::Error;
 use opentelemetry::sdk::export::trace;
+use opentelemetry::trace::StatusCode;
 use opentelemetry::{Key, Value};
 use std::time::SystemTime;
 
@@ -61,7 +62,13 @@ pub(crate) fn encode(
             rmp::encode::write_i64(&mut encoded, duration)?;
 
             rmp::encode::write_str(&mut encoded, "error")?;
-            rmp::encode::write_i32(&mut encoded, span.status_code as i32)?;
+            rmp::encode::write_i32(
+                &mut encoded,
+                match span.status_code {
+                    StatusCode::Error => 1,
+                    _ => 0,
+                },
+            )?;
 
             rmp::encode::write_str(&mut encoded, "meta")?;
             rmp::encode::write_map_len(&mut encoded, span.attributes.len() as u32)?;


### PR DESCRIPTION
opentelemetry's `StatusCode` enum can be 0 (Unset), 1 (Ok) or 2 (Error).

otel specification says "don't ever use Ok, just leave it unset".

So for, non-error spans, the opentelemetry-datadog exporter does the right thing: it sets the datadog trace's status code to 0.

https://github.com/open-telemetry/opentelemetry-rust/blob/269c8004ff726c9af8327c40c66448a4517b81aa/opentelemetry-datadog/src/exporter/model/v05.rs#L114

However, for errors, the opentelemetry-datadog exporter sets the status_code to 2.

This isn't explicitly discouraged by the available Datadog docs, but it causes something really interesting: the trace
shows up with a "red" left border in Datadog APM (instead of a "green" one). The "Ok/Error" filter filters those traces correctly. However, half the UI is missing: when opening the trace, there's no '!' in the left-hand corner, there's no "Errors (1)" tab, and there's no detail of the error being shown in a user-friendly way.

**tl;dr In the Datadog backend, there's some code that does "status_code != 0", and some code that does "status_code == 1". The 2 value isn't set by their Go exporter, and so the opentelemetry-rust exporter should never use it.**