### PR TITLE
Few leftover fixes for shift to slack

### DIFF
--- a/opentelemetry-api/README.md
+++ b/opentelemetry-api/README.md
@@ -11,11 +11,7 @@ The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry_api)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![codecov](https://codecov.io/gh/open-telemetry/opentelemetry-rust/branch/main/graph/badge.svg)](https://codecov.io/gh/open-telemetry/opentelemetry-rust)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Website](https://opentelemetry.io/) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023) |
-[Documentation](https://docs.rs/opentelemetry)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry-aws/README.md
+++ b/opentelemetry-aws/README.md
@@ -10,10 +10,7 @@ Additional types for exporting [`OpenTelemetry`] data to AWS.
 [![Documentation](https://docs.rs/opentelemetry-aws/badge.svg)](https://docs.rs/opentelemetry-aws)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry-aws)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Documentation](https://docs.rs/opentelemetry-aws) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry-contrib/README.md
+++ b/opentelemetry-contrib/README.md
@@ -10,10 +10,7 @@ Community supported vendor integrations for applications instrumented with [`Ope
 [![Documentation](https://docs.rs/opentelemetry-contrib/badge.svg)](https://docs.rs/opentelemetry-contrib)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry-contrib)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Documentation](https://docs.rs/opentelemetry-contrib) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry-datadog/README.md
+++ b/opentelemetry-datadog/README.md
@@ -10,10 +10,7 @@ Community supported vendor integrations for applications instrumented with [`Ope
 [![Documentation](https://docs.rs/opentelemetry-datadog/badge.svg)](https://docs.rs/opentelemetry-datadog)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry-datadog)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Documentation](https://docs.rs/opentelemetry-datadog) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry-dynatrace/README.md
+++ b/opentelemetry-dynatrace/README.md
@@ -10,10 +10,7 @@
 [![Documentation](https://docs.rs/opentelemetry-dynatrace/badge.svg)](https://docs.rs/opentelemetry-dynatrace)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry-dynatrace)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Documentation](https://docs.rs/opentelemetry-dynatrace) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry-http/README.md
+++ b/opentelemetry-http/README.md
@@ -8,10 +8,7 @@ The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
 
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Website](https://opentelemetry.io/) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023) |
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -10,10 +10,7 @@
 [![Documentation](https://docs.rs/opentelemetry-jaeger/badge.svg)](https://docs.rs/opentelemetry-jaeger)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry-jaeger)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Documentation](https://docs.rs/opentelemetry-jaeger) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -10,10 +10,7 @@
 [![Documentation](https://docs.rs/opentelemetry-otlp/badge.svg)](https://docs.rs/opentelemetry-otlp)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry-otlp)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Documentation](https://docs.rs/opentelemetry-otlp) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry-prometheus/README.md
+++ b/opentelemetry-prometheus/README.md
@@ -10,10 +10,7 @@
 [![Documentation](https://docs.rs/opentelemetry-prometheus/badge.svg)](https://docs.rs/opentelemetry-prometheus)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry-prometheus)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Documentation](https://docs.rs/opentelemetry-prometheus) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry-sdk/README.md
+++ b/opentelemetry-sdk/README.md
@@ -11,11 +11,8 @@ The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry_sdk)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![codecov](https://codecov.io/gh/open-telemetry/opentelemetry-rust/branch/main/graph/badge.svg)](https://codecov.io/gh/open-telemetry/opentelemetry-rust)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
-[Website](https://opentelemetry.io/) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023) |
-[Documentation](https://docs.rs/opentelemetry-rust)
 
 ## Overview
 

--- a/opentelemetry-semantic-conventions/README.md
+++ b/opentelemetry-semantic-conventions/README.md
@@ -10,10 +10,7 @@ Semantic conventions for applications instrumented with [`OpenTelemetry`].
 [![Documentation](https://docs.rs/opentelemetry-semantic-conventions/badge.svg)](https://docs.rs/opentelemetry-semantic-conventions)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry-semantic-conventions)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Documentation](https://docs.rs/opentelemetry-semantic-conventions) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -10,10 +10,8 @@
 [![Documentation](https://docs.rs/opentelemetry-zipkin/badge.svg)](https://docs.rs/opentelemetry-zipkin)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry-zipkin)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
-[Documentation](https://docs.rs/opentelemetry-zipkin) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry-zpages/README.md
+++ b/opentelemetry-zpages/README.md
@@ -7,9 +7,7 @@
 ZPages server written in Rust
 
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amaster)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -11,11 +11,7 @@ The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![codecov](https://codecov.io/gh/open-telemetry/opentelemetry-rust/branch/main/graph/badge.svg)](https://codecov.io/gh/open-telemetry/opentelemetry-rust)
-[![Gitter chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/open-telemetry/opentelemetry-rust)
-
-[Website](https://opentelemetry.io/) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023) |
-[Documentation](https://docs.rs/opentelemetry)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
 ## Overview
 


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-rust/pull/988, this does a bit more cleanup.