### PR TITLE
fix(otlp): upgrade tonic to 0.5.

### DIFF
--- a/examples/external-otlp-tonic-tokio/Cargo.toml
+++ b/examples/external-otlp-tonic-tokio/Cargo.toml
@@ -9,5 +9,5 @@ opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio", "metrics
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic", "tls", "tls-roots"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-tonic = "0.4.0"
+tonic = "0.5.0"
 url = "2.2.0"

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -39,19 +39,22 @@ async-trait = "0.1"
 futures = "0.3"
 grpcio = { version = "0.9", optional = true }
 opentelemetry = { version = "0.15", default-features = false, features = ["trace"], path = "../opentelemetry" }
-prost = { version = "0.7", optional = true }
+prost = { version = "0.8", optional = true }
 protobuf = { version = "2.18", optional = true }
 thiserror = "1.0"
-tonic = { version = "0.4", optional = true }
+tonic = { version = "0.5", optional = true }
 tokio = { version = "1.0", features = ["full"], optional = true }
 opentelemetry-http = { version = "0.4", path = "../opentelemetry-http", optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false }
 surf = { version = "2.0", optional = true, default-features = false }
 http = "0.2"
+tower = { version = "0.4", optional = true }
 
 [dev-dependencies]
 chrono = "0.4"
 tokio-stream = { version = "0.1", features = ["net"] }
+# need tokio runtime to run smoke tests.
+opentelemetry = { version = "0.15", features = ["trace", "rt-tokio"], path = "../opentelemetry" }
 protobuf-codegen = { version = "2.16"}
 protoc-grpcio = { version = "3.0"}
 
@@ -59,7 +62,7 @@ protoc-grpcio = { version = "3.0"}
 trace = ["opentelemetry/trace"]
 metrics = ["opentelemetry/metrics", "default"]
 
-default = ["tonic", "tonic-build", "prost", "tokio"]
+default = ["tonic", "tonic-build", "prost", "tokio", "tower"]
 tls = ["tonic/tls"]
 tls-roots = ["tls", "tonic/tls-roots"]
 
@@ -75,5 +78,5 @@ reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
 surf-client = ["surf", "opentelemetry-http/surf"]
 
 [build-dependencies]
-tonic-build = { version = "0.4", optional = true }
-prost-build = {version = "0.7", optional = true }
+tonic-build = { version = "0.5", optional = true }
+prost-build = {version = "0.8", optional = true }

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -48,7 +48,6 @@ opentelemetry-http = { version = "0.4", path = "../opentelemetry-http", optional
 reqwest = { version = "0.11", optional = true, default-features = false }
 surf = { version = "2.0", optional = true, default-features = false }
 http = "0.2"
-tower = { version = "0.4", optional = true }
 
 [dev-dependencies]
 chrono = "0.4"
@@ -62,7 +61,7 @@ protoc-grpcio = { version = "3.0"}
 trace = ["opentelemetry/trace"]
 metrics = ["opentelemetry/metrics", "default"]
 
-default = ["tonic", "tonic-build", "prost", "tokio", "tower"]
+default = ["tonic", "tonic-build", "prost", "tokio"]
 tls = ["tonic/tls"]
 tls-roots = ["tls", "tonic/tls-roots"]
 


### PR DESCRIPTION
We no longer have a universal type for both the client with interceptors and the client without interceptors. So instead of using interceptors we just add the headers for each request as needed.

close #596 