### PR TITLE
fix: update `dashmap` to avoid soundness hole

### DIFF
--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 async-std = { version = "1.6", features = ["unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
-dashmap = { version = "4.0.1", optional = true }
+dashmap = { version = "5.3.4", optional = true }
 fnv = { version = "1.0", optional = true }
 futures-channel = "0.3"
 futures-executor = "0.3"


### PR DESCRIPTION
xacrimon/dashmap#167 has a soundness hole pre `5.1.0`.