### PR TITLE
Fix formatting in ShouldSample docs

### DIFF
--- a/opentelemetry-sdk/src/trace/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler.rs
@@ -51,7 +51,7 @@ use opentelemetry_http::HttpClient;
 ///   and [`SpanExporter`]s will receive spans with the `Sampled` flag set for
 ///   processing.
 ///
-/// The flag combination `Sampled == false` and `is_recording` == true` means
+/// The flag combination `Sampled == false` and `is_recording == true` means
 /// that the current `Span` does record information, but most likely the child
 /// `Span` will not.
 ///


### PR DESCRIPTION
As I was going through the docs I noticed this typo made the [hard to read](https://docs.rs/opentelemetry/latest/opentelemetry/sdk/trace/trait.ShouldSample.html).