### PR TITLE
Move `IdGenerator` to SDK, rename `RandomIdGenerator`

### DIFF
--- a/opentelemetry-api/src/trace/mod.rs
+++ b/opentelemetry-api/src/trace/mod.rs
@@ -138,7 +138,6 @@
 
 use futures_channel::{mpsc::TrySendError, oneshot::Canceled};
 use std::borrow::Cow;
-use std::fmt;
 use std::time;
 use thiserror::Error;
 
@@ -215,15 +214,6 @@ impl From<&'static str> for TraceError {
 #[derive(Error, Debug)]
 #[error("{0}")]
 struct Custom(String);
-
-/// Interface for generating IDs
-pub trait IdGenerator: Send + Sync + fmt::Debug {
-    /// Generate a new `TraceId`
-    fn new_trace_id(&self) -> TraceId;
-
-    /// Generate a new `SpanId`
-    fn new_span_id(&self) -> SpanId;
-}
 
 /// A `Span` has the ability to add events. Events have a time associated
 /// with the moment when they are added to the `Span`.

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -79,7 +79,7 @@
 //!
 //! ```no_run
 //! use opentelemetry::{KeyValue, trace::Tracer};
-//! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
+//! use opentelemetry::sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
 //! use opentelemetry::sdk::export::trace::ExportResult;
 //! use opentelemetry::global::shutdown_tracer_provider;
 //! use opentelemetry_datadog::{new_pipeline, ApiVersion, Error};
@@ -118,7 +118,7 @@
 //!         .with_trace_config(
 //!             trace::config()
 //!                 .with_sampler(Sampler::AlwaysOn)
-//!                 .with_id_generator(IdGenerator::default())
+//!                 .with_id_generator(RandomIdGenerator::default())
 //!         )
 //!         .install_batch(opentelemetry::runtime::Tokio)?;
 //!

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -141,7 +141,7 @@
 //!
 //! ```no_run
 //! use opentelemetry::{KeyValue, trace::{Tracer, TraceError}};
-//! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
+//! use opentelemetry::sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
 //! use opentelemetry::global;
 //!
 //! fn main() -> Result<(), TraceError> {
@@ -153,7 +153,7 @@
 //!         .with_trace_config(
 //!             trace::config()
 //!                 .with_sampler(Sampler::AlwaysOn)
-//!                 .with_id_generator(IdGenerator::default())
+//!                 .with_id_generator(RandomIdGenerator::default())
 //!                 .with_max_events_per_span(64)
 //!                 .with_max_attributes_per_span(16)
 //!                 .with_max_events_per_span(16)

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -86,7 +86,7 @@
 //!
 //! ```no_run
 //! use opentelemetry::{KeyValue, trace::Tracer};
-//! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
+//! use opentelemetry::sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
 //! use opentelemetry::sdk::metrics::{selectors, PushController};
 //! use opentelemetry::sdk::util::tokio_interval_stream;
 //! use opentelemetry_otlp::{Protocol, WithExportConfig, ExportConfig};
@@ -112,7 +112,7 @@
 //!         .with_trace_config(
 //!             trace::config()
 //!                 .with_sampler(Sampler::AlwaysOn)
-//!                 .with_id_generator(IdGenerator::default())
+//!                 .with_id_generator(RandomIdGenerator::default())
 //!                 .with_max_events_per_span(64)
 //!                 .with_max_attributes_per_span(16)
 //!                 .with_max_events_per_span(16)

--- a/opentelemetry-sdk/src/trace/config.rs
+++ b/opentelemetry-sdk/src/trace/config.rs
@@ -2,9 +2,8 @@
 //!
 //! Configuration represents the global tracing configuration, overrides
 //! can be set for the default OpenTelemetry limits and Sampler.
-use crate::trace::{span_limit::SpanLimits, Sampler, ShouldSample};
+use crate::trace::{span_limit::SpanLimits, IdGenerator, RandomIdGenerator, Sampler, ShouldSample};
 use opentelemetry_api::global::{handle_error, Error};
-use opentelemetry_api::trace::IdGenerator;
 use std::env;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -98,7 +97,7 @@ impl Default for Config {
     fn default() -> Self {
         let mut config = Config {
             sampler: Box::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn))),
-            id_generator: Box::new(crate::trace::IdGenerator::default()),
+            id_generator: Box::new(RandomIdGenerator::default()),
             span_limits: SpanLimits::default(),
             resource: None,
         };

--- a/opentelemetry-sdk/src/trace/id_generator/aws.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/aws.rs
@@ -1,4 +1,5 @@
-use opentelemetry_api::trace::{IdGenerator, SpanId, TraceId};
+use crate::trace::{IdGenerator, RandomIdGenerator};
+use opentelemetry_api::trace::{SpanId, TraceId};
 use std::time::{Duration, UNIX_EPOCH};
 
 /// Generates AWS X-Ray compliant Trace and Span ids.
@@ -34,7 +35,7 @@ use std::time::{Duration, UNIX_EPOCH};
 /// [xray-trace-id]: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids
 #[derive(Debug, Default)]
 pub struct XrayIdGenerator {
-    sdk_default_generator: crate::trace::IdGenerator,
+    sdk_default_generator: RandomIdGenerator,
 }
 
 impl IdGenerator for XrayIdGenerator {

--- a/opentelemetry-sdk/src/trace/id_generator/mod.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/mod.rs
@@ -4,21 +4,30 @@ pub(super) mod aws;
 use opentelemetry_api::trace::{SpanId, TraceId};
 use rand::{rngs, Rng};
 use std::cell::RefCell;
+use std::fmt;
 
-/// Default [`crate::trace::IdGenerator`] implementation.
+/// Interface for generating IDs
+pub trait IdGenerator: Send + Sync + fmt::Debug {
+    /// Generate a new `TraceId`
+    fn new_trace_id(&self) -> TraceId;
+
+    /// Generate a new `SpanId`
+    fn new_span_id(&self) -> SpanId;
+}
+
+/// Default [`IdGenerator`] implementation.
+///
 /// Generates Trace and Span ids using a random number generator.
 #[derive(Clone, Debug, Default)]
-pub struct IdGenerator {
+pub struct RandomIdGenerator {
     _private: (),
 }
 
-impl opentelemetry_api::trace::IdGenerator for IdGenerator {
-    /// Generate new `TraceId` using thread local rng
+impl IdGenerator for RandomIdGenerator {
     fn new_trace_id(&self) -> TraceId {
         CURRENT_RNG.with(|rng| TraceId::from(rng.borrow_mut().gen::<[u8; 16]>()))
     }
 
-    /// Generate new `SpanId` using thread local rng
     fn new_span_id(&self) -> SpanId {
         CURRENT_RNG.with(|rng| SpanId::from(rng.borrow_mut().gen::<[u8; 8]>()))
     }

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -21,7 +21,7 @@ mod tracer;
 pub use config::{config, Config};
 pub use evicted_hash_map::EvictedHashMap;
 pub use evicted_queue::EvictedQueue;
-pub use id_generator::{aws::XrayIdGenerator, IdGenerator};
+pub use id_generator::{aws::XrayIdGenerator, IdGenerator, RandomIdGenerator};
 pub use provider::{Builder, TracerProvider};
 pub use runtime::{TraceRuntime, TrySend};
 pub use sampler::{Sampler, ShouldSample};

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -88,7 +88,7 @@
 //!
 //! ```no_run
 //! use opentelemetry::{KeyValue, trace::Tracer};
-//! use opentelemetry::sdk::{trace::{self, IdGenerator, Sampler}, Resource};
+//! use opentelemetry::sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
 //! use opentelemetry::sdk::export::trace::ExportResult;
 //! use opentelemetry::global;
 //! use opentelemetry_http::{HttpClient, HttpError};
@@ -129,7 +129,7 @@
 //!         .with_trace_config(
 //!             trace::config()
 //!                 .with_sampler(Sampler::AlwaysOn)
-//!                 .with_id_generator(IdGenerator::default())
+//!                 .with_id_generator(RandomIdGenerator::default())
 //!                 .with_max_events_per_span(64)
 //!                 .with_max_attributes_per_span(16)
 //!                 .with_max_events_per_span(16)


### PR DESCRIPTION
The [spec] defines `IdGenerator` as part of the SDK. This also renames the default generator to match other language implementations in calling the default id generator `RandomIdGenerator`.

[spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/sdk.md#id-generators