### PR TITLE
Update tonic, prost, and friends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,8 @@ members = [
     "examples/zpages"
 ]
 exclude = ["examples/external-otlp-grpcio-async-std"]
+
+[patch.crates-io]
+# revert tonic to 2018 edition so opentelemetry can use it
+tonic = { git = "https://github.com/hyperium/tonic", rev = "101f2f76d4a62" } # branch = master
+tonic-build = { git = "https://github.com/hyperium/tonic", rev = "101f2f76d4a62" } # branch = master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,3 @@ members = [
     "examples/zpages"
 ]
 exclude = ["examples/external-otlp-grpcio-async-std"]
-
-[patch.crates-io]
-# revert tonic to 2018 edition so opentelemetry can use it
-tonic = { git = "https://github.com/hyperium/tonic", rev = "101f2f76d4a62" } # branch = master
-tonic-build = { git = "https://github.com/hyperium/tonic", rev = "101f2f76d4a62" } # branch = master

--- a/examples/external-otlp-tonic-tokio/Cargo.toml
+++ b/examples/external-otlp-tonic-tokio/Cargo.toml
@@ -9,5 +9,5 @@ opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio", "metrics
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic", "tls", "tls-roots"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-tonic = "0.5.0"
+tonic = "0.6"
 url = "2.2.0"

--- a/examples/external-otlp-tonic-tokio/Cargo.toml
+++ b/examples/external-otlp-tonic-tokio/Cargo.toml
@@ -9,5 +9,5 @@ opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio", "metrics
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic", "tls", "tls-roots"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-tonic = "0.6"
+tonic = "0.6.2"
 url = "2.2.0"

--- a/examples/grpc/Cargo.toml
+++ b/examples/grpc/Cargo.toml
@@ -16,11 +16,11 @@ doc = false
 
 [dependencies]
 http = "0.2"
-tonic = "0.6"
+tonic = "0.6.2"
 prost = "0.9"
 tokio = { version = "1.0", features = ["full"] }
 opentelemetry = { path = "../../opentelemetry" }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }
 
 [build-dependencies]
-tonic-build = "0.6"
+tonic-build = "0.6.2"

--- a/examples/grpc/Cargo.toml
+++ b/examples/grpc/Cargo.toml
@@ -16,11 +16,11 @@ doc = false
 
 [dependencies]
 http = "0.2"
-tonic = "0.5"
-prost = "0.8"
+tonic = "0.6"
+prost = "0.9"
 tokio = { version = "1.0", features = ["full"] }
 opentelemetry = { path = "../../opentelemetry" }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }
 
 [build-dependencies]
-tonic-build = "0.5"
+tonic-build = "0.6"

--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/client.rs"
 
 [dependencies]
 http = "0.2"
-tonic = "0.5"
-prost = "0.8"
+tonic = "0.6"
+prost = "0.9"
 tokio = { version = "1.0", features = ["full"] }
 opentelemetry = { version = "0.14", features = ["rt-tokio"] }
 opentelemetry-jaeger = "0.13"
@@ -25,4 +25,4 @@ tracing-opentelemetry = "0.13"
 tracing-futures = "0.2"
 
 [build-dependencies]
-tonic-build = "0.5"
+tonic-build = "0.6"

--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/client.rs"
 
 [dependencies]
 http = "0.2"
-tonic = "0.6"
+tonic = "0.6.2"
 prost = "0.9"
 tokio = { version = "1.0", features = ["full"] }
 opentelemetry = { version = "0.14", features = ["rt-tokio"] }
@@ -25,4 +25,4 @@ tracing-opentelemetry = "0.13"
 tracing-futures = "0.2"
 
 [build-dependencies]
-tonic-build = "0.6"
+tonic-build = "0.6.2"

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -43,7 +43,7 @@ opentelemetry = { version = "0.16", default-features = false, features = ["trace
 prost = { version = "0.9", optional = true }
 protobuf = { version = "2.18", optional = true }
 thiserror = "1.0"
-tonic = { version = "0.6", optional = true }
+tonic = { version = "0.6.2", optional = true }
 tokio = { version = "1.0", features = ["full"], optional = true }
 opentelemetry-http = { version = "0.5", path = "../opentelemetry-http", optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false }
@@ -80,5 +80,5 @@ reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
 surf-client = ["surf", "opentelemetry-http/surf"]
 
 [build-dependencies]
-tonic-build = { version = "0.6", default-features = false, features = ["transport", "prost"], optional = true }
+tonic-build = { version = "0.6.2", default-features = false, features = ["transport", "prost"], optional = true }
 prost-build = { version = "0.9", optional = true }

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -40,10 +40,10 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 grpcio = { version = "0.9", optional = true }
 opentelemetry = { version = "0.16", default-features = false, features = ["trace"], path = "../opentelemetry" }
-prost = { version = "0.8", optional = true }
+prost = { version = "0.9", optional = true }
 protobuf = { version = "2.18", optional = true }
 thiserror = "1.0"
-tonic = { version = "0.5", optional = true }
+tonic = { version = "0.6", optional = true }
 tokio = { version = "1.0", features = ["full"], optional = true }
 opentelemetry-http = { version = "0.5", path = "../opentelemetry-http", optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false }
@@ -80,5 +80,5 @@ reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
 surf-client = ["surf", "opentelemetry-http/surf"]
 
 [build-dependencies]
-tonic-build = { version = "0.5", default-features = false, features = ["transport", "prost"], optional = true }
-prost-build = {version = "0.8", optional = true }
+tonic-build = { version = "0.6", default-features = false, features = ["transport", "prost"], optional = true }
+prost-build = { version = "0.9", optional = true }

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -277,9 +277,7 @@ impl MetricsExporter {
         .connect_lazy();
 
         #[cfg(not(feature = "tls"))]
-        let channel = endpoint
-            .timeout(config.timeout)
-            .connect_lazy();
+        let channel = endpoint.timeout(config.timeout).connect_lazy();
 
         let client = MetricsServiceClient::new(channel);
 

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -274,14 +274,12 @@ impl MetricsExporter {
             None => endpoint,
         }
         .timeout(config.timeout)
-        .connect_lazy()
-        .map_err::<crate::Error, _>(Into::into)?;
+        .connect_lazy();
 
         #[cfg(not(feature = "tls"))]
         let channel = endpoint
             .timeout(config.timeout)
-            .connect_lazy()
-            .map_err::<crate::Error, _>(Into::into)?;
+            .connect_lazy();
 
         let client = MetricsServiceClient::new(channel);
 

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -338,10 +338,10 @@ impl SpanExporter {
             None => endpoint,
         }
         .timeout(config.timeout)
-        .connect_lazy()?;
+        .connect_lazy();
 
         #[cfg(not(feature = "tls"))]
-        let channel = endpoint.timeout(config.timeout).connect_lazy()?;
+        let channel = endpoint.timeout(config.timeout).connect_lazy();
 
         SpanExporter::from_tonic_channel(config, tonic_config, channel)
     }

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tonic-build = "0.6"
+tonic-build = "0.6.2"
 which = "4.0.2"
 
 [dependencies]
@@ -27,7 +27,7 @@ opentelemetry = { version = "0.16", path = "../opentelemetry" }
 prost = "0.9"
 prost-types = "0.9"
 rustls = "0.19"
-tonic = { version = "0.6", features = ["tls", "transport"] }
+tonic = { version = "0.6.2", features = ["tls", "transport"] }
 tokio = { version = "1.1", optional = true }
 yup-oauth2 = { version = "5.0.1", optional = true }
 webpki-roots = "0.21"

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tonic-build = "0.5.0"
+tonic-build = "0.6"
 which = "4.0.2"
 
 [dependencies]
@@ -24,10 +24,10 @@ hyper = "0.14.2"
 hyper-rustls = { version = "0.22.1", optional = true }
 log = "0.4"
 opentelemetry = { version = "0.16", path = "../opentelemetry" }
-prost = "0.8"
-prost-types = "0.8"
+prost = "0.9"
+prost-types = "0.9"
 rustls = "0.19"
-tonic = { version = "0.5", features = ["tls", "transport"] }
+tonic = { version = "0.6", features = ["tls", "transport"] }
 tokio = { version = "1.1", optional = true }
 yup-oauth2 = { version = "5.0.1", optional = true }
 webpki-roots = "0.21"


### PR DESCRIPTION
Updates tonic and tonic-build to 0.6 and prost, prost-build, and prost-types to 0.8.

When building this locally I get this error:

```
error: failed to run custom build command for `opentelemetry-zpages v0.1.0 (opentelemetry-rust/opentelemetry-zpages)`

Caused by:
  process didn't exit successfully: `opentelemetry-rust/target/debug/build/opentelemetry-zpages-5a7a6985eea043c2/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'protoc binary not found: cannot find binary path', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/protoc-2.25.2/src/lib.rs:203:17
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

However I also get that `main` so not sure if its a an issue in my setup or a general issue.