### PR TITLE
In opentelemetry-stackdriver, add option to authenticate with existing GCP Authentication Manager

### DIFF
--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -457,6 +457,12 @@ impl GcpAuthorizer {
             project_id,
         })
     }
+    pub fn from_gcp_auth(manager: gcp_auth::AuthenticationManager, project_id: String) -> Self {
+        Self {
+            manager,
+            project_id,
+        }
+    }
 }
 
 #[cfg(feature = "gcp_auth")]


### PR DESCRIPTION
## Changes

In my project I am already using a gcp_auth for other Google APIs and would love to use the existing struct instead of authenticating with GCP twice. Additionally being able to specify the project ID separately is useful if my app needs to reach out to a different project than the default one.

I have added a simple function that just creates the `Authenticator` from an existing `AuthenticationManager`

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
