### PR TITLE
Set license metadata for new `-api` and `-sdk` subcrates

### DIFF
--- a/opentelemetry-api/Cargo.toml
+++ b/opentelemetry-api/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "opentelemetry-api"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "opentelemetry-sdk"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
The `opentelemetry-api` and `opentelemetry-sdk` crates were created in https://github.com/open-telemetry/opentelemetry-rust/pull/735 without license metadata. The `LICENSE` files in the respective directories indicate that they're licensed under `Apache-2.0`, so it makes sense to add this information to the crate metadata.

This change is useful for people that have a dependency on the `main` branch and want to use a tool such as [`cargo-lichking`](https://github.com/Nemo157/cargo-lichking) to automatically check the licenses of dependencies for compatibility.