### PR TITLE
Move the SDK out of opentelemetry crate, which is now the API only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       run: ./scripts/patch_dependencies.sh
     - name: Run tests
       run: cargo --version &&
-        cargo test --manifest-path=opentelemetry/Cargo.toml --features trace,metrics,rt-tokio,testing &&
+        cargo test --manifest-path=opentelemetry/Cargo.toml --features trace,metrics,testing &&
         cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --features rt-tokio &&
         cargo test --manifest-path=opentelemetry-zipkin/Cargo.toml
   cargo-deny:

--- a/examples/logs-basic/Cargo.toml
+++ b/examples/logs-basic/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-opentelemetry_api = { path = "../../opentelemetry-api", features = ["logs"] }
+opentelemetry = { path = "../../opentelemetry", features = ["logs"] }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["logs"] }
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["logs"]}
 opentelemetry-appender-log = { path = "../../opentelemetry-appender-log", default-features = false}

--- a/examples/logs-basic/src/main.rs
+++ b/examples/logs-basic/src/main.rs
@@ -1,5 +1,5 @@
 use log::{error, Level};
-use opentelemetry_api::KeyValue;
+use opentelemetry::KeyValue;
 use opentelemetry_appender_log::OpenTelemetryLogBridge;
 use opentelemetry_sdk::logs::{Config, LoggerProvider};
 use opentelemetry_sdk::Resource;

--- a/examples/metrics-advanced/Cargo.toml
+++ b/examples/metrics-advanced/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-opentelemetry_api = { path = "../../opentelemetry-api", features = ["metrics"] }
+opentelemetry = { path = "../../opentelemetry", features = ["metrics"] }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["metrics", "rt-tokio"] }
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["metrics"]}
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -1,6 +1,6 @@
-use opentelemetry_api::metrics::Unit;
-use opentelemetry_api::Key;
-use opentelemetry_api::{metrics::MeterProvider as _, KeyValue};
+use opentelemetry::metrics::Unit;
+use opentelemetry::Key;
+use opentelemetry::{metrics::MeterProvider as _, KeyValue};
 use opentelemetry_sdk::metrics::{Instrument, MeterProvider, PeriodicReader, Stream};
 use opentelemetry_sdk::{runtime, Resource};
 use std::error::Error;

--- a/examples/metrics-basic/Cargo.toml
+++ b/examples/metrics-basic/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-opentelemetry_api = { path = "../../opentelemetry-api", features = ["metrics"] }
+opentelemetry = { path = "../../opentelemetry", features = ["metrics"] }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["metrics", "rt-tokio"] }
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["metrics"]}
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -1,5 +1,5 @@
-use opentelemetry_api::metrics::Unit;
-use opentelemetry_api::{metrics::MeterProvider as _, KeyValue};
+use opentelemetry::metrics::Unit;
+use opentelemetry::{metrics::MeterProvider as _, KeyValue};
 use opentelemetry_sdk::metrics::{MeterProvider, PeriodicReader};
 use opentelemetry_sdk::{runtime, Resource};
 use std::error::Error;

--- a/examples/traceresponse/Cargo.toml
+++ b/examples/traceresponse/Cargo.toml
@@ -19,6 +19,7 @@ doc = false
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1.0", features = ["full"] }
 opentelemetry = { path = "../../opentelemetry" }
+opentelemetry_sdk = { path = "../../opentelemetry-sdk" }
 opentelemetry-http = { path = "../../opentelemetry-http" }
 opentelemetry-contrib = { path = "../../opentelemetry-contrib" }
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["trace"] }

--- a/examples/traceresponse/src/client.rs
+++ b/examples/traceresponse/src/client.rs
@@ -1,16 +1,14 @@
 use hyper::http::HeaderValue;
 use hyper::{body::Body, Client};
-use opentelemetry::global;
-use opentelemetry::propagation::TextMapPropagator;
-use opentelemetry::sdk::propagation::TraceContextPropagator;
-use opentelemetry::sdk::trace::TracerProvider;
-use opentelemetry::trace::SpanKind;
 use opentelemetry::{
-    trace::{TraceContextExt, Tracer},
+    global,
+    propagation::TextMapPropagator,
+    trace::{SpanKind, TraceContextExt, Tracer},
     Context, KeyValue,
 };
 use opentelemetry_contrib::trace::propagator::trace_context_response::TraceContextResponsePropagator;
 use opentelemetry_http::{HeaderExtractor, HeaderInjector};
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::TracerProvider};
 use opentelemetry_stdout::SpanExporter;
 
 fn init_tracer() {

--- a/examples/traceresponse/src/server.rs
+++ b/examples/traceresponse/src/server.rs
@@ -1,12 +1,16 @@
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Request, Response, Server};
-use opentelemetry::propagation::TextMapPropagator;
-use opentelemetry::sdk::trace::TracerProvider;
-use opentelemetry::trace::{SpanKind, TraceContextExt};
-use opentelemetry::Context;
-use opentelemetry::{global, sdk::propagation::TraceContextPropagator, trace::Tracer};
+use hyper::{
+    service::{make_service_fn, service_fn},
+    Body, Request, Response, Server,
+};
+use opentelemetry::{
+    global,
+    propagation::TextMapPropagator,
+    trace::{SpanKind, TraceContextExt, Tracer},
+    Context,
+};
 use opentelemetry_contrib::trace::propagator::trace_context_response::TraceContextResponsePropagator;
 use opentelemetry_http::{HeaderExtractor, HeaderInjector};
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::TracerProvider};
 use opentelemetry_stdout::SpanExporter;
 use std::{convert::Infallible, net::SocketAddr};
 

--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -14,14 +14,15 @@ name = "grpc-client"
 path = "src/client.rs"
 
 [dependencies]
-opentelemetry = { version = "0.19", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.18", features = ["rt-tokio"] }
+opentelemetry = { version = "0.20" }
+opentelemetry_sdk = { version = "0.20", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.19", features = ["rt-tokio"] }
 prost = "0.11"
 tokio = { version = "1.28", features = ["full"] }
 tonic = "0.9.2"
 tracing = "0.1"
 tracing-futures = "0.2"
-tracing-opentelemetry = "0.19"
+tracing-opentelemetry = "0.20"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]

--- a/examples/tracing-grpc/src/server.rs
+++ b/examples/tracing-grpc/src/server.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
     let tracer = opentelemetry_jaeger::new_agent_pipeline()
         .with_service_name("grpc-server")
-        .install_batch(opentelemetry::runtime::Tokio)?;
+        .install_batch(opentelemetry_sdk::runtime::Tokio)?;
     tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::new("INFO"))
         .with(tracing_opentelemetry::layer().with_tracer(tracer))

--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -11,9 +11,9 @@ rust-version = "1.64"
 edition = "2021"
 
 [dependencies]
-opentelemetry_api = { version = "0.20", path = "../opentelemetry-api", features = ["logs"]}
+opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["logs"]}
 log = {version = "0.4.17", features = ["kv_unstable", "std"]}
 
 [features]
-logs_level_enabled = ["opentelemetry_api/logs_level_enabled"]
+logs_level_enabled = ["opentelemetry/logs_level_enabled"]
 default = ["logs_level_enabled"]

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -1,5 +1,5 @@
 use log::{Level, Metadata, Record};
-use opentelemetry_api::logs::{AnyValue, LogRecordBuilder, Logger, LoggerProvider, Severity};
+use opentelemetry::logs::{AnyValue, LogRecordBuilder, Logger, LoggerProvider, Severity};
 use std::borrow::Cow;
 
 pub struct OpenTelemetryLogBridge<P, L>

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 rust-version = "1.64"
 
 [dependencies]
-opentelemetry_api = { version = "0.20", path = "../opentelemetry-api", features = ["logs"] }
+opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["logs"] }
 opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk", features = ["logs"] }
 tracing = {version = "0.1.37", default-features = false, features = ["std"]}
 tracing-core = "0.1.31"
@@ -22,5 +22,5 @@ once_cell = "1.13.0"
 opentelemetry-stdout = { path = "../opentelemetry-stdout", features = ["logs"] }
 
 [features]
-logs_level_enabled = ["opentelemetry_api/logs_level_enabled", "opentelemetry_sdk/logs_level_enabled"]
+logs_level_enabled = ["opentelemetry/logs_level_enabled", "opentelemetry_sdk/logs_level_enabled"]
 default = ["logs_level_enabled"]

--- a/opentelemetry-appender-tracing/examples/basic.rs
+++ b/opentelemetry-appender-tracing/examples/basic.rs
@@ -1,6 +1,6 @@
 //! run with `$ cargo run --example basic
 
-use opentelemetry_api::KeyValue;
+use opentelemetry::KeyValue;
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::{
     logs::{Config, LoggerProvider},

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,7 +1,5 @@
+use opentelemetry::logs::{LogRecord, Logger, LoggerProvider, Severity};
 use std::borrow::Cow;
-
-use opentelemetry_api::logs::{LogRecord, Logger, LoggerProvider, Severity};
-
 use tracing_subscriber::Layer;
 
 const INSTRUMENTATION_LIBRARY_NAME: &str = "opentelemetry-appender-tracing";

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -20,14 +20,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["trace"]
-trace = ["opentelemetry_api/trace"]
+trace = ["opentelemetry/trace"]
 
 [dependencies]
 once_cell = "1.12"
-opentelemetry_api = { version = "0.20", path = "../opentelemetry-api" }
+opentelemetry = { version = "0.21", path = "../opentelemetry" }
 
 [dev-dependencies]
-opentelemetry_api = { path = "../opentelemetry-api", features = ["trace"] }
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["trace", "testing"] }
 opentelemetry-http = { path = "../opentelemetry-http" }
 opentelemetry-stdout = { path = "../opentelemetry-stdout", features = ["trace"] }

--- a/opentelemetry-aws/src/lib.rs
+++ b/opentelemetry-aws/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ### Quick start
 //! ```no_run
-//! use opentelemetry_api::{global, trace::{Tracer, TracerProvider as _}};
+//! use opentelemetry::{global, trace::{Tracer, TracerProvider as _}};
 //! use opentelemetry_aws::trace::XrayPropagator;
 //! use opentelemetry_sdk::trace::TracerProvider;
 //! use opentelemetry_stdout::SpanExporter;
@@ -45,7 +45,7 @@ pub use trace::XrayPropagator;
 #[cfg(feature = "trace")]
 pub mod trace {
     use once_cell::sync::Lazy;
-    use opentelemetry_api::{
+    use opentelemetry::{
         global::{self, Error},
         propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
         trace::{
@@ -81,7 +81,7 @@ pub mod trace {
     /// ## Example
     ///
     /// ```
-    /// use opentelemetry_api::global;
+    /// use opentelemetry::global;
     /// use opentelemetry_aws::trace::XrayPropagator;
     ///
     /// global::set_text_map_propagator(XrayPropagator::default());
@@ -310,7 +310,7 @@ pub mod trace {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use opentelemetry_api::trace::TraceState;
+        use opentelemetry::trace::TraceState;
         use opentelemetry_sdk::testing::trace::TestSpan;
         use std::collections::HashMap;
         use std::str::FromStr;

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -23,17 +23,17 @@ default = []
 base64_format = ["base64", "binary_propagator"]
 binary_propagator = []
 jaeger_json_exporter = ["serde_json", "futures-core", "futures-util", "async-trait", "opentelemetry-semantic-conventions"]
-rt-tokio = ["tokio", "opentelemetry/rt-tokio"]
-rt-tokio-current-thread = ["tokio", "opentelemetry/rt-tokio-current-thread"]
-rt-async-std = ["async-std", "opentelemetry/rt-async-std"]
+rt-tokio = ["tokio", "opentelemetry_sdk/rt-tokio"]
+rt-tokio-current-thread = ["tokio", "opentelemetry_sdk/rt-tokio-current-thread"]
+rt-async-std = ["async-std", "opentelemetry_sdk/rt-async-std"]
 
 [dependencies]
 async-std = { version = "1.10", optional = true }
 async-trait = { version = "0.1", optional = true }
 base64 = { version = "0.13", optional = true }
 once_cell = "1.17.1"
-opentelemetry = { version = "0.20", path = "../opentelemetry", features = ["trace"] }
-opentelemetry_api = { version = "0.20", path = "../opentelemetry-api" }
+opentelemetry = { version = "0.21", path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk" }
 opentelemetry-semantic-conventions = { version = "0.12", path = "../opentelemetry-semantic-conventions", optional = true }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.0", features = ["fs", "io-util"], optional = true }
@@ -44,4 +44,4 @@ futures-util = { version = "0.3", optional = true }
 
 [dev-dependencies]
 base64 = "0.13"
-opentelemetry = { path = "../opentelemetry", features = ["trace", "testing"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["trace", "testing"] }

--- a/opentelemetry-contrib/src/trace/propagator/trace_context_response.rs
+++ b/opentelemetry-contrib/src/trace/propagator/trace_context_response.rs
@@ -12,10 +12,9 @@
 //!
 //! [w3c trace-context docs]: https://w3c.github.io/trace-context/#traceresponse-header
 use once_cell::sync::Lazy;
-use opentelemetry::trace::{SpanContext, SpanId, TraceId, TraceState};
-use opentelemetry_api::{
+use opentelemetry::{
     propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
-    trace::{TraceContextExt, TraceFlags},
+    trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState},
     Context,
 };
 
@@ -132,10 +131,10 @@ impl TextMapPropagator for TraceContextResponsePropagator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::{testing::trace::TestSpan, trace::TraceState};
-    use opentelemetry_api::{
+    use opentelemetry::{
         propagation::{Extractor, TextMapPropagator},
-        trace::{SpanContext, SpanId, TraceId},
+        testing::trace::TestSpan,
+        trace::{SpanContext, SpanId, TraceId, TraceState},
     };
     use std::{collections::HashMap, str::FromStr};
 

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -26,7 +26,8 @@ surf-client = ["surf", "opentelemetry-http/surf"]
 [dependencies]
 indexmap = "2.0"
 once_cell = "1.12"
-opentelemetry = { version = "0.20", path = "../opentelemetry", features = ["trace"] }
+opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["trace"] }
+opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk", features = ["trace"] }
 opentelemetry-http = { version = "0.9", path = "../opentelemetry-http" }
 opentelemetry-semantic-conventions = { version = "0.12", path = "../opentelemetry-semantic-conventions" }
 rmp = "0.8"
@@ -34,7 +35,7 @@ url = "2.2"
 reqwest = { version = "0.11", default-features = false, optional = true }
 surf = { version = "2.0", default-features = false, optional = true }
 thiserror = "1.0"
-itertools = "0.10"
+itertools = "0.11"
 http = "0.2"
 futures-core = "0.3"
 
@@ -44,7 +45,7 @@ base64 = "0.13"
 bytes = "1"
 futures-util = { version = "0.3", features = ["io"] }
 isahc = "1.4"
-opentelemetry = { path = "../opentelemetry", features = ["trace", "testing"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["trace", "testing"] }
 
 [[example]]
 name = "datadog"

--- a/opentelemetry-datadog/examples/datadog.rs
+++ b/opentelemetry-datadog/examples/datadog.rs
@@ -1,6 +1,5 @@
-use opentelemetry::global;
-use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::{
+    global::{self, shutdown_tracer_provider},
     trace::{Span, TraceContextExt, Tracer},
     Key,
 };

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -4,25 +4,23 @@ mod model;
 pub use model::ApiVersion;
 pub use model::Error;
 pub use model::FieldMappingFn;
-use opentelemetry::runtime::RuntimeChannel;
-
-use std::borrow::Cow;
-use std::fmt::{Debug, Formatter};
 
 use crate::exporter::model::FieldMapping;
 use futures_core::future::BoxFuture;
 use http::{Method, Request, Uri};
 use itertools::Itertools;
-use opentelemetry::sdk::export::trace;
-use opentelemetry::sdk::export::trace::SpanData;
-use opentelemetry::sdk::resource::ResourceDetector;
-use opentelemetry::sdk::resource::SdkProvidedResourceDetector;
-use opentelemetry::sdk::trace::{BatchMessage, Config};
-use opentelemetry::sdk::Resource;
-use opentelemetry::trace::TraceError;
-use opentelemetry::{global, sdk, trace::TracerProvider, KeyValue};
+use opentelemetry::{global, trace::TraceError, KeyValue};
 use opentelemetry_http::{HttpClient, ResponseExt};
+use opentelemetry_sdk::{
+    export::trace::{ExportResult, SpanData, SpanExporter},
+    resource::{ResourceDetector, SdkProvidedResourceDetector},
+    runtime::RuntimeChannel,
+    trace::{BatchMessage, Config, Tracer, TracerProvider},
+    Resource,
+};
 use opentelemetry_semantic_conventions as semcov;
+use std::borrow::Cow;
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
@@ -143,7 +141,7 @@ pub fn new_pipeline() -> DatadogPipelineBuilder {
 /// Builder for `ExporterConfig` struct.
 pub struct DatadogPipelineBuilder {
     agent_endpoint: String,
-    trace_config: Option<sdk::trace::Config>,
+    trace_config: Option<Config>,
     api_version: ApiVersion,
     client: Option<Arc<dyn HttpClient>>,
     mapping: Mapping,
@@ -283,14 +281,14 @@ impl DatadogPipelineBuilder {
     }
 
     /// Install the Datadog trace exporter pipeline using a simple span processor.
-    pub fn install_simple(mut self) -> Result<sdk::trace::Tracer, TraceError> {
+    pub fn install_simple(mut self) -> Result<Tracer, TraceError> {
         let (config, service_name) = self.build_config_and_service_name();
         let exporter = self.build_exporter_with_service_name(service_name)?;
-        let mut provider_builder =
-            sdk::trace::TracerProvider::builder().with_simple_exporter(exporter);
+        let mut provider_builder = TracerProvider::builder().with_simple_exporter(exporter);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let tracer = provider.versioned_tracer(
+        let tracer = opentelemetry::trace::TracerProvider::versioned_tracer(
+            &provider,
             "opentelemetry-datadog",
             Some(env!("CARGO_PKG_VERSION")),
             Some(semcov::SCHEMA_URL),
@@ -305,14 +303,14 @@ impl DatadogPipelineBuilder {
     pub fn install_batch<R: RuntimeChannel<BatchMessage>>(
         mut self,
         runtime: R,
-    ) -> Result<sdk::trace::Tracer, TraceError> {
+    ) -> Result<Tracer, TraceError> {
         let (config, service_name) = self.build_config_and_service_name();
         let exporter = self.build_exporter_with_service_name(service_name)?;
-        let mut provider_builder =
-            sdk::trace::TracerProvider::builder().with_batch_exporter(exporter, runtime);
+        let mut provider_builder = TracerProvider::builder().with_batch_exporter(exporter, runtime);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let tracer = provider.versioned_tracer(
+        let tracer = opentelemetry::trace::TracerProvider::versioned_tracer(
+            &provider,
             "opentelemetry-datadog",
             Some(env!("CARGO_PKG_VERSION")),
             Some(semcov::SCHEMA_URL),
@@ -358,7 +356,7 @@ impl DatadogPipelineBuilder {
     }
 
     /// Assign the SDK trace configuration
-    pub fn with_trace_config(mut self, config: sdk::trace::Config) -> Self {
+    pub fn with_trace_config(mut self, config: Config) -> Self {
         self.trace_config = Some(config);
         self
     }
@@ -411,14 +409,14 @@ fn group_into_traces(spans: Vec<SpanData>) -> Vec<Vec<SpanData>> {
 async fn send_request(
     client: Arc<dyn HttpClient>,
     request: http::Request<Vec<u8>>,
-) -> trace::ExportResult {
+) -> ExportResult {
     let _ = client.send(request).await?.error_for_status()?;
     Ok(())
 }
 
-impl trace::SpanExporter for DatadogExporter {
+impl SpanExporter for DatadogExporter {
     /// Export spans to datadog-agent
-    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, trace::ExportResult> {
+    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
         let request = match self.build_request(batch) {
             Ok(req) => req,
             Err(err) => return Box::pin(std::future::ready(Err(err))),

--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -1,6 +1,6 @@
 use crate::exporter::ModelConfig;
 use http::uri;
-use opentelemetry::sdk::export::{
+use opentelemetry_sdk::export::{
     trace::{self, SpanData},
     ExportError,
 };
@@ -48,7 +48,7 @@ static SAMPLING_PRIORITY_KEY: &str = "_sampling_priority_v1";
 ///                 "datadog spans"
 ///             })
 ///            .with_agent_endpoint("http://localhost:8126")
-///            .install_batch(opentelemetry::runtime::Tokio)?;
+///            .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 ///
 ///    Ok(())
 /// }
@@ -189,11 +189,14 @@ impl ApiVersion {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use opentelemetry::sdk::InstrumentationLibrary;
-    use opentelemetry::sdk::{self, Resource};
     use opentelemetry::{
         trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState},
         Key, KeyValue,
+    };
+    use opentelemetry_sdk::{
+        self,
+        trace::{EvictedHashMap, EvictedQueue},
+        InstrumentationLibrary, Resource,
     };
     use std::borrow::Cow;
     use std::time::{Duration, SystemTime};
@@ -215,11 +218,11 @@ pub(crate) mod tests {
         let end_time = start_time.checked_add(Duration::from_secs(1)).unwrap();
 
         let capacity = 3;
-        let mut attributes = sdk::trace::EvictedHashMap::new(capacity, capacity as usize);
+        let mut attributes = EvictedHashMap::new(capacity, capacity as usize);
         attributes.insert(Key::new("span.type").string("web"));
 
-        let events = sdk::trace::EvictedQueue::new(capacity);
-        let links = sdk::trace::EvictedQueue::new(capacity);
+        let events = EvictedQueue::new(capacity);
+        let links = EvictedQueue::new(capacity);
         let resource = Resource::new(vec![KeyValue::new("host.name", "test")]);
 
         trace::SpanData {

--- a/opentelemetry-datadog/src/exporter/model/v03.rs
+++ b/opentelemetry-datadog/src/exporter/model/v03.rs
@@ -1,14 +1,12 @@
 use crate::exporter::model::{Error, SAMPLING_PRIORITY_KEY};
 use crate::exporter::ModelConfig;
-use opentelemetry::sdk::export::trace;
-use opentelemetry::sdk::export::trace::SpanData;
-use opentelemetry::trace::Status;
-use opentelemetry::{Key, Value};
+use opentelemetry::{trace::Status, Key, Value};
+use opentelemetry_sdk::export::trace::SpanData;
 use std::time::SystemTime;
 
 pub(crate) fn encode<S, N, R>(
     model_config: &ModelConfig,
-    traces: Vec<Vec<trace::SpanData>>,
+    traces: Vec<Vec<SpanData>>,
     get_service_name: S,
     get_name: N,
     get_resource: R,

--- a/opentelemetry-datadog/src/exporter/model/v05.rs
+++ b/opentelemetry-datadog/src/exporter/model/v05.rs
@@ -1,10 +1,8 @@
 use crate::exporter::intern::StringInterner;
 use crate::exporter::model::SAMPLING_PRIORITY_KEY;
 use crate::exporter::{Error, ModelConfig};
-use opentelemetry::sdk::export::trace;
-use opentelemetry::sdk::export::trace::SpanData;
-use opentelemetry::trace::Status;
-use opentelemetry::{Key, Value};
+use opentelemetry::{trace::Status, Key, Value};
+use opentelemetry_sdk::export::trace::SpanData;
 use std::time::SystemTime;
 
 use super::unified_tags::{UnifiedTagField, UnifiedTags};
@@ -58,7 +56,7 @@ const SPAN_NUM_ELEMENTS: u32 = 12;
 //
 pub(crate) fn encode<S, N, R>(
     model_config: &ModelConfig,
-    traces: Vec<Vec<trace::SpanData>>,
+    traces: Vec<Vec<SpanData>>,
     get_service_name: S,
     get_name: N,
     get_resource: R,
@@ -122,7 +120,7 @@ fn encode_traces<S, N, R>(
     get_service_name: S,
     get_name: N,
     get_resource: R,
-    traces: Vec<Vec<trace::SpanData>>,
+    traces: Vec<Vec<SpanData>>,
     unified_tags: &UnifiedTags,
 ) -> Result<Vec<u8>, Error>
 where

--- a/opentelemetry-datadog/src/lib.rs
+++ b/opentelemetry-datadog/src/lib.rs
@@ -49,7 +49,7 @@
 //! ```no_run
 //! # fn main() -> Result<(), opentelemetry::trace::TraceError> {
 //! let tracer = opentelemetry_datadog::new_pipeline()
-//!     .install_batch(opentelemetry::runtime::Tokio)?;
+//!     .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -81,8 +81,8 @@
 //!
 //! ```no_run
 //! use opentelemetry::{KeyValue, trace::Tracer};
-//! use opentelemetry::sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
-//! use opentelemetry::sdk::export::trace::ExportResult;
+//! use opentelemetry_sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
+//! use opentelemetry_sdk::export::trace::ExportResult;
 //! use opentelemetry::global::shutdown_tracer_provider;
 //! use opentelemetry_datadog::{new_pipeline, ApiVersion, Error};
 //! use opentelemetry_http::{HttpClient, HttpError};
@@ -122,7 +122,7 @@
 //!                 .with_sampler(Sampler::AlwaysOn)
 //!                 .with_id_generator(RandomIdGenerator::default())
 //!         )
-//!         .install_batch(opentelemetry::runtime::Tokio)?;
+//!         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...
@@ -317,8 +317,8 @@ mod propagator {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use opentelemetry::testing::trace::TestSpan;
         use opentelemetry::trace::TraceState;
+        use opentelemetry_sdk::testing::trace::TestSpan;
         use std::collections::HashMap;
 
         #[rustfmt::skip]

--- a/opentelemetry-dynatrace/Cargo.toml
+++ b/opentelemetry-dynatrace/Cargo.toml
@@ -36,7 +36,7 @@ surf-client = ["surf", "opentelemetry-http/surf"]
 isahc-client = ["isahc", "opentelemetry-http/isahc"]
 
 rt-tokio = ["tokio", "opentelemetry/rt-tokio"]
-rt-async-std = ["async-std", "opentelemetry/rt-async-std"]
+rt-async-std = ["async-std"]
 
 wasm = [
     "base64",
@@ -58,6 +58,7 @@ http = "0.2"
 isahc = { version = "1.4", default-features = false, optional = true }
 js-sys = { version = "0.3.5", optional = true }
 opentelemetry = { version = "0.19", default-features = false }
+opentelemetry_sdk = { version = "0.19", features = ["metrics"] }
 opentelemetry-http = { version = "0.8", default-features = false }
 reqwest = { version = "0.11", default-features = false, optional = true }
 surf = { version = "2.0", default-features = false, optional = true }
@@ -80,6 +81,6 @@ features = [
 optional = true
 
 [dev-dependencies]
-opentelemetry = { version = "0.19.0", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.19.0", features = ["rt-tokio"] }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "sync", "test-util"] }
 hyper = { version = "0.14", default-features = false, features = ["server", "tcp", "http1"] }

--- a/opentelemetry-dynatrace/src/lib.rs
+++ b/opentelemetry-dynatrace/src/lib.rs
@@ -9,9 +9,9 @@
 //!
 //! ```no_run
 //! use opentelemetry::runtime;
-//! use opentelemetry::sdk::export::metrics::aggregation::cumulative_temporality_selector;
-//! use opentelemetry::sdk::metrics::selectors;
-//! use opentelemetry::sdk::util::tokio_interval_stream;
+//! use opentelemetry_sdk::export::metrics::aggregation::cumulative_temporality_selector;
+//! use opentelemetry_sdk::metrics::selectors;
+//! use opentelemetry_sdk::util::tokio_interval_stream;
 //! use opentelemetry_dynatrace::ExportConfig;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
@@ -44,8 +44,8 @@
 //! ```
 //! # #[cfg(feature = "reqwest-client")] {
 //! use opentelemetry::runtime;
-//! use opentelemetry::sdk::metrics::selectors;
-//! use opentelemetry::sdk::export::metrics::aggregation::cumulative_temporality_selector;
+//! use opentelemetry_sdk::metrics::selectors;
+//! use opentelemetry_sdk::export::metrics::aggregation::cumulative_temporality_selector;
 //! use opentelemetry::KeyValue;
 //! use opentelemetry_dynatrace::transform::DimensionSet;
 //! use opentelemetry_dynatrace::ExportConfig;
@@ -122,8 +122,8 @@ pub use crate::exporter::ExportConfig;
 #[cfg(feature = "metrics")]
 pub use crate::metric::{DynatraceMetricsPipeline, MetricsExporter};
 
-use opentelemetry::sdk::export::ExportError;
 use opentelemetry_http::HttpClient;
+use opentelemetry_sdk::export::ExportError;
 use std::collections::HashMap;
 
 /// Dynatrace pipeline builder.
@@ -237,8 +237,8 @@ impl DynatraceExporterBuilder {
 ///
 /// ```no_run
 /// use opentelemetry::runtime;
-/// use opentelemetry::sdk::export::metrics::aggregation::cumulative_temporality_selector;
-/// use opentelemetry::sdk::metrics::selectors;
+/// use opentelemetry_sdk::export::metrics::aggregation::cumulative_temporality_selector;
+/// use opentelemetry_sdk::metrics::selectors;
 /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 /// let meter = opentelemetry_dynatrace::new_pipeline()
 ///     .metrics(

--- a/opentelemetry-dynatrace/src/metric.rs
+++ b/opentelemetry-dynatrace/src/metric.rs
@@ -13,17 +13,17 @@ use http::{
     Method, Uri, Version,
 };
 use opentelemetry::metrics::Result;
-use opentelemetry::runtime::Runtime;
-use opentelemetry::sdk::export::metrics::aggregation::{
-    AggregationKind, Temporality, TemporalitySelector,
-};
-use opentelemetry::sdk::export::metrics::{AggregatorSelector, InstrumentationLibraryReader};
-use opentelemetry::sdk::metrics::controllers::BasicController;
-use opentelemetry::sdk::metrics::sdk_api::Descriptor;
-use opentelemetry::sdk::metrics::{controllers, processors};
-use opentelemetry::sdk::{export::metrics, Resource};
 use opentelemetry::{global, Context};
 use opentelemetry_http::HttpClient;
+use opentelemetry_sdk::export::metrics::aggregation::{
+    AggregationKind, Temporality, TemporalitySelector,
+};
+use opentelemetry_sdk::export::metrics::{AggregatorSelector, InstrumentationLibraryReader};
+use opentelemetry_sdk::metrics::controllers::BasicController;
+use opentelemetry_sdk::metrics::sdk_api::Descriptor;
+use opentelemetry_sdk::metrics::{controllers, processors};
+use opentelemetry_sdk::runtime::Runtime;
+use opentelemetry_sdk::{export::metrics, Resource};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::{Debug, Formatter, Write};

--- a/opentelemetry-dynatrace/src/transform/metrics.rs
+++ b/opentelemetry-dynatrace/src/transform/metrics.rs
@@ -2,18 +2,18 @@
 use crate::transform::common::get_time;
 use opentelemetry::attributes::merge_iters;
 use opentelemetry::metrics::MetricsError;
-use opentelemetry::sdk::export::metrics::aggregation::{Count, Temporality, TemporalitySelector};
-use opentelemetry::sdk::metrics::aggregators::{
+use opentelemetry::{global, Key, KeyValue, Value};
+use opentelemetry_sdk::export::metrics::aggregation::{Count, Temporality, TemporalitySelector};
+use opentelemetry_sdk::metrics::aggregators::{
     HistogramAggregator, LastValueAggregator, SumAggregator,
 };
-use opentelemetry::sdk::{
+use opentelemetry_sdk::{
     export::metrics::{
         aggregation::{Histogram as SdkHistogram, LastValue, Sum as SdkSum},
         Record,
     },
     metrics::sdk_api::{Number, NumberKind},
 };
-use opentelemetry::{global, Key, KeyValue, Value};
 use std::borrow::Cow;
 use std::cmp;
 use std::collections::{btree_map, BTreeMap};
@@ -600,16 +600,16 @@ mod tests {
     use crate::transform::common::get_time;
     use crate::transform::metrics::MetricLine;
     use crate::transform::record_to_metric_line;
-    use opentelemetry::sdk::export::metrics::aggregation::{
-        cumulative_temporality_selector, delta_temporality_selector,
-    };
-    use opentelemetry::sdk::export::metrics::record;
-    use opentelemetry::sdk::metrics::aggregators::{
-        histogram, last_value, Aggregator, SumAggregator,
-    };
-    use opentelemetry::sdk::metrics::sdk_api::{Descriptor, InstrumentKind, Number, NumberKind};
     use opentelemetry::{attributes::AttributeSet, metrics::MetricsError};
     use opentelemetry::{Context, KeyValue};
+    use opentelemetry_sdk::export::metrics::aggregation::{
+        cumulative_temporality_selector, delta_temporality_selector,
+    };
+    use opentelemetry_sdk::export::metrics::record;
+    use opentelemetry_sdk::metrics::aggregators::{
+        histogram, last_value, Aggregator, SumAggregator,
+    };
+    use opentelemetry_sdk::metrics::sdk_api::{Descriptor, InstrumentKind, Number, NumberKind};
     use std::borrow::Cow;
     use std::sync::Arc;
     use std::time::{Duration, SystemTime};

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "1"
 http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["http2", "client", "tcp"], optional = true }
 isahc = { version = "1.4", default-features = false, optional = true }
-opentelemetry_api = { version = "0.20", path = "../opentelemetry-api", features = ["trace"] }
+opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["trace"] }
 reqwest = { version = "0.11", default-features = false, features = ["blocking"], optional = true }
 surf = { version = "2.0", default-features = false, optional = true }
 tokio = { version = "1.0", default-features = false, features = ["time"], optional = true }

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 pub use bytes::Bytes;
 #[doc(no_inline)]
 pub use http::{Request, Response};
-use opentelemetry_api::{
+use opentelemetry::{
     propagation::{Extractor, Injector},
     trace::TraceError,
 };

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -29,7 +29,8 @@ hyper = { version = "0.14", default-features = false, features = ["client"], opt
 hyper-tls = { version = "0.5.0", default-features = false, optional = true }
 isahc = { version = "1.4", default-features = false, optional = true }
 js-sys = { version = "0.3", optional = true }
-opentelemetry = { version = "0.20", default-features = false, features = ["trace"], path = "../opentelemetry" }
+opentelemetry = { version = "0.21", default-features = false, features = ["trace"], path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.20", default-features = false, features = ["trace"], path = "../opentelemetry-sdk" }
 opentelemetry-http = { version = "0.9", path = "../opentelemetry-http", optional = true }
 opentelemetry-semantic-conventions = { version = "0.12", path = "../opentelemetry-semantic-conventions" }
 pin-project-lite = { version = "0.2", optional = true }
@@ -53,7 +54,7 @@ futures-util = { version = "0.3", default-features = false, features = ["std", "
 tokio = { version = "1.0", features = ["net", "sync"] }
 bytes = "1"
 futures-executor = "0.3"
-opentelemetry = { default-features = false, features = ["trace", "testing"], path = "../opentelemetry" }
+opentelemetry_sdk = { features = ["trace", "testing", "rt-tokio"], path = "../opentelemetry-sdk" }
 
 [dependencies.web-sys]
 version = "0.3.4"
@@ -102,7 +103,7 @@ wasm_collector_client = [
     "wasm-bindgen-futures",
     "web-sys",
 ]
-rt-tokio = ["tokio", "opentelemetry/rt-tokio"]
-rt-tokio-current-thread = ["tokio", "opentelemetry/rt-tokio-current-thread"]
-rt-async-std = ["async-std", "opentelemetry/rt-async-std"]
+rt-tokio = ["tokio", "opentelemetry_sdk/rt-tokio"]
+rt-tokio-current-thread = ["tokio", "opentelemetry_sdk/rt-tokio-current-thread"]
+rt-async-std = ["async-std", "opentelemetry_sdk/rt-async-std"]
 integration_test = ["tonic", "prost", "prost-types", "rt-tokio", "collector_client", "hyper_collector_client", "hyper_tls_collector_client", "reqwest_collector_client", "surf_collector_client", "isahc_collector_client"]

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -74,7 +74,7 @@ opentelemetry-jaeger = { version = "*", features = ["rt-tokio"] }
 
 ```rust
 let tracer = opentelemetry_jaeger::new_agent_pipeline()
-    .install_batch(opentelemetry::runtime::Tokio)?;
+    .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 ```
 
 [`rt-tokio`]: https://tokio.rs

--- a/opentelemetry-jaeger/examples/actix-udp/Cargo.toml
+++ b/opentelemetry-jaeger/examples/actix-udp/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 opentelemetry = { path = "../../../opentelemetry" }
 opentelemetry-jaeger = { path = "../.." }
+opentelemetry_sdk = { path = "../../../opentelemetry-sdk" }
 actix-web = "4.1"
 actix-service = "2"
-env_logger = "0.9"
+env_logger = "0.10.0"

--- a/opentelemetry-jaeger/examples/actix-udp/src/main.rs
+++ b/opentelemetry-jaeger/examples/actix-udp/src/main.rs
@@ -1,24 +1,22 @@
 use actix_service::Service;
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpServer};
-use opentelemetry::trace::TraceError;
-use opentelemetry::{global, sdk::trace as sdktrace};
 use opentelemetry::{
-    trace::{FutureExt, TraceContextExt, Tracer},
-    Key,
+    global,
+    trace::{FutureExt, TraceContextExt, TraceError, Tracer},
+    Key, KeyValue,
 };
+use opentelemetry_sdk::{trace::config, Resource};
 
-fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
+fn init_tracer() -> Result<opentelemetry_sdk::trace::Tracer, TraceError> {
     opentelemetry_jaeger::new_agent_pipeline()
         .with_endpoint("localhost:6831")
         .with_service_name("trace-udp-demo")
-        .with_trace_config(opentelemetry::sdk::trace::config().with_resource(
-            opentelemetry::sdk::Resource::new(vec![
-                opentelemetry::KeyValue::new("service.name", "my-service"), // this will not override the trace-udp-demo
-                opentelemetry::KeyValue::new("service.namespace", "my-namespace"),
-                opentelemetry::KeyValue::new("exporter", "jaeger"),
-            ]),
-        ))
+        .with_trace_config(config().with_resource(Resource::new(vec![
+            KeyValue::new("service.name", "my-service"), // this will not override the trace-udp-demo
+            KeyValue::new("service.namespace", "my-namespace"),
+            KeyValue::new("exporter", "jaeger"),
+        ])))
         .install_simple()
 }
 

--- a/opentelemetry-jaeger/examples/remote-sampler/Cargo.toml
+++ b/opentelemetry-jaeger/examples/remote-sampler/Cargo.toml
@@ -5,8 +5,8 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
+opentelemetry = { path = "../../../opentelemetry" }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "jaeger_remote_sampler"] }
-opentelemetry_api = { path = "../../../opentelemetry-api" }
 opentelemetry-stdout = { path = "../../../opentelemetry-stdout", features = ["trace"] }
 reqwest = "0.11.10"
 tokio = { version = "1.18", features = ["macros", "rt-multi-thread"] }

--- a/opentelemetry-jaeger/examples/remote-sampler/src/main.rs
+++ b/opentelemetry-jaeger/examples/remote-sampler/src/main.rs
@@ -1,5 +1,5 @@
-use opentelemetry_api::global;
-use opentelemetry_api::trace::Tracer;
+use opentelemetry::global;
+use opentelemetry::trace::Tracer;
 use opentelemetry_sdk::runtime;
 use opentelemetry_sdk::trace::{Sampler, TracerProvider as SdkTracerProvider};
 use std::time::Duration;

--- a/opentelemetry-jaeger/src/exporter/collector.rs
+++ b/opentelemetry-jaeger/src/exporter/collector.rs
@@ -14,7 +14,7 @@ pub(crate) use wasm_collector_client::WasmCollector;
 mod collector_client {
     use super::*;
     use crate::exporter::thrift::jaeger;
-    use opentelemetry::sdk::export::trace::ExportResult;
+    use opentelemetry_sdk::export::trace::ExportResult;
     use std::io::Cursor;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use thrift::protocol::TBinaryOutputProtocol;

--- a/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
@@ -185,8 +185,8 @@ mod collector_client_tests {
     use crate::config::collector::http_client::test_http_client;
     use crate::exporter::thrift::jaeger::Batch;
     use crate::new_collector_pipeline;
-    use opentelemetry::runtime::Tokio;
     use opentelemetry::trace::TraceError;
+    use opentelemetry_sdk::runtime::Tokio;
 
     #[test]
     fn test_bring_your_own_client() -> Result<(), TraceError> {

--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -5,8 +5,8 @@ use crate::exporter::config::{
 use crate::exporter::uploader::{AsyncUploader, Uploader};
 use crate::{Exporter, JaegerTraceRuntime};
 use http::Uri;
-use opentelemetry::sdk::trace::BatchConfig;
-use opentelemetry::{sdk, sdk::trace::Config as TraceConfig, trace::TraceError};
+use opentelemetry::trace::TraceError;
+use opentelemetry_sdk::trace::{BatchConfig, BatchSpanProcessor, Config, Tracer, TracerProvider};
 use std::borrow::BorrowMut;
 use std::convert::TryFrom;
 use std::env;
@@ -80,7 +80,7 @@ const ENV_PASSWORD: &str = "OTEL_EXPORTER_JAEGER_PASSWORD";
 /// let tracer = opentelemetry_jaeger::new_collector_pipeline()
 ///         .with_surf()
 ///         .with_reqwest()
-///         .install_batch(opentelemetry::runtime::Tokio)
+///         .install_batch(opentelemetry_sdk::runtime::Tokio)
 /// #       .unwrap();
 /// ```
 ///
@@ -91,7 +91,7 @@ const ENV_PASSWORD: &str = "OTEL_EXPORTER_JAEGER_PASSWORD";
 #[derive(Debug)]
 pub struct CollectorPipeline {
     transformation_config: TransformationConfig,
-    trace_config: Option<TraceConfig>,
+    trace_config: Option<Config>,
     batch_config: Option<BatchConfig>,
 
     #[cfg(feature = "collector_client")]
@@ -155,7 +155,7 @@ impl HasRequiredConfig for CollectorPipeline {
         f(self.transformation_config.borrow_mut())
     }
 
-    fn set_trace_config(&mut self, config: TraceConfig) {
+    fn set_trace_config(&mut self, config: Config) {
         self.trace_config = Some(config)
     }
 
@@ -392,16 +392,17 @@ impl CollectorPipeline {
     /// # Examples
     /// Set service name via resource.
     /// ```rust
-    /// use opentelemetry::{sdk::{self, Resource}, KeyValue};
+    /// use opentelemetry::KeyValue;
+    /// use opentelemetry_sdk::{Resource, trace::Config};
     ///
     /// let pipeline = opentelemetry_jaeger::new_collector_pipeline()
     ///                 .with_trace_config(
-    ///                       sdk::trace::Config::default()
+    ///                       Config::default()
     ///                         .with_resource(Resource::new(vec![KeyValue::new("service.name", "my-service")]))
     ///                 );
     ///
     /// ```
-    pub fn with_trace_config(mut self, config: sdk::trace::Config) -> Self {
+    pub fn with_trace_config(mut self, config: Config) -> Self {
         self.set_trace_config(config);
         self
     }
@@ -411,7 +412,7 @@ impl CollectorPipeline {
     /// # Examples
     /// Set max queue size.
     /// ```rust
-    /// use opentelemetry::sdk::trace::BatchConfig;
+    /// use opentelemetry_sdk::trace::BatchConfig;
     ///
     /// let pipeline = opentelemetry_jaeger::new_collector_pipeline()
     ///                 .with_batch_processor_config(
@@ -440,8 +441,8 @@ impl CollectorPipeline {
     pub fn build_batch<R: JaegerTraceRuntime>(
         mut self,
         runtime: R,
-    ) -> Result<sdk::trace::TracerProvider, TraceError> {
-        let mut builder = sdk::trace::TracerProvider::builder();
+    ) -> Result<TracerProvider, TraceError> {
+        let mut builder = TracerProvider::builder();
         // build sdk trace config and jaeger process.
         // some attributes like service name has attributes like service name
         let export_instrument_library = self.transformation_config.export_instrument_library;
@@ -452,7 +453,7 @@ impl CollectorPipeline {
         let batch_config = self.batch_config.take();
         let uploader = self.build_uploader::<R>()?;
         let exporter = Exporter::new(process.into(), export_instrument_library, uploader);
-        let batch_processor = sdk::trace::BatchSpanProcessor::builder(exporter, runtime)
+        let batch_processor = BatchSpanProcessor::builder(exporter, runtime)
             .with_batch_config(batch_config.unwrap_or_default())
             .build();
 
@@ -466,10 +467,7 @@ impl CollectorPipeline {
     /// tracer provider.
     ///
     /// The tracer name is `opentelemetry-jaeger`. The tracer version will be the version of this crate.
-    pub fn install_batch<R: JaegerTraceRuntime>(
-        self,
-        runtime: R,
-    ) -> Result<sdk::trace::Tracer, TraceError> {
+    pub fn install_batch<R: JaegerTraceRuntime>(self, runtime: R) -> Result<Tracer, TraceError> {
         let tracer_provider = self.build_batch(runtime)?;
         install_tracer_provider_and_get_tracer(tracer_provider)
     }
@@ -532,7 +530,7 @@ impl CollectorPipeline {
 mod tests {
     use super::*;
     use crate::config::collector::http_client::test_http_client;
-    use opentelemetry::runtime::Tokio;
+    use opentelemetry_sdk::runtime::Tokio;
 
     #[test]
     fn test_collector_defaults() {

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -5,12 +5,12 @@
 ))]
 use crate::exporter::addrs_and_family;
 use async_trait::async_trait;
-use opentelemetry::{runtime::RuntimeChannel, sdk::trace::BatchMessage};
+use opentelemetry_sdk::{runtime::RuntimeChannel, trace::BatchMessage};
 use std::net::ToSocketAddrs;
 
 /// Jaeger Trace Runtime is an extension to [`RuntimeChannel`].
 ///
-/// [`RuntimeChannel`]: opentelemetry::sdk::runtime::RuntimeChannel
+/// [`RuntimeChannel`]: opentelemetry_sdk::runtime::RuntimeChannel
 #[async_trait]
 pub trait JaegerTraceRuntime: RuntimeChannel<BatchMessage> + std::fmt::Debug {
     /// A communication socket between Jaeger client and agent.
@@ -25,7 +25,7 @@ pub trait JaegerTraceRuntime: RuntimeChannel<BatchMessage> + std::fmt::Debug {
 
 #[cfg(feature = "rt-tokio")]
 #[async_trait]
-impl JaegerTraceRuntime for opentelemetry::runtime::Tokio {
+impl JaegerTraceRuntime for opentelemetry_sdk::runtime::Tokio {
     type Socket = tokio::net::UdpSocket;
 
     fn create_socket<T: ToSocketAddrs>(&self, endpoint: T) -> thrift::Result<Self::Socket> {
@@ -44,7 +44,7 @@ impl JaegerTraceRuntime for opentelemetry::runtime::Tokio {
 
 #[cfg(feature = "rt-tokio-current-thread")]
 #[async_trait]
-impl JaegerTraceRuntime for opentelemetry::runtime::TokioCurrentThread {
+impl JaegerTraceRuntime for opentelemetry_sdk::runtime::TokioCurrentThread {
     type Socket = tokio::net::UdpSocket;
 
     fn create_socket<T: ToSocketAddrs>(&self, endpoint: T) -> thrift::Result<Self::Socket> {
@@ -63,7 +63,7 @@ impl JaegerTraceRuntime for opentelemetry::runtime::TokioCurrentThread {
 
 #[cfg(feature = "rt-async-std")]
 #[async_trait]
-impl JaegerTraceRuntime for opentelemetry::runtime::AsyncStd {
+impl JaegerTraceRuntime for opentelemetry_sdk::runtime::AsyncStd {
     type Socket = async_std::net::UdpSocket;
 
     fn create_socket<T: ToSocketAddrs>(&self, endpoint: T) -> thrift::Result<Self::Socket> {

--- a/opentelemetry-jaeger/src/exporter/thrift/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/thrift/mod.rs
@@ -1,10 +1,9 @@
 //! Thrift generated Jaeger client
 //!
 //! Definitions: <https://github.com/uber/jaeger-idl/blob/master/thrift/>
-use std::time::{Duration, SystemTime};
 
-use opentelemetry::trace::Event;
-use opentelemetry::{Key, KeyValue, Value};
+use opentelemetry::{trace::Event, Key, KeyValue, Value};
+use std::time::{Duration, SystemTime};
 
 pub(crate) mod agent;
 pub(crate) mod jaeger;

--- a/opentelemetry-jaeger/src/exporter/uploader.rs
+++ b/opentelemetry-jaeger/src/exporter/uploader.rs
@@ -3,8 +3,7 @@
 use crate::exporter::collector;
 use crate::exporter::{agent, jaeger};
 use async_trait::async_trait;
-use opentelemetry::sdk::export::trace;
-use opentelemetry::sdk::export::trace::ExportResult;
+use opentelemetry_sdk::export::trace::ExportResult;
 use std::fmt::Debug;
 
 use crate::exporter::thrift::jaeger::Batch;
@@ -12,7 +11,7 @@ use crate::exporter::JaegerTraceRuntime;
 
 #[async_trait]
 pub(crate) trait Uploader: Debug + Send + Sync {
-    async fn upload(&self, batch: jaeger::Batch) -> trace::ExportResult;
+    async fn upload(&self, batch: jaeger::Batch) -> ExportResult;
 }
 
 #[derive(Debug)]
@@ -22,10 +21,10 @@ pub(crate) enum SyncUploader {
 
 #[async_trait]
 impl Uploader for SyncUploader {
-    async fn upload(&self, batch: jaeger::Batch) -> trace::ExportResult {
+    async fn upload(&self, batch: jaeger::Batch) -> ExportResult {
         match self {
             SyncUploader::Agent(client) => {
-                // TODO Implement retry behaviour
+                // TODO Implement retry behavior
                 client
                     .lock()
                     .expect("Failed to lock agent client")

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -28,11 +28,10 @@
 //! exporting telemetry:
 //!
 //! ```no_run
-//! use opentelemetry::trace::Tracer;
-//! use opentelemetry::global;
+//! use opentelemetry::{global, trace::{Tracer, TraceError}};
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), opentelemetry::trace::TraceError> {
+//! async fn main() -> Result<(), TraceError> {
 //!     global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
 //!     let tracer = opentelemetry_jaeger::new_agent_pipeline().install_simple()?;
 //!
@@ -48,11 +47,10 @@
 //!
 //! Or if you are running on an async runtime like Tokio and want to report spans in batches
 //! ```no_run
-//! use opentelemetry::trace::Tracer;
-//! use opentelemetry::global;
-//! use opentelemetry::runtime::Tokio;
+//! use opentelemetry::{global, trace::{Tracer, TraceError}};
+//! use opentelemetry_sdk::runtime::Tokio;
 //!
-//! fn main() -> Result<(), opentelemetry::trace::TraceError> {
+//! fn main() -> Result<(), TraceError> {
 //!     global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
 //!     let tracer = opentelemetry_jaeger::new_agent_pipeline().install_batch(Tokio)?;
 //!
@@ -75,14 +73,14 @@
 //!
 //! ```toml
 //! [dependencies]
-//! opentelemetry = { version = "*", features = ["rt-tokio"] }
+//! opentelemetry_sdk = { version = "*", features = ["rt-tokio"] }
 //! opentelemetry-jaeger = { version = "*", features = ["rt-tokio"] }
 //! ```
 //!
 //! ```no_run
 //! # fn main() -> Result<(), opentelemetry::trace::TraceError> {
 //! let tracer = opentelemetry_jaeger::new_agent_pipeline()
-//!     .install_batch(opentelemetry::runtime::Tokio)?;
+//!     .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -127,7 +125,7 @@
 //!         .with_password("s3cr3t")
 //!         .with_isahc()
 //!         //.with_http_client(<your client>) provide custom http client implementation
-//!         .install_batch(opentelemetry::runtime::Tokio)?;
+//!         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...
@@ -174,7 +172,8 @@
 //!
 //! ### Export to agents
 //! ```no_run
-//! use opentelemetry::{sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource}, global, KeyValue, trace::{Tracer, TraceError}};
+//! use opentelemetry::{global, KeyValue, trace::{Tracer, TraceError}};
+//! use opentelemetry_sdk::{trace::{config, RandomIdGenerator, Sampler}, Resource};
 //!
 //! fn main() -> Result<(), TraceError> {
 //!     global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
@@ -185,7 +184,7 @@
 //!         .with_auto_split_batch(true)
 //!         .with_instrumentation_library_tags(false)
 //!         .with_trace_config(
-//!             trace::config()
+//!             config()
 //!                 .with_sampler(Sampler::AlwaysOn)
 //!                 .with_id_generator(RandomIdGenerator::default())
 //!                 .with_max_events_per_span(64)
@@ -194,7 +193,7 @@
 //!                 .with_resource(Resource::new(vec![KeyValue::new("key", "value"),
 //!                           KeyValue::new("process_key", "process_value")])),
 //!         )
-//!         .install_batch(opentelemetry::runtime::Tokio)?;
+//!         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...
@@ -210,7 +209,8 @@
 //! ### Export to collectors
 //! Note that this example requires `collecotr_client` and `isahc_collector_client` feature.
 //! ```ignore
-//! use opentelemetry::{sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource}, global, KeyValue, trace::{Tracer, TraceError}};
+//! use opentelemetry::{global, KeyValue, trace::{Tracer, TraceError}};
+//! use opentelemetry_sdk::{trace::{config, RandomIdGenerator, Sampler}, Resource};
 //!
 //! fn main() -> Result<(), TraceError> {
 //!     global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
@@ -218,7 +218,7 @@
 //!         .with_endpoint("http://localhost:14250/api/trace") // set collector endpoint
 //!         .with_service_name("my_app") // the name of the application
 //!         .with_trace_config(
-//!             trace::config()
+//!             config()
 //!                 .with_sampler(Sampler::AlwaysOn)
 //!                 .with_id_generator(RandomIdGenerator::default())
 //!                 .with_max_events_per_span(64)
@@ -234,7 +234,7 @@
 //!         .with_username("username")
 //!         .with_password("s3cr3t")
 //!         .with_timeout(std::time::Duration::from_secs(2))
-//!         .install_batch(opentelemetry::runtime::Tokio)?;
+//!         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...

--- a/opentelemetry-jaeger/tests/integration_test.rs
+++ b/opentelemetry-jaeger/tests/integration_test.rs
@@ -1,11 +1,13 @@
 #[cfg(feature = "integration_test")]
 mod tests {
-    use opentelemetry::sdk::trace::Tracer as SdkTracer;
-    use opentelemetry::trace::{Status, TraceContextExt, Tracer};
-    use opentelemetry::KeyValue;
+    use opentelemetry::{
+        trace::{Status, TraceContextExt, Tracer},
+        KeyValue,
+    };
     use opentelemetry_jaeger::testing::{
         jaeger_api_v2 as jaeger_api, jaeger_client::JaegerTestClient,
     };
+    use opentelemetry_sdk::trace::Tracer as SdkTracer;
     use std::collections::HashMap;
 
     const SERVICE_NAME: &str = "opentelemetry_jaeger_integration_test";
@@ -73,7 +75,7 @@ mod tests {
                     opentelemetry_jaeger::new_agent_pipeline()
                         .with_endpoint(agent_endpoint)
                         .with_service_name(format!("{}-{}", SERVICE_NAME, "agent"))
-                        .install_batch(opentelemetry::runtime::Tokio)
+                        .install_batch(opentelemetry_sdk::runtime::Tokio)
                         .expect("cannot create tracer using default configuration")
                 }),
             ),
@@ -84,7 +86,7 @@ mod tests {
                         .with_endpoint(collector_endpoint)
                         .with_reqwest()
                         .with_service_name(format!("{}-{}", SERVICE_NAME, "collector_reqwest"))
-                        .install_batch(opentelemetry::runtime::Tokio)
+                        .install_batch(opentelemetry_sdk::runtime::Tokio)
                         .expect("cannot create tracer using default configuration")
                 }),
             ),
@@ -95,7 +97,7 @@ mod tests {
                         .with_endpoint(collector_endpoint)
                         .with_isahc()
                         .with_service_name(format!("{}-{}", SERVICE_NAME, "collector_isahc"))
-                        .install_batch(opentelemetry::runtime::Tokio)
+                        .install_batch(opentelemetry_sdk::runtime::Tokio)
                         .expect("cannot create tracer using default configuration")
                 }),
             ),
@@ -106,7 +108,7 @@ mod tests {
                         .with_endpoint(collector_endpoint)
                         .with_surf()
                         .with_service_name(format!("{}-{}", SERVICE_NAME, "collector_surf"))
-                        .install_batch(opentelemetry::runtime::Tokio)
+                        .install_batch(opentelemetry_sdk::runtime::Tokio)
                         .expect("cannot create tracer using default configuration")
                 }),
             ),
@@ -117,7 +119,7 @@ mod tests {
                         .with_endpoint(collector_endpoint)
                         .with_hyper()
                         .with_service_name(format!("{}-{}", SERVICE_NAME, "collector_hyper"))
-                        .install_batch(opentelemetry::runtime::Tokio)
+                        .install_batch(opentelemetry_sdk::runtime::Tokio)
                         .expect("cannot create tracer using default configuration")
                 }),
             ),

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -76,7 +76,7 @@ opentelemetry-otlp = { version = "*", features = ["grpc-sys"] }
 
 ```rust
 let tracer = opentelemetry_otlp::new_pipeline()
-    .install_batch(opentelemetry::runtime::AsyncStd)?;
+    .install_batch(opentelemetry_sdk::runtime::AsyncStd)?;
 ```
 
 [`tokio`]: https://tokio.rs

--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 once_cell = "1.17"
-opentelemetry_api = { path = "../../../opentelemetry-api" }
+opentelemetry = { path = "../../../opentelemetry" }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "metrics"] }
 opentelemetry-otlp = { path = "../..", features = ["http-proto", "reqwest-client"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -1,9 +1,7 @@
 use once_cell::sync::Lazy;
-use opentelemetry_api::global;
-use opentelemetry_api::trace::TraceError;
-use opentelemetry_api::{
-    metrics,
-    trace::{TraceContextExt, Tracer},
+use opentelemetry::{
+    global, metrics,
+    trace::{TraceContextExt, TraceError, Tracer},
     Key, KeyValue,
 };
 use opentelemetry_otlp::WithExportConfig;

--- a/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 once_cell = "1.17"
-opentelemetry_api = { path = "../../../opentelemetry-api", features = ["metrics", "logs"] }
+opentelemetry = { path = "../../../opentelemetry", features = ["metrics", "logs"] }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "logs"] }
 opentelemetry-otlp = { path = "../../../opentelemetry-otlp", features = ["tonic", "metrics", "logs"] }
 opentelemetry-semantic-conventions = { path = "../../../opentelemetry-semantic-conventions" }

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -1,12 +1,10 @@
 use log::{info, Level};
 use once_cell::sync::Lazy;
-use opentelemetry_api::global;
-use opentelemetry_api::global::{
-    logger_provider, shutdown_logger_provider, shutdown_tracer_provider,
-};
-use opentelemetry_api::logs::LogError;
-use opentelemetry_api::trace::TraceError;
-use opentelemetry_api::{
+use opentelemetry::global;
+use opentelemetry::global::{logger_provider, shutdown_logger_provider, shutdown_tracer_provider};
+use opentelemetry::logs::LogError;
+use opentelemetry::trace::TraceError;
+use opentelemetry::{
     metrics,
     trace::{TraceContextExt, Tracer},
     Key, KeyValue,

--- a/opentelemetry-otlp/examples/external-otlp-grpcio-async-std/Cargo.toml
+++ b/opentelemetry-otlp/examples/external-otlp-grpcio-async-std/Cargo.toml
@@ -7,8 +7,9 @@ publish = false
 
 [dependencies]
 async-std = { version = "= 1.10.0", features = ["attributes"] }
-env_logger = "0.9.0"
-opentelemetry = { path = "../../../opentelemetry", features = ["rt-async-std"] }
+env_logger = "0.10.0"
+opentelemetry = { path = "../../../opentelemetry" }
+opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-async-std"] }
 opentelemetry-otlp = { path = "../../../opentelemetry-otlp", features = [
     "grpc-sys",
     "trace",

--- a/opentelemetry-otlp/examples/external-otlp-grpcio-async-std/src/main.rs
+++ b/opentelemetry-otlp/examples/external-otlp-grpcio-async-std/src/main.rs
@@ -9,26 +9,24 @@
 //! ```
 use opentelemetry::{
     global::{shutdown_tracer_provider, tracer},
-    sdk::trace as sdktrace,
     trace::TraceError,
     trace::{TraceContextExt, Tracer},
     Key,
 };
 use opentelemetry_otlp::WithExportConfig;
-use url::Url;
-
 use std::{
     collections::HashMap,
     env::{remove_var, set_var, var, vars},
     error::Error,
 };
+use url::Url;
 
 // Use the variables to try and export the example to any external collector that accepts otlp
 // like: oltp itself, honeycomb or lightstep
 const ENDPOINT: &str = "OTLP_GRPCIO_ENDPOINT";
 const HEADER_PREFIX: &str = "OTLP_GRPCIO_";
 
-fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
+fn init_tracer() -> Result<opentelemetry_sdk::trace::Tracer, TraceError> {
     let endpoint = var(ENDPOINT).unwrap_or_else(|_| {
         panic!(
             "You must specify and endpoint to connect to with the variable {:?}.",
@@ -65,7 +63,7 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
                 .with_headers(headers)
                 .with_tls(true),
         )
-        .install_batch(opentelemetry::runtime::AsyncStd)
+        .install_batch(opentelemetry_sdk::runtime::AsyncStd)
 }
 
 const LEMONS_KEY: Key = Key::from_static_str("ex.com/lemons");

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 once_cell = "1.17"
-opentelemetry_api = { version = "0.20", path = "../opentelemetry-api", default-features = false, features = ["metrics"] }
+opentelemetry = { version = "0.21", path = "../opentelemetry", default-features = false, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk", default-features = false, features = ["metrics"] }
 prometheus = "0.13"
 protobuf = "2.14"

--- a/opentelemetry-prometheus/examples/hyper.rs
+++ b/opentelemetry-prometheus/examples/hyper.rs
@@ -4,7 +4,7 @@ use hyper::{
     Body, Method, Request, Response, Server,
 };
 use once_cell::sync::Lazy;
-use opentelemetry_api::{
+use opentelemetry::{
     metrics::{Counter, Histogram, MeterProvider as _, Unit},
     KeyValue,
 };

--- a/opentelemetry-prometheus/src/config.rs
+++ b/opentelemetry-prometheus/src/config.rs
@@ -1,9 +1,8 @@
 use core::fmt;
-use std::sync::{Arc, Mutex};
-
 use once_cell::sync::OnceCell;
-use opentelemetry_api::metrics::{MetricsError, Result};
+use opentelemetry::metrics::{MetricsError, Result};
 use opentelemetry_sdk::metrics::{reader::AggregationSelector, ManualReaderBuilder};
+use std::sync::{Arc, Mutex};
 
 use crate::{Collector, PrometheusExporter};
 

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -3,7 +3,7 @@
 //! [Prometheus]: https://prometheus.io
 //!
 //! ```
-//! use opentelemetry_api::{metrics::MeterProvider as _, KeyValue};
+//! use opentelemetry::{metrics::MeterProvider as _, KeyValue};
 //! use opentelemetry_sdk::metrics::MeterProvider;
 //! use prometheus::{Encoder, TextEncoder};
 //!
@@ -94,7 +94,7 @@
 #![cfg_attr(test, deny(warnings))]
 
 use once_cell::sync::{Lazy, OnceCell};
-use opentelemetry_api::{
+use opentelemetry::{
     global,
     metrics::{MetricsError, Result},
     Context, Key, Value,

--- a/opentelemetry-prometheus/src/utils.rs
+++ b/opentelemetry-prometheus/src/utils.rs
@@ -1,4 +1,4 @@
-use opentelemetry_api::metrics::Unit;
+use opentelemetry::metrics::Unit;
 use std::borrow::Cow;
 
 const NON_APPLICABLE_ON_PER_UNIT: [&str; 8] = ["1", "d", "h", "min", "s", "ms", "us", "ns"];

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -2,9 +2,9 @@ use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
-use opentelemetry_api::metrics::{Meter, MeterProvider as _, Unit};
-use opentelemetry_api::Key;
-use opentelemetry_api::KeyValue;
+use opentelemetry::metrics::{Meter, MeterProvider as _, Unit};
+use opentelemetry::Key;
+use opentelemetry::KeyValue;
 use opentelemetry_prometheus::ExporterBuilder;
 use opentelemetry_sdk::metrics::{new_view, Aggregation, Instrument, MeterProvider, Stream};
 use opentelemetry_sdk::resource::{

--- a/opentelemetry-semantic-conventions/Cargo.toml
+++ b/opentelemetry-semantic-conventions/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-opentelemetry = { version = "0.20", default-features = false, path = "../opentelemetry" }
+opentelemetry = { version = "0.21", default-features = false, path = "../opentelemetry" }
 
 [dev-dependencies]
-opentelemetry = { default-features = false, features = ["trace"], path = "../opentelemetry" }
+opentelemetry_sdk = { features = ["trace"], path = "../opentelemetry-sdk" }

--- a/opentelemetry-semantic-conventions/src/resource.rs
+++ b/opentelemetry-semantic-conventions/src/resource.rs
@@ -14,11 +14,11 @@
 //! ## Usage
 //!
 //! ```
-//! use opentelemetry::sdk;
+//! use opentelemetry_sdk::{trace::{config, TracerProvider}, Resource};
 //! use opentelemetry_semantic_conventions as semconv;
 //!
-//! let _tracer = sdk::trace::TracerProvider::builder()
-//!     .with_config(sdk::trace::config().with_resource(sdk::Resource::new(vec![
+//! let _tracer = TracerProvider::builder()
+//!     .with_config(config().with_resource(Resource::new(vec![
 //!         semconv::resource::SERVICE_NAME.string("my-service"),
 //!         semconv::resource::SERVICE_NAMESPACE.string("my-namespace"),
 //!     ])))
@@ -99,7 +99,7 @@ pub const CLOUD_REGION: Key = Key::from_static_str("cloud.region");
 /// * **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
 ///   Take care not to use the &#34;invoked ARN&#34; directly but replace any
 ///   [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html)
-///   with the resolved function version, as the same runtime instance may be invokable with
+///   with the resolved function version, as the same runtime instance may be invocable with
 ///   multiple different aliases.
 /// * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names)
 /// * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id) of the invoked function,

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -16,7 +16,8 @@ hex = "0.4"
 http = "0.2"
 hyper = "0.14.2"
 hyper-rustls = { version = "0.24", optional = true }
-opentelemetry = { version = "0.20", path = "../opentelemetry" }
+opentelemetry = { version = "0.21", path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk" }
 opentelemetry-semantic-conventions = { version = "0.12", path = "../opentelemetry-semantic-conventions" }
 prost = "0.11.0"
 prost-types = "0.11.1"

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -27,16 +27,16 @@ use futures_core::future::BoxFuture;
 use futures_util::stream::StreamExt;
 use opentelemetry::{
     global::handle_error,
-    sdk::{
-        export::{
-            trace::{ExportResult, SpanData, SpanExporter},
-            ExportError,
-        },
-        trace::{EvictedHashMap, EvictedQueue},
-        Resource,
-    },
     trace::{SpanId, TraceError},
     Key, Value,
+};
+use opentelemetry_sdk::{
+    export::{
+        trace::{ExportResult, SpanData, SpanExporter},
+        ExportError,
+    },
+    trace::{EvictedHashMap, EvictedQueue},
+    Resource,
 };
 use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 use opentelemetry_semantic_conventions::trace::{
@@ -824,8 +824,8 @@ const MAX_ATTRIBUTES_PER_SPAN: usize = 32;
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use opentelemetry::{sdk::trace::EvictedHashMap, KeyValue, Value};
+    use opentelemetry::{KeyValue, Value};
+    use opentelemetry_sdk::trace::EvictedHashMap;
     use opentelemetry_semantic_conventions as semcov;
 
     #[test]

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -16,22 +16,22 @@ edition = "2021"
 rust-version = "1.64"
 
 [features]
-trace = ["opentelemetry_api/trace", "opentelemetry_sdk/trace", "futures-util"]
-metrics = ["async-trait", "opentelemetry_api/metrics", "opentelemetry_sdk/metrics"]
-logs = ["opentelemetry_api/logs", "opentelemetry_sdk/logs", "async-trait", "thiserror"]
+trace = ["opentelemetry/trace", "opentelemetry_sdk/trace", "futures-util"]
+metrics = ["async-trait", "opentelemetry/metrics", "opentelemetry_sdk/metrics"]
+logs = ["opentelemetry/logs", "opentelemetry_sdk/logs", "async-trait", "thiserror"]
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
 thiserror = { version = "1", optional = true }
 futures-util = { version = "0.3", optional = true, default-features = false }
-opentelemetry_api = { version = "0.20", path = "../opentelemetry-api", default_features = false }
+opentelemetry = { version = "0.21", path = "../opentelemetry", default_features = false }
 opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk", default_features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ordered-float = "3.4.0"
 
 [dev-dependencies]
-opentelemetry_api = { version = "0.20", path = "../opentelemetry-api", features = ["metrics"] }
+opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk", features = ["rt-tokio", "metrics"] }
 tokio = { version = "1.27", features = ["full"] }

--- a/opentelemetry-stdout/README.md
+++ b/opentelemetry-stdout/README.md
@@ -31,7 +31,7 @@ crate provides exporters that export to stdout or any implementation of
 Export telemetry signals to stdout.
 
 ```rust
-use opentelemetry_api::{
+use opentelemetry::{
     metrics::MeterProvider as _,
     trace::{Span, Tracer, TracerProvider as _},
     Context, KeyValue,

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -1,7 +1,7 @@
 //! run with `$ cargo run --example basic --all-features
 
 #[cfg(all(feature = "metrics", feature = "trace"))]
-use opentelemetry_api::{
+use opentelemetry::{
     metrics::MeterProvider as _,
     trace::{Span, Tracer, TracerProvider as _},
     KeyValue,

--- a/opentelemetry-stdout/src/common.rs
+++ b/opentelemetry-stdout/src/common.rs
@@ -69,8 +69,8 @@ impl From<Cow<'static, str>> for Key {
     }
 }
 
-impl From<opentelemetry_api::Key> for Key {
-    fn from(value: opentelemetry_api::Key) -> Self {
+impl From<opentelemetry::Key> for Key {
+    fn from(value: opentelemetry::Key) -> Self {
         Key(value.as_str().to_string().into())
     }
 }
@@ -122,24 +122,24 @@ impl Hash for Value {
     }
 }
 
-impl From<opentelemetry_api::Value> for Value {
-    fn from(value: opentelemetry_api::Value) -> Self {
+impl From<opentelemetry::Value> for Value {
+    fn from(value: opentelemetry::Value) -> Self {
         match value {
-            opentelemetry_api::Value::Bool(b) => Value::Bool(b),
-            opentelemetry_api::Value::I64(i) => Value::Int(i),
-            opentelemetry_api::Value::F64(f) => Value::Double(f),
-            opentelemetry_api::Value::String(s) => Value::String(s.into()),
-            opentelemetry_api::Value::Array(a) => match a {
-                opentelemetry_api::Array::Bool(b) => {
+            opentelemetry::Value::Bool(b) => Value::Bool(b),
+            opentelemetry::Value::I64(i) => Value::Int(i),
+            opentelemetry::Value::F64(f) => Value::Double(f),
+            opentelemetry::Value::String(s) => Value::String(s.into()),
+            opentelemetry::Value::Array(a) => match a {
+                opentelemetry::Array::Bool(b) => {
                     Value::Array(b.into_iter().map(Value::Bool).collect())
                 }
-                opentelemetry_api::Array::I64(i) => {
+                opentelemetry::Array::I64(i) => {
                     Value::Array(i.into_iter().map(Value::Int).collect())
                 }
-                opentelemetry_api::Array::F64(f) => {
+                opentelemetry::Array::F64(f) => {
                     Value::Array(f.into_iter().map(Value::Double).collect())
                 }
-                opentelemetry_api::Array::String(s) => {
+                opentelemetry::Array::String(s) => {
                     Value::Array(s.into_iter().map(|s| Value::String(s.into())).collect())
                 }
             },
@@ -148,17 +148,17 @@ impl From<opentelemetry_api::Value> for Value {
 }
 
 #[cfg(feature = "logs")]
-impl From<opentelemetry_api::logs::AnyValue> for Value {
-    fn from(value: opentelemetry_api::logs::AnyValue) -> Self {
+impl From<opentelemetry::logs::AnyValue> for Value {
+    fn from(value: opentelemetry::logs::AnyValue) -> Self {
         match value {
-            opentelemetry_api::logs::AnyValue::Boolean(b) => Value::Bool(b),
-            opentelemetry_api::logs::AnyValue::Int(i) => Value::Int(i),
-            opentelemetry_api::logs::AnyValue::Double(d) => Value::Double(d),
-            opentelemetry_api::logs::AnyValue::String(s) => Value::String(s.into()),
-            opentelemetry_api::logs::AnyValue::ListAny(a) => {
+            opentelemetry::logs::AnyValue::Boolean(b) => Value::Bool(b),
+            opentelemetry::logs::AnyValue::Int(i) => Value::Int(i),
+            opentelemetry::logs::AnyValue::Double(d) => Value::Double(d),
+            opentelemetry::logs::AnyValue::String(s) => Value::String(s.into()),
+            opentelemetry::logs::AnyValue::ListAny(a) => {
                 Value::Array(a.into_iter().map(Into::into).collect())
             }
-            opentelemetry_api::logs::AnyValue::Map(m) => Value::KeyValues(
+            opentelemetry::logs::AnyValue::Map(m) => Value::KeyValues(
                 m.into_iter()
                     .map(|(key, value)| KeyValue {
                         key: key.into(),
@@ -166,7 +166,7 @@ impl From<opentelemetry_api::logs::AnyValue> for Value {
                     })
                     .collect(),
             ),
-            opentelemetry_api::logs::AnyValue::Bytes(b) => Value::BytesValue(b),
+            opentelemetry::logs::AnyValue::Bytes(b) => Value::BytesValue(b),
         }
     }
 }
@@ -179,8 +179,8 @@ pub(crate) struct KeyValue {
 }
 
 #[cfg(feature = "logs")]
-impl From<(opentelemetry_api::Key, opentelemetry_api::logs::AnyValue)> for KeyValue {
-    fn from((key, value): (opentelemetry_api::Key, opentelemetry_api::logs::AnyValue)) -> Self {
+impl From<(opentelemetry::Key, opentelemetry::logs::AnyValue)> for KeyValue {
+    fn from((key, value): (opentelemetry::Key, opentelemetry::logs::AnyValue)) -> Self {
         KeyValue {
             key: key.into(),
             value: value.into(),
@@ -188,8 +188,8 @@ impl From<(opentelemetry_api::Key, opentelemetry_api::logs::AnyValue)> for KeyVa
     }
 }
 
-impl From<opentelemetry_api::KeyValue> for KeyValue {
-    fn from(value: opentelemetry_api::KeyValue) -> Self {
+impl From<opentelemetry::KeyValue> for KeyValue {
+    fn from(value: opentelemetry::KeyValue) -> Self {
         KeyValue {
             key: value.key.into(),
             value: value.value.into(),
@@ -197,8 +197,8 @@ impl From<opentelemetry_api::KeyValue> for KeyValue {
     }
 }
 
-impl From<&opentelemetry_api::KeyValue> for KeyValue {
-    fn from(value: &opentelemetry_api::KeyValue) -> Self {
+impl From<&opentelemetry::KeyValue> for KeyValue {
+    fn from(value: &opentelemetry::KeyValue) -> Self {
         KeyValue {
             key: value.key.clone().into(),
             value: value.value.clone().into(),
@@ -206,8 +206,8 @@ impl From<&opentelemetry_api::KeyValue> for KeyValue {
     }
 }
 
-impl From<(opentelemetry_api::Key, opentelemetry_api::Value)> for KeyValue {
-    fn from((key, value): (opentelemetry_api::Key, opentelemetry_api::Value)) -> Self {
+impl From<(opentelemetry::Key, opentelemetry::Value)> for KeyValue {
+    fn from((key, value): (opentelemetry::Key, opentelemetry::Value)) -> Self {
         KeyValue {
             key: key.into(),
             value: value.into(),

--- a/opentelemetry-stdout/src/lib.rs
+++ b/opentelemetry-stdout/src/lib.rs
@@ -5,9 +5,9 @@
 //! ```no_run
 //! # #[cfg(all(feature = "metrics", feature = "trace"))]
 //! {
-//! use opentelemetry_api::metrics::MeterProvider as _;
-//! use opentelemetry_api::trace::{Span, Tracer, TracerProvider as _};
-//! use opentelemetry_api::{Context, KeyValue};
+//! use opentelemetry::metrics::MeterProvider as _;
+//! use opentelemetry::trace::{Span, Tracer, TracerProvider as _};
+//! use opentelemetry::{Context, KeyValue};
 //!
 //! use opentelemetry_sdk::metrics::{MeterProvider, PeriodicReader};
 //! use opentelemetry_sdk::runtime;

--- a/opentelemetry-stdout/src/logs/exporter.rs
+++ b/opentelemetry-stdout/src/logs/exporter.rs
@@ -1,12 +1,11 @@
-use core::fmt;
-use std::io::{stdout, Write};
-
 use async_trait::async_trait;
-use opentelemetry_api::{
+use core::fmt;
+use opentelemetry::{
     logs::{LogError, LogResult},
     ExportError,
 };
 use opentelemetry_sdk::export::logs::{ExportResult, LogData};
+use std::io::{stdout, Write};
 
 type Encoder =
     Box<dyn Fn(&mut dyn Write, crate::logs::transform::LogData) -> LogResult<()> + Send + Sync>;

--- a/opentelemetry-stdout/src/logs/mod.rs
+++ b/opentelemetry-stdout/src/logs/mod.rs
@@ -4,7 +4,7 @@
 //! [`Write`] instance. By default it will write to [`Stdout`].
 //!
 //! [`LogExporter`]: opentelemetry_sdk::export::logs::LogExporter
-//! [`LogRecord`]: opentelemetry_api::logs::LogRecord
+//! [`LogRecord`]: opentelemetry::logs::LogRecord
 //! [`Write`]: std::io::Write
 //! [`Stdout`]: std::io::Stdout
 // TODO: Add an example for using this exporter.

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -1,11 +1,6 @@
-use core::fmt;
-use std::{
-    io::{stdout, Write},
-    sync::Mutex,
-};
-
 use async_trait::async_trait;
-use opentelemetry_api::metrics::{MetricsError, Result};
+use core::fmt;
+use opentelemetry::metrics::{MetricsError, Result};
 use opentelemetry_sdk::metrics::{
     data,
     exporter::PushMetricsExporter,
@@ -14,6 +9,10 @@ use opentelemetry_sdk::metrics::{
         TemporalitySelector,
     },
     Aggregation, InstrumentKind,
+};
+use std::{
+    io::{stdout, Write},
+    sync::Mutex,
 };
 
 use crate::MetricsData;

--- a/opentelemetry-stdout/src/metrics/transform.rs
+++ b/opentelemetry-stdout/src/metrics/transform.rs
@@ -1,5 +1,6 @@
+use crate::common::{AttributeSet, KeyValue, Resource, Scope};
 use chrono::{LocalResult, TimeZone, Utc};
-use opentelemetry_api::{global, metrics::MetricsError};
+use opentelemetry::{global, metrics::MetricsError};
 use opentelemetry_sdk::metrics::data;
 use serde::{Serialize, Serializer};
 use std::{
@@ -7,8 +8,6 @@ use std::{
     borrow::Cow,
     time::{SystemTime, UNIX_EPOCH},
 };
-
-use crate::common::{AttributeSet, KeyValue, Resource, Scope};
 
 /// Transformed metrics data that can be serialized
 #[derive(Serialize, Debug, Clone)]
@@ -73,8 +72,8 @@ impl Unit {
     }
 }
 
-impl From<opentelemetry_api::metrics::Unit> for Unit {
-    fn from(unit: opentelemetry_api::metrics::Unit) -> Self {
+impl From<opentelemetry::metrics::Unit> for Unit {
+    fn from(unit: opentelemetry::metrics::Unit) -> Self {
         Unit(unit.as_str().to_string().into())
     }
 }

--- a/opentelemetry-stdout/src/trace/exporter.rs
+++ b/opentelemetry-stdout/src/trace/exporter.rs
@@ -1,9 +1,8 @@
 use core::fmt;
-use std::io::{stdout, Write};
-
 use futures_util::future::BoxFuture;
-use opentelemetry_api::trace::{TraceError, TraceResult};
+use opentelemetry::trace::{TraceError, TraceResult};
 use opentelemetry_sdk::export::{self, trace::ExportResult};
+use std::io::{stdout, Write};
 
 use crate::trace::transform::SpanData;
 

--- a/opentelemetry-stdout/src/trace/transform.rs
+++ b/opentelemetry-stdout/src/trace/transform.rs
@@ -1,9 +1,7 @@
-use std::{borrow::Cow, collections::HashMap, time::SystemTime};
-
+use crate::common::{as_unix_nano, KeyValue, Resource, Scope};
 use opentelemetry_sdk::AttributeSet;
 use serde::{Serialize, Serializer};
-
-use crate::common::{as_unix_nano, KeyValue, Resource, Scope};
+use std::{borrow::Cow, collections::HashMap, time::SystemTime};
 
 /// Transformed trace data that can be serialized
 #[derive(Debug, Serialize)]
@@ -132,14 +130,14 @@ impl Serialize for SpanKind {
     }
 }
 
-impl From<opentelemetry_api::trace::SpanKind> for SpanKind {
-    fn from(value: opentelemetry_api::trace::SpanKind) -> Self {
+impl From<opentelemetry::trace::SpanKind> for SpanKind {
+    fn from(value: opentelemetry::trace::SpanKind) -> Self {
         match value {
-            opentelemetry_api::trace::SpanKind::Client => SpanKind::Client,
-            opentelemetry_api::trace::SpanKind::Server => SpanKind::Server,
-            opentelemetry_api::trace::SpanKind::Producer => SpanKind::Producer,
-            opentelemetry_api::trace::SpanKind::Consumer => SpanKind::Consumer,
-            opentelemetry_api::trace::SpanKind::Internal => SpanKind::Internal,
+            opentelemetry::trace::SpanKind::Client => SpanKind::Client,
+            opentelemetry::trace::SpanKind::Server => SpanKind::Server,
+            opentelemetry::trace::SpanKind::Producer => SpanKind::Producer,
+            opentelemetry::trace::SpanKind::Consumer => SpanKind::Consumer,
+            opentelemetry::trace::SpanKind::Internal => SpanKind::Internal,
         }
     }
 }
@@ -152,8 +150,8 @@ struct Event {
     dropped_attributes_count: u32,
 }
 
-impl From<opentelemetry_api::trace::Event> for Event {
-    fn from(value: opentelemetry_api::trace::Event) -> Self {
+impl From<opentelemetry::trace::Event> for Event {
+    fn from(value: opentelemetry::trace::Event) -> Self {
         Event {
             name: value.name,
             attributes: value.attributes.into_iter().map(Into::into).collect(),
@@ -173,8 +171,8 @@ struct Link {
     dropped_attributes_count: u32,
 }
 
-impl From<opentelemetry_api::trace::Link> for Link {
-    fn from(value: opentelemetry_api::trace::Link) -> Self {
+impl From<opentelemetry::trace::Link> for Link {
+    fn from(value: opentelemetry::trace::Link) -> Self {
         Link {
             trace_id: format!("{:x}", value.span_context.trace_id()),
             span_id: format!("{:x}", value.span_context.span_id()),
@@ -198,18 +196,18 @@ fn is_zero(v: &u32) -> bool {
     *v == 0
 }
 
-impl From<opentelemetry_api::trace::Status> for Status {
-    fn from(value: opentelemetry_api::trace::Status) -> Self {
+impl From<opentelemetry::trace::Status> for Status {
+    fn from(value: opentelemetry::trace::Status) -> Self {
         match value {
-            opentelemetry_api::trace::Status::Unset => Status {
+            opentelemetry::trace::Status::Unset => Status {
                 message: None,
                 code: 0,
             },
-            opentelemetry_api::trace::Status::Error { description } => Status {
+            opentelemetry::trace::Status::Error { description } => Status {
                 message: Some(description),
                 code: 1,
             },
-            opentelemetry_api::trace::Status::Ok => Status {
+            opentelemetry::trace::Status::Ok => Status {
                 message: None,
                 code: 2,
             },

--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 [dependencies]
 eventheader = "0.3.2"
 eventheader_dynamic = "0.3.2"
-opentelemetry_api = { version = "0.20", path = "../opentelemetry-api", features = ["logs"] }
+opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["logs"] }
 opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk", features = ["logs"] }
 async-std = { version="1.6" }
 async-trait = { version="0.1" }
@@ -27,7 +27,7 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
 microbench = "0.5"
 
 [features]
-logs_level_enabled = ["opentelemetry_api/logs_level_enabled", "opentelemetry_sdk/logs_level_enabled"]
+logs_level_enabled = ["opentelemetry/logs_level_enabled", "opentelemetry_sdk/logs_level_enabled"]
 default=["logs_level_enabled"]
 
 [[example]]

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use opentelemetry_api::{logs::AnyValue, logs::Severity, Key};
+use opentelemetry::{logs::AnyValue, logs::Severity, Key};
 use std::{cell::RefCell, str, time::SystemTime};
 
 /// Provider group associated with the user_events exporter
@@ -325,7 +325,7 @@ impl opentelemetry_sdk::export::logs::LogExporter for UserEventsExporter {
     async fn export(
         &mut self,
         batch: Vec<opentelemetry_sdk::export::logs::LogData>,
-    ) -> opentelemetry_api::logs::LogResult<()> {
+    ) -> opentelemetry::logs::LogResult<()> {
         for log_data in batch {
             let _ = self.export_log_data(&log_data);
         }

--- a/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
+++ b/opentelemetry-user-events-logs/src/logs/reentrant_logprocessor.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use opentelemetry_api::logs::LogResult;
+use opentelemetry::logs::LogResult;
 use opentelemetry_sdk::export::logs::LogData;
 
 #[cfg(feature = "logs_level_enabled")]
@@ -52,7 +52,7 @@ impl opentelemetry_sdk::logs::LogProcessor for ReentrantLogProcessor {
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(
         &self,
-        level: opentelemetry_api::logs::Severity,
+        level: opentelemetry::logs::Severity,
         target: &str,
         name: &str,
     ) -> bool {

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.64"
 
 [dependencies]
-opentelemetry_api = { version = "0.20", path = "../opentelemetry-api", features = ["metrics"] }
+opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk", features = ["metrics", "rt-tokio"] }
 opentelemetry-proto = { version = "0.3", path = "../opentelemetry-proto", features = ["gen-tonic", "metrics"] }
 eventheader = { version = "= 0.3.2" }

--- a/opentelemetry-user-events-metrics/examples/basic.rs
+++ b/opentelemetry-user-events-metrics/examples/basic.rs
@@ -1,5 +1,5 @@
 //! run with `$ cargo run --example basic --all-features
-use opentelemetry_api::{
+use opentelemetry::{
     metrics::{MeterProvider as _, Unit},
     KeyValue,
 };

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -1,7 +1,6 @@
 use crate::transform::transform_resource_metrics;
 use async_trait::async_trait;
-
-use opentelemetry_api::metrics::{MetricsError, Result};
+use opentelemetry::metrics::{MetricsError, Result};
 use opentelemetry_sdk::metrics::{
     data::{ResourceMetrics, Temporality},
     exporter::PushMetricsExporter,

--- a/opentelemetry-user-events-metrics/src/transform/mod.rs
+++ b/opentelemetry-user-events-metrics/src/transform/mod.rs
@@ -1,8 +1,4 @@
-use std::any::Any;
-use std::fmt;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-use opentelemetry_api::{global, metrics::MetricsError};
+use opentelemetry::{global, metrics::MetricsError};
 use opentelemetry_proto::tonic::common::v1::InstrumentationScope as TonicInstrumentationScope;
 use opentelemetry_proto::tonic::resource::v1::Resource as TonicResource;
 use opentelemetry_proto::tonic::{
@@ -21,6 +17,9 @@ use opentelemetry_sdk::metrics::data::{
     Sum as SdkSum,
 };
 use opentelemetry_sdk::Resource as SdkResource;
+use std::any::Any;
+use std::fmt;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 pub(crate) fn transform_resource_metrics(
     metrics: &SDKResourceMetrics,

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -28,7 +28,8 @@ surf-client = ["surf", "opentelemetry-http/surf"]
 
 [dependencies]
 async-trait = "0.1"
-opentelemetry = { version = "0.20", path = "../opentelemetry", features = ["trace"] }
+opentelemetry = { version = "0.21", path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk", features = ["trace"] }
 opentelemetry-http = { version = "0.9", path = "../opentelemetry-http" }
 opentelemetry-semantic-conventions = { version = "0.12", path = "../opentelemetry-semantic-conventions" }
 serde_json = "1.0"
@@ -45,4 +46,4 @@ futures-core = "0.3"
 bytes = "1"
 futures-util = { version = "0.3", features = ["io"] }
 hyper = "0.14"
-opentelemetry = { default-features = false, features = ["trace", "testing"], path = "../opentelemetry" }
+opentelemetry_sdk = { default-features = false, features = ["trace", "testing"], path = "../opentelemetry-sdk" }

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -73,7 +73,7 @@ opentelemetry-zipkin = { version = "*", features = ["reqwest-client"], default-f
 
 ```rust
 let tracer = opentelemetry_zipkin::new_pipeline()
-    .install_batch(opentelemetry::runtime::Tokio)?;
+    .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 ```
 
 [`rt-tokio`]: https://tokio.rs

--- a/opentelemetry-zipkin/examples/zipkin.rs
+++ b/opentelemetry-zipkin/examples/zipkin.rs
@@ -1,6 +1,7 @@
-use opentelemetry::global;
-use opentelemetry::global::shutdown_tracer_provider;
-use opentelemetry::trace::{Span, Tracer};
+use opentelemetry::{
+    global::{self, shutdown_tracer_provider},
+    trace::{Span, Tracer},
+};
 use std::thread;
 use std::time::Duration;
 

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -6,19 +6,15 @@ use async_trait::async_trait;
 use futures_core::future::BoxFuture;
 use http::Uri;
 use model::endpoint::Endpoint;
-use opentelemetry::runtime::RuntimeChannel;
-use opentelemetry::sdk::resource::ResourceDetector;
-use opentelemetry::sdk::resource::SdkProvidedResourceDetector;
-use opentelemetry::sdk::trace::Config;
-use opentelemetry::sdk::Resource;
-use opentelemetry::{
-    global, sdk,
-    sdk::export::{trace, ExportError},
-    sdk::trace::BatchMessage,
-    trace::{TraceError, TracerProvider},
-    KeyValue,
-};
+use opentelemetry::{global, trace::TraceError, KeyValue};
 use opentelemetry_http::HttpClient;
+use opentelemetry_sdk::{
+    export::{trace, ExportError},
+    resource::{ResourceDetector, SdkProvidedResourceDetector},
+    runtime::RuntimeChannel,
+    trace::{BatchMessage, Config, Tracer, TracerProvider},
+    Resource,
+};
 use opentelemetry_semantic_conventions as semcov;
 use std::borrow::Cow;
 #[cfg(all(
@@ -58,7 +54,7 @@ pub struct ZipkinPipelineBuilder {
     service_name: Option<String>,
     service_addr: Option<SocketAddr>,
     collector_endpoint: String,
-    trace_config: Option<sdk::trace::Config>,
+    trace_config: Option<Config>,
     client: Option<Arc<dyn HttpClient>>,
 }
 
@@ -169,14 +165,14 @@ impl ZipkinPipelineBuilder {
     }
 
     /// Install the Zipkin trace exporter pipeline with a simple span processor.
-    pub fn install_simple(mut self) -> Result<sdk::trace::Tracer, TraceError> {
+    pub fn install_simple(mut self) -> Result<Tracer, TraceError> {
         let (config, endpoint) = self.init_config_and_endpoint();
         let exporter = self.init_exporter_with_endpoint(endpoint)?;
-        let mut provider_builder =
-            sdk::trace::TracerProvider::builder().with_simple_exporter(exporter);
+        let mut provider_builder = TracerProvider::builder().with_simple_exporter(exporter);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let tracer = provider.versioned_tracer(
+        let tracer = opentelemetry::trace::TracerProvider::versioned_tracer(
+            &provider,
             "opentelemetry-zipkin",
             Some(env!("CARGO_PKG_VERSION")),
             Some(semcov::SCHEMA_URL),
@@ -191,14 +187,14 @@ impl ZipkinPipelineBuilder {
     pub fn install_batch<R: RuntimeChannel<BatchMessage>>(
         mut self,
         runtime: R,
-    ) -> Result<sdk::trace::Tracer, TraceError> {
+    ) -> Result<Tracer, TraceError> {
         let (config, endpoint) = self.init_config_and_endpoint();
         let exporter = self.init_exporter_with_endpoint(endpoint)?;
-        let mut provider_builder =
-            sdk::trace::TracerProvider::builder().with_batch_exporter(exporter, runtime);
+        let mut provider_builder = TracerProvider::builder().with_batch_exporter(exporter, runtime);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let tracer = provider.versioned_tracer(
+        let tracer = opentelemetry::trace::TracerProvider::versioned_tracer(
+            &provider,
             "opentelemetry-zipkin",
             Some(env!("CARGO_PKG_VERSION")),
             Some(semcov::SCHEMA_URL),
@@ -233,7 +229,7 @@ impl ZipkinPipelineBuilder {
     }
 
     /// Assign the SDK trace configuration.
-    pub fn with_trace_config(mut self, config: sdk::trace::Config) -> Self {
+    pub fn with_trace_config(mut self, config: Config) -> Self {
         self.trace_config = Some(config);
         self
     }

--- a/opentelemetry-zipkin/src/exporter/model/annotation.rs
+++ b/opentelemetry-zipkin/src/exporter/model/annotation.rs
@@ -1,7 +1,6 @@
-use std::time::{Duration, SystemTime};
-
 use opentelemetry::trace::Event;
 use serde::Serialize;
+use std::time::{Duration, SystemTime};
 
 #[derive(TypedBuilder, Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/opentelemetry-zipkin/src/exporter/model/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/model/mod.rs
@@ -1,8 +1,8 @@
 use opentelemetry::{
-    sdk::export::trace,
     trace::{SpanKind, Status},
     Key, KeyValue,
 };
+use opentelemetry_sdk::export::trace::SpanData;
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 
@@ -28,9 +28,9 @@ fn into_zipkin_span_kind(kind: SpanKind) -> Option<span::Kind> {
     }
 }
 
-/// Converts a `trace::SpanData` to a `span::SpanData` for a given `ExporterConfig`, which can then
+/// Converts a `SpanData` to a `SpanData` for a given `ExporterConfig`, which can then
 /// be ingested into a Zipkin collector.
-pub(crate) fn into_zipkin_span(local_endpoint: Endpoint, span_data: trace::SpanData) -> span::Span {
+pub(crate) fn into_zipkin_span(local_endpoint: Endpoint, span_data: SpanData) -> span::Span {
     // see tests in create/exporter/model/span.rs
     let mut user_defined_span_kind = false;
     let mut tags = map_from_kvs(

--- a/opentelemetry-zipkin/src/exporter/model/span.rs
+++ b/opentelemetry-zipkin/src/exporter/model/span.rs
@@ -59,10 +59,12 @@ mod tests {
     use crate::exporter::model::endpoint::Endpoint;
     use crate::exporter::model::span::{Kind, Span};
     use crate::exporter::model::{into_zipkin_span, OTEL_ERROR_DESCRIPTION, OTEL_STATUS_CODE};
-    use opentelemetry::sdk::export::trace::SpanData;
-    use opentelemetry::sdk::trace::{EvictedHashMap, EvictedQueue};
-    use opentelemetry::sdk::Resource;
     use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId};
+    use opentelemetry_sdk::{
+        export::trace::SpanData,
+        trace::{EvictedHashMap, EvictedQueue},
+        Resource,
+    };
     use std::borrow::Cow;
     use std::collections::HashMap;
     use std::net::Ipv4Addr;

--- a/opentelemetry-zipkin/src/exporter/uploader.rs
+++ b/opentelemetry-zipkin/src/exporter/uploader.rs
@@ -2,8 +2,8 @@
 use crate::exporter::model::span::Span;
 use crate::exporter::Error;
 use http::{header::CONTENT_TYPE, Method, Request, Uri};
-use opentelemetry::sdk::export::trace::ExportResult;
 use opentelemetry_http::{HttpClient, ResponseExt};
+use opentelemetry_sdk::export::trace::ExportResult;
 use std::fmt::Debug;
 use std::sync::Arc;
 

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -55,7 +55,7 @@
 //! ```no_run
 //! # fn main() -> Result<(), opentelemetry::trace::TraceError> {
 //! let tracer = opentelemetry_zipkin::new_pipeline()
-//!     .install_batch(opentelemetry::runtime::Tokio)?;
+//!     .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -87,10 +87,9 @@
 //!
 //!
 //! ```no_run
-//! use opentelemetry::{KeyValue, trace::Tracer};
-//! use opentelemetry::sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
-//! use opentelemetry::sdk::export::trace::ExportResult;
-//! use opentelemetry::global;
+//! use opentelemetry::{global, KeyValue, trace::Tracer};
+//! use opentelemetry_sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
+//! use opentelemetry_sdk::export::trace::ExportResult;
 //! use opentelemetry_http::{HttpClient, HttpError};
 //! use async_trait::async_trait;
 //! use bytes::Bytes;
@@ -143,7 +142,7 @@
 //!                 .with_max_events_per_span(16)
 //!                 .with_resource(Resource::new(vec![KeyValue::new("key", "value")])),
 //!         )
-//!         .install_batch(opentelemetry::runtime::Tokio)?;
+//!         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...

--- a/opentelemetry-zpages/Cargo.toml
+++ b/opentelemetry-zpages/Cargo.toml
@@ -20,7 +20,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-opentelemetry = { path = "../opentelemetry", default-features = false, features = ["trace"] }
+opentelemetry = { path = "../opentelemetry" }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", default-features = false, features = ["trace"] }
 opentelemetry-proto = { path = "../opentelemetry-proto", features = ["zpages", "gen-tonic", "with-serde"], default-features = false }
 async-channel = "1.6"
 futures-channel = "0.3"
@@ -30,7 +31,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt"] }
-opentelemetry = { path = "../opentelemetry", features = ["trace", "testing"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["trace", "testing"] }
 rand = "0.8"
 hyper = { version = "0.14", features = ["full"] }
 

--- a/opentelemetry-zpages/examples/zpages.rs
+++ b/opentelemetry-zpages/examples/zpages.rs
@@ -1,8 +1,13 @@
 use hyper::http::{Request, Response};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Server};
-use opentelemetry::trace::{Span, Status};
-use opentelemetry::{global, runtime::Tokio, sdk::trace, trace::Tracer};
+use opentelemetry::trace::Tracer;
+use opentelemetry::{
+    global,
+    trace::{Span, Status},
+};
+use opentelemetry_sdk::runtime::Tokio;
+use opentelemetry_sdk::trace::TracerProvider;
 use opentelemetry_zpages::{tracez, TracezError, TracezQuerier, TracezResponse};
 use rand::Rng;
 use std::str::FromStr;
@@ -85,7 +90,7 @@ fn tracez_response_or_server_error(resp: Result<TracezResponse, TracezError>) ->
 #[tokio::main]
 async fn main() {
     let (processor, querier) = tracez(5, Tokio);
-    let provider = trace::TracerProvider::builder()
+    let provider = TracerProvider::builder()
         .with_span_processor(processor)
         .build();
     global::set_tracer_provider(provider);

--- a/opentelemetry-zpages/src/lib.rs
+++ b/opentelemetry-zpages/src/lib.rs
@@ -16,12 +16,13 @@
 //!
 //! ```no_run
 //! # use opentelemetry_zpages::tracez;
-//! # use opentelemetry::{global, runtime::Tokio, sdk::trace, trace::Tracer};
+//! # use opentelemetry::{global, trace::Tracer};
+//! # use opentelemetry_sdk::{runtime::Tokio, trace::TracerProvider};
 //! # use std::sync::Arc;
 //!
 //! # fn main() {
 //!     let (processor, querier) = tracez(5, Tokio);
-//!     let provider = trace::TracerProvider::builder()
+//!     let provider = TracerProvider::builder()
 //!         .with_span_processor(processor)
 //!         .build();
 //!     global::set_tracer_provider(provider);
@@ -37,7 +38,7 @@
 //!
 //!
 //! [`ZPagesSpanProcessor`]: trace::span_processor::ZPagesSpanProcessor
-//! [`TracerProvider`]: opentelemetry::trace::TracerProvider
+//! [`TracerProvider`]: opentelemetry_sdk::trace::TracerProvider
 //! [here]: https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples/zpages
 #![warn(
     future_incompatible,

--- a/opentelemetry-zpages/src/trace/aggregator.rs
+++ b/opentelemetry-zpages/src/trace/aggregator.rs
@@ -2,19 +2,15 @@
 //!
 //! Process the span information, aggregate counts for latency, running, and errors for spans grouped
 //! by name.
-use std::collections::HashMap;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-use async_channel::Receiver;
-
-use futures_util::StreamExt as _;
-
-use opentelemetry::trace::Status;
-
 use crate::trace::{TracezError, TracezMessage, TracezQuery, TracezResponse};
 use crate::SpanQueue;
-use opentelemetry::sdk::export::trace::SpanData;
+use async_channel::Receiver;
+use futures_util::StreamExt as _;
+use opentelemetry::trace::Status;
 use opentelemetry_proto::tonic::tracez::v1::TracezCounts;
+use opentelemetry_sdk::export::trace::SpanData;
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const LATENCY_BUCKET: [Duration; 9] = [
     Duration::from_micros(0),
@@ -196,17 +192,16 @@ impl<T: From<SpanData>> From<SpanQueue> for Vec<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, SystemTime};
-
+    use crate::trace::{
+        aggregator::{SpanAggregator, LATENCY_BUCKET_COUNT},
+        span_queue::SpanQueue,
+        TracezMessage,
+    };
     use opentelemetry::trace::{SpanContext, SpanId, Status, TraceFlags, TraceId, TraceState};
-
-    use crate::trace::aggregator::{SpanAggregator, LATENCY_BUCKET_COUNT};
-    use crate::trace::span_queue::SpanQueue;
-    use crate::trace::TracezMessage;
-    use opentelemetry::sdk::export::trace::SpanData;
-    use opentelemetry::testing::trace::new_test_export_span_data;
+    use opentelemetry_sdk::{export::trace::SpanData, testing::trace::new_test_export_span_data};
     use std::borrow::Cow;
     use std::cmp::min;
+    use std::time::{Duration, SystemTime};
 
     enum Action {
         Start,

--- a/opentelemetry-zpages/src/trace/mod.rs
+++ b/opentelemetry-zpages/src/trace/mod.rs
@@ -1,11 +1,9 @@
 //! Tracez implementation
 //!
-use opentelemetry_proto::tonic::tracez::v1::{ErrorData, LatencyData, RunningData, TracezCounts};
-
 use async_channel::{SendError, Sender};
 use futures_channel::oneshot::{self, Canceled};
-use opentelemetry::runtime::Runtime;
-use opentelemetry::sdk::export::trace::SpanData;
+use opentelemetry_proto::tonic::tracez::v1::{ErrorData, LatencyData, RunningData, TracezCounts};
+use opentelemetry_sdk::{export::trace::SpanData, runtime::Runtime};
 use serde::ser::SerializeSeq;
 use serde::Serializer;
 use std::fmt::Formatter;
@@ -22,16 +20,17 @@ pub(crate) mod span_queue;
 /// The `sample_size` config how may spans to sample for each unique span name.
 ///
 /// [`ZPagesSpanProcessor`]: span_processor::ZPagesSpanProcessor
-/// [`TracerProvider`]: opentelemetry::trace::TracerProvider
+/// [`TracerProvider`]: opentelemetry_sdk::trace::TracerProvider
 ///
 /// ## Example
 /// ```no_run
 /// # use opentelemetry_zpages::tracez;
-/// # use opentelemetry::{global, runtime::Tokio, sdk::trace, trace::Tracer};
+/// # use opentelemetry::{global, trace::Tracer};
+/// # use opentelemetry_sdk::{runtime::Tokio, trace::TracerProvider};
 /// # use std::sync::Arc;
 /// # fn main() {
 ///     let (processor, querier) = tracez(5, Tokio); // sample 5 spans for each unique span name
-///     let provider = trace::TracerProvider::builder()
+///     let provider = TracerProvider::builder()
 ///         .with_span_processor(processor)
 ///         .build();
 ///     global::set_tracer_provider(provider);

--- a/opentelemetry-zpages/src/trace/span_processor.rs
+++ b/opentelemetry-zpages/src/trace/span_processor.rs
@@ -4,14 +4,14 @@
 //! for further process.
 //!
 //! [`SpanAggregator`]:../struct.SpanAggregator.html
-use std::fmt::Formatter;
-
-use async_channel::Sender;
-
 use crate::trace::TracezMessage;
-use opentelemetry::sdk::trace::{Span, SpanProcessor};
-use opentelemetry::trace::TraceResult;
-use opentelemetry::{sdk::export::trace::SpanData, Context};
+use async_channel::Sender;
+use opentelemetry::{trace::TraceResult, Context};
+use opentelemetry_sdk::{
+    export::trace::SpanData,
+    trace::{Span, SpanProcessor},
+};
+use std::fmt::Formatter;
 
 /// ZPagesSpanProcessor is an alternative to external exporters. It sends span data to zPages server
 /// where it will be archive and user can use this information for debug purpose.

--- a/opentelemetry-zpages/src/trace/span_queue.rs
+++ b/opentelemetry-zpages/src/trace/span_queue.rs
@@ -1,7 +1,7 @@
 //! # Span Queue
 
-use opentelemetry::sdk::export::trace::SpanData;
 use opentelemetry::trace::SpanContext;
+use opentelemetry_sdk::export::trace::SpanData;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -106,8 +106,8 @@ impl SpanQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::testing::trace::new_test_export_span_data;
     use opentelemetry::trace::{SpanId, TraceFlags, TraceId, TraceState};
+    use opentelemetry_sdk::testing::trace::new_test_export_span_data;
     use std::time::SystemTime;
 
     enum Action {

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+- `opentelemetry` crate now only carries the API types #1186. Use the `opentelemetry_sdk` crate for the SDK types. 
 
 ## [v0.20.0](https://github.com/open-telemetry/opentelemetry-rust/compare/v0.19.0...v0.20.0)
 This release should been seen as 1.0-rc3 following 1.0-rc2 in v0.19.0. Refer to CHANGELOG.md in individual creates for details on changes made in different creates.

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry"
-version = "0.20.0"
+version = "0.21.0"
 description = "A metrics collection and distributed tracing framework"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"
@@ -22,18 +22,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 opentelemetry_api = { version = "0.20", path = "../opentelemetry-api" }
-opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk" }
 
 [dev-dependencies]
+opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk" }
 opentelemetry-stdout = { version = "0.1", path = "../opentelemetry-stdout", features = ["trace"] }
 
 [features]
 default = ["trace"]
-trace = ["opentelemetry_api/trace", "opentelemetry_sdk/trace"]
-metrics = ["opentelemetry_api/metrics", "opentelemetry_sdk/metrics"]
-logs = ["opentelemetry_sdk/logs"]
+trace = ["opentelemetry_api/trace"]
+metrics = ["opentelemetry_api/metrics"]
+logs = ["opentelemetry_api/logs"]
 logs_level_enabled = ["logs"]
-testing = ["opentelemetry_api/testing", "opentelemetry_sdk/testing"]
-rt-tokio = ["opentelemetry_sdk/rt-tokio"]
-rt-tokio-current-thread = ["opentelemetry_sdk/rt-tokio-current-thread"]
-rt-async-std = ["opentelemetry_sdk/rt-async-std"]
+testing = ["opentelemetry_api/testing"]

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -15,9 +15,9 @@
 //! # {
 //! use opentelemetry::{
 //!     global,
-//!     sdk::trace::TracerProvider,
 //!     trace::{Tracer, TracerProvider as _},
 //! };
+//! use opentelemetry_sdk::trace::TracerProvider;
 //!
 //! fn main() {
 //!     // Create a new trace pipeline that prints to stdout
@@ -228,22 +228,3 @@
 #![cfg_attr(test, deny(warnings))]
 
 pub use opentelemetry_api::*;
-pub use opentelemetry_sdk::runtime;
-
-#[doc(hidden)]
-#[cfg(feature = "testing")]
-pub mod testing {
-    pub use opentelemetry_sdk::testing::*;
-}
-
-/// # OpenTelemetry SDK
-///
-/// This SDK provides an opinionated reference implementation of
-/// the OpenTelemetry API. The SDK implements the specifics of
-/// deciding which data to collect through `Sampler`s, and
-/// facilitates the delivery of telemetry data to storage systems
-/// through `Exporter`s. These can be configured on `Tracer` and
-/// `Meter` creation.
-pub mod sdk {
-    pub use opentelemetry_sdk::*;
-}

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -14,7 +14,7 @@ if rustup component add clippy; then
     `# Exit with a nonzero code if there are clippy warnings` \
     -Dwarnings
 
-  cargo_feature opentelemetry "trace,rt-tokio,rt-tokio-current-thread,rt-async-std,testing"
+  cargo_feature opentelemetry "trace,metrics,logs,logs_level_enabled,testing"
 
   cargo_feature opentelemetry-otlp "default"
   cargo_feature opentelemetry-otlp "default,tls"


### PR DESCRIPTION
Fixes #1186

## Changes

- remove the re-exports of `opentelemetry_sdk` types from `opentelemetry`
- fix all places that were using `opentelemetry::sdk` to use `opentelemetry_sdk`
- removed features of `opentelemetry` that did not pass-thru to `opentelemetry_api`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)