### PR TITLE
Cleanup external-otlp examples

### DIFF
--- a/examples/external-otlp-grpcio-async-std/Cargo.toml
+++ b/examples/external-otlp-grpcio-async-std/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 async-std = { version = "= 1.10.0", features = ["attributes"] }
-env_logger = "0.8.2"
+env_logger = "0.9.0"
 opentelemetry = { path = "../../opentelemetry", features = ["rt-async-std"] }
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = [
     "grpc-sys",

--- a/examples/external-otlp-tonic-tokio/Cargo.toml
+++ b/examples/external-otlp-tonic-tokio/Cargo.toml
@@ -5,9 +5,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-opentelemetry = { path = "../../opentelemetry", features = ["rt-tokio", "metrics"] }
-opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic", "tls", "tls-roots"] }
+env_logger = "0.9.0"
+opentelemetry = {path = "../../opentelemetry", features = ["rt-tokio", "metrics"]}
+opentelemetry-otlp = {path = "../../opentelemetry-otlp", features = ["tonic", "tls", "tls-roots"]}
 serde_json = "1.0"
-tokio = { version = "1.0", features = ["full"] }
-tonic = { version = "0.8.0", features = ["tls"] }
+tokio = {version = "1.0", features = ["full"]}
+tonic = {version = "0.8.0", features = ["tls"]}
 url = "2.2.0"


### PR DESCRIPTION
* Fix comment header to use simpler language
* Fix comment header to refer to correct binary
* Coalesce use statements
* Update env_logger to 0.9.0
* ensure that both examples are formatted the same