### PR TITLE
fix(doc): replace kitchen sink examples with docs.rs links.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "opentelemetry/src/testing" # test harnesses
+  - "opentelemetry-jaeger/src/exporter/thrift" # auto generated files
+  - "opentelemetry-otlp/src/proto" # auto generated files

--- a/opentelemetry-datadog/README.md
+++ b/opentelemetry-datadog/README.md
@@ -34,59 +34,10 @@ to [`Datadog`].
 
 ## Kitchen Sink Full Configuration
 
- Example showing how to override all configuration options. See the
+ [Example]((https://docs.rs/opentelemetry-datadog/latest/opentelemetry_datadog/#kitchen-sink-full-configuration)) showing how to override all configuration options. See the
  [`DatadogPipelineBuilder`] docs for details of each option.
 
  [`DatadogPipelineBuilder`]: struct.DatadogPipelineBuilder.html
-
- ```no_run
- use opentelemetry::{KeyValue, trace::Tracer};
- use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
- use opentelemetry::sdk::export::trace::ExportResult;
- use opentelemetry_datadog::{new_pipeline, ApiVersion, Error};
- use opentelemetry_http::HttpClient;
- use async_trait::async_trait;
-
- // reqwest and surf are supported through features, if you prefer an
- // alternate http client you can add support by implementing HttpClient as
- // shown here.
- #[derive(Debug)]
- struct IsahcClient(isahc::HttpClient);
-
- #[async_trait]
- impl HttpClient for IsahcClient {
-   async fn send(&self, request: http::Request<Vec<u8>>) -> ExportResult {
-     let result = self.0.send_async(request).await.map_err(|err| Error::Other(err.to_string()))?;
-
-     if result.status().is_success() {
-       Ok(())
-     } else {
-       Err(Error::Other(result.status().to_string()).into())
-     }
-   }
- }
-
- fn main() -> Result<(), opentelemetry::trace::TraceError> {
-     let tracer = new_pipeline()
-         .with_service_name("my_app")
-         .with_version(ApiVersion::Version05)
-         .with_agent_endpoint("http://localhost:8126")
-         .with_trace_config(
-             trace::config()
-                 .with_sampler(Sampler::AlwaysOn)
-                 .with_id_generator(IdGenerator::default())
-         )
-         .install_batch(opentelemetry::runtime::Tokio)?;
-
-     tracer.in_span("doing_work", |cx| {
-         // Traced app logic here...
-     });
-     
-     opentelemetry::global::shutdown_tracer_provider();
-
-     Ok(())
- }
- ```
 
 [`Datadog`]: https://www.datadoghq.com/
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry

--- a/opentelemetry-jaeger/CHANGELOG.md
+++ b/opentelemetry-jaeger/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Set client-to-agent UDP comm based on runtime #599
+- Set client-to-agent UDP comm based on runtime #599. Users should change their `tokio` feature to `rt-tokio`. Similar with async-std
 - Update to opentelemetry v0.16.0
 
 ## v0.14.0

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -139,47 +139,10 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 
 ## Kitchen Sink Full Configuration
 
-Example showing how to override all configuration options. See the
+[Example]((https://docs.rs/opentelemetry-jaeger/latest/opentelemetry_jaeger/#kitchen-sink-full-configuration)) showing how to override all configuration options. See the
 [`PipelineBuilder`] docs for details of each option.
 
 [`PipelineBuilder`]: https://docs.rs/opentelemetry-jaeger/latest/opentelemetry_jaeger/struct.PipelineBuilder.html
-
-```rust
-use opentelemetry::global;
-use opentelemetry::sdk::{
-    trace::{self, IdGenerator, Sampler},
-    Resource,
-};
-use opentelemetry::trace::Tracer;
-use opentelemetry::KeyValue;
-
-fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
-    let tracer = opentelemetry_jaeger::new_pipeline()
-        .with_agent_endpoint("localhost:6831")
-        .with_service_name("my_app")
-        .with_tags(vec![KeyValue::new("process_key", "process_value")])
-        .with_max_packet_size(9_216)
-        .with_trace_config(
-            trace::config()
-                .with_sampler(Sampler::AlwaysOn)
-                .with_id_generator(IdGenerator::default())
-                .with_max_events_per_span(64)
-                .with_max_attributes_per_span(16)
-                .with_max_events_per_span(16)
-                .with_resource(Resource::new(vec![KeyValue::new("key", "value")])),
-        )
-        .install_batch(opentelemetry::runtime::Tokio)?;
-
-    tracer.in_span("doing_work", |cx| {
-        // Traced app logic here...
-    });
-
-    global::shutdown_tracer_provider(); // sending remaining spans
-
-    Ok(())
-}
-```
 
 ## Supported Rust Versions
 

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -89,10 +89,10 @@ impl HasExportConfig for HttpExporterBuilder {
 ///
 /// ## Examples
 /// ```no_run
-///
+/// use crate::opentelemetry_otlp::WithExportConfig;
 /// let exporter_builder = opentelemetry_otlp::new_exporter()
 ///                         .tonic()
-///                         .with_endpoint("http://localhost:7201")
+///                         .with_endpoint("http://localhost:7201");
 /// ```
 pub trait WithExportConfig {
     /// Set the address of the OTLP collector. If not set, the default address is used.
@@ -108,7 +108,7 @@ pub trait WithExportConfig {
     ///
     /// If the value in environment variables is illegal, will fall back to use default value.
     fn with_env(self) -> Self;
-    /// Set export config.
+    /// Set export config. This will override all previous configuration.
     fn with_export_config(self, export_config: ExportConfig) -> Self;
 }
 

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -209,7 +209,7 @@ where
         }
     }
 
-    /// Build push controller
+    /// Build push controller.
     pub fn build(self) -> Result<PushController> {
         let exporter = self
             .exporter_pipeline


### PR DESCRIPTION
* Replace kitchen sink examples with docs.rs links. Having the same code in different places causes inconsistency from time to time. Rust docs check if the example is update-to-date so it's easier to maintain.
* Add codecov.yml to ignore generated code
* Update opentelemetry-jaeger CHANGELOG.md, add upgrade note.
* Add metrics example in opentelemtry-otlp, fixes #615 