### PR TITLE
feat(jaeger): remove internal message queue between exporter and exporting tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ members = [
     "examples/zpages"
 ]
 exclude = ["examples/external-otlp-grpcio-async-std"]
+
+[profile.release]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,3 @@ members = [
     "examples/zpages"
 ]
 exclude = ["examples/external-otlp-grpcio-async-std"]
-
-[profile.release]
-debug = true

--- a/opentelemetry-api/Cargo.toml
+++ b/opentelemetry-api/Cargo.toml
@@ -10,7 +10,7 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
 indexmap = "=1.8"
 once_cell = "1.12.0"
-pin-project-lite = { version = "0.2.9", optional = true }
+pin-project-lite = { version = "0.2", optional = true }
 thiserror = "1"
 tokio-stream = { version = "0.1", optional = true }
 

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -37,7 +37,7 @@ pin-project-lite = { version = "0.2.9", optional = true }
 reqwest = { version = "0.11", default-features = false, optional = true }
 surf = { version = "2.0", optional = true }
 thiserror = "1.0"
-thrift = "0.15"
+thrift = "0.16"
 tokio = { version = "1.0", features = ["net", "sync"], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4.18", optional = true }

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -33,7 +33,7 @@ once_cell = "1.12"
 opentelemetry = { version = "0.17", default-features = false, features = ["trace"], path = "../opentelemetry" }
 opentelemetry-http = { version = "0.6", path = "../opentelemetry-http", optional = true }
 opentelemetry-semantic-conventions = { version = "0.9", path = "../opentelemetry-semantic-conventions" }
-pin-project-lite = { version = "0.2.9", optional = true }
+pin-project-lite = { version = "0.2", optional = true }
 reqwest = { version = "0.11", default-features = false, optional = true }
 surf = { version = "2.0", optional = true }
 thiserror = "1.0"

--- a/opentelemetry-jaeger/src/exporter/config/agent.rs
+++ b/opentelemetry-jaeger/src/exporter/config/agent.rs
@@ -10,6 +10,7 @@ use opentelemetry::sdk::trace::{Config, TracerProvider};
 use opentelemetry::trace::TraceError;
 use std::borrow::BorrowMut;
 use std::{env, net};
+use std::sync::Arc;
 
 /// The max size of UDP packet we want to send, synced with jaeger-agent
 const UDP_PACKET_MAX_LENGTH: usize = 65_000;
@@ -235,7 +236,7 @@ impl AgentPipeline {
             self.trace_config.take(),
             self.transformation_config.service_name.take(),
         );
-        let exporter = Exporter::new_sync(
+        let exporter = Exporter::new(
             process.into(),
             self.transformation_config.export_instrument_library,
             self.build_sync_agent_uploader()?,
@@ -273,10 +274,9 @@ impl AgentPipeline {
             self.transformation_config.service_name.take(),
         );
         let uploader = self.build_async_agent_uploader(runtime.clone())?;
-        let exporter = Exporter::new_async(
+        let exporter = Exporter::new(
             process.into(),
             export_instrument_library,
-            runtime.clone(),
             uploader,
         );
 
@@ -323,10 +323,9 @@ impl AgentPipeline {
             self.transformation_config.service_name.take(),
         );
         let uploader = self.build_async_agent_uploader(runtime.clone())?;
-        Ok(Exporter::new_async(
+        Ok(Exporter::new(
             process.into(),
             export_instrument_library,
-            runtime,
             uploader,
         ))
     }
@@ -337,14 +336,14 @@ impl AgentPipeline {
             self.trace_config.take(),
             self.transformation_config.service_name.take(),
         );
-        Ok(Exporter::new_sync(
+        Ok(Exporter::new(
             process.into(),
             self.transformation_config.export_instrument_library,
             self.build_sync_agent_uploader()?,
         ))
     }
 
-    fn build_async_agent_uploader<R>(self, runtime: R) -> Result<Box<dyn Uploader>, TraceError>
+    fn build_async_agent_uploader<R>(self, runtime: R) -> Result<Arc<dyn Uploader>, TraceError>
     where
         R: JaegerTraceRuntime,
     {
@@ -355,17 +354,17 @@ impl AgentPipeline {
             self.auto_split_batch,
         )
         .map_err::<Error, _>(Into::into)?;
-        Ok(Box::new(AsyncUploader::Agent(agent)))
+        Ok(Arc::new(AsyncUploader::Agent(futures::lock::Mutex::new(agent))))
     }
 
-    fn build_sync_agent_uploader(self) -> Result<Box<dyn Uploader>, TraceError> {
+    fn build_sync_agent_uploader(self) -> Result<Arc<dyn Uploader>, TraceError> {
         let agent = AgentSyncClientUdp::new(
             self.agent_endpoint?.as_slice(),
             self.max_packet_size,
             self.auto_split_batch,
         )
         .map_err::<Error, _>(Into::into)?;
-        Ok(Box::new(SyncUploader::Agent(agent)))
+        Ok(Arc::new(SyncUploader::Agent(std::sync::Mutex::new(agent))))
     }
 }
 

--- a/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
@@ -187,7 +187,7 @@ mod collector_client_tests {
             .with_endpoint("localhost:6831")
             .with_http_client(test_http_client::TestHttpClient);
         let (_, process) = build_config_and_process(None, None);
-        let mut uploader = invalid_uri_builder.build_uploader::<Tokio>()?;
+        let uploader = invalid_uri_builder.build_uploader::<Tokio>()?;
         let res = futures_executor::block_on(async {
             uploader
                 .upload(Batch::new(process.into(), Vec::new()))

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -20,7 +20,6 @@ use self::runtime::JaegerTraceRuntime;
 use self::thrift::jaeger;
 use futures::future::BoxFuture;
 use std::convert::TryInto;
-use std::ops::Deref;
 use std::sync::Arc;
 
 #[cfg(feature = "isahc_collector_client")]
@@ -77,7 +76,6 @@ pub struct Process {
 }
 
 impl trace::SpanExporter for Exporter {
-    /// Export spans to Jaeger
     fn export(&mut self, batch: Vec<trace::SpanData>) -> BoxFuture<'static, trace::ExportResult> {
         let mut jaeger_spans: Vec<jaeger::Span> = Vec::with_capacity(batch.len());
         let process = self.process.clone();

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -18,10 +18,10 @@ use std::convert::TryFrom;
 
 use self::runtime::JaegerTraceRuntime;
 use self::thrift::jaeger;
-use futures::channel::{mpsc, oneshot};
 use futures::future::BoxFuture;
-use futures::StreamExt;
 use std::convert::TryInto;
+use std::ops::Deref;
+use std::sync::Arc;
 
 #[cfg(feature = "isahc_collector_client")]
 #[allow(unused_imports)] // this is actually used to configure authentication
@@ -44,108 +44,25 @@ const INSTRUMENTATION_LIBRARY_NAME: &str = "otel.library.name";
 /// Instrument Library version MUST be reported in Jaeger Span tags with the following key
 const INSTRUMENTATION_LIBRARY_VERSION: &str = "otel.library.version";
 
-#[derive(Debug)]
-enum ExportMessage {
-    Export {
-        batch: Vec<trace::SpanData>,
-        tx: oneshot::Sender<trace::ExportResult>,
-    },
-    Shutdown,
-}
-
 /// Jaeger span exporter
 #[derive(Debug)]
 pub struct Exporter {
-    tx: mpsc::Sender<ExportMessage>,
-
-    // In the switch to concurrent exports, the non-test code which used this
-    // value was moved into the ExporterTask implementation. However, there's
-    // still a test that relies on this value being here, thus the
-    // allow(dead_code).
-    #[allow(dead_code)]
+    /// Whether or not to export instrumentation information.
+    export_instrumentation_lib: bool,
+    uploader: Arc<dyn Uploader>,
     process: jaeger::Process,
 }
 
 impl Exporter {
-    fn new_async<R>(
+    fn new(
         process: jaeger::Process,
         export_instrumentation_lib: bool,
-        runtime: R,
-        uploader: Box<dyn Uploader>,
-    ) -> Exporter
-    where
-        R: JaegerTraceRuntime,
-    {
-        let (tx, rx) = mpsc::channel(64);
-
-        let exporter_task = ExporterTask {
-            rx,
-            export_instrumentation_lib,
-            uploader,
-            process: process.clone(),
-        };
-
-        runtime.spawn(Box::pin(exporter_task.run()));
-
-        Exporter { tx, process }
-    }
-
-    fn new_sync(
-        process: jaeger::Process,
-        export_instrumentation_lib: bool,
-        uploader: Box<dyn Uploader>,
+        uploader: Arc<dyn Uploader>,
     ) -> Exporter {
-        let (tx, rx) = mpsc::channel(64);
-
-        let exporter_task = ExporterTask {
-            rx,
+        Exporter {
             export_instrumentation_lib,
             uploader,
-            process: process.clone(),
-        };
-
-        std::thread::spawn(move || {
-            futures_executor::block_on(exporter_task.run());
-        });
-
-        Exporter { tx, process }
-    }
-}
-
-struct ExporterTask {
-    rx: mpsc::Receiver<ExportMessage>,
-    process: jaeger::Process,
-    /// Whether or not to export instrumentation information.
-    export_instrumentation_lib: bool,
-    uploader: Box<dyn Uploader>,
-}
-
-impl ExporterTask {
-    async fn run(mut self) {
-        while let Some(message) = self.rx.next().await {
-            match message {
-                ExportMessage::Export { batch, tx } => {
-                    let mut jaeger_spans: Vec<jaeger::Span> = Vec::with_capacity(batch.len());
-                    let process = self.process.clone();
-
-                    for span in batch.into_iter() {
-                        jaeger_spans.push(convert_otel_span_into_jaeger_span(
-                            span,
-                            self.export_instrumentation_lib,
-                        ));
-                    }
-
-                    let res = self
-                        .uploader
-                        .upload(jaeger::Batch::new(process, jaeger_spans))
-                        .await;
-
-                    // Errors here might be completely expected if the receiver didn't
-                    // care about the result.
-                    let _ = tx.send(res);
-                }
-                ExportMessage::Shutdown => break,
-            }
+            process,
         }
     }
 }
@@ -162,17 +79,22 @@ pub struct Process {
 impl trace::SpanExporter for Exporter {
     /// Export spans to Jaeger
     fn export(&mut self, batch: Vec<trace::SpanData>) -> BoxFuture<'static, trace::ExportResult> {
-        let (tx, rx) = oneshot::channel();
+        let mut jaeger_spans: Vec<jaeger::Span> = Vec::with_capacity(batch.len());
+        let process = self.process.clone();
 
-        if let Err(err) = self.tx.try_send(ExportMessage::Export { batch, tx }) {
-            return Box::pin(futures::future::ready(Err(Into::into(err))));
+        for span in batch.into_iter() {
+            jaeger_spans.push(convert_otel_span_into_jaeger_span(
+                span,
+                self.export_instrumentation_lib,
+            ));
         }
 
-        Box::pin(async move { rx.await? })
-    }
-
-    fn shutdown(&mut self) {
-        let _ = self.tx.try_send(ExportMessage::Shutdown);
+        let uploader = self.uploader.clone();
+        Box::pin(async move {
+            uploader
+                .upload(jaeger::Batch::new(process, jaeger_spans))
+                .await
+        })
     }
 }
 

--- a/opentelemetry-jaeger/src/exporter/uploader.rs
+++ b/opentelemetry-jaeger/src/exporter/uploader.rs
@@ -11,7 +11,7 @@ use crate::exporter::thrift::jaeger::Batch;
 use crate::exporter::JaegerTraceRuntime;
 
 #[async_trait]
-pub(crate) trait Uploader: Debug + Send + Sync{
+pub(crate) trait Uploader: Debug + Send + Sync {
     async fn upload(&self, batch: jaeger::Batch) -> trace::ExportResult;
 }
 


### PR DESCRIPTION
#781 introduced an internal queue between jaeger exporter's `export` method and uploader that actually handles the exporting because Uploader's `upload` methods takes a mutable reference and hence cannot be called concurrently. 

The internal queue helped unblock #781 but has following problems:
- when sending to collectors we use HTTP clients and those clients are `Send + Sync` thus the queue is not needed.
- The queue has an arbitrary capacity of 64, if we can concurrently export more than 64 spans it can result in span dropping. 

This PR proposes that:
- Make `upload` takes immutable self so that we can call it concurrently.
- Internally add lock around agent uploader 
- Remove the internal queue inside jaeger exporter.

