### PR TITLE
Add `opentelemetry::sdk::logs::config()` for parity with `open telemetry::sdk::trace::config()`

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -8,6 +8,7 @@
   casing
 - Log warning if view is created with empty criteria (#1266)
 - Add exponential histogram support (#1267)
+- Add `opentelemetry::sdk::logs::config()` for parity with `opentelemetry::sdk::trace::config()` (#1197)
 
 ### Changed
 

--- a/opentelemetry-sdk/src/logs/config.rs
+++ b/opentelemetry-sdk/src/logs/config.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::Resource;
 
-/// Default trace configuration
+/// Default log configuration
 pub fn config() -> Config {
     Config::default()
 }

--- a/opentelemetry-sdk/src/logs/config.rs
+++ b/opentelemetry-sdk/src/logs/config.rs
@@ -2,6 +2,11 @@ use std::borrow::Cow;
 
 use crate::Resource;
 
+/// Default trace configuration
+pub fn config() -> Config {
+    Config::default()
+}
+
 /// Log emitter configuration.
 #[derive(Debug, Default)]
 pub struct Config {

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -4,7 +4,7 @@ mod config;
 mod log_emitter;
 mod log_processor;
 
-pub use config::Config;
+pub use config::{config, Config};
 pub use log_emitter::{Builder, Logger, LoggerProvider};
 pub use log_processor::{
     BatchConfig, BatchLogProcessor, BatchLogProcessorBuilder, BatchMessage, LogProcessor,

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -21,6 +21,7 @@ This release should been seen as 1.0-rc3 following 1.0-rc2 in v0.19.0. Refer to 
 - Create tracer using a shared instrumentation library #1129
 - Add `Context::map_current` #1140
 - Add unit/doc tests for metrics #1213
+- Add `opentelemetry::sdk::logs::config()` for parity with `opentelemetry::sdk::trace::config()` (#1197)
 
 ### Changed
 


### PR DESCRIPTION
## Changes

Adds a `opentelemetry::sdk::logs::config()` function, equivalent to `opentelemetry::sdk::logs::Config::default()`, as such a method exists for `open telemetry::sdk::trace`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
