### PR TITLE
opentelemetry-zipkin: Add Environment Variables

### DIFF
--- a/opentelemetry-zipkin/CHANGELOG.md
+++ b/opentelemetry-zipkin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## unreleased
+
+## Added
+
+- Add support for OTEL_EXPORTER_ZIPKIN_* variables. #718
+
+## Changed
+
+- Add defaults for timeouts to HTTP clients #718
+
 ## v0.15.0
 
 ### Changed
@@ -116,5 +126,5 @@
 
 ### Added
 
-- Exporter to Zipkin collector through HTTP API 
+- Exporter to Zipkin collector through HTTP API
 

--- a/opentelemetry-zipkin/src/exporter/env.rs
+++ b/opentelemetry-zipkin/src/exporter/env.rs
@@ -1,0 +1,63 @@
+use std::env;
+use std::time::Duration;
+
+/// Default Zipkin collector endpoint
+const DEFAULT_COLLECTOR_ENDPOINT: &str = "http://127.0.0.1:9411/api/v2/spans";
+
+/// HTTP endpoint for Zipkin collector.
+/// e.g. "http://localhost:9411/api/v2/spans"
+const ENV_ENDPOINT: &str = "OTEL_EXPORTER_ZIPKIN_ENDPOINT";
+
+/// Maximum time the Zipkin exporter will wait for each batch export
+const ENV_TIMEOUT: &str = "OTEL_EXPORTER_ZIPKIN_TIMEOUT";
+
+/// Default Zipkin timeout in milliseconds
+const DEFAULT_COLLECTOR_TIMEOUT: Duration = Duration::from_millis(10_000);
+
+pub(crate) fn get_timeout() -> Duration {
+    match env::var(ENV_TIMEOUT).ok().filter(|var| !var.is_empty()) {
+        Some(timeout) => match timeout.parse() {
+            Ok(timeout) => Duration::from_millis(timeout),
+            Err(e) => {
+                eprintln!("{} malformed defaulting to 10000: {}", ENV_TIMEOUT, e);
+                DEFAULT_COLLECTOR_TIMEOUT
+            }
+        },
+        None => DEFAULT_COLLECTOR_TIMEOUT,
+    }
+}
+
+pub(crate) fn get_endpoint() -> String {
+    match env::var(ENV_ENDPOINT).ok().filter(|var| !var.is_empty()) {
+        Some(endpoint) => endpoint,
+        None => DEFAULT_COLLECTOR_ENDPOINT.to_string(),
+    }
+}
+
+#[test]
+fn test_collector_defaults() {
+    // Ensure the variables are undefined.
+    env::remove_var(ENV_TIMEOUT);
+    env::remove_var(ENV_ENDPOINT);
+    assert_eq!(DEFAULT_COLLECTOR_TIMEOUT, get_timeout());
+    assert_eq!(DEFAULT_COLLECTOR_ENDPOINT, get_endpoint());
+}
+
+#[test]
+fn test_collector_bad_timeout() {
+    env::set_var(ENV_TIMEOUT, "a");
+    assert_eq!(DEFAULT_COLLECTOR_TIMEOUT, get_timeout());
+}
+
+#[test]
+fn test_collector_good_timeout() {
+    env::set_var(ENV_TIMEOUT, "777");
+    assert_eq!(Duration::from_millis(777), get_timeout());
+}
+
+#[test]
+fn test_collector_custom_endpoint() {
+    let custom_endpoint = "https://example.com/api/v2/spans";
+    env::set_var(ENV_ENDPOINT, custom_endpoint);
+    assert_eq!(custom_endpoint, get_endpoint());
+}

--- a/opentelemetry/src/sdk/resource/env.rs
+++ b/opentelemetry/src/sdk/resource/env.rs
@@ -132,6 +132,8 @@ mod tests {
     #[test]
     fn test_sdk_provided_resource_detector() {
         const SERVICE_NAME: &str = "service.name";
+        // Ensure no env var set
+        env::remove_var(OTEL_RESOURCE_ATTRIBUTES);
         let no_env = SdkProvidedResourceDetector.detect(Duration::from_secs(1));
         assert_eq!(
             no_env.get(Key::from_static_str(SERVICE_NAME)),


### PR DESCRIPTION
As described in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md
* Add support for:
** OTEL_EXPORTER_ZIPKIN_ENDPOINT
** OTEL_EXPORTER_ZIPKIN_TIMEOUT
* Update Default to use

Closes #534

Signed-off-by: Harold Dost <h.dost@criteo.com>