### PR TITLE
opentelemetry-jaeger: Fix clearing span context in Propagator

### DIFF
--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -513,10 +513,9 @@ mod propagator {
         }
 
         fn extract_with_context(&self, cx: &Context, extractor: &dyn Extractor) -> Context {
-            cx.with_remote_span_context(
-                self.extract_span_context(extractor)
-                    .unwrap_or_else(|_| SpanContext::empty_context()),
-            )
+            self.extract_span_context(extractor)
+                .map(|sc| cx.with_remote_span_context(sc))
+                .unwrap_or_else(|_| cx.clone())
         }
 
         fn fields(&self) -> FieldIter<'_> {


### PR DESCRIPTION
When `Propagator::extract_with_context()` is run with an Extractor empty
of trace metadata, it returns an empty (invalid) Context, clearing
TraceId, and disabling downwards propagation. As there is already an
implicit TraceId (if we're in a Span), we'd like to use it, traces have
to start somewhere.

This just aligns the mechanics with opentelemetry-sdk[1]: if span
extraction errors out we return a clone of the existing context.

[1] https://github.com/open-telemetry/opentelemetry-rust/blob/fd587c39da24a47c1f4a5b3d423409400f4c8681/opentelemetry-sdk/src/propagation/trace_context.rs#L136-L138