### PR TITLE
Cleanup documentation related to current context and use map_current

### DIFF
--- a/opentelemetry-api/src/baggage.rs
+++ b/opentelemetry-api/src/baggage.rs
@@ -308,8 +308,9 @@ pub trait BaggageExt {
     /// ```
     /// use opentelemetry_api::{baggage::BaggageExt, Context, KeyValue, Value};
     ///
-    /// let some_context = Context::current();
-    /// let cx = some_context.with_baggage(vec![KeyValue::new("my-name", "my-value")]);
+    /// let cx = Context::map_current(|cx| {
+    ///     cx.with_baggage(vec![KeyValue::new("my-name", "my-value")])
+    /// });
     ///
     /// assert_eq!(
     ///     cx.baggage().get("my-name"),
@@ -339,14 +340,14 @@ pub trait BaggageExt {
         baggage: T,
     ) -> Self;
 
-    /// Returns a clone of the given context with the included name/value pairs.
+    /// Returns a clone of the given context with no baggage.
     ///
     /// # Examples
     ///
     /// ```
     /// use opentelemetry_api::{baggage::BaggageExt, Context, KeyValue, Value};
     ///
-    /// let cx = Context::current().with_cleared_baggage();
+    /// let cx = Context::map_current(|cx| cx.with_cleared_baggage());
     ///
     /// assert_eq!(cx.baggage().len(), 0);
     /// ```
@@ -377,7 +378,7 @@ impl BaggageExt for Context {
     }
 
     fn current_with_baggage<T: IntoIterator<Item = I>, I: Into<KeyValueMetadata>>(kvs: T) -> Self {
-        Context::current().with_baggage(kvs)
+        Context::map_current(|cx| cx.with_baggage(kvs))
     }
 
     fn with_cleared_baggage(&self) -> Self {

--- a/opentelemetry-api/src/trace/context.rs
+++ b/opentelemetry-api/src/trace/context.rs
@@ -229,7 +229,7 @@ pub trait TraceContextExt {
     /// use opentelemetry_api::{trace::TraceContextExt, Context};
     ///
     /// // Add an event to the currently active span
-    /// Context::current().span().add_event("An event!", vec![]);
+    /// Context::map_current(|cx| cx.span().add_event("An event!", vec![]));
     /// ```
     fn span(&self) -> SpanRef<'_>;
 
@@ -240,7 +240,7 @@ pub trait TraceContextExt {
     /// ```
     /// use opentelemetry_api::{trace::TraceContextExt, Context};
     ///
-    /// assert!(!Context::current().has_active_span());
+    /// assert!(!Context::map_current(|cx| cx.has_active_span()));
     /// ```
     fn has_active_span(&self) -> bool;
 
@@ -348,7 +348,7 @@ pub fn get_active_span<F, T>(f: F) -> T
 where
     F: FnOnce(SpanRef<'_>) -> T,
 {
-    f(Context::current().span())
+    Context::map_current(|cx| f(cx.span()))
 }
 
 pin_project! {


### PR DESCRIPTION
- use `Context::map_current` in documentation examples to promote better performance by default
- fix a documentation typo in `BaggageExt::with_cleared_baggage`
- use `Context::map_current` in `trace::context::get_active_span()` and `BaggageExt::with_cleared_baggage` to avoid expensive cloning of the current context

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
