### PR TITLE
Improve OTLP environment variable handling

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## Main
+
+### Changed
+
+- Improve OTLP exporter environment variable handling #911
+- OTLP exporter default endpoint changed to http #911
 
 ## v0.11.0
 

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ### Changed
 
-- Improve OTLP exporter environment variable handling #911
-- OTLP exporter default endpoint changed to http #911
+- Improve OTLP exporter environment variable handling #912
+- OTLP exporter default endpoint changed to http #912
 
 ## v0.11.0
 

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -202,7 +202,8 @@ pub use crate::metric::{
 
 pub use crate::exporter::{
     HasExportConfig, WithExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT,
-    OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT, OTEL_EXPORTER_OTLP_TIMEOUT,
+    OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT, OTEL_EXPORTER_OTLP_PROTOCOL,
+    OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT, OTEL_EXPORTER_OTLP_TIMEOUT,
     OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT,
 };
 
@@ -368,7 +369,7 @@ impl ExportError for Error {
 
 /// The communication protocol to use when exporting data.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Protocol {
     /// GRPC protocol
     Grpc,


### PR DESCRIPTION
OTLP exporter default endpoint changed to http

There are a couple of places that the OTLP exporter differed from the spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md

1. OTEL_EXPORTER_OTLP_PROTOCOL was not supported.
2. The default endpoint used https rather than http.

The following has changed:
1. OTEL_EXPORTER_OTLP_PROTOCOL is supported.
2. If http-proto feature is enabled the default will be to use http-proto rather than grpc.
3. The default endpoint will be set according to the default protocol.
4. The default endpoint uses http rather than https.
5. Tests added.

Fixes #909 #908