### PR TITLE
trace: spec compliant trace and span ids

### DIFF
--- a/opentelemetry-contrib/src/trace/propagator/binary/binary_propagator.rs
+++ b/opentelemetry-contrib/src/trace/propagator/binary/binary_propagator.rs
@@ -36,9 +36,9 @@ impl BinaryFormat for BinaryPropagator {
         if !context.is_valid() {
             return res;
         }
-        res[2..18].copy_from_slice(&context.trace_id().to_u128().to_be_bytes());
+        res[2..18].copy_from_slice(&context.trace_id().to_bytes());
         res[18] = 1;
-        res[19..27].copy_from_slice(&context.span_id().to_u64().to_be_bytes());
+        res[19..27].copy_from_slice(&context.span_id().to_bytes());
         res[27] = 2;
         res[28] = context.trace_flags().to_u8();
 
@@ -50,12 +50,12 @@ impl BinaryFormat for BinaryPropagator {
         if bytes.is_empty() {
             return SpanContext::empty_context();
         }
-        let trace_id: u128;
+        let trace_id: [u8; 16];
         let mut span_id = 0;
         let mut trace_flags = 0;
         let mut b = &bytes[1..];
         if b.len() >= 17 && b[0] == 0 {
-            trace_id = u128::from_be_bytes(b[1..17].try_into().unwrap());
+            trace_id = b[1..17].try_into().unwrap();
             b = &b[17..];
         } else {
             return SpanContext::empty_context();
@@ -69,7 +69,7 @@ impl BinaryFormat for BinaryPropagator {
         }
 
         let span_context = SpanContext::new(
-            TraceId::from_u128(trace_id),
+            TraceId::from(trace_id),
             SpanId::from_u64(span_id),
             TraceFlags::new(trace_flags),
             true,

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -277,7 +277,7 @@ mod tests {
 
         let mut traces = group_into_traces(batch);
         // We need to sort the output in order to compare, but this is not required by the Datadog agent
-        traces.sort_by_key(|t| t[0].span_context.trace_id().to_u128());
+        traces.sort_by_key(|t| u128::from_be_bytes(t[0].span_context.trace_id().to_bytes()));
 
         assert_eq!(traces, expected);
     }

--- a/opentelemetry-datadog/src/exporter/model/v03.rs
+++ b/opentelemetry-datadog/src/exporter/model/v03.rs
@@ -47,13 +47,22 @@ pub(crate) fn encode(
             rmp::encode::write_str(&mut encoded, &span.name)?;
 
             rmp::encode::write_str(&mut encoded, "trace_id")?;
-            rmp::encode::write_u64(&mut encoded, span.span_context.trace_id().to_u128() as u64)?;
+            rmp::encode::write_u64(
+                &mut encoded,
+                u128::from_be_bytes(span.span_context.trace_id().to_bytes()) as u64,
+            )?;
 
             rmp::encode::write_str(&mut encoded, "span_id")?;
-            rmp::encode::write_u64(&mut encoded, span.span_context.span_id().to_u64())?;
+            rmp::encode::write_u64(
+                &mut encoded,
+                u64::from_be_bytes(span.span_context.span_id().to_bytes()),
+            )?;
 
             rmp::encode::write_str(&mut encoded, "parent_id")?;
-            rmp::encode::write_u64(&mut encoded, span.parent_span_id.to_u64())?;
+            rmp::encode::write_u64(
+                &mut encoded,
+                u64::from_be_bytes(span.parent_span_id.to_bytes()),
+            )?;
 
             rmp::encode::write_str(&mut encoded, "start")?;
             rmp::encode::write_i64(&mut encoded, start)?;

--- a/opentelemetry-datadog/src/exporter/model/v05.rs
+++ b/opentelemetry-datadog/src/exporter/model/v05.rs
@@ -110,9 +110,18 @@ fn encode_traces(
                 interner.intern(span.instrumentation_lib.name.as_ref()),
             )?;
             rmp::encode::write_u32(&mut encoded, interner.intern(&span.name))?;
-            rmp::encode::write_u64(&mut encoded, span.span_context.trace_id().to_u128() as u64)?;
-            rmp::encode::write_u64(&mut encoded, span.span_context.span_id().to_u64())?;
-            rmp::encode::write_u64(&mut encoded, span.parent_span_id.to_u64())?;
+            rmp::encode::write_u64(
+                &mut encoded,
+                u128::from_be_bytes(span.span_context.trace_id().to_bytes()) as u64,
+            )?;
+            rmp::encode::write_u64(
+                &mut encoded,
+                u64::from_be_bytes(span.span_context.span_id().to_bytes()),
+            )?;
+            rmp::encode::write_u64(
+                &mut encoded,
+                u64::from_be_bytes(span.parent_span_id.to_bytes()),
+            )?;
             rmp::encode::write_i64(&mut encoded, start)?;
             rmp::encode::write_i64(&mut encoded, duration)?;
             rmp::encode::write_i32(

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -304,12 +304,7 @@ mod propagator {
                 return Err(());
             }
 
-            // allow variable length, padding 0 when length is less than 32
-            let padded_trace_id = format!("{:0>32}", trace_id);
-
-            u128::from_str_radix(padded_trace_id.as_str(), 16)
-                .map(TraceId::from_u128)
-                .map_err(|_| ())
+            TraceId::from_hex(trace_id).map_err(|_| ())
         }
 
         /// Extract span id from the header.
@@ -386,8 +381,8 @@ mod propagator {
                 };
                 let header_value = format!(
                     "{:032x}:{:016x}:{:01}:{:01}",
-                    span_context.trace_id().to_u128(),
-                    span_context.span_id().to_u64(),
+                    span_context.trace_id(),
+                    span_context.span_id(),
                     DEPRECATED_PARENT_SPAN,
                     flag,
                 );

--- a/opentelemetry-otlp/src/transform/traces.rs
+++ b/opentelemetry-otlp/src/transform/traces.rs
@@ -1,6 +1,6 @@
 use crate::transform::common::to_nanos;
 use opentelemetry::sdk::{self, export::trace::SpanData};
-use opentelemetry::trace::{Link, SpanKind, StatusCode};
+use opentelemetry::trace::{Link, SpanId, SpanKind, StatusCode};
 
 #[cfg(feature = "tonic")]
 mod tonic {
@@ -36,18 +36,8 @@ mod tonic {
     impl From<Link> for span::Link {
         fn from(link: Link) -> Self {
             span::Link {
-                trace_id: link
-                    .span_context()
-                    .trace_id()
-                    .to_u128()
-                    .to_be_bytes()
-                    .to_vec(),
-                span_id: link
-                    .span_context()
-                    .span_id()
-                    .to_u64()
-                    .to_be_bytes()
-                    .to_vec(),
+                trace_id: link.span_context().trace_id().to_bytes().to_vec(),
+                span_id: link.span_context().span_id().to_bytes().to_vec(),
                 trace_state: link.span_context().trace_state().header(),
                 attributes: Attributes::from(link.attributes().clone()).0,
                 dropped_attributes_count: link.dropped_attributes_count(),
@@ -69,22 +59,12 @@ mod tonic {
                 instrumentation_library_spans: vec![InstrumentationLibrarySpans {
                     instrumentation_library: Default::default(),
                     spans: vec![Span {
-                        trace_id: source_span
-                            .span_context
-                            .trace_id()
-                            .to_u128()
-                            .to_be_bytes()
-                            .to_vec(),
-                        span_id: source_span
-                            .span_context
-                            .span_id()
-                            .to_u64()
-                            .to_be_bytes()
-                            .to_vec(),
+                        trace_id: source_span.span_context.trace_id().to_bytes().to_vec(),
+                        span_id: source_span.span_context.span_id().to_bytes().to_vec(),
                         trace_state: source_span.span_context.trace_state().header(),
                         parent_span_id: {
-                            if source_span.parent_span_id.to_u64() > 0 {
-                                source_span.parent_span_id.to_u64().to_be_bytes().to_vec()
+                            if source_span.parent_span_id != SpanId::INVALID {
+                                source_span.parent_span_id.to_bytes().to_vec()
                             } else {
                                 vec![]
                             }
@@ -165,18 +145,8 @@ mod prost {
     impl From<Link> for span::Link {
         fn from(link: Link) -> Self {
             span::Link {
-                trace_id: link
-                    .span_context()
-                    .trace_id()
-                    .to_u128()
-                    .to_be_bytes()
-                    .to_vec(),
-                span_id: link
-                    .span_context()
-                    .span_id()
-                    .to_u64()
-                    .to_be_bytes()
-                    .to_vec(),
+                trace_id: link.span_context().trace_id().to_bytes().to_vec(),
+                span_id: link.span_context().span_id().to_bytes().to_vec(),
                 trace_state: link.span_context().trace_state().header(),
                 attributes: Attributes::from(link.attributes().clone()).0,
                 dropped_attributes_count: link.dropped_attributes_count(),
@@ -198,22 +168,12 @@ mod prost {
                 instrumentation_library_spans: vec![InstrumentationLibrarySpans {
                     instrumentation_library: Default::default(),
                     spans: vec![Span {
-                        trace_id: source_span
-                            .span_context
-                            .trace_id()
-                            .to_u128()
-                            .to_be_bytes()
-                            .to_vec(),
-                        span_id: source_span
-                            .span_context
-                            .span_id()
-                            .to_u64()
-                            .to_be_bytes()
-                            .to_vec(),
+                        trace_id: source_span.span_context.trace_id().to_bytes().to_vec(),
+                        span_id: source_span.span_context.span_id().to_bytes().to_vec(),
                         trace_state: source_span.span_context.trace_state().header(),
                         parent_span_id: {
-                            if source_span.parent_span_id.to_u64() > 0 {
-                                source_span.parent_span_id.to_u64().to_be_bytes().to_vec()
+                            if source_span.parent_span_id != SpanId::INVALID {
+                                source_span.parent_span_id.to_bytes().to_vec()
                             } else {
                                 vec![]
                             }
@@ -269,7 +229,6 @@ mod grpcio {
         Status, Status_StatusCode,
     };
     use crate::transform::common::grpcio::Attributes;
-    use protobuf::reflect::ProtobufValue;
     use protobuf::{RepeatedField, SingularPtrField};
 
     impl From<SpanKind> for Span_SpanKind {
@@ -297,18 +256,8 @@ mod grpcio {
     impl From<Link> for Span_Link {
         fn from(link: Link) -> Self {
             Span_Link {
-                trace_id: link
-                    .span_context()
-                    .trace_id()
-                    .to_u128()
-                    .to_be_bytes()
-                    .to_vec(),
-                span_id: link
-                    .span_context()
-                    .span_id()
-                    .to_u64()
-                    .to_be_bytes()
-                    .to_vec(),
+                trace_id: link.span_context().trace_id().to_bytes().to_vec(),
+                span_id: link.span_context().span_id().to_bytes().to_vec(),
                 trace_state: link.span_context().trace_state().header(),
                 attributes: Attributes::from(link.attributes().clone()).0,
                 dropped_attributes_count: link.dropped_attributes_count(),
@@ -332,22 +281,12 @@ mod grpcio {
                     InstrumentationLibrarySpans {
                         instrumentation_library: Default::default(),
                         spans: RepeatedField::from_vec(vec![Span {
-                            trace_id: source_span
-                                .span_context
-                                .trace_id()
-                                .to_u128()
-                                .to_be_bytes()
-                                .to_vec(),
-                            span_id: source_span
-                                .span_context
-                                .span_id()
-                                .to_u64()
-                                .to_be_bytes()
-                                .to_vec(),
+                            trace_id: source_span.span_context.trace_id().to_bytes().to_vec(),
+                            span_id: source_span.span_context.span_id().to_bytes().to_vec(),
                             trace_state: source_span.span_context.trace_state().header(),
                             parent_span_id: {
-                                if source_span.parent_span_id.to_u64().is_non_zero() {
-                                    source_span.parent_span_id.to_u64().to_be_bytes().to_vec()
+                                if source_span.parent_span_id != SpanId::INVALID {
+                                    source_span.parent_span_id.to_bytes().to_vec()
                                 } else {
                                     vec![]
                                 }

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -174,14 +174,12 @@ impl StackDriverExporter {
                             name: format!(
                                 "projects/{}/traces/{}/spans/{}",
                                 authorizer.project_id(),
-                                hex::encode(span.span_context.trace_id().to_u128().to_be_bytes()),
-                                hex::encode(span.span_context.span_id().to_u64().to_be_bytes())
+                                hex::encode(span.span_context.trace_id().to_bytes()),
+                                hex::encode(span.span_context.span_id().to_bytes())
                             ),
                             display_name: Some(to_truncate(span.name.into_owned())),
-                            span_id: hex::encode(
-                                span.span_context.span_id().to_u64().to_be_bytes(),
-                            ),
-                            parent_span_id: hex::encode(span.parent_span_id.to_u64().to_be_bytes()),
+                            span_id: hex::encode(span.span_context.span_id().to_bytes()),
+                            parent_span_id: hex::encode(span.parent_span_id.to_bytes()),
                             start_time: Some(span.start_time.into()),
                             end_time: Some(span.end_time.into()),
                             attributes: Some(Attributes {

--- a/opentelemetry-zipkin/src/exporter/model/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/model/mod.rs
@@ -82,9 +82,9 @@ pub(crate) fn into_zipkin_span(local_endpoint: Endpoint, span_data: trace::SpanD
     }
 
     span::Span::builder()
-        .trace_id(span_data.span_context.trace_id().to_hex())
-        .parent_id(span_data.parent_span_id.to_hex())
-        .id(span_data.span_context.span_id().to_hex())
+        .trace_id(span_data.span_context.trace_id().to_string())
+        .parent_id(span_data.parent_span_id.to_string())
+        .id(span_data.span_context.span_id().to_string())
         .name(span_data.name.into_owned())
         .kind(if user_defined_span_kind {
             None

--- a/opentelemetry-zpages/src/transform.rs
+++ b/opentelemetry-zpages/src/transform.rs
@@ -11,9 +11,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 impl From<SpanData> for LatencyData {
     fn from(span_data: SpanData) -> Self {
         LatencyData {
-            traceid: span_data.span_context.trace_id().to_byte_array().to_vec(),
-            spanid: span_data.span_context.span_id().to_byte_array().to_vec(),
-            parentid: span_data.parent_span_id.to_byte_array().to_vec(),
+            traceid: span_data.span_context.trace_id().to_bytes().to_vec(),
+            spanid: span_data.span_context.span_id().to_bytes().to_vec(),
+            parentid: span_data.parent_span_id.to_bytes().to_vec(),
             starttime: to_nanos(span_data.start_time),
             endtime: to_nanos(span_data.end_time),
             attributes: Attributes::from(span_data.attributes).0,
@@ -27,9 +27,9 @@ impl From<SpanData> for LatencyData {
 impl From<SpanData> for ErrorData {
     fn from(span_data: SpanData) -> Self {
         ErrorData {
-            traceid: span_data.span_context.trace_id().to_byte_array().to_vec(),
-            spanid: span_data.span_context.span_id().to_byte_array().to_vec(),
-            parentid: span_data.parent_span_id.to_byte_array().to_vec(),
+            traceid: span_data.span_context.trace_id().to_bytes().to_vec(),
+            spanid: span_data.span_context.span_id().to_bytes().to_vec(),
+            parentid: span_data.parent_span_id.to_bytes().to_vec(),
             starttime: to_nanos(span_data.start_time),
             attributes: Attributes::from(span_data.attributes).0,
             events: span_data.events.iter().cloned().map(Into::into).collect(),
@@ -46,9 +46,9 @@ impl From<SpanData> for ErrorData {
 impl From<SpanData> for RunningData {
     fn from(span_data: SpanData) -> Self {
         RunningData {
-            traceid: span_data.span_context.trace_id().to_byte_array().to_vec(),
-            spanid: span_data.span_context.span_id().to_byte_array().to_vec(),
-            parentid: span_data.parent_span_id.to_byte_array().to_vec(),
+            traceid: span_data.span_context.trace_id().to_bytes().to_vec(),
+            spanid: span_data.span_context.span_id().to_bytes().to_vec(),
+            parentid: span_data.parent_span_id.to_bytes().to_vec(),
             starttime: to_nanos(span_data.start_time),
             attributes: Attributes::from(span_data.attributes).0,
             events: span_data.events.iter().cloned().map(Into::into).collect(),
@@ -105,18 +105,8 @@ impl From<(StatusCode, String)> for Status {
 impl From<Link> for Span_Link {
     fn from(link: Link) -> Self {
         Span_Link {
-            trace_id: link
-                .span_context()
-                .trace_id()
-                .to_u128()
-                .to_be_bytes()
-                .to_vec(),
-            span_id: link
-                .span_context()
-                .span_id()
-                .to_u64()
-                .to_be_bytes()
-                .to_vec(),
+            trace_id: link.span_context().trace_id().to_bytes().to_vec(),
+            span_id: link.span_context().span_id().to_bytes().to_vec(),
             trace_state: link.span_context().trace_state().header(),
             attributes: Attributes::from(link.attributes().clone()).0,
             dropped_attributes_count: link.dropped_attributes_count(),

--- a/opentelemetry/src/sdk/propagation/composite.rs
+++ b/opentelemetry/src/sdk/propagation/composite.rs
@@ -143,9 +143,9 @@ mod tests {
             injector.set(
                 "testheader",
                 format!(
-                    "{}-{}-{:02x}",
-                    span_context.trace_id().to_u128(),
-                    span_context.span_id().to_u64(),
+                    "{:x}-{:x}-{:02x}",
+                    span_context.trace_id(),
+                    span_context.span_id(),
                     span_context.trace_flags()
                 ),
             )

--- a/opentelemetry/src/sdk/propagation/trace_context.rs
+++ b/opentelemetry/src/sdk/propagation/trace_context.rs
@@ -71,9 +71,7 @@ impl TraceContextPropagator {
         }
 
         // Parse trace id section
-        let trace_id = u128::from_str_radix(parts[1], 16)
-            .map_err(|_| ())
-            .map(TraceId::from_u128)?;
+        let trace_id = TraceId::from_hex(parts[1]).map_err(|_| ())?;
 
         // Ensure span id is lowercase
         if parts[2].chars().any(|c| c.is_ascii_uppercase()) {
@@ -81,9 +79,7 @@ impl TraceContextPropagator {
         }
 
         // Parse span id section
-        let span_id = u64::from_str_radix(parts[2], 16)
-            .map_err(|_| ())
-            .map(SpanId::from_u64)?;
+        let span_id = SpanId::from_hex(parts[2]).map_err(|_| ())?;
 
         // Parse trace flags section
         let opts = u8::from_str_radix(parts[3], 16).map_err(|_| ())?;
@@ -123,8 +119,8 @@ impl TextMapPropagator for TraceContextPropagator {
             let header_value = format!(
                 "{:02x}-{:032x}-{:016x}-{:02x}",
                 SUPPORTED_VERSION,
-                span_context.trace_id().to_u128(),
-                span_context.span_id().to_u64(),
+                span_context.trace_id(),
+                span_context.span_id(),
                 span_context.trace_flags() & TraceFlags::SAMPLED
             );
             injector.set(TRACEPARENT_HEADER, header_value);

--- a/opentelemetry/src/sdk/trace/id_generator/aws.rs
+++ b/opentelemetry/src/sdk/trace/id_generator/aws.rs
@@ -43,10 +43,8 @@ pub struct XrayIdGenerator {
 impl IdGenerator for XrayIdGenerator {
     /// Generates a new `TraceId` that can be converted to an X-Ray Trace ID
     fn new_trace_id(&self) -> TraceId {
-        let mut default_trace_id: String = format!(
-            "{:024x}",
-            self.sdk_default_generator.new_trace_id().to_u128()
-        );
+        let mut default_trace_id: String =
+            format!("{:024x}", self.sdk_default_generator.new_trace_id());
 
         default_trace_id.truncate(24);
 
@@ -56,6 +54,7 @@ impl IdGenerator for XrayIdGenerator {
             .as_secs();
 
         TraceId::from_hex(format!("{:08x}{}", epoch_time_seconds, default_trace_id).as_str())
+            .unwrap_or(TraceId::INVALID)
     }
 
     /// Generates a new `SpanId` that can be converted to an X-Ray Segment ID
@@ -86,7 +85,7 @@ mod tests {
             .unwrap()
             .as_secs();
 
-        let trace_as_hex: String = format!("{:032x}", trace_id.to_u128());
+        let trace_as_hex: String = format!("{:032x}", trace_id);
         let (timestamp, _xray_id) = trace_as_hex.split_at(8_usize);
 
         let trace_time: u64 = u64::from_str_radix(timestamp, 16).unwrap();

--- a/opentelemetry/src/sdk/trace/id_generator/mod.rs
+++ b/opentelemetry/src/sdk/trace/id_generator/mod.rs
@@ -20,7 +20,7 @@ impl crate::trace::IdGenerator for IdGenerator {
 
     /// Generate new `SpanId` using thread local rng
     fn new_span_id(&self) -> SpanId {
-        CURRENT_RNG.with(|rng| SpanId::from_u64(rng.borrow_mut().gen()))
+        CURRENT_RNG.with(|rng| SpanId::from(rng.borrow_mut().gen::<[u8; 8]>()))
     }
 }
 

--- a/opentelemetry/src/sdk/trace/id_generator/mod.rs
+++ b/opentelemetry/src/sdk/trace/id_generator/mod.rs
@@ -15,7 +15,7 @@ pub struct IdGenerator {
 impl crate::trace::IdGenerator for IdGenerator {
     /// Generate new `TraceId` using thread local rng
     fn new_trace_id(&self) -> TraceId {
-        CURRENT_RNG.with(|rng| TraceId::from_u128(rng.borrow_mut().gen()))
+        CURRENT_RNG.with(|rng| TraceId::from(rng.borrow_mut().gen::<[u8; 16]>()))
     }
 
     /// Generate new `SpanId` using thread local rng

--- a/opentelemetry/src/sdk/trace/sampler.rs
+++ b/opentelemetry/src/sdk/trace/sampler.rs
@@ -138,8 +138,9 @@ impl ShouldSample for Sampler {
                     SamplingDecision::RecordAndSample
                 } else {
                     let prob_upper_bound = (prob.max(0.0) * (1u64 << 63) as f64) as u64;
-                    // The trace_id is already randomly generated, so we don't need a new one here
-                    let rnd_from_trace_id = (trace_id.to_u128() as u64) >> 1;
+                    // TODO: update behavior when the spec definition resolves
+                    // https://github.com/open-telemetry/opentelemetry-specification/issues/1413
+                    let rnd_from_trace_id = (trace_id.0 as u64) >> 1;
 
                     if rnd_from_trace_id < prob_upper_bound {
                         SamplingDecision::RecordAndSample
@@ -243,7 +244,7 @@ mod tests {
                     None
                 };
 
-                let trace_id = TraceId::from_u128(rng.gen());
+                let trace_id = TraceId::from(rng.gen::<[u8; 16]>());
                 if sampler
                     .should_sample(
                         parent_context.as_ref(),

--- a/opentelemetry/src/sdk/trace/tracer.rs
+++ b/opentelemetry/src/sdk/trace/tracer.rs
@@ -203,7 +203,7 @@ impl crate::trace::Tracer for Tracer {
                 builder
                     .trace_id
                     .unwrap_or_else(|| config.id_generator.new_trace_id()),
-                SpanId::invalid(),
+                SpanId::INVALID,
                 false,
                 TraceFlags::default(),
             ));

--- a/opentelemetry/src/testing/trace.rs
+++ b/opentelemetry/src/testing/trace.rs
@@ -7,7 +7,7 @@ use crate::{
         trace::{Config, EvictedHashMap, EvictedQueue},
         InstrumentationLibrary,
     },
-    trace::{Span, SpanContext, SpanId, SpanKind, StatusCode},
+    trace::{Span, SpanContext, SpanId, SpanKind, StatusCode, TraceId},
     KeyValue,
 };
 use async_trait::async_trait;
@@ -157,5 +157,19 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for TestExportError {
 impl<T> From<std::sync::mpsc::SendError<T>> for TestExportError {
     fn from(err: std::sync::mpsc::SendError<T>) -> Self {
         TestExportError(err.to_string())
+    }
+}
+
+// Helper to create trace ids for testing
+impl TraceId {
+    pub fn from_u128(num: u128) -> Self {
+        TraceId(num)
+    }
+}
+
+// Helper to create span ids for testing
+impl SpanId {
+    pub fn from_u64(num: u64) -> Self {
+        SpanId(num)
     }
 }

--- a/opentelemetry/src/trace/noop.rs
+++ b/opentelemetry/src/trace/noop.rs
@@ -63,8 +63,8 @@ impl NoopSpan {
     pub fn new() -> Self {
         NoopSpan {
             span_context: trace::SpanContext::new(
-                trace::TraceId::invalid(),
-                trace::SpanId::invalid(),
+                trace::TraceId::INVALID,
+                trace::SpanId::INVALID,
                 TraceFlags::default(),
                 false,
                 TraceState::default(),

--- a/opentelemetry/src/trace/span_context.rs
+++ b/opentelemetry/src/trace/span_context.rs
@@ -139,12 +139,6 @@ impl From<[u8; 16]> for TraceId {
     }
 }
 
-impl From<TraceId> for [u8; 16] {
-    fn from(id: TraceId) -> [u8; 16] {
-        id.to_bytes()
-    }
-}
-
 impl fmt::Debug for TraceId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("{:032x}", self.0))
@@ -204,12 +198,6 @@ impl SpanId {
 impl From<[u8; 8]> for SpanId {
     fn from(bytes: [u8; 8]) -> Self {
         SpanId::from_bytes(bytes)
-    }
-}
-
-impl From<SpanId> for [u8; 8] {
-    fn from(id: SpanId) -> [u8; 8] {
-        id.to_bytes()
     }
 }
 

--- a/opentelemetry/src/trace/span_context.rs
+++ b/opentelemetry/src/trace/span_context.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::fmt;
 use std::hash::Hash;
+use std::num::ParseIntError;
 use std::ops::{BitAnd, BitOr, Not};
 use std::str::FromStr;
 use thiserror::Error;
@@ -94,89 +95,139 @@ impl fmt::LowerHex for TraceFlags {
     }
 }
 
-/// TraceId is an 16-byte value which uniquely identifies a given trace
-/// The actual `u128` value is wrapped in a tuple struct in order to leverage the newtype pattern
+/// A 16-byte value which identifies a given trace.
+///
+/// The id is valid if it contains at least one non-zero byte.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Copy, Hash)]
-pub struct TraceId(u128);
+#[derive(Clone, PartialEq, Eq, Copy, Hash)]
+pub struct TraceId(pub(crate) u128);
 
 impl TraceId {
-    /// Construct a new invalid (zero-valued) TraceId
-    pub fn invalid() -> Self {
-        TraceId(0)
+    /// Invalid trace id
+    pub const INVALID: TraceId = TraceId(0);
+
+    /// Create a trace id from its representation as a byte array.
+    pub const fn from_bytes(bytes: [u8; 16]) -> Self {
+        TraceId(u128::from_be_bytes(bytes))
     }
 
-    /// Convert from u128 to TraceId
-    pub fn from_u128(item: u128) -> Self {
-        TraceId(item)
-    }
-
-    /// Convert from TraceId to u128
-    pub fn to_u128(self) -> u128 {
-        self.0
-    }
-
-    /// Convert from TraceId to Hexadecimal String
-    pub fn to_hex(self) -> String {
-        format!("{:032x}", self.0)
-    }
-
-    /// Convert from TraceId to Big-Endian byte array
-    pub fn to_byte_array(self) -> [u8; 16] {
+    /// Return the representation of this trace id as a byte array.
+    pub const fn to_bytes(self) -> [u8; 16] {
         self.0.to_be_bytes()
     }
 
-    /// Construct a new TraceId from Hexadecimal String
-    pub fn from_hex(hex: &str) -> Self {
-        TraceId(u128::from_str_radix(hex, 16).unwrap_or(0))
-    }
-
-    /// Construct a new TraceId from Big-Endian byte array
-    pub fn from_byte_array(byte_array: [u8; 16]) -> Self {
-        TraceId(u128::from_be_bytes(byte_array))
+    /// Converts a string in base 16 to a trace id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use opentelemetry::trace::TraceId;
+    ///
+    /// assert!(TraceId::from_hex("42").is_ok());
+    /// assert!(TraceId::from_hex("58406520a006649127e371903a2de979").is_ok());
+    ///
+    /// assert!(TraceId::from_hex("not_hex").is_err());
+    /// ```
+    pub fn from_hex(hex: &str) -> Result<Self, ParseIntError> {
+        u128::from_str_radix(hex, 16).map(TraceId)
     }
 }
 
-/// SpanId is an 8-byte value which uniquely identifies a given span within a trace
-/// The actual `u64` value is wrapped in a tuple struct in order to leverage the newtype pattern
+impl From<[u8; 16]> for TraceId {
+    fn from(bytes: [u8; 16]) -> Self {
+        TraceId::from_bytes(bytes)
+    }
+}
+
+impl From<TraceId> for [u8; 16] {
+    fn from(id: TraceId) -> [u8; 16] {
+        id.to_bytes()
+    }
+}
+
+impl fmt::Debug for TraceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{:032x}", self.0))
+    }
+}
+
+impl fmt::Display for TraceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{:032x}", self.0))
+    }
+}
+
+impl fmt::LowerHex for TraceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+/// An 8-byte value which identifies a given span.
+///
+/// The id is valid if it contains at least one non-zero byte.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Copy, Hash)]
-pub struct SpanId(u64);
+#[derive(Clone, PartialEq, Eq, Copy, Hash)]
+pub struct SpanId(pub(crate) u64);
 
 impl SpanId {
-    /// Construct a new invalid (zero-valued) SpanId
-    pub fn invalid() -> Self {
-        SpanId(0)
+    /// Invalid span id
+    pub const INVALID: SpanId = SpanId(0);
+
+    /// Create a span id from its representation as a byte array.
+    pub const fn from_bytes(bytes: [u8; 8]) -> Self {
+        SpanId(u64::from_be_bytes(bytes))
     }
 
-    /// Convert from u64 to SpanId
-    pub fn from_u64(item: u64) -> Self {
-        SpanId(item)
-    }
-
-    /// Convert from SpanId to u64
-    pub fn to_u64(self) -> u64 {
-        self.0
-    }
-
-    /// Convert from SpanId to Hexadecimal String
-    pub fn to_hex(self) -> String {
-        format!("{:016x}", self.0)
-    }
-
-    /// Convert from SpanId to Big-Endian byte array
-    pub fn to_byte_array(self) -> [u8; 8] {
+    /// Return the representation of this span id as a byte array.
+    pub const fn to_bytes(self) -> [u8; 8] {
         self.0.to_be_bytes()
     }
 
-    /// Construct a new SpanId from Hexadecimal String
-    pub fn from_hex(hex: &str) -> Self {
-        SpanId(u64::from_str_radix(hex, 16).unwrap_or(0))
+    /// Converts a string in base 16 to a span id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use opentelemetry::trace::SpanId;
+    ///
+    /// assert!(SpanId::from_hex("42").is_ok());
+    /// assert!(SpanId::from_hex("58406520a0066491").is_ok());
+    ///
+    /// assert!(SpanId::from_hex("not_hex").is_err());
+    /// ```
+    pub fn from_hex(hex: &str) -> Result<Self, ParseIntError> {
+        u64::from_str_radix(hex, 16).map(SpanId)
     }
+}
 
-    /// Construct a new SpanId from Big-Endian byte array
-    pub fn from_byte_array(byte_array: [u8; 8]) -> Self {
-        SpanId(u64::from_be_bytes(byte_array))
+impl From<[u8; 8]> for SpanId {
+    fn from(bytes: [u8; 8]) -> Self {
+        SpanId::from_bytes(bytes)
+    }
+}
+
+impl From<SpanId> for [u8; 8] {
+    fn from(id: SpanId) -> [u8; 8] {
+        id.to_bytes()
+    }
+}
+
+impl fmt::Debug for SpanId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{:016x}", self.0))
+    }
+}
+
+impl fmt::Display for SpanId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{:016x}", self.0))
+    }
+}
+
+impl fmt::LowerHex for SpanId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
     }
 }
 
@@ -420,8 +471,8 @@ impl SpanContext {
     /// Create an invalid empty span context
     pub fn empty_context() -> Self {
         SpanContext::new(
-            TraceId::invalid(),
-            SpanId::invalid(),
+            TraceId::INVALID,
+            SpanId::INVALID,
             TraceFlags::default(),
             false,
             TraceState::default(),
@@ -519,22 +570,24 @@ mod tests {
     #[test]
     fn test_trace_id() {
         for test_case in trace_id_test_data() {
-            assert_eq!(test_case.0.to_hex(), test_case.1);
-            assert_eq!(test_case.0.to_byte_array(), test_case.2);
+            assert_eq!(format!("{}", test_case.0), test_case.1);
+            assert_eq!(format!("{:032x}", test_case.0), test_case.1);
+            assert_eq!(test_case.0.to_bytes(), test_case.2);
 
-            assert_eq!(test_case.0, TraceId::from_hex(test_case.1));
-            assert_eq!(test_case.0, TraceId::from_byte_array(test_case.2));
+            assert_eq!(test_case.0, TraceId::from_hex(test_case.1).unwrap());
+            assert_eq!(test_case.0, TraceId::from_bytes(test_case.2));
         }
     }
 
     #[test]
     fn test_span_id() {
         for test_case in span_id_test_data() {
-            assert_eq!(test_case.0.to_hex(), test_case.1);
-            assert_eq!(test_case.0.to_byte_array(), test_case.2);
+            assert_eq!(format!("{}", test_case.0), test_case.1);
+            assert_eq!(format!("{:016x}", test_case.0), test_case.1);
+            assert_eq!(test_case.0.to_bytes(), test_case.2);
 
-            assert_eq!(test_case.0, SpanId::from_hex(test_case.1));
-            assert_eq!(test_case.0, SpanId::from_byte_array(test_case.2));
+            assert_eq!(test_case.0, SpanId::from_hex(test_case.1).unwrap());
+            assert_eq!(test_case.0, SpanId::from_bytes(test_case.2));
         }
     }
 


### PR DESCRIPTION
The spec only defines conversions between ids and hex/binary values. This updates the `TraceId` and `SpanId` APIs to be compliant by removing explicit conversions from u128/u64 (except for test convenience methods) and adding methods for converting to/from byte arrays and hex strings.