### PR TITLE
[user_events exporter] Fix the exporter log format

### DIFF
--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
 use eventheader::{FieldFormat, Level, Opcode};
 use eventheader_dynamic::EventBuilder;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
-use std::{borrow::Cow};
 
 use opentelemetry_api::{logs::AnyValue, logs::Severity, Key};
 use std::{cell::RefCell, str, time::SystemTime};
@@ -246,7 +246,6 @@ impl UserEventsExporter {
                     cs_b_count += 1;
                     is_severity_text_present = true;
                 }
-                print!("cs_b_count {}", cs_b_count);
                 if cs_b_count > 0 {
                     eb.add_struct("PartB", cs_b_count, 0);
                     {

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
 use eventheader::{FieldFormat, Level, Opcode};
 use eventheader_dynamic::EventBuilder;
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
+use std::{borrow::Cow};
 
 use opentelemetry_api::{logs::AnyValue, logs::Severity, Key};
 use std::{cell::RefCell, str, time::SystemTime};
@@ -46,7 +46,6 @@ impl ExporterConfig {
         }
     }
 }
-
 pub(crate) struct UserEventsExporter {
     provider: Arc<eventheader_dynamic::Provider>,
     exporter_config: ExporterConfig,
@@ -241,13 +240,13 @@ impl UserEventsExporter {
                     is_body_present = true;
                 }
                 if level != Level::Invalid {
-                    cs_b_count += cs_b_count;
+                    cs_b_count += 1;
                 }
                 if log_data.record.severity_text.is_some() {
-                    cs_b_count += cs_b_count;
+                    cs_b_count += 1;
                     is_severity_text_present = true;
                 }
-
+                print!("cs_b_count {}", cs_b_count);
                 if cs_b_count > 0 {
                     eb.add_struct("PartB", cs_b_count, 0);
                     {
@@ -357,4 +356,11 @@ impl opentelemetry_sdk::export::logs::LogExporter for UserEventsExporter {
         };
         false
     }
+}
+
+#[cfg(target_os = "linux")]
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn validate_user_events_output() {}
 }

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -356,10 +356,3 @@ impl opentelemetry_sdk::export::logs::LogExporter for UserEventsExporter {
         false
     }
 }
-
-#[cfg(target_os = "linux")]
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn validate_user_events_output() {}
-}


### PR DESCRIPTION
## Changes

A minor correction has been made to the user_events log exporter. Within the user_events eventheader structure, there are various sections or structs, each encompassing subfields. When these sections are created, the quantity of fields within them needs to be defined. An error in the exporter led to an incorrect calculation of this count concerning the presence of the event_id and event_name fields. This issue has now been addressed and fixed.

These issues should be caught in unit-tests. Will be separately adding unit-test for the exporter, as it would need some code restructure


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
