### PR TITLE
Fix deriving endpoint URLs from OTEL_EXPORTER_OTLP_ENDPOINT

### DIFF
--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -41,6 +41,7 @@ pub const OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: &str = "OTEL_EXPORTER_OTLP_METRIC
 pub const OTEL_EXPORTER_OTLP_METRICS_TIMEOUT: &str = "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT";
 /// Compression algorithm to use, defaults to none.
 pub const OTEL_EXPORTER_OTLP_METRICS_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_METRICS_COMPRESSION";
+
 impl OtlpPipeline {
     /// Create a OTLP metrics pipeline.
     pub fn metrics<RT>(self, rt: RT) -> OtlpMetricPipeline<RT>


### PR DESCRIPTION
According to the spec, if OTEL_EXPORTER_OTLP_ENDPOINT env variable is set, the full URL to use for traces is formed by appending "/v1/traces" to OTEL_EXPORTER_OTLP_ENDPOINT. Similarly, the metrics URL is formed by appending "/v1/metrics". We were doing this correctly in the grpc-tonic exporter, in `SpanExporter::new_tonic`, but the corresponding `SpanExporter::new_grpcio` and `SpanExporter::new_http` functions didn't get the memo. As a result, if you used the HTTP protocol or the grpcio implementation, and set
OTEL_EXPORTER_OTLP_ENDPOINT=http://foobar:4318/, the traces would be incorrectly sent to "http://foobar:4318/", when the correct destination would be "http://foobar:4318/v1/traces"

The timeout settings had similar issues; the per-signal TIMEOUT env variable was not always taken into account.

To fix, move the logic for forming the full URLs into ExporterConfig, and use it in all the different implementations. Similarly for the timeouts.

Add a test case with the three examples given in the OpenTelemetry specification.