### PR TITLE
Create tracer using a shared instrumentation library

### DIFF
--- a/opentelemetry-api/src/common.rs
+++ b/opentelemetry-api/src/common.rs
@@ -464,7 +464,7 @@ pub struct InstrumentationLibrary {
     pub schema_url: Option<Cow<'static, str>>,
 
     /// Specifies the instrumentation scope attributes to associate with emitted telemetry.
-    pub attributes: Option<Vec<KeyValue>>,
+    pub attributes: Vec<KeyValue>,
 }
 
 // Uniqueness for InstrumentationLibrary/InstrumentationScope does not depend on attributes
@@ -498,7 +498,7 @@ impl InstrumentationLibrary {
             name: name.into(),
             version: version.map(Into::into),
             schema_url: schema_url.map(Into::into),
-            attributes,
+            attributes: attributes.unwrap_or_default(),
         }
     }
 }

--- a/opentelemetry-api/src/trace/noop.rs
+++ b/opentelemetry-api/src/trace/noop.rs
@@ -5,12 +5,10 @@
 //! to have minimal resource utilization and runtime impact.
 use crate::{
     propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
-    trace,
-    trace::{TraceContextExt, TraceFlags, TraceState},
-    Context, KeyValue,
+    trace::{self, TraceContextExt, TraceFlags, TraceState},
+    Context, InstrumentationLibrary, KeyValue,
 };
-use std::borrow::Cow;
-use std::time::SystemTime;
+use std::{borrow::Cow, sync::Arc, time::SystemTime};
 
 /// A no-op instance of a `TracerProvider`.
 #[derive(Clone, Debug, Default)]
@@ -29,13 +27,7 @@ impl trace::TracerProvider for NoopTracerProvider {
     type Tracer = NoopTracer;
 
     /// Returns a new `NoopTracer` instance.
-    fn versioned_tracer(
-        &self,
-        _name: impl Into<Cow<'static, str>>,
-        _version: Option<impl Into<Cow<'static, str>>>,
-        _schema_url: Option<impl Into<Cow<'static, str>>>,
-        _attributes: Option<Vec<KeyValue>>,
-    ) -> Self::Tracer {
+    fn library_tracer(&self, _library: Arc<InstrumentationLibrary>) -> Self::Tracer {
         NoopTracer::new()
     }
 }

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -135,14 +135,17 @@ impl opentelemetry_api::trace::TracerProvider for TracerProvider {
         } else {
             name
         };
-        let instrumentation_lib = Arc::new(InstrumentationLibrary::new(
+
+        self.library_tracer(Arc::new(InstrumentationLibrary::new(
             component_name,
             version,
             schema_url,
             attributes,
-        ));
+        )))
+    }
 
-        Tracer::new(instrumentation_lib, Arc::downgrade(&self.inner))
+    fn library_tracer(&self, library: Arc<InstrumentationLibrary>) -> Self::Tracer {
+        Tracer::new(library, Arc::downgrade(&self.inner))
     }
 }
 


### PR DESCRIPTION
Would like to submit this for review/comments...

I noticed two things regarding creating tracers:
1. a lot of repetition in passing around the following:
```rust
        name: Cow<'static, str>,
        version: Option<Cow<'static, str>>,
        schema_url: Option<Cow<'static, str>>,
        attributes: Option<Vec<KeyValue>>,
```
2. the inability of a user to use a shared `InstrumentationLibrary` to create tracers at multiple different places.  IOW, user can now have a lazy static `InstrumentationLibrary` and hopefully in the future could use it for tracing as well as metrics.

## Changes

Rather than have the SDK be the only place that creates the `InstrumentationLibrary` internal to its `versioned_tracer` implementation, it now can accept one from the user.

The debatable part is how I did this to minimize disruption. I added a new `library_tracer` function to the `global::TracerProvider` api trait and then default-implemented the existing `versioned_tracer` to defer to the new function.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
