### PR TITLE
Fix timestamps in log-appenders

### DIFF
--- a/opentelemetry-appender-log/CHANGELOG.md
+++ b/opentelemetry-appender-log/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## vNext
 
-- Populate TimeStamp on LogRecord, instead of ObservedTimeStamp
-  [#1175](https://github.com/open-telemetry/opentelemetry-rust/pull/1175).
-
 ## v0.1.0
 
 Initial crate release

--- a/opentelemetry-appender-log/CHANGELOG.md
+++ b/opentelemetry-appender-log/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- - Add log appender versions to loggers (#1182).
+- Add log appender versions to loggers (#1182).
 
 ## v0.1.0
 

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -1,6 +1,6 @@
 use log::{Level, Metadata, Record};
 use opentelemetry_api::logs::{AnyValue, LogRecordBuilder, Logger, LoggerProvider, Severity};
-use std::{borrow::Cow};
+use std::borrow::Cow;
 
 pub struct OpenTelemetryLogBridge<P, L>
 where

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -31,8 +31,9 @@ where
             self.logger.emit(
                 LogRecordBuilder::new()
                     .with_severity_number(map_severity_to_otel_severity(record.level()))
-                    .with_timestamp(SystemTime::now())
                     .with_severity_text(record.level().as_str())
+                    // Not populating ObservedTimestamp, instead relying on OpenTelemetry
+                    // API to populate it with current time.
                     .with_body(AnyValue::from(record.args().to_string()))
                     .build(),
             );

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -1,6 +1,5 @@
 use log::{Level, Metadata, Record};
 use opentelemetry_api::logs::{AnyValue, LogRecordBuilder, Logger, LoggerProvider, Severity};
-use std::time::SystemTime;
 
 pub struct OpenTelemetryLogBridge<P, L>
 where

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## vNext
 
-- Populate TimeStamp on LogRecord [#1175](https://github.com/open-telemetry/opentelemetry-rust/pull/1175).
-
 ## v0.1.0
 
 Initial crate release

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -99,7 +99,9 @@ where
         let mut log_record: LogRecord = LogRecord::default();
         log_record.severity_number = Some(map_severity_to_otel_severity(meta.level().as_str()));
         log_record.severity_text = Some(meta.level().to_string().into());
-        log_record.timestamp = Some(SystemTime::now());
+        
+        // Not populating ObservedTimestamp, instead relying on OpenTelemetry
+        // API to populate it with current time.
 
         let mut visitor = EventVisitor {
             log_record: &mut log_record,

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, time::SystemTime};
+use std::borrow::Cow;
 
 use opentelemetry_api::logs::{LogRecord, Logger, LoggerProvider, Severity};
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -99,7 +99,7 @@ where
         let mut log_record: LogRecord = LogRecord::default();
         log_record.severity_number = Some(map_severity_to_otel_severity(meta.level().as_str()));
         log_record.severity_text = Some(meta.level().to_string().into());
-        
+
         // Not populating ObservedTimestamp, instead relying on OpenTelemetry
         // API to populate it with current time.
 


### PR DESCRIPTION
Following up on : https://github.com/open-telemetry/opentelemetry-rust/pull/1178#discussion_r1282268221.
After #1178 , there is no longer the need to populate ObservedTS from log-appenders. This is mostly reverting #1175 due to #1178.