### PR TITLE
fix(metrics): remove in_memory settings

### DIFF
--- a/examples/hyper-prometheus/src/main.rs
+++ b/examples/hyper-prometheus/src/main.rs
@@ -76,13 +76,10 @@ struct AppState {
 
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let controller = controllers::basic(
-        processors::factory(
-            selectors::simple::histogram([1.0, 2.0, 5.0, 10.0, 20.0, 50.0]),
-            aggregation::cumulative_temporality_selector(),
-        )
-        .with_memory(true),
-    )
+    let controller = controllers::basic(processors::factory(
+        selectors::simple::histogram([1.0, 2.0, 5.0, 10.0, 20.0, 50.0]),
+        aggregation::cumulative_temporality_selector(),
+    ))
     .build();
 
     let exporter = opentelemetry_prometheus::exporter(controller).init();

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -15,7 +15,6 @@
 //!             selectors::simple::histogram([1.0, 2.0, 5.0, 10.0, 20.0, 50.0]),
 //!             aggregation::cumulative_temporality_selector(),
 //!         )
-//!         .with_memory(true),
 //!     )
 //!     .build();
 //!

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -9,13 +9,10 @@ use prometheus::{Encoder, TextEncoder};
 #[test]
 fn free_unused_instruments() {
     let cx = Context::new();
-    let controller = controllers::basic(
-        processors::factory(
-            selectors::simple::histogram(vec![-0.5, 1.0]),
-            aggregation::cumulative_temporality_selector(),
-        )
-        .with_memory(true),
-    )
+    let controller = controllers::basic(processors::factory(
+        selectors::simple::histogram(vec![-0.5, 1.0]),
+        aggregation::cumulative_temporality_selector(),
+    ))
     .with_resource(Resource::new(vec![KeyValue::new("R", "V")]))
     .build();
     let exporter = opentelemetry_prometheus::exporter(controller).init();
@@ -46,13 +43,10 @@ fn free_unused_instruments() {
 #[test]
 fn test_add() {
     let cx = Context::new();
-    let controller = controllers::basic(
-        processors::factory(
-            selectors::simple::histogram(vec![-0.5, 1.0]),
-            aggregation::cumulative_temporality_selector(),
-        )
-        .with_memory(true),
-    )
+    let controller = controllers::basic(processors::factory(
+        selectors::simple::histogram(vec![-0.5, 1.0]),
+        aggregation::cumulative_temporality_selector(),
+    ))
     .with_resource(Resource::new(vec![KeyValue::new("R", "V")]))
     .build();
     let exporter = opentelemetry_prometheus::exporter(controller).init();
@@ -105,13 +99,10 @@ fn test_add() {
 #[test]
 fn test_sanitization() {
     let cx = Context::new();
-    let controller = controllers::basic(
-        processors::factory(
-            selectors::simple::histogram(vec![-0.5, 1.0]),
-            aggregation::cumulative_temporality_selector(),
-        )
-        .with_memory(true),
-    )
+    let controller = controllers::basic(processors::factory(
+        selectors::simple::histogram(vec![-0.5, 1.0]),
+        aggregation::cumulative_temporality_selector(),
+    ))
     .with_resource(Resource::new(vec![KeyValue::new(
         "service.name",
         "Test Service",

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -39,6 +39,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 bincode = "1.2"
 criterion = "0.3.1"
 rand_distr = "0.4.0"
+crossbeam-queue = "0.3.1"
 
 [features]
 default = ["trace"]

--- a/opentelemetry-sdk/src/metrics/controllers/basic.rs
+++ b/opentelemetry-sdk/src/metrics/controllers/basic.rs
@@ -414,10 +414,10 @@ impl BasicControllerBuilder {
     /// Sets the interval between calls to `collect` a checkpoint.
     ///
     /// When pulling metrics and not exporting, this is the minimum time between
-    /// calls to `collect.In a pull-only configuration, collection is performed on
-    /// demand; set this to `0` to always recompute the export record set.
+    /// calls to a pull-only configuration, collection is performed on
+    /// demand; set this to `0` to always collect.
     ///
-    /// When exporting metrics, this must be > 0.
+    /// When exporting metrics, this must be > 0s.
     ///
     /// Default value is 10s.
     pub fn with_collect_period(mut self, collect_period: Duration) -> Self {

--- a/opentelemetry-sdk/src/metrics/processors/basic.rs
+++ b/opentelemetry-sdk/src/metrics/processors/basic.rs
@@ -37,8 +37,7 @@ pub struct BasicProcessorBuilder {
 
 impl fmt::Debug for BasicProcessorBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BasicProcessorBuilder")
-            .finish()
+        f.debug_struct("BasicProcessorBuilder").finish()
     }
 }
 
@@ -269,7 +268,6 @@ impl LockedCheckpointer for BasicLockedProcessor<'_> {
     }
 }
 
-
 #[derive(Debug)]
 struct BasicProcessorState {
     values: HashMap<StateKey, StateValue>,
@@ -331,10 +329,10 @@ impl Reader for BasicProcessorState {
                         return Err(MetricsError::Other("No cumulative to delta".into()));
                     }
 
-                    if  value.updated != self.finished_collection.wrapping_sub(1) {
+                    if value.updated != self.finished_collection.wrapping_sub(1) {
                         // skip processing if there is no update in last collection internal and
                         // temporality is Delta
-                        return Ok(())
+                        return Ok(());
                     }
 
                     agg = Some(&value.current);

--- a/opentelemetry-sdk/src/metrics/processors/basic.rs
+++ b/opentelemetry-sdk/src/metrics/processors/basic.rs
@@ -27,32 +27,17 @@ where
     BasicProcessorBuilder {
         aggregator_selector: Arc::new(aggregator_selector),
         temporality_selector: Arc::new(temporality_selector),
-        memory: false,
     }
 }
 
 pub struct BasicProcessorBuilder {
     aggregator_selector: Arc<dyn AggregatorSelector + Send + Sync>,
     temporality_selector: Arc<dyn TemporalitySelector + Send + Sync>,
-    memory: bool,
-}
-
-impl BasicProcessorBuilder {
-    /// Memory controls whether the processor remembers metric instruments and
-    /// attribute sets that were previously reported.
-    ///
-    /// When Memory is `true`, [`Reader::try_for_each`] will visit metrics that were
-    /// not updated in the most recent interval.
-    pub fn with_memory(mut self, memory: bool) -> Self {
-        self.memory = memory;
-        self
-    }
 }
 
 impl fmt::Debug for BasicProcessorBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BasicProcessorBuilder")
-            .field("memory", &self.memory)
             .finish()
     }
 }
@@ -62,7 +47,7 @@ impl CheckpointerFactory for BasicProcessorBuilder {
         Arc::new(BasicProcessor {
             aggregator_selector: Arc::clone(&self.aggregator_selector),
             temporality_selector: Arc::clone(&self.temporality_selector),
-            state: Mutex::new(BasicProcessorState::with_memory(self.memory)),
+            state: Mutex::new(BasicProcessorState::default()),
         })
     }
 }
@@ -240,7 +225,6 @@ impl LockedCheckpointer for BasicLockedProcessor<'_> {
         }
         let finished_collection = self.state.finished_collection;
         self.state.finished_collection = self.state.finished_collection.wrapping_add(1);
-        let has_memory = self.state.config.memory;
 
         let mut result = Ok(());
 
@@ -261,7 +245,7 @@ impl LockedCheckpointer for BasicLockedProcessor<'_> {
                 // If this processor does not require memory, stale, stateless
                 // entries can be removed. This implies that they were not updated
                 // over the previous full collection interval.
-                if stale && stateless && !has_memory {
+                if stale && stateless {
                     return false;
                 }
                 return true;
@@ -285,18 +269,9 @@ impl LockedCheckpointer for BasicLockedProcessor<'_> {
     }
 }
 
-#[derive(Debug, Default)]
-struct BasicProcessorConfig {
-    /// Memory controls whether the processor remembers metric instruments and attribute
-    /// sets that were previously reported. When Memory is true,
-    /// `CheckpointSet::try_for_each` will visit metrics that were not updated in
-    /// the most recent interval.
-    memory: bool,
-}
 
 #[derive(Debug)]
 struct BasicProcessorState {
-    config: BasicProcessorConfig,
     values: HashMap<StateKey, StateValue>,
     // Note: the timestamp logic currently assumes all exports are deltas.
     process_start: SystemTime,
@@ -306,18 +281,9 @@ struct BasicProcessorState {
     finished_collection: u64,
 }
 
-impl BasicProcessorState {
-    fn with_memory(memory: bool) -> Self {
-        let mut state = BasicProcessorState::default();
-        state.config.memory = memory;
-        state
-    }
-}
-
 impl Default for BasicProcessorState {
     fn default() -> Self {
         BasicProcessorState {
-            config: BasicProcessorConfig::default(),
             values: HashMap::default(),
             process_start: opentelemetry_api::time::now(),
             interval_start: opentelemetry_api::time::now(),
@@ -344,12 +310,6 @@ impl Reader for BasicProcessorState {
             let agg;
             let start;
 
-            // If the processor does not have memory and it was not updated in the
-            // prior round, do not visit this value.
-            if !self.config.memory && value.updated != self.finished_collection.wrapping_sub(1) {
-                return Ok(());
-            }
-
             match temporality_selector
                 .temporality_for(&value.descriptor, value.current.aggregation().kind())
             {
@@ -369,6 +329,12 @@ impl Reader for BasicProcessorState {
                     // Precomputed sums are a special case.
                     if instrument_kind.precomputed_sum() {
                         return Err(MetricsError::Other("No cumulative to delta".into()));
+                    }
+
+                    if  value.updated != self.finished_collection.wrapping_sub(1) {
+                        // skip processing if there is no update in last collection internal and
+                        // temporality is Delta
+                        return Ok(())
                     }
 
                     agg = Some(&value.current);
@@ -417,7 +383,7 @@ struct StateValue {
     /// multiple `Accumulator`s during a single collection
     /// round, which may happen either because:
     ///
-    /// (1) multiple `Accumulator`s output the same `Accumulation.
+    /// (1) multiple `Accumulator`s output the same `Accumulation`.
     /// (2) one `Accumulator` is configured with dimensionality reduction.
     current_owned: bool,
 

--- a/opentelemetry-sdk/tests/metrics.rs
+++ b/opentelemetry-sdk/tests/metrics.rs
@@ -3,13 +3,14 @@
 mod metrics {
     use std::time::Duration;
 
-    use opentelemetry_api::metrics::{Counter, MeterProvider};
+    use opentelemetry_api::metrics::{Counter, MeterProvider, UpDownCounter};
     use opentelemetry_api::Context;
     use opentelemetry_sdk::export::metrics::aggregation::{
-        cumulative_temporality_selector, delta_temporality_selector, Sum, TemporalitySelector,
+        cumulative_temporality_selector, delta_temporality_selector, LastValue, Sum,
+        TemporalitySelector,
     };
     use opentelemetry_sdk::export::metrics::InstrumentationLibraryReader;
-    use opentelemetry_sdk::metrics::aggregators::SumAggregator;
+    use opentelemetry_sdk::metrics::aggregators::{LastValueAggregator, SumAggregator};
     use opentelemetry_sdk::metrics::controllers::BasicController;
     use opentelemetry_sdk::metrics::sdk_api::NumberKind;
     use opentelemetry_sdk::metrics::{controllers, processors, selectors};
@@ -23,10 +24,13 @@ mod metrics {
         {
             temporality: F,
             controller: BasicController,
-            counter: Counter<f64>,
             context: Context,
 
-            results: Vec<f64>,
+            gauge_tx: crossbeam_channel::Sender<i64>,
+            counter: Counter<f64>,
+            up_down_counter: UpDownCounter<f64>,
+
+            results: Vec<Vec<(String, f64)>>,
         }
 
         impl<T, F> TestSuite<T, F>
@@ -36,69 +40,164 @@ mod metrics {
         {
             fn setup(f: F) -> Self {
                 let controller = controllers::basic(processors::factory(
-                    selectors::simple::inexpensive(), // basically give us SUM aggregation
+                    selectors::simple::inexpensive(), // basically give us Sum aggregation except for gauge, which is LastValue aggregation
                     f(),
                 ))
                 .with_collect_period(Duration::ZERO) // require manual collection
                 .build();
                 let meter = controller.versioned_meter("test", None, None);
+                let (gauge_tx, gauge_rx) = crossbeam_channel::bounded(10);
+                let gauge = meter.i64_observable_gauge("gauge").init();
+                meter
+                    .register_callback(move |cx| {
+                        if let Ok(val) = gauge_rx.try_recv() {
+                            gauge.observe(cx, val, &[]);
+                        }
+                    })
+                    .expect("failed to register callback");
                 TestSuite {
                     controller,
                     temporality: f,
                     counter: meter.f64_counter("counter").init(),
+                    up_down_counter: meter.f64_up_down_counter("up_down_counter").init(),
                     context: Context::new(),
+                    gauge_tx,
                     results: Vec::new(),
                 }
             }
 
-            fn add(&mut self, val: f64) {
+            fn add_counter(&mut self, val: f64) {
                 self.counter.add(&self.context, val, &[]);
+            }
+
+            fn change_up_down_counter(&mut self, val: f64) {
+                self.up_down_counter.add(&self.context, val, &[]);
+            }
+
+            fn change_gauge(&mut self, val: i64) {
+                self.gauge_tx.send(val).unwrap();
             }
 
             fn collect_and_save(&mut self) {
                 self.controller.collect(&self.context).unwrap();
 
                 let temporality = (self.temporality)();
+                let mut result_per_round = Vec::new();
                 self.controller
                     .try_for_each(&mut |_library, reader| {
                         reader.try_for_each(&temporality, &mut |record| {
-                            let agg = record
+                            if let Some(sum_agg) = record
                                 .aggregator()
                                 .unwrap()
                                 .as_any()
                                 .downcast_ref::<SumAggregator>()
-                                .unwrap();
-                            self.results
-                                .push(agg.sum().unwrap().to_f64(&NumberKind::F64));
+                            {
+                                result_per_round.push((
+                                    record.descriptor().name().to_owned(),
+                                    sum_agg.sum().unwrap().to_f64(&NumberKind::F64),
+                                ));
+                            }
+
+                            if let Some(last_value_agg) = record
+                                .aggregator()
+                                .unwrap()
+                                .as_any()
+                                .downcast_ref::<LastValueAggregator>()
+                            {
+                                result_per_round.push((
+                                    record.descriptor().name().to_owned(),
+                                    last_value_agg
+                                        .last_value()
+                                        .unwrap()
+                                        .0
+                                        .to_f64(&NumberKind::I64),
+                                ))
+                            }
+
                             Ok(())
                         })?;
                         Ok(())
                     })
                     .expect("no error expected");
+                // sort result per round stablely so we have deterministic results
+                result_per_round.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.total_cmp(&b.1)));
+                self.results.push(result_per_round);
             }
 
-            fn expect(self, expected: Vec<f64>) {
-                assert_eq!(self.results, expected)
+            fn expect(self, expected: Vec<Vec<(impl Into<String>, f64)>>) {
+                assert_eq!(
+                    self.results,
+                    expected
+                        .into_iter()
+                        .map(|v| v
+                            .into_iter()
+                            .map(|(k, v)| (k.into(), v))
+                            .collect::<Vec<_>>())
+                        .collect::<Vec<_>>()
+                );
             }
         }
 
         let mut cumulative = TestSuite::setup(cumulative_temporality_selector);
-        cumulative.add(10.0);
-        cumulative.add(5.3);
+        // round 1
+        cumulative.add_counter(10.0);
+        cumulative.add_counter(5.3);
         cumulative.collect_and_save();
-
+        // round 2
         cumulative.collect_and_save();
-        cumulative.add(10.0);
+        // round 3
+        cumulative.add_counter(0.0);
+        cumulative.change_up_down_counter(-1.0);
+        cumulative.change_gauge(-1);
         cumulative.collect_and_save();
-        cumulative.expect(vec![15.3, 15.3, 25.3]);
+        // round 4
+        cumulative.change_up_down_counter(1.0);
+        cumulative.add_counter(10.0);
+        cumulative.collect_and_save();
+        // round 5
+        cumulative.change_gauge(1);
+        cumulative.collect_and_save();
+        // assert
+        cumulative.expect(vec![
+            vec![("counter", 15.3)],
+            vec![("counter", 15.3)],
+            vec![
+                ("counter", 15.3),
+                ("gauge", -1.0),
+                ("up_down_counter", -1.0),
+            ],
+            vec![("counter", 25.3), ("gauge", -1.0), ("up_down_counter", 0.0)],
+            vec![("counter", 25.3), ("gauge", 1.0), ("up_down_counter", 0.0)],
+        ]);
 
         let mut delta = TestSuite::setup(delta_temporality_selector);
-        delta.add(10.0);
-        delta.add(5.3);
+        // round 1
+        delta.add_counter(10.0);
+        delta.add_counter(5.3);
         delta.collect_and_save();
+        // round 2
         delta.collect_and_save();
-        delta.add(10.0);
+        // round 3
+        delta.add_counter(10.0);
         delta.collect_and_save();
-        delta.expect(vec![15.3, 10.0])
+        // round 4
+        delta.add_counter(0.0);
+        delta.collect_and_save();
+        // round 5
+        delta.change_up_down_counter(-1.0);
+        delta.change_gauge(-1);
+        delta.collect_and_save();
+        // round 6
+        delta.change_up_down_counter(1.0);
+        delta.collect_and_save();
+        // assert
+        delta.expect(vec![
+            vec![("counter", 15.3)],
+            vec![], // no change and no data exported
+            vec![("counter", 10.0)],
+            vec![("counter", 0.0)],
+            vec![("gauge", -1.0), ("up_down_counter", -1.0)],
+            vec![("up_down_counter", 1.0)],
+        ])
     }
 }

--- a/opentelemetry-sdk/tests/metrics.rs
+++ b/opentelemetry-sdk/tests/metrics.rs
@@ -1,0 +1,104 @@
+#[cfg(test)]
+#[cfg(feature = "metrics")]
+mod metrics {
+    use std::time::Duration;
+
+    use opentelemetry_api::metrics::{Counter, MeterProvider};
+    use opentelemetry_api::Context;
+    use opentelemetry_sdk::export::metrics::aggregation::{
+        cumulative_temporality_selector, delta_temporality_selector, Sum, TemporalitySelector,
+    };
+    use opentelemetry_sdk::export::metrics::InstrumentationLibraryReader;
+    use opentelemetry_sdk::metrics::aggregators::SumAggregator;
+    use opentelemetry_sdk::metrics::controllers::BasicController;
+    use opentelemetry_sdk::metrics::sdk_api::NumberKind;
+    use opentelemetry_sdk::metrics::{controllers, processors, selectors};
+
+    #[test]
+    fn test_temporality() {
+        struct TestSuite<T, F>
+        where
+            T: TemporalitySelector + Clone + Send + Sync + 'static,
+            F: Fn() -> T,
+        {
+            temporality: F,
+            controller: BasicController,
+            counter: Counter<f64>,
+            context: Context,
+
+            results: Vec<f64>,
+        }
+
+        impl<T, F> TestSuite<T, F>
+        where
+            F: Fn() -> T,
+            T: TemporalitySelector + Clone + Send + Sync + 'static,
+        {
+            fn setup(f: F) -> Self {
+                let controller = controllers::basic(processors::factory(
+                    selectors::simple::inexpensive(), // basically give us SUM aggregation
+                    f(),
+                ))
+                .with_collect_period(Duration::ZERO) // require manual collection
+                .build();
+                let meter = controller.versioned_meter("test", None, None);
+                TestSuite {
+                    controller,
+                    temporality: f,
+                    counter: meter.f64_counter("counter").init(),
+                    context: Context::new(),
+                    results: Vec::new(),
+                }
+            }
+
+            fn add(&mut self, val: f64) {
+                self.counter.add(&self.context, val, &[]);
+            }
+
+            fn collect_and_save(&mut self) {
+                self.controller.collect(&self.context).unwrap();
+
+                let temporality = (self.temporality)();
+                self.controller
+                    .try_for_each(&mut |_library, reader| {
+                        reader.try_for_each(&temporality, &mut |record| {
+                            let agg = record
+                                .aggregator()
+                                .unwrap()
+                                .as_any()
+                                .downcast_ref::<SumAggregator>()
+                                .unwrap();
+                            self.results
+                                .push(agg.sum().unwrap().to_f64(&NumberKind::F64));
+                            Ok(())
+                        })?;
+                        Ok(())
+                    })
+                    .expect("no error expected");
+            }
+
+            fn expect(self, expected: Vec<f64>) {
+                assert_eq!(self.results, expected)
+            }
+        }
+
+        let mut cumulative = TestSuite::setup(cumulative_temporality_selector);
+        cumulative.add(10.0);
+        cumulative.add(5.3);
+        cumulative.collect_and_save();
+
+        cumulative.collect_and_save();
+        cumulative.add(10.0);
+        cumulative.collect_and_save();
+        cumulative.expect(vec![15.3, 15.3, 25.3]);
+
+        let mut delta = TestSuite::setup(delta_temporality_selector);
+        delta.add(10.0);
+        delta.add(5.3);
+        delta.collect_and_save();
+        delta.collect_and_save();
+        delta.add(10.0);
+        delta.collect_and_save();
+        delta.expect(vec![15.3, 10.0])
+    }
+}


### PR DESCRIPTION
The `memory` settings are used to control whether the processor should process the instrument that is not updated in this collection interval.  

Users can achieve the same behavior using temporality. It also causes bugs when memory is `true` but the temporality is `Delta`. In this case, I think we should delete the record if the instrument didn't update. But if `memory` is `true` it will prevent the stale record from deleting.

**Is this fix #939?**
Well, sort of. The root cause of #939 is we don't delete the stale record for `Delta` temporality because the memory is set to `true`, which should be fixed now that we remove the memory settings. However, for #939 the bigger issue is we shouldn't allow user to use `Detla` temporality with Prometheus exporter. 

> A Prometheus Exporter MUST only support [Cumulative Temporality](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#temporality).
