### PR TITLE
Add with_log_config to OtlpLogPipeline

### DIFF
--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -413,6 +413,12 @@ impl OtlpLogPipeline {
         self
     }
 
+    /// Set the log provider configuration.
+    pub fn with_log_config(mut self, log_config: opentelemetry_sdk::logs::Config) -> Self {
+        self.log_config = Some(log_config);
+        self
+    }
+
     /// Returns a [`Logger`] with the name `opentelemetry-otlp` and the
     /// current crate version, using the configured log exporter.
     ///


### PR DESCRIPTION
## Changes

Adds a `with_log_config` method to `OtlpLogPipeline` to set the log config. This matches the design of similar methods on `OtlpTracePipeline`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
