### PR TITLE
bump MSRV to 1.64 and indexmap to 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.60.0
+        toolchain: 1.64.0
         override: true
     - name: Patch dependencies versions # some dependencies bump MSRV without major version bump
       run: ./scripts/patch_dependencies.sh

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.60+][msrv]*
+*Compiler support: [requires `rustc` 1.64+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
@@ -168,7 +168,7 @@ above, please let us know! We'd love to add your project to the list!
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.60. The current OpenTelemetry version is not guaranteed to build
+version is 1.64. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-api/CHANGELOG.md
+++ b/opentelemetry-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNext
+
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
 ## v0.20.0
 
 ### Added

--- a/opentelemetry-api/Cargo.toml
+++ b/opentelemetry-api/Cargo.toml
@@ -7,12 +7,12 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [dependencies]
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
-indexmap = "1.8"
+indexmap = "2.0"
 once_cell = "1.12.0"
 pin-project-lite = { version = "0.2", optional = true }
 thiserror = "1"

--- a/opentelemetry-api/README.md
+++ b/opentelemetry-api/README.md
@@ -21,7 +21,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.60+][msrv]*
+*Compiler support: [requires `rustc` 1.64+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io

--- a/opentelemetry-api/src/lib.rs
+++ b/opentelemetry-api/src/lib.rs
@@ -2,7 +2,7 @@
 //! services to capture distributed traces and metrics from your application. You
 //! can analyze them using [Prometheus], [Jaeger], and other observability tools.
 //!
-//! *Compiler support: [requires `rustc` 1.60+][msrv]*
+//! *Compiler support: [requires `rustc` 1.64+][msrv]*
 //!
 //! [Prometheus]: https://prometheus.io
 //! [Jaeger]: https://www.jaegertracing.io
@@ -11,7 +11,7 @@
 //! ## Supported Rust Versions
 //!
 //! OpenTelemetry is built against the latest stable release. The minimum
-//! supported version is 1.60. The current OpenTelemetry version is not
+//! supported version is 1.64. The current OpenTelemetry version is not
 //! guaranteed to build on Rust versions earlier than the minimum supported
 //! version.
 //!

--- a/opentelemetry-api/src/order_map.rs
+++ b/opentelemetry-api/src/order_map.rs
@@ -377,7 +377,7 @@ impl<K, V, S> OrderMap<K, V, S> {
     /// Valid indices are *0 <= index < self.len()*
     ///
     /// Computes in **O(1)** time.
-    pub fn get_index_mut(&mut self, index: usize) -> Option<(&mut K, &mut V)> {
+    pub fn get_index_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
         self.0.get_index_mut(index)
     }
 

--- a/opentelemetry-api/src/trace/span.rs
+++ b/opentelemetry-api/src/trace/span.rs
@@ -260,9 +260,10 @@ pub enum SpanKind {
 ///
 /// Only the value of the last call will be recorded, and implementations are
 /// free to ignore previous calls.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd)]
 pub enum Status {
     /// The default status.
+    #[default]
     Unset,
 
     /// The operation contains an error.
@@ -295,12 +296,6 @@ impl Status {
         Status::Error {
             description: description.into(),
         }
-    }
-}
-
-impl Default for Status {
-    fn default() -> Self {
-        Status::Unset
     }
 }
 

--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/ope
 readme = "README.md"
 keywords = ["opentelemetry", "log", "logs"]
 license = "Apache-2.0"
-rust-version = "1.60"
+rust-version = "1.64"
 edition = "2021"
 
 [dependencies]

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/ope
 readme = "README.md"
 keywords = ["opentelemetry", "log", "logs", "tracing"]
 license = "Apache-2.0"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [dependencies]
 opentelemetry_api = { version = "0.20", path = "../opentelemetry-api", features = ["logs"] }

--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNext
+
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
 ## v0.8.0
 
 ### Changed

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-contrib/CHANGELOG.md
+++ b/opentelemetry-contrib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNext
+
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
 ## v0.12.0
 
 ### Added
@@ -11,6 +17,7 @@
 - update to opentelemetry-api v0.20.0
 
 ## v0.11.0
+
 ### Changed
 - Handle `parent_span_id` in jaeger JSON exporter [#907](https://github.com/open-telemetry/opentelemetry-rust/pull/907).
 - Bump MSRV to 1.57 [#953](https://github.com/open-telemetry/opentelemetry-rust/pull/953).

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
 ### Fixed
 
 - Do not set an empty span as the active span when the propagator does not find a remote span.
@@ -17,6 +21,7 @@
 - Fix the array encoding length of datadog version 05 exporter #1002
 
 ## v0.7.0
+  
 ### Added
 - [Breaking] Add support for unified tagging [#931](https://github.com/open-telemetry/opentelemetry-rust/pull/931).
 

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -24,7 +24,7 @@ reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 surf-client = ["surf", "opentelemetry-http/surf"]
 
 [dependencies]
-indexmap = "1.8"
+indexmap = "2.0"
 once_cell = "1.12"
 opentelemetry = { version = "0.20", path = "../opentelemetry", features = ["trace"] }
 opentelemetry-http = { version = "0.9", path = "../opentelemetry-http" }

--- a/opentelemetry-dynatrace/CHANGELOG.md
+++ b/opentelemetry-dynatrace/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## Unreleased
+## vNext
 
 ### Changed
 
 - Add deprecation note to Dynatrace exporter
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ## v0.3.0
 

--- a/opentelemetry-dynatrace/Cargo.toml
+++ b/opentelemetry-dynatrace/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "metrics", "dynatrace"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNext
+
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
 ## v0.9.0
 
 ### Changed
@@ -7,6 +13,7 @@
 - Update to opentelemetry-api v0.20.0
 
 ## v0.8.0
+
 ### Changed
 - Add response headers in response for `HttpClient` implementations [#918](https://github.com/open-telemetry/opentelemetry-rust/pull/918).
 - Bump MSRV to 1.57 [#953](https://github.com/open-telemetry/opentelemetry-rust/pull/953).

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 keywords = ["opentelemetry", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [dependencies]
 async-trait = "0.1"

--- a/opentelemetry-http/README.md
+++ b/opentelemetry-http/README.md
@@ -18,7 +18,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a HTTP client interface for use by trace exporters, as well as
 helper types to inject and extract key value pairs into/from HTTP headers.
 
-*Compiler support: [requires `rustc` 1.60+][msrv]*
+*Compiler support: [requires `rustc` 1.64+][msrv]*
 
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
 [msrv]: #supported-rust-versions
@@ -26,7 +26,7 @@ helper types to inject and extract key value pairs into/from HTTP headers.
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.60. The current OpenTelemetry version is not guaranteed to build
+version is 1.64. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-jaeger/CHANGELOG.md
+++ b/opentelemetry-jaeger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNext
+
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
 ## v0.19.0
 
 ### Changed

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "jaeger", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -20,7 +20,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a trace pipeline and exporter for sending span information to a
 Jaeger `agent` or `collector` endpoint for processing and visualization.
 
-*Compiler support: [requires `rustc` 1.60+][msrv]*
+*Compiler support: [requires `rustc` 1.64+][msrv]*
 
 [`Jaeger`]: https://www.jaegertracing.io/
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
@@ -146,7 +146,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.60. The current OpenTelemetry version is not guaranteed to build
+version is 1.64. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -172,6 +172,7 @@ enum ClientConfig {
     Wasm, // no config is available for wasm for now. But we can add in the future
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for ClientConfig {
     fn default() -> Self {
         // as long as collector is enabled, we will in favor of it

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -6,7 +6,7 @@
 //! supports accepting data in the OTLP protocol.
 //! See the [Jaeger Docs] for details about Jaeger and deployment information.
 //!
-//! *Compiler support: [requires `rustc` 1.60+][msrv]*
+//! *Compiler support: [requires `rustc` 1.64+][msrv]*
 //!
 //! [Jaeger Docs]: https://www.jaegertracing.io/docs/
 //! [jaeger-deprecation]: https://github.com/open-telemetry/opentelemetry-specification/pull/2858/files
@@ -285,13 +285,13 @@
 //! # Supported Rust Versions
 //!
 //! OpenTelemetry is built against the latest stable release. The minimum
-//! supported version is 1.60. The current OpenTelemetry version is not
+//! supported version is 1.64. The current OpenTelemetry version is not
 //! guaranteed to build on Rust versions earlier than the minimum supported
 //! version.
 //!
 //! The current stable Rust compiler and the three most recent minor versions
 //! before it will always be supported. For example, if the current stable
-//! compiler version is 1.60, the minimum supported version will not be
+//! compiler version is 1.64, the minimum supported version will not be
 //! increased past 1.46, three minor versions prior. Increasing the minimum
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## vNext
 
-## Added
+### Added
 
 - Add `build_{signal}_exporter` methods to client builders (#1187)
+
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ## v0.13.0
 
 ### Added
+
 - Add OTLP HTTP Metrics Exporter [#1020](https://github.com/open-telemetry/opentelemetry-rust/pull/1020).
 - Add tonic compression support [#1165](https://github.com/open-telemetry/opentelemetry-rust/pull/1165).
 
@@ -24,6 +29,7 @@
 ## v0.12.0
 
 ### Added
+
 - Add batch config for otlp pipeline [#979](https://github.com/open-telemetry/opentelemetry-rust/pull/979).
 - Add tonic interceptor [#901](https://github.com/open-telemetry/opentelemetry-rust/pull/901).
 
@@ -38,7 +44,6 @@
 - Fix the issue where tonic exporter builder ignored provided metadata [#937](https://github.com/open-telemetry/opentelemetry-rust/pull/937).
 - Export `MetricsExporterBuilder` [#943](https://github.com/open-telemetry/opentelemetry-rust/pull/943).
 - Report OTLP http export errors [#945](https://github.com/open-telemetry/opentelemetry-rust/pull/945).
-- Bump MSRV to 1.57 [#953](https://github.com/open-telemetry/opentelemetry-rust/pull/953).
 - Change to export using v0.19.0 protobuf definitions. [#989](https://github.com/open-telemetry/opentelemetry-rust/pull/989).
 - Update dependencies and bump MSRV to 1.60 [#969](https://github.com/open-telemetry/opentelemetry-rust/pull/969).
 

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 autotests = false
 
 [[test]]

--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## Unreleased
+## vNext
+
 ### Changed
+
 - allow custom units in prometheus suffix [#1188](https://github.com/open-telemetry/opentelemetry-rust/pull/1188)
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ## v0.13.0
 

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "prometheus", "metrics", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Implement tonic metrics proto transformations (#1184)
 
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
 ### Fixed
 
 - Rename `traces` feature to the more standard `trace` (#1183)

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 autotests = false
 
 [lib]

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## vNext
 
+### Changed
+
 - Default Resource (the one used when no other Resource is explicitly provided) now includes `TelemetryResourceDetector`,
   populating "telemetry.sdk.*" attributes.
   [#1066](https://github.com/open-telemetry/opentelemetry-rust/pull/1193).
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ## v0.20.0
 

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [dependencies]
 opentelemetry_api = { version = "0.20", path = "../opentelemetry-api/" }
@@ -36,7 +36,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
-indexmap = "1.8"
+indexmap = "2.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 pprof = { version = "0.12", features = ["flamegraph", "criterion"] }
 

--- a/opentelemetry-sdk/README.md
+++ b/opentelemetry-sdk/README.md
@@ -21,7 +21,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.60+][msrv]*
+*Compiler support: [requires `rustc` 1.64+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io

--- a/opentelemetry-semantic-conventions/CHANGELOG.md
+++ b/opentelemetry-semantic-conventions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNext
+
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
 ## v0.12.0
 
 ### Changed
@@ -8,6 +14,7 @@
 - Update to opentelemetry-api v0.20.0
 
 ## v0.11.0
+
 ### Changed
 - Update to `opentelemetry` v0.19.
 - Update to `opentelemetry_http` v0.8.

--- a/opentelemetry-semantic-conventions/Cargo.toml
+++ b/opentelemetry-semantic-conventions/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## V0.17.0
+## vNext
+
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
+## v0.17.0
 
 ### Added
 
@@ -14,6 +20,7 @@
 - Update to opentelemetry v0.20.0
 
 ## v0.16.0
+
 ### Changed
 - Update to `opentelemetry` v0.19.
 - Update to `opentelemetry-semantic-conventions` v0.11.

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 license = "Apache-2.0"
 edition = "2021"
 exclude = ["/proto"]
-rust-version = "1.60"
+rust-version = "1.64"
 
 [dependencies]
 async-trait = "0.1.48"

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [features]
 trace = ["opentelemetry_api/trace", "opentelemetry_sdk/trace", "futures-util"]

--- a/opentelemetry-stdout/README.md
+++ b/opentelemetry-stdout/README.md
@@ -20,7 +20,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides exporters that export to stdout or any implementation of
 [`std::io::Write`].
 
-*Compiler support: [requires `rustc` 1.60+][msrv]*
+*Compiler support: [requires `rustc` 1.64+][msrv]*
 
 [`std::io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
@@ -70,7 +70,7 @@ Recorded traces and metrics will now be sent to stdout:
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.60. The current OpenTelemetry version is not guaranteed to build
+version is 1.64. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 keywords = ["opentelemetry", "metrics", "user-events"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [dependencies]
 opentelemetry_api = { version = "0.20", path = "../opentelemetry-api", features = ["metrics"] }

--- a/opentelemetry-zipkin/CHANGELOG.md
+++ b/opentelemetry-zipkin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNext
+
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
 ## v0.17.0
 
 ### Changed
@@ -7,6 +13,7 @@
 - Update to opentelemetry v0.20.0
 
 ## v0.17.0
+
 ## Changed
 - Update to `opentelemetry` v0.19.
 - Update to `opentelemetry-http` v0.8.
@@ -144,4 +151,3 @@
 ### Added
 
 - Exporter to Zipkin collector through HTTP API
-

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -21,7 +21,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a trace pipeline and exporter for sending span information to a
 Zipkin collector for processing and visualization.
 
-*Compiler support: [requires `rustc` 1.60+][msrv]*
+*Compiler support: [requires `rustc` 1.64+][msrv]*
 
 [`Zipkin`]: https://zipkin.io/
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
@@ -105,12 +105,12 @@ available so be sure to match them appropriately.
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.60. The current OpenTelemetry version is not guaranteed to build on
+version is 1.64. The current OpenTelemetry version is not guaranteed to build on
 Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions before
 it will always be supported. For example, if the current stable compiler version
-is 1.60, the minimum supported version will not be increased past 1.46, three
+is 1.64, the minimum supported version will not be increased past 1.46, three
 minor versions prior. Increasing the minimum supported compiler version is not
 considered a semver breaking change as long as doing so complies with this
 policy.

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -3,7 +3,7 @@
 //! Collects OpenTelemetry spans and reports them to a given Zipkin collector
 //! endpoint. See the [Zipkin Docs] for details and deployment information.
 //!
-//! *Compiler support: [requires `rustc` 1.60+][msrv]*
+//! *Compiler support: [requires `rustc` 1.64+][msrv]*
 //!
 //! [Zipkin Docs]: https://zipkin.io/
 //! [msrv]: #supported-rust-versions
@@ -167,7 +167,7 @@
 //! ## Supported Rust Versions
 //!
 //! OpenTelemetry is built against the latest stable release. The minimum
-//! supported version is 1.60. The current OpenTelemetry version is not
+//! supported version is 1.64. The current OpenTelemetry version is not
 //! guaranteed to build on Rust versions earlier than the minimum supported
 //! version.
 //!

--- a/opentelemetry-zpages/CHANGELOG.md
+++ b/opentelemetry-zpages/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNext
+
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
 ## v0.5.0
 
 ### Updates
@@ -7,6 +13,7 @@
 - Update to opentelemetry-api v0.20.0
 
 ## v0.4.0
+
 - Update to opentelemetry v0.19.0
 - Update to opentelemetry-proto v0.2.0
 - Bump MSRV to 1.57 [#953](https://github.com/open-telemetry/opentelemetry-rust/pull/953).
@@ -27,4 +34,5 @@
 ## v0.1.0
 
 ### Added
+
 - Add Tracez http endpoint.

--- a/opentelemetry-zpages/Cargo.toml
+++ b/opentelemetry-zpages/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNext
+
+### Changed
+
+- Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+
 ## [v0.20.0](https://github.com/open-telemetry/opentelemetry-rust/compare/v0.19.0...v0.20.0)
 This release should been seen as 1.0-rc3 following 1.0-rc2 in v0.19.0. Refer to CHANGELOG.md in individual creates for details on changes made in different creates.
 

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -14,7 +14,7 @@ categories = [
 keywords = ["opentelemetry", "logging", "tracing", "metrics", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -21,7 +21,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.60+][msrv]*
+*Compiler support: [requires `rustc` 1.64+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
@@ -133,7 +133,7 @@ above, please let us know! We'd love to add your project to the list!
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.60. The current OpenTelemetry version is not guaranteed to build
+version is 1.64. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -2,7 +2,7 @@
 //! services to capture distributed traces and metrics from your application. You
 //! can analyze them using [Prometheus], [Jaeger], and other observability tools.
 //!
-//! *Compiler support: [requires `rustc` 1.60+][msrv]*
+//! *Compiler support: [requires `rustc` 1.64+][msrv]*
 //!
 //! [Prometheus]: https://prometheus.io
 //! [Jaeger]: https://www.jaegertracing.io
@@ -197,7 +197,7 @@
 //! ## Supported Rust Versions
 //!
 //! OpenTelemetry is built against the latest stable release. The minimum
-//! supported version is 1.60. The current OpenTelemetry version is not
+//! supported version is 1.64. The current OpenTelemetry version is not
 //! guaranteed to build on Rust versions earlier than the minimum supported
 //! version.
 //!


### PR DESCRIPTION
Due to requirement of #1199, this is a separate PR to bump MSRV.
Contributing factors:
- `tokio` now has MSRV of 1.63
- we're using older `indexmap 1.18`, and `indexmap 2.0` has MSRV of 1.64

## Changes
- bump MSRV to 1.64
- bump `indexmap` to 2.0
- fix newly exposed lint about deriving `Default` instead of manually implementing

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
