### PR TITLE
implement w3c trace context response propagation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "examples/grpc",
     "examples/http",
     "examples/hyper-prometheus",
+    "examples/traceresponse",
     "examples/tracing-grpc",
     "examples/jaeger-remote-sampler",
     "examples/zipkin",

--- a/examples/traceresponse/Cargo.toml
+++ b/examples/traceresponse/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "traceresponse"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]] # Bin to run the http server
+name = "http-server"
+path = "src/server.rs"
+doc = false
+
+[[bin]] # Bin to run the client
+name = "http-client"
+path = "src/client.rs"
+doc = false
+
+[dependencies]
+hyper = { version = "0.14", features = ["full"] }
+tokio = { version = "1.0", features = ["full"] }
+opentelemetry = { path = "../../opentelemetry" }
+opentelemetry-http = { path = "../../opentelemetry-http" }
+opentelemetry-contrib = { path = "../../opentelemetry-contrib" }

--- a/examples/traceresponse/README.md
+++ b/examples/traceresponse/README.md
@@ -1,0 +1,29 @@
+# HTTP Example
+
+This is a simple example using [hyper] that demonstrates tracing http request
+from client to server, and from the server back to the client using the
+[W3C Trace Context Response] header. The example shows key aspects of tracing
+such as:
+
+- Root Span (on Client)
+- Child Span (on Client)
+- Child Span from a Remote Parent (on Server)
+- SpanContext Propagation (from Client to Server)
+- SpanContext Propagation (from Server to Client)
+- Span Events
+- Span Attributes
+
+[hyper]: https://hyper.rs/
+[W3C Trace Context Response]: https://w3c.github.io/trace-context/#traceresponse-header
+
+## Usage
+
+```shell
+# Run server
+$ cargo run --bin http-server
+
+# In another tab, run client
+$ cargo run --bin http-client
+
+# The spans should be visible in stdout in the order that they were exported.
+```

--- a/examples/traceresponse/README.md
+++ b/examples/traceresponse/README.md
@@ -6,7 +6,6 @@ from client to server, and from the server back to the client using the
 such as:
 
 - Root Span (on Client)
-- Child Span (on Client)
 - Child Span from a Remote Parent (on Server)
 - SpanContext Propagation (from Client to Server)
 - SpanContext Propagation (from Server to Client)

--- a/examples/traceresponse/src/client.rs
+++ b/examples/traceresponse/src/client.rs
@@ -1,0 +1,66 @@
+use hyper::http::HeaderValue;
+use hyper::{body::Body, Client};
+use opentelemetry::global;
+use opentelemetry::propagation::TextMapPropagator;
+use opentelemetry::sdk::export::trace::stdout;
+use opentelemetry::sdk::{
+    propagation::TraceContextPropagator,
+    trace::{self, Sampler},
+};
+use opentelemetry::{
+    trace::{TraceContextExt, Tracer},
+    Context, KeyValue,
+};
+use opentelemetry_contrib::trace::propagator::trace_context_response::TraceContextResponsePropagator;
+use opentelemetry_http::{HeaderExtractor, HeaderInjector};
+
+fn init_tracer() -> impl Tracer {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+    // Install stdout exporter pipeline to be able to retrieve the collected spans.
+    // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
+    // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
+    stdout::new_pipeline()
+        .with_trace_config(trace::config().with_sampler(Sampler::AlwaysOn))
+        .install_simple()
+}
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    let _tracer = init_tracer();
+
+    let client = Client::new();
+    let span = global::tracer("example/client").start("say hello");
+    let cx = Context::current_with_span(span);
+
+    let mut req = hyper::Request::builder().uri("http://127.0.0.1:3000");
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&cx, &mut HeaderInjector(req.headers_mut().unwrap()))
+    });
+    let res = client.request(req.body(Body::from("Hallo!"))?).await?;
+
+    let response_propagator: &dyn TextMapPropagator = &TraceContextResponsePropagator::new();
+
+    let response_cx =
+        response_propagator.extract_with_context(&cx, &mut HeaderExtractor(res.headers()));
+
+    let response_span = response_cx.span();
+
+    cx.span().add_event(
+        "Got response!".to_string(),
+        vec![
+            KeyValue::new("status", res.status().to_string()),
+            KeyValue::new(
+                "traceresponse",
+                res.headers()
+                    .get("traceresponse")
+                    .unwrap_or(&HeaderValue::from_static(""))
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+            ),
+            KeyValue::new("child_sampled", response_span.span_context().is_sampled()),
+        ],
+    );
+
+    Ok(())
+}

--- a/examples/traceresponse/src/client.rs
+++ b/examples/traceresponse/src/client.rs
@@ -7,6 +7,7 @@ use opentelemetry::sdk::{
     propagation::TraceContextPropagator,
     trace::{self, Sampler},
 };
+use opentelemetry::trace::SpanKind;
 use opentelemetry::{
     trace::{TraceContextExt, Tracer},
     Context, KeyValue,
@@ -29,7 +30,11 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sy
     let _tracer = init_tracer();
 
     let client = Client::new();
-    let span = global::tracer("example/client").start("say hello");
+    let tracer = global::tracer("example/client");
+    let span = tracer
+        .span_builder("say hello")
+        .with_kind(SpanKind::Client)
+        .start(&tracer);
     let cx = Context::current_with_span(span);
 
     let mut req = hyper::Request::builder().uri("http://127.0.0.1:3000");

--- a/examples/traceresponse/src/client.rs
+++ b/examples/traceresponse/src/client.rs
@@ -36,7 +36,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sy
     global::get_text_map_propagator(|propagator| {
         propagator.inject_context(&cx, &mut HeaderInjector(req.headers_mut().unwrap()))
     });
-    let res = client.request(req.body(Body::from("Hallo!"))?).await?;
+    let res = client.request(req.body(Body::from("Hello!"))?).await?;
 
     let response_propagator: &dyn TextMapPropagator = &TraceContextResponsePropagator::new();
 

--- a/examples/traceresponse/src/client.rs
+++ b/examples/traceresponse/src/client.rs
@@ -46,7 +46,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sy
     let response_propagator: &dyn TextMapPropagator = &TraceContextResponsePropagator::new();
 
     let response_cx =
-        response_propagator.extract_with_context(&cx, &mut HeaderExtractor(res.headers()));
+        response_propagator.extract_with_context(&cx, &HeaderExtractor(res.headers()));
 
     let response_span = response_cx.span();
 

--- a/examples/traceresponse/src/server.rs
+++ b/examples/traceresponse/src/server.rs
@@ -1,0 +1,58 @@
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Request, Response, Server};
+use opentelemetry::propagation::TextMapPropagator;
+use opentelemetry::trace::FutureExt;
+use opentelemetry::{
+    global,
+    sdk::export::trace::stdout,
+    sdk::{
+        propagation::TraceContextPropagator,
+        trace::{self, Sampler},
+    },
+    trace::{Span, Tracer},
+};
+use opentelemetry_contrib::trace::propagator::trace_context_response::TraceContextResponsePropagator;
+use opentelemetry_http::{HeaderExtractor, HeaderInjector};
+use std::{convert::Infallible, net::SocketAddr};
+
+async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
+    let parent_cx = global::get_text_map_propagator(|propagator| {
+        propagator.extract(&HeaderExtractor(req.headers()))
+    });
+    let _cx_guard = parent_cx.attach();
+    let mut span = global::tracer("example/server").start("hello");
+    span.add_event("handling this...", Vec::new());
+
+    let mut res = Response::new("Hello, World!".into());
+
+    let response_propagator: &dyn TextMapPropagator = &TraceContextResponsePropagator::new();
+    response_propagator.inject(&mut HeaderInjector(res.headers_mut()));
+
+    Ok(res)
+}
+
+fn init_tracer() -> impl Tracer {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    // Install stdout exporter pipeline to be able to retrieve the collected spans.
+    // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces. In a production
+    // application, use `Sampler::ParentBased` or `Sampler::TraceIdRatioBased` with a desired ratio.
+    stdout::new_pipeline()
+        .with_trace_config(trace::config().with_sampler(Sampler::AlwaysOn))
+        .install_simple()
+}
+
+#[tokio::main]
+async fn main() {
+    let _tracer = init_tracer();
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+
+    let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
+
+    let server = Server::bind(&addr).serve(make_svc);
+
+    println!("Listening on {addr}");
+    if let Err(e) = server.await {
+        eprintln!("server error: {e}");
+    }
+}

--- a/examples/traceresponse/src/server.rs
+++ b/examples/traceresponse/src/server.rs
@@ -22,7 +22,7 @@ async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     });
     let _cx_guard = parent_cx.attach();
 
-    let tracer = global::tracer("example/client");
+    let tracer = global::tracer("example/server");
     let span = tracer
         .span_builder("say hello")
         .with_kind(SpanKind::Server)

--- a/examples/traceresponse/src/server.rs
+++ b/examples/traceresponse/src/server.rs
@@ -1,7 +1,7 @@
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request, Response, Server};
 use opentelemetry::propagation::TextMapPropagator;
-use opentelemetry::trace::{FutureExt, SpanKind, TraceContextExt};
+use opentelemetry::trace::{SpanKind, TraceContextExt};
 use opentelemetry::Context;
 use opentelemetry::{
     global,

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -32,7 +32,9 @@ async-std = { version = "1.10", optional = true }
 async-trait = { version = "0.1", optional = true }
 base64 = { version = "0.13", optional = true }
 futures = { version = "0.3", optional = true }
+once_cell = "1.17.1"
 opentelemetry = { version = "0.18", path = "../opentelemetry", features = ["trace"] }
+opentelemetry_api = { version = "0.18", path = "../opentelemetry-api" }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.0", features = ["fs", "io-util"], optional = true }
 

--- a/opentelemetry-contrib/src/trace/propagator/mod.rs
+++ b/opentelemetry-contrib/src/trace/propagator/mod.rs
@@ -9,3 +9,4 @@
 //!
 //! This module also provides relative types for those propagators.
 pub mod binary;
+pub mod trace_context_response;

--- a/opentelemetry-contrib/src/trace/propagator/trace_context_response.rs
+++ b/opentelemetry-contrib/src/trace/propagator/trace_context_response.rs
@@ -1,0 +1,237 @@
+//! # W3C Trace Context HTTP Response Propagator
+//!
+//! The traceresponse HTTP response header field identifies a completed request
+//! in a tracing system. It has four fields:
+//!
+//!    - version
+//!    - trace-id
+//!    - parent-id
+//!    - trace-flags
+//!
+//! See the [w3c trace-context docs] for more details.
+//!
+//! [w3c trace-context docs]: https://w3c.github.io/trace-context/#traceresponse-header
+use once_cell::sync::Lazy;
+use opentelemetry::trace::{SpanContext, SpanId, TraceId, TraceState};
+use opentelemetry_api::{
+    propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
+    trace::{TraceContextExt, TraceFlags},
+    Context,
+};
+
+const SUPPORTED_VERSION: u8 = 0;
+const MAX_VERSION: u8 = 254;
+const TRACERESPONSE_HEADER: &str = "traceresponse";
+
+static TRACE_CONTEXT_HEADER_FIELDS: Lazy<[String; 1]> =
+    Lazy::new(|| [TRACERESPONSE_HEADER.to_owned()]);
+
+/// Propagates trace response using the [W3C TraceContext] format
+///
+/// [W3C TraceContext]: https://w3c.github.io/trace-context/#traceresponse-header
+#[derive(Clone, Debug, Default)]
+pub struct TraceContextResponsePropagator {
+    _private: (),
+}
+
+impl TraceContextResponsePropagator {
+    /// Create a new `TraceContextPropagator`.
+    pub fn new() -> Self {
+        TraceContextResponsePropagator { _private: () }
+    }
+
+    /// Extract span context from w3c trace-context header.
+    fn extract_span_context(&self, extractor: &dyn Extractor) -> Result<SpanContext, ()> {
+        let header_value = extractor.get(TRACERESPONSE_HEADER).unwrap_or("").trim();
+        let parts = header_value.split_terminator('-').collect::<Vec<&str>>();
+        // Ensure parts are not out of range.
+        if parts.len() < 4 {
+            return Err(());
+        }
+
+        // Ensure version is within range, for version 0 there must be 4 parts.
+        let version = u8::from_str_radix(parts[0], 16).map_err(|_| ())?;
+        if version > MAX_VERSION || version == 0 && parts.len() != 4 {
+            return Err(());
+        }
+
+        // Ensure trace id is lowercase
+        if parts[1].chars().any(|c| c.is_ascii_uppercase()) {
+            return Err(());
+        }
+
+        // Parse trace id section
+        let trace_id = TraceId::from_hex(parts[1]).map_err(|_| ())?;
+
+        // Ensure span id is lowercase
+        if parts[2].chars().any(|c| c.is_ascii_uppercase()) {
+            return Err(());
+        }
+
+        // Parse span id section
+        let span_id = SpanId::from_hex(parts[2]).map_err(|_| ())?;
+
+        // Parse trace flags section
+        let opts = u8::from_str_radix(parts[3], 16).map_err(|_| ())?;
+
+        // Ensure opts are valid for version 0
+        if version == 0 && opts > 2 {
+            return Err(());
+        }
+
+        // Build trace flags clearing all flags other than the trace-context
+        // supported sampling bit.
+        let trace_flags = TraceFlags::new(opts) & TraceFlags::SAMPLED;
+
+        // create context
+        let span_context =
+            SpanContext::new(trace_id, span_id, trace_flags, true, TraceState::default());
+
+        // Ensure span is valid
+        if !span_context.is_valid() {
+            return Err(());
+        }
+
+        Ok(span_context)
+    }
+}
+
+impl TextMapPropagator for TraceContextResponsePropagator {
+    /// Properly encodes the values of the `SpanContext` and injects them
+    /// into the `Injector`.
+    fn inject_context(&self, cx: &Context, injector: &mut dyn Injector) {
+        let span = cx.span();
+        let span_context = span.span_context();
+        if span_context.is_valid() {
+            let header_value = format!(
+                "{:02x}-{:032x}-{:016x}-{:02x}",
+                SUPPORTED_VERSION,
+                span_context.trace_id(),
+                span_context.span_id(),
+                span_context.trace_flags() & TraceFlags::SAMPLED
+            );
+            injector.set(TRACERESPONSE_HEADER, header_value);
+        }
+    }
+
+    /// Retrieves encoded `SpanContext`s using the `Extractor`. It decodes
+    /// the `SpanContext` and returns it. If no `SpanContext` was retrieved
+    /// OR if the retrieved SpanContext is invalid then an empty `SpanContext`
+    /// is returned.
+    fn extract_with_context(&self, cx: &Context, extractor: &dyn Extractor) -> Context {
+        self.extract_span_context(extractor)
+            .map(|sc| cx.with_remote_span_context(sc))
+            .unwrap_or_else(|_| cx.clone())
+    }
+
+    fn fields(&self) -> FieldIter<'_> {
+        FieldIter::new(TRACE_CONTEXT_HEADER_FIELDS.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::{testing::trace::TestSpan, trace::TraceState};
+    use opentelemetry_api::{
+        propagation::{Extractor, TextMapPropagator},
+        trace::{SpanContext, SpanId, TraceId},
+    };
+    use std::{collections::HashMap, str::FromStr};
+
+    #[rustfmt::skip]
+    fn extract_data() -> Vec<(&'static str, SpanContext)> {
+        vec![
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00", SpanContext::new(TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), SpanId::from_u64(0x00f0_67aa_0ba9_02b7), TraceFlags::default(), true, TraceState::default())),
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", SpanContext::new(TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), SpanId::from_u64(0x00f0_67aa_0ba9_02b7), TraceFlags::SAMPLED, true, TraceState::default())),
+            ("02-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", SpanContext::new(TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), SpanId::from_u64(0x00f0_67aa_0ba9_02b7), TraceFlags::SAMPLED, true, TraceState::default())),
+            ("02-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-09", SpanContext::new(TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), SpanId::from_u64(0x00f0_67aa_0ba9_02b7), TraceFlags::SAMPLED, true, TraceState::default())),
+            ("02-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-08", SpanContext::new(TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), SpanId::from_u64(0x00f0_67aa_0ba9_02b7), TraceFlags::default(), true, TraceState::default())),
+            ("02-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-09-XYZxsf09", SpanContext::new(TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), SpanId::from_u64(0x00f0_67aa_0ba9_02b7), TraceFlags::SAMPLED, true, TraceState::default())),
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01-", SpanContext::new(TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), SpanId::from_u64(0x00f0_67aa_0ba9_02b7), TraceFlags::SAMPLED, true, TraceState::default())),
+            ("01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-09-", SpanContext::new(TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), SpanId::from_u64(0x00f0_67aa_0ba9_02b7), TraceFlags::SAMPLED, true, TraceState::default())),
+        ]
+    }
+
+    #[rustfmt::skip]
+    fn extract_data_invalid() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("0000-00000000000000000000000000000000-0000000000000000-01", "wrong version length"),
+            ("00-ab00000000000000000000000000000000-cd00000000000000-01", "wrong trace ID length"),
+            ("00-ab000000000000000000000000000000-cd0000000000000000-01", "wrong span ID length"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-0100", "wrong trace flag length"),
+            ("qw-00000000000000000000000000000000-0000000000000000-01",   "bogus version"),
+            ("00-qw000000000000000000000000000000-cd00000000000000-01",   "bogus trace ID"),
+            ("00-ab000000000000000000000000000000-qw00000000000000-01",   "bogus span ID"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-qw",   "bogus trace flag"),
+            ("A0-00000000000000000000000000000000-0000000000000000-01",   "upper case version"),
+            ("00-AB000000000000000000000000000000-cd00000000000000-01",   "upper case trace ID"),
+            ("00-ab000000000000000000000000000000-CD00000000000000-01",   "upper case span ID"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-A1",   "upper case trace flag"),
+            ("00-00000000000000000000000000000000-0000000000000000-01",   "zero trace ID and span ID"),
+            ("00-ab000000000000000000000000000000-cd00000000000000-09",   "trace-flag unused bits set"),
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",      "missing options"),
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-",     "empty options"),
+        ]
+    }
+
+    #[rustfmt::skip]
+    fn inject_data() -> Vec<(&'static str, SpanContext)> {
+        vec![
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", SpanContext::new(TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), SpanId::from_u64(0x00f0_67aa_0ba9_02b7), TraceFlags::SAMPLED, true, TraceState::from_str("foo=bar").unwrap())),
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00", SpanContext::new(TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), SpanId::from_u64(0x00f0_67aa_0ba9_02b7), TraceFlags::default(), true, TraceState::from_str("foo=bar").unwrap())),
+            ("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", SpanContext::new(TraceId::from_u128(0x4bf9_2f35_77b3_4da6_a3ce_929d_0e0e_4736), SpanId::from_u64(0x00f0_67aa_0ba9_02b7), TraceFlags::new(0xff), true, TraceState::from_str("foo=bar").unwrap())),
+            ("", SpanContext::empty_context()),
+        ]
+    }
+
+    #[test]
+    fn extract_w3c_traceresponse() {
+        let propagator = TraceContextResponsePropagator::new();
+
+        for (traceresponse, expected_context) in extract_data() {
+            let mut extractor = HashMap::new();
+            extractor.insert(TRACERESPONSE_HEADER.to_string(), traceresponse.to_string());
+
+            assert_eq!(
+                propagator.extract(&extractor).span().span_context(),
+                &expected_context
+            )
+        }
+    }
+
+    #[test]
+    fn extract_w3c_traceresponse_reject_invalid() {
+        let propagator = TraceContextResponsePropagator::new();
+
+        for (invalid_header, reason) in extract_data_invalid() {
+            let mut extractor = HashMap::new();
+            extractor.insert(TRACERESPONSE_HEADER.to_string(), invalid_header.to_string());
+
+            assert_eq!(
+                propagator.extract(&extractor).span().span_context(),
+                &SpanContext::empty_context(),
+                "{}",
+                reason
+            )
+        }
+    }
+
+    #[test]
+    fn inject_w3c_traceresponse() {
+        let propagator = TraceContextResponsePropagator::new();
+
+        for (expected_trace_response, context) in inject_data() {
+            let mut injector = HashMap::new();
+            propagator.inject_context(
+                &Context::current_with_span(TestSpan(context)),
+                &mut injector,
+            );
+
+            assert_eq!(
+                Extractor::get(&injector, TRACERESPONSE_HEADER).unwrap_or(""),
+                expected_trace_response
+            );
+        }
+    }
+}


### PR DESCRIPTION
Adds a `TraceContextResponsePropagator` to the contrib crate implementing the [W3C Trace Context Response Header].

Fixes #523

[W3C Trace Context Response Header]: https://w3c.github.io/trace-context/#traceresponse-header