### PR TITLE
Improve tracer and meter creation ergonomics from #1018

### DIFF
--- a/examples/hyper-prometheus/src/main.rs
+++ b/examples/hyper-prometheus/src/main.rs
@@ -76,7 +76,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let provider = MeterProvider::builder().with_reader(exporter).build();
     let cx = Context::new();
 
-    let meter = provider.meter("hyper-prometheus-example".into());
+    let meter = provider.meter("hyper-prometheus-example");
     let state = Arc::new(AppState {
         registry,
         http_counter: meter

--- a/opentelemetry-api/src/common.rs
+++ b/opentelemetry-api/src/common.rs
@@ -442,7 +442,7 @@ pub struct InstrumentationLibrary {
     /// let library = opentelemetry_api::InstrumentationLibrary::new(
     ///     "my-crate",
     ///     Some(env!("CARGO_PKG_VERSION")),
-    ///     None,
+    ///     Some("https://opentelemetry.io/schemas/1.17.0"),
     ///     None,
     /// );
     /// ```
@@ -478,15 +478,12 @@ impl hash::Hash for InstrumentationLibrary {
 
 impl InstrumentationLibrary {
     /// Create an new instrumentation library.
-    pub fn new<T>(
-        name: T,
-        version: Option<T>,
-        schema_url: Option<T>,
+    pub fn new(
+        name: impl Into<Cow<'static, str>>,
+        version: Option<impl Into<Cow<'static, str>>>,
+        schema_url: Option<impl Into<Cow<'static, str>>>,
         attributes: Option<Vec<KeyValue>>,
-    ) -> InstrumentationLibrary
-    where
-        T: Into<Cow<'static, str>>,
-    {
+    ) -> InstrumentationLibrary {
         InstrumentationLibrary {
             name: name.into(),
             version: version.map(Into::into),

--- a/opentelemetry-api/src/global/mod.rs
+++ b/opentelemetry-api/src/global/mod.rs
@@ -57,9 +57,9 @@
 //!     // End users of your library will configure their global tracer provider
 //!     // so you can use the global tracer without any setup
 //!     let tracer = global::tracer_provider().versioned_tracer(
-//!         "my-library-name".into(),
-//!         Some(env!("CARGO_PKG_VERSION").into()),
-//!         None,
+//!         "my-library-name",
+//!         Some(env!("CARGO_PKG_VERSION")),
+//!         Some("https://opentelemetry.io/schemas/1.17.0"),
 //!         None,
 //!     );
 //!
@@ -152,15 +152,10 @@ mod trace;
 pub use error_handler::{handle_error, set_error_handler, Error};
 #[cfg(feature = "metrics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-pub use metrics::{
-    meter, meter_provider, meter_with_version, set_meter_provider, GlobalMeterProvider,
-};
+pub use metrics::*;
 #[cfg(feature = "trace")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
-pub use propagation::{get_text_map_propagator, set_text_map_propagator};
+pub use propagation::*;
 #[cfg(feature = "trace")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
-pub use trace::{
-    set_tracer_provider, shutdown_tracer_provider, tracer, tracer_provider, BoxedSpan, BoxedTracer,
-    GlobalTracerProvider, ObjectSafeTracer, ObjectSafeTracerProvider,
-};
+pub use trace::*;

--- a/opentelemetry-api/src/global/trace.rs
+++ b/opentelemetry-api/src/global/trace.rs
@@ -7,6 +7,8 @@ use std::mem;
 use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
 
+/// Allows a specific [`crate::trace::Span`] to be used generically by [`BoxedSpan`]
+/// instances by mirroring the interface and boxing the return types.
 pub trait ObjectSafeSpan {
     /// An API to record events at a specific time in the context of a given `Span`.
     ///
@@ -351,15 +353,17 @@ impl trace::TracerProvider for GlobalTracerProvider {
     /// Create a versioned tracer using the global provider.
     fn versioned_tracer(
         &self,
-        name: Cow<'static, str>,
-        version: Option<Cow<'static, str>>,
-        schema_url: Option<Cow<'static, str>>,
+        name: impl Into<Cow<'static, str>>,
+        version: Option<impl Into<Cow<'static, str>>>,
+        schema_url: Option<impl Into<Cow<'static, str>>>,
         attributes: Option<Vec<KeyValue>>,
     ) -> Self::Tracer {
-        BoxedTracer(
-            self.provider
-                .versioned_tracer_boxed(name, version, schema_url, attributes),
-        )
+        BoxedTracer(self.provider.versioned_tracer_boxed(
+            name.into(),
+            version.map(Into::into),
+            schema_url.map(Into::into),
+            attributes,
+        ))
     }
 }
 

--- a/opentelemetry-api/src/global/trace.rs
+++ b/opentelemetry-api/src/global/trace.rs
@@ -103,7 +103,7 @@ pub trait ObjectSafeSpan {
     ///
     /// For more details, refer to [`Span::end`]
     ///
-    /// [`Span::end`]: Span::end()
+    /// [`Span::end`]: trace::Span::end
     fn end_with_timestamp(&mut self, timestamp: SystemTime);
 }
 

--- a/opentelemetry-api/src/metrics/meter.rs
+++ b/opentelemetry-api/src/metrics/meter.rs
@@ -22,8 +22,13 @@ pub trait MeterProvider {
     ///
     /// If the name is empty, then an implementation defined default name will
     /// be used instead.
-    fn meter(&self, name: Cow<'static, str>) -> Meter {
-        self.versioned_meter(name, None, None, None)
+    fn meter(&self, name: impl Into<Cow<'static, str>>) -> Meter {
+        self.versioned_meter(
+            name,
+            None::<Cow<'static, str>>,
+            None::<Cow<'static, str>>,
+            None,
+        )
     }
 
     /// Creates an implementation of the [`Meter`] interface.
@@ -34,9 +39,9 @@ pub trait MeterProvider {
     /// default name will be used instead.
     fn versioned_meter(
         &self,
-        name: Cow<'static, str>,
-        version: Option<Cow<'static, str>>,
-        schema_url: Option<Cow<'static, str>>,
+        name: impl Into<Cow<'static, str>>,
+        version: Option<impl Into<Cow<'static, str>>>,
+        schema_url: Option<impl Into<Cow<'static, str>>>,
         attributes: Option<Vec<KeyValue>>,
     ) -> Meter;
 }

--- a/opentelemetry-api/src/metrics/noop.rs
+++ b/opentelemetry-api/src/metrics/noop.rs
@@ -28,9 +28,9 @@ impl NoopMeterProvider {
 impl MeterProvider for NoopMeterProvider {
     fn versioned_meter(
         &self,
-        _name: Cow<'static, str>,
-        _version: Option<Cow<'static, str>>,
-        _schema_url: Option<Cow<'static, str>>,
+        _name: impl Into<Cow<'static, str>>,
+        _version: Option<impl Into<Cow<'static, str>>>,
+        _schema_url: Option<impl Into<Cow<'static, str>>>,
         _attributes: Option<Vec<KeyValue>>,
     ) -> Meter {
         Meter::new(Arc::new(NoopMeterCore::new()))

--- a/opentelemetry-api/src/trace/mod.rs
+++ b/opentelemetry-api/src/trace/mod.rs
@@ -52,9 +52,9 @@
 //!
 //!     // Get a tracer for this library
 //!     let tracer = tracer_provider.versioned_tracer(
-//!         "my_name".into(),
-//!         Some(env!("CARGO_PKG_VERSION").into()),
-//!         None,
+//!         "my_name",
+//!         Some(env!("CARGO_PKG_VERSION")),
+//!         Some("https://opentelemetry.io/schemas/1.17.0"),
 //!         None
 //!     );
 //!

--- a/opentelemetry-api/src/trace/noop.rs
+++ b/opentelemetry-api/src/trace/noop.rs
@@ -31,9 +31,9 @@ impl trace::TracerProvider for NoopTracerProvider {
     /// Returns a new `NoopTracer` instance.
     fn versioned_tracer(
         &self,
-        _name: Cow<'static, str>,
-        _version: Option<Cow<'static, str>>,
-        _schema_url: Option<Cow<'static, str>>,
+        _name: impl Into<Cow<'static, str>>,
+        _version: Option<impl Into<Cow<'static, str>>>,
+        _schema_url: Option<impl Into<Cow<'static, str>>>,
         _attributes: Option<Vec<KeyValue>>,
     ) -> Self::Tracer {
         NoopTracer::new()

--- a/opentelemetry-api/src/trace/tracer_provider.rs
+++ b/opentelemetry-api/src/trace/tracer_provider.rs
@@ -26,18 +26,23 @@ pub trait TracerProvider {
     /// let provider = global::tracer_provider();
     ///
     /// // tracer used in applications/binaries
-    /// let tracer = provider.tracer("my_app".into());
+    /// let tracer = provider.tracer("my_app");
     ///
     /// // tracer used in libraries/crates that optionally includes version and schema url
     /// let tracer = provider.versioned_tracer(
-    ///     "my_library".into(),
-    ///     Some(env!("CARGO_PKG_VERSION").into()),
-    ///     Some("https://opentelemetry.io/schema/1.0.0".into()),
+    ///     "my_library",
+    ///     Some(env!("CARGO_PKG_VERSION")),
+    ///     Some("https://opentelemetry.io/schema/1.0.0"),
     ///     Some(vec![KeyValue::new("key", "value")]),
     /// );
     /// ```
-    fn tracer(&self, name: Cow<'static, str>) -> Self::Tracer {
-        self.versioned_tracer(name, None, None, None)
+    fn tracer(&self, name: impl Into<Cow<'static, str>>) -> Self::Tracer {
+        self.versioned_tracer(
+            name,
+            None::<Cow<'static, str>>,
+            None::<Cow<'static, str>>,
+            None,
+        )
     }
 
     /// Returns a new versioned tracer with a given name.
@@ -54,21 +59,21 @@ pub trait TracerProvider {
     /// let provider = global::tracer_provider();
     ///
     /// // tracer used in applications/binaries
-    /// let tracer = provider.tracer("my_app".into());
+    /// let tracer = provider.tracer("my_app");
     ///
     /// // tracer used in libraries/crates that optionally includes version and schema url
     /// let tracer = provider.versioned_tracer(
-    ///     "my_library".into(),
-    ///     Some(env!("CARGO_PKG_VERSION").into()),
-    ///     Some("https://opentelemetry.io/schema/1.0.0".into()),
+    ///     "my_library",
+    ///     Some(env!("CARGO_PKG_VERSION")),
+    ///     Some("https://opentelemetry.io/schema/1.0.0"),
     ///     None,
     /// );
     /// ```
     fn versioned_tracer(
         &self,
-        name: Cow<'static, str>,
-        version: Option<Cow<'static, str>>,
-        schema_url: Option<Cow<'static, str>>,
+        name: impl Into<Cow<'static, str>>,
+        version: Option<impl Into<Cow<'static, str>>>,
+        schema_url: Option<impl Into<Cow<'static, str>>>,
         attributes: Option<Vec<KeyValue>>,
     ) -> Self::Tracer;
 }

--- a/opentelemetry-aws/src/lib.rs
+++ b/opentelemetry-aws/src/lib.rs
@@ -21,7 +21,7 @@
 //!     let provider = TracerProvider::builder()
 //!         .with_simple_exporter(SpanExporter::default())
 //!         .build();
-//!     let tracer = provider.tracer("readme_example".into());
+//!     let tracer = provider.tracer("readme_example");
 //!
 //!     let mut req = hyper::Request::builder().uri("http://127.0.0.1:3000");
 //!     tracer.in_span("doing_work", |cx| {

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 base64_format = ["base64", "binary_propagator"]
 binary_propagator = []
-jaeger_json_exporter = ["serde_json", "futures", "async-trait"]
+jaeger_json_exporter = ["serde_json", "futures", "async-trait", "opentelemetry-semantic-conventions"]
 rt-tokio = ["tokio", "opentelemetry/rt-tokio"]
 rt-tokio-current-thread = ["tokio", "opentelemetry/rt-tokio-current-thread"]
 rt-async-std = ["async-std", "opentelemetry/rt-async-std"]
@@ -35,6 +35,7 @@ futures = { version = "0.3", optional = true }
 once_cell = "1.17.1"
 opentelemetry = { version = "0.19", path = "../opentelemetry", features = ["trace"] }
 opentelemetry_api = { version = "0.19", path = "../opentelemetry-api" }
+opentelemetry-semantic-conventions = { version = "0.11", path = "../opentelemetry-semantic-conventions", optional = true }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.0", features = ["fs", "io-util"], optional = true }
 

--- a/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
+++ b/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
@@ -6,6 +6,7 @@ use futures::{future::BoxFuture, FutureExt};
 use opentelemetry::sdk::export::trace::{ExportResult, SpanData, SpanExporter};
 use opentelemetry::sdk::trace::{TraceRuntime, Tracer};
 use opentelemetry::trace::{SpanId, TraceError};
+use opentelemetry_semantic_conventions::SCHEMA_URL;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -46,9 +47,9 @@ impl<R: JaegerJsonRuntime> JaegerJsonExporter<R> {
         let provider = provider_builder.build();
 
         let tracer = provider.versioned_tracer(
-            "opentelemetry".into(),
-            Some(env!("CARGO_PKG_VERSION").into()),
-            None,
+            "opentelemetry",
+            Some(env!("CARGO_PKG_VERSION")),
+            Some(SCHEMA_URL),
             None,
         );
         let _ = opentelemetry::global::set_tracer_provider(provider);

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -290,9 +290,9 @@ impl DatadogPipelineBuilder {
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
         let tracer = provider.versioned_tracer(
-            "opentelemetry-datadog".into(),
-            Some(env!("CARGO_PKG_VERSION").into()),
-            None,
+            "opentelemetry-datadog",
+            Some(env!("CARGO_PKG_VERSION")),
+            Some(semcov::SCHEMA_URL),
             None,
         );
         let _ = global::set_tracer_provider(provider);
@@ -312,9 +312,9 @@ impl DatadogPipelineBuilder {
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
         let tracer = provider.versioned_tracer(
-            "opentelemetry-datadog".into(),
-            Some(env!("CARGO_PKG_VERSION").into()),
-            None,
+            "opentelemetry-datadog",
+            Some(env!("CARGO_PKG_VERSION")),
+            Some(semcov::SCHEMA_URL),
             None,
         );
         let _ = global::set_tracer_provider(provider);

--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -234,7 +234,12 @@ pub(crate) mod tests {
             links,
             status: Status::Ok,
             resource: Cow::Owned(resource),
-            instrumentation_lib: InstrumentationLibrary::new("component", None, None, None),
+            instrumentation_lib: InstrumentationLibrary::new(
+                "component",
+                None::<&'static str>,
+                None::<&'static str>,
+                None,
+            ),
         }
     }
 

--- a/opentelemetry-jaeger/src/exporter/config/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/mod.rs
@@ -121,9 +121,9 @@ pub(crate) fn install_tracer_provider_and_get_tracer(
     tracer_provider: sdk::trace::TracerProvider,
 ) -> Result<sdk::trace::Tracer, TraceError> {
     let tracer = tracer_provider.versioned_tracer(
-        "opentelemetry-jaeger".into(),
-        Some(env!("CARGO_PKG_VERSION").into()),
-        None,
+        "opentelemetry-jaeger",
+        Some(env!("CARGO_PKG_VERSION")),
+        Some(semcov::SCHEMA_URL),
         None,
     );
     let _ = global::set_tracer_provider(tracer_provider);

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -39,6 +39,7 @@ grpcio = { version = "0.12", optional = true }
 opentelemetry_api = { version = "0.19", default-features = false, path = "../opentelemetry-api" }
 opentelemetry_sdk = { version = "0.19", default-features = false, path = "../opentelemetry-sdk" }
 opentelemetry-http = { version = "0.8", path = "../opentelemetry-http", optional = true }
+opentelemetry-semantic-conventions = { version = "0.11", path = "../opentelemetry-semantic-conventions" }
 protobuf = { version = "2.18", optional = true }
 
 prost = { version = "0.11.0", optional = true }

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -62,6 +62,7 @@ use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData},
     trace::TraceRuntime,
 };
+use opentelemetry_semantic_conventions::SCHEMA_URL;
 
 use async_trait::async_trait;
 
@@ -165,9 +166,9 @@ fn build_simple_with_exporter(
     }
     let provider = provider_builder.build();
     let tracer = provider.versioned_tracer(
-        "opentelemetry-otlp".into(),
-        Some(env!("CARGO_PKG_VERSION").into()),
-        None,
+        "opentelemetry-otlp",
+        Some(env!("CARGO_PKG_VERSION")),
+        Some(SCHEMA_URL),
         None,
     );
     let _ = global::set_tracer_provider(provider);
@@ -191,9 +192,9 @@ fn build_batch_with_exporter<R: TraceRuntime>(
     }
     let provider = provider_builder.build();
     let tracer = provider.versioned_tracer(
-        "opentelemetry-otlp".into(),
-        Some(env!("CARGO_PKG_VERSION").into()),
-        None,
+        "opentelemetry-otlp",
+        Some(env!("CARGO_PKG_VERSION")),
+        Some(SCHEMA_URL),
         None,
     );
     let _ = global::set_tracer_provider(provider);

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! // set up a meter meter to create instruments
 //! let provider = MeterProvider::builder().with_reader(exporter).build();
-//! let meter = provider.meter("my-app".into());
+//! let meter = provider.meter("my-app");
 //!
 //! // Use two instruments
 //! let counter = meter

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -302,7 +302,8 @@ fn prometheus_exporter_integration() {
                 .unwrap(),
             )
             .build();
-        let meter = provider.versioned_meter("testmeter".into(), Some("v0.1.0".into()), None, None);
+        let meter =
+            provider.versioned_meter("testmeter", Some("v0.1.0"), None::<&'static str>, None);
         (tc.record_metrics)(&cx, meter);
 
         let content = fs::read_to_string(Path::new("./tests/data").join(tc.expected_file))
@@ -354,7 +355,7 @@ fn multiple_scopes() {
         .build();
 
     let foo_counter = provider
-        .versioned_meter("meterfoo".into(), Some("v0.1.0".into()), None, None)
+        .versioned_meter("meterfoo", Some("v0.1.0"), None::<&'static str>, None)
         .u64_counter("foo")
         .with_unit(Unit::new("ms"))
         .with_description("meter foo counter")
@@ -362,7 +363,7 @@ fn multiple_scopes() {
     foo_counter.add(&cx, 100, &[KeyValue::new("type", "foo")]);
 
     let bar_counter = provider
-        .versioned_meter("meterbar".into(), Some("v0.1.0".into()), None, None)
+        .versioned_meter("meterbar", Some("v0.1.0"), None::<&'static str>, None)
         .u64_counter("bar")
         .with_unit(Unit::new("ms"))
         .with_description("meter bar counter")
@@ -689,8 +690,8 @@ fn duplicate_metrics() {
             .with_reader(exporter)
             .build();
 
-        let meter_a = provider.versioned_meter("ma".into(), Some("v0.1.0".into()), None, None);
-        let meter_b = provider.versioned_meter("mb".into(), Some("v0.1.0".into()), None, None);
+        let meter_a = provider.versioned_meter("ma", Some("v0.1.0"), None::<&'static str>, None);
+        let meter_b = provider.versioned_meter("mb", Some("v0.1.0"), None::<&'static str>, None);
 
         (tc.record_metrics)(&cx, meter_a, meter_b);
 

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -122,7 +122,7 @@ fn bench_counter(
         builder = builder.with_view(view);
     }
     let provider = builder.build();
-    let cntr = provider.meter("test".into()).u64_counter("hello").init();
+    let cntr = provider.meter("test").u64_counter("hello").init();
 
     (cx, rdr, cntr)
 }
@@ -316,7 +316,7 @@ fn benchmark_collect_histogram(b: &mut Bencher, n: usize) {
     let mtr = MeterProvider::builder()
         .with_reader(r.clone())
         .build()
-        .meter("sdk/metric/bench/histogram".into());
+        .meter("sdk/metric/bench/histogram");
 
     for i in 0..n {
         let h = mtr.i64_histogram(format!("fake_data_{i}")).init();

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -115,7 +115,7 @@ fn trace_benchmark_group<F: Fn(&sdktrace::Tracer)>(c: &mut Criterion, name: &str
             .with_config(sdktrace::config().with_sampler(sdktrace::Sampler::AlwaysOn))
             .with_simple_exporter(VoidExporter)
             .build();
-        let always_sample = provider.tracer("always-sample".into());
+        let always_sample = provider.tracer("always-sample");
 
         b.iter(|| f(&always_sample));
     });
@@ -125,7 +125,7 @@ fn trace_benchmark_group<F: Fn(&sdktrace::Tracer)>(c: &mut Criterion, name: &str
             .with_config(sdktrace::config().with_sampler(sdktrace::Sampler::AlwaysOff))
             .with_simple_exporter(VoidExporter)
             .build();
-        let never_sample = provider.tracer("never-sample".into());
+        let never_sample = provider.tracer("never-sample");
         b.iter(|| f(&never_sample));
     });
 

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -19,7 +19,7 @@
 //!     let provider = TracerProvider::builder()
 //!         .with_simple_exporter(exporter)
 //!         .build();
-//!     let tracer = provider.tracer("readme_example".into());
+//!     let tracer = provider.tracer("readme_example");
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -76,9 +76,9 @@ impl MeterProvider {
 impl opentelemetry_api::metrics::MeterProvider for MeterProvider {
     fn versioned_meter(
         &self,
-        name: Cow<'static, str>,
-        version: Option<Cow<'static, str>>,
-        schema_url: Option<Cow<'static, str>>,
+        name: impl Into<Cow<'static, str>>,
+        version: Option<impl Into<Cow<'static, str>>>,
+        schema_url: Option<impl Into<Cow<'static, str>>>,
         attributes: Option<Vec<KeyValue>>,
     ) -> ApiMeter {
         let inst_provider: Arc<dyn InstrumentProvider + Send + Sync> =

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -24,7 +24,7 @@
 //! let provider = MeterProvider::builder().with_resource(resource).build();
 //!
 //! // Use the meter provider to create meter instances
-//! let meter = provider.meter("my_app".into());
+//! let meter = provider.meter("my_app");
 //!
 //! // Create instruments scoped to the meter
 //! let counter = meter

--- a/opentelemetry-sdk/src/propagation/composite.rs
+++ b/opentelemetry-sdk/src/propagation/composite.rs
@@ -44,7 +44,7 @@ use std::collections::HashSet;
 ///
 /// // And a given span
 /// let example_span = sdktrace::TracerProvider::default()
-///     .tracer("example-component".into())
+///     .tracer("example-component")
 ///     .start("span-name");
 ///
 /// // with the current context, call inject to add the headers

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -122,12 +122,13 @@ impl opentelemetry_api::trace::TracerProvider for TracerProvider {
     /// Create a new versioned `Tracer` instance.
     fn versioned_tracer(
         &self,
-        name: Cow<'static, str>,
-        version: Option<Cow<'static, str>>,
-        schema_url: Option<Cow<'static, str>>,
+        name: impl Into<Cow<'static, str>>,
+        version: Option<impl Into<Cow<'static, str>>>,
+        schema_url: Option<impl Into<Cow<'static, str>>>,
         attributes: Option<Vec<opentelemetry_api::KeyValue>>,
     ) -> Self::Tracer {
         // Use default value if name is invalid empty string
+        let name = name.into();
         let component_name = if name.is_empty() {
             Cow::Borrowed(DEFAULT_COMPONENT_NAME)
         } else {

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -251,7 +251,7 @@ mod tests {
     fn init() -> (crate::trace::Tracer, SpanData) {
         let provider = crate::trace::TracerProvider::default();
         let config = provider.config();
-        let tracer = provider.tracer("opentelemetry".into());
+        let tracer = provider.tracer("opentelemetry");
         let data = SpanData {
             parent_span_id: SpanId::from_u64(0),
             span_kind: trace::SpanKind::Internal,
@@ -500,7 +500,7 @@ mod tests {
         let provider_builder =
             crate::trace::TracerProvider::builder().with_simple_exporter(exporter);
         let provider = provider_builder.build();
-        let tracer = provider.tracer("opentelemetry-test".into());
+        let tracer = provider.tracer("opentelemetry-test");
 
         let mut event1 = Event::with_name("test event");
         for i in 0..(DEFAULT_MAX_ATTRIBUTES_PER_EVENT * 2) {
@@ -535,7 +535,7 @@ mod tests {
         let provider_builder =
             crate::trace::TracerProvider::builder().with_simple_exporter(exporter);
         let provider = provider_builder.build();
-        let tracer = provider.tracer("opentelemetry-test".into());
+        let tracer = provider.tracer("opentelemetry-test");
 
         let mut link = Link::new(
             SpanContext::new(
@@ -569,7 +569,7 @@ mod tests {
         let provider = crate::trace::TracerProvider::builder()
             .with_simple_exporter(NoopSpanExporter::new())
             .build();
-        let tracer = provider.tracer("test".into());
+        let tracer = provider.tracer("test");
 
         let mut span = tracer.start("test_span");
         span.add_event("test_event", vec![]);

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -322,7 +322,7 @@ mod tests {
         let tracer_provider = crate::trace::TracerProvider::builder()
             .with_config(config)
             .build();
-        let tracer = tracer_provider.tracer("test".into());
+        let tracer = tracer_provider.tracer("test");
         let trace_state = TraceState::from_key_value(vec![("foo", "bar")]).unwrap();
 
         let parent_context = Context::new().with_span(TestSpan(SpanContext::new(
@@ -349,7 +349,7 @@ mod tests {
             .build();
 
         let context = Context::current_with_span(TestSpan(SpanContext::empty_context()));
-        let tracer = tracer_provider.tracer("test".into());
+        let tracer = tracer_provider.tracer("test");
         let span = tracer.start_with_context("must_not_be_sampled", &context);
 
         assert!(!span.span_context().is_sampled());
@@ -362,7 +362,7 @@ mod tests {
         let tracer_provider = crate::trace::TracerProvider::builder()
             .with_config(config)
             .build();
-        let tracer = tracer_provider.tracer("test".into());
+        let tracer = tracer_provider.tracer("test");
 
         let _attached = Context::current_with_span(TestSpan(SpanContext::empty_context())).attach();
         let span = tracer.span_builder("must_not_be_sampled").start(&tracer);

--- a/opentelemetry-semantic-conventions/src/lib.rs
+++ b/opentelemetry-semantic-conventions/src/lib.rs
@@ -17,3 +17,7 @@
 
 pub mod resource;
 pub mod trace;
+
+/// The schema URL that matches the version of the semantic conventions that
+/// this crate defines.
+pub const SCHEMA_URL: &str = "https://opentelemetry.io/schemas/1.17.0";

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -35,12 +35,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let meter_provider = init_metrics();
     let cx = Context::new();
 
-    let tracer = tracer_provider.tracer("stdout-test".into());
+    let tracer = tracer_provider.tracer("stdout-test");
     let mut span = tracer.start("test_span");
     span.set_attribute(KeyValue::new("test_key", "test_value"));
     span.end();
 
-    let meter = meter_provider.meter("stdout-test".into());
+    let meter = meter_provider.meter("stdout-test");
     let c = meter.u64_counter("test_events").init();
     c.add(&cx, 1, &[KeyValue::new("test_key", "test_value")]);
 

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -176,9 +176,9 @@ impl ZipkinPipelineBuilder {
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
         let tracer = provider.versioned_tracer(
-            "opentelemetry-zipkin".into(),
-            Some(env!("CARGO_PKG_VERSION").into()),
-            None,
+            "opentelemetry-zipkin",
+            Some(env!("CARGO_PKG_VERSION")),
+            Some(semcov::SCHEMA_URL),
             None,
         );
         let _ = global::set_tracer_provider(provider);
@@ -198,9 +198,9 @@ impl ZipkinPipelineBuilder {
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
         let tracer = provider.versioned_tracer(
-            "opentelemetry-zipkin".into(),
-            Some(env!("CARGO_PKG_VERSION").into()),
-            None,
+            "opentelemetry-zipkin",
+            Some(env!("CARGO_PKG_VERSION")),
+            Some(semcov::SCHEMA_URL),
             None,
         );
         let _ = global::set_tracer_provider(provider);

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -24,7 +24,7 @@
 //!     let provider = TracerProvider::builder()
 //!         .with_simple_exporter(opentelemetry_stdout::SpanExporter::default())
 //!         .build();
-//!     let tracer = provider.tracer("readme_example".into());
+//!     let tracer = provider.tracer("readme_example");
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...


### PR DESCRIPTION
This makes #1018 less of a breaking change by allowing existing uses that pass static strings to continue working without adding `.into` at each callsite.

It also updates the doc examples and exporters to correctly use schema URLs instead of passing `None`.