### PR TITLE
Allow Custom Samplers

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## to be released
+
+### Changed
+
+- *BREAKING* `struct`s which implement `ShouldSample` a.k.a Custom Samplers must now
+  implement `Clone`. This enables (#833)
+
 ## v0.1.0
 
 - SDK split from `opentelemetry` crate

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -306,7 +306,7 @@ mod tests {
         Context, Key, Value,
     };
 
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     struct TestSampler {}
 
     impl ShouldSample for TestSampler {


### PR DESCRIPTION
This adds the ability for users to combine custom samplers with the built-in Parent-Based Sampler.