### PR TITLE
Move force_flush from tracer provider API to SDK #588

### DIFF
--- a/opentelemetry-api/src/global/mod.rs
+++ b/opentelemetry-api/src/global/mod.rs
@@ -157,7 +157,6 @@ pub use propagation::{get_text_map_propagator, set_text_map_propagator};
 #[cfg(feature = "trace")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 pub use trace::{
-    force_flush_tracer_provider, set_tracer_provider, shutdown_tracer_provider, tracer,
-    tracer_provider, BoxedSpan, BoxedTracer, GlobalTracerProvider, ObjectSafeTracer,
-    ObjectSafeTracerProvider,
+    set_tracer_provider, shutdown_tracer_provider, tracer, tracer_provider, BoxedSpan, BoxedTracer,
+    GlobalTracerProvider, ObjectSafeTracer, ObjectSafeTracerProvider,
 };

--- a/opentelemetry-api/src/trace/noop.rs
+++ b/opentelemetry-api/src/trace/noop.rs
@@ -3,7 +3,6 @@
 //! This implementation is returned as the global tracer if no `Tracer`
 //! has been set. It is also useful for testing purposes as it is intended
 //! to have minimal resource utilization and runtime impact.
-use crate::trace::TraceResult;
 use crate::{
     propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
     trace,
@@ -37,11 +36,6 @@ impl trace::TracerProvider for NoopTracerProvider {
         _schema_url: Option<&'static str>,
     ) -> Self::Tracer {
         NoopTracer::new()
-    }
-
-    /// Return an empty `Vec` as there isn't any span processors in `NoopTracerProvider`
-    fn force_flush(&self) -> Vec<TraceResult<()>> {
-        Vec::new()
     }
 }
 

--- a/opentelemetry-api/src/trace/tracer_provider.rs
+++ b/opentelemetry-api/src/trace/tracer_provider.rs
@@ -1,4 +1,4 @@
-use crate::trace::{TraceResult, Tracer};
+use crate::trace::Tracer;
 use std::borrow::Cow;
 
 /// Types that can create instances of [`Tracer`].
@@ -67,7 +67,4 @@ pub trait TracerProvider {
         version: Option<&'static str>,
         schema_url: Option<&'static str>,
     ) -> Self::Tracer;
-
-    /// Force flush all remaining spans in span processors and return results.
-    fn force_flush(&self) -> Vec<TraceResult<()>>;
 }

--- a/opentelemetry-jaeger/tests/integration_test.rs
+++ b/opentelemetry-jaeger/tests/integration_test.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "integration_test")]
 mod tests {
     use opentelemetry::sdk::trace::Tracer as SdkTracer;
-    use opentelemetry::trace::{Status, TraceContextExt, Tracer, TracerProvider};
+    use opentelemetry::trace::{Status, TraceContextExt, Tracer};
     use opentelemetry::KeyValue;
     use opentelemetry_jaeger::testing::{
         jaeger_api_v2 as jaeger_api, jaeger_client::JaegerTestClient,

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -69,6 +69,14 @@ impl TracerProvider {
     pub fn config(&self) -> &crate::trace::Config {
         &self.inner.config
     }
+
+    /// Force flush all remaining spans in span processors and return results.
+    pub fn force_flush(&self) -> Vec<TraceResult<()>> {
+        self.span_processors()
+            .iter()
+            .map(|processor| processor.force_flush())
+            .collect()
+    }
 }
 
 impl opentelemetry_api::trace::TracerProvider for TracerProvider {
@@ -96,14 +104,6 @@ impl opentelemetry_api::trace::TracerProvider for TracerProvider {
         );
 
         Tracer::new(instrumentation_lib, Arc::downgrade(&self.inner))
-    }
-
-    /// Force flush all remaining spans in span processors and return results.
-    fn force_flush(&self) -> Vec<TraceResult<()>> {
-        self.span_processors()
-            .iter()
-            .map(|processor| processor.force_flush())
-            .collect()
     }
 }
 
@@ -200,7 +200,7 @@ mod tests {
     use crate::trace::provider::TracerProviderInner;
     use crate::trace::{Config, Span, SpanProcessor};
     use crate::Resource;
-    use opentelemetry_api::trace::{TraceError, TraceResult, TracerProvider};
+    use opentelemetry_api::trace::{TraceError, TraceResult};
     use opentelemetry_api::{Context, Key, KeyValue};
     use std::env;
     use std::sync::Arc;


### PR DESCRIPTION
Removed force_flush from TracerProvider trait in API and added it as pub fn in TracerProvider implementation in SDK