### PR TITLE
Add OTLPMetricPipeline builder methods for delta and lowmemory

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+
+## Unreleased
+
+### Added
+- Added builder methods to configure delta, low-memory temporality for OTLP
+  Metric pipeline
+
 ## v0.12.0
 
 ### Added

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -141,12 +141,11 @@ impl LowMemoryTemporalitySelector {
 impl TemporalitySelector for LowMemoryTemporalitySelector {
     fn temporality(&self, kind: InstrumentKind) -> Temporality {
         match kind {
-            InstrumentKind::Counter            
-            | InstrumentKind::Histogram => Temporality::Delta,
+            InstrumentKind::Counter | InstrumentKind::Histogram => Temporality::Delta,
             InstrumentKind::UpDownCounter
             | InstrumentKind::ObservableCounter
             | InstrumentKind::ObservableGauge
-            | InstrumentKind::ObservableUpDownCounter => Temporality::Cumulative
+            | InstrumentKind::ObservableUpDownCounter => Temporality::Cumulative,
         }
     }
 }


### PR DESCRIPTION
## Changes

Add new builder methods to help build OTLP Metrics Pipeline with desired Temporality. This PR specifically adds
builders to support the "Delta" and "LowMemory" temporality preference from the spec:
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md#additional-configuration

Note that the env variable support for the same (OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE), is *not* part of this PR, and will be offered as a separate PR.


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
