### PR TITLE
Logs API/SDK - few perf improvements

### DIFF
--- a/opentelemetry-api/src/logs/logger.rs
+++ b/opentelemetry-api/src/logs/logger.rs
@@ -66,7 +66,7 @@ pub trait LoggerProvider {
     ///     Some("https://opentelemetry.io/schema/1.0.0"),
     ///     None,
     /// ));
-    /// let logger = provider.library_logger(library);
+    /// let logger = provider.library_logger(library, true);
     /// ```
     fn library_logger(
         &self,

--- a/opentelemetry-api/src/logs/logger.rs
+++ b/opentelemetry-api/src/logs/logger.rs
@@ -62,7 +62,7 @@ pub trait LoggerProvider {
     /// // logger used in libraries/crates that optionally includes version and schema url
     /// let library = std::sync::Arc::new(InstrumentationLibrary::new(
     ///     env!("CARGO_PKG_NAME"),
-    ///     Some(env!("CARGO_PKG_VERSION"))
+    ///     Some(env!("CARGO_PKG_VERSION")),
     ///     Some("https://opentelemetry.io/schema/1.0.0"),
     ///     None,
     /// ));

--- a/opentelemetry-api/src/logs/logger.rs
+++ b/opentelemetry-api/src/logs/logger.rs
@@ -53,7 +53,7 @@ pub trait LoggerProvider {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry_api::{global, InstrumentationLibrary, trace::LoggerProvider};
+    /// use opentelemetry_api::{global, InstrumentationLibrary, logs::LoggerProvider};
     ///
     /// let provider = global::logger_provider();
     ///

--- a/opentelemetry-api/src/logs/noop.rs
+++ b/opentelemetry-api/src/logs/noop.rs
@@ -1,8 +1,8 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 use crate::{
     logs::{LogRecord, Logger, LoggerProvider},
-    KeyValue,
+    InstrumentationLibrary, KeyValue,
 };
 
 /// A no-op implementation of a [`LoggerProvider`].
@@ -18,6 +18,14 @@ impl NoopLoggerProvider {
 
 impl LoggerProvider for NoopLoggerProvider {
     type Logger = NoopLogger;
+
+    fn library_logger(
+        &self,
+        _library: Arc<InstrumentationLibrary>,
+        _include_trace_context: bool,
+    ) -> Self::Logger {
+        NoopLogger(())
+    }
 
     fn versioned_logger(
         &self,

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -43,11 +43,23 @@ impl opentelemetry_api::logs::LoggerProvider for LoggerProvider {
             name
         };
 
-        Logger::new(
-            InstrumentationLibrary::new(component_name, version, schema_url, attributes),
-            Arc::downgrade(&self.inner),
+        self.library_logger(
+            Arc::new(InstrumentationLibrary::new(
+                component_name,
+                version,
+                schema_url,
+                attributes,
+            )),
             include_trace_context,
         )
+    }
+
+    fn library_logger(
+        &self,
+        library: Arc<InstrumentationLibrary>,
+        include_trace_context: bool,
+    ) -> Self::Logger {
+        Logger::new(library, Arc::downgrade(&self.inner), include_trace_context)
     }
 }
 
@@ -171,13 +183,13 @@ impl Builder {
 /// [`LogRecord`]: opentelemetry_api::logs::LogRecord
 pub struct Logger {
     include_trace_context: bool,
-    instrumentation_lib: InstrumentationLibrary,
+    instrumentation_lib: Arc<InstrumentationLibrary>,
     provider: Weak<LoggerProviderInner>,
 }
 
 impl Logger {
     pub(crate) fn new(
-        instrumentation_lib: InstrumentationLibrary,
+        instrumentation_lib: Arc<InstrumentationLibrary>,
         provider: Weak<LoggerProviderInner>,
         include_trace_context: bool,
     ) -> Self {
@@ -220,7 +232,7 @@ impl opentelemetry_api::logs::Logger for Logger {
             let data = LogData {
                 record,
                 resource: config.resource.clone(),
-                instrumentation: self.instrumentation_lib.clone(),
+                instrumentation: self.instrumentation_library().clone(),
             };
             processor.emit(data);
         }


### PR DESCRIPTION
Fixes #

## Changes

Few perf improvements in logs api/sdk picked from the recent changes in tracing api/sdk by @shaun-cox ( #1093 and #1129), so:

- change sdk:::Logger to hold Arc instead of whole InstrumentationLib instance, so cloning logger instance is much cheaper.
-  API to returns a new versioned logger with the given instrumentation library. This will allow user to share the instrumentation library with multiple loggers.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
