### PR TITLE
Remove context from metrics force_flush

### DIFF
--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -97,7 +97,7 @@ use once_cell::sync::{Lazy, OnceCell};
 use opentelemetry::{
     global,
     metrics::{MetricsError, Result},
-    Context, Key, Value,
+    Key, Value,
 };
 use opentelemetry_sdk::{
     metrics::{
@@ -174,8 +174,8 @@ impl MetricReader for PrometheusExporter {
         self.reader.collect(rm)
     }
 
-    fn force_flush(&self, cx: &Context) -> Result<()> {
-        self.reader.force_flush(cx)
+    fn force_flush(&self) -> Result<()> {
+        self.reader.force_flush()
     }
 
     fn shutdown(&self) -> Result<()> {

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Changed dependency from `opentelemetry_api` to `opentelemetry` as the latter
   is now the API crate. [#1226](https://github.com/open-telemetry/opentelemetry-rust/pull/1226)
 
+### Removed
+
+- Remove context from Metric force_flush [#1245](https://github.com/open-telemetry/opentelemetry-rust/pull/1245)
+
 ## v0.20.0
 
 ### Added

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Weak};
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use opentelemetry::{
     metrics::{Counter, Histogram, MeterProvider as _, Result},
-    Context, Key, KeyValue,
+    Key, KeyValue,
 };
 use opentelemetry_sdk::{
     metrics::{

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -45,8 +45,8 @@ impl MetricReader for SharedReader {
         self.0.collect(rm)
     }
 
-    fn force_flush(&self, cx: &Context) -> Result<()> {
-        self.0.force_flush(cx)
+    fn force_flush(&self) -> Result<()> {
+        self.0.force_flush()
     }
 
     fn shutdown(&self) -> Result<()> {

--- a/opentelemetry-sdk/src/metrics/manual_reader.rs
+++ b/opentelemetry-sdk/src/metrics/manual_reader.rs
@@ -6,7 +6,6 @@ use std::{
 use opentelemetry::{
     global,
     metrics::{MetricsError, Result},
-    Context,
 };
 
 use super::{
@@ -145,7 +144,7 @@ impl MetricReader for ManualReader {
     }
 
     /// ForceFlush is a no-op, it always returns nil.
-    fn force_flush(&self, _cx: &Context) -> Result<()> {
+    fn force_flush(&self) -> Result<()> {
         Ok(())
     }
 

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -9,7 +9,7 @@ use std::{
 
 use opentelemetry::{
     metrics::{noop::NoopMeterCore, InstrumentProvider, Meter as ApiMeter, MetricsError, Result},
-    Context, KeyValue,
+    KeyValue,
 };
 
 use crate::{instrumentation::Scope, Resource};
@@ -68,12 +68,11 @@ impl MeterProvider {
     ///
     /// fn main() {
     ///     let provider = init_metrics();
-    ///     let cx = Context::new();
     ///
     ///     // create instruments + record measurements
     ///
     ///     // force all instruments to flush
-    ///     provider.force_flush(&cx).unwrap();
+    ///     provider.force_flush().unwrap();
     ///
     ///     // record more measurements..
     ///
@@ -83,8 +82,8 @@ impl MeterProvider {
     ///     global::shutdown_meter_provider();
     /// }
     /// ```
-    pub fn force_flush(&self, cx: &Context) -> Result<()> {
-        self.pipes.force_flush(cx)
+    pub fn force_flush(&self) -> Result<()> {
+        self.pipes.force_flush()
     }
 
     /// Shuts down the meter provider flushing all pending telemetry and releasing

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -14,7 +14,6 @@ use futures_util::{
 use opentelemetry::{
     global,
     metrics::{MetricsError, Result},
-    Context,
 };
 
 use crate::runtime::Runtime;
@@ -345,7 +344,7 @@ impl MetricReader for PeriodicReader {
         }
     }
 
-    fn force_flush(&self, _cx: &Context) -> Result<()> {
+    fn force_flush(&self) -> Result<()> {
         let mut inner = self.inner.lock()?;
         let (sender, receiver) = oneshot::channel();
         inner

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -8,7 +8,6 @@ use std::{
 use opentelemetry::{
     global,
     metrics::{CallbackRegistration, MetricsError, Result, Unit},
-    Context,
 };
 
 use crate::{
@@ -103,8 +102,8 @@ impl Pipeline {
     }
 
     /// Send accumulated telemetry
-    fn force_flush(&self, cx: &Context) -> Result<()> {
-        self.reader.force_flush(cx)
+    fn force_flush(&self) -> Result<()> {
+        self.reader.force_flush()
     }
 
     /// Shut down pipeline
@@ -611,10 +610,10 @@ impl Pipelines {
     }
 
     /// Force flush all pipelines
-    pub(crate) fn force_flush(&self, cx: &Context) -> Result<()> {
+    pub(crate) fn force_flush(&self) -> Result<()> {
         let mut errs = vec![];
         for pipeline in &self.0 {
-            if let Err(err) = pipeline.force_flush(cx) {
+            if let Err(err) = pipeline.force_flush() {
                 errs.push(err);
             }
         }

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -1,7 +1,7 @@
 //! Interfaces for reading and producing metrics
 use std::{fmt, sync::Weak};
 
-use opentelemetry::{metrics::Result, Context};
+use opentelemetry::metrics::Result;
 
 use super::{
     aggregation::Aggregation,
@@ -49,7 +49,7 @@ pub trait MetricReader:
     ///
     /// There is no guaranteed that all telemetry be flushed or all resources have
     /// been released on error.
-    fn force_flush(&self, cx: &Context) -> Result<()>;
+    fn force_flush(&self) -> Result<()>;
 
     /// Flushes all metric measurements held in an export pipeline and releases any
     /// held computational resources.

--- a/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
@@ -28,7 +28,7 @@ use std::sync::{Arc, Mutex};
 ///
 /// ```
 ///# use opentelemetry_sdk::{metrics, runtime};
-///# use opentelemetry::{Context, KeyValue};
+///# use opentelemetry::{KeyValue};
 ///# use opentelemetry::metrics::MeterProvider;
 ///# use opentelemetry_sdk::testing::metrics::InMemoryMetricsExporter;
 ///# use opentelemetry_sdk::metrics::PeriodicReader;
@@ -45,11 +45,10 @@ use std::sync::{Arc, Mutex};
 ///
 ///  // Create and record metrics using the MeterProvider
 ///  let meter = meter_provider.meter(std::borrow::Cow::Borrowed("example"));
-///  let cx = Context::new();
 ///  let counter = meter.u64_counter("my_counter").init();
 ///  counter.add(1, &[KeyValue::new("key", "value")]);
 ///
-///  meter_provider.force_flush(&cx).unwrap();
+///  meter_provider.force_flush().unwrap();
 ///
 ///  // Retrieve the finished metrics from the exporter
 ///  let finished_metrics = exporter.get_finished_metrics().unwrap();

--- a/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
+++ b/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
@@ -7,7 +7,7 @@ use crate::metrics::{
     pipeline::Pipeline,
     reader::{AggregationSelector, MetricProducer, MetricReader, TemporalitySelector},
 };
-use opentelemetry::{metrics::Result, Context};
+use opentelemetry::metrics::Result;
 
 #[derive(Debug)]
 pub struct TestMetricReader {}
@@ -21,13 +21,12 @@ impl MetricReader for TestMetricReader {
         Ok(())
     }
 
-    fn force_flush(&self, _cx: &Context) -> Result<()> {
+    fn force_flush(&self) -> Result<()> {
         Ok(())
     }
 
     fn shutdown(&self) -> Result<()> {
-        let cx = Context::new();
-        self.force_flush(&cx)
+        self.force_flush()
     }
 }
 


### PR DESCRIPTION
More like a follow up clean up from : https://github.com/open-telemetry/opentelemetry-rust/pull/1076