### PR TITLE
Fix OrderMap reference in log subsystem

### DIFF
--- a/opentelemetry-api/src/logs/mod.rs
+++ b/opentelemetry-api/src/logs/mod.rs
@@ -13,9 +13,6 @@ pub use logger::{Logger, LoggerProvider};
 pub use noop::NoopLoggerProvider;
 pub use record::{AnyValue, LogRecord, LogRecordBuilder, Severity, TraceContext};
 
-use std::collections::hash_map::RandomState;
-
-
 /// Describe the result of operations in log SDK.
 pub type LogResult<T> = Result<T, LogError>;
 

--- a/opentelemetry-api/src/logs/mod.rs
+++ b/opentelemetry-api/src/logs/mod.rs
@@ -13,8 +13,14 @@ pub use logger::{Logger, LoggerProvider};
 pub use noop::NoopLoggerProvider;
 pub use record::{AnyValue, LogRecord, LogRecordBuilder, Severity, TraceContext};
 
+use std::collections::hash_map::RandomState;
+
+
 /// Describe the result of operations in log SDK.
 pub type LogResult<T> = Result<T, LogError>;
+
+/// re-export OrderMap to mitigate breaking change
+pub type OrderMap<K, V, S = RandomState> = crate::order_map::OrderMap<K, V, S>;
 
 #[derive(Error, Debug)]
 #[non_exhaustive]

--- a/opentelemetry-api/src/logs/mod.rs
+++ b/opentelemetry-api/src/logs/mod.rs
@@ -19,9 +19,6 @@ use std::collections::hash_map::RandomState;
 /// Describe the result of operations in log SDK.
 pub type LogResult<T> = Result<T, LogError>;
 
-/// re-export OrderMap to mitigate breaking change
-pub type OrderMap<K, V, S = RandomState> = crate::order_map::OrderMap<K, V, S>;
-
 #[derive(Error, Debug)]
 #[non_exhaustive]
 /// Errors returned by the log SDK.

--- a/opentelemetry-api/src/logs/record.rs
+++ b/opentelemetry-api/src/logs/record.rs
@@ -1,6 +1,6 @@
 use crate::{
-    trace::{OrderMap, SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId},
-    Array, Key, StringValue, Value,
+    trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId},
+    Array, Key, OrderMap, StringValue, Value,
 };
 use std::{borrow::Cow, time::SystemTime};
 


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

As part of PR #1061, the OrderMap module was moved from `copentelemetry-api::trace` to  `opentelemetry-api` root. This PR ensures that log subsystem should refer to the OrderMap module from `opentelemetry-api`, and not from `opentelemetry-api::trace`. ~~Also added the reexport in logs to ensure that existing usage (if any) is not broken.~~

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
