### PR TITLE
feat(datadog): allow custom mapping in datadog.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "opentelemetry-proto/src/proto/opentelemetry-proto"]
 	path = opentelemetry-proto/src/proto/opentelemetry-proto
 	url = https://github.com/open-telemetry/opentelemetry-proto
-	branch = tags/v0.9.0
+	branch = tags/v0.14.0

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -294,7 +294,7 @@ impl DatadogPipelineBuilder {
     }
 
     /// Custom the value used for `resource` field in datadog spans.
-    /// See [`AttributeMappingFn`] for details.
+    /// See [`FieldMappingFn`] for details.
     pub fn with_resource_mapping<F>(mut self, f: F) -> Self
     where
         F: for<'a> Fn(&'a SpanData, &'a ModelConfig) -> &'a str + Send + Sync + 'static,
@@ -304,7 +304,7 @@ impl DatadogPipelineBuilder {
     }
 
     /// Custom the value used for `name` field in datadog spans.
-    /// See [`AttributeMappingFn`] for details.
+    /// See [`FieldMappingFn`] for details.
     pub fn with_name_mapping<F>(mut self, f: F) -> Self
     where
         F: for<'a> Fn(&'a SpanData, &'a ModelConfig) -> &'a str + Send + Sync + 'static,
@@ -314,7 +314,7 @@ impl DatadogPipelineBuilder {
     }
 
     /// Custom the value used for `service_name` field in datadog spans.
-    /// See [`AttributeMappingFn`] for details.
+    /// See [`FieldMappingFn`] for details.
     pub fn with_service_name_mapping<F>(mut self, f: F) -> Self
     where
         F: for<'a> Fn(&'a SpanData, &'a ModelConfig) -> &'a str + Send + Sync + 'static,
@@ -360,7 +360,7 @@ impl trace::SpanExporter for DatadogExporter {
 
 /// Helper struct to custom the mapping between Opentelemetry spans and datadog spans.
 ///
-/// This struct will be passed to [`AttributeMappingFn`]
+/// This struct will be passed to [`FieldMappingFn`]
 #[derive(Default, Debug)]
 #[non_exhaustive]
 pub struct ModelConfig {

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -362,9 +362,9 @@ impl trace::SpanExporter for DatadogExporter {
 ///
 /// This struct will be passed to [`AttributeMappingFn`]
 #[derive(Default, Debug)]
+#[non_exhaustive]
 pub struct ModelConfig {
     pub service_name: String,
-    _private: (),
 }
 
 fn mapping_debug(f: &Option<FieldMapping>) -> String {

--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -37,6 +37,8 @@ mod v05;
 ///             })
 ///            .with_agent_endpoint("http://localhost:8126")
 ///            .install_batch(opentelemetry::runtime::Tokio)?;
+///
+///    Ok(())
 /// }
 /// ```
 pub type FieldMappingFn = dyn for<'a> Fn(&'a SpanData, &'a ModelConfig) -> &'a str + Send + Sync;

--- a/opentelemetry-datadog/src/exporter/model/v03.rs
+++ b/opentelemetry-datadog/src/exporter/model/v03.rs
@@ -1,10 +1,10 @@
 use crate::exporter::model::Error;
+use crate::exporter::ModelConfig;
 use opentelemetry::sdk::export::trace;
+use opentelemetry::sdk::export::trace::SpanData;
 use opentelemetry::trace::Status;
 use opentelemetry::{Key, Value};
 use std::time::SystemTime;
-use opentelemetry::sdk::export::trace::SpanData;
-use crate::exporter::ModelConfig;
 
 pub(crate) fn encode<S, N, R>(
     model_config: &ModelConfig,
@@ -13,9 +13,11 @@ pub(crate) fn encode<S, N, R>(
     get_name: N,
     get_resource: R,
 ) -> Result<Vec<u8>, Error>
-    where for<'a> S: Fn(&'a SpanData, &'a ModelConfig) -> &'a str,
-          for<'a> N: Fn(&'a SpanData, &'a ModelConfig) -> &'a str,
-          for<'a> R: Fn(&'a SpanData, &'a ModelConfig) -> &'a str {
+where
+    for<'a> S: Fn(&'a SpanData, &'a ModelConfig) -> &'a str,
+    for<'a> N: Fn(&'a SpanData, &'a ModelConfig) -> &'a str,
+    for<'a> R: Fn(&'a SpanData, &'a ModelConfig) -> &'a str,
+{
     let mut encoded = Vec::new();
     rmp::encode::write_array_len(&mut encoded, traces.len() as u32)?;
 

--- a/opentelemetry-datadog/src/exporter/model/v05.rs
+++ b/opentelemetry-datadog/src/exporter/model/v05.rs
@@ -1,9 +1,10 @@
 use crate::exporter::intern::StringInterner;
-use crate::exporter::Error;
+use crate::exporter::{Error, ModelConfig};
 use opentelemetry::sdk::export::trace;
 use opentelemetry::trace::Status;
 use opentelemetry::{Key, Value};
 use std::time::SystemTime;
+use opentelemetry::sdk::export::trace::SpanData;
 
 // Protocol documentation sourced from https://github.com/DataDog/datadog-agent/blob/c076ea9a1ffbde4c76d35343dbc32aecbbf99cb9/pkg/trace/api/version.go
 //
@@ -50,12 +51,18 @@ use std::time::SystemTime;
 //
 // 		The dictionary in this case would be []string{""}, having only the empty string at index 0.
 //
-pub(crate) fn encode(
-    service_name: &str,
+pub(crate) fn encode<S, N, R>(
+    model_config: &ModelConfig,
     traces: Vec<Vec<trace::SpanData>>,
-) -> Result<Vec<u8>, Error> {
+    get_service_name: S,
+    get_name: N,
+    get_resource: R,
+) -> Result<Vec<u8>, Error>
+    where for<'a> S: Fn(&'a SpanData, &'a ModelConfig) -> &'a str,
+          for<'a> N: Fn(&'a SpanData, &'a ModelConfig) -> &'a str,
+          for<'a> R: Fn(&'a SpanData, &'a ModelConfig) -> &'a str{
     let mut interner = StringInterner::new();
-    let mut encoded_traces = encode_traces(&mut interner, service_name, traces)?;
+    let mut encoded_traces = encode_traces(&mut interner, model_config, get_service_name, get_name, get_resource, traces)?;
 
     let mut payload = Vec::new();
     rmp::encode::write_array_len(&mut payload, 2)?;
@@ -70,15 +77,19 @@ pub(crate) fn encode(
     Ok(payload)
 }
 
-fn encode_traces(
+fn encode_traces<S, N, R>(
     interner: &mut StringInterner,
-    service_name: &str,
+    model_config: &ModelConfig,
+    get_service_name: S,
+    get_name: N,
+    get_resource: R,
     traces: Vec<Vec<trace::SpanData>>,
-) -> Result<Vec<u8>, Error> {
+) -> Result<Vec<u8>, Error>
+    where for<'a> S: Fn(&'a SpanData, &'a ModelConfig) -> &'a str,
+          for<'a> N: Fn(&'a SpanData, &'a ModelConfig) -> &'a str,
+          for<'a> R: Fn(&'a SpanData, &'a ModelConfig) -> &'a str {
     let mut encoded = Vec::new();
     rmp::encode::write_array_len(&mut encoded, traces.len() as u32)?;
-
-    let service_interned = interner.intern(service_name);
 
     for trace in traces.into_iter() {
         rmp::encode::write_array_len(&mut encoded, trace.len() as u32)?;
@@ -104,12 +115,12 @@ fn encode_traces(
 
             // Datadog span name is OpenTelemetry component name - see module docs for more information
             rmp::encode::write_array_len(&mut encoded, 12)?;
-            rmp::encode::write_u32(&mut encoded, service_interned)?;
+            rmp::encode::write_u32(&mut encoded, interner.intern(get_service_name(&span, model_config)))?;
             rmp::encode::write_u32(
                 &mut encoded,
-                interner.intern(span.instrumentation_lib.name.as_ref()),
+                interner.intern(get_name(&span, model_config)),
             )?;
-            rmp::encode::write_u32(&mut encoded, interner.intern(&span.name))?;
+            rmp::encode::write_u32(&mut encoded, interner.intern(get_resource(&span, model_config)))?;
             rmp::encode::write_u64(
                 &mut encoded,
                 u128::from_be_bytes(span.span_context.trace_id().to_bytes()) as u64,

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! For standard values see [here](https://github.com/DataDog/dd-trace-go/blob/ecb0b805ef25b00888a2fb62d465a5aa95e7301e/ddtrace/ext/app_types.go#L31).
 //!
-//! If the default mapping is not fit for your use case, you may change some of them by providing [`AttributesMappingFn`](crate::exporter::AttributeMappingFn)s in pipeline.
+//! If the default mapping is not fit for your use case, you may change some of them by providing [`FieldMappingFn`]s in pipeline.
 //!
 //! ## Performance
 //!

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -29,7 +29,9 @@
 //! Datadog additionally has a span_type string that alters the rendering of the spans in the web UI.
 //! This can be set as the `span.type` OpenTelemetry span attribute.
 //!
-//! For standard values see [here](https://github.com/DataDog/dd-trace-go/blob/ecb0b805ef25b00888a2fb62d465a5aa95e7301e/ddtrace/ext/app_types.go#L31)
+//! For standard values see [here](https://github.com/DataDog/dd-trace-go/blob/ecb0b805ef25b00888a2fb62d465a5aa95e7301e/ddtrace/ext/app_types.go#L31).
+//!
+//! If the default mapping is not fit for your use case, you may change some of them by providing [`AttributesMappingFn`](crate::exporter::AttributeMappingFn)s in pipeline.
 //!
 //! ## Performance
 //!
@@ -385,5 +387,8 @@ mod propagator {
     }
 }
 
-pub use exporter::{new_pipeline, ApiVersion, DatadogExporter, DatadogPipelineBuilder, Error};
+pub use exporter::{
+    new_pipeline, ApiVersion, DatadogExporter, DatadogPipelineBuilder, Error, FieldMappingFn,
+    ModelConfig,
+};
 pub use propagator::DatadogPropagator;


### PR DESCRIPTION
There is no official mapping between opentelemetry spans and datadog spans so in some cases our default mapping may not be ideal. 

This PR introduct three functions to allow users to override the mappings for `name`, `resource` and `service_name` fields in datadog spans.

cc @hamiltop