### PR TITLE
chore: reduce Tokio feature demands

### DIFF
--- a/examples/actix-http/Cargo.toml
+++ b/examples/actix-http/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio"] }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["reqwest_collector_client", "rt-tokio-current-thread"] }
 thrift = "0.13"
-actix-web = "4.0.0-beta.4"
-actix-service = "2.0.0-beta.5"
+actix-web = "4.0.0"
+actix-service = "2.0.0"
 env_logger = "0.8.2"
 tokio = { version = "1", features = ["full"] }

--- a/opentelemetry-api/src/lib.rs
+++ b/opentelemetry-api/src/lib.rs
@@ -51,7 +51,7 @@ pub use context::{Context, ContextGuard};
 
 mod common;
 
-#[cfg(feature = "testing")]
+#[cfg(any(feature = "testing", test))]
 #[doc(hidden)]
 pub mod testing;
 

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -28,5 +28,5 @@ lazy_static = "1.4"
 [dev-dependencies]
 opentelemetry = { path = "../opentelemetry", features = ["trace", "testing"] }
 opentelemetry-http = { path = "../opentelemetry-http" }
-hyper = { version = "0.14", features = ["full"] }
-tokio = { version = "1.0", features = ["full"] }
+hyper = { version = "0.14" }
+tokio = { version = "1.0", features = ["macros", "rt"] }

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -41,7 +41,7 @@ protobuf = { version = "2.18", optional = true }
 
 prost = { version = "0.9", optional = true }
 tonic = { version = "0.6.2", optional = true }
-tokio = { version = "1.0", features = ["full"], optional = true }
+tokio = { version = "1.0", features = ["sync", "rt"], optional = true }
 
 reqwest = { version = "0.11", optional = true, default-features = false }
 surf = { version = "2.0", optional = true, default-features = false }
@@ -52,8 +52,9 @@ thiserror = "1.0"
 [dev-dependencies]
 tokio-stream = { version = "0.1", features = ["net"] }
 # need tokio runtime to run smoke tests.
-opentelemetry = { features = ["trace", "rt-tokio"], path = "../opentelemetry" }
+opentelemetry = { features = ["trace", "rt-tokio", "testing"], path = "../opentelemetry" }
 time = { version = "0.3", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [features]
 # telemetry pillars and functions

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -24,8 +24,7 @@ prometheus = "0.13"
 protobuf = "2.14"
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full"] }
-hyper = { version = "0.14", features = ["full"] }
+opentelemetry = { version = "0.17", path = "../opentelemetry", default-features = false, features = ["metrics", "testing"] }
 lazy_static = "1.4"
 
 [features]

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -36,7 +36,7 @@ pub mod metrics;
 pub mod propagation;
 pub mod resource;
 pub mod runtime;
-#[cfg(feature = "testing")]
+#[cfg(any(feature = "testing", test))]
 #[doc(hidden)]
 pub mod testing;
 #[cfg(feature = "trace")]

--- a/opentelemetry-zpages/Cargo.toml
+++ b/opentelemetry-zpages/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 opentelemetry = { version = "0.17", path = "../opentelemetry", default-features = false, features = ["trace"] }
-opentelemetry-proto = { path = "../opentelemetry-proto", features = ["with-serde", "zpages", "gen-protoc"], default-features = false }
+opentelemetry-proto = { version = "0.1", path = "../opentelemetry-proto", features = ["with-serde", "zpages", "gen-protoc"], default-features = false }
 async-channel = "1.6"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
@@ -29,5 +29,5 @@ serde = "1.0"
 serde_json = "1.0"
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full"] }
-opentelemetry = { path = "../opentelemetry", default-features = false, features = ["trace", "testing"] }
+tokio = { version = "1.0", features = ["macros", "rt"] }
+opentelemetry = { version = "0.17", path = "../opentelemetry", default-features = false, features = ["trace", "testing"] }

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -27,7 +27,7 @@ opentelemetry-sdk = { version = "0.1", path = "../opentelemetry-sdk" }
 default = ["trace"]
 trace = ["opentelemetry-api/trace", "opentelemetry-sdk/trace"]
 metrics = ["opentelemetry-api/metrics", "opentelemetry-sdk/metrics"]
-testing = ["opentelemetry-sdk/testing"]
+testing = ["opentelemetry-api/testing", "opentelemetry-sdk/testing"]
 rt-tokio = ["opentelemetry-sdk/rt-tokio"]
 rt-tokio-current-thread = ["opentelemetry-sdk/rt-tokio-current-thread"]
 rt-async-std = ["opentelemetry-sdk/rt-async-std"]


### PR DESCRIPTION
This also makes a few small fixes to being able to compile some of the crates in isolation in testing contexts. The four primary crates altered were isolated by commenting out every other crate in the workspace `Cargo.toml` and ensuring that `cargo build` and `cargo test` succeeded. This indicates that the features specified by that crate and its dependencies were sufficient.

In doing this, I noted that some of the `testing` features were not being requested by the candidate crates, so I threaded through the appropriate feature demands to `opentelemetry`, `opentelemetry-api`, and `opentelemetry-sdk`.

I then uncommented everything and ensured that it all compiles and tests too. There I discovered that the `actix-http` example was failing. Changing the `beta` dependency versions to the release versions cleared those errors for me.

Fixes #747 