### PR TITLE
Add basic stress testing framework + counter.add test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "examples/jaeger-remote-sampler",
     "examples/zipkin",
     "examples/multiple-span-processors",
-    "examples/zpages"
+    "examples/zpages",
+    "stress",
 ]
 exclude = ["examples/external-otlp-grpcio-async-std"]

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stress"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]] # Bin to run the metrics stress tests
+name = "metrics"
+path = "src/metrics.rs"
+doc = false
+
+[dependencies]
+ctrlc = "3.2.5"
+num_cpus = "1.15.0"
+rayon = "1.7.0"

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -11,5 +11,8 @@ doc = false
 
 [dependencies]
 ctrlc = "3.2.5"
+lazy_static = "1.4.0"
 num_cpus = "1.15.0"
 rayon = "1.7.0"
+opentelemetry_api = { path = "../opentelemetry-api", features = ["metrics"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics"] }

--- a/stress/README.md
+++ b/stress/README.md
@@ -25,12 +25,12 @@ cargo run --release --bin metrics
 ```
 
 ```text
-Throughput: 4278494.00 requests/sec
-Throughput: 4157096.50 requests/sec
-Throughput: 4190185.50 requests/sec
-Throughput: 4185362.50 requests/sec
-Throughput: 4225514.00 requests/sec
-Throughput: 4220563.00 requests/sec
-Throughput: 4203673.50 requests/sec
-Throughput: 4230679.50 requests/sec
+Throughput: 4813019.00 requests/sec
+Throughput: 4805997.50 requests/sec
+Throughput: 4796934.50 requests/sec
+Throughput: 4817836.50 requests/sec
+Throughput: 4812457.00 requests/sec
+Throughput: 4773890.50 requests/sec
+Throughput: 4760047.00 requests/sec
+Throughput: 4851061.50 requests/sec
 ```

--- a/stress/README.md
+++ b/stress/README.md
@@ -24,6 +24,10 @@ e.g.
 cargo run --release --bin metrics
 ```
 
+Press (Ctrl + C) to quit the tests.
+
+Example output:
+
 ```text
 Throughput: 4813019.00 requests/sec
 Throughput: 4805997.50 requests/sec

--- a/stress/README.md
+++ b/stress/README.md
@@ -1,25 +1,36 @@
-# HTTP Example
+# OpenTelemetry Stress Tests
 
-This is a simple example using [hyper] that demonstrates tracing http request from client to server. The example
-shows key aspects of tracing such as:
+## Why would you need stress test
 
-- Root Span (on Client)
-- Child Span (on Client)
-- Child Span from a Remote Parent (on Server)
-- SpanContext Propagation (from Client to Server)
-- Span Events
-- Span Attributes
-
-[hyper]: https://hyper.rs/
+* It helps you to understand performance.
+* You can keep it running for days and nights to verify stability.
+* You can use it to generate lots of load to your backend system.
+* You can use it with other stress tools (e.g. a memory limiter) to verify how
+  your code reacts to certain resource constraints.
 
 ## Usage
 
-```shell
-# Run server
-$ cargo run --bin http-server
+Open a console, run the following command from the current folder:
 
-# In another tab, run client
-$ cargo run --bin http-client
+```sh
+cargo run --bin X
+```
 
-# The spans should be visible in stdout in the order that they were exported.
+where `X` is the specific stress test you would like to run.
+
+e.g.
+
+```sh
+cargo run --bin metrics
+```
+
+```text
+Throughput: 70878.00 requests/sec
+Throughput: 70272.00 requests/sec
+Throughput: 70326.00 requests/sec
+Throughput: 71724.00 requests/sec
+Throughput: 74382.00 requests/sec
+Throughput: 74856.00 requests/sec
+Throughput: 75666.00 requests/sec
+Total requests processed: 1035564
 ```

--- a/stress/README.md
+++ b/stress/README.md
@@ -25,12 +25,14 @@ cargo run --release --bin metrics
 ```
 
 ```text
-Throughput: 70878.00 requests/sec
-Throughput: 70272.00 requests/sec
-Throughput: 70326.00 requests/sec
-Throughput: 71724.00 requests/sec
-Throughput: 74382.00 requests/sec
-Throughput: 74856.00 requests/sec
-Throughput: 75666.00 requests/sec
-Total requests processed: 1035564
+Throughput: 412998.00 requests/sec
+Throughput: 404226.00 requests/sec
+Throughput: 417000.00 requests/sec
+Throughput: 403440.00 requests/sec
+Throughput: 395148.00 requests/sec
+Throughput: 404172.00 requests/sec
+Throughput: 395412.00 requests/sec
+Throughput: 400740.00 requests/sec
+Throughput: 390132.00 requests/sec
+Total requests processed: 7418976
 ```

--- a/stress/README.md
+++ b/stress/README.md
@@ -25,14 +25,12 @@ cargo run --release --bin metrics
 ```
 
 ```text
-Throughput: 412998.00 requests/sec
-Throughput: 404226.00 requests/sec
-Throughput: 417000.00 requests/sec
-Throughput: 403440.00 requests/sec
-Throughput: 395148.00 requests/sec
-Throughput: 404172.00 requests/sec
-Throughput: 395412.00 requests/sec
-Throughput: 400740.00 requests/sec
-Throughput: 390132.00 requests/sec
-Total requests processed: 7418976
+Throughput: 4278494.00 requests/sec
+Throughput: 4157096.50 requests/sec
+Throughput: 4190185.50 requests/sec
+Throughput: 4185362.50 requests/sec
+Throughput: 4225514.00 requests/sec
+Throughput: 4220563.00 requests/sec
+Throughput: 4203673.50 requests/sec
+Throughput: 4230679.50 requests/sec
 ```

--- a/stress/README.md
+++ b/stress/README.md
@@ -13,7 +13,7 @@
 Open a console, run the following command from the current folder:
 
 ```sh
-cargo run --bin X
+cargo run --release --bin X
 ```
 
 where `X` is the specific stress test you would like to run.
@@ -21,7 +21,7 @@ where `X` is the specific stress test you would like to run.
 e.g.
 
 ```sh
-cargo run --bin metrics
+cargo run --release --bin metrics
 ```
 
 ```text

--- a/stress/README.md
+++ b/stress/README.md
@@ -1,0 +1,25 @@
+# HTTP Example
+
+This is a simple example using [hyper] that demonstrates tracing http request from client to server. The example
+shows key aspects of tracing such as:
+
+- Root Span (on Client)
+- Child Span (on Client)
+- Child Span from a Remote Parent (on Server)
+- SpanContext Propagation (from Client to Server)
+- Span Events
+- Span Attributes
+
+[hyper]: https://hyper.rs/
+
+## Usage
+
+```shell
+# Run server
+$ cargo run --bin http-server
+
+# In another tab, run client
+$ cargo run --bin http-client
+
+# The spans should be visible in stdout in the order that they were exported.
+```

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -1,0 +1,45 @@
+use rayon::prelude::*;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+const SLIDING_WINDOW_SIZE: u64 = 2; // In seconds
+
+static STOP: AtomicBool = AtomicBool::new(false);
+
+fn main() {
+    ctrlc::set_handler(move || {
+        STOP.store(true, Ordering::SeqCst);
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    // Main loop
+    let mut start_time = Instant::now();
+    let mut end_time = Instant::now();
+    let mut count: u64 = 0;
+    let mut total_count: u64 = 0;
+    loop {
+        let elapsed = end_time.duration_since(start_time).as_secs();
+        if elapsed >= SLIDING_WINDOW_SIZE {
+            let throughput = count as f64 / elapsed as f64;
+            println!("Throughput: {:.2} requests/sec", throughput);
+            start_time = Instant::now();
+            count = 0;
+        }
+
+        let num_threads = num_cpus::get();
+        (0..num_threads).into_par_iter().for_each(|_| {
+            let x = 1 + 1;
+        });
+
+        count += num_threads as u64;
+        total_count += num_threads as u64;
+
+        if STOP.load(Ordering::SeqCst) {
+            break;
+        }
+
+        end_time = Instant::now();
+    }
+
+    println!("Total requests processed: {}", total_count);
+}

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -1,10 +1,10 @@
 use lazy_static::lazy_static;
-use std::borrow::Cow;
 use opentelemetry_api::{
     metrics::{Counter, MeterProvider as _},
     Context,
 };
 use opentelemetry_sdk::metrics::{ManualReader, MeterProvider};
+use std::borrow::Cow;
 
 mod throughput;
 
@@ -13,7 +13,10 @@ lazy_static! {
     static ref PROVIDER: MeterProvider = MeterProvider::builder()
         .with_reader(ManualReader::builder().build())
         .build();
-    static ref COUNTER: Counter<u64> = PROVIDER.meter(<&str as Into<Cow<'static, str>>>::into("test")).u64_counter("hello").init();
+    static ref COUNTER: Counter<u64> = PROVIDER
+        .meter(<&str as Into<Cow<'static, str>>>::into("test"))
+        .u64_counter("hello")
+        .init();
 }
 
 fn main() {

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -1,20 +1,19 @@
 use lazy_static::lazy_static;
+use std::borrow::Cow;
 use opentelemetry_api::{
-    metrics::{Counter, MeterProvider as _,},
+    metrics::{Counter, MeterProvider as _},
     Context,
 };
-use opentelemetry_sdk::{
-    metrics::{
-        ManualReader, MeterProvider
-    },
-};
+use opentelemetry_sdk::metrics::{ManualReader, MeterProvider};
 
 mod throughput;
 
 lazy_static! {
     static ref CONTEXT: Context = Context::new();
-    static ref PROVIDER: MeterProvider = MeterProvider::builder().with_reader(ManualReader::builder().build()).build();
-    static ref COUNTER: Counter<u64> = PROVIDER.meter("test".into()).u64_counter("hello").init();
+    static ref PROVIDER: MeterProvider = MeterProvider::builder()
+        .with_reader(ManualReader::builder().build())
+        .build();
+    static ref COUNTER: Counter<u64> = PROVIDER.meter(<&str as Into<Cow<'static, str>>>::into("test")).u64_counter("hello").init();
 }
 
 fn main() {

--- a/stress/src/throughput.rs
+++ b/stress/src/throughput.rs
@@ -6,7 +6,6 @@ const SLIDING_WINDOW_SIZE: u64 = 2; // In seconds
 
 static STOP: AtomicBool = AtomicBool::new(false);
 
-
 pub fn test_throughput<F>(func: F)
 where
     F: Fn() + Sync,

--- a/stress/src/throughput.rs
+++ b/stress/src/throughput.rs
@@ -1,6 +1,6 @@
 use rayon::prelude::*;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Instant;
 
 const SLIDING_WINDOW_SIZE: u64 = 2; // In seconds
@@ -17,15 +17,14 @@ where
     .expect("Error setting Ctrl-C handler");
     let mut start_time = Instant::now();
     let mut end_time = Instant::now();
-    let counter = Arc::new(Mutex::new(vec![0; num_cpus::get()]));
     let mut total_count_old: u64 = 0;
-    let counts = counter.clone();
+    let total_count = Arc::new(AtomicU64::new(0));
+    let total_count_clone = Arc::clone(&total_count);
 
-    rayon::spawn(move || {
-        (0..num_cpus::get()).into_par_iter().for_each(|i| loop {
+    rayon::spawn( move || {
+        (0..num_cpus::get()).into_par_iter().for_each(|_| loop {
             func();
-            let mut counts = counts.lock().unwrap();
-            counts[i] += 1;
+            total_count_clone.fetch_add(1, Ordering::SeqCst);
             if STOP.load(Ordering::SeqCst) {
                 break;
             }
@@ -35,10 +34,9 @@ where
     loop {
         let elapsed = end_time.duration_since(start_time).as_secs();
         if elapsed >= SLIDING_WINDOW_SIZE {
-            let counts = counter.lock().unwrap();
-            let total_count: usize = counts.iter().sum();
-            let current_count = total_count as u64 - total_count_old;
-            total_count_old = total_count as u64;
+            let total_count_u64 = total_count.load(Ordering::Relaxed);
+            let current_count = total_count_u64 - total_count_old;
+            total_count_old = total_count_u64;
             let throughput = current_count as f64 / elapsed as f64;
             println!("Throughput: {:.2} requests/sec", throughput);
             start_time = Instant::now();

--- a/stress/src/throughput.rs
+++ b/stress/src/throughput.rs
@@ -1,0 +1,49 @@
+use rayon::prelude::*;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+const SLIDING_WINDOW_SIZE: u64 = 2; // In seconds
+
+static STOP: AtomicBool = AtomicBool::new(false);
+
+
+pub fn test_throughput<F>(func: F)
+where
+    F: Fn() + Sync,
+{
+    ctrlc::set_handler(move || {
+        STOP.store(true, Ordering::SeqCst);
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    // Main loop
+    let mut start_time = Instant::now();
+    let mut end_time = Instant::now();
+    let mut count: u64 = 0;
+    let mut total_count: u64 = 0;
+    loop {
+        let elapsed = end_time.duration_since(start_time).as_secs();
+        if elapsed >= SLIDING_WINDOW_SIZE {
+            let throughput = count as f64 / elapsed as f64;
+            println!("Throughput: {:.2} requests/sec", throughput);
+            start_time = Instant::now();
+            count = 0;
+        }
+
+        let num_threads = num_cpus::get();
+        (0..num_threads).into_par_iter().for_each(|_| {
+            func();
+        });
+
+        count += num_threads as u64;
+        total_count += num_threads as u64;
+
+        if STOP.load(Ordering::SeqCst) {
+            break;
+        }
+
+        end_time = Instant::now();
+    }
+
+    println!("Total requests processed: {}", total_count);
+}

--- a/stress/src/throughput.rs
+++ b/stress/src/throughput.rs
@@ -21,7 +21,7 @@ where
     let total_count = Arc::new(AtomicU64::new(0));
     let total_count_clone = Arc::clone(&total_count);
 
-    rayon::spawn( move || {
+    rayon::spawn(move || {
         (0..num_cpus::get()).into_par_iter().for_each(|_| loop {
             func();
             total_count_clone.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
Discussed in the weekly Rust SIG, creates a stress testing framework under the folder `stress` to test throughput of functions in our API.

Measures the amount of times a certain function is called within a sliding window (2 seconds, can be configured in the future) to using the max number of cpus available.

Note this provides basic functionality and only prints to the console. 
Sample output:

```text
Throughput: 412998.00 requests/sec
Throughput: 404226.00 requests/sec
Throughput: 417000.00 requests/sec
Throughput: 403440.00 requests/sec
Throughput: 395148.00 requests/sec
Throughput: 404172.00 requests/sec
Throughput: 395412.00 requests/sec
Throughput: 400740.00 requests/sec
Throughput: 390132.00 requests/sec
Total requests processed: 7418976
```