### PR TITLE
fix(otlp): metadata is not set correctly

### DIFF
--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -369,8 +369,7 @@ fn group_into_traces(spans: Vec<SpanData>) -> Vec<Vec<SpanData>> {
     spans
         .into_iter()
         .into_group_map_by(|span_data| span_data.span_context.trace_id())
-        .into_iter()
-        .map(|(_, trace)| trace)
+        .into_values()
         .collect()
 }
 

--- a/opentelemetry-datadog/src/exporter/model/v05.rs
+++ b/opentelemetry-datadog/src/exporter/model/v05.rs
@@ -77,7 +77,7 @@ where
     let mut payload = Vec::new();
     rmp::encode::write_array_len(&mut payload, 2)?;
 
-    rmp::encode::write_array_len(&mut payload, interner.len() as u32)?;
+    rmp::encode::write_array_len(&mut payload, interner.len())?;
     for data in interner.iter() {
         rmp::encode::write_str(&mut payload, data)?;
     }

--- a/opentelemetry-otlp/src/exporter/grpcio.rs
+++ b/opentelemetry-otlp/src/exporter/grpcio.rs
@@ -111,3 +111,35 @@ impl GrpcioExporterBuilder {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::GrpcioExporterBuilder;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_with_headers() {
+        // metadata should merge with the current one with priority instead of just replacing it
+        let mut headers = HashMap::new();
+        headers.insert("key".to_string(), "value".to_string());
+        let builder = GrpcioExporterBuilder::default().with_headers(headers);
+        let result = builder.grpcio_config.headers.unwrap();
+        assert_eq!(result.get("key").unwrap(), "value");
+        assert!(result.get("User-Agent").is_some());
+
+        // metadata should override entries with the same key in the default one
+        let mut headers = HashMap::new();
+        headers.insert("User-Agent".to_string(), "baz".to_string());
+        let builder = GrpcioExporterBuilder::default().with_headers(headers);
+        let result = builder.grpcio_config.headers.unwrap();
+        assert_eq!(result.get("User-Agent").unwrap(), "baz");
+        assert_eq!(
+            result.len(),
+            GrpcioExporterBuilder::default()
+                .grpcio_config
+                .headers
+                .unwrap()
+                .len()
+        );
+    }
+}

--- a/opentelemetry-otlp/src/transform/metrics.rs
+++ b/opentelemetry-otlp/src/transform/metrics.rs
@@ -179,10 +179,7 @@ pub(crate) mod tonic {
                                     .unwrap_or_default()
                                     .to_string(),
                                 instrumentation_library: Some(instrumentation_library.into()),
-                                metrics: metrics
-                                    .into_iter()
-                                    .map(|(_k, v)| v)
-                                    .collect::<Vec<Metric>>(), // collect values
+                                metrics: metrics.into_values().collect::<Vec<Metric>>(), // collect values
                             },
                         )
                         .collect::<Vec<InstrumentationLibraryMetrics>>(),

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
@@ -196,6 +196,37 @@ impl SeverityNumber {
             SeverityNumber::Fatal4 => "SEVERITY_NUMBER_FATAL4",
         }
     }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SEVERITY_NUMBER_UNSPECIFIED" => Some(Self::Unspecified),
+            "SEVERITY_NUMBER_TRACE" => Some(Self::Trace),
+            "SEVERITY_NUMBER_TRACE2" => Some(Self::Trace2),
+            "SEVERITY_NUMBER_TRACE3" => Some(Self::Trace3),
+            "SEVERITY_NUMBER_TRACE4" => Some(Self::Trace4),
+            "SEVERITY_NUMBER_DEBUG" => Some(Self::Debug),
+            "SEVERITY_NUMBER_DEBUG2" => Some(Self::Debug2),
+            "SEVERITY_NUMBER_DEBUG3" => Some(Self::Debug3),
+            "SEVERITY_NUMBER_DEBUG4" => Some(Self::Debug4),
+            "SEVERITY_NUMBER_INFO" => Some(Self::Info),
+            "SEVERITY_NUMBER_INFO2" => Some(Self::Info2),
+            "SEVERITY_NUMBER_INFO3" => Some(Self::Info3),
+            "SEVERITY_NUMBER_INFO4" => Some(Self::Info4),
+            "SEVERITY_NUMBER_WARN" => Some(Self::Warn),
+            "SEVERITY_NUMBER_WARN2" => Some(Self::Warn2),
+            "SEVERITY_NUMBER_WARN3" => Some(Self::Warn3),
+            "SEVERITY_NUMBER_WARN4" => Some(Self::Warn4),
+            "SEVERITY_NUMBER_ERROR" => Some(Self::Error),
+            "SEVERITY_NUMBER_ERROR2" => Some(Self::Error2),
+            "SEVERITY_NUMBER_ERROR3" => Some(Self::Error3),
+            "SEVERITY_NUMBER_ERROR4" => Some(Self::Error4),
+            "SEVERITY_NUMBER_FATAL" => Some(Self::Fatal),
+            "SEVERITY_NUMBER_FATAL2" => Some(Self::Fatal2),
+            "SEVERITY_NUMBER_FATAL3" => Some(Self::Fatal3),
+            "SEVERITY_NUMBER_FATAL4" => Some(Self::Fatal4),
+            _ => None,
+        }
+    }
 }
 /// Masks for LogRecord.flags field.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -215,6 +246,14 @@ impl LogRecordFlags {
             LogRecordFlags::LogRecordFlagTraceFlagsMask => {
                 "LOG_RECORD_FLAG_TRACE_FLAGS_MASK"
             }
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "LOG_RECORD_FLAG_UNSPECIFIED" => Some(Self::LogRecordFlagUnspecified),
+            "LOG_RECORD_FLAG_TRACE_FLAGS_MASK" => Some(Self::LogRecordFlagTraceFlagsMask),
+            _ => None,
         }
     }
 }

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
@@ -687,6 +687,15 @@ impl AggregationTemporality {
             AggregationTemporality::Cumulative => "AGGREGATION_TEMPORALITY_CUMULATIVE",
         }
     }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "AGGREGATION_TEMPORALITY_UNSPECIFIED" => Some(Self::Unspecified),
+            "AGGREGATION_TEMPORALITY_DELTA" => Some(Self::Delta),
+            "AGGREGATION_TEMPORALITY_CUMULATIVE" => Some(Self::Cumulative),
+            _ => None,
+        }
+    }
 }
 /// DataPointFlags is defined as a protobuf 'uint32' type and is to be used as a
 /// bit-field representing 32 distinct boolean flags.  Each flag defined in this
@@ -713,6 +722,14 @@ impl DataPointFlags {
         match self {
             DataPointFlags::FlagNone => "FLAG_NONE",
             DataPointFlags::FlagNoRecordedValue => "FLAG_NO_RECORDED_VALUE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "FLAG_NONE" => Some(Self::FlagNone),
+            "FLAG_NO_RECORDED_VALUE" => Some(Self::FlagNoRecordedValue),
+            _ => None,
         }
     }
 }

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.trace.v1.rs
@@ -276,6 +276,18 @@ pub mod span {
                 SpanKind::Consumer => "SPAN_KIND_CONSUMER",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "SPAN_KIND_UNSPECIFIED" => Some(Self::Unspecified),
+                "SPAN_KIND_INTERNAL" => Some(Self::Internal),
+                "SPAN_KIND_SERVER" => Some(Self::Server),
+                "SPAN_KIND_CLIENT" => Some(Self::Client),
+                "SPAN_KIND_PRODUCER" => Some(Self::Producer),
+                "SPAN_KIND_CONSUMER" => Some(Self::Consumer),
+                _ => None,
+            }
+        }
     }
 }
 /// The Status type defines a logical error model that is suitable for different
@@ -325,6 +337,15 @@ pub mod status {
                 StatusCode::Unset => "STATUS_CODE_UNSET",
                 StatusCode::Ok => "STATUS_CODE_OK",
                 StatusCode::Error => "STATUS_CODE_ERROR",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "STATUS_CODE_UNSET" => Some(Self::Unset),
+                "STATUS_CODE_OK" => Some(Self::Ok),
+                "STATUS_CODE_ERROR" => Some(Self::Error),
+                _ => None,
             }
         }
     }
@@ -407,6 +428,15 @@ pub mod constant_sampler {
                 ConstantDecision::AlwaysOff => "ALWAYS_OFF",
                 ConstantDecision::AlwaysOn => "ALWAYS_ON",
                 ConstantDecision::AlwaysParent => "ALWAYS_PARENT",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "ALWAYS_OFF" => Some(Self::AlwaysOff),
+                "ALWAYS_ON" => Some(Self::AlwaysOn),
+                "ALWAYS_PARENT" => Some(Self::AlwaysParent),
+                _ => None,
             }
         }
     }

--- a/opentelemetry-sdk/src/trace/config.rs
+++ b/opentelemetry-sdk/src/trace/config.rs
@@ -91,7 +91,7 @@ impl Default for Config {
     fn default() -> Self {
         let mut config = Config {
             sampler: Box::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn))),
-            id_generator: Box::new(RandomIdGenerator::default()),
+            id_generator: Box::<RandomIdGenerator>::default(),
             span_limits: SpanLimits::default(),
             resource: Cow::Owned(Resource::default()),
         };

--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampling_strategy.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampling_strategy.rs
@@ -196,11 +196,11 @@ pub(crate) struct PerOperationStrategies {
 
 impl PerOperationStrategies {
     pub(crate) fn update(&mut self, remote_strategies: PerOperationSamplingStrategies) {
-        self.default_prob = remote_strategies.default_sampling_probability as f64;
+        self.default_prob = remote_strategies.default_sampling_probability;
         self.default_lower_bound_traces_per_second =
-            remote_strategies.default_lower_bound_traces_per_second as f64;
+            remote_strategies.default_lower_bound_traces_per_second;
         self.default_upper_bound_traces_per_second =
-            remote_strategies.default_upper_bound_traces_per_second as f64;
+            remote_strategies.default_upper_bound_traces_per_second;
 
         self.operation_prob = remote_strategies
             .per_operation_strategies

--- a/opentelemetry-stackdriver/src/proto/api.rs
+++ b/opentelemetry-stackdriver/src/proto/api.rs
@@ -425,6 +425,20 @@ impl FieldBehavior {
             FieldBehavior::NonEmptyDefault => "NON_EMPTY_DEFAULT",
         }
     }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "FIELD_BEHAVIOR_UNSPECIFIED" => Some(Self::Unspecified),
+            "OPTIONAL" => Some(Self::Optional),
+            "REQUIRED" => Some(Self::Required),
+            "OUTPUT_ONLY" => Some(Self::OutputOnly),
+            "INPUT_ONLY" => Some(Self::InputOnly),
+            "IMMUTABLE" => Some(Self::Immutable),
+            "UNORDERED_LIST" => Some(Self::UnorderedList),
+            "NON_EMPTY_DEFAULT" => Some(Self::NonEmptyDefault),
+            _ => None,
+        }
+    }
 }
 /// A simple descriptor of a resource type.
 ///
@@ -580,6 +594,15 @@ pub mod resource_descriptor {
                 History::FutureMultiPattern => "FUTURE_MULTI_PATTERN",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "HISTORY_UNSPECIFIED" => Some(Self::Unspecified),
+                "ORIGINALLY_SINGLE_PATTERN" => Some(Self::OriginallySinglePattern),
+                "FUTURE_MULTI_PATTERN" => Some(Self::FutureMultiPattern),
+                _ => None,
+            }
+        }
     }
     /// A flag representing a specific style that a resource claims to conform to.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -606,6 +629,14 @@ pub mod resource_descriptor {
             match self {
                 Style::Unspecified => "STYLE_UNSPECIFIED",
                 Style::DeclarativeFriendly => "DECLARATIVE_FRIENDLY",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "STYLE_UNSPECIFIED" => Some(Self::Unspecified),
+                "DECLARATIVE_FRIENDLY" => Some(Self::DeclarativeFriendly),
+                _ => None,
             }
         }
     }
@@ -690,6 +721,15 @@ pub mod label_descriptor {
                 ValueType::Int64 => "INT64",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "STRING" => Some(Self::String),
+                "BOOL" => Some(Self::Bool),
+                "INT64" => Some(Self::Int64),
+                _ => None,
+            }
+        }
     }
 }
 /// The launch stage as defined by [Google Cloud Platform
@@ -750,6 +790,20 @@ impl LaunchStage {
             LaunchStage::Beta => "BETA",
             LaunchStage::Ga => "GA",
             LaunchStage::Deprecated => "DEPRECATED",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "LAUNCH_STAGE_UNSPECIFIED" => Some(Self::Unspecified),
+            "UNIMPLEMENTED" => Some(Self::Unimplemented),
+            "PRELAUNCH" => Some(Self::Prelaunch),
+            "EARLY_ACCESS" => Some(Self::EarlyAccess),
+            "ALPHA" => Some(Self::Alpha),
+            "BETA" => Some(Self::Beta),
+            "GA" => Some(Self::Ga),
+            "DEPRECATED" => Some(Self::Deprecated),
+            _ => None,
         }
     }
 }

--- a/opentelemetry-stackdriver/src/proto/devtools/cloudtrace/v2.rs
+++ b/opentelemetry-stackdriver/src/proto/devtools/cloudtrace/v2.rs
@@ -174,6 +174,15 @@ pub mod span {
                         Type::Received => "RECEIVED",
                     }
                 }
+                /// Creates an enum from field names used in the ProtoBuf definition.
+                pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                    match value {
+                        "TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+                        "SENT" => Some(Self::Sent),
+                        "RECEIVED" => Some(Self::Received),
+                        _ => None,
+                    }
+                }
             }
         }
         /// A `TimeEvent` can contain either an `Annotation` object or a
@@ -256,6 +265,15 @@ pub mod span {
                     Type::ParentLinkedSpan => "PARENT_LINKED_SPAN",
                 }
             }
+            /// Creates an enum from field names used in the ProtoBuf definition.
+            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                match value {
+                    "TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+                    "CHILD_LINKED_SPAN" => Some(Self::ChildLinkedSpan),
+                    "PARENT_LINKED_SPAN" => Some(Self::ParentLinkedSpan),
+                    _ => None,
+                }
+            }
         }
     }
     /// A collection of links, which are references from this span to a span
@@ -311,6 +329,18 @@ pub mod span {
                 SpanKind::Client => "CLIENT",
                 SpanKind::Producer => "PRODUCER",
                 SpanKind::Consumer => "CONSUMER",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "SPAN_KIND_UNSPECIFIED" => Some(Self::Unspecified),
+                "INTERNAL" => Some(Self::Internal),
+                "SERVER" => Some(Self::Server),
+                "CLIENT" => Some(Self::Client),
+                "PRODUCER" => Some(Self::Producer),
+                "CONSUMER" => Some(Self::Consumer),
+                _ => None,
             }
         }
     }

--- a/opentelemetry-stackdriver/src/proto/logging/type.rs
+++ b/opentelemetry-stackdriver/src/proto/logging/type.rs
@@ -124,4 +124,19 @@ impl LogSeverity {
             LogSeverity::Emergency => "EMERGENCY",
         }
     }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "DEFAULT" => Some(Self::Default),
+            "DEBUG" => Some(Self::Debug),
+            "INFO" => Some(Self::Info),
+            "NOTICE" => Some(Self::Notice),
+            "WARNING" => Some(Self::Warning),
+            "ERROR" => Some(Self::Error),
+            "CRITICAL" => Some(Self::Critical),
+            "ALERT" => Some(Self::Alert),
+            "EMERGENCY" => Some(Self::Emergency),
+            _ => None,
+        }
+    }
 }

--- a/opentelemetry-stackdriver/src/proto/logging/v2.rs
+++ b/opentelemetry-stackdriver/src/proto/logging/v2.rs
@@ -582,6 +582,15 @@ pub mod tail_log_entries_response {
                     Reason::NotConsumed => "NOT_CONSUMED",
                 }
             }
+            /// Creates an enum from field names used in the ProtoBuf definition.
+            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                match value {
+                    "REASON_UNSPECIFIED" => Some(Self::Unspecified),
+                    "RATE_LIMIT" => Some(Self::RateLimit),
+                    "NOT_CONSUMED" => Some(Self::NotConsumed),
+                    _ => None,
+                }
+            }
         }
     }
 }

--- a/opentelemetry-zpages/src/trace/aggregator.rs
+++ b/opentelemetry-zpages/src/trace/aggregator.rs
@@ -166,7 +166,7 @@ fn latency_bucket(start_time: SystemTime, end_time: SystemTime) -> usize {
             .unwrap_or_else(|_| Duration::from_millis(0));
     for (idx, lower) in LATENCY_BUCKET.iter().copied().enumerate().skip(1) {
         if lower > latency {
-            return (idx - 1) as usize;
+            return idx - 1;
         }
     }
     LATENCY_BUCKET.len() - 1


### PR DESCRIPTION
Fix #935.

Also update the proto & fix the lint issue raised with rust version 1.66