### PR TITLE
prometheus: Add metric namespace config

### DIFF
--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Add `with_namespace` option to exporter config.
+
 ## v0.12.0
 
 ### Changed
@@ -7,7 +13,7 @@
 - Update to `opentelemetry` v0.19.
 - Bump MSRV to 1.57 [#953](https://github.com/open-telemetry/opentelemetry-rust/pull/953).
 - Update dependencies and bump MSRV to 1.60 [#969](https://github.com/open-telemetry/opentelemetry-rust/pull/969).
-- Add `otel_scope_info` and `scope` labels [#974](https://github.com/open-telemetry/opentelemetry-rust/pull/974). 
+- Add `otel_scope_info` and `scope` labels [#974](https://github.com/open-telemetry/opentelemetry-rust/pull/974).
 
 ## v0.11.0
 

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -188,6 +188,7 @@ struct Collector {
     without_units: bool,
     disable_scope_info: bool,
     create_target_info_once: OnceCell<MetricFamily>,
+    namespace: Option<String>,
     inner: Mutex<CollectorInner>,
 }
 
@@ -200,9 +201,14 @@ struct CollectorInner {
 impl Collector {
     fn get_name(&self, m: &data::Metric) -> Cow<'static, str> {
         let name = sanitize_name(&m.name);
-        match get_unit_suffixes(&m.unit) {
-            Some(suffix) if !self.without_units => Cow::Owned(format!("{name}{suffix}")),
-            _ => name,
+        match (
+            &self.namespace,
+            get_unit_suffixes(&m.unit).filter(|_| !self.without_units),
+        ) {
+            (Some(namespace), Some(suffix)) => Cow::Owned(format!("{namespace}{name}{suffix}")),
+            (Some(namespace), None) => Cow::Owned(format!("{namespace}{name}")),
+            (None, Some(suffix)) => Cow::Owned(format!("{name}{suffix}")),
+            (None, None) => name,
         }
     }
 }

--- a/opentelemetry-prometheus/tests/data/with_namespace.txt
+++ b/opentelemetry-prometheus/tests/data/with_namespace.txt
@@ -1,0 +1,9 @@
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+# HELP target_info Target metadata
+# TYPE target_info gauge
+target_info{service_name="prometheus_test",telemetry_sdk_language="rust",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1
+# HELP test_foo_total a simple counter
+# TYPE test_foo_total counter
+test_foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -256,6 +256,28 @@ fn prometheus_exporter_integration() {
             }),
             ..Default::default()
         },
+        TestCase {
+            name: "with namespace",
+            builder: ExporterBuilder::default().with_namespace("test"),
+            expected_file: "with_namespace.txt",
+            record_metrics: Box::new(|cx, meter| {
+                let attrs = vec![
+                    Key::new("A").string("B"),
+                    Key::new("C").string("D"),
+                    Key::new("E").bool(true),
+                    Key::new("F").i64(42),
+                ];
+                let counter = meter
+                    .f64_counter("foo")
+                    .with_description("a simple counter")
+                    .init();
+
+                counter.add(cx, 5.0, &attrs);
+                counter.add(cx, 10.3, &attrs);
+                counter.add(cx, 9.0, &attrs);
+            }),
+            ..Default::default()
+        },
     ];
 
     for tc in test_cases {


### PR DESCRIPTION
Allows optionally adding a prefix to all exported prometheus metrics.