### PR TITLE
chore: use pprof only if target_os is not windows

### DIFF
--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -38,6 +38,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dev-dependencies]
 indexmap = "1.8"
 criterion = { version = "0.5", features = ["html_reports"] }
+[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { version = "0.12", features = ["flamegraph", "criterion"] }
 
 [features]

--- a/opentelemetry-sdk/benches/context.rs
+++ b/opentelemetry-sdk/benches/context.rs
@@ -10,6 +10,7 @@ use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
     trace as sdktrace,
 };
+#[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -86,9 +87,16 @@ impl SpanExporter for NoopExporter {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/key_value_map.rs
+++ b/opentelemetry-sdk/benches/key_value_map.rs
@@ -4,6 +4,7 @@ use criterion::{
 use indexmap::IndexMap;
 use opentelemetry_api::{Key, KeyValue, Value};
 use opentelemetry_sdk::trace::EvictedHashMap;
+#[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
 use std::iter::Iterator;
 
@@ -200,9 +201,16 @@ const MAP_KEYS: [&str; 64] = [
     "key.56", "key.57", "key.58", "key.59", "key.60", "key.61", "key.62", "key.63", "key.64",
 ];
 
+#[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/span_builder.rs
+++ b/opentelemetry-sdk/benches/span_builder.rs
@@ -8,6 +8,7 @@ use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
     trace as sdktrace,
 };
+#[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -99,9 +100,16 @@ const MAP_KEYS: [&str; 64] = [
     "key.56", "key.57", "key.58", "key.59", "key.60", "key.61", "key.62", "key.63", "key.64",
 ];
 
+#[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -8,6 +8,7 @@ use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
     trace as sdktrace,
 };
+#[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -89,9 +90,16 @@ fn trace_benchmark_group<F: Fn(&sdktrace::Tracer)>(c: &mut Criterion, name: &str
     group.finish();
 }
 
+#[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
     targets = criterion_benchmark
 }
 criterion_main!(benches);


### PR DESCRIPTION
Following [this](https://github.com/open-telemetry/opentelemetry-rust/pull/1090) pr introduced a breaking change for running cargo bench in Windows due to pprof not being able to [compile](https://github.com/tikv/pprof-rs/issues/9) in Windows. Similar to [this](https://github.com/tokio-rs/tracing-opentelemetry/issues/39), only use pprof if not on a Windows machine.