### PR TITLE
fix: enable `with_reqwest` when `reqwest_rustls_collector_client` feature is enabled

### DIFF
--- a/opentelemetry-jaeger/CHANGELOG.md
+++ b/opentelemetry-jaeger/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Main
 ### Fixed
 - allow span id to be less than 16 characters in propagator [#1084](https://github.com/open-telemetry/opentelemetry-rust/pull/1084)
+- `reqwest_rustls_collector_client` now includes `with_reqwest` [#1159](https://github.com/open-telemetry/opentelemetry-rust/pull/1159)
 
 ## v0.18.0
 

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -91,7 +91,7 @@ hyper_tls_collector_client = ["hyper_collector_client", "hyper-tls"]
 isahc_collector_client = ["isahc", "opentelemetry-http/isahc"]
 reqwest_blocking_collector_client = ["reqwest/blocking", "collector_client", "headers", "opentelemetry-http/reqwest"]
 reqwest_collector_client = ["reqwest", "collector_client", "headers", "opentelemetry-http/reqwest"]
-reqwest_rustls_collector_client = ["reqwest", "reqwest/rustls-tls-native-roots", "collector_client", "headers", "opentelemetry-http/reqwest"]
+reqwest_rustls_collector_client = ["reqwest_collector_client", "reqwest/rustls-tls-native-roots"]
 surf_collector_client = ["surf", "collector_client", "opentelemetry-http/surf"]
 wasm_collector_client = [
     "base64",


### PR DESCRIPTION
Fixes #1155

## Changes

- extend the `reqwest_rustls_collector_client` feature using `reqwest_collector_client` so any method enabled by `reqwest_collector_client` will be accesiable by `reqwest_rustls_collector_client`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
