### PR TITLE
Fix EvictedQueue bug with zero capacity

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Propagate shutdown calls from `PeriodicReader` to metrics exporter
   [#1138](https://github.com/open-telemetry/opentelemetry-rust/pull/1138).
 
+### Changed
+
+- Fix EvictedQueue bug when capacity is set to 0
+  [#1151](https://github.com/open-telemetry/opentelemetry-rust/pull/1151).
+
 ### Removed
 
 - Samplers no longer has access to `InstrumentationLibrary` as one of parameters


### PR DESCRIPTION
The EvictedQueue was checking for the length _before_ inserting, and popping extra items, then doing the insertion. In the case where the capacity is set to zero, it caused the pop operation to be a no-op on the first insert, and then insert an item anyway.

This commit fixes the issue by moving the length check after the insert and popping any extra items.

Fixes #1148

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [X] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
