### PR TITLE
Add compression support for otlp tonic

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add OTLP HTTP Metrics Exporter [#1020](https://github.com/open-telemetry/opentelemetry-rust/pull/1020).
+- Add tonic compression support [#1165](https://github.com/open-telemetry/opentelemetry-rust/pull/1165).
 
 ## v0.12.0
 

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -70,6 +70,7 @@ default = ["grpc-tonic", "trace"]
 
 # grpc using tonic
 grpc-tonic = ["tonic", "prost", "http", "tokio", "opentelemetry-proto/gen-tonic"]
+gzip-tonic = ["tonic/gzip"]
 tls = ["tonic/tls"]
 tls-roots = ["tls", "tonic/tls-roots"]
 

--- a/opentelemetry-otlp/src/exporter/grpcio.rs
+++ b/opentelemetry-otlp/src/exporter/grpcio.rs
@@ -1,3 +1,4 @@
+use crate::exporter::Compression;
 use crate::ExportConfig;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
@@ -45,14 +46,6 @@ pub struct Credentials {
     pub cert: String,
     /// Credential key
     pub key: String,
-}
-
-/// The compression algorithm to use when sending data.
-#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
-#[derive(Clone, Copy, Debug)]
-pub enum Compression {
-    /// Compresses data using gzip.
-    Gzip,
 }
 
 impl From<Compression> for grpcio::CompressionAlgorithms {

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -249,13 +249,15 @@ impl<B: HasExportConfig> WithExportConfig for B {
 mod tests {
     // If an env test fails then the mutex will be poisoned and the following error will be displayed.
     const LOCK_POISONED_MESSAGE: &str = "one of the other pipeline builder from env tests failed";
+
     use crate::exporter::{
         default_endpoint, default_protocol, WithExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT,
         OTEL_EXPORTER_OTLP_GRPC_ENDPOINT_DEFAULT, OTEL_EXPORTER_OTLP_HTTP_ENDPOINT_DEFAULT,
         OTEL_EXPORTER_OTLP_PROTOCOL_GRPC, OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF,
         OTEL_EXPORTER_OTLP_TIMEOUT, OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT,
     };
-    use crate::{new_exporter, Protocol, OTEL_EXPORTER_OTLP_PROTOCOL};
+    use crate::{new_exporter, Compression, Protocol, OTEL_EXPORTER_OTLP_PROTOCOL};
+    use std::str::FromStr;
     use std::sync::Mutex;
 
     // Make sure env tests are not running concurrently
@@ -376,5 +378,16 @@ mod tests {
 
         std::env::remove_var(OTEL_EXPORTER_OTLP_TIMEOUT);
         assert!(std::env::var(OTEL_EXPORTER_OTLP_TIMEOUT).is_err());
+    }
+
+    #[test]
+    fn test_compression_parse() {
+        assert_eq!(Compression::from_str("gzip").unwrap(), Compression::Gzip);
+        Compression::from_str("bad_compression").expect_err("bad compression");
+    }
+
+    #[test]
+    fn test_compression_to_str() {
+        assert_eq!(Compression::Gzip.to_string(), "gzip");
     }
 }

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -12,6 +12,7 @@ use crate::{Error, Protocol};
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -88,8 +89,15 @@ impl Default for ExportConfig {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Compression {
     /// Compresses data using gzip.
-    #[cfg(any(feature = "gzip-tonic", feature = "grpc-sys"))]
     Gzip,
+}
+
+impl Display for Compression {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Compression::Gzip => write!(f, "gzip"),
+        }
+    }
 }
 
 impl FromStr for Compression {
@@ -97,7 +105,6 @@ impl FromStr for Compression {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            #[cfg(any(feature = "gzip-tonic", feature = "grpc-sys"))]
             "gzip" => Ok(Compression::Gzip),
             _ => Err(Error::UnsupportedCompressionAlgorithm(s.to_string())),
         }

--- a/opentelemetry-otlp/src/exporter/tonic.rs
+++ b/opentelemetry-otlp/src/exporter/tonic.rs
@@ -45,14 +45,14 @@ pub(crate) fn resolve_compression(
     env_override: &'static str,
 ) -> Result<Option<CompressionEncoding>, crate::Error> {
     if let Some(compression) = tonic_config.compression {
-        return Ok(Some(compression.try_into()?));
-    }
-    if let Ok(compression) = std::env::var(env_override) {
-        return Ok(Some(compression.parse::<Compression>()?.try_into()?));
+        Ok(Some(compression.try_into()?))
+    } else if let Ok(compression) = std::env::var(env_override) {
+        Ok(Some(compression.parse::<Compression>()?.try_into()?))
     } else if let Ok(compression) = std::env::var(OTEL_EXPORTER_OTLP_COMPRESSION) {
-        return Ok(Some(compression.parse::<Compression>()?.try_into()?));
-    };
-    Ok(None)
+        Ok(Some(compression.parse::<Compression>()?.try_into()?))
+    } else {
+        Ok(None)
+    }
 }
 
 /// Build a trace exporter that uses [tonic] as grpc layer and opentelemetry protocol.

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -398,6 +398,7 @@ pub(crate) fn to_nanos(time: SystemTime) -> u64 {
         .as_nanos() as u64
 }
 
+#[cfg(feature = "grpc-tonic")]
 pub(crate) fn resolve_compression(
     tonic_config: &TonicConfig,
     env_override: &'static str,

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -397,20 +397,3 @@ pub(crate) fn to_nanos(time: SystemTime) -> u64 {
         .unwrap_or_else(|_| Duration::from_secs(0))
         .as_nanos() as u64
 }
-
-#[cfg(feature = "grpc-tonic")]
-pub(crate) fn resolve_compression(
-    tonic_config: &TonicConfig,
-    env_override: &'static str,
-) -> Result<Option<Compression>, Error> {
-    tonic_config
-        .compression
-        .map(Ok)
-        .or_else(|| {
-            std::env::var(OTEL_EXPORTER_OTLP_COMPRESSION)
-                .or_else(|_| std::env::var(env_override))
-                .ok()
-                .map(|v| v.parse())
-        })
-        .transpose()
-}

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -4,7 +4,7 @@
 
 #[cfg(feature = "grpc-tonic")]
 use {
-    crate::exporter::tonic::{TonicConfig, TonicExporterBuilder},
+    crate::exporter::tonic::{resolve_compression, TonicConfig, TonicExporterBuilder},
     opentelemetry_proto::tonic::collector::logs::v1::{
         logs_service_client::LogsServiceClient as TonicLogsServiceClient,
         ExportLogsServiceRequest as TonicRequest,
@@ -46,7 +46,7 @@ use {
 use std::{collections::HashMap, sync::Arc};
 
 use crate::exporter::ExportConfig;
-use crate::{resolve_compression, OtlpPipeline};
+use crate::OtlpPipeline;
 use async_trait::async_trait;
 use std::{
     borrow::Cow,
@@ -239,7 +239,7 @@ impl LogExporter {
         if let Some(compression) =
             resolve_compression(&tonic_config, OTEL_EXPORTER_OTLP_LOGS_COMPRESSION)?
         {
-            log_exporter = log_exporter.send_compressed(compression.into());
+            log_exporter = log_exporter.send_compressed(compression);
         }
         Ok(LogExporter::Tonic {
             timeout: config.timeout,

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -388,7 +388,6 @@ impl SpanExporter {
         tonic_config: TonicConfig,
         channel: tonic::transport::Channel,
     ) -> Result<Self, crate::Error> {
-        #[allow(unused_mut)]
         let mut trace_exporter = TonicTraceServiceClient::new(channel);
         if let Some(compression) =
             resolve_compression(&tonic_config, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION)?

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use std::str::FromStr;
 #[cfg(feature = "grpc-tonic")]
 use {
-    crate::exporter::tonic::{TonicConfig, TonicExporterBuilder},
+    crate::exporter::tonic::{resolve_compression, TonicConfig, TonicExporterBuilder},
     opentelemetry_proto::tonic::collector::trace::v1::{
         trace_service_client::TraceServiceClient as TonicTraceServiceClient,
         ExportTraceServiceRequest as TonicRequest,
@@ -51,8 +51,6 @@ use {
 use {std::collections::HashMap, std::sync::Arc};
 
 use crate::exporter::ExportConfig;
-#[cfg(feature = "gzip-tonic")]
-use crate::resolve_compression;
 use crate::OtlpPipeline;
 
 use opentelemetry_api::{
@@ -392,11 +390,10 @@ impl SpanExporter {
     ) -> Result<Self, crate::Error> {
         #[allow(unused_mut)]
         let mut trace_exporter = TonicTraceServiceClient::new(channel);
-        #[cfg(feature = "gzip-tonic")]
         if let Some(compression) =
             resolve_compression(&tonic_config, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION)?
         {
-            trace_exporter = trace_exporter.send_compressed(compression.into())
+            trace_exporter = trace_exporter.send_compressed(compression)
         }
 
         Ok(SpanExporter::Tonic {

--- a/opentelemetry-otlp/tests/smoke.rs
+++ b/opentelemetry-otlp/tests/smoke.rs
@@ -9,6 +9,8 @@ use opentelemetry_proto::tonic::collector::trace::v1::{
 use std::{net::SocketAddr, sync::Mutex};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::TcpListenerStream;
+#[cfg(feature = "gzip-tonic")]
+use tonic::codec::CompressionEncoding;
 
 struct MockServer {
     tx: Mutex<mpsc::Sender<ExportTraceServiceRequest>>,
@@ -57,6 +59,10 @@ async fn setup() -> (SocketAddr, mpsc::Receiver<ExportTraceServiceRequest>) {
     });
 
     let (req_tx, req_rx) = mpsc::channel(10);
+    #[cfg(feature = "gzip-tonic")]
+    let service = TraceServiceServer::new(MockServer::new(req_tx))
+        .accept_compressed(CompressionEncoding::Gzip);
+    #[cfg(not(feature = "gzip-tonic"))]
     let service = TraceServiceServer::new(MockServer::new(req_tx));
     tokio::task::spawn(async move {
         tonic::transport::Server::builder()
@@ -80,6 +86,13 @@ async fn smoke_tracer() {
         let tracer = opentelemetry_otlp::new_pipeline()
             .tracing()
             .with_exporter(
+                #[cfg(feature = "gzip-tonic")]
+                opentelemetry_otlp::new_exporter()
+                    .tonic()
+                    .with_compression(opentelemetry_otlp::Compression::Gzip)
+                    .with_endpoint(format!("http://{}", addr))
+                    .with_metadata(metadata),
+                #[cfg(not(feature = "gzip-tonic"))]
                 opentelemetry_otlp::new_exporter()
                     .tonic()
                     .with_endpoint(format!("http://{}", addr))


### PR DESCRIPTION
Part of #774

Design discussion issue (if applicable) #

It looks like there needs to be a larger refactor to allow compression to be pushed up to `ExportConfig` and to have `with_env` set the variables to something that allows late binding. It'd be better to do this separately though as it affects all the settings in `ExportConfig`.



## Changes

Adds the ability to use compression when using grpc-tonic.

Added support for the following env variables:
* OTEL_EXPORTER_OTLP_LOGS_COMPRESSION
* OTEL_EXPORTER_OTLP_TRACES_COMPRESSION
* OTEL_EXPORTER_OTLP_METRICS_COMPRESSION
* OTEL_EXPORTER_OTLP_COMPRESSION

This doesn't use `with_env` yet as it is impossible currently to detect at this point if compression is enabled for logs|metrics|traces.

Longer term we can add a new enum for use in `ExportConfig` like:

```rust
enum ConfigSetting<T> {
  Env,
  Some(T),
  None
}
```
Which would allow `with_env` to mark a field as being resolved by env variable. Thus allowing `OTEL_EXPORTER_OTLP_LOGS_COMPRESSION` to be used for logs, `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` for traces etc...

I'm happy to try to do this as a follow-up.

Follow up: 
I just noticed that `from_env` was removed from the jaeger exporter, so maybe if we are going in the same direction with the otlp exporter then there's not need for the above.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
