### PR TITLE
Add Sync bound on the LogExporter and SpanExporter traits

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -13,6 +13,7 @@
   is now the API crate. [#1226](https://github.com/open-telemetry/opentelemetry-rust/pull/1226)
 - Add in memory span exporter [#1216](https://github.com/open-telemetry/opentelemetry-rust/pull/1216)
 - Add in memory log exporter [#1231](https://github.com/open-telemetry/opentelemetry-rust/pull/1231)
+- Add `Sync` bound to the `SpanExporter` and `LogExporter` traits [#1240](https://github.com/open-telemetry/opentelemetry-rust/pull/1240)
 
 ### Removed
 

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -11,7 +11,7 @@ use std::{borrow::Cow, fmt::Debug};
 
 /// `LogExporter` defines the interface that log exporters should implement.
 #[async_trait]
-pub trait LogExporter: Send + Debug {
+pub trait LogExporter: Send + Sync + Debug {
     /// Exports a batch of [`LogData`].
     async fn export(&mut self, batch: Vec<LogData>) -> LogResult<()>;
     /// Shuts down the exporter.

--- a/opentelemetry-sdk/src/export/trace.rs
+++ b/opentelemetry-sdk/src/export/trace.rs
@@ -16,7 +16,7 @@ pub type ExportResult = Result<(), TraceError>;
 /// The goal of the interface is to minimize burden of implementation for
 /// protocol-dependent telemetry exporters. The protocol exporter is expected to
 /// be primarily a simple telemetry data encoder and transmitter.
-pub trait SpanExporter: Send + Debug {
+pub trait SpanExporter: Send + Sync + Debug {
     /// Exports a batch of readable spans. Protocol exporters that will
     /// implement this function are typically expected to serialize and transmit
     /// the data to the destination.


### PR DESCRIPTION
## Changes

Previously, the `opentelemetry_otlp::LogExporter` and `opentelemetry_otlp::SpanExporter` used `Box<dyn ...Expoter>` without ~~`Send` and~~ `Sync` bounds, making them impossible to use on a multi-threaded tokio runtime. This adds these ~~`Send` and~~ `Sync` bounds.

Note that this is technically a breaking change because previously the `LogExporter::new` or `SpanExpoter::new` constructors could be used with a custom non-threadsafe implementation of the `LogExporter` and `SpanExporter` traits. I can add a changelog entry if that is considered big-enough of a user-facing change.

Other note about consistency: The `MetricsClient` already has both `Send` and `Sync` bounds (through the traits themselves). 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
