### PR TITLE
Add stdout exporter example for Logs.

### DIFF
--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -10,7 +10,7 @@ categories = [
     "development-tools::profiling",
     "asynchronous",
 ]
-keywords = ["opentelemetry", "tracing", "metrics"]
+keywords = ["opentelemetry", "tracing", "metrics", "logs"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.60"
@@ -24,8 +24,8 @@ logs = ["opentelemetry_api/logs", "opentelemetry_sdk/logs", "async-trait", "this
 async-trait = { version = "0.1", optional = true }
 thiserror = { version = "1", optional = true }
 futures-util = { version = "0.3", optional = true, default-features = false }
-opentelemetry_api = { version = "0.19", path = "../opentelemetry-api", default_features = false }
-opentelemetry_sdk = { version = "0.19", path = "../opentelemetry-sdk", default_features = false }
+opentelemetry_api = { path = "../opentelemetry-api", default_features = false, features = ["logs", "trace", "metrics"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", default_features = false, features = ["logs", "trace", "metrics"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ordered-float = "3.4.0"

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -24,8 +24,8 @@ logs = ["opentelemetry_api/logs", "opentelemetry_sdk/logs", "async-trait", "this
 async-trait = { version = "0.1", optional = true }
 thiserror = { version = "1", optional = true }
 futures-util = { version = "0.3", optional = true, default-features = false }
-opentelemetry_api = { path = "../opentelemetry-api", default_features = false, features = ["logs", "trace", "metrics"] }
-opentelemetry_sdk = { path = "../opentelemetry-sdk", default_features = false, features = ["logs", "trace", "metrics"]}
+opentelemetry_api = { version = "0.19", path = "../opentelemetry-api", default_features = false }
+opentelemetry_sdk = { version = "0.19", path = "../opentelemetry-sdk", default_features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ordered-float = "3.4.0"

--- a/opentelemetry-stdout/examples/logs_basics.rs
+++ b/opentelemetry-stdout/examples/logs_basics.rs
@@ -1,0 +1,58 @@
+//! run with `$ cargo run --example basic --all-features
+
+#[cfg(all(feature = "logs", feature = "trace"))]
+use opentelemetry_api::{
+    logs::LoggerProvider as _,
+    logs::LogRecordBuilder,
+    logs::Logger,
+    logs::Severity,
+    trace::{Span, Tracer, TracerProvider as _, mark_span_as_active},
+    Context, KeyValue,
+};
+#[cfg(all(feature = "logs", feature = "trace"))]
+use opentelemetry_sdk::{
+    logs::LoggerProvider,
+    runtime,
+    trace::TracerProvider,
+};
+
+#[cfg(all(feature = "logs", feature = "trace"))]
+fn init_trace() -> TracerProvider {
+    let exporter = opentelemetry_stdout::SpanExporter::default();
+    TracerProvider::builder()
+        .with_simple_exporter(exporter)
+        .build()
+}
+
+#[cfg(all(feature = "logs", feature = "trace"))]
+fn init_logger() -> LoggerProvider {
+    let exporter = opentelemetry_stdout::LogExporter::default();
+    LoggerProvider::builder()
+        .with_simple_exporter(exporter)
+        .build()
+}
+
+#[tokio::main]
+#[cfg(all(feature = "logs", feature = "trace"))]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use opentelemetry_api::logs::LogRecordBuilder;
+
+    let logger_provider = init_logger();
+    let tracer_provider = init_trace();
+    let cx = Context::new();
+
+    let tracer = tracer_provider.tracer("stdout-test");
+    let logger = logger_provider.versioned_logger("stdout-test", None, None, None, true);
+    let mut span = tracer.start("test_span");
+    span.set_attribute(KeyValue::new("test_key", "test_value"));
+    let span_active = mark_span_as_active(span);
+    let log_record = LogRecordBuilder::new()
+                        .with_body("test log".into())
+                        .with_severity_number(Severity::Info)
+                        .build();
+    logger.emit(log_record);
+    drop(span_active);
+    Ok(())
+}
+#[cfg(not(all(feature = "logs", feature = "trace")))]
+fn main() {}


### PR DESCRIPTION
Design discussion issue (if applicable) #

## Changes

Add the stdout exporter example for Logs. The example will
 - Initialize TraceProvider and LoggerProvider
 - Initialize Tracer and Logger object
 - Create Span, and make it active(current)
 - Emit Log.
 - Make the Span inactive (implicitly end/export it).

This will export the Span, along with the Log. The Log will have the trace_id and span_id of currently active span.
Output example:
```
{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"unknown_service"}}]},"scopeLogs":[{"scope":{"name":"stdout-test"},"logRecords":[{"severityNumber":9,"body":{"stringValue":"test log"},"attributes":[],"droppedAttributesCount":0,"flags":1,"spanId":"abf95442ac326a3b","traceId":"6b3271b5c619652bc28ad70810e7f131"}]}]}]}

{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"unknown_service"}}]},"scopeSpans":[{"scope":{"name":"stdout-test"},"spans":[{"traceId":"6b3271b5c619652bc28ad70810e7f131","spanId":"abf95442ac326a3b","parentSpanId":"","name":"test_span","kind":1,"startTimeUnixNano":1684817629827077900,"endTimeUnixNano":1684817629827244600,"attributes":[{"key":"test_key","value":{"stringValue":"test_value"}}],"droppedAttributesCount":0,"droppedEventsCount":0,"droppedLinksCount":0,"status":{}}]}]}]}

```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
