### PR TITLE
Make SpanProcessor::on_start take a mutable span

### DIFF
--- a/opentelemetry/src/sdk/trace/provider.rs
+++ b/opentelemetry/src/sdk/trace/provider.rs
@@ -182,7 +182,7 @@ mod tests {
     }
 
     impl SpanProcessor for TestSpanProcessor {
-        fn on_start(&self, _span: &Span, _cx: &Context) {
+        fn on_start(&self, _span: &mut Span, _cx: &Context) {
             unimplemented!()
         }
 

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -69,7 +69,7 @@ pub trait SpanProcessor: Send + Sync + std::fmt::Debug {
     /// `on_start` is called when a `Span` is started.  This method is called
     /// synchronously on the thread that started the span, therefore it should
     /// not block or throw exceptions.
-    fn on_start(&self, span: &Span, cx: &Context);
+    fn on_start(&self, span: &mut Span, cx: &Context);
     /// `on_end` is called after a `Span` is ended (i.e., the end timestamp is
     /// already set). This method is called synchronously within the `Span::end`
     /// API, therefore it should not block or throw an exception.
@@ -139,7 +139,7 @@ impl SimpleSpanProcessor {
 }
 
 impl SpanProcessor for SimpleSpanProcessor {
-    fn on_start(&self, _span: &Span, _cx: &Context) {
+    fn on_start(&self, _span: &mut Span, _cx: &Context) {
         // Ignored
     }
 
@@ -239,7 +239,7 @@ impl<R: TraceRuntime> fmt::Debug for BatchSpanProcessor<R> {
 }
 
 impl<R: TraceRuntime> SpanProcessor for BatchSpanProcessor<R> {
-    fn on_start(&self, _span: &Span, _cx: &Context) {
+    fn on_start(&self, _span: &mut Span, _cx: &Context) {
         // Ignored
     }
 

--- a/opentelemetry/src/sdk/trace/tracer.rs
+++ b/opentelemetry/src/sdk/trace/tracer.rs
@@ -313,11 +313,11 @@ impl crate::trace::Tracer for Tracer {
         });
 
         let span_context = SpanContext::new(trace_id, span_id, flags, false, span_trace_state);
-        let span = Span::new(span_context, inner, self.clone(), span_limits);
+        let mut span = Span::new(span_context, inner, self.clone(), span_limits);
 
         // Call `on_start` for all processors
         for processor in provider.span_processors() {
-            processor.on_start(&span, &parent_context)
+            processor.on_start(&mut span, &parent_context)
         }
 
         span


### PR DESCRIPTION
As a side effect of #505, `SpanProcessor::on_start` callbacks are no
longer able to modify the span. The [OpenTelemetry spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#onstart) states that the
span parameter is a [read/write span object](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#additional-span-interfaces). This PR introduces a breaking
change to restore adherence to the spec.
