### PR TITLE
feat(stackdriver): Added mappings from OTel attributes to Google Cloud Traces

### DIFF
--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -17,6 +17,7 @@ http = "0.2"
 hyper = "0.14.2"
 hyper-rustls = { version = "0.22.1", optional = true }
 opentelemetry = { version = "0.17", path = "../opentelemetry" }
+opentelemetry-semantic-conventions = { version = "0.9", path = "../opentelemetry-semantic-conventions" }
 prost = "0.9"
 prost-types = "0.9"
 thiserror = "1.0.30"


### PR DESCRIPTION
When sending data to Google Cloud Traces, for OTel attributes to appear in the console correctly, the exporter must map them to a particular `project.traces` [label](https://cloud.google.com/trace/docs/reference/v1/rest/v1/projects.traces). The code is similar to what Google's own Golang OTel exporter does [here](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/main/exporter/trace/trace_proto.go#L234).

The PR also checks to ensure that label keys are less than 128 bytes long as GCP will reject those.