### PR TITLE
Enable features of criterion for benchmarking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,9 @@ members = [
     "stress",
 ]
 exclude = ["examples/external-otlp-grpcio-async-std"]
+
+[profile.bench]
+# https://doc.rust-lang.org/cargo/reference/profiles.html#bench
+# See function names in profiling reports.
+# 2/true is too much, 0 is not enough, 1 is just right for back traces
+debug = 1

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -37,7 +37,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
 bincode = "1.2"
-criterion = "0.4.0"
+criterion = { version = "0.4.0", features = ["html_reports"] }
+pprof = { version = "0.11.1", features = ["flamegraph", "criterion"] }
 rand_distr = "0.4.0"
 crossbeam-queue = "0.3.1"
 

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -8,6 +8,7 @@ use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
     trace as sdktrace,
 };
+use pprof::criterion::{Output, PProfProfiler};
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("EvictedHashMap");
@@ -132,5 +133,9 @@ fn trace_benchmark_group<F: Fn(&sdktrace::Tracer)>(c: &mut Criterion, name: &str
     group.finish();
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/opentelemetry-sdk/src/trace/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler.rs
@@ -367,6 +367,7 @@ mod tests {
     #[test]
     fn clone_a_parent_sampler() {
         let sampler = Sampler::ParentBased(Box::new(Sampler::AlwaysOn));
+        #[allow(clippy::redundant_clone)]
         let cloned_sampler = sampler.clone();
 
         let cx = Context::current_with_value("some_value");


### PR DESCRIPTION
## Changes

- enable benches to be profiled and generate flame graphs
- enable benches to generate html reports
- freebie: fix one new clippy lint since I'm using rustc 1.70 locally

## Background

I've identified several improvements that can be made to the performance of starting/ending spans which I'll be submitting individual PRs subsequently.
The changes here are simply pre-requisite to enable criterion to generate useful plots to study the effects of changes.

An example for profiling in a local environment, assuming the changes in this PR and running on Linux, are:
```bash
export "RUSTFLAGS=-C force-frame-pointers=yes -C target-cpu=native"
taskset -c 2 cargo bench -p opentelemetry_sdk --bench trace -- --save-baseline main start-end-span/
taskset -c 2 cargo bench -p opentelemetry_sdk --bench trace -- --profile-time 20 start-end-span/
```

Then view `target/criterion/report/index.html` to see the data.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
