### PR TITLE
build: bump thrift to 0.16

### DIFF
--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -37,7 +37,7 @@ pin-project = { version = "1.0", optional = true }
 reqwest = { version = "0.11", default-features = false, optional = true }
 surf = { version = "2.0", default-features = false, optional = true }
 thiserror = "1.0"
-thrift = "0.15"
+thrift = "0.16"
 tokio = { version = "1.0", features = ["net", "sync"], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4.18", optional = true }


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

Thrift forget to bump the version on crates.io for a long time, and recently they do it.