### PR TITLE
Headers on exporters

### DIFF
--- a/opentelemetry-otlp/src/exporter/grpcio.rs
+++ b/opentelemetry-otlp/src/exporter/grpcio.rs
@@ -25,7 +25,10 @@ pub struct GrpcioConfig {
 impl Default for GrpcioConfig {
     fn default() -> Self {
         let mut headers: HashMap<String, String> = HashMap::new();
-        headers.insert("User-Agent".to_string(), format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")));
+        headers.insert(
+            "User-Agent".to_string(),
+            format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")),
+        );
         GrpcioConfig {
             credentials: None,
             headers: Some(headers),

--- a/opentelemetry-otlp/src/exporter/grpcio.rs
+++ b/opentelemetry-otlp/src/exporter/grpcio.rs
@@ -3,6 +3,8 @@ use crate::ExportConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use super::default_headers;
+
 /// Configuration of grpcio
 #[derive(Debug)]
 pub struct GrpcioConfig {
@@ -24,14 +26,9 @@ pub struct GrpcioConfig {
 
 impl Default for GrpcioConfig {
     fn default() -> Self {
-        let mut headers: HashMap<String, String> = HashMap::new();
-        headers.insert(
-            "User-Agent".to_string(),
-            format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")),
-        );
         GrpcioConfig {
             credentials: None,
-            headers: Some(headers),
+            headers: Some(default_headers()),
             compression: None,
             use_tls: None,
             completion_queue_count: 2,

--- a/opentelemetry-otlp/src/exporter/grpcio.rs
+++ b/opentelemetry-otlp/src/exporter/grpcio.rs
@@ -25,7 +25,7 @@ pub struct GrpcioConfig {
 impl Default for GrpcioConfig {
     fn default() -> Self {
         let mut headers: HashMap<String, String> = HashMap::new();
-        headers.insert("User-Agent".to_string(), format!("OTel OLTP Exporter Rust/{}", env!("CARGO_PKG_VERSION")));
+        headers.insert("User-Agent".to_string(), format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")));
         GrpcioConfig {
             credentials: None,
             headers: Some(headers),

--- a/opentelemetry-otlp/src/exporter/grpcio.rs
+++ b/opentelemetry-otlp/src/exporter/grpcio.rs
@@ -24,9 +24,11 @@ pub struct GrpcioConfig {
 
 impl Default for GrpcioConfig {
     fn default() -> Self {
+        let mut headers: HashMap<String, String> = HashMap::new();
+        headers.insert("User-Agent".to_string(), format!("OTel OLTP Exporter Rust/{}", env!("CARGO_PKG_VERSION")));
         GrpcioConfig {
             credentials: None,
-            headers: None,
+            headers: Some(headers),
             compression: None,
             use_tls: None,
             completion_queue_count: 2,
@@ -85,7 +87,9 @@ impl GrpcioExporterBuilder {
 
     /// Set additional headers to send to the collector.
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
-        self.grpcio_config.headers = Some(headers);
+        let mut inst_headers = self.http_config.headers.unwrap_or_default();
+        inst_headers.extend(headers.into_iter());
+        self.grpcio_config.headers = Some(inst_headers);
         self
     }
 

--- a/opentelemetry-otlp/src/exporter/grpcio.rs
+++ b/opentelemetry-otlp/src/exporter/grpcio.rs
@@ -87,7 +87,7 @@ impl GrpcioExporterBuilder {
 
     /// Set additional headers to send to the collector.
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
-        let mut inst_headers = self.http_config.headers.unwrap_or_default();
+        let mut inst_headers = self.grpcio_config.headers.unwrap_or_default();
         inst_headers.extend(headers.into_iter());
         self.grpcio_config.headers = Some(inst_headers);
         self

--- a/opentelemetry-otlp/src/exporter/http.rs
+++ b/opentelemetry-otlp/src/exporter/http.rs
@@ -66,12 +66,16 @@ pub struct HttpExporterBuilder {
 
 impl Default for HttpExporterBuilder {
     fn default() -> Self {
+        let mut headers: HashMap<String, String> = HashMap::new();
+        headers.insert("User-Agent".to_string(), format!("OTel OLTP Exporter Rust/{}", env!("CARGO_PKG_VERSION")));
+        let mut default_config = HttpConfig::default();
+        default_config.headers = Some(headers);
         HttpExporterBuilder {
             exporter_config: ExportConfig {
                 protocol: Protocol::HttpBinary,
                 ..ExportConfig::default()
             },
-            http_config: HttpConfig::default(),
+            http_config: default_config,
         }
     }
 }
@@ -85,7 +89,10 @@ impl HttpExporterBuilder {
 
     /// Set additional headers to send to the collector.
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
-        self.http_config.headers = Some(headers);
+        // headers will be wrapped, so we must do some logic to unwrap first.
+        let mut inst_headers = self.http_config.headers.unwrap_or_default();
+        inst_headers.extend(headers.into_iter());
+        self.http_config.headers = Some(inst_headers);
         self
     }
 }

--- a/opentelemetry-otlp/src/exporter/http.rs
+++ b/opentelemetry-otlp/src/exporter/http.rs
@@ -67,7 +67,7 @@ pub struct HttpExporterBuilder {
 impl Default for HttpExporterBuilder {
     fn default() -> Self {
         let mut headers: HashMap<String, String> = HashMap::new();
-        headers.insert("User-Agent".to_string(), format!("OTel OLTP Exporter Rust/{}", env!("CARGO_PKG_VERSION")));
+        headers.insert("User-Agent".to_string(), format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")));
         let mut default_config = HttpConfig::default();
         default_config.headers = Some(headers);
         HttpExporterBuilder {

--- a/opentelemetry-otlp/src/exporter/http.rs
+++ b/opentelemetry-otlp/src/exporter/http.rs
@@ -67,7 +67,10 @@ pub struct HttpExporterBuilder {
 impl Default for HttpExporterBuilder {
     fn default() -> Self {
         let mut headers: HashMap<String, String> = HashMap::new();
-        headers.insert("User-Agent".to_string(), format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")));
+        headers.insert(
+            "User-Agent".to_string(),
+            format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")),
+        );
         let mut default_config = HttpConfig::default();
         default_config.headers = Some(headers);
         HttpExporterBuilder {

--- a/opentelemetry-otlp/src/exporter/http.rs
+++ b/opentelemetry-otlp/src/exporter/http.rs
@@ -71,14 +71,16 @@ impl Default for HttpExporterBuilder {
             "User-Agent".to_string(),
             format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")),
         );
-        let mut default_config = HttpConfig::default();
-        default_config.headers = Some(headers);
+
         HttpExporterBuilder {
             exporter_config: ExportConfig {
                 protocol: Protocol::HttpBinary,
                 ..ExportConfig::default()
             },
-            http_config: default_config,
+            http_config: HttpConfig {
+                headers: Some(headers),
+                ..HttpConfig::default()
+            },
         }
     }
 }

--- a/opentelemetry-otlp/src/exporter/http.rs
+++ b/opentelemetry-otlp/src/exporter/http.rs
@@ -3,6 +3,8 @@ use opentelemetry_http::HttpClient;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use super::default_headers;
+
 /// Configuration of the http transport
 #[cfg(feature = "http-proto")]
 #[derive(Debug)]
@@ -66,19 +68,13 @@ pub struct HttpExporterBuilder {
 
 impl Default for HttpExporterBuilder {
     fn default() -> Self {
-        let mut headers: HashMap<String, String> = HashMap::new();
-        headers.insert(
-            "User-Agent".to_string(),
-            format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")),
-        );
-
         HttpExporterBuilder {
             exporter_config: ExportConfig {
                 protocol: Protocol::HttpBinary,
                 ..ExportConfig::default()
             },
             http_config: HttpConfig {
-                headers: Some(headers),
+                headers: Some(default_headers()),
                 ..HttpConfig::default()
             },
         }

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -9,6 +9,7 @@ use crate::exporter::http::HttpExporterBuilder;
 #[cfg(feature = "grpc-tonic")]
 use crate::exporter::tonic::TonicExporterBuilder;
 use crate::Protocol;
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -51,6 +52,16 @@ impl Default for ExportConfig {
             timeout: Duration::from_secs(OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT),
         }
     }
+}
+
+/// default user-agent headers
+fn default_headers() -> HashMap<String, String> {
+    let mut headers = HashMap::new();
+    headers.insert(
+        "User-Agent".to_string(),
+        format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")),
+    );
+    headers
 }
 
 /// Provide access to the export config field within the exporter builders.

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -38,7 +38,10 @@ impl Default for TonicExporterBuilder {
         let mut map = MetadataMap::new();
         map.insert(
             "User-Agent",
-            format!("OTel OLTP Exporter Rust/{}", env!("CARGO_PKG_VERSION")).as_str().parse().unwrap(),
+            format!("OTel OLTP Exporter Rust/{}", env!("CARGO_PKG_VERSION"))
+                .as_str()
+                .parse()
+                .unwrap(),
         );
         tonic_config.metadata = Some(map);
         TonicExporterBuilder {
@@ -59,7 +62,12 @@ impl TonicExporterBuilder {
 
     /// Set custom metadata entries to send to the collector.
     pub fn with_metadata(mut self, metadata: MetadataMap) -> Self {
-        self.tonic_config.metadata = Some(metadata);
+        // extending metadatamaps is harder than just casting back/forth
+        let incoming_headers = metadata.into_headers();
+        let mut existing_headers = self.tonic_config.metadata.unwrap_or_default().into_headers();
+        existing_headers.extend(incoming_headers.into_iter());
+
+        self.tonic_config.metadata = Some(MetadataMap::from_headers(existing_headers));
         self
     }
 

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -1,8 +1,9 @@
 use crate::ExportConfig;
-use http::HeaderMap;
 use tonic::metadata::MetadataMap;
 #[cfg(feature = "tls")]
 use tonic::transport::ClientTlsConfig;
+
+use super::default_headers;
 
 /// Configuration for [tonic]
 ///
@@ -35,15 +36,14 @@ pub struct TonicExporterBuilder {
 
 impl Default for TonicExporterBuilder {
     fn default() -> Self {
-        let mut tonic_config = TonicConfig::default();
-        let mut headers: HeaderMap = HeaderMap::new();
-        headers.insert(
-            "User-Agent",
-            format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION"))
-                .parse()
-                .unwrap(),
-        );
-        tonic_config.metadata = Some(MetadataMap::from_headers(headers));
+        let tonic_config = TonicConfig {
+            metadata: Some(MetadataMap::from_headers(
+                (&default_headers())
+                    .try_into()
+                    .expect("invalid tonic headers"),
+            )),
+            ..TonicConfig::default()
+        };
 
         TonicExporterBuilder {
             exporter_config: ExportConfig::default(),

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -64,7 +64,11 @@ impl TonicExporterBuilder {
     pub fn with_metadata(mut self, metadata: MetadataMap) -> Self {
         // extending metadatamaps is harder than just casting back/forth
         let incoming_headers = metadata.into_headers();
-        let mut existing_headers = self.tonic_config.metadata.unwrap_or_default().into_headers();
+        let mut existing_headers = self
+            .tonic_config
+            .metadata
+            .unwrap_or_default()
+            .into_headers();
         existing_headers.extend(incoming_headers.into_iter());
 
         self.tonic_config.metadata = Some(MetadataMap::from_headers(existing_headers));

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -39,10 +39,12 @@ impl Default for TonicExporterBuilder {
         let mut headers: HeaderMap = HeaderMap::new();
         headers.insert(
             "User-Agent",
-            format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")).parse().unwrap(),
+            format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION"))
+                .parse()
+                .unwrap(),
         );
         tonic_config.metadata = Some(MetadataMap::from_headers(headers));
-        
+
         TonicExporterBuilder {
             exporter_config: ExportConfig::default(),
             tonic_config,

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -1,4 +1,5 @@
 use crate::ExportConfig;
+use http::HeaderMap;
 use tonic::metadata::MetadataMap;
 #[cfg(feature = "tls")]
 use tonic::transport::ClientTlsConfig;
@@ -35,15 +36,13 @@ pub struct TonicExporterBuilder {
 impl Default for TonicExporterBuilder {
     fn default() -> Self {
         let mut tonic_config = TonicConfig::default();
-        let mut map = MetadataMap::new();
-        map.insert(
+        let mut headers: HeaderMap = HeaderMap::new();
+        headers.insert(
             "User-Agent",
-            format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION"))
-                .as_str()
-                .parse()
-                .unwrap(),
+            format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION")).parse().unwrap(),
         );
-        tonic_config.metadata = Some(map);
+        tonic_config.metadata = Some(MetadataMap::from_headers(headers));
+        
         TonicExporterBuilder {
             exporter_config: ExportConfig::default(),
             tonic_config,

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -38,7 +38,7 @@ impl Default for TonicExporterBuilder {
         let mut map = MetadataMap::new();
         map.insert(
             "User-Agent",
-            format!("OTel OLTP Exporter Rust/{}", env!("CARGO_PKG_VERSION"))
+            format!("OTel OTLP Exporter Rust/{}", env!("CARGO_PKG_VERSION"))
                 .as_str()
                 .parse()
                 .unwrap(),

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -65,15 +65,7 @@ impl TonicExporterBuilder {
     /// Set custom metadata entries to send to the collector.
     pub fn with_metadata(mut self, metadata: MetadataMap) -> Self {
         // extending metadatamaps is harder than just casting back/forth
-        let incoming_headers = metadata.into_headers();
-        let mut existing_headers = self
-            .tonic_config
-            .metadata
-            .unwrap_or_default()
-            .into_headers();
-        existing_headers.extend(incoming_headers.into_iter());
-
-        self.tonic_config.metadata = Some(MetadataMap::from_headers(existing_headers));
+        self.tonic_config.metadata.get_or_insert(metadata);
         self
     }
 

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -1,5 +1,4 @@
 use crate::ExportConfig;
-use http::HeaderMap;
 use tonic::metadata::MetadataMap;
 #[cfg(feature = "tls")]
 use tonic::transport::ClientTlsConfig;
@@ -37,12 +36,14 @@ pub struct TonicExporterBuilder {
 
 impl Default for TonicExporterBuilder {
     fn default() -> Self {
-        let mut tonic_config = TonicConfig::default();
-        tonic_config.metadata = Some(MetadataMap::from_headers(
-            (&default_headers())
-                .try_into()
-                .expect("Invalid tonic headers"),
-        ));
+        let tonic_config = TonicConfig {
+            metadata: Some(MetadataMap::from_headers(
+                (&default_headers())
+                    .try_into()
+                    .expect("Invalid tonic headers"),
+            )),
+            ..Default::default()
+        };
 
         TonicExporterBuilder {
             exporter_config: ExportConfig::default(),

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -25,11 +25,28 @@ pub struct TonicConfig {
 ///
 /// [tonic]: <https://github.com/hyperium/tonic>
 /// [channel]: tonic::transport::Channel
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct TonicExporterBuilder {
     pub(crate) exporter_config: ExportConfig,
     pub(crate) tonic_config: TonicConfig,
     pub(crate) channel: Option<tonic::transport::Channel>,
+}
+
+impl Default for TonicExporterBuilder {
+    fn default() -> Self {
+        let mut tonic_config = TonicConfig::default();
+        let mut map = MetadataMap::new();
+        map.insert(
+            "User-Agent",
+            format!("OTel OLTP Exporter Rust/{}", env!("CARGO_PKG_VERSION")).as_str().parse().unwrap(),
+        );
+        tonic_config.metadata = Some(map);
+        TonicExporterBuilder {
+            exporter_config: ExportConfig::default(),
+            tonic_config: tonic_config,
+            channel: Option::default(),
+        }
+    }
 }
 
 impl TonicExporterBuilder {

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -46,7 +46,7 @@ impl Default for TonicExporterBuilder {
         tonic_config.metadata = Some(map);
         TonicExporterBuilder {
             exporter_config: ExportConfig::default(),
-            tonic_config: tonic_config,
+            tonic_config,
             channel: Option::default(),
         }
     }

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -42,7 +42,8 @@ impl Default for TonicExporterBuilder {
                     .try_into()
                     .expect("Invalid tonic headers"),
             )),
-            ..Default::default()
+            #[cfg(feature = "tls")]
+            tls_config: None,
         };
 
         TonicExporterBuilder {

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -1,4 +1,5 @@
 use crate::ExportConfig;
+use http::HeaderMap;
 use tonic::metadata::MetadataMap;
 #[cfg(feature = "tls")]
 use tonic::transport::ClientTlsConfig;
@@ -36,14 +37,12 @@ pub struct TonicExporterBuilder {
 
 impl Default for TonicExporterBuilder {
     fn default() -> Self {
-        let tonic_config = TonicConfig {
-            metadata: Some(MetadataMap::from_headers(
-                (&default_headers())
-                    .try_into()
-                    .expect("invalid tonic headers"),
-            )),
-            ..TonicConfig::default()
-        };
+        let mut tonic_config = TonicConfig::default();
+        tonic_config.metadata = Some(MetadataMap::from_headers(
+            (&default_headers())
+                .try_into()
+                .expect("Invalid tonic headers"),
+        ));
 
         TonicExporterBuilder {
             exporter_config: ExportConfig::default(),


### PR DESCRIPTION
Resolves #889 

Adds headers to oltp exporters specifying `User-Agent` for current version of `OTel OLTP Exporter Rust/$version`.