### PR TITLE
Update otel-collector image in basic-otlp-http example

### DIFF
--- a/examples/basic-otlp-http/docker-compose.yaml
+++ b/examples/basic-otlp-http/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
 
   # Collector
   otel-collector:
-    image: otel/opentelemetry-collector-dev:latest
+    image: otel/opentelemetry-collector:latest
     command: ["--config=/etc/otel-collector-config.yaml", "${OTELCOL_ARGS}"]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -69,7 +69,9 @@ pub use prometheus::{Encoder, TextEncoder};
 
 use opentelemetry::global;
 use opentelemetry::sdk::{
-    export::metrics::{CheckpointSet, ExportKindSelector, Histogram, LastValue, Record, Sum},
+    export::metrics::{
+        AggregatorSelector, CheckpointSet, ExportKindSelector, Histogram, LastValue, Record, Sum,
+    },
     metrics::{
         aggregators::{HistogramAggregator, LastValueAggregator, SumAggregator},
         controllers,
@@ -149,6 +151,9 @@ pub struct ExporterBuilder {
     ///
     /// If not set it will be defaulted to port 9464
     port: Option<u16>,
+
+    /// The aggregator selector used by the prometheus exporter.
+    aggegator_selector: Option<Box<dyn AggregatorSelector + Send + Sync>>,
 }
 
 impl Default for ExporterBuilder {
@@ -176,6 +181,7 @@ impl Default for ExporterBuilder {
             registry: None,
             host: env::var(ENV_EXPORTER_HOST).ok().filter(|s| !s.is_empty()),
             port,
+            aggegator_selector: None,
         }
     }
 }
@@ -240,6 +246,17 @@ impl ExporterBuilder {
         }
     }
 
+    /// Set the aggregation selector for the prometheus exporter
+    pub fn with_aggregator_selector<T>(self, aggregator_selector: T) -> Self
+    where
+        T: AggregatorSelector + Send + Sync + 'static,
+    {
+        ExporterBuilder {
+            aggegator_selector: Some(Box::new(aggregator_selector)),
+            ..self
+        }
+    }
+
     /// Sets up a complete export pipeline with the recommended setup, using the
     /// recommended selector and standard processor.
     pub fn try_init(self) -> Result<PrometheusExporter, MetricsError> {
@@ -251,7 +268,9 @@ impl ExporterBuilder {
         let default_histogram_boundaries = self
             .default_histogram_boundaries
             .unwrap_or_else(|| vec![0.5, 0.9, 0.99]);
-        let selector = Box::new(Selector::Histogram(default_histogram_boundaries));
+        let selector = self
+            .aggegator_selector
+            .unwrap_or_else(|| Box::new(Selector::Histogram(default_histogram_boundaries)));
         let mut controller_builder = controllers::pull(selector, Box::new(EXPORT_KIND_SELECTOR))
             .with_cache_period(self.cache_period.unwrap_or(DEFAULT_CACHE_PERIOD))
             .with_memory(true);


### PR DESCRIPTION
### Problem
The otel-collector image `otel/opentelemetry-collector-dev:latest` seems outdated causing following errors when running `docker-compose up`:

```
otel-collector_1     | 2021-11-16T05:39:39.121Z	info	service/collector.go:303	Starting otelcol...	{"Version": "v0.33.0-50-g0594aa1a", "NumCPU": 6}
otel-collector_1     | 2021-11-16T05:39:39.121Z	info	service/collector.go:242	Loading configuration...
otel-collector_1     | Error: cannot load configuration: unknown extensions type "pprof" for pprof
otel-collector_1     | 2021/11/16 05:39:39 collector server run finished with error: cannot load configuration: unknown extensions type "pprof" for pprof
basic-otlp-http_otel-collector_1 exited with code 1
```

### Proposed solution
Update otel-collector image from `otel/opentelemetry-collector-dev:latest` to `otel/opentelemetry-collector:latest`

### Tests
Followed [README.md](https://github.com/open-telemetry/opentelemetry-rust/blob/main/examples/basic-otlp-http/README.md) steps and checked the Jaeger trace as expected.