### PR TITLE
api: make `TraceStateError` priviate

### DIFF
--- a/opentelemetry-api/src/trace/mod.rs
+++ b/opentelemetry-api/src/trace/mod.rs
@@ -145,7 +145,7 @@ mod tracer_provider;
 pub use self::{
     context::{get_active_span, mark_span_as_active, FutureExt, SpanRef, TraceContextExt},
     span::{Span, SpanKind, StatusCode},
-    span_context::{SpanContext, SpanId, TraceFlags, TraceId, TraceState, TraceStateError},
+    span_context::{SpanContext, SpanId, TraceFlags, TraceId, TraceState},
     tracer::{SamplingDecision, SamplingResult, SpanBuilder, Tracer},
     tracer_provider::TracerProvider,
 };


### PR DESCRIPTION
This change simplifies the error handling in the `trace` module by making `TraceStateError` private, and exposing these errors as the more general `TraceError`.