### PR TITLE
Match API and SDK crate name underscores

### DIFF
--- a/examples/jaeger-remote-sampler/Cargo.toml
+++ b/examples/jaeger-remote-sampler/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-opentelemetry-sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio", "jaeger_remote_sampler"] }
-opentelemetry-api = { path = "../../opentelemetry-api" }
+opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio", "jaeger_remote_sampler"] }
+opentelemetry_api = { path = "../../opentelemetry-api" }
 opentelemetry-http = { path = "../../opentelemetry-http", features = ["reqwest"] }
 reqwest = "0.11.10"
 tokio = { version = "1.18", features = ["macros", "rt-multi-thread"] }

--- a/opentelemetry-api/Cargo.toml
+++ b/opentelemetry-api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "opentelemetry-api"
+name = "opentelemetry_api"
 version = "0.18.0"
 description = "OpenTelemetry is a metrics collection and distributed tracing framework"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"

--- a/opentelemetry-api/README.md
+++ b/opentelemetry-api/README.md
@@ -6,9 +6,9 @@
 
 The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
 
-[![Crates.io: opentelemetry-api](https://img.shields.io/crates/v/opentelemetry-api.svg)](https://crates.io/crates/opentelemetry-api)
-[![Documentation](https://docs.rs/opentelemetry-api/badge.svg)](https://docs.rs/opentelemetry-api)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-api)](./LICENSE)
+[![Crates.io: opentelemetry-api](https://img.shields.io/crates/v/opentelemetry_api.svg)](https://crates.io/crates/opentelemetry_api)
+[![Documentation](https://docs.rs/opentelemetry_api/badge.svg)](https://docs.rs/opentelemetry_api)
+[![LICENSE](https://img.shields.io/crates/l/opentelemetry_api)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![codecov](https://codecov.io/gh/open-telemetry/opentelemetry-rust/branch/main/graph/badge.svg)](https://codecov.io/gh/open-telemetry/opentelemetry-rust)
 [![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "1"
 http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["http2", "client", "tcp"], optional = true }
 isahc = { version = "1.4", default-features = false, optional = true }
-opentelemetry-api = { version = "0.18", path = "../opentelemetry-api", features = ["trace"] }
+opentelemetry_api = { version = "0.18", path = "../opentelemetry-api", features = ["trace"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking"], optional = true }
 surf = { version = "2.0", default-features = false, optional = true }
 tokio = { version = "1.0", default-features = false, features = ["time"], optional = true }

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "opentelemetry-sdk"
+name = "opentelemetry_sdk"
 version = "0.18.0"
 description = "The SDK for the OpenTelemetry metrics collection and distributed tracing framework"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-opentelemetry-api = { version = "0.18", path = "../opentelemetry-api/" }
+opentelemetry_api = { version = "0.18", path = "../opentelemetry-api/" }
 opentelemetry-http = { version = "0.7.0", path = "../opentelemetry-http", optional = true }
 async-std = { version = "1.6", features = ["unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
@@ -42,10 +42,10 @@ rand_distr = "0.4.0"
 
 [features]
 default = ["trace"]
-trace = ["opentelemetry-api/trace", "crossbeam-channel", "rand", "async-trait", "percent-encoding"]
+trace = ["opentelemetry_api/trace", "crossbeam-channel", "rand", "async-trait", "percent-encoding"]
 jaeger_remote_sampler = ["trace", "opentelemetry-http", "http", "serde", "serde_json", "url"]
-metrics = ["opentelemetry-api/metrics", "dashmap", "fnv"]
-testing = ["opentelemetry-api/testing", "trace", "metrics", "rt-async-std", "rt-tokio", "rt-tokio-current-thread", "tokio/macros", "tokio/rt-multi-thread"]
+metrics = ["opentelemetry_api/metrics", "dashmap", "fnv"]
+testing = ["opentelemetry_api/testing", "trace", "metrics", "rt-async-std", "rt-tokio", "rt-tokio-current-thread", "tokio/macros", "tokio/rt-multi-thread"]
 rt-tokio = ["tokio", "tokio-stream"]
 rt-tokio-current-thread = ["tokio", "tokio-stream"]
 rt-async-std = ["async-std"]

--- a/opentelemetry-sdk/README.md
+++ b/opentelemetry-sdk/README.md
@@ -6,9 +6,9 @@
 
 The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
 
-[![Crates.io: opentelemetry-sdk](https://img.shields.io/crates/v/opentelemetry-sdk.svg)](https://crates.io/crates/opentelemetry-sdk)
-[![Documentation](https://docs.rs/opentelemetry-sdk/badge.svg)](https://docs.rs/opentelemetry-sdk)
-[![LICENSE](https://img.shields.io/crates/l/opentelemetry-sdk)](./LICENSE)
+[![Crates.io: opentelemetry-sdk](https://img.shields.io/crates/v/opentelemetry_sdk.svg)](https://crates.io/crates/opentelemetry_sdk)
+[![Documentation](https://docs.rs/opentelemetry_sdk/badge.svg)](https://docs.rs/opentelemetry_sdk)
+[![LICENSE](https://img.shields.io/crates/l/opentelemetry_sdk)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![codecov](https://codecov.io/gh/open-telemetry/opentelemetry-rust/branch/main/graph/badge.svg)](https://codecov.io/gh/open-telemetry/opentelemetry-rust)
 [![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -21,14 +21,14 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-opentelemetry-api = { version = "0.18.0", path = "../opentelemetry-api" }
-opentelemetry-sdk = { version = "0.18.0", path = "../opentelemetry-sdk" }
+opentelemetry_api = { version = "0.18.0", path = "../opentelemetry-api" }
+opentelemetry_sdk = { version = "0.18.0", path = "../opentelemetry-sdk" }
 
 [features]
 default = ["trace"]
-trace = ["opentelemetry-api/trace", "opentelemetry-sdk/trace"]
-metrics = ["opentelemetry-api/metrics", "opentelemetry-sdk/metrics"]
-testing = ["opentelemetry-api/testing", "opentelemetry-sdk/testing"]
-rt-tokio = ["opentelemetry-sdk/rt-tokio"]
-rt-tokio-current-thread = ["opentelemetry-sdk/rt-tokio-current-thread"]
-rt-async-std = ["opentelemetry-sdk/rt-async-std"]
+trace = ["opentelemetry_api/trace", "opentelemetry_sdk/trace"]
+metrics = ["opentelemetry_api/metrics", "opentelemetry_sdk/metrics"]
+testing = ["opentelemetry_api/testing", "opentelemetry_sdk/testing"]
+rt-tokio = ["opentelemetry_sdk/rt-tokio"]
+rt-tokio-current-thread = ["opentelemetry_sdk/rt-tokio-current-thread"]
+rt-async-std = ["opentelemetry_sdk/rt-async-std"]


### PR DESCRIPTION
The existing [api](https://crates.io/crates/opentelemetry_api) and [sdk](https://crates.io/crates/opentelemetry_sdk) crates that this will replace were previously registered with underscores, so this matches that to enable publishing.