### PR TITLE
Fix Lint check CI by removing unneccesary conversion

### DIFF
--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -76,7 +76,6 @@ fn build_tonic() {
 fn build_content_map(path: impl AsRef<Path>) -> HashMap<String, String> {
     std::fs::read_dir(path)
         .expect("cannot open dictionary of generated files")
-        .into_iter()
         .flatten()
         .map(|entry| {
             let path = entry.path();

--- a/opentelemetry-sdk/benches/batch_span_processor.rs
+++ b/opentelemetry-sdk/benches/batch_span_processor.rs
@@ -14,7 +14,6 @@ use tokio::runtime::Runtime;
 
 fn get_span_data() -> Vec<SpanData> {
     (0..200)
-        .into_iter()
         .map(|_| SpanData {
             span_context: SpanContext::new(
                 TraceId::from_u128(12),


### PR DESCRIPTION
Trying to address https://github.com/open-telemetry/opentelemetry-rust/pull/986#issuecomment-1464058408