### PR TITLE
Update Cargo.toml

### DIFF
--- a/opentelemetry-api/Cargo.toml
+++ b/opentelemetry-api/Cargo.toml
@@ -11,7 +11,7 @@ lazy_static = "1.4"
 pin-project = { version = "1.0.2", optional = true }
 thiserror = "1"
 tokio-stream = { version = "0.1", optional = true }
-indexmap = "1"
+indexmap = "1.8"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
I propose to fix the lower bound of `indexmap` to `1.8` as versions below `1.7` are not compiling. I get the following error: 

```bash
error[E0432]: unresolved imports `indexmap::map::IntoKeys`, `indexmap::map::IntoValues`
 --> /home/peter/.cargo/git/checkouts/opentelemetry-rust-458e5dd530230e7a/a767fd3/opentelemetry-api/src/trace/order_map.rs:3:29
  |
3 |     Drain, Entry, IntoIter, IntoKeys, IntoValues, Iter, IterMut, Keys, Values, ValuesMut,
  |                             ^^^^^^^^  ^^^^^^^^^^ no `IntoValues` in `map`
  |                             |
  |                             no `IntoKeys` in `map`

error[E0599]: no method named `into_keys` found for struct `IndexMap` in the current scope
  --> /home/peter/.cargo/git/checkouts/opentelemetry-rust-458e5dd530230e7a/a767fd3/opentelemetry-api/src/trace/order_map.rs:95:16
   |
95 |         self.0.into_keys()
   |                ^^^^^^^^^ method not found in `IndexMap<K, V, S>`

error[E0599]: no method named `into_values` found for struct `IndexMap` in the current scope
   --> /home/peter/.cargo/git/checkouts/opentelemetry-rust-458e5dd530230e7a/a767fd3/opentelemetry-api/src/trace/order_map.rs:111:16
    |
111 |         self.0.into_values()
    |                ^^^^^^^^^^^ method not found in `IndexMap<K, V, S>`

error[E0308]: mismatched types
   --> /home/peter/.cargo/git/checkouts/opentelemetry-rust-458e5dd530230e7a/a767fd3/opentelemetry-api/src/trace/order_map.rs:561:29
    |
561 |         Self(IndexMap::from(arr))
    |                             ^^^ expected struct `IndexMap`, found array
    |
    = note: expected struct `IndexMap<K, V>`
                found array `[(K, V); N]`

error[E0308]: mismatched types
   --> /home/peter/.cargo/git/checkouts/opentelemetry-rust-458e5dd530230e7a/a767fd3/opentelemetry-api/src/trace/order_map.rs:647:29
    |
647 |         Self(IndexMap::from(arr))
    |                             ^^^ expected struct `IndexMap`, found array
    |
    = note: expected struct `IndexMap<Key, Value>`
                found array `[(Key, Value); N]`

Some errors have detailed explanations: E0308, E0432, E0599.
For more information about an error, try `rustc --explain E0308`
```