### PR TITLE
chore: Bump actix-web examples dependencies

### DIFF
--- a/examples/actix-http-tracing/Cargo.toml
+++ b/examples/actix-http-tracing/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2018"
 publish = false
 
 [dependencies]
-actix-web = "3.2"
-actix-web-opentelemetry = { version = "0.9", features = ["metrics"] }
-opentelemetry = { version = "0.11", features = ["metrics", "tokio"] }
-opentelemetry-jaeger = { version = "0.10", features = ["tokio"] }
-opentelemetry-prometheus = "0.4"
+actix-web = "4.1"
+actix-web-opentelemetry = { version = "0.12", features = ["metrics"] }
+opentelemetry = { version = "0.17", features = ["metrics", "tokio"] }
+opentelemetry-jaeger = { version = "0.16", features = ["tokio"] }
+opentelemetry-prometheus = "0.10"
 tracing = "0.1"
-tracing-opentelemetry = "0.10"
-tracing-subscriber = "0.2"
+tracing-opentelemetry = "0.17"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/actix-http-tracing/src/main.rs
+++ b/examples/actix-http-tracing/src/main.rs
@@ -30,9 +30,9 @@ async fn main() -> io::Result<()> {
 
     // Start an otel jaeger trace pipeline
     global::set_text_map_propagator(TraceContextPropagator::new());
-    let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
+    let tracer = opentelemetry_jaeger::new_pipeline()
         .with_service_name("app_name")
-        .install()
+        .install_simple()
         .unwrap();
 
     // Initialize `tracing` using `opentelemetry-tracing` and configure logging

--- a/examples/actix-http/Cargo.toml
+++ b/examples/actix-http/Cargo.toml
@@ -7,8 +7,7 @@ publish = false
 [dependencies]
 opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio"] }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["reqwest_collector_client", "rt-tokio-current-thread"] }
-thrift = "0.13"
-actix-web = "4.0.0"
+actix-web = "4.1.0"
 actix-service = "2.0.0"
-env_logger = "0.8.2"
+env_logger = "0.9.0"
 tokio = { version = "1", features = ["full"] }

--- a/examples/actix-http/src/main.rs
+++ b/examples/actix-http/src/main.rs
@@ -13,6 +13,7 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
     opentelemetry_jaeger::new_collector_pipeline()
         .with_endpoint("http://127.0.0.1:14268/api/traces")
         .with_service_name("trace-http-demo")
+        .with_reqwest()
         .install_batch(opentelemetry::runtime::TokioCurrentThread)
 }
 

--- a/examples/actix-udp/Cargo.toml
+++ b/examples/actix-udp/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 [dependencies]
 opentelemetry = { path = "../../opentelemetry" }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }
-thrift = "0.13"
-actix-web = "3"
-actix-service = "1"
-env_logger = "0.8.2"
+actix-web = "4.1"
+actix-service = "2"
+env_logger = "0.9"


### PR DESCRIPTION
Bump the dependencies of `actix-*` examples and make them compile.

However, I cannot get `actix-http` to work, while `actix-http-tracing` and `actix-udp` run just fine. The thread panics after the first request that it receives:

```
[2022-06-13T23:01:07Z INFO  actix_server::builder] Starting 4 workers
[2022-06-13T23:01:07Z INFO  actix_server::server] Actix runtime found; starting in Actix runtime
[2022-06-13T23:01:30Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET / HTTP/1.1" 200 5 "-" "curl/7.83.1" 0.000652
thread '<unnamed>' panicked at 'there is no reactor running, must be called from the context of a Tokio 1.x runtime', /home/atanunq/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/runtime/context.rs:54:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
OpenTelemetry trace error occurred. oneshot canceled
```

 I've traced it to [this thread](https://github.com/open-telemetry/opentelemetry-rust/blob/75348915b50879b300cfe2af3e750e3a313a4bc7/opentelemetry-jaeger/src/exporter/mod.rs#L85-L87) being unable to execute any tokio tasks, including the necessary [http send](https://github.com/open-telemetry/opentelemetry-rust/blob/3806258ee5db2223395fd38daac1d9e352974a17/opentelemetry-http/src/lib.rs#L65-L72). Though, my async runtime understanding only goes so far. Could it be a misconfiguration on my side?