### PR TITLE
Support rustls in jaeger reqwest collector

### DIFF
--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -83,6 +83,7 @@ collector_client = ["http", "opentelemetry-http"]
 isahc_collector_client = ["isahc", "opentelemetry-http/isahc"]
 reqwest_blocking_collector_client = ["reqwest/blocking", "collector_client", "headers", "opentelemetry-http/reqwest"]
 reqwest_collector_client = ["reqwest", "collector_client", "headers", "opentelemetry-http/reqwest"]
+reqwest_rustls_collector_client = ["reqwest", "reqwest/rustls-tls-native-roots", "collector_client", "headers", "opentelemetry-http/reqwest"]
 surf_collector_client = ["surf", "collector_client", "opentelemetry-http/surf"]
 wasm_collector_client = [
     "base64",

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -112,6 +112,7 @@ Then you can use the [`with_collector_endpoint`] method to specify the endpoint:
 // * surf_collector_client
 // * reqwest_collector_client
 // * reqwest_blocking_collector_client
+// * reqwest_rustls_collector_client
 // * isahc_collector_client
 
 // You can also provide your own implementation by enable


### PR DESCRIPTION
Same need as described in https://github.com/open-telemetry/opentelemetry-rust/issues/472 for the zipkin collector we would like to use a feature to control the dependencies downstream. Thanks!