### PR TITLE
Fix a missing import when http-proto is enabled without grpc-sys

### DIFF
--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -27,7 +27,6 @@ use {
         logs_service::ExportLogsServiceRequest as GrpcRequest,
         logs_service_grpc::LogsServiceClient as GrpcioLogServiceClient,
     },
-    std::sync::Arc,
 };
 
 #[cfg(feature = "http-proto")]
@@ -44,7 +43,7 @@ use {
 };
 
 #[cfg(any(feature = "grpc-sys", feature = "http-proto"))]
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::exporter::ExportConfig;
 use crate::OtlpPipeline;


### PR DESCRIPTION
Fixes an issue compiling `opentelemetry-otlp` with the `logs` and `http-proto` features, but not `grpc-sys`:

```
error[E0412]: cannot find type `Arc` in this scope
   --> opentelemetry-otlp\src\logs.rs:164:30
    |
164 |         log_exporter: Option<Arc<dyn HttpClient>>,
    |                              ^^^ not found in this scope
    |
help: consider importing one of these items
    |
6   | use std::sync::Arc;
    |
6   | use tonic::codegen::Arc;
    |

For more information about this error, try `rustc --explain E0412`.
error: could not compile `opentelemetry-otlp` (lib) due to previous error
```