### PR TITLE
Extend deprecation note on Dynatrace metrics exporter

### DIFF
--- a/opentelemetry-dynatrace/README.md
+++ b/opentelemetry-dynatrace/README.md
@@ -2,17 +2,35 @@
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png
 
-# OpenTelemetry Dynatrace
+# Dynatrace
 
-[`Dynatrace`] integration for applications instrumented with [`OpenTelemetry`].
+[Dynatrace](https://www.dynatrace.com/integrations/opentelemetry) supports native
+OpenTelemetry protocol (OTLP) ingest for traces, metrics and logs.
+All signals can be sent directly to Dynatrace via **OTLP protobuf over HTTP**
+using the built-in OTLP/HTTP Exporter available in the OpenTelemetry Rust SDK.
+More information on configuring your Rust applications to use the OTLP exporter can be found in the
+[Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/otel-wt-rust).
 
+## Dynatrace OpenTelemetry Metrics Exporter for Rust 
+
+![Static Badge](https://img.shields.io/badge/status-deprecated-orange)
 [![Crates.io: opentelemetry-dynatrace](https://img.shields.io/crates/v/opentelemetry-dynatrace.svg)](https://crates.io/crates/opentelemetry-dynatrace)
 [![Documentation](https://docs.rs/opentelemetry-dynatrace/badge.svg)](https://docs.rs/opentelemetry-dynatrace)
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry-dynatrace)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
-## Overview
+> **Warning**
+> Dynatrace supports native OpenTelemetry protocol (OTLP) ingest for traces, metrics and logs.
+> Therefore, the proprietary Dynatrace OpenTelemetry metrics exporter is deprecated in favor of exporting via OTLP/HTTP.
+>
+> The exporter is still available but after the end of 2023, no support, updates, or compatibility with newer OTel versions will be provided.
+>
+> Please refer to the [migration guide](https://www.dynatrace.com/support/help/shortlink/migrating-dynatrace-metrics-exporter-otlp-exporter#migrate-applications) for instructions on how to migrate to the OTLP HTTP exporter, as well as reasoning and benefits for this transition.
+>
+> For an example on how to configure the OTLP exporter in a Rust application, check out the [Rust integration walk-through](https://www.dynatrace.com/support/help/shortlink/otel-wt-rust) page in the Dynatrace documentation.
+
+### Overview
 
 [`OpenTelemetry`] is a collection of tools, APIs, and SDKs used to instrument,
 generate, collect, and export telemetry data (metrics, logs, and traces) for
@@ -20,14 +38,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides additional propagators and exporters for sending telemetry data
 to [`Dynatrace`].
 
-> **Warning**
-> This exporter is deprecated.
-> Dynatrace supports ingesting Traces and Metrics natively via OTLP, and therefore these should be sent directly to Dynatrace via **OTLP protobuf over HTTP** using the built-in [`opentelemetry-otlp`] exporter instead.
-> See the [Dynatrace documentation for Rust] and the [Dynatrace documentation for ingesting metrics via OTLP] for details.
-
-[Dynatrace documentation for ingesting metrics via OTLP]: https://www.dynatrace.com/support/help/shortlink/send-metrics-via-otlp-exporter
-
-## Exporter features
+### Exporter features
 
 * **Metrics** - Ingest metric data to Dynatrace using the [Dynatrace Metrics ingestion protocol].
 
@@ -45,7 +56,7 @@ state of the OpenTelemetry SDK for Rust.
 [Dynatrace documentation for Rust]: https://www.dynatrace.com/support/help/shortlink/opent-rust
 [`open-telemetry/opentelemetry-rust`]: https://github.com/open-telemetry/opentelemetry-rust
 
-### Examples
+#### Examples
 
 The examples directory contains an [advanced example](../examples/dynatrace) 
 showing the ingestion of trace data and metric data together.
@@ -53,7 +64,7 @@ showing the ingestion of trace data and metric data together.
 [`opentelemetry-otlp`]: https://crates.io/crates/opentelemetry-otlp
 [`opentelemetry-dynatrace`]: https://crates.io/crates/opentelemetry-dynatrace
 
-## Performance
+### Performance
 
 For optimal performance, a batch exporter is used. You can enable the `rt-tokio` 
 feature flag to use the [`tokio`] runtime, or enable the `rt-async-std` feature 
@@ -63,7 +74,7 @@ you automatically.
 [`tokio`]: https://tokio.rs
 [`async-std`]: https://async.rs
 
-## Choosing an HTTP client
+### Choosing an HTTP client
 
 The HTTP client that this exporter will use can be overridden with feature 
 flags. By default the `reqwest-client` feature flag is enabled which will use 
@@ -82,7 +93,7 @@ You can also configure your own http client implementation using the `HttpClient
 [`isahc`]: https://docs.rs/isahc/latest/isahc/
 [`surf`]: https://docs.rs/surf/latest/surf/
 
-## WebAssembly
+### WebAssembly
 
 WebAssembly support can be enabled with the `wasm` feature flag.
 


### PR DESCRIPTION
## Changes

This PR extends the deprecation notice added in https://github.com/open-telemetry/opentelemetry-rust/pull/1113 with links to the Dynatrace documentation on how to migrate to the OTLP HTTP exporter, as well as other minor details.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] ~~Unit tests added/updated (if applicable)~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes~~ (previously added changelog still applies.
* [ ] ~~Changes in public API reviewed (if applicable)~~
