### PR TITLE
chore: use tonic and prost patch releases

### DIFF
--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -45,9 +45,9 @@ tokio = { version = "1.0", features = ["net", "sync"], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4.18", optional = true }
 
-tonic = { version = "0.8.3", optional = true }
-prost = { version = "0.11.6", optional = true }
-prost-types = { version = "0.11.6", optional = true }
+tonic = { version = "0.8", optional = true }
+prost = { version = "0.11", optional = true }
+prost-types = { version = "0.11", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["net", "sync"] }

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -40,8 +40,8 @@ opentelemetry = { version = "0.19", default-features = false, features = ["trace
 opentelemetry-http = { version = "0.8", path = "../opentelemetry-http", optional = true }
 protobuf = { version = "2.18", optional = true }
 
-prost = { version = "0.11.0", optional = true }
-tonic = { version = "0.8.0", optional = true }
+prost = { version = "0.11", optional = true }
+tonic = { version = "0.8", optional = true }
 tokio = { version = "1.0", features = ["sync", "rt"], optional = true }
 
 reqwest = { version = "0.11", optional = true, default-features = false }

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -44,8 +44,8 @@ with-serde = ["protobuf/with-serde", "serde", "serde_json"]
 
 [dependencies]
 grpcio = { version = "0.12", optional = true }
-tonic = { version = "0.8.0", optional = true }
-prost = { version = "0.11.0", optional = true }
+tonic = { version = "0.8", optional = true }
+prost = { version = "0.11", optional = true }
 protobuf = { version = "2.18", optional = true } # todo: update to 3.0 so we have docs for generated types.
 opentelemetry = { version = "0.19", default-features = false, features = ["trace", "metrics"], path = "../opentelemetry" }
 futures = { version = "0.3", default-features = false, features = ["std"] }
@@ -54,8 +54,8 @@ serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-protobuf-codegen = { version = "2.16" }
-protoc-grpcio = { version = "3.0" }
-tonic-build = { version = "0.8.0" }
-prost-build = { version = "0.11.1" }
+protobuf-codegen = "2.16"
+protoc-grpcio = "3.0"
+tonic-build = "0.8"
+prost-build = "0.11"
 tempfile = "3.3.0"

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -19,10 +19,10 @@ hyper = "0.14.2"
 hyper-rustls = { version = "0.23", optional = true }
 opentelemetry = { version = "0.19", path = "../opentelemetry" }
 opentelemetry-semantic-conventions = { version = "0.11", path = "../opentelemetry-semantic-conventions" }
-prost = "0.11.0"
-prost-types = "0.11.1"
+prost = "0.11"
+prost-types = "0.11"
 thiserror = "1.0.30"
-tonic = { version = "0.8.0", features = ["gzip", "tls", "transport"] }
+tonic = { version = "0.8", features = ["gzip", "tls", "transport"] }
 yup-oauth2 = { version = "8.1.0", optional = true }
 
 [features]
@@ -35,5 +35,5 @@ tls-webpki-roots = ["tonic/tls-webpki-roots"]
 reqwest = "0.11.9"
 tempfile = "3.3.0"
 tokio = "1"
-tonic-build = "0.8.0"
+tonic-build = "0.8"
 walkdir = "2.3.2"


### PR DESCRIPTION
This follows the Cargo.toml package definition of the tonic crate that loosely couples patch releases to the prost crate, allowing users to globally pin a specific patch release to their needs if required.