### PR TITLE
[Logs SDK] Modify LogRecord to use Vector instead of OrderMap for attributes

### DIFF
--- a/opentelemetry-api/src/logs/record.rs
+++ b/opentelemetry-api/src/logs/record.rs
@@ -342,12 +342,11 @@ impl LogRecordBuilder {
         K: Into<Key>,
         V: Into<AnyValue>,
     {
-        if let Some(ref mut map) = self.record.attributes {
-            map.push((key.into(), value.into()));
+        if let Some(ref mut vec) = self.record.attributes {
+            vec.push((key.into(), value.into()));
         } else {
-            let mut map = Vec::with_capacity(1);
-            map.push((key.into(), value.into()));
-            self.record.attributes = Some(map);
+            let vec = vec![(key.into(), value.into())];
+            self.record.attributes = Some(vec);
         }
 
         self

--- a/opentelemetry-api/src/logs/record.rs
+++ b/opentelemetry-api/src/logs/record.rs
@@ -326,7 +326,8 @@ impl LogRecordBuilder {
         }
     }
 
-    /// Assign attributes, overriding previously set attributes
+    /// Assign attributes. 
+    /// The SDK doesn't carry on any deduplication on these attributes.
     pub fn with_attributes(self, attributes: Vec<(Key, AnyValue)>) -> Self {
         Self {
             record: LogRecord {
@@ -336,7 +337,8 @@ impl LogRecordBuilder {
         }
     }
 
-    /// Set a single attribute for this record
+    /// Set a single attribute for this record.
+    /// The SDK doesn't carry on any deduplication on these attributes.
     pub fn with_attribute<K, V>(mut self, key: K, value: V) -> Self
     where
         K: Into<Key>,

--- a/opentelemetry-api/src/logs/record.rs
+++ b/opentelemetry-api/src/logs/record.rs
@@ -326,7 +326,7 @@ impl LogRecordBuilder {
         }
     }
 
-    /// Assign attributes. 
+    /// Assign attributes.
     /// The SDK doesn't carry on any deduplication on these attributes.
     pub fn with_attributes(self, attributes: Vec<(Key, AnyValue)>) -> Self {
         Self {

--- a/opentelemetry-api/src/logs/record.rs
+++ b/opentelemetry-api/src/logs/record.rs
@@ -27,7 +27,7 @@ pub struct LogRecord {
     pub body: Option<AnyValue>,
 
     /// Additional attributes associated with this record
-    pub attributes: Option<OrderMap<Key, AnyValue>>,
+    pub attributes: Option<Vec<(Key, AnyValue)>>,
 }
 
 impl LogRecord {
@@ -327,7 +327,7 @@ impl LogRecordBuilder {
     }
 
     /// Assign attributes, overriding previously set attributes
-    pub fn with_attributes(self, attributes: OrderMap<Key, AnyValue>) -> Self {
+    pub fn with_attributes(self, attributes: Vec<(Key, AnyValue)>) -> Self {
         Self {
             record: LogRecord {
                 attributes: Some(attributes),
@@ -343,10 +343,10 @@ impl LogRecordBuilder {
         V: Into<AnyValue>,
     {
         if let Some(ref mut map) = self.record.attributes {
-            map.insert(key.into(), value.into());
+            map.push((key.into(), value.into()));
         } else {
-            let mut map = OrderMap::with_capacity(1);
-            map.insert(key.into(), value.into());
+            let mut map = Vec::with_capacity(1);
+            map.push((key.into(), value.into()));
             self.record.attributes = Some(map);
         }
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,7 +1,6 @@
-use opentelemetry_api::{
-    logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    Key,
-};
+use std::vec;
+
+use opentelemetry_api::logs::{LogRecord, Logger, LoggerProvider, Severity};
 
 use tracing_subscriber::Layer;
 
@@ -16,52 +15,47 @@ impl<'a> tracing::field::Visit for EventVisitor<'a> {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         if field.name() == "message" {
             self.log_record.body = Some(format!("{value:?}").into());
-        } else if let Some(ref mut map) = self.log_record.attributes {
-            map.push((field.name().into(), format!("{value:?}").into()));
+        } else if let Some(ref mut vec) = self.log_record.attributes {
+            vec.push((field.name().into(), format!("{value:?}").into()));
         } else {
-            let mut map = Vec::with_capacity(1);
-            map.push((field.name().into(), format!("{value:?}").into()));
-            self.log_record.attributes = Some(map);
+            let vec = vec![(field.name().into(), format!("{value:?}").into())];
+            self.log_record.attributes = Some(vec);
         }
     }
 
     fn record_str(&mut self, field: &tracing_core::Field, value: &str) {
-        if let Some(ref mut map) = self.log_record.attributes {
-            map.push((field.name().into(), value.to_owned().into()));
+        if let Some(ref mut vec) = self.log_record.attributes {
+            vec.push((field.name().into(), value.to_owned().into()));
         } else {
-            let mut map: Vec<(Key, AnyValue)> = Vec::with_capacity(1);
-            map.push((field.name().into(), value.to_owned().into()));
-            self.log_record.attributes = Some(map);
+            let vec = vec![(field.name().into(), value.to_owned().into())];
+            self.log_record.attributes = Some(vec);
         }
     }
 
     fn record_bool(&mut self, field: &tracing_core::Field, value: bool) {
-        if let Some(ref mut map) = self.log_record.attributes {
-            map.push((field.name().into(), value.into()));
+        if let Some(ref mut vec) = self.log_record.attributes {
+            vec.push((field.name().into(), value.into()));
         } else {
-            let mut map = Vec::with_capacity(1);
-            map.push((field.name().into(), value.into()));
-            self.log_record.attributes = Some(map);
+            let vec = vec![(field.name().into(), value.into())];
+            self.log_record.attributes = Some(vec);
         }
     }
 
     fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
-        if let Some(ref mut map) = self.log_record.attributes {
-            map.push((field.name().into(), value.into()));
+        if let Some(ref mut vec) = self.log_record.attributes {
+            vec.push((field.name().into(), value.into()));
         } else {
-            let mut map = Vec::with_capacity(1);
-            map.push((field.name().into(), value.into()));
-            self.log_record.attributes = Some(map);
+            let vec = vec![(field.name().into(), value.into())];
+            self.log_record.attributes = Some(vec);
         }
     }
 
     fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
-        if let Some(ref mut map) = self.log_record.attributes {
-            map.push((field.name().into(), value.into()));
+        if let Some(ref mut vec) = self.log_record.attributes {
+            vec.push((field.name().into(), value.into()));
         } else {
-            let mut map = Vec::with_capacity(1);
-            map.push((field.name().into(), value.into()));
-            self.log_record.attributes = Some(map);
+            let vec = vec![(field.name().into(), value.into())];
+            self.log_record.attributes = Some(vec);
         }
     }
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,6 +1,6 @@
 use opentelemetry_api::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    Key, OrderMap,
+    Key,
 };
 
 use tracing_subscriber::Layer;
@@ -17,50 +17,50 @@ impl<'a> tracing::field::Visit for EventVisitor<'a> {
         if field.name() == "message" {
             self.log_record.body = Some(format!("{value:?}").into());
         } else if let Some(ref mut map) = self.log_record.attributes {
-            map.insert(field.name().into(), format!("{value:?}").into());
+            map.push((field.name().into(), format!("{value:?}").into()));
         } else {
-            let mut map = OrderMap::with_capacity(1);
-            map.insert(field.name().into(), format!("{value:?}").into());
+            let mut map = Vec::with_capacity(1);
+            map.push((field.name().into(), format!("{value:?}").into()));
             self.log_record.attributes = Some(map);
         }
     }
 
     fn record_str(&mut self, field: &tracing_core::Field, value: &str) {
         if let Some(ref mut map) = self.log_record.attributes {
-            map.insert(field.name().into(), value.to_owned().into());
+            map.push((field.name().into(), value.to_owned().into()));
         } else {
-            let mut map: OrderMap<Key, AnyValue> = OrderMap::with_capacity(1);
-            map.insert(field.name().into(), value.to_owned().into());
+            let mut map: Vec<(Key, AnyValue)> = Vec::with_capacity(1);
+            map.push((field.name().into(), value.to_owned().into()));
             self.log_record.attributes = Some(map);
         }
     }
 
     fn record_bool(&mut self, field: &tracing_core::Field, value: bool) {
         if let Some(ref mut map) = self.log_record.attributes {
-            map.insert(field.name().into(), value.into());
+            map.push((field.name().into(), value.into()));
         } else {
-            let mut map = OrderMap::with_capacity(1);
-            map.insert(field.name().into(), value.into());
+            let mut map = Vec::with_capacity(1);
+            map.push((field.name().into(), value.into()));
             self.log_record.attributes = Some(map);
         }
     }
 
     fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
         if let Some(ref mut map) = self.log_record.attributes {
-            map.insert(field.name().into(), value.into());
+            map.push((field.name().into(), value.into()));
         } else {
-            let mut map = OrderMap::with_capacity(1);
-            map.insert(field.name().into(), value.into());
+            let mut map = Vec::with_capacity(1);
+            map.push((field.name().into(), value.into()));
             self.log_record.attributes = Some(map);
         }
     }
 
     fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
         if let Some(ref mut map) = self.log_record.attributes {
-            map.insert(field.name().into(), value.into());
+            map.push((field.name().into(), value.into()));
         } else {
-            let mut map = OrderMap::with_capacity(1);
-            map.insert(field.name().into(), value.into());
+            let mut map = Vec::with_capacity(1);
+            map.push((field.name().into(), value.into()));
             self.log_record.attributes = Some(map);
         }
     }

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -221,7 +221,7 @@ impl UserEventsExporter {
                 let (mut event_id, mut event_name) = (0, "");
                 let mut event_count = 0;
                 if log_data.record.attributes.is_some() {
-                    for (k, v) in log_data.record.attributes.as_ref().unwrap().into_iter() {
+                    for (k, v) in log_data.record.attributes.as_ref().unwrap().iter() {
                         if k.as_str() == EVENT_ID {
                             event_id = match v {
                                 AnyValue::Int(value) => {

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -107,22 +107,22 @@ impl UserEventsExporter {
     fn add_attributes_to_event(
         &self,
         eb: &mut EventBuilder,
-        attribs: &mut dyn Iterator<Item = (&Key, &AnyValue)>,
+        attribs: &mut dyn Iterator<Item = &(Key, AnyValue)>,
     ) {
         for attrib in attribs {
             if attrib.0.to_string() == EVENT_ID || attrib.0.to_string() == EVENT_NAME {
                 continue;
             }
             let field_name = &attrib.0.to_string();
-            match attrib.1 {
+            match attrib.1.to_owned() {
                 AnyValue::Boolean(b) => {
-                    eb.add_value(field_name, *b, FieldFormat::Boolean, 0);
+                    eb.add_value(field_name, b, FieldFormat::Boolean, 0);
                 }
                 AnyValue::Int(i) => {
-                    eb.add_value(field_name, *i, FieldFormat::SignedInt, 0);
+                    eb.add_value(field_name, i, FieldFormat::SignedInt, 0);
                 }
                 AnyValue::Double(f) => {
-                    eb.add_value(field_name, *f, FieldFormat::Float, 0);
+                    eb.add_value(field_name, f, FieldFormat::Float, 0);
                 }
                 AnyValue::String(s) => {
                     eb.add_str(field_name, &s.to_string(), FieldFormat::Default, 0);


### PR DESCRIPTION

## Changes

This is to further validate the benchmark introduced in #1121, changing the `LogRecord` to store attributes in `Vec` instead of `OrderMap`/`IndexMap`.  The benchmark was done to emit the tokio-tracing log to user-event exporter.
As an example, to emit the error log with below attributes:

```
error!(
        event_name = "my-event-name",
        event_id = 20,
        user_name = "otel user",
        user_email = "otel@opentelemetry.io",
        login_success =  false
)
```

With `OrderMap`:
It takes around ~1000 ns to emit a single event.
With `Vector`:
It takes around ~700 ns to emit a single event.

The user_events tracepoint was disabled, so no actual export was happening. Which means most of the above overhead was coming from logs SDK (and not the exporter). 

The user_events export iterate over the attributes to serialize, and doesn't require to do any lookup on particular key. 

These changes come at below cost:
 - If the number of attributes are large, and exporter need to do direct lookup for particular attribute - the operation would be fast in OrderMap as compared to Vector. I feel this use-case is somewhat rare.
 - The duplicate key detection need to be done by application/instrumentation library before writing attributes.

The PR is raised to further discuss if these changes would be good for log signal, or any better suggestion. Another option I thought was to have SDK support both data structures, and let user select which one to use. Something like this (not tested):

```rust

enum AttributeData<K, V> {
    HashStore(HashMap<K, V>),
    VectorStore(Vec<(K, V)>),
}

 
impl<K, V> AttributeData<K, V> {
    fn iterator(&self) -> Box<dyn Iterator<Item = &(K, V)>> {
        match self {
            AttributeData::HashStore(index_map) => {
                Box::new(index_map.iter().map(|(k, v)| &(k, v)))
            }
            AttributeData::VectorStore(vector) => Box::new(vector.iter()),
        }
    }

  fn insert(&mut self, key: K, value: V) {
        match self {
            AttributeData::HashStore(index_map) => {
                index_map.insert(key, value);
            }
            AttributeData::VectorStore(vector) => {
                vector.push((key, value));
            }
        }
    }
}

pub struct LogRecord {
    // existing fields ..

    /// Additional attributes associated with this record
    pub attributes: Option<AttributeData<Key, AnyValue>>,
}
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
