### PR TITLE
fix: allow user to set arbitrary units in promethus suffix.

### DIFF
--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Changed
+- allow custom units in prometheus suffix [#1188](https://github.com/open-telemetry/opentelemetry-rust/pull/1188)
+
 ## v0.13.0
 
 ### Added

--- a/opentelemetry-prometheus/src/utils.rs
+++ b/opentelemetry-prometheus/src/utils.rs
@@ -36,7 +36,7 @@ pub(crate) fn get_unit_suffixes(unit: &Unit) -> Option<Cow<'static, str>> {
         };
     }
 
-    None
+    Some(Cow::Owned(unit.as_str().to_string()))
 }
 
 fn get_prom_units(unit: &str) -> Option<&'static str> {
@@ -185,7 +185,9 @@ mod tests {
             ("1/y", Some(Cow::Owned("per_year".to_owned()))),
             ("m/s", Some(Cow::Owned("meters_per_second".to_owned()))),
             // No match
-            ("invalid", None),
+            ("invalid", Some(Cow::Owned("invalid".to_string()))),
+            ("invalid/invalid", None),
+            ("seconds", Some(Cow::Owned("seconds".to_string()))),
             ("", None),
         ];
         for (unit_str, expected_suffix) in test_cases {


### PR DESCRIPTION
Fixes #1173

## Changes

Before this change, if user-specific the full name of the unit. It will not be added to the suffix of the result metrics.
After this change, most of the user-specific unit will be added to the result metrics with the exception of any unit containing `/`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
