### PR TITLE
limit futures deps

### DIFF
--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -51,6 +51,7 @@ http = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
+futures-util = "0.3"
 tokio-stream = { version = "0.1", features = ["net"] }
 # need tokio runtime to run smoke tests.
 opentelemetry = { features = ["trace", "rt-tokio"], path = "../opentelemetry" }

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -36,7 +36,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3"
+futures-core = "0.3"
 grpcio = { version = "0.9", optional = true }
 opentelemetry = { version = "0.16", default-features = false, features = ["trace"], path = "../opentelemetry" }
 prost = { version = "0.8", optional = true }

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -14,7 +14,7 @@ use crate::proto::collector::metrics::v1::{
 };
 use crate::transform::{record_to_metric, sink, CheckpointedMetrics};
 use crate::{Error, OtlpPipeline};
-use futures::Stream;
+use futures_core::Stream;
 use opentelemetry::metrics::{Descriptor, Result};
 use opentelemetry::sdk::export::metrics::{AggregatorSelector, ExportKindSelector};
 use opentelemetry::sdk::metrics::{PushController, PushControllerWorker};

--- a/opentelemetry-otlp/src/proto/grpcio/metrics_service_grpc.rs
+++ b/opentelemetry-otlp/src/proto/grpcio/metrics_service_grpc.rs
@@ -50,7 +50,7 @@ impl MetricsServiceClient {
     pub fn export_async(&self, req: &super::metrics_service::ExportMetricsServiceRequest) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::metrics_service::ExportMetricsServiceResponse>> {
         self.export_async_opt(req, ::grpcio::CallOption::default())
     }
-    pub fn spawn<F>(&self, f: F) where F: ::futures::Future<Output = ()> + Send + 'static {
+    pub fn spawn<F>(&self, f: F) where F: ::futures_core::Future<Output = ()> + Send + 'static {
         self.client.spawn(f)
     }
 }

--- a/opentelemetry-otlp/src/proto/grpcio/trace_service_grpc.rs
+++ b/opentelemetry-otlp/src/proto/grpcio/trace_service_grpc.rs
@@ -50,7 +50,7 @@ impl TraceServiceClient {
     pub fn export_async(&self, req: &super::trace_service::ExportTraceServiceRequest) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::trace_service::ExportTraceServiceResponse>> {
         self.export_async_opt(req, ::grpcio::CallOption::default())
     }
-    pub fn spawn<F>(&self, f: F) where F: ::futures::Future<Output = ()> + Send + 'static {
+    pub fn spawn<F>(&self, f: F) where F: ::futures_core::Future<Output = ()> + Send + 'static {
         self.client.spawn(f)
     }
 }

--- a/opentelemetry-otlp/tests/smoke.rs
+++ b/opentelemetry-otlp/tests/smoke.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures_util::StreamExt;
 use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::trace::{Span, SpanKind, Tracer};
 use opentelemetry_otlp::proto::collector::trace::v1::{

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -25,7 +25,9 @@ async-std = { version = "1.6", features = ["unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
 dashmap = { version = "4.0.1", optional = true }
 fnv = { version = "1.0", optional = true }
-futures = "0.3"
+futures-channel = "0.3"
+futures-executor = "0.3"
+futures-util = { version = "0.3", features = ["sink"] }
 lazy_static = "1.4"
 percent-encoding = { version = "2.0", optional = true }
 pin-project = { version = "1.0.2", optional = true }

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -26,7 +26,7 @@ async-trait = { version = "0.1", optional = true }
 dashmap = { version = "4.0.1", optional = true }
 fnv = { version = "1.0", optional = true }
 futures-channel = "0.3"
-futures-executor = "0.3"
+futures-executor = { version = "0.3", optional = true }
 futures-util = { version = "0.3", features = ["sink"] }
 lazy_static = "1.4"
 percent-encoding = { version = "2.0", optional = true }
@@ -48,7 +48,7 @@ rand_distr = "0.4.0"
 
 [features]
 default = ["trace"]
-trace = ["crossbeam-channel", "rand", "pin-project", "async-trait", "percent-encoding"]
+trace = ["crossbeam-channel", "futures-executor", "rand", "pin-project", "async-trait", "percent-encoding"]
 metrics = ["dashmap", "fnv"]
 serialize = ["serde"]
 testing = ["trace", "metrics", "rt-async-std", "rt-tokio", "rt-tokio-current-thread", "tokio/macros", "tokio/rt-multi-thread"]

--- a/opentelemetry/benches/batch_span_processor.rs
+++ b/opentelemetry/benches/batch_span_processor.rs
@@ -65,7 +65,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                                 }
                             }));
                         }
-                        futures::future::join_all(handles).await;
+                        futures_util::future::join_all(handles).await;
                         let _ =
                             Arc::<BatchSpanProcessor<Tokio>>::get_mut(&mut shared_span_processor)
                                 .unwrap()

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -674,7 +674,7 @@ mod tests {
     // single -> no shutdown -> not export
     // single -> shutdown -> hang forever
 
-    // When using |fut| tokio::task::spawn_blocking(|| futures::executor::block_on(fut))
+    // When using |fut| tokio::task::spawn_blocking(|| futures_executor::block_on(fut))
     // to spawn the worker task in batch processor
     //
     // multiple -> no shutdown -> hang forever

--- a/opentelemetry/src/runtime.rs
+++ b/opentelemetry/src/runtime.rs
@@ -6,7 +6,7 @@
 //! [Tokio]: https://crates.io/crates/tokio
 //! [async-std]: https://crates.io/crates/async-std
 
-use futures::{future::BoxFuture, Stream};
+use futures_util::{future::BoxFuture, Stream};
 use std::{future::Future, time::Duration};
 
 /// A runtime is an abstraction of an async runtime like [Tokio] or [async-std]. It allows
@@ -23,7 +23,7 @@ pub trait Runtime: Clone + Send + Sync + 'static {
     /// not important.
     type Delay: Future + Send;
 
-    /// Create a [Stream][futures::Stream], which returns a new item every
+    /// Create a [Stream][futures_util::Stream], which returns a new item every
     /// [Duration][std::time::Duration].
     fn interval(&self, duration: Duration) -> Self::Interval;
 

--- a/opentelemetry/src/sdk/export/metrics/stdout.rs
+++ b/opentelemetry/src/sdk/export/metrics/stdout.rs
@@ -19,7 +19,7 @@ use crate::{
     metrics::{Descriptor, MetricsError, Result},
     KeyValue,
 };
-use futures::Stream;
+use futures_util::Stream;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
 use std::fmt;

--- a/opentelemetry/src/sdk/metrics/controllers/push.rs
+++ b/opentelemetry/src/sdk/metrics/controllers/push.rs
@@ -9,7 +9,8 @@ use crate::sdk::{
     },
     Resource,
 };
-use futures::{channel::mpsc, task, Future, Stream, StreamExt};
+use futures_channel::mpsc;
+use futures_util::{task, Future, Stream, StreamExt};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time;
@@ -87,7 +88,7 @@ impl Future for PushControllerWorker {
     type Output = ();
     fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
         loop {
-            match futures::ready!(self.messages.poll_next_unpin(cx)) {
+            match futures_util::ready!(self.messages.poll_next_unpin(cx)) {
                 // Span batch interval time reached, export current spans.
                 Some(PushMessage::Tick) => self.on_tick(),
                 // Stream has terminated or processor is shutdown, return to finish execution.
@@ -181,7 +182,7 @@ where
             (self.interval)(self.period.unwrap_or(*DEFAULT_PUSH_PERIOD)).map(|_| PushMessage::Tick);
 
         (self.spawn)(PushControllerWorker {
-            messages: Box::pin(futures::stream::select(message_receiver, ticker)),
+            messages: Box::pin(futures_util::stream::select(message_receiver, ticker)),
             accumulator,
             processor,
             exporter: self.exporter,

--- a/opentelemetry/src/sdk/trace/runtime.rs
+++ b/opentelemetry/src/sdk/trace/runtime.rs
@@ -13,7 +13,7 @@ use crate::runtime::Tokio;
 use crate::runtime::TokioCurrentThread;
 use crate::sdk::trace::BatchMessage;
 use crate::trace::TraceError;
-use futures::Stream;
+use futures_util::Stream;
 use std::fmt::Debug;
 
 #[cfg(any(

--- a/opentelemetry/src/sdk/trace/span_processor.rs
+++ b/opentelemetry/src/sdk/trace/span_processor.rs
@@ -42,7 +42,8 @@ use crate::{
     trace::{TraceError, TraceResult},
     Context,
 };
-use futures::{channel::oneshot, executor, future::Either, pin_mut, StreamExt};
+use futures_channel::oneshot;
+use futures_util::{future::Either, pin_mut, StreamExt};
 use std::{env, fmt, str::FromStr, thread, time::Duration};
 
 /// Delay interval between two consecutive exports.
@@ -116,7 +117,7 @@ impl SimpleSpanProcessor {
             .name("opentelemetry-exporter".to_string())
             .spawn(move || {
                 while let Ok(Some(span)) = span_rx.recv() {
-                    if let Err(err) = executor::block_on(exporter.export(vec![span])) {
+                    if let Err(err) = futures_executor::block_on(exporter.export(vec![span])) {
                         global::handle_error(err);
                     }
                 }
@@ -256,7 +257,7 @@ impl<R: TraceRuntime> SpanProcessor for BatchSpanProcessor<R> {
         self.message_sender
             .try_send(BatchMessage::Flush(Some(res_sender)))?;
 
-        futures::executor::block_on(res_receiver)
+        futures_executor::block_on(res_receiver)
             .map_err(|err| TraceError::Other(err.into()))
             .and_then(|identity| identity)
     }
@@ -266,7 +267,7 @@ impl<R: TraceRuntime> SpanProcessor for BatchSpanProcessor<R> {
         self.message_sender
             .try_send(BatchMessage::Shutdown(res_sender))?;
 
-        futures::executor::block_on(res_receiver)
+        futures_executor::block_on(res_receiver)
             .map_err(|err| TraceError::Other(err.into()))
             .and_then(|identity| identity)
     }
@@ -300,7 +301,7 @@ impl<R: TraceRuntime> BatchSpanProcessor<R> {
         // Spawn worker process via user-defined spawn function.
         runtime.spawn(Box::pin(async move {
             let mut spans = Vec::new();
-            let mut messages = Box::pin(futures::stream::select(message_receiver, ticker));
+            let mut messages = Box::pin(futures_util::stream::select(message_receiver, ticker));
 
             while let Some(message) = messages.next().await {
                 match message {
@@ -403,7 +404,7 @@ where
     let timeout = runtime.delay(time_out);
     pin_mut!(export);
     pin_mut!(timeout);
-    match futures::future::select(export, timeout).await {
+    match futures_util::future::select(export, timeout).await {
         Either::Left((export_res, _)) => export_res,
         Either::Right((_, _)) => ExportResult::Err(TraceError::ExportTimedOut(time_out)),
     }
@@ -551,7 +552,7 @@ mod tests {
         new_test_export_span_data, new_test_exporter, new_tokio_test_exporter,
     };
     use async_trait::async_trait;
-    use futures::Future;
+    use futures_util::Future;
     use std::fmt::Debug;
     use std::time::Duration;
 

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -296,7 +296,7 @@ impl<T: std::future::Future> std::future::Future for WithContext<T> {
     }
 }
 
-impl<T: futures::Stream> futures::Stream for WithContext<T> {
+impl<T: futures_util::Stream> futures_util::Stream for WithContext<T> {
     type Item = T::Item;
 
     fn poll_next(self: Pin<&mut Self>, task_cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
@@ -306,9 +306,9 @@ impl<T: futures::Stream> futures::Stream for WithContext<T> {
     }
 }
 
-impl<I, T: futures::Sink<I>> futures::Sink<I> for WithContext<T>
+impl<I, T: futures_util::Sink<I>> futures_util::Sink<I> for WithContext<T>
 where
-    T: futures::Sink<I>,
+    T: futures_util::Sink<I>,
 {
     type Error = T::Error;
 
@@ -339,7 +339,7 @@ where
     fn poll_close(
         self: Pin<&mut Self>,
         task_cx: &mut TaskContext<'_>,
-    ) -> futures::task::Poll<Result<(), Self::Error>> {
+    ) -> futures_util::task::Poll<Result<(), Self::Error>> {
         let this = self.project();
         let _enter = this.otel_cx.clone().attach();
         T::poll_close(this.inner, task_cx)

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -168,7 +168,7 @@
 //! # }
 //! ```
 
-use ::futures::channel::{mpsc::TrySendError, oneshot::Canceled};
+use futures_channel::{mpsc::TrySendError, oneshot::Canceled};
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;


### PR DESCRIPTION
This change removes the dependency on futures-io by depending directly on futures-core in opentelemetry-otlp and futures-util, futures-channel, and futures-executor in opentelemetry