### PR TITLE
Add .cspell.json configuration file

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,65 @@
+// http://cspell.org/configuration/
+{
+    "version": "0.2",
+    "language": "en,en-US",
+    "useGitignore": true,
+    "minWordLength": 4,
+    "ignorePaths": [
+        "target/**"
+    ],
+    // list of words to be ignored.  unlike `words` below, these won't be
+    // suggested as corrections for misspelled words.
+    "ignoreWords": [
+        "otel",
+        "rustdoc",
+        "rustfilt"
+    ],
+    // these are words that are always considered incorrect.
+    "flagWords": [
+        "recieve",
+        "reciever",
+        "seperate",
+        "hte",
+        "teh"
+    ],
+    // these are words that are always correct and can be thought of as our
+    // workspace dictionary.
+    "words": [
+        "opentelemetry",
+        "OTLP",
+        "quantile",
+        "zipkin"
+    ],
+    "enabledLanguageIds": [
+        "jsonc",
+        "markdown",
+        "plaintext",
+        "rust",
+        "shellscript"
+    ],
+    "languageSettings": [
+        {
+            "languageId": "jsonc",
+            "includeRegExpList": [
+                "CStyleComment"
+            ]
+        },
+        {
+            "languageId": "markdown",
+            "caseSensitive": false
+        },
+        {
+            "languageId": "rust",
+            "includeRegExpList": [
+                "CStyleComment",
+                "strings"
+            ]
+        },
+        {
+            "languageId": "shellscript",
+            "includeRegExpList": [
+                "/#.*/g"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Changes

Adds a configuration file in the root which configures optional spell-checking tools for project-specific spellings of terms used throughout the source code. There is no effect for contributors that do not use any spell-checking tools in their editor, but for those that do this configuration hides all of the false-positive spelling issues which makes it easier to catch spelling mistakes before they are committed.

Open to suggestions about other alternatives. I happen to use [vscode-spell-checker](https://github.com/streetsidesoftware/vscode-spell-checker).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
