### PR TITLE
trace: remove unused `Tracer::invalid` method

### DIFF
--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -237,12 +237,6 @@ impl trace::Tracer for BoxedTracer {
     /// which is not possible if it takes generic type parameters.
     type Span = BoxedSpan;
 
-    /// Returns a span with an inactive `SpanContext`. Used by functions that
-    /// need to return a default span like `get_active_span` if no span is present.
-    fn invalid(&self) -> Self::Span {
-        BoxedSpan(self.0.invalid_boxed())
-    }
-
     /// Starts a new `Span`.
     ///
     /// Each span has zero or one parent spans and zero or more child spans, which
@@ -278,9 +272,6 @@ impl trace::Tracer for BoxedTracer {
 ///
 /// [`Tracer`]: crate::trace::Tracer
 pub trait ObjectSafeTracer {
-    /// Create a new invalid span for use in cases where there are no active spans.
-    fn invalid_boxed(&self) -> Box<dyn ObjectSafeSpan + Send + Sync>;
-
     /// Returns a trait object so the underlying implementation can be swapped
     /// out at runtime.
     fn start_with_context_boxed(
@@ -299,11 +290,6 @@ where
     S: trace::Span + Send + Sync + 'static,
     T: trace::Tracer<Span = S>,
 {
-    /// Create a new invalid span for use in cases where there are no active spans.
-    fn invalid_boxed(&self) -> Box<dyn ObjectSafeSpan + Send + Sync> {
-        Box::new(self.invalid())
-    }
-
     /// Returns a trait object so the underlying implementation can be swapped
     /// out at runtime.
     fn start_with_context_boxed(

--- a/opentelemetry/src/sdk/trace/tracer.rs
+++ b/opentelemetry/src/sdk/trace/tracer.rs
@@ -123,17 +123,6 @@ impl crate::trace::Tracer for Tracer {
     /// This implementation of `Tracer` produces `sdk::Span` instances.
     type Span = Span;
 
-    /// Returns a span with an inactive `SpanContext`. Used by functions that
-    /// need to return a default span like `get_active_span` if no span is present.
-    fn invalid(&self) -> Self::Span {
-        Span::new(
-            SpanContext::empty_context(),
-            None,
-            self.clone(),
-            SpanLimits::default(),
-        )
-    }
-
     /// Starts a new `Span` with a given context.
     ///
     /// Each span has zero or one parent spans and zero or more child spans, which

--- a/opentelemetry/src/trace/noop.rs
+++ b/opentelemetry/src/trace/noop.rs
@@ -139,11 +139,6 @@ impl NoopTracer {
 impl trace::Tracer for NoopTracer {
     type Span = NoopSpan;
 
-    /// Returns a `NoopSpan` as they are always invalid.
-    fn invalid(&self) -> Self::Span {
-        NoopSpan::new()
-    }
-
     /// Starts a new `NoopSpan` with a given context.
     ///
     /// If the context contains a valid span, it's span context is propagated.
@@ -173,7 +168,7 @@ impl trace::Tracer for NoopTracer {
                 span_context: cx.span().span_context().clone(),
             }
         } else {
-            self.invalid()
+            NoopSpan::new()
         }
     }
 }

--- a/opentelemetry/src/trace/tracer.rs
+++ b/opentelemetry/src/trace/tracer.rs
@@ -159,10 +159,6 @@ pub trait Tracer {
     /// The `Span` type used by this `Tracer`.
     type Span: Span;
 
-    /// Returns a span with an invalid `SpanContext`. Used by functions that
-    /// need to return a default span like `get_active_span` if no span is present.
-    fn invalid(&self) -> Self::Span;
-
     /// Starts a new `Span`.
     ///
     /// By default the currently active `Span` is set as the new `Span`'s


### PR DESCRIPTION
This method is not part of the trace spec and is not currently being used in a meaningful way.