### PR TITLE
Audit/minimize dependencies to futures-rs crates

### DIFF
--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { version = "1.0", features = ["fs", "io-util"], optional = true }
 
 # futures
 futures-core = { version = "0.3", optional = true }
-futures-util = { version = "0.3", optional = true }
+futures-util = { version = "0.3", optional = true, default-features = false }
 
 [dev-dependencies]
 base64 = "0.13"

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -43,7 +43,7 @@ futures-core = "0.3"
 async-trait = "0.1"
 base64 = "0.13"
 bytes = "1"
-futures-util = { version = "0.3", features = ["io"] }
+futures-util = { version = "0.3", default-features = false, features = ["io"] }
 isahc = "1.4"
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["trace", "testing"] }
 

--- a/opentelemetry-dynatrace/Cargo.toml
+++ b/opentelemetry-dynatrace/Cargo.toml
@@ -36,11 +36,10 @@ surf-client = ["surf", "opentelemetry-http/surf"]
 isahc-client = ["isahc", "opentelemetry-http/isahc"]
 
 rt-tokio = ["tokio", "opentelemetry/rt-tokio"]
-rt-async-std = ["async-std"]
+rt-async-std = ["async-std", "futures-channel"]
 
 wasm = [
     "base64",
-    "futures-util",
     "getrandom/js",
     "js-sys",
     "wasm-bindgen",
@@ -51,8 +50,7 @@ wasm = [
 [dependencies]
 async-std = { version = "= 1.10.0", features = ["unstable"], optional = true }
 base64 = { version = "0.21", optional = true }
-futures = "0.3"
-futures-util = { version = "0.3", optional = true }
+futures-channel = { version = "0.3", optional = true }
 getrandom = { version = "0.2", optional = true }
 http = "0.2"
 isahc = { version = "1.4", default-features = false, optional = true }
@@ -82,5 +80,6 @@ optional = true
 
 [dev-dependencies]
 opentelemetry_sdk = { version = "0.19.0", features = ["rt-tokio"] }
+futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "sync", "test-util"] }
 hyper = { version = "0.14", default-features = false, features = ["server", "tcp", "http1"] }

--- a/opentelemetry-dynatrace/src/metric.rs
+++ b/opentelemetry-dynatrace/src/metric.rs
@@ -233,7 +233,7 @@ pub struct MetricsExporter {
     sender: Arc<Mutex<tokio::sync::mpsc::Sender<ClientMessage>>>,
 
     #[cfg(all(not(feature = "rt-tokio"), feature = "rt-async-std"))]
-    sender: Arc<Mutex<futures::channel::mpsc::Sender<ClientMessage>>>,
+    sender: Arc<Mutex<futures_channel::mpsc::Sender<ClientMessage>>>,
 
     endpoint: Uri,
 
@@ -292,7 +292,7 @@ impl MetricsExporter {
         }));
 
         #[cfg(all(not(feature = "rt-tokio"), feature = "rt-async-std"))]
-        let (sender, mut receiver) = futures::channel::mpsc::channel::<ClientMessage>(2);
+        let (sender, mut receiver) = futures_channel::mpsc::channel::<ClientMessage>(2);
 
         #[cfg(all(not(feature = "rt-tokio"), feature = "rt-async-std"))]
         async_std::task::spawn(Box::pin(async move {

--- a/opentelemetry-dynatrace/tests/http_test.rs
+++ b/opentelemetry-dynatrace/tests/http_test.rs
@@ -1,6 +1,6 @@
 #[cfg(all(feature = "metrics", feature = "rt-tokio"))]
 mod test {
-    use futures::future::BoxFuture;
+    use futures_util::future::BoxFuture;
     use http::header::{HeaderValue, AUTHORIZATION, USER_AGENT};
     use hyper::{
         body,
@@ -20,18 +20,18 @@ mod test {
         tick_rx: tokio::sync::watch::Receiver<usize>,
     }
     impl runtime::Runtime for TestRuntime {
-        type Interval = futures::stream::Once<BoxFuture<'static, ()>>;
+        type Interval = futures_util::stream::Once<BoxFuture<'static, ()>>;
 
         type Delay = Pin<Box<tokio::time::Sleep>>;
 
         fn interval(&self, _duration: Duration) -> Self::Interval {
             let mut tick_rx = self.tick_rx.clone();
-            futures::stream::once(Box::pin(async move {
+            futures_util::stream::once(Box::pin(async move {
                 let _ = tick_rx.changed().await.is_ok();
             }))
         }
 
-        fn spawn(&self, future: futures::future::BoxFuture<'static, ()>) {
+        fn spawn(&self, future: BoxFuture<'static, ()>) {
             tokio::spawn(future);
         }
 

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -51,7 +51,7 @@ tokio-stream = { version = "0.1", features = ["net"] }
 opentelemetry_sdk = { features = ["trace", "rt-tokio", "testing"], path = "../opentelemetry-sdk" }
 time = { version = "0.3", features = ["macros"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-futures = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", default-features = false }
 
 [features]
 # telemetry pillars and functions

--- a/opentelemetry-otlp/tests/smoke.rs
+++ b/opentelemetry-otlp/tests/smoke.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures_util::StreamExt;
 use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::trace::{Span, SpanKind, Tracer};
 use opentelemetry_otlp::WithExportConfig;

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -42,4 +42,4 @@ tempfile = "3.3.0"
 tokio = "1"
 tonic-build = "0.9.0"
 walkdir = "2.3.2"
-futures = "0.3"
+futures-util = {version = "0.3", default-features = false }

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -21,7 +21,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
+futures-core = "0.3"
+futures-sink = "0.3"
 indexmap = "2.0"
 once_cell = "1.12.0"
 pin-project-lite = { version = "0.2", optional = true }

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -4,7 +4,8 @@ use crate::{
     trace::{Span, SpanContext, Status},
     Context, ContextGuard, KeyValue,
 };
-use futures_util::{sink::Sink, stream::Stream};
+use futures_core::stream::Stream;
+use futures_sink::Sink;
 use once_cell::sync::Lazy;
 use pin_project_lite::pin_project;
 use std::{


### PR DESCRIPTION
## Changes

- prefer `futures-util` with no default features to the other `futures` wrapper
- prefer `futures-core` and `futures-sink` to `futures-util` if that's all that's being used.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
