### PR TITLE
Fix stdout exporter dependency

### DIFF
--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -25,12 +25,12 @@ opentelemetry_api = { version = "0.20", path = "../opentelemetry-api" }
 opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk" }
 
 [dev-dependencies]
-opentelemetry-stdout = { path = "../opentelemetry-stdout" }
+opentelemetry-stdout = { version = "0.1", path = "../opentelemetry-stdout", features = ["trace"] }
 
 [features]
 default = ["trace"]
-trace = ["opentelemetry_api/trace", "opentelemetry_sdk/trace", "opentelemetry-stdout/trace"]
-metrics = ["opentelemetry_api/metrics", "opentelemetry_sdk/metrics", "opentelemetry-stdout/metrics"]
+trace = ["opentelemetry_api/trace", "opentelemetry_sdk/trace"]
+metrics = ["opentelemetry_api/metrics", "opentelemetry_sdk/metrics"]
 logs = ["opentelemetry_sdk/logs"]
 logs_level_enabled = ["logs"]
 testing = ["opentelemetry_api/testing", "opentelemetry_sdk/testing"]


### PR DESCRIPTION
Currently blocking some crate releases that depend on the top level `opentelemetry` crate.