### PR TITLE
Update main readme with logging status

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,16 @@ available:
 * opentelemetry-appender-tracing // TODO: Add link once available
 * opentelemetry-appender-slog // TODO: Add link once available
 
-If you already use the logging APIs from above, continue to use them, and use the appenders above to bridge the logs to OpenTelemetry. If you are using a library not listed here, feel free to
-contribute a new appender for the same.
+If you already use the logging APIs from above, continue to use them, and use
+the appenders above to bridge the logs to OpenTelemetry. If you are using a
+library not listed here, feel free to contribute a new appender for the same.
 
 If you are starting fresh, then consider using
 [tracing](https://github.com/tokio-rs/tracing) as your logging API. It supports
 structured logging and is actively maintained.
 
-Project versioning information and stability guarantees can be found [here](VERSIONING.md).
+Project versioning information and stability guarantees can be found
+[here](VERSIONING.md).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,31 @@ observability tools.
 
 ## Project Status
 
-[OpenTelemetry Signal Status for Rust][otel-signals-rust]. Libraries adhere to [Stability Guarantees.][otel-signal-stability]
+| Signal  | Status     |
+| ------- | ---------- |
+| Logs    | Alpha*     |
+| Metrics | Alpha      |
+| Traces  | Beta       |
+
+*OpenTelemetry Rust is not introducing a new end user callable Logging API.
+Instead, it provides [Logs Bridge
+API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/bridge-api.md),
+that allows one to write log appenders that can bridge existing logging
+libraries to the OpenTelemetry log data model. The following log appenders are
+available:
+
+* [opentelemetry-appender-log](opentelemetry-appender-log/README.md)
+* opentelemetry-appender-tracing // TODO: Add link once available
+* opentelemetry-appender-slog // TODO: Add link once available
+
+If you already use the logging APIs from above, continue to use them, and use the appenders above to bridge the logs to OpenTelemetry. If you are using a library not listed here, feel free to
+contribute a new appender for the same.
+
+If you are starting fresh, then consider using
+[tracing](https://github.com/tokio-rs/tracing) as your logging API. It supports
+structured logging and is actively maintained.
+
+Project versioning information and stability guarantees can be found [here](VERSIONING.md).
 
 ## Getting Started
 
@@ -138,8 +162,6 @@ above, please let us know! We'd love to add your project to the list!
 [`Tide`]: https://crates.io/crates/tide
 [`opentelemetry-stackdriver`]: https://crates.io/crates/opentelemetry-stackdriver
 [Cloud Trace]: https://cloud.google.com/trace/
-[otel-signals-rust]: https://opentelemetry.io/docs/instrumentation/rust/#status-and-releases
-[otel-signal-stability]: https://opentelemetry.io/docs/reference/specification/versioning-and-stability/
 
 ## Supported Rust Versions
 


### PR DESCRIPTION
## Changes

1. Add project status right in this repo so it is easy to maintain and update. (There was some [erroneous update](https://github.com/open-telemetry/opentelemetry.io/pull/2416) to the status earlier by mistake).

2. Added logging status
    a. Clarify that OTel Rust is not building its own new logging api (similar to what Otel C++ did)
    b. Provide a recommendation to use tokio/tracing for logging needs.

3. Updated link to versioning doc from this repo.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
