### PR TITLE
Fix default resource detection for tracer provider

### DIFF
--- a/opentelemetry/src/sdk/resource/mod.rs
+++ b/opentelemetry/src/sdk/resource/mod.rs
@@ -110,7 +110,7 @@ impl Resource {
 
         let mut resource = Resource::empty();
 
-        // attrs from self must be added first so they have priority
+        // attrs from self take the less priority, even when the new value is empty.
         for (k, v) in self.attrs.iter() {
             resource.attrs.insert(k.clone(), v.clone());
         }


### PR DESCRIPTION
Spec [says](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable)
>The SDK MUST extract information from the OTEL_RESOURCE_ATTRIBUTES environment variable and merge this, as the secondary resource, with any resource information provided by the user, i.e. the user provided resource information has higher priority.
