### PR TITLE
feat: add batch config for opentelemetry otlp pipeline

### DIFF
--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -180,7 +180,7 @@ fn build_batch_with_exporter<R: TraceRuntime>(
     let batch_processor = sdk::trace::BatchSpanProcessor::builder(exporter, runtime)
         .with_batch_config(batch_config.unwrap_or_default())
         .build();
-    provider_builder = builder.with_span_processor(batch_processor);
+    provider_builder = provider_builder.with_span_processor(batch_processor);
 
     if let Some(config) = trace_config {
         provider_builder = provider_builder.with_config(config);

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -100,7 +100,7 @@ impl OtlpTracePipeline {
         self
     }
 
-    /// Set the batch span processor configuration.
+    /// Set the batch span processor configuration, and it will override the env vars.
     pub fn with_batch_config(mut self, batch_config: sdk::trace::BatchConfig) -> Self {
         self.batch_config = Some(batch_config);
         self


### PR DESCRIPTION
PR for #915

- Add a `batch_config` field to the `OtlpTracePipeline`, and add a `with_batch_config` to set the batch span processor configuration for `OtlpTracePipeline`.
- build `BatchSpanProcessor` with `batch_config` in `build_batch_with_exporter`.