### PR TITLE
Allow ref counted keys and values

### DIFF
--- a/examples/external-otlp-grpcio-async-std/Cargo.toml
+++ b/examples/external-otlp-grpcio-async-std/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-async-std = { version = "= 1.8.0", features = ["attributes"] }
+async-std = { version = "= 1.10.0", features = ["attributes"] }
 env_logger = "0.8.2"
 opentelemetry = { path = "../../opentelemetry", features = ["rt-async-std"] }
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = [

--- a/examples/external-otlp-tonic-tokio/src/main.rs
+++ b/examples/external-otlp-tonic-tokio/src/main.rs
@@ -62,7 +62,7 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
             opentelemetry_otlp::new_exporter()
                 .tonic()
                 .with_endpoint(endpoint.as_str())
-                .with_metadata(dbg!(metadata))
+                .with_metadata(metadata)
                 .with_tls_config(
                     ClientTlsConfig::new().domain_name(
                         endpoint

--- a/opentelemetry-api/src/common.rs
+++ b/opentelemetry-api/src/common.rs
@@ -1,23 +1,35 @@
 use std::borrow::Cow;
-use std::fmt;
+use std::sync::Arc;
+use std::{fmt, hash};
 
 /// The key part of attribute [KeyValue] pairs.
 ///
 /// See the [attribute naming] spec for guidelines.
 ///
 /// [attribute naming]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/common/attribute-naming.md
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Key(Cow<'static, str>);
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Key(OtelString);
 
 impl Key {
     /// Create a new `Key`.
-    pub fn new<S: Into<Cow<'static, str>>>(value: S) -> Self {
-        Key(value.into())
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use opentelemetry_api::Key;
+    /// use std::sync::Arc;
+    ///
+    /// let key1 = Key::new("my_static_str");
+    /// let key2 = Key::new(String::from("my_owned_string"));
+    /// let key3 = Key::new(Arc::from("my_ref_counted_str"));
+    /// ```
+    pub fn new(value: impl Into<Key>) -> Self {
+        value.into()
     }
 
     /// Create a new const `Key`.
     pub const fn from_static_str(value: &'static str) -> Self {
-        Key(Cow::Borrowed(value))
+        Key(OtelString::Static(value))
     }
 
     /// Create a `KeyValue` pair for `bool` values.
@@ -44,8 +56,8 @@ impl Key {
         }
     }
 
-    /// Create a `KeyValue` pair for `String` values.
-    pub fn string<T: Into<Cow<'static, str>>>(self, value: T) -> KeyValue {
+    /// Create a `KeyValue` pair for string-like values.
+    pub fn string(self, value: impl Into<StringValue>) -> KeyValue {
         KeyValue {
             key: self,
             value: Value::String(value.into()),
@@ -62,34 +74,95 @@ impl Key {
 
     /// Returns a reference to the underlying key name
     pub fn as_str(&self) -> &str {
-        self.0.as_ref()
+        self.0.as_str()
     }
 }
 
 impl From<&'static str> for Key {
     /// Convert a `&str` to a `Key`.
     fn from(key_str: &'static str) -> Self {
-        Key(Cow::from(key_str))
+        Key(OtelString::Static(key_str))
     }
 }
 
 impl From<String> for Key {
     /// Convert a `String` to a `Key`.
     fn from(string: String) -> Self {
-        Key(Cow::from(string))
+        Key(OtelString::Owned(string))
+    }
+}
+
+impl From<Arc<str>> for Key {
+    /// Convert a `String` to a `Key`.
+    fn from(string: Arc<str>) -> Self {
+        Key(OtelString::RefCounted(string))
+    }
+}
+
+impl fmt::Debug for Key {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(fmt)
     }
 }
 
 impl From<Key> for String {
-    /// Converts `Key` instances into `String`.
     fn from(key: Key) -> Self {
-        key.0.into_owned()
+        match key.0 {
+            OtelString::Owned(s) => s,
+            OtelString::Static(s) => s.to_string(),
+            OtelString::RefCounted(s) => s.to_string(),
+        }
     }
 }
 
 impl fmt::Display for Key {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(fmt)
+        match &self.0 {
+            OtelString::Owned(s) => s.fmt(fmt),
+            OtelString::Static(s) => s.fmt(fmt),
+            OtelString::RefCounted(s) => s.fmt(fmt),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq)]
+enum OtelString {
+    Static(&'static str),
+    Owned(String),
+    RefCounted(Arc<str>),
+}
+
+impl OtelString {
+    fn as_str(&self) -> &str {
+        match self {
+            OtelString::Owned(s) => s.as_ref(),
+            OtelString::Static(s) => s,
+            OtelString::RefCounted(s) => s.as_ref(),
+        }
+    }
+}
+
+impl PartialOrd for OtelString {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.as_str().partial_cmp(other.as_str())
+    }
+}
+
+impl Ord for OtelString {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl PartialEq for OtelString {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str().eq(other.as_str())
+    }
+}
+
+impl hash::Hash for OtelString {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state)
     }
 }
 
@@ -103,7 +176,7 @@ pub enum Array {
     /// Array of floats
     F64(Vec<f64>),
     /// Array of strings
-    String(Vec<Cow<'static, str>>),
+    String(Vec<StringValue>),
 }
 
 impl fmt::Display for Array {
@@ -118,7 +191,7 @@ impl fmt::Display for Array {
                     if i > 0 {
                         write!(fmt, ",")?;
                     }
-                    write!(fmt, "{:?}", t)?;
+                    write!(fmt, "\"{}\"", t)?;
                 }
                 write!(fmt, "]")
             }
@@ -153,8 +226,41 @@ into_array!(
     (Vec<bool>, Array::Bool),
     (Vec<i64>, Array::I64),
     (Vec<f64>, Array::F64),
-    (Vec<Cow<'static, str>>, Array::String),
+    (Vec<StringValue>, Array::String),
 );
+
+impl From<Vec<&'static str>> for Array {
+    /// Convenience method for creating a `Value` from a `&'static str`.
+    fn from(ss: Vec<&'static str>) -> Self {
+        Array::String(
+            ss.into_iter()
+                .map(|s| StringValue(OtelString::Static(s)))
+                .collect(),
+        )
+    }
+}
+
+impl From<Vec<String>> for Array {
+    /// Convenience method for creating a `Value` from a `String`.
+    fn from(ss: Vec<String>) -> Self {
+        Array::String(
+            ss.into_iter()
+                .map(|s| StringValue(OtelString::Owned(s)))
+                .collect(),
+        )
+    }
+}
+
+impl From<Vec<Arc<str>>> for Array {
+    /// Convenience method for creating a `Value` from a `String`.
+    fn from(ss: Vec<Arc<str>>) -> Self {
+        Array::String(
+            ss.into_iter()
+                .map(|s| StringValue(OtelString::RefCounted(s)))
+                .collect(),
+        )
+    }
+}
 
 /// The value part of attribute [KeyValue] pairs.
 #[derive(Clone, Debug, PartialEq)]
@@ -166,9 +272,73 @@ pub enum Value {
     /// f64 values
     F64(f64),
     /// String values
-    String(Cow<'static, str>),
+    String(StringValue),
     /// Array of homogeneous values
     Array(Array),
+}
+
+/// Wrapper for string-like values
+#[derive(Clone, PartialEq, Hash)]
+pub struct StringValue(OtelString);
+
+impl fmt::Debug for StringValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for StringValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            OtelString::Owned(s) => s.fmt(f),
+            OtelString::Static(s) => s.fmt(f),
+            OtelString::RefCounted(s) => s.fmt(f),
+        }
+    }
+}
+
+impl StringValue {
+    /// Returns a string slice to this value
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<StringValue> for String {
+    fn from(s: StringValue) -> Self {
+        match s.0 {
+            OtelString::Owned(s) => s,
+            OtelString::Static(s) => s.to_string(),
+            OtelString::RefCounted(s) => s.to_string(),
+        }
+    }
+}
+
+impl From<&'static str> for StringValue {
+    fn from(s: &'static str) -> Self {
+        StringValue(OtelString::Static(s))
+    }
+}
+
+impl From<String> for StringValue {
+    fn from(s: String) -> Self {
+        StringValue(OtelString::Owned(s))
+    }
+}
+
+impl From<Arc<str>> for StringValue {
+    fn from(s: Arc<str>) -> Self {
+        StringValue(OtelString::RefCounted(s))
+    }
+}
+
+impl From<Cow<'static, str>> for StringValue {
+    fn from(s: Cow<'static, str>) -> Self {
+        match s {
+            Cow::Owned(s) => StringValue(OtelString::Owned(s)),
+            Cow::Borrowed(s) => StringValue(OtelString::Static(s)),
+        }
+    }
 }
 
 impl Value {
@@ -180,7 +350,7 @@ impl Value {
             Value::Bool(v) => format!("{}", v).into(),
             Value::I64(v) => format!("{}", v).into(),
             Value::F64(v) => format!("{}", v).into(),
-            Value::String(v) => Cow::Borrowed(v.as_ref()),
+            Value::String(v) => Cow::Borrowed(v.as_str()),
             Value::Array(v) => format!("{}", v).into(),
         }
     }
@@ -206,7 +376,7 @@ from_values!(
     (bool, Value::Bool);
     (i64, Value::I64);
     (f64, Value::F64);
-    (Cow<'static, str>, Value::String);
+    (StringValue, Value::String);
 );
 
 impl From<&'static str> for Value {
@@ -223,14 +393,28 @@ impl From<String> for Value {
     }
 }
 
+impl From<Arc<str>> for Value {
+    /// Convenience method for creating a `Value` from a `String`.
+    fn from(s: Arc<str>) -> Self {
+        Value::String(s.into())
+    }
+}
+
+impl From<Cow<'static, str>> for Value {
+    /// Convenience method for creating a `Value` from a `String`.
+    fn from(s: Cow<'static, str>) -> Self {
+        Value::String(s.into())
+    }
+}
+
 impl fmt::Display for Value {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Value::Bool(v) => fmt.write_fmt(format_args!("{}", v)),
-            Value::I64(v) => fmt.write_fmt(format_args!("{}", v)),
-            Value::F64(v) => fmt.write_fmt(format_args!("{}", v)),
-            Value::String(v) => fmt.write_fmt(format_args!("{}", v)),
-            Value::Array(v) => fmt.write_fmt(format_args!("{}", v)),
+            Value::Bool(v) => v.fmt(fmt),
+            Value::I64(v) => v.fmt(fmt),
+            Value::F64(v) => v.fmt(fmt),
+            Value::String(v) => fmt.write_str(v.as_str()),
+            Value::Array(v) => v.fmt(fmt),
         }
     }
 }

--- a/opentelemetry-api/src/common.rs
+++ b/opentelemetry-api/src/common.rs
@@ -229,39 +229,6 @@ into_array!(
     (Vec<StringValue>, Array::String),
 );
 
-impl From<Vec<&'static str>> for Array {
-    /// Convenience method for creating a `Value` from a `&'static str`.
-    fn from(ss: Vec<&'static str>) -> Self {
-        Array::String(
-            ss.into_iter()
-                .map(|s| StringValue(OtelString::Static(s)))
-                .collect(),
-        )
-    }
-}
-
-impl From<Vec<String>> for Array {
-    /// Convenience method for creating a `Value` from a `String`.
-    fn from(ss: Vec<String>) -> Self {
-        Array::String(
-            ss.into_iter()
-                .map(|s| StringValue(OtelString::Owned(s)))
-                .collect(),
-        )
-    }
-}
-
-impl From<Vec<Arc<str>>> for Array {
-    /// Convenience method for creating a `Value` from a `String`.
-    fn from(ss: Vec<Arc<str>>) -> Self {
-        Array::String(
-            ss.into_iter()
-                .map(|s| StringValue(OtelString::RefCounted(s)))
-                .collect(),
-        )
-    }
-}
-
 /// The value part of attribute [KeyValue] pairs.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value {
@@ -294,6 +261,12 @@ impl fmt::Display for StringValue {
             OtelString::Static(s) => s.fmt(f),
             OtelString::RefCounted(s) => s.fmt(f),
         }
+    }
+}
+
+impl AsRef<str> for StringValue {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
     }
 }
 
@@ -380,28 +353,24 @@ from_values!(
 );
 
 impl From<&'static str> for Value {
-    /// Convenience method for creating a `Value` from a `&'static str`.
     fn from(s: &'static str) -> Self {
         Value::String(s.into())
     }
 }
 
 impl From<String> for Value {
-    /// Convenience method for creating a `Value` from a `String`.
     fn from(s: String) -> Self {
         Value::String(s.into())
     }
 }
 
 impl From<Arc<str>> for Value {
-    /// Convenience method for creating a `Value` from a `String`.
     fn from(s: Arc<str>) -> Self {
         Value::String(s.into())
     }
 }
 
 impl From<Cow<'static, str>> for Value {
-    /// Convenience method for creating a `Value` from a `String`.
     fn from(s: Cow<'static, str>) -> Self {
         Value::String(s.into())
     }

--- a/opentelemetry-api/src/lib.rs
+++ b/opentelemetry-api/src/lib.rs
@@ -55,7 +55,7 @@ mod common;
 #[doc(hidden)]
 pub mod testing;
 
-pub use common::{Array, ExportError, InstrumentationLibrary, Key, KeyValue, Value};
+pub use common::{Array, ExportError, InstrumentationLibrary, Key, KeyValue, StringValue, Value};
 
 #[cfg(feature = "metrics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = { version = "1", optional = true}
 futures = {version = "0.3", optional = true}
 async-trait = {version = "0.1", optional = true}
 tokio = { version = "1.0", features = ["fs", "io-util"], optional = true }
-async-std = { version = "1.6", optional = true }
+async-std = { version = "1.10", optional = true }
 
 
 [dev-dependencies]

--- a/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
+++ b/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
@@ -193,7 +193,7 @@ fn opentelemetry_value_to_json(value: &opentelemetry::Value) -> (&str, serde_jso
         opentelemetry::Value::Bool(b) => ("bool", serde_json::json!(b)),
         opentelemetry::Value::I64(i) => ("int64", serde_json::json!(i)),
         opentelemetry::Value::F64(f) => ("float64", serde_json::json!(f)),
-        opentelemetry::Value::String(s) => ("string", serde_json::json!(s)),
+        opentelemetry::Value::String(s) => ("string", serde_json::json!(s.as_str())),
         v @ opentelemetry::Value::Array(_) => ("string", serde_json::json!(v.to_string())),
     }
 }

--- a/opentelemetry-datadog/src/exporter/model/v03.rs
+++ b/opentelemetry-datadog/src/exporter/model/v03.rs
@@ -41,7 +41,7 @@ where
             if let Some(Value::String(s)) = span.attributes.get(&Key::new("span.type")) {
                 rmp::encode::write_map_len(&mut encoded, 11)?;
                 rmp::encode::write_str(&mut encoded, "type")?;
-                rmp::encode::write_str(&mut encoded, s.as_ref())?;
+                rmp::encode::write_str(&mut encoded, s.as_str())?;
             } else {
                 rmp::encode::write_map_len(&mut encoded, 10)?;
             }

--- a/opentelemetry-datadog/src/exporter/model/v05.rs
+++ b/opentelemetry-datadog/src/exporter/model/v05.rs
@@ -121,7 +121,7 @@ where
                 .unwrap_or(0);
 
             let span_type = match span.attributes.get(&Key::new("span.type")) {
-                Some(Value::String(s)) => interner.intern(s.as_ref()),
+                Some(Value::String(s)) => interner.intern(s.as_str()),
                 _ => interner.intern(""),
             };
 

--- a/opentelemetry-dynatrace/Cargo.toml
+++ b/opentelemetry-dynatrace/Cargo.toml
@@ -49,7 +49,7 @@ wasm = [
 ]
 
 [dependencies]
-async-std = { version = "= 1.8.0", features = ["unstable"], optional = true }
+async-std = { version = "= 1.10.0", features = ["unstable"], optional = true }
 base64 = { version = "0.13", optional = true }
 futures = "0.3"
 futures-util = { version = "0.3", optional = true }

--- a/opentelemetry-dynatrace/src/transform/metrics.rs
+++ b/opentelemetry-dynatrace/src/transform/metrics.rs
@@ -801,7 +801,7 @@ mod tests {
             let dimensions = DimensionSet::from(vec![
                 KeyValue::new("KEY", "VALUE"),
                 KeyValue::new("test.abc_123-", "value.123_foo-bar"),
-                KeyValue::new(METRICS_SOURCE, "opentelemetry".to_string()),
+                KeyValue::new(METRICS_SOURCE, "opentelemetry"),
             ]);
 
             let expect = vec![
@@ -892,7 +892,7 @@ mod tests {
             let dimensions = DimensionSet::from(vec![
                 KeyValue::new("KEY", "VALUE"),
                 KeyValue::new("test.abc_123-", "value.123_foo-bar"),
-                KeyValue::new(METRICS_SOURCE, "opentelemetry".to_string()),
+                KeyValue::new(METRICS_SOURCE, "opentelemetry"),
             ]);
 
             let expect = vec![MetricLine {
@@ -936,7 +936,7 @@ mod tests {
             let dimensions = DimensionSet::from(vec![
                 KeyValue::new("KEY", "VALUE"),
                 KeyValue::new("test.abc_123-", "value.123_foo-bar"),
-                KeyValue::new(METRICS_SOURCE, "opentelemetry".to_string()),
+                KeyValue::new(METRICS_SOURCE, "opentelemetry"),
             ]);
 
             let expect = vec![MetricLine {
@@ -1005,7 +1005,7 @@ mod tests {
             let dimensions = DimensionSet::from(vec![
                 KeyValue::new("KEY", "VALUE"),
                 KeyValue::new("test.abc_123-", "value.123_foo-bar"),
-                KeyValue::new(METRICS_SOURCE, "opentelemetry".to_string()),
+                KeyValue::new(METRICS_SOURCE, "opentelemetry"),
             ]);
 
             let expect = vec![MetricLine {
@@ -1072,7 +1072,7 @@ mod tests {
             let dimensions = DimensionSet::from(vec![
                 KeyValue::new("KEY", "VALUE"),
                 KeyValue::new("test.abc_123-", "value.123_foo-bar"),
-                KeyValue::new(METRICS_SOURCE, "opentelemetry".to_string()),
+                KeyValue::new(METRICS_SOURCE, "opentelemetry"),
             ]);
 
             let expect = vec![MetricLine {
@@ -1142,7 +1142,7 @@ mod tests {
             let dimensions = DimensionSet::from(vec![
                 KeyValue::new("KEY", "VALUE"),
                 KeyValue::new("test.abc_123-", "value.123_foo-bar"),
-                KeyValue::new(METRICS_SOURCE, "opentelemetry".to_string()),
+                KeyValue::new(METRICS_SOURCE, "opentelemetry"),
             ]);
 
             let expect = vec![MetricLine {

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-async-std = { version = "= 1.8.0", optional = true }
+async-std = { version = "= 1.10.0", optional = true }
 async-trait = "0.1"
 base64 = { version = "0.13", optional = true }
 futures = "0.3"

--- a/opentelemetry-proto/src/transform/common.rs
+++ b/opentelemetry-proto/src/transform/common.rs
@@ -62,7 +62,7 @@ pub mod tonic {
                     Value::Bool(val) => Some(any_value::Value::BoolValue(val)),
                     Value::I64(val) => Some(any_value::Value::IntValue(val)),
                     Value::F64(val) => Some(any_value::Value::DoubleValue(val)),
-                    Value::String(val) => Some(any_value::Value::StringValue(val.into_owned())),
+                    Value::String(val) => Some(any_value::Value::StringValue(val.to_string())),
                     Value::Array(array) => Some(any_value::Value::ArrayValue(match array {
                         Array::Bool(vals) => array_into_proto(vals),
                         Array::I64(vals) => array_into_proto(vals),
@@ -144,7 +144,7 @@ pub mod grpcio {
                 Value::Bool(val) => any_value.set_bool_value(val),
                 Value::I64(val) => any_value.set_int_value(val),
                 Value::F64(val) => any_value.set_double_value(val),
-                Value::String(val) => any_value.set_string_value(val.into_owned()),
+                Value::String(val) => any_value.set_string_value(val.to_string()),
                 Value::Array(array) => any_value.set_array_value(match array {
                     Array::Bool(vals) => array_into_proto(vals),
                     Array::I64(vals) => array_into_proto(vals),

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-async-std = { version = "= 1.8.0", features = ["unstable"], optional = true }
+async-std = { version = "= 1.10.0", features = ["unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 dashmap = { version = "4.0.1", optional = true }

--- a/opentelemetry-sdk/src/export/metrics/stdout.rs
+++ b/opentelemetry-sdk/src/export/metrics/stdout.rs
@@ -94,7 +94,7 @@ where
             let encoded_inst_attributes = if !desc.instrumentation_name().is_empty() {
                 let inst_attributes = AttributeSet::from_attributes(iter::once(KeyValue::new(
                     "instrumentation.name",
-                    desc.instrumentation_name().to_owned(),
+                    desc.instrumentation_name(),
                 )));
                 inst_attributes.encoded(Some(self.attribute_encoder.as_ref()))
             } else {

--- a/opentelemetry-sdk/src/propagation/baggage.rs
+++ b/opentelemetry-sdk/src/propagation/baggage.rs
@@ -186,7 +186,6 @@ mod tests {
     use opentelemetry_api::{
         baggage::BaggageMetadata, propagation::TextMapPropagator, Key, KeyValue, Value,
     };
-    use std::borrow::Cow;
     use std::collections::HashMap;
 
     #[rustfmt::skip]
@@ -247,7 +246,7 @@ mod tests {
                 vec![
                     KeyValue::new("key1", Value::Array(vec![true, false].into())),
                     KeyValue::new("key2", Value::Array(vec![123, 456].into())),
-                    KeyValue::new("key3", Value::Array(vec![Cow::from("val1"), Cow::from("val2")].into())),
+                    KeyValue::new("key3", Value::Array(vec!["val1", "val2"].into())),
                 ],
                 vec![
                     "key1=[true%2Cfalse]",

--- a/opentelemetry-sdk/src/propagation/baggage.rs
+++ b/opentelemetry-sdk/src/propagation/baggage.rs
@@ -184,7 +184,7 @@ impl TextMapPropagator for BaggagePropagator {
 mod tests {
     use super::*;
     use opentelemetry_api::{
-        baggage::BaggageMetadata, propagation::TextMapPropagator, Key, KeyValue, Value,
+        baggage::BaggageMetadata, propagation::TextMapPropagator, Key, KeyValue, StringValue, Value,
     };
     use std::collections::HashMap;
 
@@ -246,7 +246,7 @@ mod tests {
                 vec![
                     KeyValue::new("key1", Value::Array(vec![true, false].into())),
                     KeyValue::new("key2", Value::Array(vec![123, 456].into())),
-                    KeyValue::new("key3", Value::Array(vec!["val1", "val2"].into())),
+                    KeyValue::new("key3", Value::Array(vec![StringValue::from("val1"), StringValue::from("val2")].into())),
                 ],
                 vec![
                     "key1=[true%2Cfalse]",

--- a/opentelemetry-sdk/src/resource/process.rs
+++ b/opentelemetry-sdk/src/resource/process.rs
@@ -4,8 +4,7 @@
 
 use crate::resource::ResourceDetector;
 use crate::Resource;
-use opentelemetry_api::{Array, KeyValue, Value};
-use std::borrow::Cow;
+use opentelemetry_api::{KeyValue, Value};
 use std::env::args_os;
 use std::process::id;
 use std::time::Duration;
@@ -25,13 +24,10 @@ impl ResourceDetector for ProcessResourceDetector {
         let arguments = args_os();
         let cmd_arg_val = arguments
             .into_iter()
-            .map(|arg| Cow::from(arg.to_string_lossy().into_owned()))
-            .collect::<Vec<Cow<'_, str>>>();
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<String>>();
         Resource::new(vec![
-            KeyValue::new(
-                "process.command_args",
-                Value::Array(Array::String(cmd_arg_val)),
-            ),
+            KeyValue::new("process.command_args", Value::Array(cmd_arg_val.into())),
             KeyValue::new("process.pid", id() as i64),
         ])
     }

--- a/opentelemetry-sdk/src/resource/process.rs
+++ b/opentelemetry-sdk/src/resource/process.rs
@@ -4,7 +4,7 @@
 
 use crate::resource::ResourceDetector;
 use crate::Resource;
-use opentelemetry_api::{KeyValue, Value};
+use opentelemetry_api::{KeyValue, StringValue, Value};
 use std::env::args_os;
 use std::process::id;
 use std::time::Duration;
@@ -24,8 +24,8 @@ impl ResourceDetector for ProcessResourceDetector {
         let arguments = args_os();
         let cmd_arg_val = arguments
             .into_iter()
-            .map(|arg| arg.to_string_lossy().into_owned())
-            .collect::<Vec<String>>();
+            .map(|arg| arg.to_string_lossy().into_owned().into())
+            .collect::<Vec<StringValue>>();
         Resource::new(vec![
             KeyValue::new("process.command_args", Value::Array(cmd_arg_val.into())),
             KeyValue::new("process.pid", id() as i64),

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -497,7 +497,7 @@ impl From<Value> for AttributeValue {
             Value::Bool(v) => attribute_value::Value::BoolValue(v),
             Value::F64(v) => attribute_value::Value::StringValue(to_truncate(v.to_string())),
             Value::I64(v) => attribute_value::Value::IntValue(v),
-            Value::String(v) => attribute_value::Value::StringValue(to_truncate(v.into_owned())),
+            Value::String(v) => attribute_value::Value::StringValue(to_truncate(v.to_string())),
             Value::Array(_) => attribute_value::Value::StringValue(to_truncate(v.to_string())),
         };
         AttributeValue {


### PR DESCRIPTION
This updates attribute `Key` and `Value` inner types from `Cow<'static, str>` to a new private `OtelString` enum to support static, owned, or ref counted values.

Resolves #809