### PR TITLE
pub use `opentelemetry_api::trace::WithContext`

### DIFF
--- a/opentelemetry-api/src/trace/mod.rs
+++ b/opentelemetry-api/src/trace/mod.rs
@@ -175,7 +175,9 @@ mod tracer;
 mod tracer_provider;
 
 pub use self::{
-    context::{get_active_span, mark_span_as_active, FutureExt, SpanRef, TraceContextExt},
+    context::{
+        get_active_span, mark_span_as_active, FutureExt, SpanRef, TraceContextExt, WithContext,
+    },
     order_map::OrderMap,
     span::{Span, SpanKind, Status},
     span_context::{SpanContext, SpanId, TraceFlags, TraceId, TraceState},


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-rust/issues/823

This scenario is specifically meant to make instrumenting async functions with contexts:

```rust
pub trait InstrumentWithContext: Instrument {
    fn instrument_cx(self, span: tracing::Span) -> Instrumented<WithContext<Self>>;
}

impl<T> InstrumentWithContext for T
where
    T: Instrument,
{
    fn instrument_cx(self, span: tracing::Span) -> Instrumented<WithContext<T>> {
        self.with_context(span.context()).instrument(span)
    }
}
```

Right now, calling `some_async_fn().instrument(tracing_span)` does not set the span's context as the `some_async_fn`'s current `Context`. 

Instead, the current flow is to chain both methods: `some_async_fn().with_context(span.context()).instrument(span).await`

This is a first step to bundling ot Contexts more consistently.

Traits involved:
* [`tracing::instrument::Instrument`](https://docs.rs/tracing/latest/tracing/instrument/trait.Instrument.html)
* [`opentelemetry::trace::FutureExt`](https://docs.rs/opentelemetry/latest/opentelemetry/trace/trait.FutureExt.html#method.with_context)