### PR TITLE
fix(datadog): send resource along with attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: test
-        args: -p opentelemetry -p opentelemetry-api -p opentelemetry-sdk -p opentelemetry-aws -p opentelemetry-jaeger -p opentelemetry-datadog -p opentelemetry-dynatrace -p opentelemetry-zipkin --all-features --no-fail-fast
+        args: -p opentelemetry -p opentelemetry_api -p opentelemetry_sdk -p opentelemetry-aws -p opentelemetry-jaeger -p opentelemetry-datadog -p opentelemetry-dynatrace -p opentelemetry-zipkin --all-features --no-fail-fast
       env:
         CARGO_INCREMENTAL: '0'
         RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'

--- a/opentelemetry-datadog/src/exporter/model/v03.rs
+++ b/opentelemetry-datadog/src/exporter/model/v03.rs
@@ -90,7 +90,14 @@ where
             )?;
 
             rmp::encode::write_str(&mut encoded, "meta")?;
-            rmp::encode::write_map_len(&mut encoded, span.attributes.len() as u32)?;
+            rmp::encode::write_map_len(
+                &mut encoded,
+                (span.attributes.len() + span.resource.len()) as u32,
+            )?;
+            for (key, value) in span.resource.iter() {
+                rmp::encode::write_str(&mut encoded, key.as_str())?;
+                rmp::encode::write_str(&mut encoded, value.as_str().as_ref())?;
+            }
             for (key, value) in span.attributes.iter() {
                 rmp::encode::write_str(&mut encoded, key.as_str())?;
                 rmp::encode::write_str(&mut encoded, value.as_str().as_ref())?;

--- a/opentelemetry-datadog/src/exporter/model/v05.rs
+++ b/opentelemetry-datadog/src/exporter/model/v05.rs
@@ -157,7 +157,14 @@ where
                     _ => 0,
                 },
             )?;
-            rmp::encode::write_map_len(&mut encoded, span.attributes.len() as u32)?;
+            rmp::encode::write_map_len(
+                &mut encoded,
+                (span.attributes.len() + span.resource.len()) as u32,
+            )?;
+            for (key, value) in span.resource.iter() {
+                rmp::encode::write_u32(&mut encoded, interner.intern(key.as_str()))?;
+                rmp::encode::write_u32(&mut encoded, interner.intern(value.as_str().as_ref()))?;
+            }
             for (key, value) in span.attributes.iter() {
                 rmp::encode::write_u32(&mut encoded, interner.intern(key.as_str()))?;
                 rmp::encode::write_u32(&mut encoded, interner.intern(value.as_str().as_ref()))?;


### PR DESCRIPTION
fix #876 

Added resource along with the attributes when converting span to datadog format.

One follow-up would be to adopt our model to be consistent with [datadog's agent](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/otlp.go), which converts the OTLP span to Datadog span. 