### PR TITLE
style(http): re-export types in trait.

### DIFF
--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -1,8 +1,11 @@
 use std::fmt::Debug;
 
+#[doc(no_inline)]
+pub use bytes::Bytes;
+#[doc(no_inline)]
+pub use http::{Request, Response};
+
 use async_trait::async_trait;
-use bytes::Bytes;
-use http::{Request, Response};
 use opentelemetry::{
     propagation::{Extractor, Injector},
     trace::TraceError,


### PR DESCRIPTION
Currently, users need to include `byte` and `http` crate to implement their own `HttpClient`. Re-export those two types make the implementation easier  