### PR TITLE
Update some dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.57
+        toolchain: 1.60.0
         override: true
     - name: Patch dependencies versions # some dependencies bump MSRV without major version bump
       run: ./scripts/patch_dependencies.sh

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.57+][msrv]*
+*Compiler support: [requires `rustc` 1.60+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
@@ -137,7 +137,7 @@ above, please let us know! We'd love to add your project to the list!
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.57. The current OpenTelemetry version is not guaranteed to build
+version is 1.60. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-api/Cargo.toml
+++ b/opentelemetry-api/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [dependencies]
 fnv = { version = "1.0", optional = true }
@@ -23,9 +23,6 @@ urlencoding = "2.1.2"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3"
 
 [features]
 default = ["trace"]

--- a/opentelemetry-api/README.md
+++ b/opentelemetry-api/README.md
@@ -25,7 +25,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.57+][msrv]*
+*Compiler support: [requires `rustc` 1.60+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io

--- a/opentelemetry-api/src/lib.rs
+++ b/opentelemetry-api/src/lib.rs
@@ -2,7 +2,7 @@
 //! services to capture distributed traces and metrics from your application. You
 //! can analyze them using [Prometheus], [Jaeger], and other observability tools.
 //!
-//! *Compiler support: [requires `rustc` 1.57+][msrv]*
+//! *Compiler support: [requires `rustc` 1.60+][msrv]*
 //!
 //! [Prometheus]: https://prometheus.io
 //! [Jaeger]: https://www.jaegertracing.io
@@ -11,7 +11,7 @@
 //! ## Supported Rust Versions
 //!
 //! OpenTelemetry is built against the latest stable release. The minimum
-//! supported version is 1.57. The current OpenTelemetry version is not
+//! supported version is 1.60. The current OpenTelemetry version is not
 //! guaranteed to build on Rust versions earlier than the minimum supported
 //! version.
 //!

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-dynatrace/Cargo.toml
+++ b/opentelemetry-dynatrace/Cargo.toml
@@ -50,7 +50,7 @@ wasm = [
 
 [dependencies]
 async-std = { version = "= 1.10.0", features = ["unstable"], optional = true }
-base64 = { version = "0.13", optional = true }
+base64 = { version = "0.21", optional = true }
 futures = "0.3"
 futures-util = { version = "0.3", optional = true }
 getrandom = { version = "0.2", optional = true }

--- a/opentelemetry-dynatrace/Cargo.toml
+++ b/opentelemetry-dynatrace/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "metrics", "dynatrace"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 keywords = ["opentelemetry", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [dependencies]
 async-trait = "0.1"

--- a/opentelemetry-http/README.md
+++ b/opentelemetry-http/README.md
@@ -21,7 +21,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a HTTP client interface for use by trace exporters, as well as
 helper types to inject and extract key value pairs into/from HTTP headers.
 
-*Compiler support: [requires `rustc` 1.57+][msrv]*
+*Compiler support: [requires `rustc` 1.60+][msrv]*
 
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
 [msrv]: #supported-rust-versions
@@ -29,7 +29,7 @@ helper types to inject and extract key value pairs into/from HTTP headers.
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.57. The current OpenTelemetry version is not guaranteed to build
+version is 1.60. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "jaeger", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-std = { version = "1.10.0", optional = true }
 async-trait = "0.1"
-base64 = { version = "0.13", optional = true }
+base64 = { version = "0.21.0", optional = true }
 futures = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["std"], optional = true }
 futures-executor = "0.3"
@@ -40,14 +40,14 @@ pin-project-lite = { version = "0.2", optional = true }
 reqwest = { version = "0.11", default-features = false, optional = true }
 surf = { version = "2.0", optional = true }
 thiserror = "1.0"
-thrift = "0.16"
+thrift = "0.17.0"
 tokio = { version = "1.0", features = ["net", "sync"], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4.18", optional = true }
 
-tonic = { version = "0.6.2", optional = true }
-prost = { version = "0.9.0", optional = true }
-prost-types = { version = "0.9.0", optional = true }
+tonic = { version = "0.8.3", optional = true }
+prost = { version = "0.11.6", optional = true }
+prost-types = { version = "0.11.6", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["net", "sync"] }

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -23,7 +23,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a trace pipeline and exporter for sending span information to a
 Jaeger `agent` or `collector` endpoint for processing and visualization.
 
-*Compiler support: [requires `rustc` 1.57+][msrv]*
+*Compiler support: [requires `rustc` 1.60+][msrv]*
 
 [`Jaeger`]: https://www.jaegertracing.io/
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry

--- a/opentelemetry-jaeger/src/exporter/collector.rs
+++ b/opentelemetry-jaeger/src/exporter/collector.rs
@@ -74,6 +74,8 @@ mod collector_client {
 #[cfg(feature = "wasm_collector_client")]
 mod wasm_collector_client {
     use crate::exporter::thrift::jaeger;
+    use base64::engine::general_purpose;
+    use base64::Engine;
     use futures_util::future;
     use http::Uri;
     use js_sys::Uint8Array;
@@ -109,9 +111,9 @@ mod wasm_collector_client {
         ) -> thrift::Result<Self> {
             let auth = if let (Some(username), Some(password)) = (username, password) {
                 let mut auth = String::from("Basic ");
-                base64::encode_config_buf(username, base64::STANDARD, &mut auth);
+                general_purpose::STANDARD.encode_string(username, &mut auth);
                 auth.push(':');
-                base64::encode_config_buf(password, base64::STANDARD, &mut auth);
+                general_purpose::STANDARD.encode_string(password, &mut auth);
                 Some(auth)
             } else {
                 None

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! See the [Jaeger Docs] for details about Jaeger and deployment information.
 //!
-//! *Compiler support: [requires `rustc` 1.57+][msrv]*
+//! *Compiler support: [requires `rustc` 1.60+][msrv]*
 //!
 //! [Jaeger Docs]: https://www.jaegertracing.io/docs/
 //! [msrv]: #supported-rust-versions
@@ -280,13 +280,13 @@
 //! # Supported Rust Versions
 //!
 //! OpenTelemetry is built against the latest stable release. The minimum
-//! supported version is 1.57. The current OpenTelemetry version is not
+//! supported version is 1.60. The current OpenTelemetry version is not
 //! guaranteed to build on Rust versions earlier than the minimum supported
 //! version.
 //!
 //! The current stable Rust compiler and the three most recent minor versions
 //! before it will always be supported. For example, if the current stable
-//! compiler version is 1.57, the minimum supported version will not be
+//! compiler version is 1.60, the minimum supported version will not be
 //! increased past 1.46, three minor versions prior. Increasing the minimum
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.

--- a/opentelemetry-jaeger/src/testing/jaeger_api_v2.rs
+++ b/opentelemetry-jaeger/src/testing/jaeger_api_v2.rs
@@ -1,6 +1,4 @@
-// generated files from jaeger proto(https://github.com/jaegertracing/jaeger-idl/tree/main/proto/api_v2)
-// DO NOT EDIT
-
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyValue {
     #[prost(string, tag = "1")]
@@ -16,75 +14,81 @@ pub struct KeyValue {
     #[prost(double, tag = "6")]
     pub v_float64: f64,
     #[prost(bytes = "vec", tag = "7")]
-    pub v_binary: std::vec::Vec<u8>,
+    pub v_binary: ::prost::alloc::vec::Vec<u8>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Log {
     #[prost(message, optional, tag = "1")]
-    pub timestamp: std::option::Option<::prost_types::Timestamp>,
+    pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(message, repeated, tag = "2")]
-    pub fields: std::vec::Vec<KeyValue>,
+    pub fields: ::prost::alloc::vec::Vec<KeyValue>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SpanRef {
     #[prost(bytes = "vec", tag = "1")]
-    pub trace_id: std::vec::Vec<u8>,
+    pub trace_id: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "2")]
-    pub span_id: std::vec::Vec<u8>,
+    pub span_id: ::prost::alloc::vec::Vec<u8>,
     #[prost(enumeration = "SpanRefType", tag = "3")]
     pub ref_type: i32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Process {
     #[prost(string, tag = "1")]
     pub service_name: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
-    pub tags: std::vec::Vec<KeyValue>,
+    pub tags: ::prost::alloc::vec::Vec<KeyValue>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Span {
     #[prost(bytes = "vec", tag = "1")]
-    pub trace_id: std::vec::Vec<u8>,
+    pub trace_id: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "2")]
-    pub span_id: std::vec::Vec<u8>,
+    pub span_id: ::prost::alloc::vec::Vec<u8>,
     #[prost(string, tag = "3")]
     pub operation_name: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "4")]
-    pub references: std::vec::Vec<SpanRef>,
+    pub references: ::prost::alloc::vec::Vec<SpanRef>,
     #[prost(uint32, tag = "5")]
     pub flags: u32,
     #[prost(message, optional, tag = "6")]
-    pub start_time: std::option::Option<::prost_types::Timestamp>,
+    pub start_time: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(message, optional, tag = "7")]
-    pub duration: std::option::Option<::prost_types::Duration>,
+    pub duration: ::core::option::Option<::prost_types::Duration>,
     #[prost(message, repeated, tag = "8")]
-    pub tags: std::vec::Vec<KeyValue>,
+    pub tags: ::prost::alloc::vec::Vec<KeyValue>,
     #[prost(message, repeated, tag = "9")]
-    pub logs: std::vec::Vec<Log>,
+    pub logs: ::prost::alloc::vec::Vec<Log>,
     #[prost(message, optional, tag = "10")]
-    pub process: std::option::Option<Process>,
+    pub process: ::core::option::Option<Process>,
     #[prost(string, tag = "11")]
     pub process_id: ::prost::alloc::string::String,
     #[prost(string, repeated, tag = "12")]
-    pub warnings: std::vec::Vec<::prost::alloc::string::String>,
+    pub warnings: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Trace {
     #[prost(message, repeated, tag = "1")]
-    pub spans: std::vec::Vec<Span>,
+    pub spans: ::prost::alloc::vec::Vec<Span>,
     #[prost(message, repeated, tag = "2")]
-    pub process_map: std::vec::Vec<trace::ProcessMapping>,
+    pub process_map: ::prost::alloc::vec::Vec<trace::ProcessMapping>,
     #[prost(string, repeated, tag = "3")]
-    pub warnings: std::vec::Vec<::prost::alloc::string::String>,
+    pub warnings: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `Trace`.
 pub mod trace {
+    #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ProcessMapping {
         #[prost(string, tag = "1")]
         pub process_id: ::prost::alloc::string::String,
         #[prost(message, optional, tag = "2")]
-        pub process: std::option::Option<super::Process>,
+        pub process: ::core::option::Option<super::Process>,
     }
 }
 /// Note that both Span and Batch may contain a Process.
@@ -96,13 +100,15 @@ pub mod trace {
 /// semantics, both Batch and Spans in the same message may contain
 /// their own instances of Process, with span.Process taking priority
 /// over batch.Process.
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Batch {
     #[prost(message, repeated, tag = "1")]
-    pub spans: std::vec::Vec<Span>,
+    pub spans: ::prost::alloc::vec::Vec<Span>,
     #[prost(message, optional, tag = "2")]
-    pub process: std::option::Option<Process>,
+    pub process: ::core::option::Option<Process>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DependencyLink {
     #[prost(string, tag = "1")]
@@ -123,29 +129,80 @@ pub enum ValueType {
     Float64 = 3,
     Binary = 4,
 }
+impl ValueType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ValueType::String => "STRING",
+            ValueType::Bool => "BOOL",
+            ValueType::Int64 => "INT64",
+            ValueType::Float64 => "FLOAT64",
+            ValueType::Binary => "BINARY",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "STRING" => Some(Self::String),
+            "BOOL" => Some(Self::Bool),
+            "INT64" => Some(Self::Int64),
+            "FLOAT64" => Some(Self::Float64),
+            "BINARY" => Some(Self::Binary),
+            _ => None,
+        }
+    }
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum SpanRefType {
     ChildOf = 0,
     FollowsFrom = 1,
 }
+impl SpanRefType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            SpanRefType::ChildOf => "CHILD_OF",
+            SpanRefType::FollowsFrom => "FOLLOWS_FROM",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CHILD_OF" => Some(Self::ChildOf),
+            "FOLLOWS_FROM" => Some(Self::FollowsFrom),
+            _ => None,
+        }
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetTraceRequest {
     #[prost(bytes = "vec", tag = "1")]
-    pub trace_id: std::vec::Vec<u8>,
+    pub trace_id: ::prost::alloc::vec::Vec<u8>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SpansResponseChunk {
     #[prost(message, repeated, tag = "1")]
-    pub spans: std::vec::Vec<Span>,
+    pub spans: ::prost::alloc::vec::Vec<Span>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArchiveTraceRequest {
     #[prost(bytes = "vec", tag = "1")]
-    pub trace_id: std::vec::Vec<u8>,
+    pub trace_id: ::prost::alloc::vec::Vec<u8>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArchiveTraceResponse {}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TraceQueryParameters {
     #[prost(string, tag = "1")]
@@ -154,30 +211,34 @@ pub struct TraceQueryParameters {
     pub operation_name: ::prost::alloc::string::String,
     #[prost(map = "string, string", tag = "3")]
     pub tags:
-        std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     #[prost(message, optional, tag = "4")]
-    pub start_time_min: std::option::Option<::prost_types::Timestamp>,
+    pub start_time_min: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(message, optional, tag = "5")]
-    pub start_time_max: std::option::Option<::prost_types::Timestamp>,
+    pub start_time_max: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(message, optional, tag = "6")]
-    pub duration_min: std::option::Option<::prost_types::Duration>,
+    pub duration_min: ::core::option::Option<::prost_types::Duration>,
     #[prost(message, optional, tag = "7")]
-    pub duration_max: std::option::Option<::prost_types::Duration>,
+    pub duration_max: ::core::option::Option<::prost_types::Duration>,
     #[prost(int32, tag = "8")]
     pub search_depth: i32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FindTracesRequest {
     #[prost(message, optional, tag = "1")]
-    pub query: std::option::Option<TraceQueryParameters>,
+    pub query: ::core::option::Option<TraceQueryParameters>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetServicesRequest {}
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetServicesResponse {
     #[prost(string, repeated, tag = "1")]
-    pub services: std::vec::Vec<::prost::alloc::string::String>,
+    pub services: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetOperationsRequest {
     #[prost(string, tag = "1")]
@@ -185,6 +246,7 @@ pub struct GetOperationsRequest {
     #[prost(string, tag = "2")]
     pub span_kind: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag = "1")]
@@ -192,36 +254,40 @@ pub struct Operation {
     #[prost(string, tag = "2")]
     pub span_kind: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetOperationsResponse {
-    ///deprecated
+    /// deprecated
     #[prost(string, repeated, tag = "1")]
-    pub operation_names: std::vec::Vec<::prost::alloc::string::String>,
+    pub operation_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(message, repeated, tag = "2")]
-    pub operations: std::vec::Vec<Operation>,
+    pub operations: ::prost::alloc::vec::Vec<Operation>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetDependenciesRequest {
     #[prost(message, optional, tag = "1")]
-    pub start_time: std::option::Option<::prost_types::Timestamp>,
+    pub start_time: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(message, optional, tag = "2")]
-    pub end_time: std::option::Option<::prost_types::Timestamp>,
+    pub end_time: ::core::option::Option<::prost_types::Timestamp>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetDependenciesResponse {
     #[prost(message, repeated, tag = "1")]
-    pub dependencies: std::vec::Vec<DependencyLink>,
+    pub dependencies: ::prost::alloc::vec::Vec<DependencyLink>,
 }
-#[doc = r" Generated client implementations."]
+/// Generated client implementations.
 pub mod query_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct QueryServiceClient<T> {
         inner: tonic::client::Grpc<T>,
     }
     impl QueryServiceClient<tonic::transport::Channel> {
-        #[doc = r" Attempt to create a new client by connecting to a given endpoint."]
+        /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
             D: std::convert::TryInto<tonic::transport::Endpoint>,
@@ -234,12 +300,16 @@ pub mod query_service_client {
     impl<T> QueryServiceClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::ResponseBody: Body + Send + 'static,
         T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     {
         pub fn new(inner: T) -> Self {
             let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
         pub fn with_interceptor<F>(
@@ -248,6 +318,7 @@ pub mod query_service_client {
         ) -> QueryServiceClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
             T: tonic::codegen::Service<
                 http::Request<tonic::body::BoxBody>,
                 Response = http::Response<
@@ -259,17 +330,19 @@ pub mod query_service_client {
         {
             QueryServiceClient::new(InterceptedService::new(inner, interceptor))
         }
-        #[doc = r" Compress requests with `gzip`."]
-        #[doc = r""]
-        #[doc = r" This requires the server to support it otherwise it might respond with an"]
-        #[doc = r" error."]
-        pub fn send_gzip(mut self) -> Self {
-            self.inner = self.inner.send_gzip();
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
             self
         }
-        #[doc = r" Enable decompressing responses with `gzip`."]
-        pub fn accept_gzip(mut self) -> Self {
-            self.inner = self.inner.accept_gzip();
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
             self
         }
         pub async fn get_trace(

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -35,7 +35,7 @@ futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
 opentelemetry-proto = { version = "0.1", path = "../opentelemetry-proto", default-features = false }
 
-grpcio = { version = "0.11", optional = true }
+grpcio = { version = "0.12", optional = true}
 opentelemetry = { version = "0.18", default-features = false, features = ["trace"], path = "../opentelemetry" }
 opentelemetry-http = { version = "0.7", path = "../opentelemetry-http", optional = true }
 protobuf = { version = "2.18", optional = true }

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 autotests = false
 
 [lib]

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -381,17 +381,17 @@ impl SpanExporter {
         }
 
         let channel: GrpcChannel = match (grpcio_config.credentials, grpcio_config.use_tls) {
-            (None, Some(true)) => builder.secure_connect(
-                config.endpoint.as_str(),
-                ChannelCredentialsBuilder::new().build(),
-            ),
+            (None, Some(true)) => builder
+                .set_credentials(ChannelCredentialsBuilder::new().build())
+                .connect(config.endpoint.as_str()),
             (None, _) => builder.connect(config.endpoint.as_str()),
-            (Some(credentials), _) => builder.secure_connect(
-                config.endpoint.as_str(),
-                ChannelCredentialsBuilder::new()
-                    .cert(credentials.cert.into(), credentials.key.into())
-                    .build(),
-            ),
+            (Some(credentials), _) => builder
+                .set_credentials(
+                    ChannelCredentialsBuilder::new()
+                        .cert(credentials.cert.into(), credentials.key.into())
+                        .build(),
+                )
+                .connect(config.endpoint.as_str()),
         };
 
         SpanExporter::Grpcio {

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "prometheus", "metrics", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -43,7 +43,7 @@ zpages = ["traces"]
 with-serde = ["protobuf/with-serde", "serde", "serde_json"]
 
 [dependencies]
-grpcio = { version = "0.11", optional = true }
+grpcio = { version = "0.12", optional = true }
 tonic = { version = "0.8.0", optional = true }
 prost = { version = "0.11.0", optional = true }
 protobuf = { version = "2.18", optional = true } # todo: update to 3.0 so we have docs for generated types.

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -14,7 +14,7 @@ categories = [
 keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 autotests = false
 
 [lib]

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -37,7 +37,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
 bincode = "1.2"
-criterion = "0.3.1"
+criterion = "0.4.0"
 rand_distr = "0.4.0"
 crossbeam-queue = "0.3.1"
 

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [dependencies]
 opentelemetry_api = { version = "0.18", path = "../opentelemetry-api/" }

--- a/opentelemetry-sdk/README.md
+++ b/opentelemetry-sdk/README.md
@@ -25,7 +25,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.57+][msrv]*
+*Compiler support: [requires `rustc` 1.60+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io

--- a/opentelemetry-semantic-conventions/Cargo.toml
+++ b/opentelemetry-semantic-conventions/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 license = "Apache-2.0"
 edition = "2021"
 exclude = ["/proto"]
-rust-version = "1.56.0"
+rust-version = "1.60"
 
 [dependencies]
 async-trait = "0.1.48"

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 license = "Apache-2.0"
 edition = "2021"
 exclude = ["/proto"]
+rust-version = "1.56.0"
 
 [dependencies]
 async-trait = "0.1.48"

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -22,7 +22,7 @@ prost = "0.11.0"
 prost-types = "0.11.1"
 thiserror = "1.0.30"
 tonic = { version = "0.8.0", features = ["gzip", "tls", "transport"] }
-yup-oauth2 = { version = "7.0.1", optional = true }
+yup-oauth2 = { version = "8.1.0", optional = true }
 
 [features]
 default = ["yup-authorizer", "tls-native-roots"]

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -420,9 +420,14 @@ impl Authorizer for YupAuthorizer {
             .await
             .map_err(|e| Error::Authorizer(e.into()))?;
 
+        let token = match token.token() {
+            Some(token) => token,
+            None => return Err(Error::Other("unable to access token contents".into())),
+        };
+
         req.metadata_mut().insert(
             "authorization",
-            MetadataValue::try_from(format!("Bearer {}", token.as_str())).unwrap(),
+            MetadataValue::try_from(format!("Bearer {}", token)).unwrap(),
         );
         Ok(())
     }

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -33,7 +33,7 @@ opentelemetry-http = { version = "0.7", path = "../opentelemetry-http", optional
 opentelemetry-semantic-conventions = { version = "0.10", path = "../opentelemetry-semantic-conventions" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-typed-builder = "0.9"
+typed-builder = "0.12"
 once_cell = "1.12"
 http = "0.2"
 reqwest = { version = "0.11", optional = true, default-features = false }

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -23,7 +23,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a trace pipeline and exporter for sending span information to a
 Zipkin collector for processing and visualization.
 
-*Compiler support: [requires `rustc` 1.57+][msrv]*
+*Compiler support: [requires `rustc` 1.60+][msrv]*
 
 [`Zipkin`]: https://zipkin.io/
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
@@ -107,12 +107,12 @@ available so be sure to match them appropriately.
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.57. The current OpenTelemetry version is not guaranteed to build on
+version is 1.60. The current OpenTelemetry version is not guaranteed to build on
 Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions before
 it will always be supported. For example, if the current stable compiler version
-is 1.57, the minimum supported version will not be increased past 1.46, three
+is 1.60, the minimum supported version will not be increased past 1.46, three
 minor versions prior. Increasing the minimum supported compiler version is not
 considered a semver breaking change as long as doing so complies with this
 policy.

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -3,7 +3,7 @@
 //! Collects OpenTelemetry spans and reports them to a given Zipkin collector
 //! endpoint. See the [Zipkin Docs] for details and deployment information.
 //!
-//! *Compiler support: [requires `rustc` 1.57+][msrv]*
+//! *Compiler support: [requires `rustc` 1.60+][msrv]*
 //!
 //! [Zipkin Docs]: https://zipkin.io/
 //! [msrv]: #supported-rust-versions
@@ -167,7 +167,7 @@
 //! ## Supported Rust Versions
 //!
 //! OpenTelemetry is built against the latest stable release. The minimum
-//! supported version is 1.57. The current OpenTelemetry version is not
+//! supported version is 1.60. The current OpenTelemetry version is not
 //! guaranteed to build on Rust versions earlier than the minimum supported
 //! version.
 //!

--- a/opentelemetry-zpages/Cargo.toml
+++ b/opentelemetry-zpages/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -14,7 +14,7 @@ categories = [
 keywords = ["opentelemetry", "logging", "tracing", "metrics", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -25,7 +25,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.57+][msrv]*
+*Compiler support: [requires `rustc` 1.60+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
@@ -130,7 +130,7 @@ above, please let us know! We'd love to add your project to the list!
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.57. The current OpenTelemetry version is not guaranteed to build
+version is 1.60. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -2,7 +2,7 @@
 //! services to capture distributed traces and metrics from your application. You
 //! can analyze them using [Prometheus], [Jaeger], and other observability tools.
 //!
-//! *Compiler support: [requires `rustc` 1.57+][msrv]*
+//! *Compiler support: [requires `rustc` 1.60+][msrv]*
 //!
 //! [Prometheus]: https://prometheus.io
 //! [Jaeger]: https://www.jaegertracing.io
@@ -192,7 +192,7 @@
 //! ## Supported Rust Versions
 //!
 //! OpenTelemetry is built against the latest stable release. The minimum
-//! supported version is 1.57. The current OpenTelemetry version is not
+//! supported version is 1.60. The current OpenTelemetry version is not
 //! guaranteed to build on Rust versions earlier than the minimum supported
 //! version.
 //!

--- a/scripts/patch_dependencies.sh
+++ b/scripts/patch_dependencies.sh
@@ -5,7 +5,4 @@ function patch_version() {
   echo "patching $1 from $latest_version to $2"
   cargo update -p $1:$latest_version --precise $2
 }
-# Dashmap >= 5.3.4 requires rust 1.59
-patch_version "dashmap" "5.1.0"
-# async-global-executor >= 2.3.0 requires rust 1.59
-patch_version "async-global-executor" "2.2.0"
+


### PR DESCRIPTION
Here are some of the easy updates from #922. I left out:

* All of the `examples`
* Updates in -contrib (base64)
* Updates in -jaeger (thrift, tonic, prost, prost-types)
* Updates in -otlp (grpc, protobuf)
* Updates in -proto (protobuf, protobuf-codegen)

For the examples, I think we have way too many example projects to reasonably maintain over time, so I think we should prune back on how many things we want to explicitly support. It would probably help if we move examples related to a particular integration crate into that crate, so that PRs are forced to update related examples. (In many cases, it looks like the example projects mainly duplicate example code from the doctests or tests in the integration crates...) This also conveniently allows me to avoid dealing with [unrelated changes](https://github.com/open-telemetry/opentelemetry-rust/pull/922#discussion_r1037053029) suggested in review.

As for grpc and protobuf, it looks like the grpcio maintainers are [uninterested](https://github.com/tikv/grpc-rs/issues/584) in updating grpcio to use protobuf 3. Personally, I think the prost/tonic stack is more attractive in any way, so I question the need for this project to maintain two gRPC integrations in parallel (and am personally not willing to spend time on that).

The base64 crate unfortunately [made their API worse](https://github.com/marshallpierce/rust-base64/issues/205) in recent releases, and the maintainer is unwilling to improve on that.