### PR TITLE
Fix basic-otlp example dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
   non-default-examples:
     strategy:
       matrix:
-        example: [opentelemetry-otlp/examples/external-otlp-grpcio-async-std]
+        example: [opentelemetry-otlp/examples/external-otlp-grpcio-async-std, opentelemetry-otlp/examples/basic-otlp]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/examples/logs-basic/Cargo.toml
+++ b/examples/logs-basic/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 opentelemetry_api = { path = "../../opentelemetry-api", features = ["logs"] }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["logs"] }
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["logs"]}
-opentelemetry-appender-log = { path = "../../opentelemetry-appender-log"}
+opentelemetry-appender-log = { path = "../../opentelemetry-appender-log", default-features = false}
 log = {version = "0.4.17"}

--- a/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
@@ -12,5 +12,5 @@ opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio
 opentelemetry-otlp = { path = "../../../opentelemetry-otlp", features = ["tonic", "metrics", "logs"] }
 opentelemetry-semantic-conventions = { path = "../../../opentelemetry-semantic-conventions" }
 tokio = { version = "1.0", features = ["full"] }
-opentelemetry-appender-log = { path = "../../../opentelemetry-appender-log"}
+opentelemetry-appender-log = { path = "../../../opentelemetry-appender-log", default-features = false}
 log = {version = "0.4.17"}


### PR DESCRIPTION
Basic-otlp was broken as it was depending on log-appender, which had set to use `logs_level_enabled` by default.

Wondering why examples are not built on CI, else we could have caught this earlier? Looks like the CI job is selectively building some examples.. Would like to learn the best practices here.