### PR TITLE
Don't use CARGO_BIN_NAME for service name

### DIFF
--- a/opentelemetry-sdk/src/resource/env.rs
+++ b/opentelemetry-sdk/src/resource/env.rs
@@ -3,7 +3,7 @@
 //! Implementation of `ResourceDetector` to extract a `Resource` from environment
 //! variables.
 use crate::resource::{Resource, ResourceDetector};
-use opentelemetry_api::{Key, KeyValue};
+use opentelemetry_api::{Key, KeyValue, Value};
 use std::env;
 use std::time::Duration;
 
@@ -64,9 +64,7 @@ fn construct_otel_resources(s: String) -> Resource {
 ///
 /// This detector will first try `OTEL_SERVICE_NAME` env. If it's not available,
 /// then it will check the `OTEL_RESOURCE_ATTRIBUTES` env and see if it contains
-/// `service.name` resource. If it's not available, it will try to use the env
-/// `CARGO_BIN_NAME` that should have been present at build time. If that was
-/// not available, it will use `unknown_service`.
+/// `service.name` resource. If it's also not available, it will use `unknown_service`.
 ///
 /// If users want to set an empty service name, they can provide
 /// a resource with empty value and `service.name` key.
@@ -82,18 +80,13 @@ impl ResourceDetector for SdkProvidedResourceDetector {
             env::var(OTEL_SERVICE_NAME)
                 .ok()
                 .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| {
+                .map(Value::from)
+                .or_else(|| {
                     EnvResourceDetector::new()
                         .detect(Duration::from_secs(0))
                         .get(Key::new("service.name"))
-                        .map(|v| v.to_string())
-                        .filter(|s| !s.is_empty())
-                        .unwrap_or_else(|| {
-                            option_env!("CARGO_BIN_NAME")
-                                .unwrap_or("unknown_service")
-                                .into()
-                        })
-                }),
+                })
+                .unwrap_or_else(|| "unknown_service".into()),
         )])
     }
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-rust/issues/1029

## Changes

Change `SdkProvidedResourceDetector` to no longer use the `CARGO_BIN_NAME` environment variable at compile time. This crate is not a binary crate, so the value of `option_env!("CARGO_BIN_NAME")` will always be false.

This can be reproduced by creating a binary crate and confirming that the detected `service.name` is `unknown_service`.

```rust
use opentelemetry::sdk::resource::{ResourceDetector, SdkProvidedResourceDetector};
use std::time::Duration;

fn main() {
    assert_eq!(
        SdkProvidedResourceDetector
            .detect(Duration::ZERO)
            .get("service.name".into()),
        Some("unknown_service".into())
    );
}
```

This effectively reverts https://github.com/open-telemetry/opentelemetry-rust/pull/991.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [X] Unit tests added/updated (if applicable)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [X] Changes in public API reviewed (if applicable)
