### PR TITLE
Add a method (and benchmark) to Context to speed up active span determination by 7x

### DIFF
--- a/opentelemetry-api/src/propagation/text_map_propagator.rs
+++ b/opentelemetry-api/src/propagation/text_map_propagator.rs
@@ -18,7 +18,7 @@ pub trait TextMapPropagator: Debug {
     /// [`Context`]: crate::Context
     /// [`Injector`]: crate::propagation::Injector
     fn inject(&self, injector: &mut dyn Injector) {
-        self.inject_context(&Context::current(), injector)
+        Context::map_current(|cx| self.inject_context(cx, injector))
     }
 
     /// Properly encodes the values of the [`Context`] and injects them into the
@@ -35,7 +35,7 @@ pub trait TextMapPropagator: Debug {
     /// [`Context`]: crate::Context
     /// [`Injector`]: crate::propagation::Extractor
     fn extract(&self, extractor: &dyn Extractor) -> Context {
-        self.extract_with_context(&Context::current(), extractor)
+        Context::map_current(|cx| self.extract_with_context(cx, extractor))
     }
 
     /// Retrieves encoded data using the provided [`Extractor`]. If no data for this

--- a/opentelemetry-api/src/trace/tracer.rs
+++ b/opentelemetry-api/src/trace/tracer.rs
@@ -169,7 +169,7 @@ pub trait Tracer {
 
     /// Start a [`Span`] from a [`SpanBuilder`].
     fn build(&self, builder: SpanBuilder) -> Self::Span {
-        self.build_with_context(builder, &Context::current())
+        Context::map_current(|cx| self.build_with_context(builder, cx))
     }
 
     /// Start a span from a [`SpanBuilder`] with a parent context.
@@ -382,7 +382,7 @@ impl SpanBuilder {
 
     /// Builds a span with the given tracer from this configuration.
     pub fn start<T: Tracer>(self, tracer: &T) -> T::Span {
-        tracer.build_with_context(self, &Context::current())
+        Context::map_current(|cx| tracer.build_with_context(self, cx))
     }
 
     /// Builds a span with the given tracer from this configuration and parent.

--- a/opentelemetry-api/src/trace/tracer.rs
+++ b/opentelemetry-api/src/trace/tracer.rs
@@ -136,7 +136,7 @@ pub trait Tracer {
     where
         T: Into<Cow<'static, str>>,
     {
-        self.build_with_context(SpanBuilder::from_name(name), &Context::current())
+        Context::map_current(|cx| self.start_with_context(name, cx))
     }
 
     /// Starts a new [`Span`] with a given context.

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -37,8 +37,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
 indexmap = "1.8"
-criterion = { version = "0.4.0", features = ["html_reports"] }
-pprof = { version = "0.11.1", features = ["flamegraph", "criterion"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+pprof = { version = "0.12", features = ["flamegraph", "criterion"] }
 
 [features]
 default = ["trace"]

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -52,6 +52,10 @@ rt-tokio-current-thread = ["tokio", "tokio-stream"]
 rt-async-std = ["async-std"]
 
 [[bench]]
+name = "context"
+harness = false
+
+[[bench]]
 name = "key_value_map"
 harness = false
 

--- a/opentelemetry-sdk/benches/context.rs
+++ b/opentelemetry-sdk/benches/context.rs
@@ -1,0 +1,94 @@
+use std::fmt::Display;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use futures_util::future::BoxFuture;
+use opentelemetry_api::{
+    trace::{TraceContextExt, Tracer, TracerProvider},
+    Context,
+};
+use opentelemetry_sdk::{
+    export::trace::{ExportResult, SpanData, SpanExporter},
+    trace as sdktrace,
+};
+use pprof::criterion::{Output, PProfProfiler};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    benchmark_group(c, BenchmarkParameter::NoActiveSpan);
+    benchmark_group(c, BenchmarkParameter::WithActiveSpan);
+}
+
+fn benchmark_group(c: &mut Criterion, p: BenchmarkParameter) {
+    let _guard = match p {
+        BenchmarkParameter::NoActiveSpan => None,
+        BenchmarkParameter::WithActiveSpan => {
+            let (provider, tracer) = tracer();
+            let guard = Context::current_with_span(tracer.start("span")).attach();
+            Some((guard, provider))
+        }
+    };
+
+    let mut group = c.benchmark_group("context");
+
+    group.bench_function(BenchmarkId::new("baseline current()", p), |b| {
+        b.iter(|| {
+            black_box(Context::current());
+        })
+    });
+
+    group.bench_function(BenchmarkId::new("current().has_active_span()", p), |b| {
+        b.iter(|| {
+            black_box(Context::current().has_active_span());
+        })
+    });
+
+    group.bench_function(
+        BenchmarkId::new("map_current(|cx| cx.has_active_span())", p),
+        |b| {
+            b.iter(|| {
+                black_box(Context::map_current(|cx| cx.has_active_span()));
+            })
+        },
+    );
+
+    group.finish();
+}
+
+#[derive(Copy, Clone)]
+enum BenchmarkParameter {
+    NoActiveSpan,
+    WithActiveSpan,
+}
+
+impl Display for BenchmarkParameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            BenchmarkParameter::NoActiveSpan => write!(f, "no-active-span"),
+            BenchmarkParameter::WithActiveSpan => write!(f, "with-active-span"),
+        }
+    }
+}
+
+fn tracer() -> (sdktrace::TracerProvider, sdktrace::Tracer) {
+    let provider = sdktrace::TracerProvider::builder()
+        .with_config(sdktrace::config().with_sampler(sdktrace::Sampler::AlwaysOn))
+        .with_simple_exporter(NoopExporter)
+        .build();
+    let tracer = provider.tracer(module_path!());
+    (provider, tracer)
+}
+
+#[derive(Debug)]
+struct NoopExporter;
+
+impl SpanExporter for NoopExporter {
+    fn export(&mut self, _spans: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+        Box::pin(futures_util::future::ready(Ok(())))
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/opentelemetry-sdk/src/propagation/trace_context.rs
+++ b/opentelemetry-sdk/src/propagation/trace_context.rs
@@ -282,7 +282,7 @@ mod tests {
         let mut injector: HashMap<String, String> = HashMap::new();
         injector.set(TRACESTATE_HEADER, state.to_string());
 
-        propagator.inject_context(&Context::current(), &mut injector);
+        Context::map_current(|cx| propagator.inject_context(cx, &mut injector));
 
         assert_eq!(Extractor::get(&injector, TRACESTATE_HEADER), Some(state))
     }

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -368,15 +368,16 @@ mod tests {
         let span = tracer.span_builder("must_not_be_sampled").start(&tracer);
         assert!(!span.span_context().is_sampled());
 
-        let _attached = Context::current()
-            .with_remote_span_context(SpanContext::new(
+        let context = Context::map_current(|cx| {
+            cx.with_remote_span_context(SpanContext::new(
                 TraceId::from_u128(1),
                 SpanId::from_u64(1),
                 TraceFlags::default(),
                 true,
                 Default::default(),
             ))
-            .attach();
+        });
+        let _attached = context.attach();
         let span = tracer.span_builder("must_not_be_sampled").start(&tracer);
 
         assert!(!span.span_context().is_sampled());


### PR DESCRIPTION
In my use case for tracing instrumentation, I only want to pay the costs of creating a new context with a new span if the current context contains an active span, but I find the current cost associated with simply checking for this condition to be unacceptably high.

Simply calling `Context::current().has_active_span()` does the following:
- clones the current context (thus cloning the contained HashMap, copying type ids and incrementing Arcs of the values)
- if the context does contain a span, atomically increments the Arc value in the HashMap
- invokes has_active_span() which checks to see if entry exists 
- drops the cloned context (thus invoking drop for the contained HashMap, decrementing Arcs of any values)

## Changes

I added a generic method to `Context` called `map_current` which, instead of cloning, allows the caller to pass a lambda to be invoked with a reference to the current context (if any) and returns a value of some type of their choosing.

With this facility, checking for an active span can look like:

```rust
Context::map_current(|cx| cx.has_active_span())
```

I added a benchmark to demonstrate the cost difference, and it is substantial.

![violin](https://github.com/open-telemetry/opentelemetry-rust/assets/30703437/6e7ed264-82a9-4505-836f-2b18963886af)

I think this new API feels like a bit of a hack compared with the completely idiomatic way of getting the current context in the first place, which would more resemble:

```rust
impl Context {
   pub fn current() -> Option<&Context>
...
```

were it not for the obvious lifetime issue of the returned reference.  So I took the standard `map` approach of using the lambda's scope to work with the valid reference to the current context and let the caller algebraically build up whatever construct they'd like to return.

I also think there is this tension between the OpenTelemetry spec, which seems to bias/favor towards full-blown "empty" values (e.g. `Context::default()` or `NoopSpan`) to represent something that is "absent", rather than promoting the powerful facilities of the particular language binding (e.g. `Option<Context>` or `Option<Span>`). This is related to #1089, for example.

I would like to see us continue to improve the idiomatic aspects of this Rust binding of the OpenTelemetry API with the goal of having this binding be the absolute highest performing one out there among them all. I think that embracing algebraic types more is key to achieving this.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
