### PR TITLE
Ensure semantic conventions schema url stays in sync

### DIFF
--- a/opentelemetry-semantic-conventions/scripts/generate-consts-from-spec.sh
+++ b/opentelemetry-semantic-conventions/scripts/generate-consts-from-spec.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CRATE_DIR="${SCRIPT_DIR}/../"
 
 # freeze the spec version and generator version to make generation reproducible
-SPEC_VERSION=v1.20.0
+SPEC_VERSION=1.20.0
 SEMCOVGEN_VERSION=0.18.0
 
 cd "$CRATE_DIR"
@@ -16,7 +16,7 @@ cd opentelemetry-specification
 
 git init
 git remote add origin https://github.com/open-telemetry/opentelemetry-specification.git
-git fetch origin "$SPEC_VERSION"
+git fetch origin "v$SPEC_VERSION"
 git reset --hard FETCH_HEAD
 cd "$CRATE_DIR"
 
@@ -41,5 +41,8 @@ docker run --rm \
 	--template /templates/semantic_attributes.rs.j2 \
 	--output /output/resource.rs \
 	--parameters conventions=resource
+
+# Keep `SCHEMA_URL` key in sync with spec version
+sed -i '' "s/\(opentelemetry.io\/schemas\/\)[^\"]*\"/\1$SPEC_VERSION\"/" src/lib.rs
 
 cargo fmt

--- a/opentelemetry-semantic-conventions/src/lib.rs
+++ b/opentelemetry-semantic-conventions/src/lib.rs
@@ -20,4 +20,4 @@ pub mod trace;
 
 /// The schema URL that matches the version of the semantic conventions that
 /// this crate defines.
-pub const SCHEMA_URL: &str = "https://opentelemetry.io/schemas/1.17.0";
+pub const SCHEMA_URL: &str = "https://opentelemetry.io/schemas/1.20.0";


### PR DESCRIPTION
It currently easy for the spec version key to get out of sync. This updates the generation script to ensure the constant is updated when the spec version is updated.