### PR TITLE
make Tracer::Clone cheaper (another 10% improvement to start-end-span/never-sample)

### DIFF
--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -135,8 +135,12 @@ impl opentelemetry_api::trace::TracerProvider for TracerProvider {
         } else {
             name
         };
-        let instrumentation_lib =
-            InstrumentationLibrary::new(component_name, version, schema_url, attributes);
+        let instrumentation_lib = Arc::new(InstrumentationLibrary::new(
+            component_name,
+            version,
+            schema_url,
+            attributes,
+        ));
 
         Tracer::new(instrumentation_lib, Arc::downgrade(&self.inner))
     }

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -22,12 +22,12 @@ use opentelemetry_api::trace::{
 };
 use opentelemetry_api::{Context, Key, KeyValue, OrderMap, Value};
 use std::fmt;
-use std::sync::Weak;
+use std::sync::{Arc, Weak};
 
 /// `Tracer` implementation to create and manage spans
 #[derive(Clone)]
 pub struct Tracer {
-    instrumentation_lib: InstrumentationLibrary,
+    instrumentation_lib: Arc<InstrumentationLibrary>,
     provider: Weak<TracerProviderInner>,
 }
 
@@ -45,7 +45,7 @@ impl fmt::Debug for Tracer {
 impl Tracer {
     /// Create a new tracer (used internally by `TracerProvider`s).
     pub(crate) fn new(
-        instrumentation_lib: InstrumentationLibrary,
+        instrumentation_lib: Arc<InstrumentationLibrary>,
         provider: Weak<TracerProviderInner>,
     ) -> Self {
         Tracer {


### PR DESCRIPTION
Fixes #1092

This is more of a workaround in that I think there is still more work to be done inside `InstrumentationLibrary` type itself, but waiting for more discussion.

## Changes

- change Tracer to hold an Arc<InstrumentationLibrary> rather than the whole 120 byte instance, so that Cloning is way cheaper
- IMO, the Arc should move internal to InstrumentationLibrary itself, but that is a bigger API-breaking change.

```text
start-end-span/always-sample
                        time:   [508.72 ns 523.52 ns 536.82 ns]
                        change: [-6.7810% -1.9044% +3.2262%] (p = 0.46 > 0.05)
                        No change in performance detected.
start-end-span/never-sample
                        time:   [120.16 ns 120.48 ns 120.81 ns]
                        change: [-10.510% -10.308% -10.116%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
