### PR TITLE
Update minimal versions

### DIFF
--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = { version = "1", optional = true }
 thiserror = "1"
 url = { version = "2.2", optional = true }
 tokio = { version = "1.0", default-features = false, features = ["rt", "time"], optional = true }
-tokio-stream = { version = "0.1", optional = true }
+tokio-stream = { version = "0.1.1", optional = true }
 http = { version = "0.2", optional = true }
 
 [package.metadata.docs.rs]

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -26,7 +26,7 @@ futures-sink = "0.3"
 indexmap = "2.0"
 once_cell = "1.12.0"
 pin-project-lite = { version = "0.2", optional = true }
-thiserror = "1"
+thiserror = "1.0.7"
 urlencoding = "2.1.2"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]


### PR DESCRIPTION
I was playing around with `cargo +nightly update -Z minimal versions` and I noticed that there were some errors in `opentelemetry-sdk`. 

I've found the minimal version that are required to build a simple test project that depends on `opentelemetry-sdk` with feature `rt-tokio`.

The commits themselves contain a link to the relevant release/changelogs.


I'm not sure if this is worthy of mentioning in the changelog here?
