### PR TITLE
Fix span processor stream import

### DIFF
--- a/opentelemetry-dynatrace/tests/http_test.rs
+++ b/opentelemetry-dynatrace/tests/http_test.rs
@@ -130,7 +130,7 @@ mod test {
             .expect("sender error while shutting down http server");
 
         // Reap the task handle to ensure that the server did indeed shut down.
-        let _ = server_handle.await.expect("http server yielded an error");
+        server_handle.await.expect("http server yielded an error");
 
         let mut metric_lines: Vec<&str> = body.lines().collect();
         metric_lines.sort_unstable();

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -14,7 +14,7 @@ dashmap = { version = "=5.1.0", optional = true }
 fnv = { version = "1.0", optional = true }
 futures-channel = "0.3"
 futures-executor = "0.3"
-futures-util = { version = "0.3", default-features = false, features = ["std", "sink", "async-await-macro"] }
+futures-util = { version = "0.3.17", default-features = false, features = ["std", "sink", "async-await-macro"] }
 once_cell = "1.10"
 percent-encoding = { version = "2.0", optional = true }
 pin-project = { version = "1.0.2", optional = true }

--- a/opentelemetry-sdk/src/metrics/aggregators/ddsketch.rs
+++ b/opentelemetry-sdk/src/metrics/aggregators/ddsketch.rs
@@ -851,7 +851,7 @@ mod tests {
                 &DdSketchConfig::new(TEST_ALPHA, TEST_MAX_BINS, TEST_KEY_EPSILON),
                 NumberKind::F64,
             ));
-        let _ = ddsketch
+        ddsketch
             .synchronized_move(&moved_ddsketch, &descriptor)
             .expect("Fail to sync move");
         let moved_ddsketch = moved_ddsketch

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -41,8 +41,7 @@ use futures_channel::oneshot;
 use futures_util::{
     future::{self, BoxFuture, Either},
     select,
-    stream::{self, FusedStream, FuturesUnordered},
-    Stream, StreamExt as _,
+    stream::{self, FusedStream, FuturesUnordered, Stream, StreamExt as _},
 };
 use opentelemetry_api::global;
 use opentelemetry_api::{

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -41,7 +41,8 @@ use futures_channel::oneshot;
 use futures_util::{
     future::{self, BoxFuture, Either},
     select,
-    stream::{self, FusedStream, FuturesUnordered, Stream, StreamExt as _},
+    stream::{self, FusedStream, FuturesUnordered},
+    Stream, StreamExt as _,
 };
 use opentelemetry_api::global;
 use opentelemetry_api::{

--- a/opentelemetry-zpages/src/trace/mod.rs
+++ b/opentelemetry-zpages/src/trace/mod.rs
@@ -47,7 +47,7 @@ pub fn tracez<R: Runtime>(
     let (tx, rx) = async_channel::unbounded();
     let span_processor = span_processor::ZPagesSpanProcessor::new(tx.clone());
     let mut aggregator = aggregator::SpanAggregator::new(rx, sample_size);
-    let _ = runtime.spawn(Box::pin(async move {
+    runtime.spawn(Box::pin(async move {
         aggregator.process().await;
     }));
     (span_processor, TracezQuerier(Arc::new(tx)))


### PR DESCRIPTION
[futures_util < 0.3.17](https://docs.rs/futures-util/0.3.16/futures_util/index.html) does not export `Stream` and `StreamExt` at the root.