### PR TITLE
Rename `get_tracer` to `tracer`

### DIFF
--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -169,7 +169,7 @@ impl DatadogPipelineBuilder {
             sdk::trace::TracerProvider::builder().with_simple_exporter(exporter);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let tracer = provider.get_tracer("opentelemetry-datadog", Some(env!("CARGO_PKG_VERSION")));
+        let tracer = provider.tracer("opentelemetry-datadog", Some(env!("CARGO_PKG_VERSION")));
         let _ = global::set_tracer_provider(provider);
         Ok(tracer)
     }
@@ -186,7 +186,7 @@ impl DatadogPipelineBuilder {
             sdk::trace::TracerProvider::builder().with_batch_exporter(exporter, runtime);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let tracer = provider.get_tracer("opentelemetry-datadog", Some(env!("CARGO_PKG_VERSION")));
+        let tracer = provider.tracer("opentelemetry-datadog", Some(env!("CARGO_PKG_VERSION")));
         let _ = global::set_tracer_provider(provider);
         Ok(tracer)
     }

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -263,7 +263,7 @@ impl PipelineBuilder {
     pub fn install_simple(self) -> Result<sdk::trace::Tracer, TraceError> {
         let tracer_provider = self.build_simple()?;
         let tracer =
-            tracer_provider.get_tracer("opentelemetry-jaeger", Some(env!("CARGO_PKG_VERSION")));
+            tracer_provider.tracer("opentelemetry-jaeger", Some(env!("CARGO_PKG_VERSION")));
         let _ = global::set_tracer_provider(tracer_provider);
         Ok(tracer)
     }
@@ -275,7 +275,7 @@ impl PipelineBuilder {
     ) -> Result<sdk::trace::Tracer, TraceError> {
         let tracer_provider = self.build_batch(runtime)?;
         let tracer =
-            tracer_provider.get_tracer("opentelemetry-jaeger", Some(env!("CARGO_PKG_VERSION")));
+            tracer_provider.tracer("opentelemetry-jaeger", Some(env!("CARGO_PKG_VERSION")));
         let _ = global::set_tracer_provider(tracer_provider);
         Ok(tracer)
     }

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -579,7 +579,7 @@ fn build_simple_with_exporter(
         provider_builder = provider_builder.with_config(config);
     }
     let provider = provider_builder.build();
-    let tracer = provider.get_tracer("opentelemetry-otlp", Some(env!("CARGO_PKG_VERSION")));
+    let tracer = provider.tracer("opentelemetry-otlp", Some(env!("CARGO_PKG_VERSION")));
     let _ = global::set_tracer_provider(provider);
     tracer
 }
@@ -595,7 +595,7 @@ fn build_batch_with_exporter<R: TraceRuntime>(
         provider_builder = provider_builder.with_config(config);
     }
     let provider = provider_builder.build();
-    let tracer = provider.get_tracer("opentelemetry-otlp", Some(env!("CARGO_PKG_VERSION")));
+    let tracer = provider.tracer("opentelemetry-otlp", Some(env!("CARGO_PKG_VERSION")));
     let _ = global::set_tracer_provider(provider);
     tracer
 }

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -156,7 +156,7 @@ impl ZipkinPipelineBuilder {
             sdk::trace::TracerProvider::builder().with_simple_exporter(exporter);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let tracer = provider.get_tracer("opentelemetry-zipkin", Some(env!("CARGO_PKG_VERSION")));
+        let tracer = provider.tracer("opentelemetry-zipkin", Some(env!("CARGO_PKG_VERSION")));
         let _ = global::set_tracer_provider(provider);
         Ok(tracer)
     }
@@ -173,7 +173,7 @@ impl ZipkinPipelineBuilder {
             sdk::trace::TracerProvider::builder().with_batch_exporter(exporter, runtime);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let tracer = provider.get_tracer("opentelemetry-zipkin", Some(env!("CARGO_PKG_VERSION")));
+        let tracer = provider.tracer("opentelemetry-zipkin", Some(env!("CARGO_PKG_VERSION")));
         let _ = global::set_tracer_provider(provider);
         Ok(tracer)
     }

--- a/opentelemetry/benches/trace.rs
+++ b/opentelemetry/benches/trace.rs
@@ -115,7 +115,7 @@ fn trace_benchmark_group<F: Fn(&sdktrace::Tracer)>(c: &mut Criterion, name: &str
             .with_config(sdktrace::config().with_sampler(sdktrace::Sampler::AlwaysOn))
             .with_simple_exporter(VoidExporter)
             .build();
-        let always_sample = provider.get_tracer("always-sample", None);
+        let always_sample = provider.tracer("always-sample", None);
 
         b.iter(|| f(&always_sample));
     });
@@ -125,7 +125,7 @@ fn trace_benchmark_group<F: Fn(&sdktrace::Tracer)>(c: &mut Criterion, name: &str
             .with_config(sdktrace::config().with_sampler(sdktrace::Sampler::AlwaysOff))
             .with_simple_exporter(VoidExporter)
             .build();
-        let never_sample = provider.get_tracer("never-sample", None);
+        let never_sample = provider.tracer("never-sample", None);
         b.iter(|| f(&never_sample));
     });
 

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -164,7 +164,7 @@ where
 /// [`GlobalTracerProvider`]: crate::global::GlobalTracerProvider
 pub trait GenericTracerProvider: fmt::Debug + 'static {
     /// Creates a named tracer instance that is a trait object through the underlying `TracerProvider`.
-    fn get_tracer_boxed(
+    fn tracer_boxed(
         &self,
         name: &'static str,
         version: Option<&'static str>,
@@ -181,12 +181,12 @@ where
     P: trace::TracerProvider<Tracer = T>,
 {
     /// Return a boxed generic tracer
-    fn get_tracer_boxed(
+    fn tracer_boxed(
         &self,
         name: &'static str,
         version: Option<&'static str>,
     ) -> Box<dyn GenericTracer + Send + Sync> {
-        Box::new(self.get_tracer(name, version))
+        Box::new(self.tracer(name, version))
     }
 
     fn force_flush(&self) -> Vec<TraceResult<()>> {
@@ -222,8 +222,8 @@ impl trace::TracerProvider for GlobalTracerProvider {
     type Tracer = BoxedTracer;
 
     /// Find or create a named tracer using the global provider.
-    fn get_tracer(&self, name: &'static str, version: Option<&'static str>) -> Self::Tracer {
-        BoxedTracer(self.provider.get_tracer_boxed(name, version))
+    fn tracer(&self, name: &'static str, version: Option<&'static str>) -> Self::Tracer {
+        BoxedTracer(self.provider.tracer_boxed(name, version))
     }
 
     /// Force flush all remaining spans in span processors and return results.
@@ -253,11 +253,11 @@ pub fn tracer_provider() -> GlobalTracerProvider {
 ///
 /// If the name is an empty string, the provider will use a default name.
 ///
-/// This is a more convenient way of expressing `global::tracer_provider().get_tracer(name, None)`.
+/// This is a more convenient way of expressing `global::tracer_provider().tracer(name, None)`.
 ///
 /// [`Tracer`]: crate::trace::Tracer
 pub fn tracer(name: &'static str) -> BoxedTracer {
-    tracer_provider().get_tracer(name, None)
+    tracer_provider().tracer(name, None)
 }
 
 /// Creates a named instance of [`Tracer`] with version info via the configured [`GlobalTracerProvider`]
@@ -267,7 +267,7 @@ pub fn tracer(name: &'static str) -> BoxedTracer {
 ///
 /// [`Tracer`]: crate::trace::Tracer
 pub fn tracer_with_version(name: &'static str, version: &'static str) -> BoxedTracer {
-    tracer_provider().get_tracer(name, Some(version))
+    tracer_provider().tracer(name, Some(version))
 }
 
 /// Sets the given [`TracerProvider`] instance as the current global provider.
@@ -410,7 +410,7 @@ mod tests {
     impl TracerProvider for TestTracerProvider {
         type Tracer = NoopTracer;
 
-        fn get_tracer(&self, _name: &'static str, _version: Option<&'static str>) -> Self::Tracer {
+        fn tracer(&self, _name: &'static str, _version: Option<&'static str>) -> Self::Tracer {
             NoopTracer::default()
         }
 

--- a/opentelemetry/src/sdk/export/trace/stdout.rs
+++ b/opentelemetry/src/sdk/export/trace/stdout.rs
@@ -100,7 +100,7 @@ where
             provider_builder = provider_builder.with_config(config);
         }
         let provider = provider_builder.build();
-        let tracer = provider.get_tracer("opentelemetry", Some(env!("CARGO_PKG_VERSION")));
+        let tracer = provider.tracer("opentelemetry", Some(env!("CARGO_PKG_VERSION")));
         let _ = global::set_tracer_provider(provider);
 
         tracer

--- a/opentelemetry/src/sdk/propagation/composite.rs
+++ b/opentelemetry/src/sdk/propagation/composite.rs
@@ -44,7 +44,7 @@ use std::collections::HashSet;
 ///
 /// // And a given span
 /// let example_span = sdktrace::TracerProvider::default()
-///     .get_tracer("example-component", None)
+///     .tracer("example-component", None)
 ///     .start("span-name");
 ///
 /// // with the current context, call inject to add the headers

--- a/opentelemetry/src/sdk/trace/provider.rs
+++ b/opentelemetry/src/sdk/trace/provider.rs
@@ -78,7 +78,7 @@ impl crate::trace::TracerProvider for TracerProvider {
     type Tracer = sdk::trace::Tracer;
 
     /// Find or create `Tracer` instance by name.
-    fn get_tracer(&self, name: &'static str, version: Option<&'static str>) -> Self::Tracer {
+    fn tracer(&self, name: &'static str, version: Option<&'static str>) -> Self::Tracer {
         // Use default value if name is invalid empty string
         let component_name = if name.is_empty() {
             DEFAULT_COMPONENT_NAME

--- a/opentelemetry/src/sdk/trace/span.rs
+++ b/opentelemetry/src/sdk/trace/span.rs
@@ -226,7 +226,7 @@ mod tests {
     fn init() -> (sdk::trace::Tracer, SpanData) {
         let provider = sdk::trace::TracerProvider::default();
         let config = provider.config();
-        let tracer = provider.get_tracer("opentelemetry", Some(env!("CARGO_PKG_VERSION")));
+        let tracer = provider.tracer("opentelemetry", Some(env!("CARGO_PKG_VERSION")));
         let data = SpanData {
             parent_span_id: SpanId::from_u64(0),
             span_kind: trace::SpanKind::Internal,
@@ -485,7 +485,7 @@ mod tests {
         let exporter = NoopSpanExporter::new();
         let provider_builder = sdk::trace::TracerProvider::builder().with_simple_exporter(exporter);
         let provider = provider_builder.build();
-        let tracer = provider.get_tracer("opentelemetry-test", None);
+        let tracer = provider.tracer("opentelemetry-test", None);
 
         let mut event1 = Event::with_name("test event");
         for i in 0..(DEFAULT_MAX_ATTRIBUTES_PER_EVENT * 2) {
@@ -519,7 +519,7 @@ mod tests {
         let exporter = NoopSpanExporter::new();
         let provider_builder = sdk::trace::TracerProvider::builder().with_simple_exporter(exporter);
         let provider = provider_builder.build();
-        let tracer = provider.get_tracer("opentelemetry-test", None);
+        let tracer = provider.tracer("opentelemetry-test", None);
 
         let mut link = Link::new(
             SpanContext::new(

--- a/opentelemetry/src/sdk/trace/tracer.rs
+++ b/opentelemetry/src/sdk/trace/tracer.rs
@@ -374,7 +374,7 @@ mod tests {
         let tracer_provider = sdk::trace::TracerProvider::builder()
             .with_config(config)
             .build();
-        let tracer = tracer_provider.get_tracer("test", None);
+        let tracer = tracer_provider.tracer("test", None);
         let trace_state = TraceState::from_key_value(vec![("foo", "bar")]).unwrap();
         let span_builder = SpanBuilder {
             parent_context: Context::new().with_span(TestSpan(SpanContext::new(
@@ -403,7 +403,7 @@ mod tests {
             .build();
 
         let context = Context::current_with_span(TestSpan(SpanContext::empty_context()));
-        let tracer = tracer_provider.get_tracer("test", None);
+        let tracer = tracer_provider.tracer("test", None);
         let span = tracer.start_with_context("must_not_be_sampled", context);
 
         assert!(!span.span_context().is_sampled());
@@ -416,7 +416,7 @@ mod tests {
         let tracer_provider = sdk::trace::TracerProvider::builder()
             .with_config(config)
             .build();
-        let tracer = tracer_provider.get_tracer("test", None);
+        let tracer = tracer_provider.tracer("test", None);
 
         let _attached = Context::current_with_span(TestSpan(SpanContext::empty_context())).attach();
         let span = tracer.span_builder("must_not_be_sampled").start(&tracer);

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -133,7 +133,7 @@ pub trait TraceContextExt {
     /// // returns a reference to an empty span by default
     /// assert_eq!(Context::current().span().span_context(), &SpanContext::empty_context());
     ///
-    /// sdktrace::TracerProvider::default().get_tracer("my-component", None).in_span("my-span", |cx| {
+    /// sdktrace::TracerProvider::default().tracer("my-component", None).in_span("my-span", |cx| {
     ///     // Returns a reference to the current span if set
     ///     assert_ne!(cx.span().span_context(), &SpanContext::empty_context());
     /// });

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -43,7 +43,7 @@
 //!     let tracer_provider = global::tracer_provider();
 //!
 //!     // Get a tracer for this library
-//!     let tracer = tracer_provider.get_tracer("my_name", Some(env!("CARGO_PKG_VERSION")));
+//!     let tracer = tracer_provider.tracer("my_name", Some(env!("CARGO_PKG_VERSION")));
 //!
 //!     // Create spans
 //!     let mut span = tracer.start("doing_work");

--- a/opentelemetry/src/trace/noop.rs
+++ b/opentelemetry/src/trace/noop.rs
@@ -30,7 +30,7 @@ impl trace::TracerProvider for NoopTracerProvider {
     type Tracer = NoopTracer;
 
     /// Returns a new `NoopTracer` instance.
-    fn get_tracer(&self, _name: &'static str, _version: Option<&'static str>) -> Self::Tracer {
+    fn tracer(&self, _name: &'static str, _version: Option<&'static str>) -> Self::Tracer {
         NoopTracer::new()
     }
 

--- a/opentelemetry/src/trace/provider.rs
+++ b/opentelemetry/src/trace/provider.rs
@@ -2,7 +2,7 @@
 //!
 //! ### Obtaining a Tracer
 //!
-//! New `Tracer` instances can be created via a `TracerProvider` and its `get_tracer`
+//! New `Tracer` instances can be created via a `TracerProvider` and its `tracer`
 //! method. This method expects an Into<String> argument:
 //!
 //! - `name` (required): This name must identify the instrumentation library (also
@@ -29,7 +29,7 @@ pub trait TracerProvider: fmt::Debug + 'static {
 
     /// Creates a named tracer instance of `Self::Tracer`.
     /// If the name is an empty string then provider uses default name.
-    fn get_tracer(&self, name: &'static str, version: Option<&'static str>) -> Self::Tracer;
+    fn tracer(&self, name: &'static str, version: Option<&'static str>) -> Self::Tracer;
 
     /// Force flush all remaining spans in span processors and return results.
     fn force_flush(&self) -> Vec<TraceResult<()>>;


### PR DESCRIPTION
Rename tracer provider methods as it is less idiomatic for rust methods to have the `get` prefix.