### PR TITLE
Propagate periodicreader.shutdown() to the exporter

### DIFF
--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -539,7 +539,7 @@ impl PushMetricsExporter for MetricsExporter {
         Ok(())
     }
 
-    async fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> Result<()> {
         match self {
             #[cfg(feature = "grpc-tonic")]
             MetricsExporter::Tonic { sender, .. } => {

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Implement cardinality limits for metric streams
   [#1066](https://github.com/open-telemetry/opentelemetry-rust/pull/1066).
+- Propagate shutdown calls from `PeriodicReader` to metrics exporter
+  [#1066](https://github.com/open-telemetry/opentelemetry-rust/pull/1066).
 
 ### Removed
 

--- a/opentelemetry-sdk/src/metrics/exporter.rs
+++ b/opentelemetry-sdk/src/metrics/exporter.rs
@@ -26,10 +26,9 @@ pub trait PushMetricsExporter:
     /// Flushes any metric data held by an exporter.
     async fn force_flush(&self) -> Result<()>;
 
-    /// Flushes all metric data held by an exporter and releases any held
-    /// computational resources.
+    /// Releases any held computational resources.
     ///
     /// After Shutdown is called, calls to Export will perform no operation and
     /// instead will return an error indicating the shutdown state.
-    async fn shutdown(&self) -> Result<()>;
+    fn shutdown(&self) -> Result<()>;
 }

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -262,6 +262,7 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
             }
             Message::Shutdown(ch) => {
                 let res = self.collect_and_export().await;
+                let _ = self.reader.exporter.shutdown();
                 if ch.send(res).is_err() {
                     global::handle_error(MetricsError::Other("shutdown channel closed".into()))
                 }

--- a/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
@@ -298,7 +298,7 @@ impl PushMetricsExporter for InMemoryMetricsExporter {
         Ok(()) // In this implementation, flush does nothing
     }
 
-    async fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> Result<()> {
         self.metrics
             .lock()
             .map(|mut metrics_guard| metrics_guard.clear())

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -76,7 +76,7 @@ impl PushMetricsExporter for MetricsExporter {
         Ok(())
     }
 
-    async fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> Result<()> {
         self.writer.lock()?.take();
         Ok(())
     }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-rust/issues/1118

Removes `async` from PushMetricsExporter.shutdown(), similar to tracing and logging.