### PR TITLE
add response headers in response for HttpClient implementations

### DIFF
--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -138,10 +138,8 @@ pub mod surf {
             for header_name in response.header_names() {
                 for header_value in &response[header_name.to_string().as_str()] {
                     headers.append(
-                        HeaderName::from_str(&header_name.to_string())
-                            .expect("it was a header name before"),
-                        HeaderValue::from_str(header_value.as_str())
-                            .expect("it was a header value before"),
+                        HeaderName::from_str(&header_name.to_string())?,
+                        HeaderValue::from_str(header_value.as_str())?,
                     );
                 }
             }

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -67,10 +67,14 @@ mod reqwest {
     impl HttpClient for reqwest::Client {
         async fn send(&self, request: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
             let request = request.try_into()?;
-            let response = self.execute(request).await?;
-            Ok(Response::builder()
+            let mut response = self.execute(request).await?;
+            let headers = std::mem::take(response.headers_mut());
+            let mut http_response = Response::builder()
                 .status(response.status())
-                .body(response.bytes().await?)?)
+                .body(response.bytes().await?)?;
+            *http_response.headers_mut() = headers;
+
+            Ok(http_response)
         }
     }
 
@@ -78,16 +82,24 @@ mod reqwest {
     impl HttpClient for reqwest::blocking::Client {
         async fn send(&self, request: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
             let request = request.try_into()?;
-            let response = self.execute(request)?;
-            Ok(Response::builder()
+            let mut response = self.execute(request)?;
+            let headers = std::mem::take(response.headers_mut());
+            let mut http_response = Response::builder()
                 .status(response.status())
-                .body(response.bytes()?)?)
+                .body(response.bytes()?)?;
+            *http_response.headers_mut() = headers;
+
+            Ok(http_response)
         }
     }
 }
 
 #[cfg(feature = "surf")]
 pub mod surf {
+    use std::str::FromStr;
+
+    use http::{header::HeaderName, HeaderMap, HeaderValue};
+
     use super::{async_trait, Bytes, HttpClient, HttpError, Request, Response};
 
     #[derive(Debug)]
@@ -122,9 +134,24 @@ pub mod surf {
             }
 
             let mut response = self.send(request_builder).await?;
-            Ok(Response::builder()
+            let mut headers = HeaderMap::new();
+            for header_name in response.header_names() {
+                for header_value in &response[header_name.to_string().as_str()] {
+                    headers.append(
+                        HeaderName::from_str(&header_name.to_string())
+                            .expect("it was a header name before"),
+                        HeaderValue::from_str(header_value.as_str())
+                            .expect("it was a header value before"),
+                    );
+                }
+            }
+            let mut http_response = Response::builder()
                 .status(response.status() as u16)
-                .body(response.body_bytes().await?.into())?)
+                .body(response.body_bytes().await?.into())?;
+
+            *http_response.headers_mut() = headers;
+
+            Ok(http_response)
         }
     }
 }
@@ -141,9 +168,14 @@ mod isahc {
             let mut response = self.send_async(request).await?;
             let mut bytes = Vec::with_capacity(response.body().len().unwrap_or(0).try_into()?);
             response.copy_to(&mut bytes).await?;
-            Ok(Response::builder()
-                .status(response.status())
-                .body(bytes.into())?)
+
+            let headers = std::mem::take(response.headers_mut());
+            let mut http_response = Response::builder()
+                .status(response.status().as_u16())
+                .body(bytes.into())?;
+            *http_response.headers_mut() = headers;
+
+            Ok(http_response)
         }
     }
 }
@@ -200,10 +232,14 @@ pub mod hyper {
                     .headers_mut()
                     .insert(http::header::AUTHORIZATION, authorization.clone());
             }
-            let response = time::timeout(self.timeout, self.inner.request(request)).await??;
-            Ok(Response::builder()
+            let mut response = time::timeout(self.timeout, self.inner.request(request)).await??;
+            let headers = std::mem::take(response.headers_mut());
+            let mut http_response = Response::builder()
                 .status(response.status())
-                .body(hyper::body::to_bytes(response.into_body()).await?)?)
+                .body(hyper::body::to_bytes(response.into_body()).await?)?;
+            *http_response.headers_mut() = headers;
+
+            Ok(http_response)
         }
     }
 }


### PR DESCRIPTION
When using `HttpClient` implementations you didn't return headers in http response.