### PR TITLE
Update main readme with sig meeting info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 The Rust special interest group (SIG) meets regularly. See the
 OpenTelemetry
-[community](https://github.com/open-telemetry/community#rust-sig)
+[community](https://github.com/open-telemetry/community#implementation-sigs)
 repo for information on this and other language SIGs.
 
 See the [public meeting
@@ -148,6 +148,10 @@ For GitHub groups see the [code owners](CODEOWNERS) file.
 
 See the [community membership document in OpenTelemetry community
 repo](https://github.com/open-telemetry/community/blob/master/community-membership.md).
+
+### Thanks to all the people who have contributed
+
+[![contributors](https://contributors-img.web.app/image?repo=open-telemetry/opentelemetry-rust)](https://github.com/open-telemetry/opentelemetry-rust/graphs/contributors)
 
 ## FAQ
 ### Where should I put third party propagators/exporters, contrib or standalone crates?

--- a/README.md
+++ b/README.md
@@ -194,4 +194,7 @@ doc](https://docs.google.com/document/d/1tGKuCsSnyT2McDncVJrMgg74_z8V06riWZa0Sr7
 If you have trouble accessing the doc, please get in touch on
 [Slack](https://cloud-native.slack.com/archives/C03GDP0H023).
 
-The meeting is open for all to join!
+The meeting is open for all to join. We invite everyone to join our meeting,
+regardless of your experience level. Whether you're a seasoned OpenTelemetry
+developer, just starting your journey, or simply curious about the work we do,
+you're more than welcome to participate!

--- a/README.md
+++ b/README.md
@@ -181,3 +181,17 @@ this policy.
 ## Contributing
 
 See the [contributing file](CONTRIBUTING.md).
+
+The Rust special interest group (SIG) meets weekly on Tuesdays at 9 AM Pacific
+Time (16:00 UTC). The meeting is subject to change depending on contributors'
+availability. Check the [OpenTelemetry community
+calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com)
+for specific dates and for Zoom meeting links. "OTel Rust SIG" is the name of
+meeting for this group.
+
+Meeting notes are available as a public [Google
+doc](https://docs.google.com/document/d/1tGKuCsSnyT2McDncVJrMgg74_z8V06riWZa0Sr79I_4/edit).
+If you have trouble accessing the doc, please get in touch on
+[Slack](https://cloud-native.slack.com/archives/C03GDP0H023).
+
+The meeting is open for all to join!


### PR DESCRIPTION
1. Putting SIG meeting info in the main readme itself for easier finding. (a practice common in many other otel repos, like Python, .NET).
2. Add the image showing all contributors (almost all OTel repos do this, so why not!)
3. Added a welcoming line about "meeting is open for all to join".