### PR TITLE
pub use tonic's MetadataMap

### DIFF
--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -1,5 +1,5 @@
 use crate::ExportConfig;
-use tonic::metadata::MetadataMap;
+pub use tonic::metadata::MetadataMap;
 #[cfg(feature = "tls")]
 use tonic::transport::ClientTlsConfig;
 

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -215,7 +215,7 @@ pub use crate::exporter::grpcio::{Compression, Credentials, GrpcioExporterBuilde
 #[cfg(feature = "http-proto")]
 pub use crate::exporter::http::HttpExporterBuilder;
 #[cfg(feature = "grpc-tonic")]
-pub use crate::exporter::tonic::TonicExporterBuilder;
+pub use crate::exporter::tonic::{MetadataMap, TonicExporterBuilder};
 
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
It seems silly to need to add tonic as an explicit dependency to be able to add metadata to requests, for instance to send data to Honeycomb (x-honeycomb-team header with API key).

Let's reexport it.