### PR TITLE
Remove `Tracer::with_span`

### DIFF
--- a/opentelemetry-api/src/trace/mod.rs
+++ b/opentelemetry-api/src/trace/mod.rs
@@ -109,12 +109,6 @@
 //! tracer.in_span("parent_span", |cx| {
 //!     // spans created here will be children of `parent_span`
 //! });
-//!
-//! // Use `with_span` to mark a span as active for a given period.
-//! let span = tracer.start("parent_span");
-//! tracer.with_span(span, |cx| {
-//!     // spans created here will be children of `parent_span`
-//! });
 //! ```
 //!
 //! #### Async active spans


### PR DESCRIPTION
This method is not part of the trace spec and the same functionality can be achieved with `mark_span_as_active` or `Context::current_with_span(span).attach()`.