### PR TITLE
fix: allow span id to be less than 16 characters in jaeger propagator

### DIFF
--- a/opentelemetry-jaeger/CHANGELOG.md
+++ b/opentelemetry-jaeger/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Main
+### Fixed
+- allow span id to be less than 16 characters in propagator [#1084](https://github.com/open-telemetry/opentelemetry-rust/pull/1084)
+
 ## v0.18.0
 
 ### Added

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -491,8 +491,7 @@ mod propagator {
                 17.. => Err(()),
                 // less than 16 will result padding on left
                 _ => {
-                    let mut padded = String::with_capacity(16 - span_id.len());
-                    padded.push_str(span_id);
+                    let padded = format!("{span_id:0>16}");
                     SpanId::from_hex(&padded).map_err(|_| ())
                 }
             }


### PR DESCRIPTION
Fixes #1047 

## Changes

When span id is less than 16 characters, padding 0 to left

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
