### PR TITLE
Add `SpanExporter::ForceFlush` and default implementation

### DIFF
--- a/opentelemetry-sdk/src/export/trace/mod.rs
+++ b/opentelemetry-sdk/src/export/trace/mod.rs
@@ -45,6 +45,25 @@ pub trait SpanExporter: Send + Debug {
     /// can decide if they want to make the shutdown timeout
     /// configurable.
     fn shutdown(&mut self) {}
+
+    /// This is a hint to ensure that the export of any Spans the exporter
+    /// has received prior to the call to this function SHOULD be completed
+    /// as soon as possible, preferably before returning from this method.
+    ///
+    /// This function SHOULD provide a way to let the caller know
+    /// whether it succeeded, failed or timed out.
+    ///
+    /// This function SHOULD only be called in cases where it is absolutely necessary,
+    /// such as when using some FaaS providers that may suspend the process after
+    /// an invocation, but before the exporter exports the completed spans.
+    ///
+    /// This function SHOULD complete or abort within some timeout. This function can be
+    /// implemented as a blocking API or an asynchronous API which notifies the caller via
+    /// a callback or an event. OpenTelemetry client authors can decide if they want to
+    /// make the flush timeout configurable.
+    fn force_flush(&mut self) -> BoxFuture<'static, ExportResult> {
+        Box::pin(async { Ok(()) })
+    }
 }
 
 /// `SpanData` contains all the information collected by a `Span` and can be used


### PR DESCRIPTION
Add `SpanExporter::ForceFlush`, and default implementation not to affect existing Exporters.

Fixes #836 