### PR TITLE
Tracing subscriber: handle string and bool values correctly.

### DIFF
--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -29,10 +29,8 @@ impl<'a> tracing::field::Visit for EventVisitor<'a> {
         if let Some(ref mut map) = self.log_record.attributes {
             map.insert(field.name().into(), value.to_owned().into());
         } else {
-            let mut map = OrderMap::with_capacity(1);
-            let k: Key = field.name().into();
-            let v: AnyValue = value.to_owned().into();
-            map.insert(k, v);
+            let mut map: OrderMap<Key, AnyValue> = OrderMap::with_capacity(1);
+            map.insert(field.name().into(), value.to_owned().into());
         }
     }
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -31,6 +31,7 @@ impl<'a> tracing::field::Visit for EventVisitor<'a> {
         } else {
             let mut map: OrderMap<Key, AnyValue> = OrderMap::with_capacity(1);
             map.insert(field.name().into(), value.to_owned().into());
+            self.log_record.attributes = Some(map);
         }
     }
 


### PR DESCRIPTION
## Changes

Override default implementation of `Visit::record_str()` and `Visit::record_bool()` to handle string and bool attribute values properly, instead of relying on `Visit::record_debug()`. This improves the performance of fetching these values from tracing crate.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
