### PR TITLE
Introduce key/value map bench

### DIFF
--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -36,6 +36,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
+indexmap = "1.8"
 criterion = { version = "0.4.0", features = ["html_reports"] }
 pprof = { version = "0.11.1", features = ["flamegraph", "criterion"] }
 
@@ -49,6 +50,14 @@ testing = ["opentelemetry_api/testing", "trace", "metrics", "logs", "rt-async-st
 rt-tokio = ["tokio", "tokio-stream"]
 rt-tokio-current-thread = ["tokio", "tokio-stream"]
 rt-async-std = ["async-std"]
+
+[[bench]]
+name = "key_value_map"
+harness = false
+
+[[bench]]
+name = "span_builder"
+harness = false
 
 [[bench]]
 name = "trace"

--- a/opentelemetry-sdk/benches/key_value_map.rs
+++ b/opentelemetry-sdk/benches/key_value_map.rs
@@ -1,0 +1,208 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize::SmallInput, BenchmarkId, Criterion,
+};
+use indexmap::IndexMap;
+use opentelemetry_api::{Key, KeyValue, Value};
+use opentelemetry_sdk::trace::EvictedHashMap;
+use pprof::criterion::{Output, PProfProfiler};
+use std::iter::Iterator;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let cap = 32;
+    let input = [(2, 32, cap), (8, 32, cap), (32, 32, cap)];
+    populate_benchmark(c, &input);
+    lookup_benchmark(c, &input);
+    populate_and_lookup_benchmark(c, &input);
+}
+
+fn populate_benchmark(c: &mut Criterion, input: &[(usize, u32, usize)]) {
+    let mut group = c.benchmark_group("populate");
+    for &(n, max, capacity) in input {
+        let parameter_string = format!("{n:02}/{max:02}/{capacity:02}");
+
+        group.bench_function(
+            BenchmarkId::new("EvictedHashMap", parameter_string.clone()),
+            |b| {
+                b.iter(|| populate_evicted_hashmap(n, max, capacity));
+            },
+        );
+        group.bench_function(
+            BenchmarkId::new("IndexMap", parameter_string.clone()),
+            |b| {
+                b.iter(|| populate_indexmap(n, max, capacity));
+            },
+        );
+        group.bench_function(BenchmarkId::new("TwoVecs", parameter_string.clone()), |b| {
+            b.iter(|| populate_twovecs(n, max, capacity));
+        });
+        group.bench_function(BenchmarkId::new("OneVec", parameter_string.clone()), |b| {
+            b.iter(|| populate_onevec(n, max, capacity));
+        });
+    }
+    group.finish();
+}
+
+fn lookup_benchmark(c: &mut Criterion, input: &[(usize, u32, usize)]) {
+    let mut group = c.benchmark_group("lookup");
+    for &(n, max, capacity) in input {
+        let lookup_keys = &MAP_KEYS[n - 2..n];
+        let parameter_string = format!("{n:02}/{max:02}/{capacity:02}");
+        group.bench_function(
+            BenchmarkId::new("EvictedHashMap", parameter_string.clone()),
+            |b| {
+                b.iter_batched(
+                    || populate_evicted_hashmap(n, max, capacity),
+                    |map| lookup_evicted_hashmap(&map, lookup_keys),
+                    SmallInput,
+                );
+            },
+        );
+        group.bench_function(
+            BenchmarkId::new("IndexMap", parameter_string.clone()),
+            |b| {
+                b.iter_batched(
+                    || populate_indexmap(n, max, capacity),
+                    |map| lookup_indexmap(&map, lookup_keys),
+                    SmallInput,
+                );
+            },
+        );
+        group.bench_function(BenchmarkId::new("OneVec", parameter_string.clone()), |b| {
+            b.iter_batched(
+                || populate_onevec(n, max, capacity),
+                |vec| lookup_onevec(&vec, lookup_keys),
+                SmallInput,
+            );
+        });
+        group.bench_function(BenchmarkId::new("TwoVecs", parameter_string.clone()), |b| {
+            b.iter_batched(
+                || populate_twovecs(n, max, capacity),
+                |(keys, vals)| lookup_twovec(&keys, &vals, lookup_keys),
+                SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn populate_and_lookup_benchmark(c: &mut Criterion, input: &[(usize, u32, usize)]) {
+    let mut group = c.benchmark_group("populate_and_lookup");
+    for &(n, max, capacity) in input {
+        let lookup_keys = &MAP_KEYS[n - 2..n];
+        let parameter_string = format!("{n:02}/{max:02}/{capacity:02}");
+        group.bench_function(
+            BenchmarkId::new("EvictedHashMap", parameter_string.clone()),
+            |b| {
+                b.iter(|| {
+                    let map = populate_evicted_hashmap(n, max, capacity);
+                    lookup_evicted_hashmap(&map, lookup_keys);
+                });
+            },
+        );
+        group.bench_function(
+            BenchmarkId::new("IndexMap", parameter_string.clone()),
+            |b| {
+                b.iter(|| {
+                    let map = populate_indexmap(n, max, capacity);
+                    lookup_indexmap(&map, lookup_keys);
+                });
+            },
+        );
+        group.bench_function(BenchmarkId::new("OneVec", parameter_string.clone()), |b| {
+            b.iter(|| {
+                let vec = populate_onevec(n, max, capacity);
+                lookup_onevec(&vec, lookup_keys);
+            });
+        });
+        group.bench_function(BenchmarkId::new("TwoVecs", parameter_string.clone()), |b| {
+            b.iter(|| {
+                let (keys, vals) = populate_twovecs(n, max, capacity);
+                lookup_twovec(&keys, &vals, lookup_keys);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn populate_evicted_hashmap(n: usize, max: u32, capacity: usize) -> EvictedHashMap {
+    let mut map = EvictedHashMap::new(max, capacity);
+    for (idx, key) in MAP_KEYS.iter().enumerate().take(n) {
+        map.insert(KeyValue::new(*key, idx as i64));
+    }
+    map
+}
+
+fn lookup_evicted_hashmap(map: &EvictedHashMap, keys: &[&'static str]) {
+    for key in keys {
+        black_box(map.get(&Key::new(*key)));
+    }
+}
+
+fn populate_indexmap(n: usize, max: u32, _capacity: usize) -> IndexMap<Key, Value> {
+    let mut map = IndexMap::with_capacity(max as usize);
+    for (idx, key) in MAP_KEYS.iter().enumerate().take(n) {
+        map.insert(Key::new(*key), Value::I64(idx as i64));
+    }
+    map
+}
+
+fn lookup_indexmap(map: &IndexMap<Key, Value>, keys: &[&'static str]) {
+    for key in keys {
+        black_box(map.get(&Key::new(*key)));
+    }
+}
+
+fn populate_onevec(n: usize, max: u32, _capacity: usize) -> Vec<(Key, Value)> {
+    let mut tuples = Vec::with_capacity(max as usize);
+    for (idx, key) in MAP_KEYS.iter().enumerate().take(n) {
+        tuples.push((Key::new(*key), Value::I64(idx as i64)));
+    }
+    tuples
+}
+
+fn lookup_onevec(vec: &[(Key, Value)], keys: &[&'static str]) {
+    for key in keys {
+        black_box(
+            vec.iter()
+                .position(|(k, _v)| *k == Key::new(*key))
+                .map(|idx| vec.get(idx)),
+        );
+    }
+}
+
+fn populate_twovecs(n: usize, max: u32, _capacity: usize) -> (Vec<Key>, Vec<Value>) {
+    let mut keys = Vec::with_capacity(max as usize);
+    let mut vals = Vec::with_capacity(max as usize);
+    for (idx, key) in MAP_KEYS.iter().enumerate().take(n) {
+        keys.push(Key::new(*key));
+        vals.push(Value::I64(idx as i64));
+    }
+    (keys, vals)
+}
+
+fn lookup_twovec(keys: &[Key], vals: &[Value], lookup_keys: &[&'static str]) {
+    for key in lookup_keys {
+        black_box(
+            keys.iter()
+                .position(|k| *k == Key::new(*key))
+                .map(|idx| vals.get(idx)),
+        );
+    }
+}
+
+const MAP_KEYS: [&str; 64] = [
+    "key.1", "key.2", "key.3", "key.4", "key.5", "key.6", "key.7", "key.8", "key.9", "key.10",
+    "key.11", "key.12", "key.13", "key.14", "key.15", "key.16", "key.17", "key.18", "key.19",
+    "key.20", "key.21", "key.22", "key.23", "key.24", "key.25", "key.26", "key.27", "key.28",
+    "key.29", "key.30", "key.31", "key.32", "key.33", "key.34", "key.35", "key.36", "key.37",
+    "key.38", "key.39", "key.40", "key.41", "key.42", "key.43", "key.44", "key.45", "key.46",
+    "key.47", "key.48", "key.49", "key.50", "key.51", "key.52", "key.53", "key.54", "key.55",
+    "key.56", "key.57", "key.58", "key.59", "key.60", "key.61", "key.62", "key.63", "key.64",
+];
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/opentelemetry-sdk/benches/span_builder.rs
+++ b/opentelemetry-sdk/benches/span_builder.rs
@@ -1,0 +1,107 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use futures_util::future::BoxFuture;
+use opentelemetry_api::{
+    trace::{OrderMap, Span, Tracer, TracerProvider},
+    KeyValue,
+};
+use opentelemetry_sdk::{
+    export::trace::{ExportResult, SpanData, SpanExporter},
+    trace as sdktrace,
+};
+use pprof::criterion::{Output, PProfProfiler};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    span_builder_benchmark_group(c)
+}
+
+fn span_builder_benchmark_group(c: &mut Criterion) {
+    let mut group = c.benchmark_group("span_builder");
+    group.bench_function("simplest", |b| {
+        let (_provider, tracer) = not_sampled_provider();
+        b.iter(|| {
+            let mut span = tracer.span_builder("span").start(&tracer);
+            span.end();
+        })
+    });
+    group.bench_function(BenchmarkId::new("with_attributes", "1"), |b| {
+        let (_provider, tracer) = not_sampled_provider();
+        b.iter(|| {
+            let mut span = tracer
+                .span_builder("span")
+                .with_attributes([KeyValue::new(MAP_KEYS[0], "value")])
+                .start(&tracer);
+            span.end();
+        })
+    });
+    group.bench_function(BenchmarkId::new("with_attributes", "4"), |b| {
+        let (_provider, tracer) = not_sampled_provider();
+        b.iter(|| {
+            let mut span = tracer
+                .span_builder("span")
+                .with_attributes([
+                    KeyValue::new(MAP_KEYS[0], "value"),
+                    KeyValue::new(MAP_KEYS[1], "value"),
+                    KeyValue::new(MAP_KEYS[2], "value"),
+                    KeyValue::new(MAP_KEYS[3], "value"),
+                ])
+                .start(&tracer);
+            span.end();
+        })
+    });
+    group.bench_function(BenchmarkId::new("with_attributes_map", "1"), |b| {
+        let (_provider, tracer) = not_sampled_provider();
+        b.iter(|| {
+            let mut span = tracer
+                .span_builder("span")
+                .with_attributes_map(OrderMap::from_iter([KeyValue::new(MAP_KEYS[0], "value")]))
+                .start(&tracer);
+            span.end();
+        })
+    });
+    group.bench_function(BenchmarkId::new("with_attributes_map", "4"), |b| {
+        let (_provider, tracer) = not_sampled_provider();
+        b.iter(|| {
+            let mut span = tracer
+                .span_builder("span")
+                .with_attributes_map(OrderMap::from_iter([KeyValue::new(MAP_KEYS[0], "value")]))
+                .start(&tracer);
+            span.end();
+        })
+    });
+    group.finish();
+}
+
+fn not_sampled_provider() -> (sdktrace::TracerProvider, sdktrace::Tracer) {
+    let provider = sdktrace::TracerProvider::builder()
+        .with_config(sdktrace::config().with_sampler(sdktrace::Sampler::AlwaysOff))
+        .with_simple_exporter(NoopExporter)
+        .build();
+    let tracer = provider.tracer("not-sampled");
+    (provider, tracer)
+}
+
+#[derive(Debug)]
+struct NoopExporter;
+
+impl SpanExporter for NoopExporter {
+    fn export(&mut self, _spans: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+        Box::pin(futures_util::future::ready(Ok(())))
+    }
+}
+
+const MAP_KEYS: [&str; 64] = [
+    "key.1", "key.2", "key.3", "key.4", "key.5", "key.6", "key.7", "key.8", "key.9", "key.10",
+    "key.11", "key.12", "key.13", "key.14", "key.15", "key.16", "key.17", "key.18", "key.19",
+    "key.20", "key.21", "key.22", "key.23", "key.24", "key.25", "key.26", "key.27", "key.28",
+    "key.29", "key.30", "key.31", "key.32", "key.33", "key.34", "key.35", "key.36", "key.37",
+    "key.38", "key.39", "key.40", "key.41", "key.42", "key.43", "key.44", "key.45", "key.46",
+    "key.47", "key.48", "key.49", "key.50", "key.51", "key.52", "key.53", "key.54", "key.55",
+    "key.56", "key.57", "key.58", "key.59", "key.60", "key.61", "key.62", "key.63", "key.64",
+];
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use futures_util::future::BoxFuture;
 use opentelemetry_api::{
     trace::{Span, Tracer, TracerProvider},
-    Key, KeyValue,
+    Key,
 };
 use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
@@ -11,21 +11,6 @@ use opentelemetry_sdk::{
 use pprof::criterion::{Output, PProfProfiler};
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("EvictedHashMap");
-    group.bench_function("insert 1", |b| {
-        b.iter(|| insert_keys(sdktrace::EvictedHashMap::new(32, 1), 1))
-    });
-    group.bench_function("insert 5", |b| {
-        b.iter(|| insert_keys(sdktrace::EvictedHashMap::new(32, 5), 5))
-    });
-    group.bench_function("insert 10", |b| {
-        b.iter(|| insert_keys(sdktrace::EvictedHashMap::new(32, 10), 10))
-    });
-    group.bench_function("insert 20", |b| {
-        b.iter(|| insert_keys(sdktrace::EvictedHashMap::new(32, 20), 20))
-    });
-    group.finish();
-
     trace_benchmark_group(c, "start-end-span", |tracer| tracer.start("foo").end());
 
     trace_benchmark_group(c, "start-end-span-4-attrs", |tracer| {
@@ -68,35 +53,6 @@ fn criterion_benchmark(c: &mut Criterion) {
         span.set_attribute(Key::new("key15").f64(123.456));
         span.end();
     });
-}
-
-const MAP_KEYS: [Key; 20] = [
-    Key::from_static_str("key1"),
-    Key::from_static_str("key2"),
-    Key::from_static_str("key3"),
-    Key::from_static_str("key4"),
-    Key::from_static_str("key5"),
-    Key::from_static_str("key6"),
-    Key::from_static_str("key7"),
-    Key::from_static_str("key8"),
-    Key::from_static_str("key9"),
-    Key::from_static_str("key10"),
-    Key::from_static_str("key11"),
-    Key::from_static_str("key12"),
-    Key::from_static_str("key13"),
-    Key::from_static_str("key14"),
-    Key::from_static_str("key15"),
-    Key::from_static_str("key16"),
-    Key::from_static_str("key17"),
-    Key::from_static_str("key18"),
-    Key::from_static_str("key19"),
-    Key::from_static_str("key20"),
-];
-
-fn insert_keys(mut map: sdktrace::EvictedHashMap, n: usize) {
-    for (idx, key) in MAP_KEYS.iter().enumerate().take(n) {
-        map.insert(KeyValue::new(key.clone(), idx as i64));
-    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Two new benchmarks:
- `key_value_map` for evaluating different implementation choices
- `span_builder` to focus on performance analysis of `SpanBuilder`

## Overview 

There are four implementations considered:
- `EvictedHashMap`: currently used by `SpanData` to carry span attributes
- `IndexMap`: currently used by `SpanBuilder` to carry span attributes (in an `OrderMap`)
- `OneVec`: `Vec<(Key, Value>)` where no hashing or duplicate key detection takes place
- `TwoVec`: a `Vec<Key>` and a `Vec<Value>`, linked by shared indices, where no hashing or duplicate key detection takes place

There are two main operations to consider for each implementation:
- `lookup`: find two attributes in "the map"
- `populate`: populate `n` (2, 8, or 32) attributes in the map

`lookup` approximates what a sampling decision might do in consulting specific keys present in the `SpanBuilder`. Its performance looks like the following: (Note, the `Vec` based implementations are pessimized for worst-case, finding the last two attributes in the map.)

![violin](https://github.com/open-telemetry/opentelemetry-rust/assets/30703437/665719f2-b1cc-4177-a50a-08b9951a953f)

`OneVec` beats `IndexMap` for 2 and 8 attributes in the map, but loses for 32 attributes.

`populate` approximates what anyone who wants to create a `Span` must pay to get attributes into the `SpanBuilder`. Its performance looks like the following:

![violin](https://github.com/open-telemetry/opentelemetry-rust/assets/30703437/2f66511f-8a75-45e4-9735-7ffc16573246)

As expected, populating hash maps is a lot more expensive than populating vectors, but that's the cost of detecting duplicates.

## Learnings

Knowing that we have to both `populate` and `lookup` when creating a `Span`, it's useful to see both together:

![violin](https://github.com/open-telemetry/opentelemetry-rust/assets/30703437/02ce908b-45e6-403e-8b93-755a9d45dc3f)

Now we see that `OneVec` beats `IndexMap` for all cases, and is more than twice as fast as `IndexMap` for 32 attributes.

So this PR is meant to do three things:
1. Give us a tool for further study.
2. Help us come to a decision or better strategy about where to handle duplicate detection of attributes. (Personally, I think the cost should be paid for by the user or in the sdk as an option, but not in the api as is currently done.)
3. Remind us all that O(1) vs. O(N) applies in the large, not necessarily for "tiny" data sets as we have here with attribute sets.  So I think #794 should be revisited in this light. e.g. if a span processor or sampling decision wants to lookup attributes, it should be considering indexing to make those lookups faster in light of how many attributes are actually present and not necessarily make everyone who creates a `SpanBuilder` that ends up producing a `Span` that is non-recording pay for indexing that will never get used.