### PR TITLE
Use faster Rng in RandomIdGenerator (0%-6% performance improvement)

### DIFF
--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -21,7 +21,7 @@ futures-util = { version = "0.3.17", default-features = false, features = ["std"
 once_cell = "1.10"
 ordered-float = "4.0"
 percent-encoding = { version = "2.0", optional = true }
-rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
+rand = { version = "0.8", default-features = false, features = ["std", "std_rng","small_rng"], optional = true }
 glob = {version = "0.3.1", optional =true}
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1", optional = true }
@@ -68,6 +68,7 @@ harness = false
 [[bench]]
 name = "trace"
 harness = false
+required-features = ["testing"]
 
 [[bench]]
 name = "batch_span_processor"

--- a/opentelemetry-sdk/src/trace/id_generator/mod.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/mod.rs
@@ -2,7 +2,7 @@
 pub(super) mod aws;
 
 use opentelemetry::trace::{SpanId, TraceId};
-use rand::{rngs, Rng};
+use rand::{rngs, Rng, SeedableRng};
 use std::cell::RefCell;
 use std::fmt;
 
@@ -35,5 +35,5 @@ impl IdGenerator for RandomIdGenerator {
 
 thread_local! {
     /// Store random number generator for each thread
-    static CURRENT_RNG: RefCell<rngs::ThreadRng> = RefCell::new(rngs::ThreadRng::default());
+    static CURRENT_RNG: RefCell<rngs::SmallRng> = RefCell::new(rngs::SmallRng::from_entropy());
 }


### PR DESCRIPTION
Represents a minimum a 11%-22% improvement in relevant benchmarks.

Fixes #808

## Changes

Swapped Rng from ThreadLocal to Pcg64Mcg for significant speed improvement.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)


## Benchmarks 

```
at 05:47:15 ➜  cargo bench -p opentelemetry_sdk --bench trace -- --baseline main
   Compiling rand_pcg v0.3.1
   Compiling opentelemetry_sdk v0.19.0 (/home/h.dost/projects/github.com/hdost/opentelemetry-rust/opentelemetry-sdk)
    Finished bench [optimized + debuginfo] target(s) in 6.57s
     Running benches/trace.rs (/home/h.dost/projects/github.com/hdost/opentelemetry-rust/target/release/deps/trace-eadd52583edeb932)
Gnuplot not found, using plotters backend
Benchmarking EvictedHashMap/insert 1: Collecting 100 samples in estimated 5.0004 s (52
EvictedHashMap/insert 1 time:   [95.338 ns 96.448 ns 97.487 ns]
                        change: [-20.671% -19.590% -18.435%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking EvictedHashMap/insert 5: Collecting 100 samples in estimated 5.0003 s (17
EvictedHashMap/insert 5 time:   [290.93 ns 294.97 ns 298.92 ns]
                        change: [-22.131% -21.194% -20.214%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
Benchmarking EvictedHashMap/insert 10: Collecting 100 samples in estimated 5.0011 s (8
EvictedHashMap/insert 10
                        time:   [605.80 ns 613.05 ns 620.85 ns]
                        change: [-22.299% -21.526% -20.657%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking EvictedHashMap/insert 20: Collecting 100 samples in estimated 5.0006 s (3
EvictedHashMap/insert 20
                        time:   [1.6257 µs 1.6457 µs 1.6656 µs]
                        change: [-14.434% -13.636% -12.633%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking start-end-span/always-sample: Collecting 100 samples in estimated 5.0001
start-end-span/always-sample
                        time:   [432.54 ns 433.88 ns 435.57 ns]
                        change: [-17.432% -17.063% -16.682%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
Benchmarking start-end-span/never-sample: Collecting 100 samples in estimated 5.0007 s
start-end-span/never-sample
                        time:   [131.14 ns 131.92 ns 132.81 ns]
                        change: [-24.020% -22.987% -22.032%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

Benchmarking start-end-span-4-attrs/always-sample: Collecting 100 samples in estimated
start-end-span-4-attrs/always-sample
                        time:   [1.1646 µs 1.1815 µs 1.1950 µs]
                        change: [-13.003% -11.021% -8.8554%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low severe
  3 (3.00%) high mild
  2 (2.00%) high severe
Benchmarking start-end-span-4-attrs/never-sample: Collecting 100 samples in estimated
start-end-span-4-attrs/never-sample
                        time:   [176.38 ns 177.05 ns 177.79 ns]
                        change: [-18.366% -18.037% -17.711%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

Benchmarking start-end-span-8-attrs/always-sample: Collecting 100 samples in estimated
start-end-span-8-attrs/always-sample
                        time:   [1.7350 µs 1.7416 µs 1.7484 µs]
                        change: [-13.517% -11.840% -9.9778%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
Benchmarking start-end-span-8-attrs/never-sample: Collecting 100 samples in estimated
start-end-span-8-attrs/never-sample
                        time:   [217.97 ns 219.36 ns 221.25 ns]
                        change: [-18.194% -17.571% -16.894%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

Benchmarking start-end-span-all-attr-types/always-sample: Collecting 100 samples in es
start-end-span-all-attr-types/always-sample
                        time:   [1.3941 µs 1.4064 µs 1.4171 µs]
                        change: [-14.897% -14.451% -13.978%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  3 (3.00%) high mild
Benchmarking start-end-span-all-attr-types/never-sample: Collecting 100 samples in est
start-end-span-all-attr-types/never-sample
                        time:   [186.94 ns 188.96 ns 190.93 ns]
                        change: [-20.653% -19.603% -18.410%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking start-end-span-all-attr-types-2x/always-sample: Collecting 100 samples in
start-end-span-all-attr-types-2x/always-sample
                        time:   [2.1476 µs 2.1576 µs 2.1675 µs]
                        change: [-12.057% -11.575% -11.138%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
Benchmarking start-end-span-all-attr-types-2x/never-sample: Collecting 100 samples in
start-end-span-all-attr-types-2x/never-sample
                        time:   [242.89 ns 244.19 ns 245.73 ns]
                        change: [-18.510% -18.000% -17.417%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```