### PR TITLE
Make LogData constructible by removing #[non_exhaustive], fixes #1217

### DIFF
--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -26,7 +26,6 @@ pub trait LogExporter: Send + Debug {
 /// `LogData` associates a [`LogRecord`] with a [`Resource`] and
 /// [`InstrumentationLibrary`].
 #[derive(Debug)]
-#[non_exhaustive]
 pub struct LogData {
     /// Log record
     pub record: LogRecord,


### PR DESCRIPTION
Fixes #1217

## Changes
Remove the `#[non_exhaustive]` attribute from `LogData` so it can be constructed, allowing direct use of `LogExporter`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
