### PR TITLE
Add js-sys as dependency for api crate when building wasm targets

### DIFF
--- a/opentelemetry-api/Cargo.toml
+++ b/opentelemetry-api/Cargo.toml
@@ -20,6 +20,9 @@ thiserror = "1"
 tokio-stream = { version = "0.1", optional = true }
 urlencoding = "2.1.2"
 
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
+js-sys = "0.3.63"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
It's used to implement now() for (non-WASI) WASM targets, but was not included as a dependency

Fixes #
Design discussion issue (if applicable) #

## Changes
Adds js-sys as a dependency to opentelemetry_api when building for non-WASI WASM targets. Without this change, the crate will not compile for these target as `js_sys::Date::now()` is used in opentelemetry-api/src/lib.rs

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
