### PR TITLE
chore(common): fix deny.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,24 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check advisories
+  docs:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+          override: true
+      - uses: arduino/setup-protoc@v1
+      - name: doc
+        run: cargo doc --no-deps --all-features
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTDOCFLAGS: -Dwarnings
   coverage:
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -99,12 +117,6 @@ jobs:
         toolchain: nightly
         components: rustfmt
         override: true
-    - uses: arduino/setup-protoc@v1
-    - name: doc
-      run: cargo doc --no-deps --all-features
-      env:
-        CARGO_INCREMENTAL: '0'
-        RUSTDOCFLAGS: -Dwarnings
     - uses: actions-rs/cargo@v1
       with:
         command: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check advisories
-          log-level: error
   docs:
     continue-on-error: true
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,13 +87,12 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check advisories
+          log-level: error
   docs:
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: true
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/deny.toml
+++ b/deny.toml
@@ -32,3 +32,6 @@ license-files = [
 ignore = [
     # empty for now
 ]
+unmaintained = "allow"
+yanked = "allow"
+unsound = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -30,8 +30,5 @@ license-files = [
 
 [advisories]
 ignore = [
-    "RUSTSEC-2021-0127", # serde_cbor is unmaintained. However, we only depend on it indirectly through criterion, which is a dev dependency.
-    "RUSTSEC-2021-0139", # ansi_term is unmaintained. It's used in 1) criterion, which is a dev dependency. 2) grpcio, but only in build.
-    "RUSTSEC-2020-0036", # failure is deprecated. It's used in protoc-grpcio, which is a build dependency.
-    "RUSTSEC-2019-0036", # Possible UB in failures, which is used in protoc-grpcio. We only use it in dev. See https://github.com/mtp401/protoc-grpcio/issues/40
+    # empty for now
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,8 @@ exclude=[
     "actix-http-tracing",
     "actix-udp",
     "actix-udp-example",
-    "tracing-grpc"
+    "tracing-grpc",
+    "http"
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -30,8 +30,9 @@ license-files = [
 
 [advisories]
 ignore = [
-    # empty for now
+    # unsoundness in indirect dependencies without a safe upgrade below
+    "RUSTSEC-2021-0145",
+    "RUSTSEC-2019-0036"
 ]
 unmaintained = "allow"
 yanked = "allow"
-unsound = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,8 @@ exclude=[
     "actix-http",
     "actix-http-tracing",
     "actix-udp",
-    "actix-udp-example"
+    "actix-udp-example",
+    "tracing-grpc"
 ]
 
 [licenses]
@@ -28,7 +29,8 @@ license-files = [
 
 [advisories]
 ignore = [
-    # time/chrono problems, have not been a problem in practice, not much we can do at this moment.
-    "RUSTSEC-2020-0071",
-    "RUSTSEC-2020-0159"
+    "RUSTSEC-2021-0127", # serde_cbor is unmaintained. However, we only depend on it indirectly through criterion, which is a dev dependency.
+    "RUSTSEC-2021-0139", # ansi_term is unmaintained. It's used in 1) criterion, which is a dev dependency. 2) grpcio, but only in build.
+    "RUSTSEC-2020-0036", # failure is deprecated. It's used in protoc-grpcio, which is a build dependency.
+    "RUSTSEC-2019-0036", # Possible UB in failures, which is used in protoc-grpcio. We only use it in dev. See https://github.com/mtp401/protoc-grpcio/issues/40
 ]

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
@@ -111,7 +111,7 @@ pub mod logs_service_client {
 pub mod logs_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with LogsServiceServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with LogsServiceServer.
     #[async_trait]
     pub trait LogsService: Send + Sync + 'static {
         /// For performance reasons, it is recommended to keep this RPC

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
@@ -114,7 +114,7 @@ pub mod metrics_service_client {
 pub mod metrics_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with MetricsServiceServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MetricsServiceServer.
     #[async_trait]
     pub trait MetricsService: Send + Sync + 'static {
         /// For performance reasons, it is recommended to keep this RPC

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
@@ -111,7 +111,7 @@ pub mod trace_service_client {
 pub mod trace_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with TraceServiceServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with TraceServiceServer.
     #[async_trait]
     pub trait TraceService: Send + Sync + 'static {
         /// For performance reasons, it is recommended to keep this RPC

--- a/opentelemetry-sdk/src/testing/trace.rs
+++ b/opentelemetry-sdk/src/testing/trace.rs
@@ -61,7 +61,7 @@ impl SpanExporter for TestSpanExporter {
     }
 
     fn shutdown(&mut self) {
-        self.tx_shutdown.send(()).unwrap();
+        let _ = self.tx_shutdown.send(()); // ignore error
     }
 }
 


### PR DESCRIPTION
Most of the warnings from deny are unmaintained/deprecated create which we depend on indirectly either in dev or build

I don't believe there are any action item for us to fix them.

Also split the doc as separate task in CI. It's confusing to fail the coverage because of the doc failures