### PR TITLE
Fix SpanRef::set_attributes mutability

### DIFF
--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fix `SpanRef::set_attributes` mutability requirement. [#1038](https://github.com/open-telemetry/opentelemetry-rust/pull/1038)
+
 ## v0.19.0
 ### Added
 - Add `WithContext` to public api [#893](https://github.com/open-telemetry/opentelemetry-rust/pull/893).

--- a/opentelemetry-api/src/trace/context.rs
+++ b/opentelemetry-api/src/trace/context.rs
@@ -139,7 +139,7 @@ impl SpanRef<'_> {
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
-    pub fn set_attributes(&mut self, attributes: impl IntoIterator<Item = KeyValue>) {
+    pub fn set_attributes(&self, attributes: impl IntoIterator<Item = KeyValue>) {
         self.with_inner_mut(move |inner| inner.set_attributes(attributes))
     }
 


### PR DESCRIPTION
`SpanRef`s already synchronize access so the reference can be `&self` instead of `&mut self`.