### PR TITLE
feat: using `Cow<'static, str>` for instrumentation library.

### DIFF
--- a/opentelemetry-datadog/src/exporter/model/v03.rs
+++ b/opentelemetry-datadog/src/exporter/model/v03.rs
@@ -41,7 +41,7 @@ pub(crate) fn encode(
             rmp::encode::write_str(&mut encoded, service_name)?;
 
             rmp::encode::write_str(&mut encoded, "name")?;
-            rmp::encode::write_str(&mut encoded, span.instrumentation_lib.name)?;
+            rmp::encode::write_str(&mut encoded, span.instrumentation_lib.name.as_ref())?;
 
             rmp::encode::write_str(&mut encoded, "resource")?;
             rmp::encode::write_str(&mut encoded, &span.name)?;

--- a/opentelemetry-datadog/src/exporter/model/v05.rs
+++ b/opentelemetry-datadog/src/exporter/model/v05.rs
@@ -105,7 +105,10 @@ fn encode_traces(
             // Datadog span name is OpenTelemetry component name - see module docs for more information
             rmp::encode::write_array_len(&mut encoded, 12)?;
             rmp::encode::write_u32(&mut encoded, service_interned)?;
-            rmp::encode::write_u32(&mut encoded, interner.intern(span.instrumentation_lib.name))?;
+            rmp::encode::write_u32(
+                &mut encoded,
+                interner.intern(span.instrumentation_lib.name.as_ref()),
+            )?;
             rmp::encode::write_u32(&mut encoded, interner.intern(&span.name))?;
             rmp::encode::write_u64(&mut encoded, span.span_context.trace_id().to_u128() as u64)?;
             rmp::encode::write_u64(&mut encoded, span.span_context.span_id().to_u64())?;

--- a/opentelemetry-otlp/src/transform/common.rs
+++ b/opentelemetry-otlp/src/transform/common.rs
@@ -9,12 +9,13 @@ pub(crate) mod tonic {
     use crate::proto::common::v1::{
         any_value, AnyValue, ArrayValue, InstrumentationLibrary, KeyValue,
     };
+    use std::borrow::Cow;
 
     impl From<opentelemetry::sdk::InstrumentationLibrary> for InstrumentationLibrary {
         fn from(library: opentelemetry::sdk::InstrumentationLibrary) -> Self {
             InstrumentationLibrary {
                 name: library.name.to_string(),
-                version: library.version.unwrap_or("").to_string(),
+                version: library.version.unwrap_or(Cow::Borrowed("")).to_string(),
             }
         }
     }
@@ -86,12 +87,13 @@ pub(crate) mod prost {
     use crate::proto::prost::common::v1::{
         any_value, AnyValue, ArrayValue, InstrumentationLibrary, KeyValue,
     };
+    use std::borrow::Cow;
 
     impl From<opentelemetry::sdk::InstrumentationLibrary> for InstrumentationLibrary {
         fn from(library: opentelemetry::sdk::InstrumentationLibrary) -> Self {
             InstrumentationLibrary {
                 name: library.name.to_string(),
-                version: library.version.unwrap_or("").to_string(),
+                version: library.version.unwrap_or(Cow::Borrowed("")).to_string(),
             }
         }
     }

--- a/opentelemetry-zipkin/src/exporter/model/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/model/mod.rs
@@ -65,7 +65,9 @@ pub(crate) fn into_zipkin_span(local_endpoint: Endpoint, span_data: trace::SpanD
                     ),
                 ]
                 .iter()
-                .filter_map(|(key, val)| val.map(|val| KeyValue::new(*key, val))),
+                .filter_map(|(key, val)| {
+                    val.as_ref().map(|val| KeyValue::new(*key, val.to_owned()))
+                }),
             )
             .filter(|kv| kv.key.as_str() != "error"),
     );

--- a/opentelemetry/src/metrics/config.rs
+++ b/opentelemetry/src/metrics/config.rs
@@ -1,5 +1,6 @@
 use crate::metrics::Unit;
 use crate::sdk::InstrumentationLibrary;
+use std::borrow::Cow;
 
 /// Config contains some options for metrics of any kind.
 #[derive(Clone, Debug, PartialEq, Hash)]
@@ -15,25 +16,22 @@ impl InstrumentConfig {
         InstrumentConfig {
             description: None,
             unit: None,
-            instrumentation_library: InstrumentationLibrary {
-                name: instrumentation_name,
-                version: None,
-            },
+            instrumentation_library: InstrumentationLibrary::new(instrumentation_name, None),
         }
     }
 
     /// Create a new config with instrumentation name and optional version
-    pub fn with_instrumentation(
-        instrumentation_name: &'static str,
-        instrumentation_version: Option<&'static str>,
+    pub fn with_instrumentation<T: Into<Cow<'static, str>>>(
+        instrumentation_name: T,
+        instrumentation_version: Option<T>,
     ) -> Self {
         InstrumentConfig {
             description: None,
             unit: None,
-            instrumentation_library: InstrumentationLibrary {
-                name: instrumentation_name,
-                version: instrumentation_version,
-            },
+            instrumentation_library: InstrumentationLibrary::new(
+                instrumentation_name,
+                instrumentation_version,
+            ),
         }
     }
 
@@ -48,12 +46,12 @@ impl InstrumentConfig {
     }
 
     /// Instrumentation name is the name given to the Meter that created this instrument.
-    pub fn instrumentation_name(&self) -> &'static str {
-        self.instrumentation_library.name
+    pub fn instrumentation_name(&self) -> Cow<'static, str> {
+        self.instrumentation_library.name.clone()
     }
 
     /// Instrumentation version returns the version of instrumentation
-    pub fn instrumentation_version(&self) -> Option<&'static str> {
-        self.instrumentation_library.version
+    pub fn instrumentation_version(&self) -> Option<Cow<'static, str>> {
+        self.instrumentation_library.version.clone()
     }
 }

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::sync::Arc;
+
 use crate::sdk::InstrumentationLibrary;
 use crate::{
     metrics::{
@@ -7,8 +10,6 @@ use crate::{
     },
     Context, KeyValue,
 };
-use std::fmt;
-use std::sync::Arc;
 
 /// Returns named meter instances
 pub trait MeterProvider: fmt::Debug {
@@ -61,7 +62,7 @@ impl Meter {
     }
 
     pub(crate) fn instrumentation_library(&self) -> InstrumentationLibrary {
-        self.instrumentation_library
+        self.instrumentation_library.clone()
     }
 
     /// Creates a new integer `CounterBuilder` for `u64` values with the given name.

--- a/opentelemetry/src/sdk/instrumentation.rs
+++ b/opentelemetry/src/sdk/instrumentation.rs
@@ -3,23 +3,31 @@
 //!
 //! [OTEPS-0083](https://github.com/open-telemetry/oteps/blob/master/text/0083-component.md)
 
+use std::borrow::Cow;
+
 /// InstrumentationLibrary contains information about instrumentation library.
 ///
 /// See `Instrumentation Libraries` for more information.
 ///
 /// [`Instrumentation Libraries`](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#instrumentation-libraries)
-#[derive(Debug, Default, Hash, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Hash, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct InstrumentationLibrary {
     /// instrumentation library name, cannot be empty
-    pub name: &'static str,
+    pub name: Cow<'static, str>,
     /// instrumentation library version, can be empty
-    pub version: Option<&'static str>,
+    pub version: Option<Cow<'static, str>>,
 }
 
 impl InstrumentationLibrary {
     /// Create an InstrumentationLibrary from name and version.
-    pub fn new(name: &'static str, version: Option<&'static str>) -> InstrumentationLibrary {
-        InstrumentationLibrary { name, version }
+    pub fn new<T>(name: T, version: Option<T>) -> InstrumentationLibrary
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        InstrumentationLibrary {
+            name: name.into(),
+            version: version.map(Into::into),
+        }
     }
 }

--- a/opentelemetry/src/sdk/trace/provider.rs
+++ b/opentelemetry/src/sdk/trace/provider.rs
@@ -16,6 +16,7 @@ use crate::{
     global,
     sdk::{self, export::trace::SpanExporter, trace::SpanProcessor},
 };
+use std::borrow::Cow;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -78,10 +79,12 @@ impl crate::trace::TracerProvider for TracerProvider {
     type Tracer = sdk::trace::Tracer;
 
     /// Find or create `Tracer` instance by name.
-    fn tracer(&self, name: &'static str, version: Option<&'static str>) -> Self::Tracer {
+    fn tracer<T: Into<Cow<'static, str>>>(&self, name: T, version: Option<T>) -> Self::Tracer {
+        let name = name.into();
+        let version = version.map(Into::<Cow<'static, str>>::into);
         // Use default value if name is invalid empty string
         let component_name = if name.is_empty() {
-            DEFAULT_COMPONENT_NAME
+            Cow::Borrowed(DEFAULT_COMPONENT_NAME)
         } else {
             name
         };

--- a/opentelemetry/src/sdk/trace/span.rs
+++ b/opentelemetry/src/sdk/trace/span.rs
@@ -234,7 +234,7 @@ fn build_export_data(
         status_code: data.status_code,
         status_message: data.status_message,
         resource,
-        instrumentation_lib: *tracer.instrumentation_library(),
+        instrumentation_lib: tracer.instrumentation_library().clone(),
     }
 }
 

--- a/opentelemetry/src/trace/noop.rs
+++ b/opentelemetry/src/trace/noop.rs
@@ -31,7 +31,7 @@ impl trace::TracerProvider for NoopTracerProvider {
     type Tracer = NoopTracer;
 
     /// Returns a new `NoopTracer` instance.
-    fn tracer(&self, _name: &'static str, _version: Option<&'static str>) -> Self::Tracer {
+    fn tracer<T: Into<Cow<'static, str>>>(&self, _name: T, _version: Option<T>) -> Self::Tracer {
         NoopTracer::new()
     }
 

--- a/opentelemetry/src/trace/tracer_provider.rs
+++ b/opentelemetry/src/trace/tracer_provider.rs
@@ -1,4 +1,5 @@
 use crate::trace::{TraceResult, Tracer};
+use std::borrow::Cow;
 use std::fmt;
 
 /// Types that can create instances of [`Tracer`].
@@ -25,7 +26,7 @@ pub trait TracerProvider: fmt::Debug + 'static {
     /// // Library tracer
     /// let tracer = provider.tracer("my_library", Some(env!("CARGO_PKG_VERSION")));
     /// ```
-    fn tracer(&self, name: &'static str, version: Option<&'static str>) -> Self::Tracer;
+    fn tracer<T: Into<Cow<'static, str>>>(&self, name: T, version: Option<T>) -> Self::Tracer;
 
     /// Force flush all remaining spans in span processors and return results.
     fn force_flush(&self) -> Vec<TraceResult<()>>;


### PR DESCRIPTION
It allows users to pass in a `String` if needed, although it will have a performance overhead because we need to clone the string every time a span gets exported. I did a quick test and it seems the overhead is manageable. Less than 10%

Users that pass a `'static str` will not be impacted as `Cow::Borrow` just copies the pointer.

Fix #666