### PR TITLE
Add IPv6 support for Jaeger agent addresses

### DIFF
--- a/opentelemetry-jaeger/src/exporter/agent.rs
+++ b/opentelemetry-jaeger/src/exporter/agent.rs
@@ -101,7 +101,7 @@ pub(crate) struct AgentAsyncClientUdp<R: JaegerTraceRuntime> {
 impl<R: JaegerTraceRuntime> AgentAsyncClientUdp<R> {
     /// Create a new UDP agent client
     pub(crate) fn new<T: ToSocketAddrs>(
-        host_port: T,
+        agent_endpoint: T,
         max_packet_size: usize,
         runtime: R,
         auto_split: bool,
@@ -112,7 +112,7 @@ impl<R: JaegerTraceRuntime> AgentAsyncClientUdp<R> {
             TCompactOutputProtocol::new(write),
         );
 
-        let conn = runtime.create_socket(host_port)?;
+        let conn = runtime.create_socket(agent_endpoint)?;
 
         Ok(AgentAsyncClientUdp {
             runtime,

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -78,12 +78,15 @@ impl JaegerTraceRuntime for opentelemetry::runtime::AsyncStd {
 }
 
 /// Sample the first address provided to designate which IP family to bind the socket to.
-/// Returns either INADDR_ANY or IN6ADDR_ANY
-fn addrs_and_family(host_port: &impl ToSocketAddrs) -> Result<(Vec<SocketAddr>, SocketAddr), io::Error> {
+/// IP families returned be INADDR_ANY as [`Ipv4Addr::UNSPECIFIED`] or
+/// IN6ADDR_ANY as [`Ipv6Addr::UNSPECIFIED`].
+fn addrs_and_family(
+    host_port: &impl ToSocketAddrs,
+) -> Result<(Vec<SocketAddr>, SocketAddr), io::Error> {
     let addrs = host_port.to_socket_addrs()?.collect::<Vec<_>>();
     let family = match addrs.first() {
-        Some(SocketAddr::V4(_)) | None => SocketAddr::from((Ipv4Addr::new(0, 0, 0, 0), 0)),
-        Some(SocketAddr::V6(_)) => SocketAddr::from((Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), 0)),
+        Some(SocketAddr::V4(_)) | None => SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)),
+        Some(SocketAddr::V6(_)) => SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0)),
     };
     Ok((addrs, family))
 }

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -80,7 +80,11 @@ impl JaegerTraceRuntime for opentelemetry::runtime::AsyncStd {
 /// Sample the first address provided to designate which IP family to bind the socket to.
 /// IP families returned be INADDR_ANY as [`Ipv4Addr::UNSPECIFIED`] or
 /// IN6ADDR_ANY as [`Ipv6Addr::UNSPECIFIED`].
-#[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread", feature = "rt-async-std"))]
+#[cfg(any(
+    feature = "rt-tokio",
+    feature = "rt-tokio-current-thread",
+    feature = "rt-async-std"
+))]
 fn addrs_and_family(
     host_port: &impl ToSocketAddrs,
 ) -> Result<(Vec<SocketAddr>, SocketAddr), io::Error> {

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -11,7 +11,7 @@ pub trait JaegerTraceRuntime: TraceRuntime + std::fmt::Debug {
     type Socket: std::fmt::Debug + Send + Sync;
 
     /// Create a new communication socket.
-    fn create_socket<T: ToSocketAddrs>(&self, host_port: T) -> thrift::Result<Self::Socket>;
+    fn create_socket<T: ToSocketAddrs>(&self, endpoint: T) -> thrift::Result<Self::Socket>;
 
     /// Send payload over the socket.
     async fn write_to_socket(&self, socket: &Self::Socket, payload: Vec<u8>) -> thrift::Result<()>;
@@ -22,9 +22,9 @@ pub trait JaegerTraceRuntime: TraceRuntime + std::fmt::Debug {
 impl JaegerTraceRuntime for opentelemetry::runtime::Tokio {
     type Socket = tokio::net::UdpSocket;
 
-    fn create_socket<T: ToSocketAddrs>(&self, host_port: T) -> thrift::Result<Self::Socket> {
-        let conn = std::net::UdpSocket::bind(bind_addr(&host_port))?;
-        conn.connect(host_port)?;
+    fn create_socket<T: ToSocketAddrs>(&self, endpoint: T) -> thrift::Result<Self::Socket> {
+        let conn = std::net::UdpSocket::bind(bind_addr(&endpoint))?;
+        conn.connect(endpoint)?;
         Ok(tokio::net::UdpSocket::from_std(conn)?)
     }
 
@@ -40,9 +40,9 @@ impl JaegerTraceRuntime for opentelemetry::runtime::Tokio {
 impl JaegerTraceRuntime for opentelemetry::runtime::TokioCurrentThread {
     type Socket = tokio::net::UdpSocket;
 
-    fn create_socket<T: ToSocketAddrs>(&self, host_port: T) -> thrift::Result<Self::Socket> {
-        let conn = std::net::UdpSocket::bind(bind_addr(&host_port))?;
-        conn.connect(host_port)?;
+    fn create_socket<T: ToSocketAddrs>(&self, endpoint: T) -> thrift::Result<Self::Socket> {
+        let conn = std::net::UdpSocket::bind(bind_addr(&endpoint))?;
+        conn.connect(endpoint)?;
         Ok(tokio::net::UdpSocket::from_std(conn)?)
     }
 
@@ -58,9 +58,9 @@ impl JaegerTraceRuntime for opentelemetry::runtime::TokioCurrentThread {
 impl JaegerTraceRuntime for opentelemetry::runtime::AsyncStd {
     type Socket = async_std::net::UdpSocket;
 
-    fn create_socket<T: ToSocketAddrs>(&self, host_port: T) -> thrift::Result<Self::Socket> {
-        let conn = std::net::UdpSocket::bind(bind_addr(&host_port))?;
-        conn.connect(host_port)?;
+    fn create_socket<T: ToSocketAddrs>(&self, endpoint: T) -> thrift::Result<Self::Socket> {
+        let conn = std::net::UdpSocket::bind(bind_addr(&endpoint))?;
+        conn.connect(endpoint)?;
         Ok(async_std::net::UdpSocket::from(conn))
     }
 

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -80,6 +80,7 @@ impl JaegerTraceRuntime for opentelemetry::runtime::AsyncStd {
 /// Sample the first address provided to designate which IP family to bind the socket to.
 /// IP families returned be INADDR_ANY as [`Ipv4Addr::UNSPECIFIED`] or
 /// IN6ADDR_ANY as [`Ipv6Addr::UNSPECIFIED`].
+#[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread", feature = "rt-async-std"))]
 fn addrs_and_family(
     host_port: &impl ToSocketAddrs,
 ) -> Result<(Vec<SocketAddr>, SocketAddr), io::Error> {

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -1,8 +1,14 @@
 use async_trait::async_trait;
 use opentelemetry::sdk::trace::TraceRuntime;
+use std::net::ToSocketAddrs;
+#[cfg(any(
+    feature = "rt-tokio",
+    feature = "rt-tokio-current-thread",
+    feature = "rt-async-std"
+))]
 use std::{
     io,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
 };
 
 /// Jaeger Trace Runtime is an extension to [`TraceRuntime`].


### PR DESCRIPTION
This adds support to setup socket binding to IN6ADDR_ANY and INADDR_ANY depending on which IP address family is provided as the agent endpoint.

Addresses #855