### PR TITLE
Add `set_attributes` method for Span

### DIFF
--- a/opentelemetry-api/src/trace/context.rs
+++ b/opentelemetry-api/src/trace/context.rs
@@ -129,6 +129,21 @@ impl SpanRef<'_> {
         self.with_inner_mut(move |inner| inner.set_attribute(attribute))
     }
 
+    /// Set multiple attributes of this span.
+    ///
+    /// Setting an attribute with the same key as an existing attribute
+    /// generally overwrites the existing attribute's value.
+    ///
+    /// Note that the OpenTelemetry project documents certain "[standard
+    /// attributes]" that have prescribed semantic meanings and are available via
+    /// the [opentelemetry_semantic_conventions] crate.
+    ///
+    /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
+    /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
+    pub fn set_attributes(&mut self, attributes: impl IntoIterator<Item = KeyValue>) {
+        self.with_inner_mut(move |inner| inner.set_attributes(attributes))
+    }
+
     /// Sets the status of this `Span`.
     ///
     /// If used, this will override the default span status, which is [`Status::Unset`].

--- a/opentelemetry-api/src/trace/span.rs
+++ b/opentelemetry-api/src/trace/span.rs
@@ -120,6 +120,25 @@ pub trait Span {
     /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
     fn set_attribute(&mut self, attribute: KeyValue);
 
+    /// Set multiple attributes of this span.
+    ///
+    /// Setting an attribute with the same key as an existing attribute
+    /// generally overwrites the existing attribute's value.
+    ///
+    /// Note that the OpenTelemetry project documents certain "[standard
+    /// attributes]" that have prescribed semantic meanings and are available via
+    /// the [opentelemetry_semantic_conventions] crate.
+    ///
+    /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
+    /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
+    fn set_attributes(&mut self, attributes: impl IntoIterator<Item = KeyValue>) {
+        if self.is_recording() {
+            for attr in attributes.into_iter() {
+                self.set_attribute(attr);
+            }
+        }
+    }
+
     /// Sets the status of this `Span`.
     ///
     /// If used, this will override the default span status, which is [`Status::Unset`].

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -373,6 +373,18 @@ mod tests {
     }
 
     #[test]
+    fn set_attributes() {
+        let mut span = create_span();
+        let attributes = [KeyValue::new("k1", "v1"), KeyValue::new("k2", "v2")];
+        span.set_attributes(attributes.clone());
+        span.with_data(|data| {
+            for kv in attributes {
+                assert_eq!(data.attributes.get(&kv.key), Some(&kv.value))
+            }
+        });
+    }
+
+    #[test]
     fn set_status() {
         {
             let mut span = create_span();


### PR DESCRIPTION
This adds the convenience  method `set_attributes` for set multiple attributes.