### PR TITLE
Reduce dependency on futures crate

### DIFF
--- a/examples/actix-http/Cargo.toml
+++ b/examples/actix-http/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio"] }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["reqwest_collector_client", "rt-tokio"] }
 thrift = "0.13"
-futures = "0.3"
 actix-web = "4.0.0-beta.4"
 actix-service = "2.0.0-beta.5"
 env_logger = "0.8.2"

--- a/examples/actix-udp/Cargo.toml
+++ b/examples/actix-udp/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 opentelemetry = { path = "../../opentelemetry" }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }
 thrift = "0.13"
-futures = "0.3"
 actix-web = "3"
 actix-service = "1"
 env_logger = "0.8.2"

--- a/examples/async/Cargo.toml
+++ b/examples/async/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 thrift = "0.13"
 tokio = { version = "1.0", features = ["full"] }
 opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio"] }

--- a/examples/async/src/main.rs
+++ b/examples/async/src/main.rs
@@ -67,7 +67,7 @@ pub async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let span = tracer.start("root");
     let cx = Context::current_with_span(span);
 
-    let (run1, run2) = futures::future::join(run(&addr), run(&addr2))
+    let (run1, run2) = futures_util::future::join(run(&addr), run(&addr2))
         .with_context(cx)
         .await;
     run1?;

--- a/examples/basic-otlp-with-selector/Cargo.toml
+++ b/examples/basic-otlp-with-selector/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 lazy_static = "1.4"
 opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio", "metrics", "serialize"] }
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic", "metrics"] }

--- a/examples/basic-otlp-with-selector/src/main.rs
+++ b/examples/basic-otlp-with-selector/src/main.rs
@@ -1,5 +1,4 @@
-use futures::stream::Stream;
-use futures::StreamExt;
+use futures_util::{Stream, StreamExt as _};
 use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::sdk::export::metrics::{ExportKind, ExportKindFor};
 use opentelemetry::sdk::{

--- a/examples/basic-otlp/Cargo.toml
+++ b/examples/basic-otlp/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 lazy_static = "1.4"
 opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio", "metrics", "serialize"] }
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic", "metrics"] }

--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -1,5 +1,4 @@
-use futures::stream::Stream;
-use futures::StreamExt;
+use futures_util::{Stream, StreamExt as _};
 use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::sdk::metrics::{selectors, PushController};
 use opentelemetry::trace::TraceError;

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 lazy_static = "1.4"
 opentelemetry = { path = "../../opentelemetry", features = ["serialize", "rt-tokio", "metrics"] }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["rt-tokio"] }

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,4 +1,4 @@
-use futures::stream::{Stream, StreamExt};
+use futures_util::{Stream, StreamExt as _};
 use opentelemetry::global;
 use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::sdk::trace::Config;

--- a/examples/external-otlp-grpcio-async-std/Cargo.toml
+++ b/examples/external-otlp-grpcio-async-std/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 [dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }
 env_logger = "0.8.2"
-futures = "0.3"
 opentelemetry = { path = "../../opentelemetry", features = [
     "rt-async-std",
     "serialize"

--- a/examples/external-otlp-tonic-tokio/Cargo.toml
+++ b/examples/external-otlp-tonic-tokio/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3"
 opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio", "metrics", "serialize"] }
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic", "tls", "tls-roots"] }
 serde_json = "1.0"

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -40,6 +40,6 @@ lazy_static = "1.4"
 [dev-dependencies]
 base64 = "0.13"
 bytes = "1"
-futures-util = "0.3"
+futures-util = { version = "0.3", features = ["io"] }
 isahc = "1.4"
 opentelemetry = { path = "../opentelemetry", features = ["trace", "testing"] }

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
-futures-util = { version = "0.3", default-features = false, features = ["io"] }
 http = "0.2"
 isahc = { version = "1.4", default-features = false, optional = true }
 opentelemetry = { version = "0.16", path = "../opentelemetry", features = ["trace"] }

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -23,7 +23,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 async-std = { version = "1.6", optional = true }
 async-trait = "0.1"
 base64 = { version = "0.13", optional = true }
-futures-util = { version = "0.3", optional = true }
+futures-util = { version = "0.3", default-features = false, features = ["std"], optional = true }
 http = { version = "0.2", optional = true }
 isahc = { version = "1.4", default-features = false, optional = true }
 js-sys = { version = "0.3", optional = true }
@@ -43,7 +43,7 @@ surf = { version = "2.0", default-features = false, optional = true }
 
 [dev-dependencies]
 bytes = "1"
-futures = "0.3"
+futures-executor = "0.3"
 opentelemetry = { default-features = false, features = ["trace", "testing"], path = "../opentelemetry" }
 
 [dependencies.web-sys]

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -869,7 +869,7 @@ mod collector_client_tests {
             Resource::new(vec![KeyValue::new("service.name", "unknown_service")]);
         let (_, process) = builder.build_config_and_process(sdk_provided_resource);
         let mut uploader = builder.init_async_uploader(Tokio)?;
-        let res = futures::executor::block_on(async {
+        let res = futures_executor::block_on(async {
             uploader
                 .upload(Batch::new(process.into(), Vec::new()))
                 .await

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -36,7 +36,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3"
+futures = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 grpcio = { version = "0.9", optional = true }
 opentelemetry = { version = "0.16", default-features = false, features = ["trace"], path = "../opentelemetry" }
 prost = { version = "0.8", optional = true }

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -14,7 +14,7 @@ use crate::proto::collector::metrics::v1::{
 };
 use crate::transform::{record_to_metric, sink, CheckpointedMetrics};
 use crate::{Error, OtlpPipeline};
-use futures::Stream;
+use futures_util::Stream;
 use opentelemetry::metrics::{Descriptor, Result};
 use opentelemetry::sdk::export::metrics::{AggregatorSelector, ExportKindSelector};
 use opentelemetry::sdk::metrics::{PushController, PushControllerWorker};

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -42,6 +42,6 @@ thiserror = { version = "1.0"}
 
 [dev-dependencies]
 bytes = "1"
-futures-util = "0.3"
+futures-util = { version = "0.3", features = ["io"] }
 isahc = "1.4"
 opentelemetry = { default-features = false, features = ["trace", "testing"], path = "../opentelemetry" }

--- a/opentelemetry-zpages/Cargo.toml
+++ b/opentelemetry-zpages/Cargo.toml
@@ -22,7 +22,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 opentelemetry = { version = "0.16", path = "../opentelemetry", default-features = false, features = ["trace"] }
 async-channel = "1.6"
-futures = "0.3"
+futures-channel = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
 grpcio = "0.9"
 protobuf = { version = "2.23.0", features = ["with-serde"] }

--- a/opentelemetry-zpages/src/trace/aggregator.rs
+++ b/opentelemetry-zpages/src/trace/aggregator.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_channel::Receiver;
 
-use futures::StreamExt;
+use futures_util::StreamExt as _;
 
 use opentelemetry::trace::StatusCode;
 

--- a/opentelemetry-zpages/src/trace/mod.rs
+++ b/opentelemetry-zpages/src/trace/mod.rs
@@ -3,11 +3,9 @@
 use crate::proto::tracez::{ErrorData, LatencyData, RunningData, TracezCounts};
 
 use async_channel::{SendError, Sender};
-use futures::channel::oneshot;
-use opentelemetry::sdk::export::trace::SpanData;
-
-use futures::channel::oneshot::Canceled;
+use futures_channel::oneshot::{self, Canceled};
 use opentelemetry::runtime::Runtime;
+use opentelemetry::sdk::export::trace::SpanData;
 use serde::ser::SerializeSeq;
 use serde::Serializer;
 use std::fmt::Formatter;

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -25,7 +25,9 @@ async-std = { version = "1.6", features = ["unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
 dashmap = { version = "4.0.1", optional = true }
 fnv = { version = "1.0", optional = true }
-futures = "0.3"
+futures-channel = "0.3"
+futures-executor = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
 lazy_static = "1.4"
 percent-encoding = { version = "2.0", optional = true }
 pin-project = { version = "1.0.2", optional = true }

--- a/opentelemetry/benches/batch_span_processor.rs
+++ b/opentelemetry/benches/batch_span_processor.rs
@@ -65,7 +65,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                                 }
                             }));
                         }
-                        futures::future::join_all(handles).await;
+                        futures_util::future::join_all(handles).await;
                         let _ =
                             Arc::<BatchSpanProcessor<Tokio>>::get_mut(&mut shared_span_processor)
                                 .unwrap()

--- a/opentelemetry/src/runtime.rs
+++ b/opentelemetry/src/runtime.rs
@@ -6,7 +6,7 @@
 //! [Tokio]: https://crates.io/crates/tokio
 //! [async-std]: https://crates.io/crates/async-std
 
-use futures::{future::BoxFuture, Stream};
+use futures_util::{future::BoxFuture, Stream};
 use std::{future::Future, time::Duration};
 
 /// A runtime is an abstraction of an async runtime like [Tokio] or [async-std]. It allows

--- a/opentelemetry/src/sdk/export/metrics/stdout.rs
+++ b/opentelemetry/src/sdk/export/metrics/stdout.rs
@@ -19,7 +19,7 @@ use crate::{
     metrics::{Descriptor, MetricsError, Result},
     KeyValue,
 };
-use futures::Stream;
+use futures_util::Stream;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
 use std::fmt;

--- a/opentelemetry/src/sdk/trace/runtime.rs
+++ b/opentelemetry/src/sdk/trace/runtime.rs
@@ -13,7 +13,7 @@ use crate::runtime::Tokio;
 use crate::runtime::TokioCurrentThread;
 use crate::sdk::trace::BatchMessage;
 use crate::trace::TraceError;
-use futures::Stream;
+use futures_util::Stream;
 use std::fmt::Debug;
 
 #[cfg(any(

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -4,6 +4,7 @@ use crate::{
     trace::{Span, SpanContext},
     Context, ContextGuard, KeyValue,
 };
+use futures_util::{Sink, Stream};
 use pin_project::pin_project;
 use std::error::Error;
 use std::sync::Mutex;
@@ -296,7 +297,7 @@ impl<T: std::future::Future> std::future::Future for WithContext<T> {
     }
 }
 
-impl<T: futures::Stream> futures::Stream for WithContext<T> {
+impl<T: Stream> Stream for WithContext<T> {
     type Item = T::Item;
 
     fn poll_next(self: Pin<&mut Self>, task_cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
@@ -306,9 +307,9 @@ impl<T: futures::Stream> futures::Stream for WithContext<T> {
     }
 }
 
-impl<I, T: futures::Sink<I>> futures::Sink<I> for WithContext<T>
+impl<I, T: Sink<I>> Sink<I> for WithContext<T>
 where
-    T: futures::Sink<I>,
+    T: Sink<I>,
 {
     type Error = T::Error;
 
@@ -339,7 +340,7 @@ where
     fn poll_close(
         self: Pin<&mut Self>,
         task_cx: &mut TaskContext<'_>,
-    ) -> futures::task::Poll<Result<(), Self::Error>> {
+    ) -> Poll<Result<(), Self::Error>> {
         let this = self.project();
         let _enter = this.otel_cx.clone().attach();
         T::poll_close(this.inner, task_cx)

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -172,7 +172,7 @@
 //! # }
 //! ```
 
-use ::futures::channel::{mpsc::TrySendError, oneshot::Canceled};
+use futures_channel::{mpsc::TrySendError, oneshot::Canceled};
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;


### PR DESCRIPTION
Size of dep graph:

| | before|after
|-|-|-|
opentelemetry|47|38
opentelemetry-contrib|122|113
opentelemetry-datadog|136|130
opentelemetry-http|53|44
opentelemetry-jaeger|129|120
opentelemetry-otlp|140|139
opentelemetry-prometheus|52|43
opentelemetry-aws|137|128
opentelemetry-semantic-conventions|48|39
opentelemetry-stackdriver|180|180
opentelemetry-zipkin|218|211
opentelemetry-zpages|149|149


Only `opentelemetry-otlp` could not have it's `futures` dep removed (yet). It is blocked on the release of https://github.com/tikv/grpc-rs/pull/554 in order for the codegen to reference `std`'s `Future`.