### PR TITLE
datadog: do not set invalid remote context

### DIFF
--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.9.0
+## vNext
 
 ### Fixed
 

--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.9.0
+
+### Fixed
+
+- Do not set an empty span as the active span when the propagator does not find a remote span.
+
 ## V0.8.0
 
 ### Changed


### PR DESCRIPTION
## Changes

When no remote span can be extracted, the datadog propagator will set the active span to an empty span. This seems to cause child spans to use the empty span's trace ID of 0, breaking propagation of new traces. The datadog agent seems to be ok with getting these traces, adding a trace ID itself.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
