### PR TITLE
Fix XrayPropagator when no header is present

### DIFF
--- a/opentelemetry-aws/src/lib.rs
+++ b/opentelemetry-aws/src/lib.rs
@@ -203,11 +203,9 @@ pub mod trace {
         }
 
         fn extract_with_context(&self, cx: &Context, extractor: &dyn Extractor) -> Context {
-            let extracted = self
-                .extract_span_context(extractor)
-                .unwrap_or_else(|_| SpanContext::empty_context());
-
-            cx.with_remote_span_context(extracted)
+            self.extract_span_context(extractor)
+                .map(|sc| cx.with_remote_span_context(sc))
+                .unwrap_or_else(|_| cx.clone())
         }
 
         fn fields(&self) -> FieldIter<'_> {


### PR DESCRIPTION
This corrects an issue where using `XrayPropagator` without the `x-amzn-trace-id` trace header present would cause spans not to get logged/processed.

#### Background

My use case is in a project that combines `tracing`, `tracing-opentelemetry`, `opentelemetry`, and `opentelemetry-jaeger`.

I initially had everything working, but when I added the `XrayPropagator` I noticed that my spans were no longer appearing in jaeger when I made requests directly to my service. I then switched to `TraceContextPropagator` and everything worked again.

This change simply copies the logic used in `TraceContextPropagator` into `XrayPropagator`.

I tested it in my local project and confirmed that with this change traces without a parent are still appearing in `jaeger`.