### PR TITLE
feat: add hash for span context & allow spans to clone and export current state at any time

### DIFF
--- a/opentelemetry/src/sdk/trace/span.rs
+++ b/opentelemetry/src/sdk/trace/span.rs
@@ -70,6 +70,21 @@ impl Span {
     {
         self.data.as_mut().map(f)
     }
+
+    /// Convert information in this span into `exporter::trace::SpanData`.
+    /// This function copies all data from the current span, which will create a
+    /// overhead.
+    pub fn exported_data(&self) -> Option<crate::sdk::export::trace::SpanData> {
+        let (span_context, tracer) = (self.span_context.clone(), &self.tracer);
+        let resource = if let Some(provider) = self.tracer.provider() {
+            provider.config().resource.clone()
+        } else {
+            None
+        };
+        self.data
+            .as_ref()
+            .map(|data| build_export_data(data.clone(), span_context, resource, tracer))
+    }
 }
 
 impl crate::trace::Span for Span {
@@ -546,5 +561,25 @@ mod tests {
         let link_vec: Vec<_> = link_queue.iter().collect();
         let processed_link = link_vec.get(0).expect("should have at least one link");
         assert_eq!(processed_link.attributes().len(), 128);
+    }
+
+    #[test]
+    fn test_span_exported_data() {
+        let provider = sdk::trace::TracerProvider::builder()
+            .with_simple_exporter(NoopSpanExporter::new())
+            .build();
+        let tracer = provider.tracer("test", None);
+
+        let mut span = tracer.start("test_span");
+        span.add_event("test_event".to_string(), vec![]);
+        span.set_status(StatusCode::Error, "".to_string());
+
+        let exported_data = span.exported_data();
+        assert!(exported_data.is_some());
+
+        drop(provider);
+        let dropped_span = tracer.start("span_with_dropped_provider");
+        // return none if the provider has already been dropped
+        assert!(dropped_span.exported_data().is_none());
     }
 }

--- a/opentelemetry/src/trace/span_context.rs
+++ b/opentelemetry/src/trace/span_context.rs
@@ -14,6 +14,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::fmt;
+use std::hash::Hash;
 use std::ops::{BitAnd, BitOr, Not};
 use std::str::FromStr;
 use thiserror::Error;
@@ -187,7 +188,7 @@ impl SpanId {
 ///
 /// [W3C specification]: https://www.w3.org/TR/trace-context/#tracestate-header
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub struct TraceState(Option<VecDeque<(String, String)>>);
 
 impl TraceState {
@@ -406,7 +407,7 @@ pub enum TraceStateError {
 /// Spans that do not have the `sampled` flag set in their [`TraceFlags`] will
 /// be ignored by most tracing tools.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Hash)]
 pub struct SpanContext {
     trace_id: TraceId,
     span_id: SpanId,


### PR DESCRIPTION
Trying to break my work on zPages into smaller commits so it's easier to review.

We need hash for span context because zPages implementation needs it to move spans around between running, error, and finished buckets.

Adding an `export_data()`  function helps the zPages implementation to sample the running spans before they finish.