### PR TITLE
Initial wasm-wasi working draft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,13 @@ members = [
     "examples/jaeger-remote-sampler",
     "examples/zipkin",
     "examples/multiple-span-processors",
-    "examples/zpages"
+    "examples/zpages",
+    "examples/wasm-wasi-bring-your-own-client"
 ]
 exclude = ["examples/external-otlp-grpcio-async-std"]
+
+[patch.crates-io]
+opentelemetry = { path = "./opentelemetry"}
+opentelemetry-otlp = { path = "./opentelemetry-otlp"}
+opentelemetry-http = { path = "./opentelemetry-http"}
+opentelemetry_api = { path = "./opentelemetry-api"}

--- a/examples/wasm-wasi-bring-your-own-client/.cargo/config.toml
+++ b/examples/wasm-wasi-bring-your-own-client/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/examples/wasm-wasi-bring-your-own-client/Cargo.toml
+++ b/examples/wasm-wasi-bring-your-own-client/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "wasm-wasi-bring-your-own-client"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+opentelemetry = { version = "0.19", default-features = false }
+opentelemetry-otlp = { version = "0.12", default-features = false, features = ["my-http"] }
+opentelemetry-http = { version = "0.8", default-features = false }
+async-trait = "0.1"
+tokio = { version = "1.27.0", default-features = false, features = ["macros", "rt"] }
+opentelemetry-semantic-conventions = { version = "0.11" } 

--- a/examples/wasm-wasi-bring-your-own-client/src/main.rs
+++ b/examples/wasm-wasi-bring-your-own-client/src/main.rs
@@ -1,0 +1,71 @@
+use opentelemetry::global::shutdown_tracer_provider;
+use opentelemetry::runtime;
+use opentelemetry::sdk::Resource;
+use opentelemetry::trace::TraceError;
+use opentelemetry::{global, sdk::trace as sdktrace};
+use opentelemetry::{
+    metrics,
+    trace::{TraceContextExt, Tracer},
+    Context, Key, KeyValue,
+};
+use opentelemetry_http::{Bytes, HttpError, Response, Request};
+use opentelemetry_otlp::{ExportConfig, WithExportConfig};
+use std::error::Error;
+use std::time::Duration;
+
+#[derive(Debug)]
+struct MyOwnHttpClient;
+
+#[async_trait::async_trait]
+impl opentelemetry_http::HttpClient for MyOwnHttpClient {
+    async fn send(&self, request: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
+        todo!()
+    }
+}
+
+fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
+    opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(
+            opentelemetry_otlp::HttpExporterBuilder::default().with_http_client(MyOwnHttpClient),
+        )
+        .with_trace_config(
+            sdktrace::config().with_resource(Resource::new(vec![KeyValue::new(
+                opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+                "trace-demo",
+            )])),
+        )
+        .install_simple()
+}
+
+const LEMONS_KEY: Key = Key::from_static_str("lemons");
+const ANOTHER_KEY: Key = Key::from_static_str("ex.com/another");
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let _ = init_tracer()?;
+    let tracer = global::tracer("ex.com/basic");
+
+    tracer.in_span("operation", |cx| {
+        let span = cx.span();
+        span.add_event(
+            "Nice operation!".to_string(),
+            vec![Key::new("bogons").i64(100)],
+        );
+        span.set_attribute(ANOTHER_KEY.string("yes"));
+
+        tracer.in_span("Sub operation...", |cx| {
+            let span = cx.span();
+            span.set_attribute(LEMONS_KEY.string("five"));
+
+            span.add_event("Sub span event", vec![]);
+        });
+    });
+
+    // // wait for 1 minutes so that we could see metrics being pushed via OTLP every 10 seconds.
+    // tokio::time::sleep(Duration::from_secs(60)).await;
+
+    shutdown_tracer_provider();
+
+    Ok(())
+}

--- a/opentelemetry-api/src/global/error_handler.rs
+++ b/opentelemetry-api/src/global/error_handler.rs
@@ -48,7 +48,7 @@ pub fn handle_error<T: Into<Error>>(err: T) {
             Error::Metric(err) => eprintln!("OpenTelemetry metrics error occurred. {}", err),
             #[cfg(feature = "trace")]
             #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
-            Error::Trace(err) => eprintln!("OpenTelemetry trace error occurred. {}", err),
+            Error::Trace(err) => eprintln!("OpenTelemetry trace error occurred. {:?}", err),
             Error::Other(err_msg) => eprintln!("OpenTelemetry error occurred. {}", err_msg),
         },
     }

--- a/opentelemetry-api/src/lib.rs
+++ b/opentelemetry-api/src/lib.rs
@@ -73,13 +73,16 @@ pub mod time {
     use std::time::SystemTime;
 
     #[doc(hidden)]
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        all(target_arch = "wasm32", target_os = "wasi")
+    ))]
     pub fn now() -> SystemTime {
         SystemTime::now()
     }
 
     #[doc(hidden)]
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     pub fn now() -> SystemTime {
         SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(js_sys::Date::now() as u64)
     }

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -80,6 +80,7 @@ openssl-vendored = ["grpcio/openssl-vendored"]
 
 # http binary
 http-proto = ["prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic", "http", "trace"]
+my-http = ["opentelemetry-http", "http", "trace", "prost", "opentelemetry-proto/gen-tonic"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]

--- a/opentelemetry-otlp/src/exporter/http.rs
+++ b/opentelemetry-otlp/src/exporter/http.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use super::default_headers;
 
 /// Configuration of the http transport
-#[cfg(feature = "http-proto")]
+#[cfg(any(feature = "http-proto", feature = "my-http"))]
 #[derive(Debug)]
 #[cfg_attr(
     all(

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -4,7 +4,7 @@
 
 #[cfg(feature = "grpc-sys")]
 use crate::exporter::grpcio::GrpcioExporterBuilder;
-#[cfg(feature = "http-proto")]
+#[cfg(any(feature = "http-proto", feature = "my-http"))]
 use crate::exporter::http::HttpExporterBuilder;
 #[cfg(feature = "grpc-tonic")]
 use crate::exporter::tonic::TonicExporterBuilder;
@@ -22,7 +22,9 @@ pub const OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT: &str = OTEL_EXPORTER_OTLP_HTTP_EN
 /// Protocol the exporter will use. Either `http/protobuf` or `grpc`.
 pub const OTEL_EXPORTER_OTLP_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_PROTOCOL";
 
-#[cfg(feature = "http-proto")]
+#[cfg(
+    not(any(feature = "grpc-tonic", feature = "grpcio"))
+)]
 /// Default protocol, using http-proto.
 pub const OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT: &str = OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF;
 #[cfg(all(
@@ -46,7 +48,7 @@ const OTEL_EXPORTER_OTLP_HTTP_ENDPOINT_DEFAULT: &str = "http://localhost:4318";
 
 #[cfg(feature = "grpc-sys")]
 pub(crate) mod grpcio;
-#[cfg(feature = "http-proto")]
+#[cfg(any(feature = "http-proto", feature = "my-http"))]
 pub(crate) mod http;
 #[cfg(feature = "grpc-tonic")]
 pub(crate) mod tonic;
@@ -123,7 +125,7 @@ impl HasExportConfig for GrpcioExporterBuilder {
     }
 }
 
-#[cfg(feature = "http-proto")]
+#[cfg(any(feature = "http-proto", feature = "my-http"))]
 impl HasExportConfig for HttpExporterBuilder {
     fn export_config(&mut self) -> &mut ExportConfig {
         &mut self.exporter_config

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -213,7 +213,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[cfg(feature = "grpc-sys")]
 pub use crate::exporter::grpcio::{Compression, Credentials, GrpcioConfig, GrpcioExporterBuilder};
-#[cfg(feature = "http-proto")]
+#[cfg(any(feature = "http-proto", feature = "my-http"))]
 pub use crate::exporter::http::HttpExporterBuilder;
 #[cfg(feature = "grpc-tonic")]
 pub use crate::exporter::tonic::{TonicConfig, TonicExporterBuilder};
@@ -289,7 +289,7 @@ pub enum Error {
     Transport(#[from] tonic::transport::Error),
 
     /// Wrap the [`tonic::codegen::http::uri::InvalidUri`] error
-    #[cfg(any(feature = "grpc-tonic", feature = "http-proto"))]
+    #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "my-http"))]
     #[error("invalid URI {0}")]
     InvalidUri(#[from] http::uri::InvalidUri),
 
@@ -316,22 +316,22 @@ pub enum Error {
     NoHttpClient,
 
     /// Http requests failed.
-    #[cfg(feature = "http-proto")]
+    #[cfg(any(feature = "http-proto", feature = "my-http"))]
     #[error("http request failed with {0}")]
     RequestFailed(#[from] http::Error),
 
     /// The provided value is invalid in HTTP headers.
-    #[cfg(feature = "http-proto")]
+    #[cfg(any(feature = "http-proto", feature = "my-http"))]
     #[error("http header value error {0}")]
     InvalidHeaderValue(#[from] http::header::InvalidHeaderValue),
 
     /// The provided name is invalid in HTTP headers.
-    #[cfg(feature = "http-proto")]
+    #[cfg(any(feature = "http-proto", feature = "my-http"))]
     #[error("http header name error {0}")]
     InvalidHeaderName(#[from] http::header::InvalidHeaderName),
 
     /// Prost encode failed
-    #[cfg(feature = "http-proto")]
+    #[cfg(any(feature = "http-proto", feature = "my-http"))]
     #[error("prost encoding error {0}")]
     EncodeError(#[from] prost::EncodeError),
 

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -44,7 +44,7 @@ with-serde = ["protobuf/with-serde", "serde", "serde_json"]
 
 [dependencies]
 grpcio = { version = "0.12", optional = true }
-tonic = { version = "0.8.0", optional = true }
+tonic = { version = "0.8.0", optional = true, default-features = false, features = ["prost", "codegen"] }
 prost = { version = "0.11.0", optional = true }
 protobuf = { version = "2.18", optional = true } # todo: update to 3.0 so we have docs for generated types.
 opentelemetry = { version = "0.19", default-features = false, features = ["trace", "metrics"], path = "../opentelemetry" }

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
@@ -51,6 +51,7 @@ pub struct ExportTracePartialSuccess {
     #[prost(string, tag = "2")]
     pub error_message: ::prost::alloc::string::String,
 }
+#[cfg(feature = "clients")]
 /// Generated client implementations.
 pub mod trace_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]


### PR DESCRIPTION
This is a POC of enabling wasm-wasi support so `opentelemetry-otlp` can be used in some "edge" platforms such as fastly. This PR destroys the non-wasm-wasi versions.
This is mainly so other users who fit this niche usecase can see what it takes.
Some important changes:
* new feature `my-http` that is meant to be used where you bring your own `HttpClient` (such as in the wasm-wasi case)
* `tonic` server/clients are not used
* There is no background thread for sending items, all the items are sent when they are received (`channels` in SpanExporter are removed).

Sample application for use on Fastly:
```rust
use opentelemetry::sdk::trace as sdktrace;
use opentelemetry::sdk::Resource;
use opentelemetry::trace::TraceError;
use opentelemetry::KeyValue;
use opentelemetry_otlp::{ExportConfig, WithExportConfig};
use log_fastly;
use opentelemetry::trace::Tracer;

#[derive(Debug)]
struct MyOwnHttpClient {
    backend: fastly::Backend,
}

#[async_trait::async_trait]
impl opentelemetry_http::HttpClient for MyOwnHttpClient {
    async fn send(
        &self,
        request: opentelemetry_http::Request<Vec<u8>>,
    ) -> Result<
        opentelemetry_http::Response<opentelemetry_http::Bytes>,
        opentelemetry_http::HttpError,
    > {
        let fastly_request = otel_request_to_fastly_request(request);
        let response = match fastly_request.send(&self.backend) {
            Ok(response) => response,
            Err(e) => {
                log::error!("Could not send tracing data {:?}", e);
                Response::new() // Always return an OK since we don't have a global error handler
                                // (yet)
            }
        };

        Ok(fastly_response_to_otel_response(response))
    }
}

fn fastly_response_to_otel_response(
    from: fastly::Response,
) -> opentelemetry_http::Response<opentelemetry_http::Bytes> {
    let response: opentelemetry_http::Response<fastly::Body> = from.into();
    let (h, b) = response.into_parts();
    let bytes = opentelemetry_http::Bytes::from(b.into_bytes());
    opentelemetry_http::Response::from_parts(h, bytes)
}

fn otel_request_to_fastly_request(from: opentelemetry_http::Request<Vec<u8>>) -> Request {
    let (h, b) = from.into_parts();
    let new_body = fastly::Body::from(b);
    let new_request = opentelemetry_http::Request::from_parts(h, new_body);
    Request::from(new_request)
}

fn init_tracer(tracing_backend: fastly::Backend) -> Result<sdktrace::Tracer, TraceError> {
    opentelemetry_otlp::new_pipeline()
        .tracing()
        .with_exporter(
            opentelemetry_otlp::HttpExporterBuilder::default()
                .with_http_client(MyOwnHttpClient {
                    backend: tracing_backend,
                })
                .with_export_config(ExportConfig {
                    endpoint: "http://localhost:4318/v1/traces".to_string(),
                    protocol: opentelemetry_otlp::Protocol::HttpBinary,
                    timeout: std::time::Duration::from_secs(5),
                }),
        )
        .with_trace_config(
            sdktrace::config()
                .with_resource(Resource::new(vec![KeyValue::new(
                    opentelemetry_semantic_conventions::resource::SERVICE_NAME,
                    "wasm_trace_test",
                )]))
                .with_sampler(opentelemetry::sdk::trace::Sampler::AlwaysOn),
        )
        .install_simple()
}

fn setup_tracing_opentelemetry() {
    let tracer = init_tracer(fastly::Backend::from_name("otel_backend").unwrap()).unwrap();
    tracer.in_span("test_trace", |_| log::info!("in test_trace")); // Makes a test trace
}

#[tokio::main(flavor = "current_thread")]
async fn main() -> Result<(), Error> {
    log_fastly::Logger::builder()
        .max_level(log::LevelFilter::Info)
        .default_endpoint("logging-endpoint")
        .echo_stdout(true)
        .init();
    fastly::log::set_panic_endpoint("logging-endpoint").unwrap();

    setup_tracing_opentelemetry();
    let response = Response::new();
    opentelemetry::global::shutdown_tracer_provider();
    response.send_to_client();
    Ok(())
}
```

with Cargo.toml:
```toml
[dependencies]
fastly = "0.9.1"
log = "0.4.14"
log-fastly = "0.9.1"
tracing = "*"
tokio = { version = "1.26.0", features = ["macros", "rt"] }
opentelemetry = { version = "0.19.0", default-features = false, features = ["rt-tokio-current-thread"] }
opentelemetry-otlp = { version = "0.12.0", default-features = false, features = ["my-http"] }
opentelemetry-http = { version = "0.8.0", default-features = false, features = [] }
async-trait = "0.1.68"
opentelemetry-semantic-conventions = { version = "0.11" } 


[patch.crates-io]

opentelemetry = {git = "https://github.com/MidasLamb/opentelemetry-rust.git", branch = "wasm-wasi-fastly"}
opentelemetry-otlp = {git = "https://github.com/MidasLamb/opentelemetry-rust.git", branch = "wasm-wasi-fastly"}
opentelemetry_api = {git = "https://github.com/MidasLamb/opentelemetry-rust.git", branch = "wasm-wasi-fastly"}
opentelemetry_sdk = {git = "https://github.com/MidasLamb/opentelemetry-rust.git", branch = "wasm-wasi-fastly"}
opentelemetry-http = {git = "https://github.com/MidasLamb/opentelemetry-rust.git", branch = "wasm-wasi-fastly"}

```