### PR TITLE
feat: add `new` method to `BoxedTracer`

### DIFF
--- a/opentelemetry-api/src/global/trace.rs
+++ b/opentelemetry-api/src/global/trace.rs
@@ -226,6 +226,13 @@ impl trace::Span for BoxedSpan {
 /// [`GlobalTracerProvider`]: crate::global::GlobalTracerProvider
 pub struct BoxedTracer(Box<dyn ObjectSafeTracer + Send + Sync>);
 
+impl BoxedTracer {
+    /// Create a `BoxedTracer` from an object-safe tracer.
+    pub fn new(tracer: Box<dyn ObjectSafeTracer + Send + Sync>) -> Self {
+        BoxedTracer(tracer)
+    }
+}
+
 impl fmt::Debug for BoxedTracer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("BoxedTracer")


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-rust/issues/1007

Adds a `new` method to `BoxedTracer`.