### PR TITLE
api: move `SpanKind` display format impl to jaeger

### DIFF
--- a/opentelemetry-api/src/trace/span.rs
+++ b/opentelemetry-api/src/trace/span.rs
@@ -1,7 +1,6 @@
 use crate::{trace::SpanContext, KeyValue};
 use std::borrow::Cow;
 use std::error::Error;
-use std::fmt;
 use std::time::SystemTime;
 
 /// The interface for a single operation within a trace.
@@ -224,18 +223,6 @@ pub enum SpanKind {
     /// application, as opposed to an operations with remote parents or
     /// children.
     Internal,
-}
-
-impl fmt::Display for SpanKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SpanKind::Client => write!(f, "client"),
-            SpanKind::Server => write!(f, "server"),
-            SpanKind::Producer => write!(f, "producer"),
-            SpanKind::Consumer => write!(f, "consumer"),
-            SpanKind::Internal => write!(f, "internal"),
-        }
-    }
 }
 
 /// The code representation of the status of a [`Span`].

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -764,7 +764,7 @@ fn build_span_tags(
     }
 
     if !user_overrides.span_kind && kind != SpanKind::Internal {
-        tags.push(Key::new(SPAN_KIND).string(kind.to_string()).into());
+        tags.push(Key::new(SPAN_KIND).string(format_span_kind(kind)).into());
     }
 
     if status_code != StatusCode::Unset {
@@ -790,6 +790,16 @@ fn build_span_tags(
     }
 
     tags
+}
+
+fn format_span_kind(kind: SpanKind) -> &'static str {
+    match kind {
+        SpanKind::Client => "client",
+        SpanKind::Server => "server",
+        SpanKind::Producer => "producer",
+        SpanKind::Consumer => "consumer",
+        SpanKind::Internal => "internal",
+    }
 }
 
 const ERROR: &str = "error";


### PR DESCRIPTION
This format implementation is jaeger specific and not defined in the otel spec.