### PR TITLE
Start adding metrics advanced (view) examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "opentelemetry-otlp/examples/basic-otlp-http",
     "opentelemetry-otlp/examples/external-otlp-grpcio-async-std",
     "examples/metrics-basic",
+    "examples/metrics-advanced",
     "examples/logs-basic",
     "examples/traceresponse",
     "examples/tracing-grpc",

--- a/examples/metrics-advanced/Cargo.toml
+++ b/examples/metrics-advanced/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "metrics-advanced"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+opentelemetry_api = { path = "../../opentelemetry-api", features = ["metrics"] }
+opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["metrics", "rt-tokio"] }
+opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["metrics"]}
+tokio = { version = "1.0", features = ["full"] }

--- a/examples/metrics-advanced/README.md
+++ b/examples/metrics-advanced/README.md
@@ -1,0 +1,17 @@
+# Metric SDK Advanced Configuration Example
+
+This example shows how to customize the OpenTelemetry Rust Metric SDK. This
+shows how to change temporality, how to customize the aggregation using the
+concept of "Views" etc. The examples write output to stdout, but could be
+replaced with other exporters.
+
+## Usage
+
+Run the following, and the Metrics will be written out to stdout.
+
+```shell
+$ cargo run
+```
+
+
+

--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -1,16 +1,19 @@
-use opentelemetry_api::Key;
 use opentelemetry_api::metrics::Unit;
+use opentelemetry_api::Key;
 use opentelemetry_api::{metrics::MeterProvider as _, KeyValue};
 use opentelemetry_sdk::metrics::{Instrument, MeterProvider, PeriodicReader, Stream};
 use opentelemetry_sdk::{runtime, Resource};
 use std::error::Error;
 
 fn init_meter_provider() -> MeterProvider {
-
     // for example 1
     let my_view_rename_and_unit = |i: &Instrument| {
         if i.name == "my_histogram" {
-            Some(Stream::new().name("my_histogram_renamed").unit(Unit::new("milliseconds")))
+            Some(
+                Stream::new()
+                    .name("my_histogram_renamed")
+                    .unit(Unit::new("milliseconds")),
+            )
         } else {
             None
         }
@@ -31,7 +34,7 @@ fn init_meter_provider() -> MeterProvider {
         .with_reader(reader)
         .with_resource(Resource::new(vec![KeyValue::new(
             "service.name",
-            "metrics-basic-example",
+            "metrics-advanced-example",
         )]))
         .with_view(my_view_rename_and_unit)
         .with_view(my_view_drop_attributes)
@@ -40,7 +43,6 @@ fn init_meter_provider() -> MeterProvider {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    
     let meter_provider = init_meter_provider();
     let meter = meter_provider.meter("mylibraryname");
 
@@ -52,8 +54,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .f64_histogram("my_histogram")
         .with_unit(Unit::new("ms"))
         .with_description("My histogram example description")
-        .init();   
-    
+        .init();
+
     // Record measurements using the histogram instrument.
     histogram.record(
         10.5,
@@ -68,7 +70,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     // Example 2 - Drop unwanted attributes using view.
     let counter = meter.u64_counter("my_counter").init();
-    
+
     // Record measurements using the Counter instrument.
     // Though we are passing 4 attributes here, only 1 will be used
     // for aggregation as view is configured to use only "mykey1"

--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -1,18 +1,28 @@
+use opentelemetry_api::Key;
 use opentelemetry_api::metrics::Unit;
 use opentelemetry_api::{metrics::MeterProvider as _, KeyValue};
-use opentelemetry_sdk::metrics::{MeterProvider, PeriodicReader, new_view, Instrument, Stream};
+use opentelemetry_sdk::metrics::{Instrument, MeterProvider, PeriodicReader, Stream};
 use opentelemetry_sdk::{runtime, Resource};
 use std::error::Error;
 
 fn init_meter_provider() -> MeterProvider {
-    let my_view = |i: &Instrument| {
+
+    // for example 1
+    let my_view_rename_and_unit = |i: &Instrument| {
         if i.name == "my_histogram" {
-            Some(
-                Stream::new().name("my_histogram_renamed")
-            )
+            Some(Stream::new().name("my_histogram_renamed").unit(Unit::new("milliseconds")))
         } else {
             None
-        }        
+        }
+    };
+
+    // for example 2
+    let my_view_drop_attributes = |i: &Instrument| {
+        if i.name == "my_counter" {
+            Some(Stream::new().allowed_attribute_keys(vec![Key::from("mykey1")]))
+        } else {
+            None
+        }
     };
 
     let exporter = opentelemetry_stdout::MetricsExporter::default();
@@ -23,35 +33,56 @@ fn init_meter_provider() -> MeterProvider {
             "service.name",
             "metrics-basic-example",
         )]))
-        .with_view(my_view)
+        .with_view(my_view_rename_and_unit)
+        .with_view(my_view_drop_attributes)
         .build()
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    // Initialize the MeterProvider with the stdout Exporter.
+    
     let meter_provider = init_meter_provider();
-
-    // Create a meter from the above MeterProvider.
     let meter = meter_provider.meter("mylibraryname");
 
-    // Create a Histogram Instrument.
+    // Example 1 - Rename metric using View.
+    // This instrument will be renamed to "my_histogram_renamed",
+    // and its unit changed to "milliseconds"
+    // using view.
     let histogram = meter
         .f64_histogram("my_histogram")
+        .with_unit(Unit::new("ms"))
         .with_description("My histogram example description")
-        .init();
-
+        .init();   
+    
     // Record measurements using the histogram instrument.
     histogram.record(
         10.5,
         [
             KeyValue::new("mykey1", "myvalue1"),
             KeyValue::new("mykey2", "myvalue2"),
+            KeyValue::new("mykey3", "myvalue3"),
+            KeyValue::new("mykey4", "myvalue4"),
         ]
         .as_ref(),
     );
 
+    // Example 2 - Drop unwanted attributes using view.
+    let counter = meter.u64_counter("my_counter").init();
     
+    // Record measurements using the Counter instrument.
+    // Though we are passing 4 attributes here, only 1 will be used
+    // for aggregation as view is configured to use only "mykey1"
+    // attribute.
+    counter.add(
+        10,
+        [
+            KeyValue::new("mykey1", "myvalue1"),
+            KeyValue::new("mykey2", "myvalue2"),
+            KeyValue::new("mykey3", "myvalue3"),
+            KeyValue::new("mykey4", "myvalue4"),
+        ]
+        .as_ref(),
+    );
 
     // Metrics are exported by default every 30 seconds when using stdout exporter,
     // however shutting down the MeterProvider here instantly flushes

--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -1,0 +1,61 @@
+use opentelemetry_api::metrics::Unit;
+use opentelemetry_api::{metrics::MeterProvider as _, KeyValue};
+use opentelemetry_sdk::metrics::{MeterProvider, PeriodicReader, new_view, Instrument, Stream};
+use opentelemetry_sdk::{runtime, Resource};
+use std::error::Error;
+
+fn init_meter_provider() -> MeterProvider {
+    let my_view = |i: &Instrument| {
+        if i.name == "my_histogram" {
+            Some(
+                Stream::new().name("my_histogram_renamed")
+            )
+        } else {
+            None
+        }        
+    };
+
+    let exporter = opentelemetry_stdout::MetricsExporter::default();
+    let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
+    MeterProvider::builder()
+        .with_reader(reader)
+        .with_resource(Resource::new(vec![KeyValue::new(
+            "service.name",
+            "metrics-basic-example",
+        )]))
+        .with_view(my_view)
+        .build()
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    // Initialize the MeterProvider with the stdout Exporter.
+    let meter_provider = init_meter_provider();
+
+    // Create a meter from the above MeterProvider.
+    let meter = meter_provider.meter("mylibraryname");
+
+    // Create a Histogram Instrument.
+    let histogram = meter
+        .f64_histogram("my_histogram")
+        .with_description("My histogram example description")
+        .init();
+
+    // Record measurements using the histogram instrument.
+    histogram.record(
+        10.5,
+        [
+            KeyValue::new("mykey1", "myvalue1"),
+            KeyValue::new("mykey2", "myvalue2"),
+        ]
+        .as_ref(),
+    );
+
+    
+
+    // Metrics are exported by default every 30 seconds when using stdout exporter,
+    // however shutting down the MeterProvider here instantly flushes
+    // the metrics, instead of waiting for the 30 sec interval.
+    meter_provider.shutdown()?;
+    Ok(())
+}

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -104,7 +104,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .as_ref(),
     );
 
-    // Note that there is no ObservableHistogram instruments.
+    // Note that there is no ObservableHistogram instrument.
 
     // Create a ObservableGauge instrument and register a callback that reports the measurement.
     let gauge = meter
@@ -128,7 +128,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     // Note that Gauge only has a Observable version.
 
-    // Metrics are exported by default every 30 seconds,
+    // Metrics are exported by default every 30 seconds when using stdout exporter,
     // however shutting down the MeterProvider here instantly flushes
     // the metrics, instead of waiting for the 30 sec interval.
     meter_provider.shutdown()?;


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-rust/issues/1060

## Changes

Add a metrics-advanced example, with 2 scenarios (rename, drop attributes) explained. If this direction is okay, I can add further scenarios. A lot of folks get confused by View, so hopefully these are useful examples.

Next steps would be to show how to change Histogram bounds (a common ask), drop an Instrument alltogether, changing temporality (default is cumulative, but a lot of backends need delta only) etc.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
