### PR TITLE
Stress test for metric modified to use random attributes

### DIFF
--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -22,7 +22,7 @@ opentelemetry_api = { path = "../opentelemetry-api", features = ["metrics", "log
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics", "logs"] }
 opentelemetry-appender-tracing = { path = "../opentelemetry-appender-tracing"}
 opentelemetry-stdout = { path = "../opentelemetry-stdout", features = ["logs"]}
-rand = "0.8.4"
+rand = { version = "0.8.4", features = ["small_rng"] }
 tracing = {version = "0.1.37", default-features = false, features = ["std"]}
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -22,6 +22,7 @@ opentelemetry_api = { path = "../opentelemetry-api", features = ["metrics", "log
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics", "logs"] }
 opentelemetry-appender-tracing = { path = "../opentelemetry-appender-tracing"}
 opentelemetry-stdout = { path = "../opentelemetry-stdout", features = ["logs"]}
+rand = "0.8.4"
 tracing = {version = "0.1.37", default-features = false, features = ["std"]}
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -1,6 +1,7 @@
 use lazy_static::lazy_static;
-use opentelemetry_api::metrics::{Counter, MeterProvider as _};
+use opentelemetry_api::{metrics::{Counter, MeterProvider as _, Histogram}, KeyValue, Value};
 use opentelemetry_sdk::metrics::{ManualReader, MeterProvider};
+use rand::Rng;
 use std::borrow::Cow;
 
 mod throughput;
@@ -9,9 +10,16 @@ lazy_static! {
     static ref PROVIDER: MeterProvider = MeterProvider::builder()
         .with_reader(ManualReader::builder().build())
         .build();
+    static ref AttributeValues: [&'static str; 10] = ["value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9", "value10"];
+
     static ref COUNTER: Counter<u64> = PROVIDER
         .meter(<&str as Into<Cow<'static, str>>>::into("test"))
         .u64_counter("hello")
+        .init();
+
+    static ref HISTOGRAM: Histogram<f64> = PROVIDER
+        .meter(<&str as Into<Cow<'static, str>>>::into("test"))
+        .f64_histogram("my_histogram")
         .init();
 }
 
@@ -20,5 +28,18 @@ fn main() {
 }
 
 fn test_counter() {
-    COUNTER.add(1, &[]);
+    let mut rng = rand::thread_rng();
+    let index_first_attribute = rng.gen_range(0..AttributeValues.len());
+    let index_second_attribute = rng.gen_range(0..AttributeValues.len());
+    let index_third_attribute = rng.gen_range(0..AttributeValues.len());
+    let index_fourth_attribute = rng.gen_range(0..AttributeValues.len());
+    let index_fifth_attribute = rng.gen_range(0..AttributeValues.len());
+    
+    HISTOGRAM.record(1.0, &[
+        KeyValue::new("attribute1", AttributeValues[index_first_attribute]),
+        KeyValue::new("attribute2", AttributeValues[index_second_attribute]),
+        // KeyValue::new("attribute3", AttributeValues[index_third_attribute]),
+        // KeyValue::new("attribute4", AttributeValues[index_fourth_attribute]),
+        // KeyValue::new("attribute5", AttributeValues[index_fifth_attribute]),
+    ]);
 }

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -4,7 +4,7 @@ use opentelemetry_api::{
     KeyValue,
 };
 use opentelemetry_sdk::metrics::{ManualReader, MeterProvider};
-use rand::Rng;
+use rand::{rngs::SmallRng, SeedableRng, Rng};
 use std::borrow::Cow;
 
 mod throughput;
@@ -28,7 +28,7 @@ fn main() {
 }
 
 fn test_counter() {
-    let mut rng = rand::thread_rng();
+    let mut rng = SmallRng::from_entropy();
     let len = ATTRIBUTE_VALUES.len();
     let index_first_attribute = rng.gen_range(0..len);
     let index_second_attribute = rng.gen_range(0..len);

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use opentelemetry_api::{metrics::{Counter, MeterProvider as _, Histogram}, KeyValue, Value};
+use opentelemetry_api::{metrics::{Counter, MeterProvider as _}, KeyValue};
 use opentelemetry_sdk::metrics::{ManualReader, MeterProvider};
 use rand::Rng;
 use std::borrow::Cow;
@@ -10,16 +10,11 @@ lazy_static! {
     static ref PROVIDER: MeterProvider = MeterProvider::builder()
         .with_reader(ManualReader::builder().build())
         .build();
-    static ref AttributeValues: [&'static str; 10] = ["value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9", "value10"];
+    static ref ATTRIBUTE_VALUES: [&'static str; 10] = ["value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9", "value10"];
 
     static ref COUNTER: Counter<u64> = PROVIDER
         .meter(<&str as Into<Cow<'static, str>>>::into("test"))
         .u64_counter("hello")
-        .init();
-
-    static ref HISTOGRAM: Histogram<f64> = PROVIDER
-        .meter(<&str as Into<Cow<'static, str>>>::into("test"))
-        .f64_histogram("my_histogram")
         .init();
 }
 
@@ -29,17 +24,15 @@ fn main() {
 
 fn test_counter() {
     let mut rng = rand::thread_rng();
-    let index_first_attribute = rng.gen_range(0..AttributeValues.len());
-    let index_second_attribute = rng.gen_range(0..AttributeValues.len());
-    let index_third_attribute = rng.gen_range(0..AttributeValues.len());
-    let index_fourth_attribute = rng.gen_range(0..AttributeValues.len());
-    let index_fifth_attribute = rng.gen_range(0..AttributeValues.len());
+    let len = ATTRIBUTE_VALUES.len();
+    let index_first_attribute = rng.gen_range(0..len);
+    let index_second_attribute = rng.gen_range(0..len);
+    let index_third_attribute = rng.gen_range(0..len);
     
-    HISTOGRAM.record(1.0, &[
-        KeyValue::new("attribute1", AttributeValues[index_first_attribute]),
-        KeyValue::new("attribute2", AttributeValues[index_second_attribute]),
-        // KeyValue::new("attribute3", AttributeValues[index_third_attribute]),
-        // KeyValue::new("attribute4", AttributeValues[index_fourth_attribute]),
-        // KeyValue::new("attribute5", AttributeValues[index_fifth_attribute]),
+    // each attribute has 10 possible values, so there are 1000 possible combinations (time-series)
+    COUNTER.add(1, &[
+        KeyValue::new("attribute1", ATTRIBUTE_VALUES[index_first_attribute]),
+        KeyValue::new("attribute2", ATTRIBUTE_VALUES[index_second_attribute]),
+        KeyValue::new("attribute3", ATTRIBUTE_VALUES[index_third_attribute]),
     ]);
 }

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -4,7 +4,7 @@ use opentelemetry_api::{
     KeyValue,
 };
 use opentelemetry_sdk::metrics::{ManualReader, MeterProvider};
-use rand::{rngs::SmallRng, SeedableRng, Rng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::borrow::Cow;
 
 mod throughput;

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -1,5 +1,8 @@
 use lazy_static::lazy_static;
-use opentelemetry_api::{metrics::{Counter, MeterProvider as _}, KeyValue};
+use opentelemetry_api::{
+    metrics::{Counter, MeterProvider as _},
+    KeyValue,
+};
 use opentelemetry_sdk::metrics::{ManualReader, MeterProvider};
 use rand::Rng;
 use std::borrow::Cow;
@@ -10,8 +13,10 @@ lazy_static! {
     static ref PROVIDER: MeterProvider = MeterProvider::builder()
         .with_reader(ManualReader::builder().build())
         .build();
-    static ref ATTRIBUTE_VALUES: [&'static str; 10] = ["value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9", "value10"];
-
+    static ref ATTRIBUTE_VALUES: [&'static str; 10] = [
+        "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
+        "value10"
+    ];
     static ref COUNTER: Counter<u64> = PROVIDER
         .meter(<&str as Into<Cow<'static, str>>>::into("test"))
         .u64_counter("hello")
@@ -28,11 +33,14 @@ fn test_counter() {
     let index_first_attribute = rng.gen_range(0..len);
     let index_second_attribute = rng.gen_range(0..len);
     let index_third_attribute = rng.gen_range(0..len);
-    
+
     // each attribute has 10 possible values, so there are 1000 possible combinations (time-series)
-    COUNTER.add(1, &[
-        KeyValue::new("attribute1", ATTRIBUTE_VALUES[index_first_attribute]),
-        KeyValue::new("attribute2", ATTRIBUTE_VALUES[index_second_attribute]),
-        KeyValue::new("attribute3", ATTRIBUTE_VALUES[index_third_attribute]),
-    ]);
+    COUNTER.add(
+        1,
+        &[
+            KeyValue::new("attribute1", ATTRIBUTE_VALUES[index_first_attribute]),
+            KeyValue::new("attribute2", ATTRIBUTE_VALUES[index_second_attribute]),
+            KeyValue::new("attribute3", ATTRIBUTE_VALUES[index_third_attribute]),
+        ],
+    );
 }


### PR DESCRIPTION
The existing test did not pass any attributes at all. This PR adds random attributes (~1000 timeseries, within the 2000 limit), so as to measure real world throughput.