### PR TITLE
OtelString::Owned carries Box<str> instead of String

### DIFF
--- a/opentelemetry-api/src/common.rs
+++ b/opentelemetry-api/src/common.rs
@@ -88,7 +88,7 @@ impl From<&'static str> for Key {
 impl From<String> for Key {
     /// Convert a `String` to a `Key`.
     fn from(string: String) -> Self {
-        Key(OtelString::Owned(string))
+        Key(OtelString::Owned(string.into_boxed_str()))
     }
 }
 
@@ -104,7 +104,7 @@ impl From<Cow<'static, str>> for Key {
     fn from(string: Cow<'static, str>) -> Self {
         match string {
             Cow::Borrowed(s) => Key(OtelString::Static(s)),
-            Cow::Owned(s) => Key(OtelString::Owned(s)),
+            Cow::Owned(s) => Key(OtelString::Owned(s.into_boxed_str())),
         }
     }
 }
@@ -118,7 +118,7 @@ impl fmt::Debug for Key {
 impl From<Key> for String {
     fn from(key: Key) -> Self {
         match key.0 {
-            OtelString::Owned(s) => s,
+            OtelString::Owned(s) => s.to_string(),
             OtelString::Static(s) => s.to_string(),
             OtelString::RefCounted(s) => s.to_string(),
         }
@@ -137,8 +137,8 @@ impl fmt::Display for Key {
 
 #[derive(Clone, Debug, Eq)]
 enum OtelString {
+    Owned(Box<str>),
     Static(&'static str),
-    Owned(String),
     RefCounted(Arc<str>),
 }
 
@@ -290,7 +290,7 @@ impl StringValue {
 impl From<StringValue> for String {
     fn from(s: StringValue) -> Self {
         match s.0 {
-            OtelString::Owned(s) => s,
+            OtelString::Owned(s) => s.to_string(),
             OtelString::Static(s) => s.to_string(),
             OtelString::RefCounted(s) => s.to_string(),
         }
@@ -305,7 +305,7 @@ impl From<&'static str> for StringValue {
 
 impl From<String> for StringValue {
     fn from(s: String) -> Self {
-        StringValue(OtelString::Owned(s))
+        StringValue(OtelString::Owned(s.into_boxed_str()))
     }
 }
 
@@ -318,7 +318,7 @@ impl From<Arc<str>> for StringValue {
 impl From<Cow<'static, str>> for StringValue {
     fn from(s: Cow<'static, str>) -> Self {
         match s {
-            Cow::Owned(s) => StringValue(OtelString::Owned(s)),
+            Cow::Owned(s) => StringValue(OtelString::Owned(s.into_boxed_str())),
             Cow::Borrowed(s) => StringValue(OtelString::Static(s)),
         }
     }


### PR DESCRIPTION
## Changes

`OtelString` was 32 bytes in size (64-bit platforms) due to the `Owned` variant holding a `String`.
Since `OtelString` is immutable, there really isn't any need to carry around the extra field internal to `String` describing the capacity of its internal vector. Instead, we change the `Owned` variant to carry a `Box<str>`, which only requires 16 bytes to carry rather than 24 bytes, and is one less level of indirection to get to the actual string data.

Net effect is to shrink the size of `OtelString` by 25%.

This shows improvements across the board for benchmarks related to span creation, especially when adding attributes.

```bash
shaun@shaun-amd:~/code/open-telemetry/opentelemetry-rust(otel-string)$ taskset -c 2,4 cargo bench -p opentelemetry_sdk --bench trace -- --baseline main start-end-span
   Compiling opentelemetry_api v0.19.0 (/home/shaun/code/open-telemetry/opentelemetry-rust/opentelemetry-api)
   Compiling opentelemetry_sdk v0.19.0 (/home/shaun/code/open-telemetry/opentelemetry-rust/opentelemetry-sdk)
    Finished bench [optimized + debuginfo] target(s) in 7.79s
     Running benches/trace.rs (target/release/deps/trace-31c2965ddd752f5b)
Gnuplot not found, using plotters backend
start-end-span/always-sample
                        time:   [343.31 ns 344.73 ns 346.50 ns]
                        change: [-1.5596% -0.5152% +0.4848%] (p = 0.35 > 0.05)
                        No change in performance detected.
start-end-span/never-sample
                        time:   [122.56 ns 122.88 ns 123.23 ns]
                        change: [-3.9032% -3.5327% -3.1872%] (p = 0.00 < 0.05)
                        Performance has improved.

start-end-span-4-attrs/always-sample
                        time:   [864.97 ns 886.17 ns 910.19 ns]
                        change: [-1.8140% +3.1562% +8.4623%] (p = 0.22 > 0.05)
                        No change in performance detected.
start-end-span-4-attrs/never-sample
                        time:   [169.38 ns 169.73 ns 170.13 ns]
                        change: [-4.3284% -4.0574% -3.7851%] (p = 0.00 < 0.05)
                        Performance has improved.

start-end-span-8-attrs/always-sample
                        time:   [1.3046 µs 1.3284 µs 1.3561 µs]
                        change: [-3.5281% +0.1555% +4.0327%] (p = 0.94 > 0.05)
                        No change in performance detected.
start-end-span-8-attrs/never-sample
                        time:   [217.17 ns 217.57 ns 217.98 ns]
                        change: [-5.1346% -4.8194% -4.4932%] (p = 0.00 < 0.05)
                        Performance has improved.

start-end-span-all-attr-types/always-sample
                        time:   [1.0142 µs 1.0441 µs 1.0765 µs]
                        change: [-2.9317% +1.2353% +5.5140%] (p = 0.57 > 0.05)
                        No change in performance detected.
start-end-span-all-attr-types/never-sample
                        time:   [183.36 ns 183.75 ns 184.19 ns]
                        change: [-3.6805% -3.3336% -3.0001%] (p = 0.00 < 0.05)
                        Performance has improved.

start-end-span-all-attr-types-2x/always-sample
                        time:   [1.5498 µs 1.5720 µs 1.5987 µs]
                        change: [-9.6115% -5.8450% -2.1828%] (p = 0.00 < 0.05)
                        Performance has improved.
start-end-span-all-attr-types-2x/never-sample
                        time:   [246.34 ns 246.98 ns 247.66 ns]
                        change: [-4.6626% -4.3700% -4.0622%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
