### PR TITLE
opentelemetry_otlp: Report version correctly with batch exporter

### DIFF
--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -206,7 +206,7 @@ fn build_batch_with_exporter<R: RuntimeChannel<BatchMessage>>(
     let provider = provider_builder.build();
     let logger = provider.versioned_logger(
         Cow::Borrowed("opentelemetry-otlp"),
-        Some(Cow::Borrowed("CARGO_PKG_VERSION")),
+        Some(Cow::Borrowed(env!("CARGO_PKG_VERSION"))),
         None,
         None,
     );


### PR DESCRIPTION
## Changes

When using `opentelemetry_otlp` with `build_batch_with_exporter` it reports the version as `"CARGO_PKG_VERSION"` instead of the value of that environment variable.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
