### PR TITLE
fix(zpages): use tonic based generated files.

### DIFF
--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Implement tonic metrics proto transformations (#1184)
+- Move proto for zPage to tonic [#1214](https://github.com/open-telemetry/opentelemetry-rust/pull/1214)
 
 ### Changed
 

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -48,7 +48,7 @@ tonic = { version = "0.9.0", default-features = false, optional = true, features
 prost = { version = "0.11.0", optional = true }
 opentelemetry_api = { version = "0.20", default-features = false, path = "../opentelemetry-api" }
 opentelemetry_sdk = { version = "0.20", default-features = false, path = "../opentelemetry-sdk" }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 
 [dev-dependencies]
 grpcio-compiler = { version = "0.12.1", default-features = false, features = ["prost-codec"] }

--- a/opentelemetry-proto/src/proto.rs
+++ b/opentelemetry-proto/src/proto.rs
@@ -65,6 +65,14 @@ pub mod tonic {
         pub mod v1;
     }
 
+    /// Generated types used in zpages.
+    #[cfg(feature = "zpages")]
+    #[path = ""]
+    pub mod tracez {
+        #[path = "opentelemetry.proto.tracez.v1.rs"]
+        pub mod v1;
+    }
+
     pub use crate::transform::common::tonic::Attributes;
 }
 
@@ -131,14 +139,6 @@ pub mod grpcio {
     #[path = ""]
     pub mod trace {
         #[path = "opentelemetry.proto.trace.v1.rs"]
-        pub mod v1;
-    }
-
-    /// Generated types used in zpages.
-    #[cfg(feature = "zpages")]
-    #[path = ""]
-    pub mod tracez {
-        #[path = "opentelemetry.proto.tracez.v1.rs"]
         pub mod v1;
     }
 

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportLogsServiceRequest {
@@ -11,6 +12,7 @@ pub struct ExportLogsServiceRequest {
         super::super::super::logs::v1::ResourceLogs,
     >,
 }
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportLogsServiceResponse {
@@ -32,6 +34,7 @@ pub struct ExportLogsServiceResponse {
     #[prost(message, optional, tag = "1")]
     pub partial_success: ::core::option::Option<ExportLogsPartialSuccess>,
 }
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportLogsPartialSuccess {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportMetricsServiceRequest {
@@ -11,6 +12,7 @@ pub struct ExportMetricsServiceRequest {
         super::super::super::metrics::v1::ResourceMetrics,
     >,
 }
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportMetricsServiceResponse {
@@ -32,6 +34,7 @@ pub struct ExportMetricsServiceResponse {
     #[prost(message, optional, tag = "1")]
     pub partial_success: ::core::option::Option<ExportMetricsPartialSuccess>,
 }
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportMetricsPartialSuccess {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTraceServiceRequest {
@@ -11,6 +12,7 @@ pub struct ExportTraceServiceRequest {
         super::super::super::trace::v1::ResourceSpans,
     >,
 }
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTraceServiceResponse {
@@ -32,6 +34,7 @@ pub struct ExportTraceServiceResponse {
     #[prost(message, optional, tag = "1")]
     pub partial_success: ::core::option::Option<ExportTracePartialSuccess>,
 }
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTracePartialSuccess {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
@@ -1,6 +1,7 @@
 /// AnyValue is used to represent any type of attribute value. AnyValue may contain a
 /// primitive value such as a string or integer or it may contain an arbitrary nested
 /// object containing arrays, key-value lists and primitives.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AnyValue {
@@ -13,6 +14,7 @@ pub struct AnyValue {
 pub mod any_value {
     /// The value is one of the listed fields. It is valid for all values to be unspecified
     /// in which case this AnyValue is considered to be "empty".
+    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
@@ -34,6 +36,7 @@ pub mod any_value {
 }
 /// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
 /// since oneof in AnyValue does not allow repeated fields.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArrayValue {
@@ -46,6 +49,7 @@ pub struct ArrayValue {
 /// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
 /// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
 /// are semantically equivalent.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyValueList {
@@ -58,6 +62,7 @@ pub struct KeyValueList {
 }
 /// KeyValue is a key-value pair that is used to store Span attributes, Link
 /// attributes, etc.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyValue {
@@ -68,6 +73,7 @@ pub struct KeyValue {
 }
 /// InstrumentationScope is a message representing the instrumentation scope information
 /// such as the fully qualified name and version.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstrumentationScope {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
@@ -8,6 +8,7 @@
 ///
 /// When new fields are added into this message, the OTLP request MUST be updated
 /// as well.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LogsData {
@@ -20,6 +21,7 @@ pub struct LogsData {
     pub resource_logs: ::prost::alloc::vec::Vec<ResourceLogs>,
 }
 /// A collection of ScopeLogs from a Resource.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceLogs {
@@ -36,6 +38,7 @@ pub struct ResourceLogs {
     pub schema_url: ::prost::alloc::string::String,
 }
 /// A collection of Logs produced by a Scope.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScopeLogs {
@@ -53,6 +56,7 @@ pub struct ScopeLogs {
 }
 /// A log record according to OpenTelemetry Log Data Model:
 /// <https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md>
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LogRecord {
@@ -134,6 +138,7 @@ pub struct LogRecord {
     pub span_id: ::prost::alloc::vec::Vec<u8>,
 }
 /// Possible values for LogRecord.SeverityNumber.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum SeverityNumber {
@@ -236,6 +241,7 @@ impl SeverityNumber {
 ///
 ///    (logRecord.flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK)
 ///
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum LogRecordFlags {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
@@ -8,6 +8,7 @@
 ///
 /// When new fields are added into this message, the OTLP request MUST be updated
 /// as well.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MetricsData {
@@ -20,6 +21,7 @@ pub struct MetricsData {
     pub resource_metrics: ::prost::alloc::vec::Vec<ResourceMetrics>,
 }
 /// A collection of ScopeMetrics from a Resource.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceMetrics {
@@ -36,6 +38,7 @@ pub struct ResourceMetrics {
     pub schema_url: ::prost::alloc::string::String,
 }
 /// A collection of Metrics produced by an Scope.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScopeMetrics {
@@ -136,6 +139,7 @@ pub struct ScopeMetrics {
 /// to support correct rate calculation.  Although it may be omitted
 /// when the start time is truly unknown, setting StartTimeUnixNano is
 /// strongly encouraged.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Metric {
@@ -160,6 +164,7 @@ pub mod metric {
     /// Data determines the aggregation type (if any) of the metric, what is the
     /// reported value type for the data points, as well as the relatationship to
     /// the time interval over which they are reported.
+    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Data {
@@ -184,6 +189,7 @@ pub mod metric {
 /// aggregation, regardless of aggregation temporalities. Therefore,
 /// AggregationTemporality is not included. Consequently, this also means
 /// "StartTimeUnixNano" is ignored for all data points.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Gauge {
@@ -192,6 +198,7 @@ pub struct Gauge {
 }
 /// Sum represents the type of a scalar metric that is calculated as a sum of all
 /// reported measurements over a time interval.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Sum {
@@ -207,6 +214,7 @@ pub struct Sum {
 }
 /// Histogram represents the type of a metric that is calculated by aggregating
 /// as a Histogram of all reported measurements over a time interval.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Histogram {
@@ -219,6 +227,7 @@ pub struct Histogram {
 }
 /// ExponentialHistogram represents the type of a metric that is calculated by aggregating
 /// as a ExponentialHistogram of all reported double measurements over a time interval.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExponentialHistogram {
@@ -235,6 +244,7 @@ pub struct ExponentialHistogram {
 /// data type. These data points cannot always be merged in a meaningful way.
 /// While they can be useful in some applications, histogram data points are
 /// recommended for new applications.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Summary {
@@ -243,6 +253,7 @@ pub struct Summary {
 }
 /// NumberDataPoint is a single data point in a timeseries that describes the
 /// time-varying scalar value of a metric.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NumberDataPoint {
@@ -282,6 +293,7 @@ pub struct NumberDataPoint {
 pub mod number_data_point {
     /// The value itself.  A point is considered invalid when one of the recognized
     /// value fields is not present inside this oneof.
+    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
@@ -301,6 +313,7 @@ pub mod number_data_point {
 /// If the histogram does not contain the distribution of values, then both
 /// "explicit_bounds" and "bucket_counts" must be omitted and only "count" and
 /// "sum" are known.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HistogramDataPoint {
@@ -382,6 +395,7 @@ pub struct HistogramDataPoint {
 /// summary statistics for a population of values, it may optionally contain the
 /// distribution of those values across a set of buckets.
 ///
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExponentialHistogramDataPoint {
@@ -479,6 +493,7 @@ pub struct ExponentialHistogramDataPoint {
 pub mod exponential_histogram_data_point {
     /// Buckets are a set of bucket counts, encoded in a contiguous array
     /// of counts.
+    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Buckets {
@@ -502,6 +517,7 @@ pub mod exponential_histogram_data_point {
 }
 /// SummaryDataPoint is a single data point in a timeseries that describes the
 /// time-varying values of a Summary metric.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SummaryDataPoint {
@@ -556,6 +572,7 @@ pub mod summary_data_point {
     ///
     /// See the following issue for more context:
     /// <https://github.com/open-telemetry/opentelemetry-proto/issues/125>
+    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ValueAtQuantile {
@@ -574,6 +591,7 @@ pub mod summary_data_point {
 /// Exemplars also hold information about the environment when the measurement
 /// was recorded, for example the span and trace ID of the active span when the
 /// exemplar was recorded.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Exemplar {
@@ -611,6 +629,7 @@ pub mod exemplar {
     /// The value of the measurement that was recorded. An exemplar is
     /// considered invalid when one of the recognized value fields is not present
     /// inside this oneof.
+    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
@@ -623,6 +642,7 @@ pub mod exemplar {
 /// AggregationTemporality defines how a metric aggregator reports aggregated
 /// values. It describes how those values relate to the time interval over
 /// which they are aggregated.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum AggregationTemporality {
@@ -719,6 +739,7 @@ impl AggregationTemporality {
 ///
 ///    (point.flags & DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK) == DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK
 ///
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum DataPointFlags {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.resource.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.resource.v1.rs
@@ -1,4 +1,5 @@
 /// Resource information.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Resource {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.trace.v1.rs
@@ -8,6 +8,7 @@
 ///
 /// When new fields are added into this message, the OTLP request MUST be updated
 /// as well.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TracesData {
@@ -20,6 +21,7 @@ pub struct TracesData {
     pub resource_spans: ::prost::alloc::vec::Vec<ResourceSpans>,
 }
 /// A collection of ScopeSpans from a Resource.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceSpans {
@@ -36,6 +38,7 @@ pub struct ResourceSpans {
     pub schema_url: ::prost::alloc::string::String,
 }
 /// A collection of Spans produced by an InstrumentationScope.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScopeSpans {
@@ -54,6 +57,7 @@ pub struct ScopeSpans {
 /// A Span represents a single operation performed by a single component of the system.
 ///
 /// The next available field id is 17.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Span {
@@ -159,6 +163,7 @@ pub struct Span {
 pub mod span {
     /// Event is a time-stamped annotation of the span, consisting of user-supplied
     /// text description and key-value pairs.
+    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Event {
@@ -185,6 +190,7 @@ pub mod span {
     /// different trace. For example, this can be used in batching operations,
     /// where a single batch handler processes multiple requests from different
     /// traces or when the handler receives a request from a different project.
+    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Link {
@@ -212,6 +218,7 @@ pub mod span {
     }
     /// SpanKind is the type of span. Can be used to specify additional relationships between spans
     /// in addition to a parent/child relationship.
+    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
     #[derive(
         Clone,
         Copy,
@@ -277,6 +284,7 @@ pub mod span {
 }
 /// The Status type defines a logical error model that is suitable for different
 /// programming environments, including REST APIs and RPC APIs.
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Status {
@@ -291,6 +299,7 @@ pub struct Status {
 pub mod status {
     /// For the semantics of status codes see
     /// <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status>
+    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
     #[derive(
         Clone,
         Copy,

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.tracez.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.tracez.v1.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TracezCounts {
@@ -11,6 +12,7 @@ pub struct TracezCounts {
     #[prost(uint32, tag = "4")]
     pub error: u32,
 }
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LatencyData {
@@ -34,6 +36,7 @@ pub struct LatencyData {
     #[prost(message, repeated, tag = "8")]
     pub links: ::prost::alloc::vec::Vec<super::super::trace::v1::span::Link>,
 }
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RunningData {
@@ -55,6 +58,7 @@ pub struct RunningData {
     #[prost(message, repeated, tag = "7")]
     pub links: ::prost::alloc::vec::Vec<super::super::trace::v1::span::Link>,
 }
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ErrorData {

--- a/opentelemetry-proto/src/transform/tracez.rs
+++ b/opentelemetry-proto/src/transform/tracez.rs
@@ -1,13 +1,13 @@
-#[cfg(feature = "gen-grpcio")]
+#[cfg(all(feature = "gen-tonic-messages", feature = "zpages"))]
 mod grpcio {
     use opentelemetry_api::trace::{Event, Status};
     use opentelemetry_sdk::export::trace::SpanData;
 
-    use crate::proto::grpcio::{
+    use crate::proto::tonic::{
         trace::v1::{span::Event as SpanEvent, Status as SpanStatus},
         tracez::v1::{ErrorData, LatencyData, RunningData},
     };
-    use crate::transform::common::{grpcio::Attributes, to_nanos};
+    use crate::transform::common::{to_nanos, tonic::Attributes};
 
     impl From<SpanData> for LatencyData {
         fn from(span_data: SpanData) -> Self {

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -12,9 +12,8 @@ const GRPCIO_PROTO_FILES: &[&str] = &[
     "src/proto/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
     "src/proto/opentelemetry-proto/opentelemetry/proto/logs/v1/logs.proto",
     "src/proto/opentelemetry-proto/opentelemetry/proto/collector/logs/v1/logs_service.proto",
-    "src/proto/tracez.proto",
 ];
-const GRPCIO_INCLUDES: &[&str] = &["src/proto/opentelemetry-proto/", "src/proto"];
+const GRPCIO_INCLUDES: &[&str] = &["src/proto/opentelemetry-proto/"];
 
 const TONIC_OUT_DIR: &str = "src/proto/tonic";
 const TONIC_PROTO_FILES: &[&str] = &[
@@ -26,8 +25,9 @@ const TONIC_PROTO_FILES: &[&str] = &[
     "src/proto/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
     "src/proto/opentelemetry-proto/opentelemetry/proto/logs/v1/logs.proto",
     "src/proto/opentelemetry-proto/opentelemetry/proto/collector/logs/v1/logs_service.proto",
+    "src/proto/tracez.proto",
 ];
-const TONIC_INCLUDES: &[&str] = &["src/proto/opentelemetry-proto"];
+const TONIC_INCLUDES: &[&str] = &["src/proto/opentelemetry-proto", "src/proto"];
 
 // This test helps to keep files generated and used by grpcio update to date.
 // If the test fails, it means the generated files has been changed. Please commit the change
@@ -59,6 +59,10 @@ fn build_tonic() {
         .build_client(true)
         .server_mod_attribute(".", "#[cfg(feature = \"gen-tonic\")]")
         .client_mod_attribute(".", "#[cfg(feature = \"gen-tonic\")]")
+        .type_attribute(
+            ".",
+            "#[cfg_attr(feature = \"with-serde\", derive(serde::Serialize, serde::Deserialize))]",
+        )
         .out_dir(out_dir.path())
         .compile(TONIC_PROTO_FILES, TONIC_INCLUDES)
         .expect("cannot compile protobuf using tonic");

--- a/opentelemetry-zpages/CHANGELOG.md
+++ b/opentelemetry-zpages/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+- Use tonic based generated files [#1214](https://github.com/open-telemetry/opentelemetry-rust/pull/1214)
 
 ## v0.5.0
 

--- a/opentelemetry-zpages/Cargo.toml
+++ b/opentelemetry-zpages/Cargo.toml
@@ -20,8 +20,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-opentelemetry = { version = "0.20", default-features = false, features = ["trace"] }
-opentelemetry-proto = { version = "0.3", features = ["zpages", "gen-protoc", "with-serde"], default-features = false }
+opentelemetry = { path = "../opentelemetry", default-features = false, features = ["trace"] }
+opentelemetry-proto = { path = "../opentelemetry-proto", features = ["zpages", "gen-tonic", "with-serde"], default-features = false }
 async-channel = "1.6"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
@@ -30,7 +30,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt"] }
-opentelemetry = { version = "0.20", features = ["trace", "testing"] }
+opentelemetry = { path = "../opentelemetry", features = ["trace", "testing"] }
 rand = "0.8"
 hyper = { version = "0.14", features = ["full"] }
 

--- a/opentelemetry-zpages/src/trace/aggregator.rs
+++ b/opentelemetry-zpages/src/trace/aggregator.rs
@@ -14,7 +14,7 @@ use opentelemetry::trace::Status;
 use crate::trace::{TracezError, TracezMessage, TracezQuery, TracezResponse};
 use crate::SpanQueue;
 use opentelemetry::sdk::export::trace::SpanData;
-use opentelemetry_proto::grpcio::tracez::TracezCounts;
+use opentelemetry_proto::tonic::tracez::v1::TracezCounts;
 
 const LATENCY_BUCKET: [Duration; 9] = [
     Duration::from_micros(0),
@@ -116,7 +116,6 @@ impl SpanAggregator {
                             .collect(),
                         running: summary.running.count() as u32,
                         error: summary.error.count() as u32,
-                        ..Default::default()
                     })
                     .collect(),
             )),

--- a/opentelemetry-zpages/src/trace/mod.rs
+++ b/opentelemetry-zpages/src/trace/mod.rs
@@ -1,6 +1,6 @@
 //! Tracez implementation
 //!
-use opentelemetry_proto::grpcio::tracez::{ErrorData, LatencyData, RunningData, TracezCounts};
+use opentelemetry_proto::tonic::tracez::v1::{ErrorData, LatencyData, RunningData, TracezCounts};
 
 use async_channel::{SendError, Sender};
 use futures_channel::oneshot::{self, Canceled};


### PR DESCRIPTION
related to #1208 

## Changes

The reason zpages cannot compile after #1202 is prost backed grpcio compiler no longer allow us to add `serde` macros onto the types. Thus, instead of using grpcio types, use tonic types in zpages fixes it.

## Merge requirement checklist

* [x [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
