### PR TITLE
fix: replace `futures` crates with `futures-*` crates.

### DIFF
--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 base64_format = ["base64", "binary_propagator"]
 binary_propagator = []
-jaeger_json_exporter = ["serde_json", "futures", "async-trait", "opentelemetry-semantic-conventions"]
+jaeger_json_exporter = ["serde_json", "futures-core", "futures-util", "async-trait", "opentelemetry-semantic-conventions"]
 rt-tokio = ["tokio", "opentelemetry/rt-tokio"]
 rt-tokio-current-thread = ["tokio", "opentelemetry/rt-tokio-current-thread"]
 rt-async-std = ["async-std", "opentelemetry/rt-async-std"]
@@ -31,13 +31,16 @@ rt-async-std = ["async-std", "opentelemetry/rt-async-std"]
 async-std = { version = "1.10", optional = true }
 async-trait = { version = "0.1", optional = true }
 base64 = { version = "0.13", optional = true }
-futures = { version = "0.3", optional = true }
 once_cell = "1.17.1"
 opentelemetry = { version = "0.19", path = "../opentelemetry", features = ["trace"] }
 opentelemetry_api = { version = "0.19", path = "../opentelemetry-api" }
 opentelemetry-semantic-conventions = { version = "0.11", path = "../opentelemetry-semantic-conventions", optional = true }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.0", features = ["fs", "io-util"], optional = true }
+
+# futures
+futures-core = { version = "0.3", optional = true }
+futures-util = { version = "0.3", optional = true }
 
 [dev-dependencies]
 base64 = "0.13"

--- a/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
+++ b/opentelemetry-contrib/src/trace/exporter/jaeger_json.rs
@@ -2,7 +2,8 @@
 //!
 
 use async_trait::async_trait;
-use futures::{future::BoxFuture, FutureExt};
+use futures_core::future::BoxFuture;
+use futures_util::FutureExt;
 use opentelemetry::runtime::RuntimeChannel;
 use opentelemetry::sdk::export::trace::{ExportResult, SpanData, SpanExporter};
 use opentelemetry::sdk::trace::{BatchMessage, Tracer};

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -23,9 +23,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 async-std = { version = "1.10.0", optional = true }
 async-trait = "0.1"
 base64 = { version = "0.21.0", optional = true }
-futures = "0.3"
-futures-util = { version = "0.3", default-features = false, features = ["std"], optional = true }
-futures-executor = "0.3"
 headers = { version = "0.3.2", optional = true }
 http = { version = "0.2", optional = true }
 hyper = { version = "0.14", default-features = false, features = ["client"], optional = true }
@@ -46,6 +43,11 @@ wasm-bindgen-futures = { version = "0.4.18", optional = true }
 tonic = { version = "0.9.0", optional = true }
 prost = { version = "0.11.6", optional = true }
 prost-types = { version = "0.11.6", optional = true }
+
+# Futures
+futures-executor = { version = "0.3", default-features = false, features = ["std"], optional = true }
+futures-core = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std", "alloc"]}
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["net", "sync"] }
@@ -93,7 +95,6 @@ reqwest_rustls_collector_client = ["reqwest", "reqwest/rustls-tls-native-roots",
 surf_collector_client = ["surf", "collector_client", "opentelemetry-http/surf"]
 wasm_collector_client = [
     "base64",
-    "futures-util",
     "http",
     "js-sys",
     "pin-project-lite",

--- a/opentelemetry-jaeger/src/exporter/config/agent.rs
+++ b/opentelemetry-jaeger/src/exporter/config/agent.rs
@@ -381,9 +381,9 @@ impl AgentPipeline {
             self.auto_split_batch,
         )
         .map_err::<Error, _>(Into::into)?;
-        Ok(Arc::new(AsyncUploader::Agent(futures::lock::Mutex::new(
-            agent,
-        ))))
+        Ok(Arc::new(AsyncUploader::Agent(
+            futures_util::lock::Mutex::new(agent),
+        )))
     }
 
     fn build_sync_agent_uploader(self) -> Result<Arc<dyn Uploader>, TraceError> {

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -18,7 +18,7 @@ use std::convert::TryFrom;
 
 use self::runtime::JaegerTraceRuntime;
 use self::thrift::jaeger;
-use futures::future::BoxFuture;
+use futures_core::future::BoxFuture;
 use std::convert::TryInto;
 use std::fmt::Display;
 use std::io;

--- a/opentelemetry-jaeger/src/exporter/uploader.rs
+++ b/opentelemetry-jaeger/src/exporter/uploader.rs
@@ -41,7 +41,7 @@ impl Uploader for SyncUploader {
 #[derive(Debug)]
 pub(crate) enum AsyncUploader<R: JaegerTraceRuntime> {
     /// Agent async client
-    Agent(futures::lock::Mutex<agent::AgentAsyncClientUdp<R>>),
+    Agent(futures_util::lock::Mutex<agent::AgentAsyncClientUdp<R>>),
     /// Collector sync client
     #[cfg(feature = "collector_client")]
     Collector(collector::AsyncHttpClient),

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -30,10 +30,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait = "0.1"
-futures = { version = "0.3", default-features = false, features = ["std"] }
-
+futures-core = "0.3"
 opentelemetry-proto = { version = "0.2", path = "../opentelemetry-proto", default-features = false }
-
 grpcio = { version = "0.12", optional = true }
 opentelemetry_api = { version = "0.19", default-features = false, path = "../opentelemetry-api" }
 opentelemetry_sdk = { version = "0.19", default-features = false, path = "../opentelemetry-sdk" }
@@ -57,6 +55,7 @@ tokio-stream = { version = "0.1", features = ["net"] }
 opentelemetry_sdk = { features = ["trace", "rt-tokio", "testing"], path = "../opentelemetry-sdk" }
 time = { version = "0.3", features = ["macros"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+futures = { version = "0.3", default-features = false, features = ["std"] }
 
 [features]
 # telemetry pillars and functions

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -65,6 +65,7 @@ use opentelemetry_sdk::{
 use opentelemetry_semantic_conventions::SCHEMA_URL;
 
 use async_trait::async_trait;
+use futures_core::future::BoxFuture;
 use sdk::runtime::RuntimeChannel;
 
 /// Target to which the exporter is going to send spans, defaults to https://localhost:4317/v1/traces.
@@ -507,10 +508,7 @@ async fn http_send_request(
 
 #[async_trait]
 impl opentelemetry_sdk::export::trace::SpanExporter for SpanExporter {
-    fn export(
-        &mut self,
-        batch: Vec<SpanData>,
-    ) -> futures::future::BoxFuture<'static, ExportResult> {
+    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
         match self {
             #[cfg(feature = "grpc-sys")]
             SpanExporter::Grpcio {

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -31,7 +31,7 @@ full = ["gen-tonic", "gen-protoc", "traces", "logs", "metrics", "zpages", "with-
 # crates used to generate rs files
 gen-tonic = ["gen-tonic-messages", "tonic/transport"]
 gen-tonic-messages = ["tonic", "prost"]
-gen-protoc = ["grpcio", "protobuf"]
+gen-protoc = ["grpcio", "protobuf", "futures"]
 
 # telemetry pillars and functions
 traces = []
@@ -49,7 +49,7 @@ prost = { version = "0.11.0", optional = true }
 protobuf = { version = "2.18", optional = true } # todo: update to 3.0 so we have docs for generated types.
 opentelemetry_api = { version = "0.19", default-features = false, features = ["trace", "metrics", "logs"], path = "../opentelemetry-api" }
 opentelemetry_sdk = { version = "0.19", default-features = false, features = ["trace", "metrics", "logs"], path = "../opentelemetry-sdk" }
-futures = { version = "0.3", default-features = false, features = ["std"] }
+futures = { version = "0.3", default-features = false, features = ["std"], optional = true } # cannot use futures-* crates as it's in generated code when working with grpcio
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -11,7 +11,6 @@ rust-version = "1.60"
 
 [dependencies]
 async-trait = "0.1.48"
-futures = { version = "0.3", default-features = false, features = ["alloc"] }
 gcp_auth = { version = "0.8", optional = true }
 hex = "0.4"
 http = "0.2"
@@ -25,6 +24,11 @@ thiserror = "1.0.30"
 tonic = { version = "0.9.0", features = ["gzip", "tls", "transport"] }
 yup-oauth2 = { version = "8.1.0", optional = true }
 
+# Futures
+futures-core = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-channel = { version = "0.3", default-features = false, features = ["std"] }
+
 [features]
 default = ["yup-authorizer", "tls-native-roots"]
 yup-authorizer = ["hyper-rustls", "yup-oauth2"]
@@ -37,3 +41,4 @@ tempfile = "3.3.0"
 tokio = "1"
 tonic-build = "0.9.0"
 walkdir = "2.3.2"
+futures = "0.3"

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -22,7 +22,8 @@ use std::{
 };
 
 use async_trait::async_trait;
-use futures::{future::BoxFuture, stream::StreamExt};
+use futures_core::future::BoxFuture;
+use futures_util::stream::StreamExt;
 use opentelemetry::{
     global::handle_error,
     sdk::{
@@ -75,7 +76,7 @@ use proto::rpc::Status;
 /// so this struct does not send link information.
 #[derive(Clone)]
 pub struct StackDriverExporter {
-    tx: futures::channel::mpsc::Sender<Vec<SpanData>>,
+    tx: futures_channel::mpsc::Sender<Vec<SpanData>>,
     pending_count: Arc<AtomicUsize>,
     maximum_shutdown_duration: Duration,
 }
@@ -196,7 +197,7 @@ impl Builder {
             None => None,
         };
 
-        let (tx, rx) = futures::channel::mpsc::channel(64);
+        let (tx, rx) = futures_channel::mpsc::channel(64);
         let pending_count = Arc::new(AtomicUsize::new(0));
         let scopes = Arc::new(match log_client {
             Some(_) => vec![TRACE_APPEND, LOGGING_WRITE],

--- a/opentelemetry-stackdriver/tests/generate.rs
+++ b/opentelemetry-stackdriver/tests/generate.rs
@@ -4,8 +4,8 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use futures::stream::FuturesUnordered;
-use futures::stream::StreamExt;
+use futures_util::stream::FuturesUnordered;
+use futures_util::stream::StreamExt;
 use walkdir::WalkDir;
 
 /// Download the latest protobuf schemas from the Google APIs GitHub repository.


### PR DESCRIPTION
fix #1064

## Changes
- Replace all `futures` crate with `futures-*` creates unless they are dev dependencies

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes