### PR TITLE
[Logs API/SDK] - Populate ObservedTimestamp within the SDK

### DIFF
--- a/opentelemetry-api/src/logs/mod.rs
+++ b/opentelemetry-api/src/logs/mod.rs
@@ -11,7 +11,9 @@ mod record;
 
 pub use logger::{Logger, LoggerProvider};
 pub use noop::NoopLoggerProvider;
-pub use record::{AnyValue, LogRecord, LogRecordBuilder, Severity, TraceContext};
+pub use record::{
+    AnyValue, LogRecord, LogRecordBuilder, ObservedTimeStamp, Severity, TraceContext,
+};
 
 /// Describe the result of operations in log SDK.
 pub type LogResult<T> = Result<T, LogError>;

--- a/opentelemetry-api/src/logs/mod.rs
+++ b/opentelemetry-api/src/logs/mod.rs
@@ -12,7 +12,7 @@ mod record;
 pub use logger::{Logger, LoggerProvider};
 pub use noop::NoopLoggerProvider;
 pub use record::{
-    AnyValue, LogRecord, LogRecordBuilder, ObservedTimeStamp, Severity, TraceContext,
+    AnyValue, LogRecord, LogRecordBuilder, ObservedTimestamp, Severity, TraceContext,
 };
 
 /// Describe the result of operations in log SDK.

--- a/opentelemetry-api/src/logs/record.rs
+++ b/opentelemetry-api/src/logs/record.rs
@@ -7,14 +7,14 @@ use std::{borrow::Cow, time::SystemTime};
 #[derive(Debug, Clone)]
 /// Timestamp for when the record was observed by OpenTelemetry
 /// Defaults to the current time.
-pub struct ObservedTimeStamp {
+pub struct ObservedTimestamp {
     /// Time when the record was observed by OpenTelemetry
     pub time: SystemTime,
 }
 
-impl Default for ObservedTimeStamp {
+impl Default for ObservedTimestamp {
     fn default() -> Self {
-        ObservedTimeStamp {
+        ObservedTimestamp {
             time: SystemTime::now(),
         }
     }
@@ -29,7 +29,7 @@ pub struct LogRecord {
     pub timestamp: Option<SystemTime>,
 
     /// Timestamp for when the record was observed by OpenTelemetry
-    pub observed_timestamp: ObservedTimeStamp,
+    pub observed_timestamp: ObservedTimestamp,
 
     /// Trace context for logs associated with spans
     pub trace_context: Option<TraceContext>,
@@ -277,7 +277,7 @@ impl LogRecordBuilder {
     pub fn with_observed_timestamp(self, timestamp: SystemTime) -> Self {
         Self {
             record: LogRecord {
-                observed_timestamp: ObservedTimeStamp { time: timestamp },
+                observed_timestamp: ObservedTimestamp { time: timestamp },
                 ..self.record
             },
         }

--- a/opentelemetry-api/src/logs/record.rs
+++ b/opentelemetry-api/src/logs/record.rs
@@ -4,6 +4,22 @@ use crate::{
 };
 use std::{borrow::Cow, time::SystemTime};
 
+#[derive(Debug, Clone)]
+/// Timestamp for when the record was observed by OpenTelemetry
+/// Defaults to the current time.
+pub struct ObservedTimeStamp {
+    /// Time when the record was observed by OpenTelemetry
+    pub time: SystemTime,
+}
+
+impl Default for ObservedTimeStamp {
+    fn default() -> Self {
+        ObservedTimeStamp {
+            time: SystemTime::now(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 /// LogRecord represents all data carried by a log record, and
@@ -13,7 +29,7 @@ pub struct LogRecord {
     pub timestamp: Option<SystemTime>,
 
     /// Timestamp for when the record was observed by OpenTelemetry
-    pub observed_timestamp: Option<SystemTime>,
+    pub observed_timestamp: ObservedTimeStamp,
 
     /// Trace context for logs associated with spans
     pub trace_context: Option<TraceContext>,
@@ -261,7 +277,7 @@ impl LogRecordBuilder {
     pub fn with_observed_timestamp(self, timestamp: SystemTime) -> Self {
         Self {
             record: LogRecord {
-                observed_timestamp: Some(timestamp),
+                observed_timestamp: ObservedTimeStamp { time: timestamp },
                 ..self.record
             },
         }

--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -87,10 +87,7 @@ pub mod tonic {
 
             LogRecord {
                 time_unix_nano: log_record.timestamp.map(to_nanos).unwrap_or_default(),
-                observed_time_unix_nano: log_record
-                    .observed_timestamp
-                    .map(to_nanos)
-                    .unwrap_or_default(),
+                observed_time_unix_nano: to_nanos(log_record.observed_timestamp.time),
                 severity_number: severity_number.into(),
                 severity_text: log_record.severity_text.map(Into::into).unwrap_or_default(),
                 body: log_record.body.map(Into::into),

--- a/opentelemetry-stdout/src/logs/transform.rs
+++ b/opentelemetry-stdout/src/logs/transform.rs
@@ -75,10 +75,9 @@ struct LogRecord {
     )]
     time_unix_nano: Option<SystemTime>,
     #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "opt_as_unix_nano"
+        serialize_with = "as_unix_nano"
     )]
-    observed_time_unix_nano: Option<SystemTime>,
+    observed_time_unix_nano: SystemTime,
     severity_number: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     severity_text: Option<Cow<'static, str>>,
@@ -113,7 +112,7 @@ impl From<opentelemetry_sdk::export::logs::LogData> for LogRecord {
                 .map(|c| c.trace_flags.map(|f| f.to_u8()))
                 .unwrap_or_default(),
             time_unix_nano: value.record.timestamp,
-            observed_time_unix_nano: value.record.observed_timestamp,
+            observed_time_unix_nano: value.record.observed_timestamp.time,
             severity_number: value
                 .record
                 .severity_number

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -194,14 +194,7 @@ impl UserEventsExporter {
                 eb.add_value("__csver__", 0x0401u16, FieldFormat::HexInt, 0);
 
                 // populate CS PartA
-                let event_time: SystemTime;
-                if log_data.record.timestamp.is_some() {
-                    event_time = log_data.record.timestamp.unwrap();
-                } else if log_data.record.observed_timestamp.is_some() {
-                    event_time = log_data.record.observed_timestamp.unwrap();
-                } else {
-                    event_time = SystemTime::now();
-                }
+                let event_time: SystemTime = log_data.record.timestamp.unwrap_or(log_data.record.observed_timestamp.time);
                 cs_a_count += 1; // for event_time
                 eb.add_struct("PartA", cs_a_count, 0);
                 {


### PR DESCRIPTION
## Changes

As per the log data model, `Observed Timestamp` should either be specified through bridge-api (by appender),  or else the SDK should set it to current time.

Refer: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/bridge-api.md 

> [Observed Timestamp](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-observedtimestamp). If unspecified the implementation SHOULD set it equal to the current time.

As of now, this is an optional field in LogRecord, and SDK doesn't default it to current timestamp if not already set. Modifying the code to make it mandatory field with default value.

**otlp log exporter output before this change:**

```
LogRecord #0
ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-08-02 06:04:50.0677901 +0000 UTC
SeverityText: INFO
SeverityNumber: Info(9)
Body: Str(hello from banana. My price is 2.99. I am also inside a Span!)
Trace ID: 32b8f0eb91e559d03b39be3004741ffe
Span ID: f471fb669a2a7a0e
Flags: 1
```
**otlp log exporter output after this change:**
```
LogRecord #0
ObservedTimestamp: 2023-08-02 06:13:50.1720326 +0000 UTC
Timestamp: 2023-08-02 06:13:50.1720323 +0000 UTC
SeverityText: INFO
SeverityNumber: Info(9)
Body: Str(hello from banana. My price is 2.99. I am also inside a Span!)
Trace ID: f722f369b03b1d46e987b5a00720064a
Span ID: 14f94c1be9e9f160
Flags: 1
```
  
## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)