### PR TITLE
Add abbility to disable stdout / stderr output.

### DIFF
--- a/opentelemetry-api/Cargo.toml
+++ b/opentelemetry-api/Cargo.toml
@@ -18,6 +18,7 @@ once_cell = "1.12.0"
 pin-project-lite = { version = "0.2", optional = true }
 thiserror = "1"
 tokio-stream = { version = "0.1", optional = true }
+tracing = { version = "0.1", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true
@@ -31,3 +32,4 @@ default = ["trace"]
 trace = ["pin-project-lite"]
 metrics = ["fnv"]
 testing = ["trace"]
+use_tracing = ["tracing"]

--- a/opentelemetry-api/Cargo.toml
+++ b/opentelemetry-api/Cargo.toml
@@ -18,7 +18,6 @@ once_cell = "1.12.0"
 pin-project-lite = { version = "0.2", optional = true }
 thiserror = "1"
 tokio-stream = { version = "0.1", optional = true }
-tracing = { version = "0.1", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true
@@ -32,4 +31,4 @@ default = ["trace"]
 trace = ["pin-project-lite"]
 metrics = ["fnv"]
 testing = ["trace"]
-use_tracing = ["tracing"]
+no_stdout = []

--- a/opentelemetry-api/src/global/error_handler.rs
+++ b/opentelemetry-api/src/global/error_handler.rs
@@ -47,7 +47,7 @@ pub fn handle_error<T: Into<Error>>(err: T) {
             #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
             Error::Metric(err) => {
                 #[cfg(not(feature = "use_tracing"))]
-                eprintn!("OpenTelemetry metrics error occurred. {}", err);
+                eprintln!("OpenTelemetry metrics error occurred. {}", err);
                 #[cfg(feature = "use_tracing")]
                 tracing::error!("OpenTelemetry metrics error occurred. {err}");
             }
@@ -55,13 +55,13 @@ pub fn handle_error<T: Into<Error>>(err: T) {
             #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
             Error::Trace(err) => {
                 #[cfg(not(feature = "use_tracing"))]
-                eprintn!("OpenTelemetry trace error occurred. {}", err);
+                eprintln!("OpenTelemetry trace error occurred. {}", err);
                 #[cfg(feature = "use_tracing")]
                 tracing::error!("OpenTelemetry trace error occurred. {err}");
             }
             Error::Other(err_msg) => {
                 #[cfg(not(feature = "use_tracing"))]
-                eprintn!("OpenTelemetry error occurred. {}", err_msg);
+                eprintln!("OpenTelemetry error occurred. {}", err_msg);
                 #[cfg(feature = "use_tracing")]
                 tracing::error!("OpenTelemetry error occurred. {err_msg}");
             }

--- a/opentelemetry-api/src/global/error_handler.rs
+++ b/opentelemetry-api/src/global/error_handler.rs
@@ -45,11 +45,26 @@ pub fn handle_error<T: Into<Error>>(err: T) {
         _ => match err.into() {
             #[cfg(feature = "metrics")]
             #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-            Error::Metric(err) => eprintln!("OpenTelemetry metrics error occurred. {}", err),
+            Error::Metric(err) => {
+                #[cfg(not(feature = "use_tracing"))]
+                eprintn!("OpenTelemetry metrics error occurred. {}", err);
+                #[cfg(feature = "use_tracing")]
+                tracing::error!("OpenTelemetry metrics error occurred. {err}");
+            }
             #[cfg(feature = "trace")]
             #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
-            Error::Trace(err) => eprintln!("OpenTelemetry trace error occurred. {}", err),
-            Error::Other(err_msg) => eprintln!("OpenTelemetry error occurred. {}", err_msg),
+            Error::Trace(err) => {
+                #[cfg(not(feature = "use_tracing"))]
+                eprintn!("OpenTelemetry trace error occurred. {}", err);
+                #[cfg(feature = "use_tracing")]
+                tracing::error!("OpenTelemetry trace error occurred. {err}");
+            }
+            Error::Other(err_msg) => {
+                #[cfg(not(feature = "use_tracing"))]
+                eprintn!("OpenTelemetry error occurred. {}", err_msg);
+                #[cfg(feature = "use_tracing")]
+                tracing::error!("OpenTelemetry error occurred. {err_msg}");
+            }
         },
     }
 }

--- a/opentelemetry-api/src/global/error_handler.rs
+++ b/opentelemetry-api/src/global/error_handler.rs
@@ -45,25 +45,22 @@ pub fn handle_error<T: Into<Error>>(err: T) {
         _ => match err.into() {
             #[cfg(feature = "metrics")]
             #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
+            #[allow(unused)]
             Error::Metric(err) => {
-                #[cfg(not(feature = "use_tracing"))]
+                #[cfg(not(feature = "no_stdout"))]
                 eprintln!("OpenTelemetry metrics error occurred. {}", err);
-                #[cfg(feature = "use_tracing")]
-                tracing::error!("OpenTelemetry metrics error occurred. {err}");
             }
             #[cfg(feature = "trace")]
             #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
+            #[allow(unused)]
             Error::Trace(err) => {
-                #[cfg(not(feature = "use_tracing"))]
+                #[cfg(not(feature = "no_stdout"))]
                 eprintln!("OpenTelemetry trace error occurred. {}", err);
-                #[cfg(feature = "use_tracing")]
-                tracing::error!("OpenTelemetry trace error occurred. {err}");
             }
+            #[allow(unused)]
             Error::Other(err_msg) => {
-                #[cfg(not(feature = "use_tracing"))]
+                #[cfg(not(feature = "no_stdout"))]
                 eprintln!("OpenTelemetry error occurred. {}", err_msg);
-                #[cfg(feature = "use_tracing")]
-                tracing::error!("OpenTelemetry error occurred. {err_msg}");
             }
         },
     }

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -39,7 +39,6 @@ opentelemetry-semantic-conventions = { version = "0.10", path = "../opentelemetr
 pin-project-lite = { version = "0.2", optional = true }
 reqwest = { version = "0.11", default-features = false, optional = true }
 surf = { version = "2.0", optional = true }
-tracing = { version = "0.1", optional = true }
 thiserror = "1.0"
 thrift = "0.16"
 tokio = { version = "1.0", features = ["net", "sync"], optional = true }
@@ -108,4 +107,4 @@ rt-tokio = ["tokio", "opentelemetry/rt-tokio"]
 rt-tokio-current-thread = ["tokio", "opentelemetry/rt-tokio-current-thread"]
 rt-async-std = ["async-std", "opentelemetry/rt-async-std"]
 integration_test = ["tonic", "prost", "prost-types", "rt-tokio", "collector_client", "hyper_collector_client", "hyper_tls_collector_client", "reqwest_collector_client", "surf_collector_client", "isahc_collector_client"]
-use_tracing = ["tracing"]
+no_stdout = []

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -39,6 +39,7 @@ opentelemetry-semantic-conventions = { version = "0.10", path = "../opentelemetr
 pin-project-lite = { version = "0.2", optional = true }
 reqwest = { version = "0.11", default-features = false, optional = true }
 surf = { version = "2.0", optional = true }
+tracing = { version = "0.1", optional = true }
 thiserror = "1.0"
 thrift = "0.16"
 tokio = { version = "1.0", features = ["net", "sync"], optional = true }
@@ -107,3 +108,4 @@ rt-tokio = ["tokio", "opentelemetry/rt-tokio"]
 rt-tokio-current-thread = ["tokio", "opentelemetry/rt-tokio-current-thread"]
 rt-async-std = ["async-std", "opentelemetry/rt-async-std"]
 integration_test = ["tonic", "prost", "prost-types", "rt-tokio", "collector_client", "hyper_collector_client", "hyper_tls_collector_client", "reqwest_collector_client", "surf_collector_client", "isahc_collector_client"]
+use_tracing = ["tracing"]

--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -122,11 +122,10 @@ impl Default for CollectorPipeline {
         if let Some(timeout) = env::var(ENV_TIMEOUT).ok().filter(|var| !var.is_empty()) {
             let timeout = match timeout.parse() {
                 Ok(timeout) => Duration::from_millis(timeout),
+                #[allow(unused)]
                 Err(e) => {
-                    #[cfg(not(feature = "use_tracing"))]
+                    #[cfg(not(feature = "no_stdout"))]
                     eprintln!("{} malformed defaulting to 10000: {}", ENV_TIMEOUT, e);
-                    #[cfg(feature = "use_tracing")]
-                    tracing::error!("{ENV_TIMEOUT} malformed defaulting to 10000: {e}");
                     DEFAULT_COLLECTOR_TIMEOUT
                 }
             };

--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -123,7 +123,10 @@ impl Default for CollectorPipeline {
             let timeout = match timeout.parse() {
                 Ok(timeout) => Duration::from_millis(timeout),
                 Err(e) => {
+                    #[cfg(not(feature = "use_tracing"))]
                     eprintln!("{} malformed defaulting to 10000: {}", ENV_TIMEOUT, e);
+                    #[cfg(feature = "use_tracing")]
+                    tracing::error!("{ENV_TIMEOUT} malformed defaulting to 10000: {e}");
                     DEFAULT_COLLECTOR_TIMEOUT
                 }
             };

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -25,7 +25,7 @@ reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
 surf-client = ["surf", "opentelemetry-http/surf"]
-use_tracing = ["tracing"]
+use_tracing = []
 
 [dependencies]
 async-trait = "0.1"
@@ -39,7 +39,6 @@ once_cell = "1.12"
 http = "0.2"
 reqwest = { version = "0.11", optional = true, default-features = false }
 surf = { version = "2.0", optional = true, default-features = false }
-tracing = { version = "0.1", optional = true }
 thiserror = { version = "1.0"}
 futures-core = "0.3"
 

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -25,6 +25,7 @@ reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
 surf-client = ["surf", "opentelemetry-http/surf"]
+use_tracing = ["tracing"]
 
 [dependencies]
 async-trait = "0.1"
@@ -38,6 +39,7 @@ once_cell = "1.12"
 http = "0.2"
 reqwest = { version = "0.11", optional = true, default-features = false }
 surf = { version = "2.0", optional = true, default-features = false }
+tracing = { version = "0.1", optional = true }
 thiserror = { version = "1.0"}
 futures-core = "0.3"
 

--- a/opentelemetry-zipkin/src/exporter/env.rs
+++ b/opentelemetry-zipkin/src/exporter/env.rs
@@ -19,7 +19,10 @@ pub(crate) fn get_timeout() -> Duration {
         Some(timeout) => match timeout.parse() {
             Ok(timeout) => Duration::from_millis(timeout),
             Err(e) => {
+                #[cfg(not(feature = "use_tracing"))]
                 eprintln!("{} malformed defaulting to 10000: {}", ENV_TIMEOUT, e);
+                #[cfg(feature = "use_tracing")]
+                tracing::error!("{ENV_TIMEOUT} malformed defaulting to 10000: {e}");
                 DEFAULT_COLLECTOR_TIMEOUT
             }
         },

--- a/opentelemetry-zipkin/src/exporter/env.rs
+++ b/opentelemetry-zipkin/src/exporter/env.rs
@@ -18,11 +18,10 @@ pub(crate) fn get_timeout() -> Duration {
     match env::var(ENV_TIMEOUT).ok().filter(|var| !var.is_empty()) {
         Some(timeout) => match timeout.parse() {
             Ok(timeout) => Duration::from_millis(timeout),
+            #[allow(unused)]
             Err(e) => {
-                #[cfg(not(feature = "use_tracing"))]
+                #[cfg(not(feature = "no_stdout"))]
                 eprintln!("{} malformed defaulting to 10000: {}", ENV_TIMEOUT, e);
-                #[cfg(feature = "use_tracing")]
-                tracing::error!("{ENV_TIMEOUT} malformed defaulting to 10000: {e}");
                 DEFAULT_COLLECTOR_TIMEOUT
             }
         },


### PR DESCRIPTION
Greetings!

Printing to stdout / stderr creates problem, when you export logs in certain format from service. So, why not to use `tracing` optionaly?