### PR TITLE
examples tracing-grpc: upgrade Cargo.toml and fix build and warnings

### DIFF
--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -13,15 +13,15 @@ name = "grpc-client"
 path = "src/client.rs"
 
 [dependencies]
-tonic = "0.6.2"
-prost = "0.9"
-tokio = { version = "1.0", features = ["full"] }
-opentelemetry = { version = "0.14", features = ["rt-tokio"] }
-opentelemetry-jaeger = "0.13"
+opentelemetry = { version = "0.19", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.18", features = ["rt-tokio"] }
+prost = "0.11"
+tokio = { version = "1.28", features = ["full"] }
+tonic = "0.9.2"
 tracing = "0.1"
-tracing-subscriber = "0.2"
-tracing-opentelemetry = "0.13"
 tracing-futures = "0.2"
+tracing-opentelemetry = "0.19"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
-tonic-build = "0.6.2"
+tonic-build = "0.9.2"

--- a/examples/tracing-grpc/README.md
+++ b/examples/tracing-grpc/README.md
@@ -1,6 +1,6 @@
 # GRPC example
 
-Example showing [Tonic] client and server interaction with OpenTelemetry context propagation.  [tracing_opentelemetry](https://docs.rs/tracing-opentelemetry/0.4.0/tracing_opentelemetry/) is used to hook into the [tracing](https://github.com/tokio-rs/tracing) ecosystem, which enables drop-in replacements for [log](https://github.com/rust-lang/log) macros and an `#[instrument]` macro that will automatically add spans to your functions.  
+Example showing [Tonic] client and server interaction with OpenTelemetry context propagation.  [tracing_opentelemetry](https://docs.rs/tracing-opentelemetry/0.4.0/tracing_opentelemetry/) is used to hook into the [tracing](https://github.com/tokio-rs/tracing) ecosystem, which enables drop-in replacements for [log](https://github.com/rust-lang/log) macros and an `#[instrument]` macro that will automatically add spans to your functions.
 
 [Tonic]: https://github.com/hyperium/tonic
 
@@ -12,7 +12,7 @@ Examples
 $ docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
 
 # Run the server
-$ cargo run --bin grpc-server 
+$ cargo run --bin grpc-server
 
 # Now run the client to make a request to the server
 $ cargo run --bin grpc-client

--- a/examples/tracing-grpc/src/server.rs
+++ b/examples/tracing-grpc/src/server.rs
@@ -1,6 +1,5 @@
 use hello_world::greeter_server::{Greeter, GreeterServer};
 use hello_world::{HelloReply, HelloRequest};
-use opentelemetry::sdk::propagation::TraceContextPropagator;
 use opentelemetry::{global, propagation::Extractor};
 use tonic::{transport::Server, Request, Response, Status};
 use tracing::*;
@@ -66,8 +65,8 @@ impl Greeter for MyGreeter {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    global::set_text_map_propagator(TraceContextPropagator::new());
-    let tracer = opentelemetry_jaeger::new_pipeline()
+    global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
+    let tracer = opentelemetry_jaeger::new_agent_pipeline()
         .with_service_name("grpc-server")
         .install_batch(opentelemetry::runtime::Tokio)?;
     tracing_subscriber::registry()


### PR DESCRIPTION
Fixes #

I couldn't get the tracing-grpc example to work. So I decided to upgrade the dependencies in Cargo.toml and fix the build / warnings.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
