### PR TITLE
Customisation support in Jaeger Propagator. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
     - name: doc
       run: cargo doc --no-deps --all-features
       env:
+        CARGO_INCREMENTAL: '0'
         RUSTDOCFLAGS: -Dwarnings
     - uses: actions-rs/cargo@v1
       with:

--- a/opentelemetry-jaeger/CHANGELOG.md
+++ b/opentelemetry-jaeger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.16.1
+
+### Changed
+
+- add propagator initialisation with custom headers and baggage prefix
+
 ## v0.16.0
 
 ### Changed

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-jaeger"
-version = "0.16.0"
+version = "0.16.1"
 description = "Jaeger exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger"

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -324,7 +324,6 @@ mod exporter;
 pub mod testing;
 
 mod propagator {
-    use once_cell::sync::Lazy;
     use opentelemetry::{
         global::{self, Error},
         propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -342,8 +342,6 @@ mod propagator {
 
     const TRACE_FLAG_DEBUG: TraceFlags = TraceFlags::new(0x04);
 
-    static JAEGER_HEADER_FIELD: Lazy<[String; 1]> = Lazy::new(|| [JAEGER_HEADER.to_owned()]);
-
     /// The Jaeger propagator propagates span contexts in [Jaeger propagation format].
     ///
     /// Cross-cutting concerns send their state to the next process using `Propagator`s,

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -424,21 +424,21 @@ mod propagator {
             custom_header_name: &'static str,
             custom_baggage_prefix: &'static str,
         ) -> Self {
-            let custom_header_name = if custom_header_name.len() > 0 {
-                custom_header_name
-            } else {
+            let custom_header_name = if custom_header_name.trim().is_empty() {
                 JAEGER_HEADER
+            } else {
+                custom_header_name
             };
 
-            let custom_baggage_prefix = if custom_baggage_prefix.len() > 0 {
-                custom_baggage_prefix
-            } else {
+            let custom_baggage_prefix = if custom_baggage_prefix.trim().is_empty() {
                 JAEGER_BAGGAGE_PREFIX
+            } else {
+                custom_baggage_prefix
             };
 
             Propagator {
-                baggage_prefix: custom_baggage_prefix,
-                header_name: custom_header_name,
+                baggage_prefix: custom_baggage_prefix.trim(),
+                header_name: custom_header_name.trim(),
                 fields: [custom_header_name.to_owned()],
             }
         }
@@ -803,22 +803,30 @@ mod propagator {
 
         #[test]
         fn test_extract_with_invalid_header() {
-            _test_extract_with_header("", JAEGER_HEADER)
+            for construct in &["", "   "] {
+                _test_extract_with_header(construct, JAEGER_HEADER)
+            }
         }
 
         #[test]
         fn test_extract_with_valid_header() {
-            _test_extract_with_header("custom-header", "custom-header")
+            for construct in &["custom-header", "custom-header   ", "   custom-header   "] {
+                _test_extract_with_header(construct, "custom-header")
+            }
         }
 
         #[test]
         fn test_inject_with_invalid_header() {
-            _test_inject_with_header("", JAEGER_HEADER)
+            for construct in &["", "   "] {
+                _test_inject_with_header(construct, JAEGER_HEADER)
+            }
         }
 
         #[test]
         fn test_inject_with_valid_header() {
-            _test_inject_with_header("custom-header", "custom-header")
+            for construct in &["custom-header", "custom-header   ", "   custom-header   "] {
+                _test_inject_with_header(construct, "custom-header")
+            }
         }
     }
 }


### PR DESCRIPTION
Add the possibility to specify custom context header and baggage prefix names in the Jaeger propagator. 

By applying this PR, anyone would be able to initialize the Jaeger propagator with a custom header name and baggage prefixes: 

```rust 
// Old way with default "uber-trace-id" and "uberctx-"
opentelemetry_jaeger::Propagator::new()
// Old way with default "uber-trace-id" and "uberctx-"
opentelemetry_jaeger::Propagator::default()

// With custom "x-my-custom-context-id" and default baggage prefix "uberctx-"
opentelemetry_jaeger::Propagator::with_custom_header("x-my-custom-context-id")

// With custom "x-my-custom-context-id" and custom baggage prefix "my-baggage-"
opentelemetry_jaeger::Propagator::with_custom_header_and_baggage("x-my-custom-context-id", "my-baggage-")

```