### PR TITLE
opentelemetry-contrib api enhancements and new_span benchmark

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -25,6 +25,7 @@
     // these are words that are always correct and can be thought of as our
     // workspace dictionary.
     "words": [
+        "hasher",
         "opentelemetry",
         "OTLP",
         "quantile",

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vscode/
 /target/
 */target/
 **/*.rs.bk

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+api = []
 default = []
 base64_format = ["base64", "binary_propagator"]
 binary_propagator = []
@@ -31,17 +32,24 @@ rt-async-std = ["async-std", "opentelemetry_sdk/rt-async-std"]
 async-std = { version = "1.10", optional = true }
 async-trait = { version = "0.1", optional = true }
 base64 = { version = "0.13", optional = true }
+futures-core = { version = "0.3", optional = true }
+futures-util = { version = "0.3", optional = true, default-features = false }
 once_cell = "1.17.1"
 opentelemetry = { version = "0.21", path = "../opentelemetry" }
-opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk" }
-opentelemetry-semantic-conventions = { version = "0.12", path = "../opentelemetry-semantic-conventions", optional = true }
+opentelemetry_sdk = { version = "0.20", optional = true, path = "../opentelemetry-sdk" }
+opentelemetry-semantic-conventions = { version = "0.12", optional = true, path = "../opentelemetry-semantic-conventions" }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.0", features = ["fs", "io-util"], optional = true }
 
-# futures
-futures-core = { version = "0.3", optional = true }
-futures-util = { version = "0.3", optional = true, default-features = false }
-
 [dev-dependencies]
 base64 = "0.13"
+criterion = { version = "0.5", features = ["html_reports"] }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["trace", "testing"] }
+[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
+pprof = { version = "0.12", features = ["flamegraph", "criterion"] }
+
+[[bench]]
+name = "new_span"
+harness = false
+required-features = ["api"]

--- a/opentelemetry-contrib/src/trace/context.rs
+++ b/opentelemetry-contrib/src/trace/context.rs
@@ -1,0 +1,161 @@
+use super::TracerSource;
+use opentelemetry::{
+    trace::{SpanBuilder, TraceContextExt as _, Tracer as _},
+    Context,
+};
+use std::{
+    fmt::{Debug, Formatter},
+    ops::{Deref, DerefMut},
+};
+
+/// Lazily creates a new span only if the current context has an active span,
+/// which will used as the new span's parent.
+///
+/// This is useful for instrumenting library crates whose activities would be
+/// undesirable to see as root spans, by themselves, outside of any application
+/// context.
+///
+/// # Examples
+///
+/// ```
+/// use opentelemetry::trace::{SpanBuilder};
+/// use opentelemetry_contrib::trace::{new_span_if_parent_sampled, TracerSource};
+///
+/// fn my_lib_fn() {
+///     let _guard = new_span_if_parent_sampled(
+///         || SpanBuilder::from_name("my span"),
+///         TracerSource::lazy(&|| opentelemetry::global::tracer(module_path!())),
+///     )
+///     .map(|cx| cx.attach());
+/// }
+/// ```
+pub fn new_span_if_parent_sampled(
+    builder_fn: impl Fn() -> SpanBuilder,
+    tracer: TracerSource<'_>,
+) -> Option<Context> {
+    Context::map_current(|current| {
+        current.span().span_context().is_sampled().then(|| {
+            let builder = builder_fn();
+            let span = tracer.get().build_with_context(builder, current);
+            current.with_span(span)
+        })
+    })
+}
+
+/// Lazily creates a new span only if the current context has a recording span,
+/// which will used as the new span's parent.
+///
+/// This is useful for instrumenting library crates whose activities would be
+/// undesirable to see as root spans, by themselves, outside of any application
+/// context.
+///
+/// # Examples
+///
+/// ```
+/// use opentelemetry::trace::{SpanBuilder};
+/// use opentelemetry_contrib::trace::{new_span_if_recording, TracerSource};
+///
+/// fn my_lib_fn() {
+///     let _guard = new_span_if_recording(
+///         || SpanBuilder::from_name("my span"),
+///         TracerSource::lazy(&|| opentelemetry::global::tracer(module_path!())),
+///     )
+///     .map(|cx| cx.attach());
+/// }
+/// ```
+pub fn new_span_if_recording(
+    builder_fn: impl Fn() -> SpanBuilder,
+    tracer: TracerSource<'_>,
+) -> Option<Context> {
+    Context::map_current(|current| {
+        current.span().is_recording().then(|| {
+            let builder = builder_fn();
+            let span = tracer.get().build_with_context(builder, current);
+            current.with_span(span)
+        })
+    })
+}
+
+/// Carries anything with an optional `opentelemetry::Context`.
+///
+/// A `Contextualized<T>` is a smart pointer which owns and instance of `T` and
+/// dereferences to it automatically.  The instance of `T` and its associated
+/// optional `Context` can be reacquired using the `Into` trait for the associated
+/// tuple type.
+///
+/// This type is mostly useful when sending `T`'s through channels with logical
+/// context propagation.
+///
+/// # Examples
+///
+/// ```
+/// use opentelemetry::trace::{SpanBuilder, TraceContextExt as _};
+/// use opentelemetry_contrib::trace::{new_span_if_parent_sampled, Contextualized, TracerSource};
+
+/// enum Message{Command};
+/// let (tx, rx) = std::sync::mpsc::channel();
+///
+/// let cx = new_span_if_parent_sampled(
+///     || SpanBuilder::from_name("my command"),
+///     TracerSource::lazy(&|| opentelemetry::global::tracer(module_path!())),
+/// );
+/// tx.send(Contextualized::new(Message::Command, cx));
+///
+/// let msg = rx.recv().unwrap();
+/// let (msg, cx) = msg.into_inner();
+/// let _guard = cx.filter(|cx| cx.has_active_span()).map(|cx| {
+///     cx.span().add_event("command received", vec![]);
+///     cx.attach()
+/// });
+/// ```
+pub struct Contextualized<T>(T, Option<Context>);
+
+impl<T> Contextualized<T> {
+    /// Creates a new instance using the specified value and optional context.
+    pub fn new(value: T, cx: Option<Context>) -> Self {
+        Self(value, cx)
+    }
+
+    /// Creates a new instance using the specified value and current context if
+    /// it has an active span.
+    pub fn pass_thru(value: T) -> Self {
+        Self::new(
+            value,
+            Context::map_current(|current| current.has_active_span().then(|| current.clone())),
+        )
+    }
+
+    /// Convert self into its constituent parts, returning a tuple.
+    pub fn into_inner(self) -> (T, Option<Context>) {
+        (self.0, self.1)
+    }
+}
+
+impl<T: Clone> Clone for Contextualized<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone())
+    }
+}
+
+impl<T: Debug> Debug for Contextualized<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Contextualized")
+            .field(&self.0)
+            .field(&self.1)
+            .finish()
+    }
+}
+
+impl<T> Deref for Contextualized<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Contextualized<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/opentelemetry-contrib/src/trace/mod.rs
+++ b/opentelemetry-contrib/src/trace/mod.rs
@@ -1,5 +1,15 @@
 //! # Opentelemetry trace contrib
 //!
 
+#[cfg(feature = "api")]
+mod context;
+#[cfg(feature = "api")]
+pub use context::{new_span_if_parent_sampled, new_span_if_recording, Contextualized};
+
 pub mod exporter;
 pub mod propagator;
+
+#[cfg(feature = "api")]
+mod tracer_source;
+#[cfg(feature = "api")]
+pub use tracer_source::TracerSource;

--- a/opentelemetry-contrib/src/trace/tracer_source.rs
+++ b/opentelemetry-contrib/src/trace/tracer_source.rs
@@ -1,0 +1,58 @@
+//! Abstracts away details for acquiring a `Tracer` by instrumented libraries.
+use once_cell::sync::OnceCell;
+use opentelemetry::global::BoxedTracer;
+use std::fmt::Debug;
+
+/// Holds either a borrowed `BoxedTracer` or a factory that can produce one when
+/// and if needed.
+///
+/// This unifies handling of obtaining a `Tracer` by library code optimizing for
+/// common cases when it will never be needed.
+#[derive(Debug)]
+pub struct TracerSource<'a> {
+    variant: Variant<'a>,
+    tracer: OnceCell<BoxedTracer>,
+}
+
+enum Variant<'a> {
+    Borrowed(&'a BoxedTracer),
+    Lazy(&'a dyn Fn() -> BoxedTracer),
+}
+
+impl<'a> TracerSource<'a> {
+    /// Construct an instance by borrowing the specified `BoxedTracer`.
+    pub fn borrowed(tracer: &'a BoxedTracer) -> Self {
+        Self {
+            variant: Variant::Borrowed(tracer),
+            tracer: OnceCell::new(),
+        }
+    }
+
+    /// Construct an instance which may lazily produce a `BoxedTracer` using
+    /// the specified factory function.
+    pub fn lazy(factory: &'a dyn Fn() -> BoxedTracer) -> Self {
+        Self {
+            variant: Variant::Lazy(factory),
+            tracer: OnceCell::new(),
+        }
+    }
+
+    /// Get the associated `BoxedTracer`, producing it if necessary.
+    pub fn get(&self) -> &BoxedTracer {
+        use Variant::*;
+        match self.variant {
+            Borrowed(tracer) => tracer,
+            Lazy(factory) => self.tracer.get_or_init(factory),
+        }
+    }
+}
+
+impl<'a> Debug for Variant<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Variant::*;
+        match self {
+            Borrowed(arg0) => f.debug_tuple("Borrowed").field(arg0).finish(),
+            Lazy(_arg0) => f.debug_tuple("Lazy").finish(),
+        }
+    }
+}

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -171,7 +171,7 @@ impl opentelemetry::trace::Tracer for Tracer {
                 .unwrap_or_else(|| config.id_generator.new_trace_id());
         };
 
-        // In order to accomodate use cases like `tracing-opentelemetry` we there is the ability
+        // In order to accommodate use cases like `tracing-opentelemetry` we there is the ability
         // to use pre-sampling. Otherwise, the standard method of sampling is followed.
         let sampling_decision = if let Some(sampling_result) = builder.sampling_result.take() {
             self.process_sampling_result(sampling_result, parent_cx)

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -109,7 +109,7 @@ impl Context {
         Context::map_current(|cx| cx.clone())
     }
 
-    /// Applys a function to the current context returning its value.
+    /// Applies a function to the current context returning its value.
     ///
     /// This can be used to build higher performing algebraic expressions for
     /// optionally creating a new context without the overhead of cloning the


### PR DESCRIPTION
## Changes

This change is a proposal for some alternative APIs that I have come up with while instrumenting my own libraries and application.  I'm adding them to `opentelemetry-contrib` along with a benchmark in that crate to demonstrate the performance differences between these alternatives and those recommended by the current opentelemetry specification.

The first proposal is `fn new_span_if_recording`, which lazily creates a new span only if the current context has a span that is recording. I've found this to be the bread-and-butter of instrumenting libraries, who might have highly used APIs but for which it's not desirable to create new root traces on behalf of applications that have the SDK configured to sample all or often, just not on particular code paths.

The next is `struct Contextualized<T>` which fills a big gap (IMO) when using channels (e.g. [Actors with Tokio](https://ryhl.io/blog/actors-with-tokio/)) within an application or library. This allows changing a channel message type seamlessly from `T` to a `Contextualized<T>` to logically propagate a `Context` from sender to receiver of the channel.  The `Examples` section of this struct provides more details.

### Benchmark

I added a benchmark, called `new_span`. It works with two axes of parameterization. The first is the environmental conditions under which the functions are executed:
- `in-cx`: There is an active span being sampled in the current context (though it's not recording)
- `no-cx`: There is no active span in context
- `no-sdk` : An SDK has not been configured at all, so instrumentation should be as close to noop as possible

The second parameter is the nature of the api being demonstrated:
- `alt` : The alternative API, which is typically what I just added to this `opentelemetry-contrib` crate
- `spec` : The recommended way as proposed (I think) by the current opentelemetry specification

There are two functions being benchmarked across the six combinations above:
- `if_parent_sampled` : this aims to compare the costs of the `spec` way to create a new span when parent-based sampling (the default SDK configuration) is used vs. the costs of an `alt` way, which simply checks if the current span context is being sampled before building any span
- `if_recording` : similar to above, but checks if current span is recording before creating a new span for both `alt` and `spec` ways.

To run the benchmark, I use
```bash
taskset -c 2,4 cargo bench -p opentelemetry-contrib --bench new_span --features="api"
```
and to get a profile, I add `-- --profile-time 30` to that command line.

Here's the results for `if_parent_sampled` on a MacBook Pro with an M2 Max CPU:
![violin](https://github.com/open-telemetry/opentelemetry-rust/assets/30703437/e4e2211a-6ace-40cb-9239-a1d083fbbc10)

This shows that with no SDK configured, its about 170ns to create a span, but could be down around 6ns with the alternative API (or some more optimization in our API crate).  That's a difference of only being able to do something 5.9M times/sec if it's wrapped by a span vs. 167M times/sec.

Similarly, by configuring the SDK to do the default of parent-based sampling, but with no active span in context, then the cost to create a new span (that will not be exported) jumps up to 255ns (or rated limited down to 3.9M times/sec).

And the cost to create a new span which will be exported in this case is up over 500ns.

Here's the results for `if_recording` where the callsite checks if the current context has a recording span before attempting to create a new span:
![violin](https://github.com/open-telemetry/opentelemetry-rust/assets/30703437/511a5b52-39f3-4c23-a907-54743b7e9e3b)

Note that `in-cx` is setup as if context was propagated to this machine from a remote one. That is, `Context::current()::with_remote_span_context` is used to establish it, so it's not in a recording state. This makes me question if the proposed API, `new_span_if_recording` is all that useful for libraries and if `new_span_if_parent_sampled` is what most libraries will want instead?  (My thought is to have them both in `-contrib` for now while we further study/discuss/improve.)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
