### PR TITLE
Impl default tracer methods and update docs

### DIFF
--- a/opentelemetry-api/src/global/trace.rs
+++ b/opentelemetry-api/src/global/trace.rs
@@ -240,30 +240,6 @@ impl trace::Tracer for BoxedTracer {
     /// which is not possible if it takes generic type parameters.
     type Span = BoxedSpan;
 
-    /// Starts a new `Span`.
-    ///
-    /// Each span has zero or one parent spans and zero or more child spans, which
-    /// represent causally related operations. A tree of related spans comprises a
-    /// trace. A span is said to be a _root span_ if it does not have a parent. Each
-    /// trace includes a single root span, which is the shared ancestor of all other
-    /// spans in the trace.
-    fn start_with_context<T>(&self, name: T, parent_cx: &Context) -> Self::Span
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        BoxedSpan(self.0.start_with_context_boxed(name.into(), parent_cx))
-    }
-
-    /// Creates a span builder
-    ///
-    /// An ergonomic way for attributes to be configured before the `Span` is started.
-    fn span_builder<T>(&self, name: T) -> trace::SpanBuilder
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        trace::SpanBuilder::from_name(name)
-    }
-
     /// Create a span from a `SpanBuilder`
     fn build_with_context(&self, builder: trace::SpanBuilder, parent_cx: &Context) -> Self::Span {
         BoxedSpan(self.0.build_with_context_boxed(builder, parent_cx))
@@ -275,14 +251,6 @@ impl trace::Tracer for BoxedTracer {
 ///
 /// [`Tracer`]: crate::trace::Tracer
 pub trait ObjectSafeTracer {
-    /// Returns a trait object so the underlying implementation can be swapped
-    /// out at runtime.
-    fn start_with_context_boxed(
-        &self,
-        name: Cow<'static, str>,
-        parent_cx: &Context,
-    ) -> Box<dyn ObjectSafeSpan + Send + Sync>;
-
     /// Returns a trait object so the underlying implementation can be swapped
     /// out at runtime.
     fn build_with_context_boxed(
@@ -297,16 +265,6 @@ where
     S: trace::Span + Send + Sync + 'static,
     T: trace::Tracer<Span = S>,
 {
-    /// Returns a trait object so the underlying implementation can be swapped
-    /// out at runtime.
-    fn start_with_context_boxed(
-        &self,
-        name: Cow<'static, str>,
-        parent_cx: &Context,
-    ) -> Box<dyn ObjectSafeSpan + Send + Sync> {
-        Box::new(self.start_with_context(name, parent_cx))
-    }
-
     /// Returns a trait object so the underlying implementation can be swapped
     /// out at runtime.
     fn build_with_context_boxed(

--- a/opentelemetry-api/src/lib.rs
+++ b/opentelemetry-api/src/lib.rs
@@ -31,7 +31,11 @@
     unused
 )]
 #![allow(clippy::needless_doctest_main)]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(
+    docsrs,
+    feature(doc_cfg, doc_auto_cfg),
+    deny(rustdoc::broken_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]

--- a/opentelemetry-api/src/trace/context.rs
+++ b/opentelemetry-api/src/trace/context.rs
@@ -48,9 +48,11 @@ impl SpanRef<'_> {
     /// Record an event in the context this span.
     ///
     /// Note that the OpenTelemetry project documents certain "[standard
-    /// attributes]" that have prescribed semantic meanings.
+    /// attributes]" that have prescribed semantic meanings and are available via
+    /// the [opentelemetry_semantic_conventions] crate.
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
+    /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
     pub fn add_event<T>(&self, name: T, attributes: Vec<KeyValue>)
     where
         T: Into<Cow<'static, str>>,
@@ -74,9 +76,11 @@ impl SpanRef<'_> {
     /// Record an event with a timestamp in the context this span.
     ///
     /// Note that the OpenTelemetry project documents certain "[standard
-    /// attributes]" that have prescribed semantic meanings.
+    /// attributes]" that have prescribed semantic meanings and are available via
+    /// the [opentelemetry_semantic_conventions] crate.
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
+    /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
     pub fn add_event_with_timestamp<T>(
         &self,
         name: T,
@@ -119,9 +123,11 @@ impl SpanRef<'_> {
     /// generally overwrites the existing attribute's value.
     ///
     /// Note that the OpenTelemetry project documents certain "[standard
-    /// attributes]" that have prescribed semantic meanings.
+    /// attributes]" that have prescribed semantic meanings and are available via
+    /// the [opentelemetry_semantic_conventions] crate.
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
+    /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
     pub fn set_attribute(&self, attribute: crate::KeyValue) {
         self.with_inner_mut(move |inner| inner.set_attribute(attribute))
     }

--- a/opentelemetry-api/src/trace/context.rs
+++ b/opentelemetry-api/src/trace/context.rs
@@ -45,7 +45,12 @@ impl SpanRef<'_> {
 }
 
 impl SpanRef<'_> {
-    /// An API to record events in the context of a given `Span`.
+    /// Record an event in the context this span.
+    ///
+    /// Note that the OpenTelemetry project documents certain "[standard
+    /// attributes]" that have prescribed semantic meanings.
+    ///
+    /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     pub fn add_event<T>(&self, name: T, attributes: Vec<KeyValue>)
     where
         T: Into<Cow<'static, str>>,
@@ -53,12 +58,12 @@ impl SpanRef<'_> {
         self.with_inner_mut(|inner| inner.add_event(name, attributes))
     }
 
-    /// Convenience method to record an exception/error as an `Event`
+    /// Record an exception event
     pub fn record_exception(&self, err: &dyn Error) {
         self.with_inner_mut(|inner| inner.record_exception(err))
     }
 
-    /// Convenience method to record a exception/error as an `Event` with custom stacktrace
+    /// Record an exception event with stacktrace
     pub fn record_exception_with_stacktrace<T>(&self, err: &dyn Error, stacktrace: T)
     where
         T: Into<Cow<'static, str>>,
@@ -66,7 +71,12 @@ impl SpanRef<'_> {
         self.with_inner_mut(|inner| inner.record_exception_with_stacktrace(err, stacktrace))
     }
 
-    /// An API to record events at a specific time in the context of a given `Span`.
+    /// Record an event with a timestamp in the context this span.
+    ///
+    /// Note that the OpenTelemetry project documents certain "[standard
+    /// attributes]" that have prescribed semantic meanings.
+    ///
+    /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     pub fn add_event_with_timestamp<T>(
         &self,
         name: T,
@@ -80,13 +90,21 @@ impl SpanRef<'_> {
         })
     }
 
-    /// Returns the `SpanContext` for the given `Span`.
+    /// A reference to the [`SpanContext`] for this span.
     pub fn span_context(&self) -> &SpanContext {
         &self.0.span_context
     }
 
-    /// Returns true if this `Span` is recording information like events with the `add_event`
-    /// operation, attributes using `set_attributes`, status with `set_status`, etc.
+    /// Returns `true` if this span is recording information.
+    ///
+    /// Spans will not be recording information after they have ended.
+    ///
+    /// This flag may be `true` despite the entire trace being sampled out. This
+    /// allows recording and processing of information about the individual
+    /// spans without sending it to the backend. An example of this scenario may
+    /// be recording and processing of all incoming requests for the processing
+    /// and building of SLA/SLO latency charts while sending only a subset -
+    /// sampled spans - to the backend.
     pub fn is_recording(&self) -> bool {
         self.0
             .inner
@@ -95,15 +113,24 @@ impl SpanRef<'_> {
             .unwrap_or(false)
     }
 
-    /// An API to set a single `Attribute` where the attribute properties are passed
-    /// as arguments. To avoid extra allocations some implementations may offer a separate API for
-    /// each of the possible value types.
+    /// Set an attribute of this span.
+    ///
+    /// Setting an attribute with the same key as an existing attribute
+    /// generally overwrites the existing attribute's value.
+    ///
+    /// Note that the OpenTelemetry project documents certain "[standard
+    /// attributes]" that have prescribed semantic meanings.
+    ///
+    /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     pub fn set_attribute(&self, attribute: crate::KeyValue) {
         self.with_inner_mut(move |inner| inner.set_attribute(attribute))
     }
 
-    /// Sets the status of the `Span`. If used, this will override the default `Span`
-    /// status, which is `Unset`. `message` MUST be ignored when the status is `OK` or `Unset`
+    /// Sets the status of this `Span`.
+    ///
+    /// If used, this will override the default span status, which is [`StatusCode::Unset`].
+    ///
+    /// [`StatusCode::Unset`]: super::StatusCode::Unset
     pub fn set_status<T>(&self, code: super::StatusCode, message: T)
     where
         T: Into<Cow<'static, str>>,
@@ -111,8 +138,10 @@ impl SpanRef<'_> {
         self.with_inner_mut(move |inner| inner.set_status(code, message))
     }
 
-    /// Updates the `Span`'s name. After this update, any sampling behavior based on the
-    /// name will depend on the implementation.
+    /// Updates the span's name.
+    ///
+    /// After this update, any sampling behavior based on the name will depend on
+    /// the implementation.
     pub fn update_name<T>(&self, new_name: T)
     where
         T: Into<Cow<'static, str>>,
@@ -120,36 +149,87 @@ impl SpanRef<'_> {
         self.with_inner_mut(move |inner| inner.update_name(new_name))
     }
 
-    /// Finishes the `Span`.
+    /// Signals that the operation described by this span has now ended.
     pub fn end(&self) {
         self.end_with_timestamp(crate::time::now());
     }
 
-    /// Finishes the `Span` with given timestamp
+    /// Signals that the operation described by this span ended at the given time.
     pub fn end_with_timestamp(&self, timestamp: std::time::SystemTime) {
         self.with_inner_mut(move |inner| inner.end_with_timestamp(timestamp))
     }
 }
 
-/// Methods for storing and retrieving trace data in a context.
+/// Methods for storing and retrieving trace data in a [`Context`].
+///
+/// See [`Context`] for examples of setting and retrieving the current context.
 pub trait TraceContextExt {
-    /// Returns a clone of the current context with the included span.
+    /// Returns a clone of the current context with the included [`Span`].
     ///
-    /// This is useful for building tracers.
+    /// # Examples
+    ///
+    /// ```
+    /// use opentelemetry_api::{global, trace::{TraceContextExt, Tracer}, Context};
+    ///
+    /// let tracer = global::tracer("example");
+    ///
+    /// // build a span
+    /// let span = tracer.start("parent_span");
+    ///
+    /// // create a new context from the currently active context that includes this span
+    /// let cx = Context::current_with_span(span);
+    ///
+    /// // create a child span by explicitly specifying the parent context
+    /// let child = tracer.start_with_context("child_span", &cx);
+    /// # drop(child)
+    /// ```
     fn current_with_span<T: crate::trace::Span + Send + Sync + 'static>(span: T) -> Self;
 
     /// Returns a clone of this context with the included span.
     ///
-    /// This is useful for building tracers.
+    /// # Examples
+    ///
+    /// ```
+    /// use opentelemetry_api::{global, trace::{TraceContextExt, Tracer}, Context};
+    ///
+    /// fn fn_with_passed_in_context(cx: &Context) {
+    ///     let tracer = global::tracer("example");
+    ///
+    ///     // build a span
+    ///     let span = tracer.start("parent_span");
+    ///
+    ///     // create a new context from the given context that includes the span
+    ///     let cx_with_parent = cx.with_span(span);
+    ///
+    ///     // create a child span by explicitly specifying the parent context
+    ///     let child = tracer.start_with_context("child_span", &cx_with_parent);
+    ///     # drop(child)
+    /// }
+    ///
     fn with_span<T: crate::trace::Span + Send + Sync + 'static>(&self, span: T) -> Self;
 
     /// Returns a reference to this context's span, or the default no-op span if
     /// none has been set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use opentelemetry_api::{trace::TraceContextExt, Context};
+    ///
+    /// // Add an event to the currently active span
+    /// Context::current().span().add_event("An event!", vec![]);
+    /// ```
     fn span(&self) -> SpanRef<'_>;
 
-    /// Used to see if a span has been marked as active
+    /// Returns whether or not an active span has been set.
     ///
-    /// This is useful for building tracers.
+    /// # Examples
+    ///
+    /// ```
+    /// use opentelemetry_api::{trace::TraceContextExt, Context};
+    ///
+    /// assert!(!Context::current().has_active_span());
+    /// ```
     fn has_active_span(&self) -> bool;
 
     /// Returns a copy of this context with the span context included.

--- a/opentelemetry-api/src/trace/mod.rs
+++ b/opentelemetry-api/src/trace/mod.rs
@@ -12,8 +12,6 @@
 //! ## Getting Started
 //!
 //! ```
-//! # #[cfg(feature = "trace")]
-//! # {
 //! use opentelemetry_api::{global, trace::{Span, Tracer, TracerProvider}};
 //!
 //! fn my_library_function() {
@@ -36,7 +34,6 @@
 //!     // End the span
 //!     span.end();
 //! }
-//! # }
 //! ```
 //!
 //! ## Overview
@@ -71,8 +68,6 @@
 //! [`Context`]: crate::Context
 //!
 //! ```
-//! # #[cfg(feature = "trace")]
-//! # {
 //! use opentelemetry_api::{global, trace::{self, Span, StatusCode, Tracer, TracerProvider}};
 //!
 //! fn may_error(rand: f32) {
@@ -98,15 +93,12 @@
 //!
 //! // Drop the guard and the span will no longer be active
 //! drop(active)
-//! # }
 //! ```
 //!
 //! Additionally [`Tracer::with_span`] and [`Tracer::in_span`] can be used as shorthand to
 //! simplify managing the parent context.
 //!
 //! ```
-//! # #[cfg(feature = "trace")]
-//! # {
 //! use opentelemetry_api::{global, trace::Tracer};
 //!
 //! // Get a tracer
@@ -123,7 +115,6 @@
 //! tracer.with_span(span, |cx| {
 //!     // spans created here will be children of `parent_span`
 //! });
-//! # }
 //! ```
 //!
 //! #### Async active spans
@@ -131,8 +122,6 @@
 //! Async spans can be propagated with [`TraceContextExt`] and [`FutureExt`].
 //!
 //! ```
-//! # #[cfg(feature = "trace")]
-//! # {
 //! use opentelemetry_api::{Context, global, trace::{FutureExt, TraceContextExt, Tracer}};
 //!
 //! async fn some_work() { }
@@ -145,7 +134,6 @@
 //!
 //! // Perform some async work with this span as the currently active parent.
 //! some_work().with_context(Context::current_with_span(span));
-//! # }
 //! ```
 
 use futures_channel::{mpsc::TrySendError, oneshot::Canceled};

--- a/opentelemetry-api/src/trace/noop.rs
+++ b/opentelemetry-api/src/trace/noop.rs
@@ -7,7 +7,7 @@ use crate::trace::TraceResult;
 use crate::{
     propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
     trace,
-    trace::{SpanBuilder, TraceContextExt, TraceFlags, TraceState},
+    trace::{TraceContextExt, TraceFlags, TraceState},
     Context, KeyValue,
 };
 use std::borrow::Cow;
@@ -145,24 +145,6 @@ impl NoopTracer {
 
 impl trace::Tracer for NoopTracer {
     type Span = NoopSpan;
-
-    /// Starts a new `NoopSpan` with a given context.
-    ///
-    /// If the context contains a valid span, it's span context is propagated.
-    fn start_with_context<T>(&self, name: T, parent_cx: &Context) -> Self::Span
-    where
-        T: Into<std::borrow::Cow<'static, str>>,
-    {
-        self.build_with_context(SpanBuilder::from_name(name), parent_cx)
-    }
-
-    /// Starts a `SpanBuilder`.
-    fn span_builder<T>(&self, name: T) -> trace::SpanBuilder
-    where
-        T: Into<std::borrow::Cow<'static, str>>,
-    {
-        trace::SpanBuilder::from_name(name)
-    }
 
     /// Builds a `NoopSpan` from a `SpanBuilder`.
     ///

--- a/opentelemetry-api/src/trace/span.rs
+++ b/opentelemetry-api/src/trace/span.rs
@@ -52,9 +52,11 @@ pub trait Span {
     /// Record an event in the context this span.
     ///
     /// Note that the OpenTelemetry project documents certain "[standard
-    /// attributes]" that have prescribed semantic meanings.
+    /// attributes]" that have prescribed semantic meanings and are available via
+    /// the [opentelemetry_semantic_conventions] crate.
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
+    /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
     fn add_event<T>(&mut self, name: T, attributes: Vec<KeyValue>)
     where
         T: Into<Cow<'static, str>>,
@@ -84,9 +86,11 @@ pub trait Span {
     /// Record an event with a timestamp in the context this span.
     ///
     /// Note that the OpenTelemetry project documents certain "[standard
-    /// attributes]" that have prescribed semantic meanings.
+    /// attributes]" that have prescribed semantic meanings and are available via
+    /// the [opentelemetry_semantic_conventions] crate.
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
+    /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
     fn add_event_with_timestamp<T>(
         &mut self,
         name: T,
@@ -116,9 +120,11 @@ pub trait Span {
     /// generally overwrites the existing attribute's value.
     ///
     /// Note that the OpenTelemetry project documents certain "[standard
-    /// attributes]" that have prescribed semantic meanings.
+    /// attributes]" that have prescribed semantic meanings and are available via
+    /// the [opentelemetry_semantic_conventions] crate.
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
+    /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
     fn set_attribute(&mut self, attribute: KeyValue);
 
     /// Sets the status of this `Span`.

--- a/opentelemetry-api/src/trace/span.rs
+++ b/opentelemetry-api/src/trace/span.rs
@@ -1,39 +1,60 @@
-//! # OpenTelemetry Span interface
-//!
-//! A `Span` represents a single operation within a trace. `Span`s can be nested to form a trace
-//! tree. Each trace contains a root span, which typically describes the end-to-end latency and,
-//! optionally, one or more sub-spans for its sub-operations.
-//!
-//! The `Span`'s start and end timestamps reflect the elapsed real time of the operation. A `Span`'s
-//! start time SHOULD be set to the current time on span creation. After the `Span` is created, it
-//! SHOULD be possible to change its name, set its `Attributes`, and add `Links` and `Events`.
-//! These MUST NOT be changed after the `Span`'s end time has been set.
-//!
-//! `Spans` are not meant to be used to propagate information within a process. To prevent misuse,
-//! implementations SHOULD NOT provide access to a `Span`'s attributes besides its `SpanContext`.
-//!
-//! Vendors may implement the `Span` interface to effect vendor-specific logic. However, alternative
-//! implementations MUST NOT allow callers to create Spans directly. All `Span`s MUST be created
-//! via a Tracer.
 use crate::{trace::SpanContext, KeyValue};
 use std::borrow::Cow;
 use std::error::Error;
 use std::fmt;
 use std::time::SystemTime;
 
-/// Interface for a single operation within a trace.
+/// The interface for a single operation within a trace.
+///
+/// Spans can be nested to form a trace tree. Each trace contains a root span,
+/// which typically describes the entire operation and, optionally, one or more
+/// sub-spans for its sub-operations.
+///
+/// The span `name` concisely identifies the work represented by the span, for
+/// example, an RPC method name, a function name, or the name of a subtask or
+/// stage within a larger computation. The span name should be the most general
+/// string that identifies a (statistically) interesting class of spans, rather
+/// than individual span instances while still being human-readable. That is,
+/// `"get_user"` is a reasonable name, while `"get_user/314159"`, where `"314159"` is
+/// a user ID, is not a good name due to its high cardinality. _Generality_
+/// should be prioritized over _human-readability_.
+///
+/// For example, here are potential span names for an endpoint that gets a
+/// hypothetical account information:
+///
+/// | Span Name         | Guidance     |
+/// | ----------------- | ------------ |
+/// | `get`             | Too general  |
+/// | `get_account/42`  | Too specific |
+/// | `get_account`     | Good, and account_id=42 would make a nice Span attribute |
+/// | `get_account/{accountId}` | Also good (using the "HTTP route") |
+///
+/// The span's start and end timestamps reflect the elapsed real time of the
+/// operation.
+///
+/// For example, if a span represents a request-response cycle (e.g. HTTP or an
+/// RPC), the span should have a start time that corresponds to the start time
+/// of the first sub-operation, and an end time of when the final sub-operation
+/// is complete. This includes:
+///
+/// * receiving the data from the request
+/// * parsing of the data (e.g. from a binary or json format)
+/// * any middleware or additional processing logic
+/// * business logic
+/// * construction of the response
+/// * sending of the response
+///
+/// Child spans (or in some cases events) may be created to represent
+/// sub-operations which require more detailed observability. Child spans should
+/// measure the timing of the respective sub-operation, and may add additional
+/// attributes.
 pub trait Span {
-    /// An API to record events in the context of a given `Span`.
+    /// Record an event in the context this span.
     ///
-    /// Events have a time associated with the moment when they are
-    /// added to the `Span`.
+    /// Note that the OpenTelemetry project documents certain "[standard
+    /// attributes]" that have prescribed semantic meanings.
     ///
-    /// Events SHOULD preserve the order in which they're set. This will typically match
-    /// the ordering of the events' timestamps.
-    ///
-    /// Note that the OpenTelemetry project documents certain ["standard event names and
-    /// keys"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
-    /// which have prescribed semantic meanings.
+    /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     fn add_event<T>(&mut self, name: T, attributes: Vec<KeyValue>)
     where
         T: Into<Cow<'static, str>>,
@@ -41,28 +62,13 @@ pub trait Span {
         self.add_event_with_timestamp(name, crate::time::now(), attributes)
     }
 
-    /// Convenience method to record an exception/error as an `Event`
-    ///
-    /// An exception SHOULD be recorded as an Event on the span during which it occurred.
-    /// The name of the event MUST be "exception".
-    ///
-    /// The semantic conventions for Errors are described in ["Semantic Conventions for Exceptions"](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/exceptions.md)
-    ///
-    /// For now we will not set `exception.stacktrace` attribute since the `Error::backtrace`
-    /// method is still in nightly. Users can provide a stacktrace by using the
-    /// `record_exception_with_stacktrace` method.
-    ///
-    /// Users can custom the exception message by overriding the `fmt::Display` trait's `fmt` method
-    /// for the error.
+    /// Record an exception event
     fn record_exception(&mut self, err: &dyn Error) {
         let attributes = vec![KeyValue::new("exception.message", err.to_string())];
-
-        self.add_event("exception".to_string(), attributes);
+        self.add_event("exception", attributes);
     }
 
-    /// Convenience method to record a exception/error as an `Event` with custom stacktrace
-    ///
-    /// See `Span:record_exception` method for more details.
+    /// Record an exception event with stacktrace
     fn record_exception_with_stacktrace<T>(&mut self, err: &dyn Error, stacktrace: T)
     where
         T: Into<Cow<'static, str>>,
@@ -72,17 +78,15 @@ pub trait Span {
             KeyValue::new("exception.stacktrace", stacktrace.into()),
         ];
 
-        self.add_event("exception".to_string(), attributes);
+        self.add_event("exception", attributes);
     }
 
-    /// An API to record events at a specific time in the context of a given `Span`.
+    /// Record an event with a timestamp in the context this span.
     ///
-    /// Events SHOULD preserve the order in which they're set. This will typically match
-    /// the ordering of the events' timestamps.
+    /// Note that the OpenTelemetry project documents certain "[standard
+    /// attributes]" that have prescribed semantic meanings.
     ///
-    /// Note that the OpenTelemetry project documents certain ["standard event names and
-    /// keys"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
-    /// which have prescribed semantic meanings.
+    /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     fn add_event_with_timestamp<T>(
         &mut self,
         name: T,
@@ -91,148 +95,128 @@ pub trait Span {
     ) where
         T: Into<Cow<'static, str>>;
 
-    /// Returns the `SpanContext` for the given `Span`. The returned value may be used even after
-    /// the `Span is finished. The returned value MUST be the same for the entire `Span` lifetime.
+    /// A reference to the [`SpanContext`] for this span.
     fn span_context(&self) -> &SpanContext;
 
-    /// Returns true if this `Span` is recording information like events with the `add_event`
-    /// operation, attributes using `set_attributes`, status with `set_status`, etc.
+    /// Returns `true` if this span is recording information.
     ///
-    /// This flag SHOULD be used to avoid expensive computations of a `Span` attributes or events in
-    /// case when a `Span` is definitely not recorded. Note that any child span's recording is
-    /// determined independently from the value of this flag (typically based on the sampled flag of
-    /// a `TraceFlag` on `SpanContext`).
+    /// Spans will not be recording information after they have ended.
     ///
-    /// This flag may be true despite the entire trace being sampled out. This allows to record and
-    /// process information about the individual Span without sending it to the backend. An example
-    /// of this scenario may be recording and processing of all incoming requests for the processing
-    /// and building of SLA/SLO latency charts while sending only a subset - sampled spans - to the
-    /// backend. See also the sampling section of SDK design.
-    ///
-    /// Users of the API should only access the `is_recording` property when instrumenting code and
-    /// never access `SampledFlag` unless used in context propagators.
+    /// This flag may be `true` despite the entire trace being sampled out. This
+    /// allows recording and processing of information about the individual
+    /// spans without sending it to the backend. An example of this scenario may
+    /// be recording and processing of all incoming requests for the processing
+    /// and building of SLA/SLO latency charts while sending only a subset -
+    /// sampled spans - to the backend.
     fn is_recording(&self) -> bool;
 
-    /// An API to set a single `Attribute` where the attribute properties are passed
-    /// as arguments. To avoid extra allocations some implementations may offer a separate API for
-    /// each of the possible value types.
+    /// Set an attribute of this span.
     ///
-    /// An `Attribute` is defined as a `KeyValue` pair.
+    /// Setting an attribute with the same key as an existing attribute
+    /// generally overwrites the existing attribute's value.
     ///
-    /// Attributes SHOULD preserve the order in which they're set. Setting an attribute
-    /// with the same key as an existing attribute SHOULD overwrite the existing
-    /// attribute's value.
+    /// Note that the OpenTelemetry project documents certain "[standard
+    /// attributes]" that have prescribed semantic meanings.
     ///
-    /// Note that the OpenTelemetry project documents certain ["standard
-    /// attributes"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
-    /// that have prescribed semantic meanings.
+    /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     fn set_attribute(&mut self, attribute: KeyValue);
 
-    /// Sets the status of the `Span`. `message` MUST be ignored when the status is `OK` or
-    /// `Unset`.
+    /// Sets the status of this `Span`.
     ///
-    /// The order of status is `Ok` > `Error` > `Unset`. That's means set the status
-    /// to `Unset` will always be ignore, set the status to `Error` only works when current
-    /// status is `Unset`, set the status to `Ok` will be consider final and any further call
-    /// to this function will be ignore.
+    /// If used, this will override the default span status, which is [`StatusCode::Unset`].
     fn set_status<T>(&mut self, code: StatusCode, message: T)
     where
         T: Into<Cow<'static, str>>;
 
-    /// Updates the `Span`'s name. After this update, any sampling behavior based on the
-    /// name will depend on the implementation.
+    /// Updates the span's name.
     ///
-    /// It is highly discouraged to update the name of a `Span` after its creation.
-    /// `Span` name is often used to group, filter and identify the logical groups of
-    /// spans. Often, filtering logic will be implemented before the `Span` creation
-    /// for performance reasons, and the name update may interfere with this logic.
-    ///
-    /// The method name is called `update_name` to differentiate this method from the
-    /// regular property. It emphasizes that this operation signifies a
-    /// major change for a `Span` and may lead to re-calculation of sampling or
-    /// filtering decisions made previously depending on the implementation.
+    /// After this update, any sampling behavior based on the name will depend on
+    /// the implementation.
     fn update_name<T>(&mut self, new_name: T)
     where
         T: Into<Cow<'static, str>>;
 
-    /// Finishes the `Span`.
-    ///
-    /// Implementations MUST ignore all subsequent calls to `end` (there might be
-    /// exceptions when the tracer is streaming events and has no mutable state
-    /// associated with the Span).
-    ///
-    /// Calls to `end` a Span MUST not have any effects on child `Span`s as they may
-    /// still be running and can be ended later.
-    ///
-    /// This API MUST be non-blocking.
+    /// Signals that the operation described by this span has now ended.
     fn end(&mut self) {
         self.end_with_timestamp(crate::time::now());
     }
 
-    /// Finishes the `Span` with given timestamp
-    ///
-    /// For more details, refer to [`Span::end`]
-    ///
-    /// [`Span::end`]: Span::end()
+    /// Signals that the operation described by this span ended at the given time.
     fn end_with_timestamp(&mut self, timestamp: SystemTime);
 }
 
-/// `SpanKind` describes the relationship between the Span, its parents,
-/// and its children in a `Trace`. `SpanKind` describes two independent
-/// properties that benefit tracing systems during analysis.
+/// `SpanKind` describes the relationship between the [`Span`], its parents, and
+/// its children in a trace.
 ///
-/// The first property described by `SpanKind` reflects whether the `Span`
-/// is a remote child or parent. `Span`s with a remote parent are
-/// interesting because they are sources of external load. `Span`s with a
-/// remote child are interesting because they reflect a non-local system
-/// dependency.
+/// `SpanKind` describes two independent properties that benefit tracing systems
+/// during analysis:
 ///
-/// The second property described by `SpanKind` reflects whether a child
-/// `Span` represents a synchronous call.  When a child span is synchronous,
-/// the parent is expected to wait for it to complete under ordinary
-/// circumstances.  It can be useful for tracing systems to know this
-/// property, since synchronous `Span`s may contribute to the overall trace
-/// latency. Asynchronous scenarios can be remote or local.
+/// The first property described by `SpanKind` reflects whether the span is a
+/// "logical" remote child or parent. By "logical", we mean that the span is
+/// logically a remote child or parent, from the point of view of the library
+/// that is being instrumented. Spans with a remote parent are interesting
+/// because they are sources of external load. Spans with a remote child are
+/// interesting because they reflect a non-local system dependency.
 ///
-/// In order for `SpanKind` to be meaningful, callers should arrange that
-/// a single `Span` does not serve more than one purpose.  For example, a
-/// server-side span should not be used directly as the parent of another
-/// remote span.  As a simple guideline, instrumentation should create a
-/// new `Span` prior to extracting and serializing the span context for a
-/// remote call.
+/// The second property described by `SpanKind` reflects whether a child span
+/// represents a synchronous call.  When a child span is synchronous, the parent
+/// is expected to wait for it to complete under ordinary circumstances. It can
+/// be useful for tracing systems to know this property, since synchronous spans
+/// may contribute to the overall trace latency. Asynchronous scenarios can be
+/// remote or local.
+///
+/// In order for `SpanKind` to be meaningful, callers should arrange that a
+/// single span does not serve more than one purpose. For example, a server-side
+/// span should not be used directly as the parent of another remote span. As a
+/// simple guideline, instrumentation should create a new span prior to
+/// extracting and serializing the SpanContext for a remote call.
+///
+/// Note: there are complex scenarios where a `SpanKind::Client` span may have a
+/// child that is also logically a `SpanKind::Client` span, or a
+/// `SpanKind::Producer` span might have a local child that is a
+/// `SpanKind::Client` span, depending on how the various libraries that are
+/// providing the functionality are built and instrumented. These scenarios,
+/// when they occur, should be detailed in the semantic conventions appropriate
+/// to the relevant libraries.
 ///
 /// To summarize the interpretation of these kinds:
 ///
 /// | `SpanKind` | Synchronous | Asynchronous | Remote Incoming | Remote Outgoing |
-/// |------------|-----|-----|-----|-----|
-/// | `Client`   | yes |     |     | yes |
-/// | `Server`   | yes |     | yes |     |
-/// | `Producer` |     | yes |     | yes |
-/// | `Consumer` |     | yes | yes |     |
-/// | `Internal` |     |     |     |     |
+/// |---|---|---|---|---|
+/// | `Client` | yes | | | yes |
+/// | `Server` | yes | | yes | |
+/// | `Producer` | | yes | | maybe |
+/// | `Consumer` | | yes | maybe | |
+/// | `Internal` | | | | |
 #[derive(Clone, Debug, PartialEq)]
 pub enum SpanKind {
-    /// Indicates that the span describes a synchronous request to
-    /// some remote service.  This span is the parent of a remote `Server`
-    /// span and waits for its response.
+    /// Indicates that the span describes a request to some remote service. This
+    /// span is usually the parent of a remote `SpanKind::Server` span and does
+    /// not end until the response is received.
     Client,
-    /// Indicates that the span covers server-side handling of a
-    /// synchronous RPC or other remote request.  This span is the child of
-    /// a remote `Client` span that was expected to wait for a response.
+
+    /// Indicates that the span covers server-side handling of a synchronous RPC
+    /// or other remote request. This span is often the child of a remote
+    /// `SpanKind::Client` span that was expected to wait for a response.
     Server,
-    /// Indicates that the span describes the parent of an
-    /// asynchronous request.  This parent span is expected to end before
-    /// the corresponding child `Consumer` span, possibly even before the
-    /// child span starts. In messaging scenarios with batching, tracing
-    /// individual messages requires a new `Producer` span per message to
-    /// be created.
+
+    /// Indicates that the span describes the initiators of an asynchronous
+    /// request. This parent span will often end before the corresponding child
+    /// `SpanKind::Consumer` span, possibly even before the child span starts.
+    ///
+    /// In messaging scenarios with batching, tracing individual messages
+    /// requires a new `SpanKind::Producer` span per message to be created.
     Producer,
-    /// Indicates that the span describes the child of an
-    /// asynchronous `Producer` request.
+
+    /// Indicates that the span describes a child of an asynchronous
+    /// `SpanKind::Producer` request.
     Consumer,
-    /// Default value. Indicates that the span represents an
-    /// internal operation within an application, as opposed to an
-    /// operations with remote parents or children.
+
+    /// Default value.
+    ///
+    /// Indicates that the span represents an internal operation within an
+    /// application, as opposed to an operations with remote parents or
+    /// children.
     Internal,
 }
 
@@ -248,15 +232,38 @@ impl fmt::Display for SpanKind {
     }
 }
 
-/// The `StatusCode` interface represents the status of a finished `Span`.
-/// It's composed of a canonical code in conjunction with an optional
-/// descriptive message.
+/// The code representation of the status of a [`Span`].
+///
+/// These values form a total order: Ok > Error > Unset. This means that setting
+/// `StatusCode::Ok` will override any prior or future attempts to set a
+/// status with `StatusCode::Error` or `StatusCode::Unset`.
+///
+/// The status code should remain unset, except for the following circumstances:
+///
+/// Generally, instrumentation libraries should not set the status code to
+/// `StatusCode::Ok`, unless explicitly configured to do so. Instrumentation
+/// libraries should leave the status code as unset unless there is an error.
+///
+/// Application developers and operators may set the status code to `StatusCode::Ok`.
+///
+/// When span status is set to `StatusCode::Ok` it should be considered final and
+/// any further attempts to change it should be ignored.
+///
+/// Analysis tools should respond to a `StatusCode::Ok` status by suppressing any
+/// errors they would otherwise generate. For example, to suppress noisy errors such
+/// as 404s.
+///
+/// Only the value of the last call will be recorded, and implementations are free
+/// to ignore previous calls.
 #[derive(Clone, Debug, PartialEq, Copy)]
 pub enum StatusCode {
     /// The default status.
     Unset,
-    /// OK is returned on success.
+
+    /// The operation has been validated by an application developer or operator to
+    /// have completed successfully.
     Ok,
+
     /// The operation contains an error.
     Error,
 }

--- a/opentelemetry-api/src/trace/span_context.rs
+++ b/opentelemetry-api/src/trace/span_context.rs
@@ -1,15 +1,3 @@
-//! # OpenTelemetry SpanContext interface
-//!
-//! A `SpanContext` represents the portion of a `Span` which must be serialized and propagated along
-//! side of a distributed context. `SpanContext`s are immutable.
-//!
-//! The OpenTelemetry `SpanContext` representation conforms to the [w3c TraceContext specification].
-//! It contains two identifiers - a `TraceId` and a `SpanId` - along with a set of common
-//! `TraceFlags` and system-specific `TraceState` values.
-//!
-//! The spec can be viewed here: <https://github.com/open-telemetry/opentelemetry-specification/blob/v1.3.0/specification/trace/api.md#spancontext>
-//!
-//! [w3c TraceContext specification]: https://www.w3.org/TR/trace-context/
 use std::collections::VecDeque;
 use std::fmt;
 use std::hash::Hash;
@@ -20,9 +8,11 @@ use thiserror::Error;
 
 /// Flags that can be set on a [`SpanContext`].
 ///
-/// The current version of the specification only supports a single flag called `sampled`.
+/// The current version of the specification only supports a single flag
+/// [`TraceFlags::SAMPLED`].
 ///
-/// See the W3C TraceContext specification's [trace-flags] section for more details.
+/// See the W3C TraceContext specification's [trace-flags] section for more
+/// details.
 ///
 /// [trace-flags]: https://www.w3.org/TR/trace-context/#trace-flags
 #[derive(Clone, Debug, Default, PartialEq, Eq, Copy, Hash)]
@@ -435,10 +425,15 @@ pub enum TraceStateError {
     InvalidList(String),
 }
 
-/// Immutable portion of a `Span` which can be serialized and propagated.
+/// Immutable portion of a [`Span`] which can be serialized and propagated.
+///
+/// This representation conforms to the [W3C TraceContext specification].
 ///
 /// Spans that do not have the `sampled` flag set in their [`TraceFlags`] will
 /// be ignored by most tracing tools.
+///
+/// [`Span`]: crate::trace::Span
+/// [W3C TraceContext specification]: https://www.w3.org/TR/trace-context
 #[derive(Clone, Debug, PartialEq, Hash, Eq)]
 pub struct SpanContext {
     trace_id: TraceId,
@@ -477,29 +472,31 @@ impl SpanContext {
         }
     }
 
-    /// A valid trace identifier is a non-zero `u128`.
+    /// The [`TraceId`] for this span context.
     pub fn trace_id(&self) -> TraceId {
         self.trace_id
     }
 
-    /// A valid span identifier is a non-zero `u64`.
+    /// The [`SpanId`] for this span context.
     pub fn span_id(&self) -> SpanId {
         self.span_id
     }
 
-    /// Returns details about the trace. Unlike `TraceState` values, these are
-    /// present in all traces. Currently, the only option is a boolean sampled flag.
+    /// Returns details about the trace.
+    ///
+    /// Unlike `TraceState` values, these are present in all traces. The current
+    /// version of the specification only supports a single flag [`TraceFlags::SAMPLED`].
     pub fn trace_flags(&self) -> TraceFlags {
         self.trace_flags
     }
 
-    /// Returns a bool flag which is true if the `SpanContext` has a valid (non-zero) `trace_id`
-    /// and a valid (non-zero) `span_id`.
+    /// Returns `true` if the span context has a valid (non-zero) `trace_id` and a
+    /// valid (non-zero) `span_id`.
     pub fn is_valid(&self) -> bool {
-        self.trace_id.0 != 0 && self.span_id.0 != 0
+        self.trace_id != TraceId::INVALID && self.span_id != SpanId::INVALID
     }
 
-    /// Returns true if the `SpanContext` was propagated from a remote parent.
+    /// Returns `true` if the span context was propagated from a remote parent.
     pub fn is_remote(&self) -> bool {
         self.is_remote
     }
@@ -511,7 +508,7 @@ impl SpanContext {
         self.trace_flags.is_sampled()
     }
 
-    /// Returns the context's `TraceState`.
+    /// A reference to the span context's [`TraceState`].
     pub fn trace_state(&self) -> &TraceState {
         &self.trace_state
     }

--- a/opentelemetry-api/src/trace/tracer_provider.rs
+++ b/opentelemetry-api/src/trace/tracer_provider.rs
@@ -2,6 +2,11 @@ use crate::trace::{TraceResult, Tracer};
 use std::borrow::Cow;
 
 /// Types that can create instances of [`Tracer`].
+///
+/// See the [`global`] module for examples of storing and retrieving tracer
+/// provider instances.
+///
+/// [`global`]: crate::global
 pub trait TracerProvider {
     /// The [`Tracer`] type that this provider will return.
     type Tracer: Tracer;

--- a/opentelemetry-contrib/src/lib.rs
+++ b/opentelemetry-contrib/src/lib.rs
@@ -20,7 +20,11 @@
     unreachable_pub,
     unused
 )]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(
+    docsrs,
+    feature(doc_cfg, doc_auto_cfg),
+    deny(rustdoc::broken_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]

--- a/opentelemetry-dynatrace/src/lib.rs
+++ b/opentelemetry-dynatrace/src/lib.rs
@@ -95,7 +95,11 @@
     unused
 )]
 #![allow(elided_lifetimes_in_paths)]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(
+    docsrs,
+    feature(doc_cfg, doc_auto_cfg),
+    deny(rustdoc::broken_intra_doc_links)
+)]
 #![cfg_attr(test, deny(warnings))]
 mod exporter;
 

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -227,7 +227,11 @@
     unreachable_pub,
     unused
 )]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(
+    docsrs,
+    feature(doc_cfg, doc_auto_cfg),
+    deny(rustdoc::broken_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -173,7 +173,11 @@
     unused
 )]
 #![allow(elided_lifetimes_in_paths)]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(
+    docsrs,
+    feature(doc_cfg, doc_auto_cfg),
+    deny(rustdoc::broken_intra_doc_links)
+)]
 #![cfg_attr(test, deny(warnings))]
 
 mod exporter;

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -58,7 +58,11 @@
     unreachable_pub,
     unused
 )]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(
+    docsrs,
+    feature(doc_cfg, doc_auto_cfg),
+    deny(rustdoc::broken_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -16,7 +16,11 @@
     unused
 )]
 #![allow(clippy::needless_doctest_main)]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(
+    docsrs,
+    feature(doc_cfg, doc_auto_cfg),
+    deny(rustdoc::broken_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -125,30 +125,6 @@ impl opentelemetry_api::trace::Tracer for Tracer {
     /// This implementation of `Tracer` produces `sdk::Span` instances.
     type Span = Span;
 
-    /// Starts a new `Span` with a given context.
-    ///
-    /// Each span has zero or one parent spans and zero or more child spans, which
-    /// represent causally related operations. A tree of related spans comprises a
-    /// trace. A span is said to be a _root span_ if it does not have a parent. Each
-    /// trace includes a single root span, which is the shared ancestor of all other
-    /// spans in the trace.
-    fn start_with_context<T>(&self, name: T, parent_cx: &Context) -> Self::Span
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        self.build_with_context(SpanBuilder::from_name(name), parent_cx)
-    }
-
-    /// Creates a span builder
-    ///
-    /// An ergonomic way for attributes to be configured before the `Span` is started.
-    fn span_builder<T>(&self, name: T) -> SpanBuilder
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        SpanBuilder::from_name(name)
-    }
-
     /// Starts a span from a `SpanBuilder`.
     ///
     /// Each span has zero or one parent spans and zero or more child spans, which

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -178,7 +178,11 @@
     unreachable_pub,
     unused
 )]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(
+    docsrs,
+    feature(doc_cfg, doc_auto_cfg),
+    deny(rustdoc::broken_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]

--- a/opentelemetry-zpages/src/lib.rs
+++ b/opentelemetry-zpages/src/lib.rs
@@ -49,7 +49,11 @@
     unused
 )]
 #![allow(elided_lifetimes_in_paths)]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(broken_intra_doc_links))]
+#![cfg_attr(
+    docsrs,
+    feature(doc_cfg, doc_auto_cfg),
+    deny(rustdoc::broken_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/master/assets/logo.svg"
 )]

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -210,7 +210,11 @@
     unused
 )]
 #![allow(clippy::needless_doctest_main)]
-#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
+#![cfg_attr(
+    docsrs,
+    feature(doc_cfg, doc_auto_cfg),
+    deny(rustdoc::broken_intra_doc_links)
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]


### PR DESCRIPTION
Added `Tracer::start_with_context` and `Tracer::span_builder` sensible default implementations and updated docs.