### PR TITLE
fix(otlp): endpoint urls for otlp http exporter.

### DIFF
--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -145,7 +145,10 @@ impl Default for TonicExporterBuilder {
         };
 
         TonicExporterBuilder {
-            exporter_config: ExportConfig::default(),
+            exporter_config: ExportConfig {
+                protocol: crate::Protocol::Grpc,
+                ..Default::default()
+            },
             tonic_config,
             channel: Option::default(),
             interceptor: Option::default(),


### PR DESCRIPTION
Follow up on #1187 

## Changes
- removed the `with_env` method as we will always check env var before creating exporters.
- append the signal path to `OTEL_EXPORTER_OTLP_ENDPOINT` per [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#endpoint-urls-for-otlphttp)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
