### PR TITLE
proto: fix doc links to tonic, prost

### DIFF
--- a/opentelemetry-proto/src/proto.rs
+++ b/opentelemetry-proto/src/proto.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "gen-tonic-messages")]
 #[path = "proto/tonic"]
-/// Generated files using [`tonic`](https://docs.rs/crate/grpcio) and [`prost`](https://docs.rs/crate/protobuf/latest)
+/// Generated files using [`tonic`](https://docs.rs/crate/tonic) and [`prost`](https://docs.rs/crate/prost)
 pub mod tonic {
     /// Service stub and clients
     #[path = ""]


### PR DESCRIPTION
## Changes

Update tonic and prost links to actually point to tonic and prost (instead of grpcio and protobuf)

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed (don't know where to find the CLA)
* [x] Unit tests added/updated (not applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes (probably unnecessary)
* [x] Changes in public API reviewed (not applicable; changes to the documentation of the public API, not the API itself)
