### PR TITLE
fix(contrib): rename binary propagator's functions.

### DIFF
--- a/opentelemetry-contrib/src/trace/propagator/binary/base64_format.rs
+++ b/opentelemetry-contrib/src/trace/propagator/binary/base64_format.rs
@@ -16,23 +16,23 @@ use opentelemetry::trace::SpanContext;
 /// representation.
 pub trait Base64Format {
     /// Serializes span context into a base64 encoded string
-    fn to_base64(&self, context: &SpanContext) -> String;
+    fn serialize_into_base64(&self, context: &SpanContext) -> String;
 
     /// Deserialize a span context from a base64 encoded string
-    fn from_base64(&self, base64: &str) -> SpanContext;
+    fn deserialize_from_base64(&self, base64: &str) -> SpanContext;
 }
 
 impl<Format> Base64Format for Format
 where
     Format: BinaryFormat,
 {
-    fn to_base64(&self, context: &SpanContext) -> String {
-        encode(&self.to_bytes(context))
+    fn serialize_into_base64(&self, context: &SpanContext) -> String {
+        encode(&self.serialize_into_bytes(context))
     }
 
-    fn from_base64(&self, base64: &str) -> SpanContext {
+    fn deserialize_from_base64(&self, base64: &str) -> SpanContext {
         if let Ok(bytes) = decode(base64.as_bytes()) {
-            self.from_bytes(bytes)
+            self.deserialize_from_bytes(bytes)
         } else {
             SpanContext::empty_context()
         }
@@ -69,23 +69,23 @@ mod tests {
     }
 
     #[test]
-    fn to_base64_conversion() {
+    fn serialize_into_base64_conversion() {
         let propagator = BinaryPropagator::new();
 
         for (context, data) in to_base64_data() {
-            assert_eq!(propagator.to_base64(&context), data)
+            assert_eq!(propagator.serialize_into_base64(&context), data)
         }
     }
 
     #[test]
-    fn from_base64_conversion() {
+    fn deserialize_from_base64_conversion() {
         let propagator = BinaryPropagator::new();
 
         for (context, data) in from_base64_data() {
-            assert_eq!(propagator.from_base64(&data), context)
+            assert_eq!(propagator.deserialize_from_base64(&data), context)
         }
         for (context, data) in to_base64_data() {
-            assert_eq!(propagator.from_base64(&data), context)
+            assert_eq!(propagator.deserialize_from_base64(&data), context)
         }
     }
 }

--- a/opentelemetry-contrib/src/trace/propagator/binary/binary_propagator.rs
+++ b/opentelemetry-contrib/src/trace/propagator/binary/binary_propagator.rs
@@ -12,10 +12,10 @@ use std::convert::TryInto;
 /// representation.
 pub trait BinaryFormat {
     /// Serializes span context into a byte array and returns the array.
-    fn to_bytes(&self, context: &SpanContext) -> [u8; 29];
+    fn serialize_into_bytes(&self, context: &SpanContext) -> [u8; 29];
 
     /// Deserializes a span context from a byte array.
-    fn from_bytes(&self, bytes: Vec<u8>) -> SpanContext;
+    fn deserialize_from_bytes(&self, bytes: Vec<u8>) -> SpanContext;
 }
 
 /// Extracts and injects `SpanContext`s from byte arrays.
@@ -31,7 +31,7 @@ impl BinaryPropagator {
 
 impl BinaryFormat for BinaryPropagator {
     /// Serializes span context into a byte array and returns the array.
-    fn to_bytes(&self, context: &SpanContext) -> [u8; 29] {
+    fn serialize_into_bytes(&self, context: &SpanContext) -> [u8; 29] {
         let mut res = [0u8; 29];
         if !context.is_valid() {
             return res;
@@ -46,7 +46,7 @@ impl BinaryFormat for BinaryPropagator {
     }
 
     /// Deserializes a span context from a byte array.
-    fn from_bytes(&self, bytes: Vec<u8>) -> SpanContext {
+    fn deserialize_from_bytes(&self, bytes: Vec<u8>) -> SpanContext {
         if bytes.is_empty() {
             return SpanContext::empty_context();
         }
@@ -159,20 +159,20 @@ mod tests {
     }
 
     #[test]
-    fn to_bytes_conversion() {
+    fn serialize_into_bytes_conversion() {
         let propagator = BinaryPropagator::new();
 
         for (context, data) in to_bytes_data() {
-            assert_eq!(propagator.to_bytes(&context), data)
+            assert_eq!(propagator.serialize_into_bytes(&context), data)
         }
     }
 
     #[test]
-    fn from_bytes_conversion() {
+    fn deserialize_from_bytes_conversion() {
         let propagator = BinaryPropagator::new();
 
         for (context, data) in from_bytes_data() {
-            assert_eq!(propagator.from_bytes(data), context)
+            assert_eq!(propagator.deserialize_from_bytes(data), context)
         }
     }
 }


### PR DESCRIPTION
Fix lint issue in rust 1.60. `from_*` is generally a static function to create the instance