### PR TITLE
Fix broken link to variables spec

### DIFF
--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -87,7 +87,7 @@ The jaeger pipeline builder can be configured dynamically via environment
 variables. All variables are optional, a full list of accepted options can be
 found in the [jaeger variables spec].
 
-[jaeger variables spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md#jaeger-exporter
+[jaeger variables spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md
 
 ### Jaeger Collector Example
 

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -96,7 +96,7 @@
 //! variables. All variables are optional, a full list of accepted options can
 //! be found in the [jaeger variables spec].
 //!
-//! [jaeger variables spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-environment-variables.md#jaeger-exporter
+//! [jaeger variables spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md
 //!
 //! ## Jaeger Collector Example
 //!


### PR DESCRIPTION
## Changes

'jaeger variables spec' link in [this](https://docs.rs/opentelemetry-jaeger/latest/opentelemetry_jaeger/#jaeger-exporter-from-environment-variables) doc section is broken (404)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
