### PR TITLE
Set timestamp correctly in log appenders

### DIFF
--- a/opentelemetry-appender-log/CHANGELOG.md
+++ b/opentelemetry-appender-log/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## vNext
+
+- Populate TimeStamp on LogRecord, instead of ObservedTimeStamp
+  [#1175](https://github.com/open-telemetry/opentelemetry-rust/pull/1175).
+
 ## v0.1.0
 
 Initial crate release

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -31,7 +31,7 @@ where
             self.logger.emit(
                 LogRecordBuilder::new()
                     .with_severity_number(map_severity_to_otel_severity(record.level()))
-                    .with_observed_timestamp(SystemTime::now())
+                    .with_timestamp(SystemTime::now())
                     .with_severity_text(record.level().as_str())
                     .with_body(AnyValue::from(record.args().to_string()))
                     .build(),

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## vNext
+
+- Populate TimeStamp on LogRecord [#1175](https://github.com/open-telemetry/opentelemetry-rust/pull/1175).
+
 ## v0.1.0
 
 Initial crate release

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,4 +1,4 @@
-use std::{vec, time::SystemTime};
+use std::{time::SystemTime, vec};
 
 use opentelemetry_api::logs::{LogRecord, Logger, LoggerProvider, Severity};
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,4 +1,4 @@
-use std::vec;
+use std::{vec, time::SystemTime};
 
 use opentelemetry_api::logs::{LogRecord, Logger, LoggerProvider, Severity};
 
@@ -99,7 +99,7 @@ where
         let mut log_record: LogRecord = LogRecord::default();
         log_record.severity_number = Some(map_severity_to_otel_severity(meta.level().as_str()));
         log_record.severity_text = Some(meta.level().to_string().into());
-        log_record.timestamp = SystemTime::now();
+        log_record.timestamp = Some(SystemTime::now());
 
         let mut visitor = EventVisitor {
             log_record: &mut log_record,

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -99,6 +99,7 @@ where
         let mut log_record: LogRecord = LogRecord::default();
         log_record.severity_number = Some(map_severity_to_otel_severity(meta.level().as_str()));
         log_record.severity_text = Some(meta.level().to_string().into());
+        log_record.timestamp = SystemTime::now();
 
         let mut visitor = EventVisitor {
             log_record: &mut log_record,


### PR DESCRIPTION
Log-Appender modified to set Timestamp, instead of ObservedTimestamp.
Tracing-Appender modified to set Timestamp (it was not setting any before).

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
