### PR TITLE
Fix `otel-collector-config.yaml` for insecure Jaeger connections

### DIFF
--- a/examples/basic-otlp-http/otel-collector-config.yaml
+++ b/examples/basic-otlp-http/otel-collector-config.yaml
@@ -10,7 +10,8 @@ exporters:
 
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:

--- a/examples/basic-otlp/otel-collector-config.yaml
+++ b/examples/basic-otlp/otel-collector-config.yaml
@@ -10,7 +10,8 @@ exporters:
 
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:


### PR DESCRIPTION
The latest exporter deployment will complain about the invalid configure ion, which now has moved to a new `tls` key.
