### PR TITLE
Implement cardinality limits for metric streams

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Implement cardinality limits for metric streams
+  [#1066](https://github.com/open-telemetry/opentelemetry-rust/pull/1066).
+
 ### Removed
+
 - Samplers no longer has access to `InstrumentationLibrary` as one of parameters
   to `should_sample`.
   [#1041](https://github.com/open-telemetry/opentelemetry-rust/pull/1041).

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -30,6 +30,7 @@ url = { version = "2.2", optional = true }
 tokio = { version = "1.0", default-features = false, features = ["rt", "time"], optional = true }
 tokio-stream = { version = "0.1", optional = true }
 http = { version = "0.2", optional = true }
+lazy_static = "1.4"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -30,7 +30,6 @@ url = { version = "2.2", optional = true }
 tokio = { version = "1.0", default-features = false, features = ["rt", "time"], optional = true }
 tokio-stream = { version = "0.1", optional = true }
 http = { version = "0.2", optional = true }
-lazy_static = "1.4"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -171,6 +171,7 @@ fn bench_counter(
 fn counters(c: &mut Criterion) {
     let (cx, _, cntr) = bench_counter(None, "cumulative");
     let (cx2, _, cntr2) = bench_counter(None, "delta");
+    let (cx3, _, cntr3) = bench_counter(None, "cumulative");
 
     let mut group = c.benchmark_group("Counter");
     group.bench_function("AddNoAttrs", |b| b.iter(|| cntr.add(&cx, 1, &[])));
@@ -278,6 +279,26 @@ fn counters(c: &mut Criterion) {
             )
         })
     });
+
+    const MAX_DATA_POINTS: i64 = 2000;
+    let mut max_attributes: Vec<KeyValue> = Vec::new();
+
+    for i in 0..MAX_DATA_POINTS-2 {
+        max_attributes.push(KeyValue::new(i.to_string(), i))
+    }
+
+    group.bench_function("AddOneTillMaxAttr", |b| {
+        b.iter(|| cntr3.add(&cx, 1, &max_attributes))
+    });
+
+    for i in MAX_DATA_POINTS..MAX_DATA_POINTS*2 {
+        max_attributes.push(KeyValue::new(i.to_string(), i))
+    }
+
+    group.bench_function("AddMaxAttr", |b| {
+        b.iter(|| cntr3.add(&cx, 1, &max_attributes))
+    });
+
     group.bench_function("AddInvalidAttr", |b| {
         b.iter(|| cntr.add(&cx, 1, &[KeyValue::new("", "V"), KeyValue::new("K", "V")]))
     });

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -288,7 +288,7 @@ fn counters(c: &mut Criterion) {
     }
 
     group.bench_function("AddOneTillMaxAttr", |b| {
-        b.iter(|| cntr3.add(&cx, 1, &max_attributes))
+        b.iter(|| cntr3.add(&cx3, 1, &max_attributes))
     });
 
     for i in MAX_DATA_POINTS..MAX_DATA_POINTS * 2 {
@@ -296,7 +296,7 @@ fn counters(c: &mut Criterion) {
     }
 
     group.bench_function("AddMaxAttr", |b| {
-        b.iter(|| cntr3.add(&cx, 1, &max_attributes))
+        b.iter(|| cntr3.add(&cx3, 1, &max_attributes))
     });
 
     group.bench_function("AddInvalidAttr", |b| {

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -283,7 +283,7 @@ fn counters(c: &mut Criterion) {
     const MAX_DATA_POINTS: i64 = 2000;
     let mut max_attributes: Vec<KeyValue> = Vec::new();
 
-    for i in 0..MAX_DATA_POINTS-2 {
+    for i in 0..MAX_DATA_POINTS - 2 {
         max_attributes.push(KeyValue::new(i.to_string(), i))
     }
 
@@ -291,7 +291,7 @@ fn counters(c: &mut Criterion) {
         b.iter(|| cntr3.add(&cx, 1, &max_attributes))
     });
 
-    for i in MAX_DATA_POINTS..MAX_DATA_POINTS*2 {
+    for i in MAX_DATA_POINTS..MAX_DATA_POINTS * 2 {
         max_attributes.push(KeyValue::new(i.to_string(), i))
     }
 

--- a/opentelemetry-sdk/src/metrics/internal/aggregator.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregator.rs
@@ -2,6 +2,8 @@ use std::sync::Arc;
 
 use crate::{attributes::AttributeSet, metrics::data::Aggregation};
 
+const STREAM_CARDINALITY_LIMIT: u32 = 2000;
+
 /// Forms an aggregation from a collection of recorded measurements.
 pub(crate) trait Aggregator<T>: Send + Sync {
     /// Records the measurement, scoped by attr, and aggregates it into an aggregation.
@@ -14,6 +16,11 @@ pub(crate) trait Aggregator<T>: Send + Sync {
     /// Used when filtering aggregators
     fn as_precompute_aggregator(&self) -> Option<Arc<dyn PrecomputeAggregator<T>>> {
         None
+    }
+
+    /// Checks whether aggregator has hit cardinality limit for metric streams
+    fn check_stream_cardinality(&self, size: usize) -> bool {
+        size < STREAM_CARDINALITY_LIMIT as usize
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/internal/aggregator.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregator.rs
@@ -1,19 +1,13 @@
 use crate::{attributes::AttributeSet, metrics::data::Aggregation};
-use once_cell::sync::OnceCell;
+use once_cell::sync::Lazy;
 use opentelemetry_api::KeyValue;
 use std::sync::Arc;
 
 const STREAM_CARDINALITY_LIMIT: u32 = 2000;
-static STREAM_OVERFLOW_ATTRIBUTE_SET: OnceCell<AttributeSet> = OnceCell::new();
-
-fn initialize_stream_overflow_attribute_set() -> AttributeSet {
+pub(crate) static STREAM_OVERFLOW_ATTRIBUTE_SET: Lazy<AttributeSet> = Lazy::new(|| {
     let key_values: [KeyValue; 1] = [KeyValue::new("otel.metric.overflow", "true")];
     AttributeSet::from(&key_values[..])
-}
-
-pub(crate) fn get_stream_overflow_attribute_set() -> &'static AttributeSet {
-    STREAM_OVERFLOW_ATTRIBUTE_SET.get_or_init(initialize_stream_overflow_attribute_set)
-}
+});
 
 /// Forms an aggregation from a collection of recorded measurements.
 pub(crate) trait Aggregator<T>: Send + Sync {

--- a/opentelemetry-sdk/src/metrics/internal/aggregator.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregator.rs
@@ -1,8 +1,15 @@
 use std::sync::Arc;
-
+use lazy_static::lazy_static;
 use crate::{attributes::AttributeSet, metrics::data::Aggregation};
+use opentelemetry_api::KeyValue;
 
-const STREAM_CARDINALITY_LIMIT: u32 = 2000;
+const STREAM_CARDINALITY_LIMIT: u32 = 2;
+lazy_static! {
+    pub static ref STREAM_OVERFLOW_ATTRIBUTE_SET: AttributeSet = {
+        let key_values: [KeyValue; 1] = [KeyValue::new("otel.metric.overflow", "true")];
+        AttributeSet::from(&key_values[..])
+    };
+}
 
 /// Forms an aggregation from a collection of recorded measurements.
 pub(crate) trait Aggregator<T>: Send + Sync {
@@ -20,7 +27,7 @@ pub(crate) trait Aggregator<T>: Send + Sync {
 
     /// Checks whether aggregator has hit cardinality limit for metric streams
     fn check_stream_cardinality(&self, size: usize) -> bool {
-        size < STREAM_CARDINALITY_LIMIT as usize
+        size < STREAM_CARDINALITY_LIMIT as usize - 1
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/internal/aggregator.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregator.rs
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use crate::{attributes::AttributeSet, metrics::data::Aggregation};
 use opentelemetry_api::KeyValue;
 
-const STREAM_CARDINALITY_LIMIT: u32 = 2;
+const STREAM_CARDINALITY_LIMIT: u32 = 2000;
 lazy_static! {
     pub static ref STREAM_OVERFLOW_ATTRIBUTE_SET: AttributeSet = {
         let key_values: [KeyValue; 1] = [KeyValue::new("otel.metric.overflow", "true")];

--- a/opentelemetry-sdk/src/metrics/internal/aggregator.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregator.rs
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use crate::{attributes::AttributeSet, metrics::data::Aggregation};
 use opentelemetry_api::KeyValue;
 
-const STREAM_CARDINALITY_LIMIT: u32 = 2000;
+const STREAM_CARDINALITY_LIMIT: u32 = 2;
 lazy_static! {
     pub static ref STREAM_OVERFLOW_ATTRIBUTE_SET: AttributeSet = {
         let key_values: [KeyValue; 1] = [KeyValue::new("otel.metric.overflow", "true")];

--- a/opentelemetry-sdk/src/metrics/internal/aggregator.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregator.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
-use lazy_static::lazy_static;
 use crate::{attributes::AttributeSet, metrics::data::Aggregation};
+use lazy_static::lazy_static;
 use opentelemetry_api::KeyValue;
+use std::sync::Arc;
 
 const STREAM_CARDINALITY_LIMIT: u32 = 2000;
 lazy_static! {

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -94,6 +94,7 @@ where
                     let mut b = Buckets::new(self.bounds.len() + 1);
                     // Ensure min and max are recorded values (not zero), for new buckets.
                     (b.min, b.max) = (measurement, measurement);
+                    b.bin(idx, measurement);
                     vacant_entry.insert(b);
                 } else {
                     values

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -11,7 +11,7 @@ use crate::metrics::{
 };
 use opentelemetry_api::{global, metrics::MetricsError};
 
-use super::{aggregator::get_stream_overflow_attribute_set, Aggregator, Number};
+use super::{aggregator::STREAM_OVERFLOW_ATTRIBUTE_SET, Aggregator, Number};
 
 #[derive(Default)]
 struct Buckets<T> {
@@ -99,7 +99,7 @@ where
                     vacant_entry.insert(b);
                 } else {
                     values
-                        .entry(get_stream_overflow_attribute_set().clone())
+                        .entry(STREAM_OVERFLOW_ATTRIBUTE_SET.clone())
                         .and_modify(|val| val.bin(idx, measurement))
                         .or_insert_with(|| {
                             let mut b = Buckets::new(self.bounds.len() + 1);

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -9,6 +9,7 @@ use crate::metrics::{
     aggregation,
     data::{self, Aggregation},
 };
+use opentelemetry_api::{global, metrics::MetricsError};
 
 use super::{aggregator::STREAM_OVERFLOW_ATTRIBUTE_SET, Aggregator, Number};
 
@@ -106,7 +107,7 @@ where
                             b.bin(idx, measurement);
                             b
                         });
-                    println!("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.");
+                    global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.".into()));
                 }
             }
         }

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, hash_map::Entry},
+    collections::{hash_map::Entry, HashMap},
     sync::{Arc, Mutex},
     time::SystemTime,
 };
@@ -81,9 +81,7 @@ where
         let size = values.len();
 
         match values.entry(attrs) {
-            Entry::Occupied(mut occupied_entry) => {
-                occupied_entry.get_mut().bin(idx, measurement)
-            }
+            Entry::Occupied(mut occupied_entry) => occupied_entry.get_mut().bin(idx, measurement),
             Entry::Vacant(vacant_entry) => {
                 if self.check_stream_cardinality(size) {
                     // N+1 buckets. For example:
@@ -111,7 +109,6 @@ where
                 }
             }
         }
-
     }
 
     fn aggregation(&self) -> Option<Box<dyn Aggregation>> {

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -8,7 +8,7 @@ use crate::attributes::AttributeSet;
 use crate::metrics::data::{self, Gauge};
 use opentelemetry_api::{global, metrics::MetricsError};
 
-use super::{aggregator::get_stream_overflow_attribute_set, Aggregator, Number};
+use super::{aggregator::STREAM_OVERFLOW_ATTRIBUTE_SET, Aggregator, Number};
 
 /// Timestamped measurement data.
 struct DataPointValue<T> {
@@ -43,7 +43,7 @@ impl<T: Number<T>> Aggregator<T> for LastValue<T> {
                     if self.is_under_cardinality_limit(size) {
                         vacant_entry.insert(d);
                     } else {
-                        values.insert(get_stream_overflow_attribute_set().clone(), d);
+                        values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone(), d);
                         global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.".into()));
                     }
                 }

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, hash_map::Entry},
+    collections::{hash_map::Entry, HashMap},
     sync::{Arc, Mutex},
     time::SystemTime,
 };
@@ -48,7 +48,6 @@ impl<T: Number<T>> Aggregator<T> for LastValue<T> {
                 }
             }
         }
-    
     }
 
     fn aggregation(&self) -> Option<Box<dyn crate::metrics::data::Aggregation>> {

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -8,7 +8,7 @@ use crate::attributes::AttributeSet;
 use crate::metrics::data::{self, Gauge};
 use opentelemetry_api::{global, metrics::MetricsError};
 
-use super::{aggregator::STREAM_OVERFLOW_ATTRIBUTE_SET, Aggregator, Number};
+use super::{aggregator::get_stream_overflow_attribute_set, Aggregator, Number};
 
 /// Timestamped measurement data.
 struct DataPointValue<T> {
@@ -40,10 +40,10 @@ impl<T: Number<T>> Aggregator<T> for LastValue<T> {
                     occupied_entry.insert(d);
                 }
                 Entry::Vacant(vacant_entry) => {
-                    if self.check_stream_cardinality(size) {
+                    if self.is_under_cardinality_limit(size) {
                         vacant_entry.insert(d);
                     } else {
-                        values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone(), d);
+                        values.insert(get_stream_overflow_attribute_set().clone(), d);
                         global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.".into()));
                     }
                 }

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crate::attributes::AttributeSet;
 use crate::metrics::data::{self, Gauge};
+use opentelemetry_api::{global, metrics::MetricsError};
 
 use super::{aggregator::STREAM_OVERFLOW_ATTRIBUTE_SET, Aggregator, Number};
 
@@ -43,7 +44,7 @@ impl<T: Number<T>> Aggregator<T> for LastValue<T> {
                         vacant_entry.insert(d);
                     } else {
                         values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone(), d);
-                        println!("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.");
+                        global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.".into()));
                     }
                 }
             }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -9,7 +9,7 @@ use crate::metrics::data::{self, Aggregation, DataPoint, Temporality};
 use opentelemetry_api::{global, metrics::MetricsError};
 
 use super::{
-    aggregator::{get_stream_overflow_attribute_set, PrecomputeAggregator},
+    aggregator::{PrecomputeAggregator, STREAM_OVERFLOW_ATTRIBUTE_SET},
     Aggregator, Number,
 };
 
@@ -41,7 +41,7 @@ impl<T: Number<T>> Aggregator<T> for ValueMap<T> {
                         vacant_entry.insert(measurement);
                     } else {
                         values
-                            .entry(get_stream_overflow_attribute_set().clone())
+                            .entry(STREAM_OVERFLOW_ATTRIBUTE_SET.clone())
                             .and_modify(|val| *val += measurement)
                             .or_insert(measurement);
                         global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.".into()));
@@ -243,7 +243,7 @@ impl<T: Number<T>> Aggregator<T> for PrecomputedMap<T> {
                     });
                 } else {
                     values.insert(
-                        get_stream_overflow_attribute_set().clone(),
+                        STREAM_OVERFLOW_ATTRIBUTE_SET.clone(),
                         PrecomputedValue {
                             measured: measurement,
                             ..Default::default()

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crate::attributes::AttributeSet;
 use crate::metrics::data::{self, Aggregation, DataPoint, Temporality};
+use opentelemetry_api::{global, metrics::MetricsError};
 
 use super::{
     aggregator::{PrecomputeAggregator, STREAM_OVERFLOW_ATTRIBUTE_SET},
@@ -43,7 +44,7 @@ impl<T: Number<T>> Aggregator<T> for ValueMap<T> {
                             .entry(STREAM_OVERFLOW_ATTRIBUTE_SET.clone())
                             .and_modify(|val| *val += measurement)
                             .or_insert(measurement);
-                        println!("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.");
+                        global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.".into()));
                     }
                 }
             }
@@ -248,7 +249,7 @@ impl<T: Number<T>> Aggregator<T> for PrecomputedMap<T> {
                             ..Default::default()
                         },
                     );
-                    println!("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.");
+                    global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.".into()));
                 }
             }
         }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, hash_map::Entry},
+    collections::{hash_map::Entry, HashMap},
     sync::{Arc, Mutex},
     time::SystemTime,
 };
@@ -7,7 +7,10 @@ use std::{
 use crate::attributes::AttributeSet;
 use crate::metrics::data::{self, Aggregation, DataPoint, Temporality};
 
-use super::{aggregator::{STREAM_OVERFLOW_ATTRIBUTE_SET, PrecomputeAggregator}, Aggregator, Number};
+use super::{
+    aggregator::{PrecomputeAggregator, STREAM_OVERFLOW_ATTRIBUTE_SET},
+    Aggregator, Number,
+};
 
 /// The storage for sums.
 #[derive(Default)]
@@ -233,16 +236,18 @@ impl<T: Number<T>> Aggregator<T> for PrecomputedMap<T> {
             }
             Entry::Vacant(vacant_entry) => {
                 if self.check_stream_cardinality(size) {
-                    vacant_entry.insert(PrecomputedValue { 
+                    vacant_entry.insert(PrecomputedValue {
                         measured: measurement,
                         ..Default::default()
                     });
                 } else {
-                    values
-                        .insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone(), PrecomputedValue { 
+                    values.insert(
+                        STREAM_OVERFLOW_ATTRIBUTE_SET.clone(),
+                        PrecomputedValue {
                             measured: measurement,
                             ..Default::default()
-                        });
+                        },
+                    );
                     println!("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.");
                 }
             }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -9,7 +9,7 @@ use crate::metrics::data::{self, Aggregation, DataPoint, Temporality};
 use opentelemetry_api::{global, metrics::MetricsError};
 
 use super::{
-    aggregator::{PrecomputeAggregator, get_stream_overflow_attribute_set},
+    aggregator::{get_stream_overflow_attribute_set, PrecomputeAggregator},
     Aggregator, Number,
 };
 

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -225,7 +225,6 @@ impl<T: Number<T>> Aggregator<T> for PrecomputedMap<T> {
             Ok(guard) => guard,
             Err(_) => return,
         };
-
         let size = values.len();
         match values.entry(attrs) {
             Entry::Occupied(mut occupied_entry) => {
@@ -239,7 +238,12 @@ impl<T: Number<T>> Aggregator<T> for PrecomputedMap<T> {
                         ..Default::default()
                     });
                 } else {
-                    println!("Warning: Maximum metric streams exceeded. Entry not added.");
+                    values
+                        .insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone(), PrecomputedValue { 
+                            measured: measurement,
+                            ..Default::default()
+                        });
+                    println!("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.");
                 }
             }
         }


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-rust/issues/1065

This PR implements a fixed cardinality limit for metric data points of the same stream to 2000. If an attempt to use an instrument to create a new metric data point for the same stream is made which would exceed the limit, the data point is added/recorded to the data point representing the overflow metric stream which is denoted by an `AttributeSet` containing only `{otel.metric.overflow: True}`.

Note there is a bit of duplication of code done on purpose to optimize for the most common scenarios, which is usually when an entry exists already within a hashmap.