### PR TITLE
feat: add method`from_env` to prometheus exporter builder

### DIFF
--- a/opentelemetry-datadog/src/exporter/model/v05.rs
+++ b/opentelemetry-datadog/src/exporter/model/v05.rs
@@ -78,7 +78,7 @@ fn encode_traces(
     let mut encoded = Vec::new();
     rmp::encode::write_array_len(&mut encoded, traces.len() as u32)?;
 
-    let service_interned = interner.intern(&service_name);
+    let service_interned = interner.intern(service_name);
 
     for trace in traces.into_iter() {
         rmp::encode::write_array_len(&mut encoded, trace.len() as u32)?;

--- a/opentelemetry-otlp/src/transform/metrics.rs
+++ b/opentelemetry-otlp/src/transform/metrics.rs
@@ -45,9 +45,9 @@ pub(crate) mod tonic {
         fn from(number: NumberWithKind<'a>) -> Self {
             match &number.1 {
                 NumberKind::I64 | NumberKind::U64 => {
-                    number_data_point::Value::AsInt(number.0.to_i64(&number.1))
+                    number_data_point::Value::AsInt(number.0.to_i64(number.1))
                 }
-                NumberKind::F64 => number_data_point::Value::AsDouble(number.0.to_f64(&number.1)),
+                NumberKind::F64 => number_data_point::Value::AsDouble(number.0.to_f64(number.1)),
             }
         }
     }

--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.9.0
+
+### Added
+
+- Add `from_env` method to prometheus exporter based on semantic environment vars
+
 ## v0.8.0
 
 ### Changed
@@ -15,9 +21,11 @@
 ## v0.6.0
 
 ### Added
+
 - Add sanitization of prometheus label names #462
 
 ### Changed
+
 - Update to opentelemetry v0.13.0
 - Update prometheus dependency #485
 

--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Added
 
-- Add `from_env` method to prometheus exporter based on semantic environment vars
+- Adds `Default` implementation to `ExporterBuilder` based on the otel specification environment variables #242
+
+### Deprecated
+
+- `PrometheusExporter::new()` is deprecated in favor of using `ExporterBuilder`
 
 ## v0.8.0
 

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -376,7 +376,7 @@ impl prometheus::core::Collector for Collector {
                 let number_kind = record.descriptor().number_kind();
                 let instrument_kind = record.descriptor().instrument_kind();
 
-                let desc = get_metric_desc(&record);
+                let desc = get_metric_desc(record);
                 let labels = get_metric_labels(record);
 
                 if let Some(hist) = agg.as_any().downcast_ref::<HistogramAggregator>() {

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 use opentelemetry::sdk::Resource;
 use opentelemetry::{
     metrics::{BatchObserverResult, MeterProvider, ObserverResult},
@@ -160,32 +158,4 @@ fn compare_export(exporter: &PrometheusExporter, mut expected: Vec<&'static str>
     expected.sort_unstable();
 
     assert_eq!(expected.join("\n"), metrics_only.join("\n"))
-}
-
-#[test]
-fn test_from_env() {
-    let otel_exporter_prometheus_host = "OTEL_EXPORTER_PROMETHEUS_HOST";
-    let otel_exporter_prometheus_port = "OTEL_EXPORTER_PROMETHEUS_PORT";
-
-    // environment variables do not exist
-    env::remove_var(otel_exporter_prometheus_host);
-    env::remove_var(otel_exporter_prometheus_port);
-    let exporter = opentelemetry_prometheus::ExporterBuilder::from_env().init();
-    assert_eq!(exporter.host(), "0.0.0.0");
-    assert_eq!(exporter.port(), "9464");
-
-    // environment variables are available and non-empty strings
-    env::set_var(otel_exporter_prometheus_host, "prometheus-test");
-    env::set_var(otel_exporter_prometheus_port, "9000");
-
-    let exporter = opentelemetry_prometheus::ExporterBuilder::from_env().init();
-    assert_eq!(exporter.host(), "prometheus-test");
-    assert_eq!(exporter.port(), "9000");
-
-    // environment variables are available and empty
-    env::set_var(otel_exporter_prometheus_host, "");
-    env::set_var(otel_exporter_prometheus_port, "");
-    let exporter = opentelemetry_prometheus::ExporterBuilder::from_env().init();
-    assert_eq!(exporter.host(), "0.0.0.0");
-    assert_eq!(exporter.port(), "9464");
 }

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use opentelemetry::sdk::Resource;
 use opentelemetry::{
     metrics::{BatchObserverResult, MeterProvider, ObserverResult},
@@ -158,4 +160,32 @@ fn compare_export(exporter: &PrometheusExporter, mut expected: Vec<&'static str>
     expected.sort_unstable();
 
     assert_eq!(expected.join("\n"), metrics_only.join("\n"))
+}
+
+#[test]
+fn test_from_env() {
+    let otel_exporter_prometheus_host = "OTEL_EXPORTER_PROMETHEUS_HOST";
+    let otel_exporter_prometheus_port = "OTEL_EXPORTER_PROMETHEUS_PORT";
+
+    // environment variables do not exist
+    env::remove_var(otel_exporter_prometheus_host);
+    env::remove_var(otel_exporter_prometheus_port);
+    let exporter = opentelemetry_prometheus::ExporterBuilder::from_env().init();
+    assert_eq!(exporter.host(), "0.0.0.0");
+    assert_eq!(exporter.port(), "9464");
+
+    // environment variables are available and non-empty strings
+    env::set_var(otel_exporter_prometheus_host, "prometheus-test");
+    env::set_var(otel_exporter_prometheus_port, "9000");
+
+    let exporter = opentelemetry_prometheus::ExporterBuilder::from_env().init();
+    assert_eq!(exporter.host(), "prometheus-test");
+    assert_eq!(exporter.port(), "9000");
+
+    // environment variables are available and empty
+    env::set_var(otel_exporter_prometheus_host, "");
+    env::set_var(otel_exporter_prometheus_port, "");
+    let exporter = opentelemetry_prometheus::ExporterBuilder::from_env().init();
+    assert_eq!(exporter.host(), "0.0.0.0");
+    assert_eq!(exporter.port(), "9464");
 }

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -109,9 +109,9 @@ pub enum Array {
 impl fmt::Display for Array {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Array::Bool(values) => display_array_str(&values, fmt),
-            Array::I64(values) => display_array_str(&values, fmt),
-            Array::F64(values) => display_array_str(&values, fmt),
+            Array::Bool(values) => display_array_str(values, fmt),
+            Array::I64(values) => display_array_str(values, fmt),
+            Array::F64(values) => display_array_str(values, fmt),
             Array::String(values) => {
                 write!(fmt, "[")?;
                 for (i, t) in values.iter().enumerate() {

--- a/opentelemetry/src/labels/mod.rs
+++ b/opentelemetry/src/labels/mod.rs
@@ -125,7 +125,7 @@ impl<'a, A: Iterator<Item = (&'a Key, &'a Value)>, B: Iterator<Item = (&'a Key, 
     type Item = (&'a Key, &'a Value);
     fn next(&mut self) -> Option<Self::Item> {
         let which = match (self.a.peek(), self.b.peek()) {
-            (Some(a), Some(b)) => Some(a.0.cmp(&b.0)),
+            (Some(a), Some(b)) => Some(a.0.cmp(b.0)),
             (Some(_), None) => Some(Ordering::Less),
             (None, Some(_)) => Some(Ordering::Greater),
             (None, None) => None,

--- a/opentelemetry/src/sdk/metrics/aggregators/ddsketch.rs
+++ b/opentelemetry/src/sdk/metrics/aggregators/ddsketch.rs
@@ -347,7 +347,7 @@ impl Inner {
             };
             (-self.log_gamma(positive_num.to_f64(kind)).ceil()) as i64 - self.offset
         } else if num.to_f64(kind) > self.key_epsilon {
-            self.log_gamma(num.to_f64(&kind)).ceil() as i64 + self.offset
+            self.log_gamma(num.to_f64(kind)).ceil() as i64 + self.offset
         } else {
             0i64
         }

--- a/opentelemetry/src/sdk/metrics/aggregators/histogram.rs
+++ b/opentelemetry/src/sdk/metrics/aggregators/histogram.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, RwLock};
 /// Create a new histogram for the given descriptor with the given boundaries
 pub fn histogram(desc: &Descriptor, boundaries: &[f64]) -> HistogramAggregator {
     let mut sorted_boundaries = boundaries.to_owned();
-    sorted_boundaries.sort_by(|a, b| a.partial_cmp(&b).unwrap());
+    sorted_boundaries.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let state = State::empty(&sorted_boundaries);
 
     HistogramAggregator {

--- a/opentelemetry/src/sdk/metrics/mod.rs
+++ b/opentelemetry/src/sdk/metrics/mod.rs
@@ -212,7 +212,7 @@ impl AccumulatorCore {
             } else {
                 // Having no updates since last collection, try to remove if
                 // there are no bound handles
-                if Arc::strong_count(&value) == 1 {
+                if Arc::strong_count(value) == 1 {
                     // There's a potential race between loading collected count and
                     // loading the strong count in this function.  Since this is the
                     // last we'll see of this record, checkpoint.
@@ -245,7 +245,7 @@ impl AccumulatorCore {
                 record.instrument.descriptor(),
                 &record.labels,
                 &self.resource,
-                &checkpoint,
+                checkpoint,
             );
             if let Err(err) = locked_processor.process(accumulation) {
                 global::handle_error(err);

--- a/opentelemetry/src/sdk/metrics/processors/basic.rs
+++ b/opentelemetry/src/sdk/metrics/processors/basic.rs
@@ -130,7 +130,7 @@ impl<'a> LockedProcessor for BasicLockedProcessor<'a> {
                 if let Some(current) = self.parent.aggregation_selector().aggregator_for(desc) {
                     value.current = current;
                     value.current_owned = true;
-                    tmp.synchronized_move(&value.current, &desc)?;
+                    tmp.synchronized_move(&value.current, desc)?;
                 }
             }
 
@@ -141,7 +141,7 @@ impl<'a> LockedProcessor for BasicLockedProcessor<'a> {
         let stateful = self
             .parent
             .export_selector
-            .export_kind_for(&desc)
+            .export_kind_for(desc)
             .memory_required(desc.instrument_kind());
 
         let mut delta = None;


### PR DESCRIPTION
Fixes #242 

Allows configuring the `PrometheusExporter` using environment variables defined in the semantic conventions of the Otel specification. Currently, supports setting the host and port for prometheus in the builder and will fall back to the defaults defined in the otel specification.