### PR TITLE
Implement Serialize & Deserialize for Sampler

### DIFF
--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -42,7 +42,6 @@ js-sys = "0.3"
 [dev-dependencies]
 bincode = "1.2"
 criterion = "0.3.1"
-serde_json = "1.0.66"
 rand_distr = "0.4.0"
 
 [features]

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -42,6 +42,7 @@ js-sys = "0.3"
 [dev-dependencies]
 bincode = "1.2"
 criterion = "0.3.1"
+serde_json = "1.0.66"
 rand_distr = "0.4.0"
 
 [features]

--- a/opentelemetry/src/sdk/trace/sampler.rs
+++ b/opentelemetry/src/sdk/trace/sampler.rs
@@ -85,7 +85,8 @@ pub enum SamplingDecision {
 }
 
 /// Sampling options
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Sampler {
     /// Always sample the trace
     AlwaysOn,
@@ -294,26 +295,5 @@ mod tests {
         );
 
         assert_eq!(result.decision, SamplingDecision::RecordAndSample);
-    }
-
-    #[cfg(feature = "serialize")]
-    #[test]
-    fn serialize_and_deserialize_sampler() {
-        macro_rules! assert_serialize_deserialize {
-            ($value:expr) => {
-                let serialized = serde_json::to_string(&$value).unwrap();
-                eprintln!("{}", serialized);
-                assert_eq!(
-                    serde_json::from_str::<Sampler>(&serialized).unwrap(),
-                    $value,
-                    "serializing and then deserializing did not produce the expected value",
-                );
-            };
-        }
-
-        assert_serialize_deserialize!(Sampler::AlwaysOn);
-        assert_serialize_deserialize!(Sampler::AlwaysOff);
-        assert_serialize_deserialize!(Sampler::TraceIdRatioBased(0.42));
-        assert_serialize_deserialize!(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)));
     }
 }

--- a/opentelemetry/src/sdk/trace/sampler.rs
+++ b/opentelemetry/src/sdk/trace/sampler.rs
@@ -85,7 +85,7 @@ pub enum SamplingDecision {
 }
 
 /// Sampling options
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Sampler {
     /// Always sample the trace
     AlwaysOn,
@@ -158,65 +158,6 @@ impl ShouldSample for Sampler {
                 Some(ctx) => ctx.span().span_context().trace_state().clone(),
                 None => TraceState::default(),
             },
-        }
-    }
-}
-
-#[cfg(feature = "serialize")]
-impl<'de> Deserialize<'de> for Sampler {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        struct SamplerVisitor;
-
-        impl<'de> serde::de::Visitor<'de> for SamplerVisitor {
-            type Value = Sampler;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(
-                    formatter,
-                    "a string that is 'always-on' or 'always-off' or a float"
-                )
-            }
-
-            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                match s {
-                    "always-on" => Ok(Sampler::AlwaysOn),
-                    "always-off" => Ok(Sampler::AlwaysOff),
-                    _ => Err(serde::de::Error::invalid_value(
-                        serde::de::Unexpected::Str(s),
-                        &self,
-                    )),
-                }
-            }
-
-            fn visit_f64<E>(self, n: f64) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Sampler::TraceIdRatioBased(n))
-            }
-        }
-
-        deserializer.deserialize_any(SamplerVisitor)
-    }
-}
-
-#[cfg(feature = "serialize")]
-impl Serialize for Sampler {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        match self {
-            Sampler::AlwaysOn => serializer.serialize_str("always-on"),
-            Sampler::AlwaysOff => serializer.serialize_str("always-off"),
-            Sampler::TraceIdRatioBased(ratio) => serializer.serialize_f64(*ratio),
-            Sampler::ParentBased(parent) => Self::serialize(parent, serializer),
         }
     }
 }
@@ -359,25 +300,20 @@ mod tests {
     #[test]
     fn serialize_and_deserialize_sampler() {
         macro_rules! assert_serialize_deserialize {
-            ($value:expr, $expected:expr) => {
+            ($value:expr) => {
                 let serialized = serde_json::to_string(&$value).unwrap();
+                eprintln!("{}", serialized);
                 assert_eq!(
                     serde_json::from_str::<Sampler>(&serialized).unwrap(),
-                    $expected,
+                    $value,
                     "serializing and then deserializing did not produce the expected value",
                 );
             };
         }
 
-        assert_serialize_deserialize!(Sampler::AlwaysOn, Sampler::AlwaysOn);
-        assert_serialize_deserialize!(Sampler::AlwaysOff, Sampler::AlwaysOff);
-        assert_serialize_deserialize!(
-            Sampler::TraceIdRatioBased(0.42),
-            Sampler::TraceIdRatioBased(0.42)
-        );
-        assert_serialize_deserialize!(
-            Sampler::ParentBased(Box::new(Sampler::AlwaysOn)),
-            Sampler::AlwaysOn
-        );
+        assert_serialize_deserialize!(Sampler::AlwaysOn);
+        assert_serialize_deserialize!(Sampler::AlwaysOff);
+        assert_serialize_deserialize!(Sampler::TraceIdRatioBased(0.42));
+        assert_serialize_deserialize!(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)));
     }
 }


### PR DESCRIPTION
Hello :wave:

I noticed that a few types like Resource and KeyValue implement `Serialize` and
`Deserialize` which is very handy for me because I can integrate the different
parameter into a configuration struct.

Unfortunately it is not yet implemented for `Sampler` so I had to implement it
on my crate but I think this could be beneficial for others.

Let me know what you think
