### PR TITLE
Switch to static resource references

### DIFF
--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -179,12 +179,13 @@ impl ApiVersion {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use opentelemetry::sdk;
     use opentelemetry::sdk::InstrumentationLibrary;
+    use opentelemetry::sdk::{self, Resource};
     use opentelemetry::{
         trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState},
         Key,
     };
+    use std::borrow::Cow;
     use std::time::{Duration, SystemTime};
 
     fn get_traces() -> Vec<Vec<trace::SpanData>> {
@@ -221,7 +222,7 @@ pub(crate) mod tests {
             events,
             links,
             status: Status::Ok,
-            resource: None,
+            resource: Cow::Owned(Resource::empty()),
             instrumentation_lib: InstrumentationLibrary::new("component", None, None),
         }
     }

--- a/opentelemetry-jaeger/src/exporter/config/agent.rs
+++ b/opentelemetry-jaeger/src/exporter/config/agent.rs
@@ -232,7 +232,6 @@ impl AgentPipeline {
         let mut builder = sdk::trace::TracerProvider::builder();
 
         let (config, process) = build_config_and_process(
-            builder.sdk_provided_resource(),
             self.trace_config.take(),
             self.transformation_config.service_name.take(),
         );
@@ -270,7 +269,6 @@ impl AgentPipeline {
         // build sdk trace config and jaeger process.
         // some attributes like service name has attributes like service name
         let (config, process) = build_config_and_process(
-            builder.sdk_provided_resource(),
             self.trace_config.take(),
             self.transformation_config.service_name.take(),
         );
@@ -312,12 +310,10 @@ impl AgentPipeline {
     where
         R: JaegerTraceRuntime,
     {
-        let builder = sdk::trace::TracerProvider::builder();
         let export_instrument_library = self.transformation_config.export_instrument_library;
         // build sdk trace config and jaeger process.
         // some attributes like service name has attributes like service name
         let (_, process) = build_config_and_process(
-            builder.sdk_provided_resource(),
             self.trace_config.take(),
             self.transformation_config.service_name.take(),
         );
@@ -331,9 +327,7 @@ impl AgentPipeline {
 
     /// Build an jaeger exporter targeting a jaeger agent and running on the sync runtime.
     pub fn build_sync_agent_exporter(mut self) -> Result<crate::Exporter, TraceError> {
-        let builder = sdk::trace::TracerProvider::builder();
         let (_, process) = build_config_and_process(
-            builder.sdk_provided_resource(),
             self.trace_config.take(),
             self.transformation_config.service_name.take(),
         );

--- a/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
@@ -179,18 +179,14 @@ mod collector_client_tests {
     use crate::exporter::thrift::jaeger::Batch;
     use crate::new_collector_pipeline;
     use opentelemetry::runtime::Tokio;
-    use opentelemetry::sdk::Resource;
     use opentelemetry::trace::TraceError;
-    use opentelemetry::KeyValue;
 
     #[test]
     fn test_bring_your_own_client() -> Result<(), TraceError> {
         let invalid_uri_builder = new_collector_pipeline()
             .with_endpoint("localhost:6831")
             .with_http_client(test_http_client::TestHttpClient);
-        let sdk_provided_resource =
-            Resource::new(vec![KeyValue::new("service.name", "unknown_service")]);
-        let (_, process) = build_config_and_process(sdk_provided_resource, None, None);
+        let (_, process) = build_config_and_process(None, None);
         let mut uploader = invalid_uri_builder.build_uploader::<Tokio>()?;
         let res = futures_executor::block_on(async {
             uploader

--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -407,7 +407,6 @@ impl CollectorPipeline {
         // some attributes like service name has attributes like service name
         let export_instrument_library = self.transformation_config.export_instrument_library;
         let (config, process) = build_config_and_process(
-            builder.sdk_provided_resource(),
             self.trace_config.take(),
             self.transformation_config.service_name.take(),
         );

--- a/opentelemetry-otlp/src/transform/metrics.rs
+++ b/opentelemetry-otlp/src/transform/metrics.rs
@@ -417,7 +417,16 @@ mod tests {
         // If we changed the sink function to process the input in parallel, we will have to sort other vectors
         // like data points in Metrics.
         fn assert_resource_metrics(mut expect: ResourceMetrics, mut actual: ResourceMetrics) {
-            assert_eq!(expect.resource, actual.resource);
+            assert_eq!(
+                expect
+                    .resource
+                    .as_mut()
+                    .map(|r| r.attributes.sort_by_key(|kv| kv.key.to_string())),
+                actual
+                    .resource
+                    .as_mut()
+                    .map(|r| r.attributes.sort_by_key(|kv| kv.key.to_string()))
+            );
             assert_eq!(
                 expect.instrumentation_library_metrics.len(),
                 actual.instrumentation_library_metrics.len()

--- a/opentelemetry-proto/src/transform/traces.rs
+++ b/opentelemetry-proto/src/transform/traces.rs
@@ -51,15 +51,13 @@ pub mod tonic {
             let span_kind: span::SpanKind = source_span.span_kind.into();
             ResourceSpans {
                 resource: Some(Resource {
-                    attributes: resource_attributes(
-                        source_span.resource.as_ref().map(AsRef::as_ref),
-                    )
-                    .0,
+                    attributes: resource_attributes(&source_span.resource).0,
                     dropped_attributes_count: 0,
                 }),
                 schema_url: source_span
                     .resource
-                    .and_then(|resource| resource.schema_url().map(|url| url.to_string()))
+                    .schema_url()
+                    .map(|url| url.to_string())
                     .unwrap_or_default(),
                 instrumentation_library_spans: vec![InstrumentationLibrarySpans {
                     schema_url: source_span
@@ -112,14 +110,11 @@ pub mod tonic {
         }
     }
 
-    fn resource_attributes(resource: Option<&sdk::Resource>) -> Attributes {
+    fn resource_attributes(resource: &sdk::Resource) -> Attributes {
         resource
-            .map(|res| {
-                res.iter()
-                    .map(|(k, v)| opentelemetry::KeyValue::new(k.clone(), v.clone()))
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default()
+            .iter()
+            .map(|(k, v)| opentelemetry::KeyValue::new(k.clone(), v.clone()))
+            .collect::<Vec<_>>()
             .into()
     }
 }
@@ -175,10 +170,7 @@ pub mod grpcio {
         fn from(source_span: SpanData) -> Self {
             ResourceSpans {
                 resource: SingularPtrField::from(Some(Resource {
-                    attributes: resource_attributes(
-                        source_span.resource.as_ref().map(AsRef::as_ref),
-                    )
-                    .0,
+                    attributes: resource_attributes(&source_span.resource).0,
                     dropped_attributes_count: 0,
                     ..Default::default()
                 })),
@@ -246,15 +238,11 @@ pub mod grpcio {
         }
     }
 
-    fn resource_attributes(resource: Option<&sdk::Resource>) -> Attributes {
+    fn resource_attributes(resource: &sdk::Resource) -> Attributes {
         resource
-            .map(|resource| {
-                resource
-                    .iter()
-                    .map(|(k, v)| opentelemetry::KeyValue::new(k.clone(), v.clone()))
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default()
+            .iter()
+            .map(|(k, v)| opentelemetry::KeyValue::new(k.clone(), v.clone()))
+            .collect::<Vec<_>>()
             .into()
     }
 }

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -4,15 +4,17 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-opentelemetry-api = { version = "0.1", path = "../opentelemetry-api/" }
 async-std = { version = "1.6", features = ["unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
+crossbeam-channel = { version = "0.5", optional = true }
 dashmap = { version = "4.0.1", optional = true }
 fnv = { version = "1.0", optional = true }
 futures-channel = "0.3"
 futures-executor = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
 lazy_static = "1.4"
+once_cell = "1.10"
+opentelemetry-api = { version = "0.1", path = "../opentelemetry-api/" }
 percent-encoding = { version = "2.0", optional = true }
 pin-project = { version = "1.0.2", optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
@@ -20,7 +22,6 @@ serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 thiserror = "1"
 tokio = { version = "1.0", default-features = false, features = ["rt", "time"], optional = true }
 tokio-stream = { version = "0.1", optional = true }
-crossbeam-channel = { version = "0.5", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-sdk/benches/batch_span_processor.rs
+++ b/opentelemetry-sdk/benches/batch_span_processor.rs
@@ -6,6 +6,8 @@ use opentelemetry_sdk::export::trace::SpanData;
 use opentelemetry_sdk::runtime::Tokio;
 use opentelemetry_sdk::testing::trace::NoopSpanExporter;
 use opentelemetry_sdk::trace::{BatchSpanProcessor, EvictedHashMap, EvictedQueue, SpanProcessor};
+use opentelemetry_sdk::Resource;
+use std::borrow::Cow;
 use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::runtime::Runtime;
@@ -30,7 +32,7 @@ fn get_span_data() -> Vec<SpanData> {
             events: EvictedQueue::new(12),
             links: EvictedQueue::new(12),
             status: Status::Unset,
-            resource: None,
+            resource: Cow::Owned(Resource::empty()),
             instrumentation_lib: Default::default(),
         })
         .collect::<Vec<SpanData>>()

--- a/opentelemetry-sdk/src/export/trace/mod.rs
+++ b/opentelemetry-sdk/src/export/trace/mod.rs
@@ -1,9 +1,9 @@
 //! Trace exporters
+use crate::Resource;
 use async_trait::async_trait;
 use opentelemetry_api::trace::{Event, Link, SpanContext, SpanId, SpanKind, Status, TraceError};
 use std::borrow::Cow;
 use std::fmt::Debug;
-use std::sync::Arc;
 use std::time::SystemTime;
 
 pub mod stdout;
@@ -73,7 +73,7 @@ pub struct SpanData {
     /// Span status
     pub status: Status,
     /// Resource contains attributes representing an entity that produced this span.
-    pub resource: Option<Arc<crate::Resource>>,
+    pub resource: Cow<'static, Resource>,
     /// Instrumentation library that produced this span
     pub instrumentation_lib: crate::InstrumentationLibrary,
 }

--- a/opentelemetry-zipkin/src/exporter/model/span.rs
+++ b/opentelemetry-zipkin/src/exporter/model/span.rs
@@ -61,7 +61,9 @@ mod tests {
     use crate::exporter::model::{into_zipkin_span, OTEL_ERROR_DESCRIPTION, OTEL_STATUS_CODE};
     use opentelemetry::sdk::export::trace::SpanData;
     use opentelemetry::sdk::trace::{EvictedHashMap, EvictedQueue};
+    use opentelemetry::sdk::Resource;
     use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId};
+    use std::borrow::Cow;
     use std::collections::HashMap;
     use std::net::Ipv4Addr;
     use std::time::SystemTime;
@@ -164,7 +166,7 @@ mod tests {
                 events: EvictedQueue::new(20),
                 links: EvictedQueue::new(20),
                 status,
-                resource: None,
+                resource: Cow::Owned(Resource::default()),
                 instrumentation_lib: Default::default(),
             };
             let local_endpoint = Endpoint::new("test".into(), None);


### PR DESCRIPTION
The spec suggests all spans should have an associated `Resource`. This change switches trace config and span data from `Option<Arc<Resource>>` to `Cow<'static, Resource>` and removes `Config::with_no_resource` to accommodate this requirement.