### PR TITLE
chore: fix new lints from Rust 1.72 update

### DIFF
--- a/opentelemetry-api/src/trace/tracer.rs
+++ b/opentelemetry-api/src/trace/tracer.rs
@@ -334,7 +334,7 @@ impl SpanBuilder {
         I: IntoIterator<Item = KeyValue>,
     {
         SpanBuilder {
-            attributes: Some(OrderMap::from_iter(attributes.into_iter())),
+            attributes: Some(OrderMap::from_iter(attributes)),
             ..self
         }
     }

--- a/opentelemetry-dynatrace/src/transform/metrics.rs
+++ b/opentelemetry-dynatrace/src/transform/metrics.rs
@@ -713,7 +713,7 @@ mod tests {
 
     #[test]
     fn test_record_to_metric_line() -> Result<(), MetricsError> {
-        let attributes = vec![("KEY", "VALUE"), ("test.abc_123-", "value.123_foo-bar")];
+        let attributes = [("KEY", "VALUE"), ("test.abc_123-", "value.123_foo-bar")];
         let attribute_set = AttributeSet::from_attributes(
             attributes
                 .iter()

--- a/opentelemetry-otlp/src/exporter/grpcio/mod.rs
+++ b/opentelemetry-otlp/src/exporter/grpcio/mod.rs
@@ -124,7 +124,7 @@ impl GrpcioExporterBuilder {
     /// Set additional headers to send to the collector.
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         let mut inst_headers = self.grpcio_config.headers.unwrap_or_default();
-        inst_headers.extend(headers.into_iter());
+        inst_headers.extend(headers);
         self.grpcio_config.headers = Some(inst_headers);
         self
     }

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -133,7 +133,7 @@ impl HttpExporterBuilder {
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         // headers will be wrapped, so we must do some logic to unwrap first.
         let mut inst_headers = self.http_config.headers.unwrap_or_default();
-        inst_headers.extend(headers.into_iter());
+        inst_headers.extend(headers);
         self.http_config.headers = Some(inst_headers);
         self
     }

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -170,7 +170,7 @@ impl TonicExporterBuilder {
             .metadata
             .unwrap_or_default()
             .into_headers();
-        existing_headers.extend(incoming_headers.into_iter());
+        existing_headers.extend(incoming_headers);
 
         self.tonic_config.metadata = Some(MetadataMap::from_headers(existing_headers));
         self

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -388,15 +388,12 @@ fn multiple_scopes() {
             Box::new(TelemetryResourceDetector),
         ],
     )
-    .merge(&mut Resource::new(
-        vec![
-            // always specify service.name because the default depends on the running OS
-            SERVICE_NAME.string("prometheus_test"),
-            // Overwrite the semconv.TelemetrySDKVersionKey value so we don't need to update every version
-            TELEMETRY_SDK_VERSION.string("latest"),
-        ]
-        .into_iter(),
-    ));
+    .merge(&mut Resource::new(vec![
+        // always specify service.name because the default depends on the running OS
+        SERVICE_NAME.string("prometheus_test"),
+        // Overwrite the semconv.TelemetrySDKVersionKey value so we don't need to update every version
+        TELEMETRY_SDK_VERSION.string("latest"),
+    ]));
 
     let provider = MeterProvider::builder()
         .with_reader(exporter)

--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -89,7 +89,7 @@ pub mod tonic {
                 body: log_record.body.map(Into::into),
                 attributes: log_record
                     .attributes
-                    .map(|attrs| Attributes::from_iter(attrs.into_iter()))
+                    .map(Attributes::from_iter)
                     .unwrap_or_default()
                     .0,
                 dropped_attributes_count: 0,
@@ -228,7 +228,7 @@ pub mod grpcio {
                 body: log_record.body.map(Into::into),
                 attributes: log_record
                     .attributes
-                    .map(|attrs| Attributes::from_iter(attrs.into_iter()))
+                    .map(Attributes::from_iter)
                     .unwrap_or_default()
                     .0,
                 dropped_attributes_count: 0,

--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -724,7 +724,7 @@ impl From<(EvictedHashMap, &Resource)> for Attributes {
         let attribute_map = resource
             .into_iter()
             .map(|(k, v)| (k.clone(), v.clone()))
-            .chain(attributes.into_iter())
+            .chain(attributes)
             .flat_map(|(k, v)| {
                 let key = k.as_str();
                 if key.len() > 128 {


### PR DESCRIPTION
While working an unrelated PR, started getting lint errors.  Turns out it was a drive-by due to [Rust 1.72](https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html) just getting released.

Here's a separate PR to fix these new lints:
- https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
- https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
