### PR TITLE
should_sample modified to not have instrumentationlibrary as a parameter

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Removed
 - Samplers no longer has access to `InstrumentationLibrary` as one of parameters
   to should_sample.
-  [#1031](https://github.com/open-telemetry/opentelemetry-rust/pull/1031).
+  [#1041](https://github.com/open-telemetry/opentelemetry-rust/pull/1041).
 
 ## v0.19.0
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+
+## Unreleased
+
+### Removed
+- Samplers no longer has access to `InstrumentationLibrary` as one of parameters
+  to should_sample.
+  [#1031](https://github.com/open-telemetry/opentelemetry-rust/pull/1031).
+
 ## v0.19.0
 
 ### Added

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Removed
 - Samplers no longer has access to `InstrumentationLibrary` as one of parameters
-  to should_sample.
+  to `should_sample`.
   [#1041](https://github.com/open-telemetry/opentelemetry-rust/pull/1041).
 
 ## v0.19.0

--- a/opentelemetry-sdk/src/trace/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler.rs
@@ -1,4 +1,3 @@
-use crate::InstrumentationLibrary;
 use opentelemetry_api::trace::OrderMap;
 use opentelemetry_api::{
     trace::{

--- a/opentelemetry-sdk/src/trace/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler.rs
@@ -379,7 +379,6 @@ mod tests {
         let cloned_sampler = sampler.clone();
 
         let cx = Context::current_with_value("some_value");
-        let instrumentation_library = InstrumentationLibrary::default();
 
         let result = sampler.should_sample(
             Some(&cx),
@@ -440,7 +439,6 @@ mod tests {
 
         for (name, delegate, parent_cx, expected) in test_cases {
             let sampler = Sampler::ParentBased(Box::new(delegate));
-            let instrumentation_library = InstrumentationLibrary::default();
             let result = sampler.should_sample(
                 Some(&parent_cx),
                 TraceId::from_u128(1),

--- a/opentelemetry-sdk/src/trace/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler.rs
@@ -82,7 +82,6 @@ pub trait ShouldSample: CloneShouldSample + Send + Sync + std::fmt::Debug {
         span_kind: &SpanKind,
         attributes: &OrderMap<Key, Value>,
         links: &[Link],
-        instrumentation_library: &InstrumentationLibrary,
     ) -> SamplingResult;
 }
 
@@ -175,7 +174,6 @@ impl ShouldSample for Sampler {
         span_kind: &SpanKind,
         attributes: &OrderMap<Key, Value>,
         links: &[Link],
-        instrumentation_library: &InstrumentationLibrary,
     ) -> SamplingResult {
         let decision = match self {
             // Always sample the trace
@@ -195,7 +193,6 @@ impl ShouldSample for Sampler {
                                 span_kind,
                                 attributes,
                                 links,
-                                instrumentation_library,
                             )
                             .decision
                     },
@@ -221,7 +218,6 @@ impl ShouldSample for Sampler {
                         span_kind,
                         attributes,
                         links,
-                        instrumentation_library,
                     )
                     .decision
             }
@@ -348,7 +344,6 @@ mod tests {
                         &SpanKind::Internal,
                         &Default::default(),
                         &[],
-                        &InstrumentationLibrary::default(),
                     )
                     .decision
                     == SamplingDecision::RecordAndSample
@@ -393,7 +388,6 @@ mod tests {
             &SpanKind::Internal,
             &Default::default(),
             &[],
-            &instrumentation_library,
         );
 
         let cloned_result = cloned_sampler.should_sample(
@@ -403,7 +397,6 @@ mod tests {
             &SpanKind::Internal,
             &Default::default(),
             &[],
-            &instrumentation_library,
         );
 
         assert_eq!(result, cloned_result);
@@ -455,7 +448,6 @@ mod tests {
                 &SpanKind::Internal,
                 &Default::default(),
                 &[],
-                &instrumentation_library,
             );
 
             assert_eq!(result.decision, expected);

--- a/opentelemetry-sdk/src/trace/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler.rs
@@ -211,14 +211,7 @@ impl ShouldSample for Sampler {
             #[cfg(feature = "jaeger_remote_sampler")]
             Sampler::JaegerRemote(remote_sampler) => {
                 remote_sampler
-                    .should_sample(
-                        parent_context,
-                        trace_id,
-                        name,
-                        span_kind,
-                        attributes,
-                        links,
-                    )
+                    .should_sample(parent_context, trace_id, name, span_kind, attributes, links)
                     .decision
             }
         };

--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
@@ -4,7 +4,7 @@ use crate::trace::{Sampler, ShouldSample, TraceRuntime};
 use futures_util::{stream, StreamExt as _};
 use http::Uri;
 use opentelemetry_api::trace::{Link, OrderMap, SamplingResult, SpanKind, TraceError, TraceId};
-use opentelemetry_api::{global, Context, InstrumentationLibrary, Key, Value};
+use opentelemetry_api::{global, Context, Key, Value};
 use opentelemetry_http::HttpClient;
 use std::str::FromStr;
 use std::sync::Arc;

--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
@@ -252,7 +252,6 @@ impl ShouldSample for JaegerRemoteSampler {
         span_kind: &SpanKind,
         attributes: &OrderMap<Key, Value>,
         links: &[Link],
-        instrumentation_library: &InstrumentationLibrary,
     ) -> SamplingResult {
         self.inner
             .should_sample(parent_context, trace_id, name)
@@ -264,7 +263,6 @@ impl ShouldSample for JaegerRemoteSampler {
                     span_kind,
                     attributes,
                     links,
-                    instrumentation_library,
                 )
             })
     }

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -295,7 +295,6 @@ mod tests {
             _span_kind: &SpanKind,
             _attributes: &OrderMap<Key, Value>,
             _links: &[Link],
-            _instrumentation_library: &InstrumentationLibrary,
         ) -> SamplingResult {
             let trace_state = parent_context
                 .unwrap()

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -75,7 +75,6 @@ impl Tracer {
         attributes: &OrderMap<Key, Value>,
         links: &[Link],
         config: &Config,
-        instrumentation_library: &InstrumentationLibrary,
     ) -> Option<(TraceFlags, Vec<KeyValue>, TraceState)> {
         let sampling_result = config.sampler.should_sample(
             Some(parent_cx),
@@ -84,7 +83,6 @@ impl Tracer {
             span_kind,
             attributes,
             links,
-            instrumentation_library,
         );
 
         self.process_sampling_result(sampling_result, parent_cx)
@@ -184,7 +182,6 @@ impl opentelemetry_api::trace::Tracer for Tracer {
                 &attribute_options,
                 link_options.as_deref().unwrap_or(&[]),
                 provider.config(),
-                &self.instrumentation_lib,
             )
         };
 

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -273,7 +273,6 @@ mod tests {
     use crate::{
         testing::trace::TestSpan,
         trace::{Config, Sampler, ShouldSample},
-        InstrumentationLibrary,
     };
     use opentelemetry_api::{
         trace::{


### PR DESCRIPTION
## Changes

Though Samplers had access to instrumentation library, it was removed from the [spec](https://github.com/open-telemetry/opentelemetry-specification/pull/1942/files). This PR is doing a clean up, to remove InstrumentationLibrary from the should_sample method.

## Merge requirement checklist

* [x] [CONTRIBUTING](../CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
