### PR TITLE
otlp: enable directly constructing a SpanExporter

### DIFF
--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -199,7 +199,7 @@ mod span;
 mod transform;
 
 pub use crate::exporter::ExportConfig;
-pub use crate::span::{OtlpTracePipeline, SpanExporter};
+pub use crate::span::{OtlpTracePipeline, SpanExporter, SpanExporterBuilder};
 
 #[cfg(feature = "metrics")]
 pub use crate::metric::{MetricsExporter, OtlpMetricPipeline};

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -202,7 +202,7 @@ pub enum SpanExporterBuilder {
 
 impl SpanExporterBuilder {
     /// Build a OTLP span exporter using the given tonic configuration and exporter configuration.
-    fn build_span_exporter(self) -> Result<SpanExporter, TraceError> {
+    pub fn build_span_exporter(self) -> Result<SpanExporter, TraceError> {
         match self {
             #[cfg(feature = "tonic")]
             SpanExporterBuilder::Tonic(builder) => Ok(match builder.channel {


### PR DESCRIPTION
Currently it is not possible to construct an `opentelemetry_otlp::SpanExporter` directly. This patch makes both the
builder and the `build_span_exporter` method public so users may construct one if necessary.

Fixes #640 