### PR TITLE
Exclude default tonic-build features

### DIFF
--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -79,5 +79,5 @@ reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
 surf-client = ["surf", "opentelemetry-http/surf"]
 
 [build-dependencies]
-tonic-build = { version = "0.5", optional = true }
+tonic-build = { version = "0.5", default-features = false, features = ["transport", "prost"], optional = true }
 prost-build = {version = "0.8", optional = true }

--- a/opentelemetry-otlp/build.rs
+++ b/opentelemetry-otlp/build.rs
@@ -17,7 +17,6 @@ fn main() {
         tonic_build::configure()
         .build_server(std::env::var_os("CARGO_FEATURE_INTEGRATION_TESTING").is_some())
         .build_client(true)
-        .format(false)
         .out_dir(out_dir)
         .compile(
             &[


### PR DESCRIPTION
Reduces the amount of unused features that gets shipped