### PR TITLE
Backport datadog: prepare for v0.3.1 patch release

### DIFF
--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.3.1
+
+### Fixed
+
+- `status_code` must be 0 or 1 #580
+
 ## v0.3.0
 
 ### Changed

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-datadog"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["OpenTelemetry Authors <cncf-opentelemetry-contributors@lists.cncf.io>"]
 description = "Datadog exporters and propagators for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-datadog"


### PR DESCRIPTION
Backport #582 into `v0.15.x`