### PR TITLE
Improve span creation performance another 3-7%

### DIFF
--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -7,20 +7,22 @@
 //! and exposes methods for creating and activating new `Spans`.
 //!
 //! Docs: <https://github.com/open-telemetry/opentelemetry-specification/blob/v1.3.0/specification/trace/api.md#tracer>
-use crate::trace::SpanLimits;
 use crate::{
     trace::{
         provider::{TracerProvider, TracerProviderInner},
         span::{Span, SpanData},
-        Config, EvictedHashMap, EvictedQueue,
+        Config, EvictedHashMap, EvictedQueue, SpanLimits,
     },
     InstrumentationLibrary,
 };
-use opentelemetry_api::trace::{
-    Link, SamplingDecision, SamplingResult, SpanBuilder, SpanContext, SpanId, SpanKind,
-    TraceContextExt, TraceFlags, TraceId, TraceState,
+use once_cell::sync::Lazy;
+use opentelemetry_api::{
+    trace::{
+        Link, SamplingDecision, SamplingResult, SpanBuilder, SpanContext, SpanId, SpanKind,
+        TraceContextExt, TraceFlags, TraceId, TraceState,
+    },
+    Context, Key, KeyValue, OrderMap, Value,
 };
-use opentelemetry_api::{Context, Key, KeyValue, OrderMap, Value};
 use std::fmt;
 use std::sync::{Arc, Weak};
 
@@ -118,6 +120,8 @@ impl Tracer {
     }
 }
 
+static EMPTY_ATTRIBUTES: Lazy<OrderMap<Key, Value>> = Lazy::new(Default::default);
+
 impl opentelemetry_api::trace::Tracer for Tracer {
     /// This implementation of `Tracer` produces `sdk::Span` instances.
     type Span = Span;
@@ -148,8 +152,6 @@ impl opentelemetry_api::trace::Tracer for Tracer {
             .take()
             .unwrap_or_else(|| config.id_generator.new_span_id());
         let span_kind = builder.span_kind.take().unwrap_or(SpanKind::Internal);
-        let mut attribute_options = builder.attributes.take().unwrap_or_default();
-        let mut link_options = builder.links.take();
         let mut parent_span_id = SpanId::INVALID;
         let trace_id;
 
@@ -179,8 +181,8 @@ impl opentelemetry_api::trace::Tracer for Tracer {
                 trace_id,
                 &builder.name,
                 &span_kind,
-                &attribute_options,
-                link_options.as_deref().unwrap_or(&[]),
+                builder.attributes.as_ref().unwrap_or(&EMPTY_ATTRIBUTES),
+                builder.links.as_deref().unwrap_or(&[]),
                 provider.config(),
             )
         };
@@ -196,6 +198,7 @@ impl opentelemetry_api::trace::Tracer for Tracer {
 
         // Build optional inner context, `None` if not recording.
         let mut span = if let Some((flags, extra_attrs, trace_state)) = sampling_decision {
+            let mut attribute_options = builder.attributes.take().unwrap_or_default();
             for extra_attr in extra_attrs {
                 attribute_options.insert(extra_attr.key, extra_attr.value);
             }
@@ -204,6 +207,8 @@ impl opentelemetry_api::trace::Tracer for Tracer {
             for (key, value) in attribute_options {
                 attributes.insert(KeyValue::new(key, value));
             }
+
+            let mut link_options = builder.links.take();
             let mut links = EvictedQueue::new(span_limits.max_links_per_span);
             if let Some(link_options) = &mut link_options {
                 let link_attributes_limit = span_limits.max_attributes_per_link as usize;


### PR DESCRIPTION
- when making a sampling decision, use a static empty set of attributes (if there were none provided via the builder) rather than creating an empty OrderMap and later dropping it.
- this also improved performance in some of the always-sample cases, and I'm speculating it had to do with better code generation that resulted from moving the mutable variable declarations down into the scopes where they are actually used.

```bash
shaun@shaun-amd:~/code/open-telemetry/opentelemetry-rust(builder-attributes *)$ taskset -c 2,4 cargo bench -p opentelemetry_sdk --bench trace -- --baseline main start-end-span start-end-span/always-sample
                        time:   [348.13 ns 349.42 ns 350.84 ns]
                        change: [-0.5069% +0.7799% +2.1015%] (p = 0.25 > 0.05)
                        No change in performance detected.
start-end-span/never-sample
                        time:   [116.25 ns 116.52 ns 116.82 ns]
                        change: [-4.3488% -4.1272% -3.8979%] (p = 0.00 < 0.05)
                        Performance has improved.

start-end-span-4-attrs/always-sample
                        time:   [878.49 ns 907.04 ns 938.14 ns]
                        change: [-6.4936% -2.5370% +1.8532%] (p = 0.24 > 0.05)
                        No change in performance detected.
start-end-span-4-attrs/never-sample
                        time:   [165.72 ns 166.01 ns 166.33 ns]
                        change: [-3.6821% -3.4829% -3.2617%] (p = 0.00 < 0.05)
                        Performance has improved.

start-end-span-8-attrs/always-sample
                        time:   [1.2934 µs 1.3199 µs 1.3499 µs]
                        change: [-10.132% -6.8767% -3.4363%] (p = 0.00 < 0.05)
                        Performance has improved.
start-end-span-8-attrs/never-sample
                        time:   [214.83 ns 215.23 ns 215.67 ns]
                        change: [-2.9651% -2.7390% -2.5258%] (p = 0.00 < 0.05)
                        Performance has improved.

start-end-span-all-attr-types/always-sample
                        time:   [951.15 ns 977.30 ns 1.0084 µs]
                        change: [-7.4325% -3.2210% +1.4973%] (p = 0.15 > 0.05)
                        No change in performance detected.
start-end-span-all-attr-types/never-sample
                        time:   [180.11 ns 180.48 ns 180.90 ns]
                        change: [-2.8578% -2.5975% -2.3072%] (p = 0.00 < 0.05)
                        Performance has improved.

start-end-span-all-attr-types-2x/always-sample
                        time:   [1.5738 µs 1.6032 µs 1.6354 µs]
                        change: [-6.1433% -3.6935% -1.1629%] (p = 0.00 < 0.05)
                        Performance has improved.
start-end-span-all-attr-types-2x/never-sample
                        time:   [247.04 ns 247.98 ns 249.03 ns]
                        change: [-2.4979% -1.9581% -1.4200%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
