### PR TITLE
Add Cijo and Lalit to list of approvers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,9 @@ For GitHub groups see the [code owners](CODEOWNERS) file.
 
 ### Approvers
 
+* [Cijo Thomas](https://github.com/cijothomas)
 * [Harold Dost](https://github.com/hdost)
+* [Lalit Kumar Bhasin](https://github.com/lalitb)
 
 ### Emeritus
 


### PR DESCRIPTION
Adding approvers must be done via PR as per OTel guidelines so adding this PR to propose the change. See https://github.com/open-telemetry/opentelemetry-rust/pull/1177#issuecomment-1663035447 for background. 
