### PR TITLE
Use the browser-only js-sys workaround only when actually targeting a browser (#1005)

### DIFF
--- a/opentelemetry-api/src/lib.rs
+++ b/opentelemetry-api/src/lib.rs
@@ -77,13 +77,16 @@ pub mod time {
     use std::time::SystemTime;
 
     #[doc(hidden)]
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        all(target_arch = "wasm32", target_os = "wasi")
+    ))]
     pub fn now() -> SystemTime {
         SystemTime::now()
     }
 
     #[doc(hidden)]
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     pub fn now() -> SystemTime {
         SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(js_sys::Date::now() as u64)
     }


### PR DESCRIPTION
wasi runtimes do provide a SystemTime implementation, see
https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi-common/src/clocks.rs