### PR TITLE
fix `cargo doc` failing on stable Rust

### DIFF
--- a/opentelemetry-proto/src/lib.rs
+++ b/opentelemetry-proto/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(doc, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 //! This crate contains generated files from [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto)
 //! repository and transformation between types from generated files and types defined in [opentelemetry](https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry)
 //!


### PR DESCRIPTION
I assume this was a simple typo. I depend on this lib and can no longer run `cargo doc` on stable. 