### PR TITLE
Make TraceContextExt::span() return an Option

### DIFF
--- a/examples/actix-http/src/main.rs
+++ b/examples/actix-http/src/main.rs
@@ -28,7 +28,9 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
 async fn index() -> &'static str {
     let tracer = global::tracer("request");
     tracer.in_span("index", |ctx| {
-        ctx.span().set_attribute(Key::new("parameter").i64(10));
+        if let Some(span) = ctx.span() {
+            span.set_attribute(Key::new("parameter").i64(10));
+        }
         "Index"
     })
 }
@@ -45,8 +47,9 @@ async fn main() -> std::io::Result<()> {
             .wrap(Logger::default())
             .wrap_fn(move |req, srv| {
                 tracer.in_span("middleware", move |cx| {
-                    cx.span()
-                        .set_attribute(Key::new("path").string(req.path().to_string()));
+                    if let Some(span) = cx.span() {
+                        span.set_attribute(Key::new("path").string(req.path().to_string()));
+                    }
                     srv.call(req).with_context(cx)
                 })
             })

--- a/examples/actix-hyper/src/main.rs
+++ b/examples/actix-hyper/src/main.rs
@@ -20,7 +20,9 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
 async fn index() -> &'static str {
     let tracer = global::tracer("request");
     tracer.in_span("index", |ctx| {
-        ctx.span().set_attribute(Key::new("parameter").i64(10));
+        if let Some(span) = ctx.span() {
+            span.set_attribute(Key::new("parameter").i64(10));
+        }
         "Index"
     })
 }
@@ -37,8 +39,10 @@ async fn main() -> std::io::Result<()> {
             .wrap(Logger::default())
             .wrap_fn(move |req, srv| {
                 tracer.in_span("middleware", move |cx| {
-                    cx.span()
-                        .set_attribute(Key::new("path").string(req.path().to_string()));
+                    if let Some(span) = cx.span() {
+                        span.set_attribute(Key::new("path").string(req.path().to_string()));
+                    }
+
                     srv.call(req).with_context(cx)
                 })
             })

--- a/examples/actix-udp/src/main.rs
+++ b/examples/actix-udp/src/main.rs
@@ -25,7 +25,10 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
 async fn index() -> &'static str {
     let tracer = global::tracer("request");
     tracer.in_span("index", |ctx| {
-        ctx.span().set_attribute(Key::new("parameter").i64(10));
+        if let Some(span) = ctx.span() {
+            span.set_attribute(Key::new("parameter").i64(10));
+        }
+
         "Index"
     })
 }
@@ -42,8 +45,10 @@ async fn main() -> std::io::Result<()> {
             .wrap_fn(|req, srv| {
                 let tracer = global::tracer("request");
                 tracer.in_span("middleware", move |cx| {
-                    cx.span()
-                        .set_attribute(Key::new("path").string(req.path().to_string()));
+                    if let Some(span) = cx.span() {
+                        span.set_attribute(Key::new("path").string(req.path().to_string()));
+                    };
+
                     srv.call(req).with_context(cx)
                 })
             })

--- a/examples/aws-xray/src/client.rs
+++ b/examples/aws-xray/src/client.rs
@@ -45,7 +45,8 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sy
 
     let res = client.request(req.body(Body::from("Hallo!"))?).await?;
 
-    cx.span().add_event(
+    // `cx` initialized with span above, so unwrapping is safe
+    cx.span().unwrap().add_event(
         "Got response!".to_string(),
         vec![KeyValue::new("status", res.status().to_string())],
     );

--- a/examples/basic-otlp-http/src/main.rs
+++ b/examples/basic-otlp-http/src/main.rs
@@ -62,7 +62,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     histogram.record(&cx, 5.5, COMMON_ATTRIBUTES.as_ref());
 
     tracer.in_span("operation", |cx| {
-        let span = cx.span();
+        let span = match cx.span() {
+            Some(span) => span,
+            None => return,
+        };
+
         span.add_event(
             "Nice operation!".to_string(),
             vec![Key::new("bogons").i64(100)],
@@ -70,7 +74,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         span.set_attribute(ANOTHER_KEY.string("yes"));
 
         tracer.in_span("Sub operation...", |cx| {
-            let span = cx.span();
+            let span = match cx.span() {
+                Some(span) => span,
+                None => return,
+            };
+
             span.set_attribute(LEMONS_KEY.string("five"));
 
             span.add_event("Sub span event", vec![]);

--- a/examples/basic-otlp/src/main.rs
+++ b/examples/basic-otlp/src/main.rs
@@ -80,7 +80,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     histogram.record(&cx, 5.5, COMMON_ATTRIBUTES.as_ref());
 
     tracer.in_span("operation", |cx| {
-        let span = cx.span();
+        let span = match cx.span() {
+            Some(span) => span,
+            None => return,
+        };
+
         span.add_event(
             "Nice operation!".to_string(),
             vec![Key::new("bogons").i64(100)],
@@ -88,7 +92,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         span.set_attribute(ANOTHER_KEY.string("yes"));
 
         tracer.in_span("Sub operation...", |cx| {
-            let span = cx.span();
+            let span = match cx.span() {
+                Some(span) => span,
+                None => return,
+            };
+
             span.set_attribute(LEMONS_KEY.string("five"));
 
             span.add_event("Sub span event", vec![]);

--- a/examples/datadog/src/main.rs
+++ b/examples/datadog/src/main.rs
@@ -24,7 +24,11 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         .install_simple()?;
 
     tracer.in_span("foo", |cx| {
-        let span = cx.span();
+        let span = match cx.span() {
+            Some(span) => span,
+            None => return,
+        };
+
         span.set_attribute(Key::new("span.type").string("web"));
         span.set_attribute(Key::new("http.url").string("http://localhost:8080/foo"));
         span.set_attribute(Key::new("http.method").string("GET"));

--- a/examples/external-otlp-tonic-tokio/src/main.rs
+++ b/examples/external-otlp-tonic-tokio/src/main.rs
@@ -85,7 +85,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let tracer = tracer("ex.com/basic");
 
     tracer.in_span("operation", |cx| {
-        let span = cx.span();
+        let span = match cx.span() {
+            Some(span) => span,
+            None => return,
+        };
+
         span.add_event(
             "Nice operation!".to_string(),
             vec![Key::new("bogons").i64(100)],
@@ -93,7 +97,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         span.set_attribute(ANOTHER_KEY.string("yes"));
 
         tracer.in_span("Sub operation...", |cx| {
-            let span = cx.span();
+            let span = match cx.span() {
+                Some(span) => span,
+                None => return,
+            };
+
             span.set_attribute(LEMONS_KEY.string("five"));
 
             span.add_event("Sub span event", vec![]);

--- a/examples/grpc/src/client.rs
+++ b/examples/grpc/src/client.rs
@@ -52,7 +52,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
 
     let response = client.say_hello(request).await?;
 
-    cx.span().add_event(
+    // `cx` initialized with span above, so unwrapping is safe
+    cx.span().unwrap().add_event(
         "response-received".to_string(),
         vec![KeyValue::new("response", format!("{response:?}"))],
     );

--- a/examples/http/src/client.rs
+++ b/examples/http/src/client.rs
@@ -35,7 +35,8 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sy
     });
     let res = client.request(req.body(Body::from("Hallo!"))?).await?;
 
-    cx.span().add_event(
+    // `cx` initialized with span above, so unwrapping is safe
+    cx.span().unwrap().add_event(
         "Got response!".to_string(),
         vec![KeyValue::new("status", res.status().to_string())],
     );

--- a/examples/traceresponse/src/client.rs
+++ b/examples/traceresponse/src/client.rs
@@ -48,9 +48,13 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sy
     let response_cx =
         response_propagator.extract_with_context(&cx, &HeaderExtractor(res.headers()));
 
-    let response_span = response_cx.span();
+    let response_span = match response_cx.span() {
+        Some(response_span) => response_span,
+        None => return Ok(()),
+    };
 
-    cx.span().add_event(
+    // `cx` initialized with span above, so unwrapping is safe
+    cx.span().unwrap().add_event(
         "Got response!".to_string(),
         vec![
             KeyValue::new("status", res.status().to_string()),

--- a/examples/traceresponse/src/server.rs
+++ b/examples/traceresponse/src/server.rs
@@ -24,7 +24,7 @@ async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
 
     let cx = Context::current_with_span(span);
 
-    cx.span().add_event("handling this...", Vec::new());
+    cx.span().unwrap().add_event("handling this...", Vec::new());
 
     let mut res = Response::new("Hello, World!".into());
 

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Change `TraceContextExt::span()` to yield an `Option` and remove `has_active_span()`. [#1089](https://github.com/open-telemetry/opentelemetry-rust/pull/1089)
 - Fix `SpanRef::set_attributes` mutability requirement. [#1038](https://github.com/open-telemetry/opentelemetry-rust/pull/1038)
 - Move OrderMap module to root of otel-api crate. [#1061](https://github.com/open-telemetry/opentelemetry-rust/pull/1061)
 

--- a/opentelemetry-api/src/logs/record.rs
+++ b/opentelemetry-api/src/logs/record.rs
@@ -286,8 +286,8 @@ impl LogRecordBuilder {
     where
         T: TraceContextExt,
     {
-        if context.has_active_span() {
-            self.with_span_context(context.span().span_context())
+        if let Some(span) = context.span() {
+            self.with_span_context(span.span_context())
         } else {
             self
         }

--- a/opentelemetry-api/src/trace/noop.rs
+++ b/opentelemetry-api/src/trace/noop.rs
@@ -143,12 +143,12 @@ impl trace::Tracer for NoopTracer {
     /// If the span builder or the context's current span contains a valid span context, it is
     /// propagated.
     fn build_with_context(&self, _builder: trace::SpanBuilder, parent_cx: &Context) -> Self::Span {
-        if parent_cx.has_active_span() {
+        if let Some(span) = parent_cx.span() {
             NoopSpan {
-                span_context: parent_cx.span().span_context().clone(),
+                span_context: span.span_context().clone(),
             }
         } else {
-            NoopSpan::new()
+            NoopSpan::default()
         }
     }
 }

--- a/opentelemetry-contrib/src/trace/propagator/trace_context_response.rs
+++ b/opentelemetry-contrib/src/trace/propagator/trace_context_response.rs
@@ -100,7 +100,11 @@ impl TextMapPropagator for TraceContextResponsePropagator {
     /// Properly encodes the values of the `SpanContext` and injects them
     /// into the `Injector`.
     fn inject_context(&self, cx: &Context, injector: &mut dyn Injector) {
-        let span = cx.span();
+        let span = match cx.span() {
+            Some(span) => span,
+            None => return,
+        };
+
         let span_context = span.span_context();
         if span_context.is_valid() {
             let header_value = format!(
@@ -194,7 +198,11 @@ mod tests {
             extractor.insert(TRACERESPONSE_HEADER.to_string(), traceresponse.to_string());
 
             assert_eq!(
-                propagator.extract(&extractor).span().span_context(),
+                propagator
+                    .extract(&extractor)
+                    .span()
+                    .unwrap()
+                    .span_context(),
                 &expected_context
             )
         }
@@ -209,7 +217,11 @@ mod tests {
             extractor.insert(TRACERESPONSE_HEADER.to_string(), invalid_header.to_string());
 
             assert_eq!(
-                propagator.extract(&extractor).span().span_context(),
+                propagator
+                    .extract(&extractor)
+                    .span()
+                    .unwrap()
+                    .span_context(),
                 &SpanContext::empty_context(),
                 "{}",
                 reason

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -270,7 +270,11 @@ mod propagator {
 
     impl TextMapPropagator for DatadogPropagator {
         fn inject_context(&self, cx: &Context, injector: &mut dyn Injector) {
-            let span = cx.span();
+            let span = match cx.span() {
+                Some(span) => span,
+                None => return,
+            };
+
             let span_context = span.span_context();
             if span_context.is_valid() {
                 injector.set(
@@ -353,7 +357,7 @@ mod propagator {
 
                 let propagator = DatadogPropagator::default();
                 let context = propagator.extract(&map);
-                assert_eq!(context.span().span_context(), &expected);
+                assert_eq!(context.span().unwrap().span_context(), &expected);
             }
         }
 
@@ -362,7 +366,10 @@ mod propagator {
             let map: HashMap<String, String> = HashMap::new();
             let propagator = DatadogPropagator::default();
             let context = propagator.extract(&map);
-            assert_eq!(context.span().span_context(), &SpanContext::empty_context())
+            assert_eq!(
+                context.span().unwrap().span_context(),
+                &SpanContext::empty_context()
+            )
         }
 
         #[test]

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -540,7 +540,11 @@ mod propagator {
 
     impl TextMapPropagator for Propagator {
         fn inject_context(&self, cx: &Context, injector: &mut dyn Injector) {
-            let span = cx.span();
+            let span = match cx.span() {
+                Some(span) => span,
+                None => return,
+            };
+
             let span_context = span.span_context();
             if span_context.is_valid() {
                 let flag: u8 = if span_context.is_sampled() {
@@ -705,7 +709,7 @@ mod propagator {
                 let mut map: HashMap<String, String> = HashMap::new();
                 map.set(context_key, format!("{}:{}:0:{}", trace_id, span_id, flag));
                 let context = propagator.extract(&map);
-                assert_eq!(context.span().span_context(), &expected);
+                assert_eq!(context.span().unwrap().span_context(), &expected);
             }
         }
 
@@ -728,7 +732,10 @@ mod propagator {
             let map: HashMap<String, String> = HashMap::new();
             let propagator = Propagator::new();
             let context = propagator.extract(&map);
-            assert_eq!(context.span().span_context(), &SpanContext::empty_context())
+            assert_eq!(
+                context.span().unwrap().span_context(),
+                &SpanContext::empty_context()
+            )
         }
 
         #[test]
@@ -749,7 +756,7 @@ mod propagator {
                     format!("{}:{}:0:{}", trace_id, span_id, flag),
                 );
                 let context = propagator.extract(&map);
-                assert_eq!(context.span().span_context(), &expected);
+                assert_eq!(context.span().unwrap().span_context(), &expected);
             }
         }
 
@@ -762,7 +769,10 @@ mod propagator {
             );
             let propagator = Propagator::new();
             let context = propagator.extract(&map);
-            assert_eq!(context.span().span_context(), &SpanContext::empty_context());
+            assert_eq!(
+                context.span().unwrap().span_context(),
+                &SpanContext::empty_context()
+            );
         }
 
         #[test]
@@ -774,7 +784,10 @@ mod propagator {
             );
             let propagator = Propagator::new();
             let context = propagator.extract(&map);
-            assert_eq!(context.span().span_context(), &SpanContext::empty_context());
+            assert_eq!(
+                context.span().unwrap().span_context(),
+                &SpanContext::empty_context()
+            );
         }
 
         #[test]
@@ -787,7 +800,7 @@ mod propagator {
             let propagator = Propagator::new();
             let context = propagator.extract(&map);
             assert_eq!(
-                context.span().span_context(),
+                context.span().unwrap().span_context(),
                 &SpanContext::new(
                     TraceId::from_u128(TRACE_ID),
                     SpanId::from_u64(SPAN_ID),

--- a/opentelemetry-jaeger/tests/integration_test.rs
+++ b/opentelemetry-jaeger/tests/integration_test.rs
@@ -31,16 +31,20 @@ mod tests {
                 tracer.in_span("step-2-1", |_cx| {});
                 tracer.in_span("step-2-2", |_cx| {
                     tracer.in_span("step-3-1", |cx| {
-                        let span = cx.span();
-                        span.set_status(Status::error("some err"))
+                        if let Some(span) = cx.span() {
+                            span.set_status(Status::error("some err"));
+                        }
                     });
                     tracer.in_span("step-3-2", |cx| {
-                        cx.span()
-                            .set_attribute(KeyValue::new("tag-3-2-1", "tag-value-3-2-1"))
+                        if let Some(span) = cx.span() {
+                            span.set_attribute(KeyValue::new("tag-3-2-1", "tag-value-3-2-1"))
+                        }
                     })
                 });
-                cx.span()
-                    .add_event("something happened", vec![KeyValue::new("key1", "value1")]);
+
+                if let Some(span) = cx.span() {
+                    span.add_event("something happened", vec![KeyValue::new("key1", "value1")]);
+                }
             });
         }
     }

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -212,8 +212,7 @@ impl opentelemetry_api::logs::Logger for Logger {
             let mut record = record.clone();
             if self.include_trace_context {
                 let ctx = Context::current();
-                if ctx.has_active_span() {
-                    let span = ctx.span();
+                if let Some(span) = ctx.span() {
                     record.trace_context = Some(span.span_context().into());
                 }
             }

--- a/opentelemetry-sdk/src/propagation/composite.rs
+++ b/opentelemetry-sdk/src/propagation/composite.rs
@@ -138,7 +138,11 @@ mod tests {
 
     impl TextMapPropagator for TestPropagator {
         fn inject_context(&self, cx: &Context, injector: &mut dyn Injector) {
-            let span = cx.span();
+            let span = match cx.span() {
+                Some(span) => span,
+                None => return,
+            };
+
             let span_context = span.span_context();
             injector.set(
                 "testheader",
@@ -210,6 +214,7 @@ mod tests {
                 composite_propagator
                     .extract(&extractor)
                     .span()
+                    .unwrap()
                     .span_context(),
                 &SpanContext::empty_context()
             );
@@ -256,6 +261,7 @@ mod tests {
                 composite_propagator
                     .extract(&extractor)
                     .span()
+                    .unwrap()
                     .span_context(),
                 &SpanContext::new(
                     TraceId::from_u128(1),

--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampling_strategy.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampling_strategy.rs
@@ -173,8 +173,8 @@ impl Inner {
                     Some(SamplingResult {
                         decision,
                         attributes: Vec::new(),
-                        trace_state: match parent_context {
-                            Some(ctx) => ctx.span().span_context().trace_state().clone(),
+                        trace_state: match parent_context.and_then(|ctx| ctx.span()) {
+                            Some(span) => span.span_context().trace_state().clone(),
                             None => TraceState::default(),
                         },
                     })

--- a/opentelemetry-zipkin/src/propagator/mod.rs
+++ b/opentelemetry-zipkin/src/propagator/mod.rs
@@ -221,7 +221,11 @@ impl TextMapPropagator for Propagator {
     /// Properly encodes the values of the `Context`'s `SpanContext` and injects
     /// them into the `Injector`.
     fn inject_context(&self, context: &Context, injector: &mut dyn Injector) {
-        let span = context.span();
+        let span = match context.span() {
+            Some(span) => span,
+            None => return,
+        };
+
         let span_context = span.span_context();
         if span_context.is_valid() {
             let is_deferred =
@@ -489,6 +493,7 @@ mod tests {
                 single_header_propagator
                     .extract(&extractor)
                     .span()
+                    .unwrap()
                     .span_context()
                     .clone(),
                 expected_context
@@ -502,6 +507,7 @@ mod tests {
                 multi_header_propagator
                     .extract(&extractor)
                     .span()
+                    .unwrap()
                     .span_context()
                     .clone(),
                 expected_context
@@ -510,6 +516,7 @@ mod tests {
                 unspecific_header_propagator
                     .extract(&extractor)
                     .span()
+                    .unwrap()
                     .span_context()
                     .clone(),
                 expected_context
@@ -526,6 +533,7 @@ mod tests {
                 single_header_propagator
                     .extract(&extractor)
                     .span()
+                    .unwrap()
                     .span_context()
                     .clone(),
                 expected_context
@@ -534,6 +542,7 @@ mod tests {
                 single_multi_propagator
                     .extract(&extractor)
                     .span()
+                    .unwrap()
                     .span_context()
                     .clone(),
                 expected_context
@@ -550,6 +559,7 @@ mod tests {
                 single_header_propagator
                     .extract(&extractor)
                     .span()
+                    .unwrap()
                     .span_context(),
                 &SpanContext::empty_context(),
             )
@@ -562,6 +572,7 @@ mod tests {
                 multi_header_propagator
                     .extract(&extractor)
                     .span()
+                    .unwrap()
                     .span_context(),
                 &SpanContext::empty_context(),
             )


### PR DESCRIPTION
## Changes

The changes that @shaun-cox made in #1088 make sense to me, but I wanted to look into the core `TraceContextExt` API, which I don't think makes much sense for Rust. Instead of having a `span()` method that fabricates a `NOOP_SPAN` and yields if it there is no active span and a separate `has_active_span()` to check if there is a currently active span, it seems more idiomatic to make `span()` yield an `Option`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)