### PR TITLE
Removed `futures-channel` from `opentelemetry` dependencies

### DIFF
--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -96,7 +96,9 @@ impl StackDriverExporter {
 impl SpanExporter for StackDriverExporter {
     fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
         match self.tx.try_send(batch) {
-            Err(e) => Box::pin(std::future::ready(Err(e.into()))),
+            Err(e) => Box::pin(std::future::ready(Err(TraceError::Other(Box::new(
+                e.into_send_error(),
+            ))))),
             Ok(()) => {
                 self.pending_count.fetch_add(1, Ordering::Relaxed);
                 Box::pin(std::future::ready(Ok(())))

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -27,6 +27,9 @@ This release should been seen as 1.0-rc3 following 1.0-rc2 in v0.19.0. Refer to 
 - Drop include_trace_context parameter from Logs API/SDK. [#1133](https://github.com/open-telemetry/opentelemetry-rust/issues/1133)
 - Synchronous instruments no longer accepts `Context` while reporting
   measurements. [#1076](https://github.com/open-telemetry/opentelemetry-rust/pull/1076).
+- Fallible conversions from `futures-channel` error types to `LogError` and
+  `TraceError` removed.
+  [#1201](https://github.com/open-telemetry/opentelemetry-rust/issues/1201)
 
 ### Fixed
 

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -21,7 +21,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
 indexmap = "2.0"
 once_cell = "1.12.0"

--- a/opentelemetry/src/logs/mod.rs
+++ b/opentelemetry/src/logs/mod.rs
@@ -1,7 +1,6 @@
 //! # OpenTelemetry Logs API
 
 use crate::ExportError;
-use futures_channel::{mpsc::TrySendError, oneshot::Canceled};
 use std::time::Duration;
 use thiserror::Error;
 
@@ -39,18 +38,6 @@ where
 {
     fn from(err: T) -> Self {
         LogError::ExportFailed(Box::new(err))
-    }
-}
-
-impl<T> From<TrySendError<T>> for LogError {
-    fn from(err: TrySendError<T>) -> Self {
-        LogError::Other(Box::new(err.into_send_error()))
-    }
-}
-
-impl From<Canceled> for LogError {
-    fn from(err: Canceled) -> Self {
-        LogError::Other(Box::new(err))
     }
 }
 

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -162,7 +162,6 @@
 //! some_work().with_context(Context::current_with_span(span));
 //! ```
 
-use futures_channel::{mpsc::TrySendError, oneshot::Canceled};
 use std::borrow::Cow;
 use std::time;
 use thiserror::Error;
@@ -215,18 +214,6 @@ where
 {
     fn from(err: T) -> Self {
         TraceError::ExportFailed(Box::new(err))
-    }
-}
-
-impl<T> From<TrySendError<T>> for TraceError {
-    fn from(err: TrySendError<T>) -> Self {
-        TraceError::Other(Box::new(err.into_send_error()))
-    }
-}
-
-impl From<Canceled> for TraceError {
-    fn from(err: Canceled) -> Self {
-        TraceError::Other(Box::new(err))
     }
 }
 


### PR DESCRIPTION
Fixes #1201 

## Changes

Removed `futures-channel` from `opentelemetry` dependencies. It was only used for a few fallible conversions to `LogError` and `TraceError` types, only one of which was being used by `opentelemetry-stackdriver`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
