### PR TITLE
Improve span creation performance by 10-20%

### DIFF
--- a/opentelemetry-api/src/trace/span_context.rs
+++ b/opentelemetry-api/src/trace/span_context.rs
@@ -120,9 +120,9 @@ impl TraceId {
     }
 }
 
-impl From<[u8; 16]> for TraceId {
-    fn from(bytes: [u8; 16]) -> Self {
-        TraceId::from_bytes(bytes)
+impl From<u128> for TraceId {
+    fn from(value: u128) -> Self {
+        TraceId(value)
     }
 }
 
@@ -181,9 +181,9 @@ impl SpanId {
     }
 }
 
-impl From<[u8; 8]> for SpanId {
-    fn from(bytes: [u8; 8]) -> Self {
-        SpanId::from_bytes(bytes)
+impl From<u64> for SpanId {
+    fn from(value: u64) -> Self {
+        SpanId(value)
     }
 }
 

--- a/opentelemetry-contrib/src/trace/propagator/binary/binary_propagator.rs
+++ b/opentelemetry-contrib/src/trace/propagator/binary/binary_propagator.rs
@@ -69,8 +69,8 @@ impl BinaryFormat for BinaryPropagator {
         }
 
         let span_context = SpanContext::new(
-            TraceId::from(trace_id),
-            SpanId::from(span_id),
+            TraceId::from_bytes(trace_id),
+            SpanId::from_bytes(span_id),
             TraceFlags::new(trace_flags),
             true,
             // TODO traceparent and tracestate should both begin with a 0 byte, figure out how to differentiate

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -201,14 +201,14 @@ mod propagator {
         fn extract_trace_id(&self, trace_id: &str) -> Result<TraceId, ExtractError> {
             trace_id
                 .parse::<u64>()
-                .map(|id| TraceId::from((id as u128).to_be_bytes()))
+                .map(|id| TraceId::from(id as u128))
                 .map_err(|_| ExtractError::TraceId)
         }
 
         fn extract_span_id(&self, span_id: &str) -> Result<SpanId, ExtractError> {
             span_id
                 .parse::<u64>()
-                .map(|id| SpanId::from(id.to_be_bytes()))
+                .map(SpanId::from)
                 .map_err(|_| ExtractError::SpanId)
         }
 

--- a/opentelemetry-sdk/src/trace/id_generator/mod.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/mod.rs
@@ -25,11 +25,11 @@ pub struct RandomIdGenerator {
 
 impl IdGenerator for RandomIdGenerator {
     fn new_trace_id(&self) -> TraceId {
-        CURRENT_RNG.with(|rng| TraceId::from(rng.borrow_mut().gen::<[u8; 16]>()))
+        CURRENT_RNG.with(|rng| TraceId::from(rng.borrow_mut().gen::<u128>()))
     }
 
     fn new_span_id(&self) -> SpanId {
-        CURRENT_RNG.with(|rng| SpanId::from(rng.borrow_mut().gen::<[u8; 8]>()))
+        CURRENT_RNG.with(|rng| SpanId::from(rng.borrow_mut().gen::<u64>()))
     }
 }
 

--- a/opentelemetry-sdk/src/trace/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler.rs
@@ -326,7 +326,7 @@ mod tests {
                     None
                 };
 
-                let trace_id = TraceId::from(rng.gen::<[u8; 16]>());
+                let trace_id = TraceId::from(rng.gen::<u128>());
                 if sampler
                     .should_sample(
                         parent_context.as_ref(),


### PR DESCRIPTION
It's cheaper to generate random u128 and u64 than it is to generate [u8; 16] and [u8; 8].

Changing `TraceId::From` and `SpanId::From` to be from these primitive types, rather than arrays, improves `start-end-span` benchmark performance by 10% in the sampling case and 21% in the non-sampling case.

```text
start-end-span/always-sample
                        time:   [517.71 ns 535.68 ns 551.39 ns]
                        change: [-14.991% -10.282% -5.3887%] (p = 0.00 < 0.05)
                        Performance has improved.
start-end-span/never-sample
                        time:   [133.18 ns 133.46 ns 133.76 ns]
                        change: [-22.160% -21.965% -21.769%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## Changes

- Change TraceId::From and SpanId::From to be from primitive types, rather than arrays with an assumed byte ordering.
- DatadogPropagator had to change too, but it will be faster as it's no longer converting to big-endian bytes just to call TraceId/SpanId::From.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
