### PR TITLE
msrv: bump from 1.49 to 1.55

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.59.0
+        toolchain: 1.55.0
         override: true
     - name: Run tests
       run: cargo --version &&

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.49+][msrv]*
+*Compiler support: [requires `rustc` 1.55+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
@@ -130,7 +130,7 @@ above, please let us know! We'd love to add your project to the list!
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.49. The current OpenTelemetry version is not guaranteed to build
+version is 1.55. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/examples/external-otlp-grpcio-async-std/Cargo.toml
+++ b/examples/external-otlp-grpcio-async-std/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-async-std = { version = "1.9.0", features = ["attributes"] }
+async-std = { version = "= 1.8.0", features = ["attributes"] }
 env_logger = "0.8.2"
 opentelemetry = { path = "../../opentelemetry", features = ["rt-async-std"] }
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = [

--- a/opentelemetry-api/README.md
+++ b/opentelemetry-api/README.md
@@ -25,7 +25,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.49+][msrv]*
+*Compiler support: [requires `rustc` 1.55+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io

--- a/opentelemetry-api/src/lib.rs
+++ b/opentelemetry-api/src/lib.rs
@@ -2,7 +2,7 @@
 //! services to capture distributed traces and metrics from your application. You
 //! can analyze them using [Prometheus], [Jaeger], and other observability tools.
 //!
-//! *Compiler support: [requires `rustc` 1.49+][msrv]*
+//! *Compiler support: [requires `rustc` 1.55+][msrv]*
 //!
 //! [Prometheus]: https://prometheus.io
 //! [Jaeger]: https://www.jaegertracing.io

--- a/opentelemetry-dynatrace/Cargo.toml
+++ b/opentelemetry-dynatrace/Cargo.toml
@@ -49,7 +49,7 @@ wasm = [
 ]
 
 [dependencies]
-async-std = { version = "1", features = ["unstable"], optional = true }
+async-std = { version = "= 1.8.0", features = ["unstable"], optional = true }
 base64 = { version = "0.13", optional = true }
 futures = "0.3"
 futures-util = { version = "0.3", optional = true }

--- a/opentelemetry-http/README.md
+++ b/opentelemetry-http/README.md
@@ -21,7 +21,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a HTTP client interface for use by trace exporters, as well as
 helper types to inject and extract key value pairs into/from HTTP headers.
 
-*Compiler support: [requires `rustc` 1.49+][msrv]*
+*Compiler support: [requires `rustc` 1.55+][msrv]*
 
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
 [msrv]: #supported-rust-versions
@@ -29,7 +29,7 @@ helper types to inject and extract key value pairs into/from HTTP headers.
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.46. The current OpenTelemetry version is not guaranteed to build
+version is 1.55. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-async-std = { version = "1.6", optional = true }
+async-std = { version = "= 1.8.0", optional = true }
 async-trait = "0.1"
 base64 = { version = "0.13", optional = true }
 futures = "0.3"

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -23,7 +23,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a trace pipeline and exporter for sending span information to a
 Jaeger `agent` or `collector` endpoint for processing and visualization.
 
-*Compiler support: [requires `rustc` 1.49+][msrv]*
+*Compiler support: [requires `rustc` 1.55+][msrv]*
 
 [`Jaeger`]: https://www.jaegertracing.io/
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
@@ -147,7 +147,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.46. The current OpenTelemetry version is not guaranteed to build
+version is 1.45. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! See the [Jaeger Docs] for details about Jaeger and deployment information.
 //!
-//! *Compiler support: [requires `rustc` 1.49+][msrv]*
+//! *Compiler support: [requires `rustc` 1.55+][msrv]*
 //!
 //! [Jaeger Docs]: https://www.jaegertracing.io/docs/
 //! [msrv]: #supported-rust-versions

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-async-std = { version = "1.6", features = ["unstable"], optional = true }
+async-std = { version = "= 1.8.0", features = ["unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 dashmap = { version = "4.0.1", optional = true }

--- a/opentelemetry-sdk/README.md
+++ b/opentelemetry-sdk/README.md
@@ -25,7 +25,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.49+][msrv]*
+*Compiler support: [requires `rustc` 1.55+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -23,7 +23,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a trace pipeline and exporter for sending span information to a
 Zipkin collector for processing and visualization.
 
-*Compiler support: [requires `rustc` 1.49+][msrv]*
+*Compiler support: [requires `rustc` 1.55+][msrv]*
 
 [`Zipkin`]: https://zipkin.io/
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
@@ -107,7 +107,7 @@ available so be sure to match them appropriately.
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.46. The current OpenTelemetry version is not guaranteed to build on
+version is 1.55. The current OpenTelemetry version is not guaranteed to build on
 Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions before

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -3,7 +3,7 @@
 //! Collects OpenTelemetry spans and reports them to a given Zipkin collector
 //! endpoint. See the [Zipkin Docs] for details and deployment information.
 //!
-//! *Compiler support: [requires `rustc` 1.49+][msrv]*
+//! *Compiler support: [requires `rustc` 1.55+][msrv]*
 //!
 //! [Zipkin Docs]: https://zipkin.io/
 //! [msrv]: #supported-rust-versions

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -25,7 +25,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.49+][msrv]*
+*Compiler support: [requires `rustc` 1.55+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
@@ -130,7 +130,7 @@ above, please let us know! We'd love to add your project to the list!
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.46. The current OpenTelemetry version is not guaranteed to build
+version is 1.55. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -2,7 +2,7 @@
 //! services to capture distributed traces and metrics from your application. You
 //! can analyze them using [Prometheus], [Jaeger], and other observability tools.
 //!
-//! *Compiler support: [requires `rustc` 1.49+][msrv]*
+//! *Compiler support: [requires `rustc` 1.55+][msrv]*
 //!
 //! [Prometheus]: https://prometheus.io
 //! [Jaeger]: https://www.jaegertracing.io


### PR DESCRIPTION
- Follow up https://github.com/open-telemetry/opentelemetry-rust/pull/799. Update the MSRV in README files.
- Pin the `async-std` version to `1.8` as any version > `1.8` will requires rustc 1.59 support, which breaks our MSRV guarantee. Ideally we should revert this change once https://github.com/async-rs/async-global-executor/issues/10 resolves and the new version releases
- Revert the MSRV in ci config from 1.59 to 1.55, it was previously bumped to unblock the PR merging. 

