### PR TITLE
trace: switch to parent context references

### DIFF
--- a/examples/aws-xray/src/server.rs
+++ b/examples/aws-xray/src/server.rs
@@ -22,7 +22,7 @@ async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
         .to_str()
         .unwrap();
 
-    let mut span = global::tracer("example/server").start_with_context("hello", parent_context);
+    let mut span = global::tracer("example/server").start_with_context("hello", &parent_context);
     span.add_event(format!("Handling - {}", x_amzn_trace_id), Vec::new());
 
     Ok(Response::new(

--- a/examples/grpc/src/server.rs
+++ b/examples/grpc/src/server.rs
@@ -47,7 +47,7 @@ impl Greeter for MyGreeter {
     ) -> Result<Response<HelloReply>, Status> {
         let parent_cx =
             global::get_text_map_propagator(|prop| prop.extract(&MetadataMap(request.metadata())));
-        let mut span = global::tracer("greeter").start_with_context("Processing reply", parent_cx);
+        let mut span = global::tracer("greeter").start_with_context("Processing reply", &parent_cx);
         span.set_attribute(KeyValue::new("request", format!("{:?}", request)));
 
         // Return an instance of type HelloReply

--- a/examples/http/src/server.rs
+++ b/examples/http/src/server.rs
@@ -16,7 +16,7 @@ async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     let parent_cx = global::get_text_map_propagator(|propagator| {
         propagator.extract(&HeaderExtractor(req.headers()))
     });
-    let mut span = global::tracer("example/server").start_with_context("hello", parent_cx);
+    let mut span = global::tracer("example/server").start_with_context("hello", &parent_cx);
     span.add_event("handling this...".to_string(), Vec::new());
 
     Ok(Response::new("Hello, World!".into()))

--- a/opentelemetry/src/sdk/trace/tracer.rs
+++ b/opentelemetry/src/sdk/trace/tracer.rs
@@ -214,10 +214,10 @@ impl crate::trace::Tracer for Tracer {
         // * There is no parent or a remote parent, in which case make decision now
         // * There is a local parent, in which case defer to the parent's decision
         let sampling_decision = if let Some(sampling_result) = builder.sampling_result.take() {
-            self.process_sampling_result(sampling_result, &parent_cx)
+            self.process_sampling_result(sampling_result, parent_cx)
         } else if no_parent || remote_parent {
             self.make_sampling_decision(
-                &parent_cx,
+                parent_cx,
                 trace_id,
                 &builder.name,
                 &span_kind,
@@ -305,7 +305,7 @@ impl crate::trace::Tracer for Tracer {
 
         // Call `on_start` for all processors
         for processor in provider.span_processors() {
-            processor.on_start(&mut span, &parent_cx)
+            processor.on_start(&mut span, parent_cx)
         }
 
         span

--- a/opentelemetry/src/sdk/trace/tracer.rs
+++ b/opentelemetry/src/sdk/trace/tracer.rs
@@ -130,11 +130,11 @@ impl crate::trace::Tracer for Tracer {
     /// trace. A span is said to be a _root span_ if it does not have a parent. Each
     /// trace includes a single root span, which is the shared ancestor of all other
     /// spans in the trace.
-    fn start_with_context<T>(&self, name: T, cx: Context) -> Self::Span
+    fn start_with_context<T>(&self, name: T, parent_cx: &Context) -> Self::Span
     where
         T: Into<Cow<'static, str>>,
     {
-        self.build(SpanBuilder::from_name_with_context(name, cx))
+        self.build_with_context(SpanBuilder::from_name(name), parent_cx)
     }
 
     /// Creates a span builder
@@ -154,7 +154,7 @@ impl crate::trace::Tracer for Tracer {
     /// trace. A span is said to be a _root span_ if it does not have a parent. Each
     /// trace includes a single root span, which is the shared ancestor of all other
     /// spans in the trace.
-    fn build(&self, mut builder: SpanBuilder) -> Self::Span {
+    fn build_with_context(&self, mut builder: SpanBuilder, parent_cx: &Context) -> Self::Span {
         let provider = self.provider();
         if provider.is_none() {
             return Span::new(
@@ -179,8 +179,8 @@ impl crate::trace::Tracer for Tracer {
         let mut flags = TraceFlags::default();
         let mut span_trace_state = Default::default();
 
-        let parent_span = if builder.parent_context.has_active_span() {
-            Some(builder.parent_context.span())
+        let parent_span = if parent_cx.has_active_span() {
+            Some(parent_cx.span())
         } else {
             None
         };
@@ -214,10 +214,10 @@ impl crate::trace::Tracer for Tracer {
         // * There is no parent or a remote parent, in which case make decision now
         // * There is a local parent, in which case defer to the parent's decision
         let sampling_decision = if let Some(sampling_result) = builder.sampling_result.take() {
-            self.process_sampling_result(sampling_result, &builder.parent_context)
+            self.process_sampling_result(sampling_result, &parent_cx)
         } else if no_parent || remote_parent {
             self.make_sampling_decision(
-                &builder.parent_context,
+                &parent_cx,
                 trace_id,
                 &builder.name,
                 &span_kind,
@@ -240,7 +240,6 @@ impl crate::trace::Tracer for Tracer {
 
         // Build optional inner context, `None` if not recording.
         let SpanBuilder {
-            parent_context,
             name,
             start_time,
             end_time,
@@ -306,7 +305,7 @@ impl crate::trace::Tracer for Tracer {
 
         // Call `on_start` for all processors
         for processor in provider.span_processors() {
-            processor.on_start(&mut span, &parent_context)
+            processor.on_start(&mut span, &parent_cx)
         }
 
         span
@@ -322,8 +321,8 @@ mod tests {
         },
         testing::trace::TestSpan,
         trace::{
-            Link, Span, SpanBuilder, SpanContext, SpanId, SpanKind, TraceContextExt, TraceFlags,
-            TraceId, TraceState, Tracer, TracerProvider,
+            Link, Span, SpanContext, SpanId, SpanKind, TraceContextExt, TraceFlags, TraceId,
+            TraceState, Tracer, TracerProvider,
         },
         Context, KeyValue,
     };
@@ -365,19 +364,17 @@ mod tests {
             .build();
         let tracer = tracer_provider.tracer("test");
         let trace_state = TraceState::from_key_value(vec![("foo", "bar")]).unwrap();
-        let span_builder = SpanBuilder {
-            parent_context: Context::new().with_span(TestSpan(SpanContext::new(
-                TraceId::from_u128(128),
-                SpanId::from_u64(64),
-                TraceFlags::SAMPLED,
-                true,
-                trace_state,
-            ))),
-            ..Default::default()
-        };
+
+        let parent_context = Context::new().with_span(TestSpan(SpanContext::new(
+            TraceId::from_u128(128),
+            SpanId::from_u64(64),
+            TraceFlags::SAMPLED,
+            true,
+            trace_state,
+        )));
 
         // Test sampler should change trace state
-        let span = tracer.build(span_builder);
+        let span = tracer.start_with_context("foo", &parent_context);
         let span_context = span.span_context();
         let expected = span_context.trace_state();
         assert_eq!(expected.get("foo"), Some("notbar"))
@@ -393,7 +390,7 @@ mod tests {
 
         let context = Context::current_with_span(TestSpan(SpanContext::empty_context()));
         let tracer = tracer_provider.tracer("test");
-        let span = tracer.start_with_context("must_not_be_sampled", context);
+        let span = tracer.start_with_context("must_not_be_sampled", &context);
 
         assert!(!span.span_context().is_sampled());
     }

--- a/opentelemetry/src/trace/tracer.rs
+++ b/opentelemetry/src/trace/tracer.rs
@@ -39,9 +39,7 @@ use std::time::SystemTime;
 ///
 /// let parent = tracer.start("foo");
 /// let parent_cx = Context::current_with_span(parent);
-/// let mut child = tracer.span_builder("bar")
-///     .with_parent_context(parent_cx.clone())
-///     .start(&tracer);
+/// let mut child = tracer.span_builder("bar").start_with_context(&tracer, &parent_cx);
 ///
 /// // ...
 ///
@@ -186,7 +184,7 @@ pub trait Tracer {
     where
         T: Into<Cow<'static, str>>,
     {
-        self.start_with_context(name, Context::current())
+        self.start_with_context(name, &Context::current())
     }
 
     /// Starts a new `Span` with a given context
@@ -212,7 +210,7 @@ pub trait Tracer {
     /// created in another process. Each propagators' deserialization must set
     /// `is_remote` to true on a parent `SpanContext` so `Span` creation knows if the
     /// parent is remote.
-    fn start_with_context<T>(&self, name: T, context: Context) -> Self::Span
+    fn start_with_context<T>(&self, name: T, parent_cx: &Context) -> Self::Span
     where
         T: Into<Cow<'static, str>>;
 
@@ -223,8 +221,13 @@ pub trait Tracer {
     where
         T: Into<Cow<'static, str>>;
 
-    /// Create a span from a `SpanBuilder`
-    fn build(&self, builder: SpanBuilder) -> Self::Span;
+    /// Create a span from a [SpanBuilder]
+    fn build(&self, builder: SpanBuilder) -> Self::Span {
+        self.build_with_context(builder, &Context::current())
+    }
+
+    /// Create a span from a [SpanBuilder] with a parent context.
+    fn build_with_context(&self, builder: SpanBuilder, parent_cx: &Context) -> Self::Span;
 
     /// Start a new span and execute the given closure with reference to the span's
     /// context.
@@ -278,7 +281,7 @@ pub trait Tracer {
     ///
     /// fn my_function() {
     ///     let tracer = global::tracer("my-component");
-    ///     // start a span with custom attributes via span bulder
+    ///     // start a span with custom attributes via span builder
     ///     let span = tracer.span_builder("span-name").with_kind(SpanKind::Server).start(&tracer);
     ///     // Mark the span as active for the duration of the closure
     ///     global::tracer("my-component").with_span(span, |_cx| {
@@ -331,8 +334,6 @@ pub trait Tracer {
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct SpanBuilder {
-    /// Parent `Context`
-    pub parent_context: Context,
     /// Trace id, useful for integrations with external tracing systems.
     pub trace_id: Option<TraceId>,
     /// Span id, useful for integrations with external tracing systems.
@@ -363,36 +364,9 @@ pub struct SpanBuilder {
 impl SpanBuilder {
     /// Create a new span builder from a span name
     pub fn from_name<T: Into<Cow<'static, str>>>(name: T) -> Self {
-        Self::from_name_with_context(name, Context::current())
-    }
-
-    /// Create a new span builder from a span name with the specified context
-    pub(crate) fn from_name_with_context<T: Into<Cow<'static, str>>>(
-        name: T,
-        parent_context: Context,
-    ) -> Self {
         SpanBuilder {
-            parent_context,
-            trace_id: None,
-            span_id: None,
-            span_kind: None,
             name: name.into(),
-            start_time: None,
-            end_time: None,
-            attributes: None,
-            events: None,
-            links: None,
-            status_code: None,
-            status_message: None,
-            sampling_result: None,
-        }
-    }
-
-    /// Assign parent context
-    pub fn with_parent_context(self, parent_context: Context) -> Self {
-        SpanBuilder {
-            parent_context,
-            ..self
+            ..Default::default()
         }
     }
 
@@ -487,6 +461,11 @@ impl SpanBuilder {
 
     /// Builds a span with the given tracer from this configuration.
     pub fn start<T: Tracer>(self, tracer: &T) -> T::Span {
-        tracer.build(self)
+        tracer.build_with_context(self, &Context::current())
+    }
+
+    /// Builds a span with the given tracer from this configuration and parent.
+    pub fn start_with_context<T: Tracer>(self, tracer: &T, parent_cx: &Context) -> T::Span {
+        tracer.build_with_context(self, parent_cx)
     }
 }


### PR DESCRIPTION
Updates `Tracer::start_with_context` to accepet a reference instead of an owned parent `Context`, and adds `Tracer::build_with_context` to allow a parent context reference to be passed with a builder as well. This also removes the need for `SpanBuilder`s to store a context.