### PR TITLE
Refactor LogRecordBuilder with in-place modifications

### DIFF
--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -17,12 +17,12 @@ where
     L: Logger + Send + Sync,
 {
     fn enabled(&self, _metadata: &Metadata) -> bool {
-        //#[cfg(feature = "logs_level_enabled")]
-        //return self.logger.event_enabled(
-        //    map_severity_to_otel_severity(_metadata.level()),
-        //    _metadata.target(),
-        // );
-        // #[cfg(not(feature = "logs_level_enabled"))]
+        #[cfg(feature = "logs_level_enabled")]
+        return self.logger.event_enabled(
+            map_severity_to_otel_severity(_metadata.level()),
+            _metadata.target(),
+        );
+        #[cfg(not(feature = "logs_level_enabled"))]
         true
     }
 

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -17,26 +17,26 @@ where
     L: Logger + Send + Sync,
 {
     fn enabled(&self, _metadata: &Metadata) -> bool {
-        #[cfg(feature = "logs_level_enabled")]
-        return self.logger.event_enabled(
-            map_severity_to_otel_severity(_metadata.level()),
-            _metadata.target(),
-        );
-        #[cfg(not(feature = "logs_level_enabled"))]
+        //#[cfg(feature = "logs_level_enabled")]
+        //return self.logger.event_enabled(
+        //    map_severity_to_otel_severity(_metadata.level()),
+        //    _metadata.target(),
+        // );
+        // #[cfg(not(feature = "logs_level_enabled"))]
         true
     }
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            self.logger.emit(
-                LogRecordBuilder::new()
-                    .with_severity_number(map_severity_to_otel_severity(record.level()))
-                    .with_severity_text(record.level().as_str())
-                    // Not populating ObservedTimestamp, instead relying on OpenTelemetry
-                    // API to populate it with current time.
-                    .with_body(AnyValue::from(record.args().to_string()))
-                    .build(),
-            );
+            let mut log_record_builder = LogRecordBuilder::new();
+            log_record_builder
+                .with_severity_number(map_severity_to_otel_severity(record.level()))
+                .with_severity_text(record.level().as_str())
+                // Not populating ObservedTimestamp, instead relying on OpenTelemetry
+                // API to populate it with current time.
+                .with_body(AnyValue::from(record.args().to_string()));
+            let log_record = log_record_builder.build();
+            self.logger.emit(log_record);
         }
     }
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -100,10 +100,9 @@ where
         _event: &tracing_core::Event<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) -> bool {
-        true
-        //let severity = map_severity_to_otel_severity(_event.metadata().level().as_str());
-        //self.logger
-        //    .event_enabled(severity, _event.metadata().target())
+        let severity = map_severity_to_otel_severity(_event.metadata().level().as_str());
+        self.logger
+            .event_enabled(severity, _event.metadata().target())
     }
 }
 

--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -83,7 +83,10 @@ pub mod tonic {
 
             LogRecord {
                 time_unix_nano: log_record.timestamp.map(to_nanos).unwrap_or_default(),
-                observed_time_unix_nano: to_nanos(log_record.observed_timestamp),
+                observed_time_unix_nano: log_record
+                    .observed_timestamp
+                    .map(to_nanos)
+                    .unwrap_or_default(),
                 severity_number: severity_number.into(),
                 severity_text: log_record.severity_text.map(Into::into).unwrap_or_default(),
                 body: log_record.body.map(Into::into),
@@ -222,7 +225,10 @@ pub mod grpcio {
 
             LogRecord {
                 time_unix_nano: log_record.timestamp.map(to_nanos).unwrap_or_default(),
-                observed_time_unix_nano: to_nanos(log_record.observed_timestamp),
+                observed_time_unix_nano: log_record
+                    .observed_timestamp
+                    .map(to_nanos)
+                    .unwrap_or_default(),
                 severity_number: severity_number.into(),
                 severity_text: log_record.severity_text.map(Into::into).unwrap_or_default(),
                 body: log_record.body.map(Into::into),

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -211,39 +211,24 @@ impl opentelemetry::logs::Logger for Logger {
             Some(provider) => provider,
             None => return,
         };
-
         let trace_context = Context::map_current(|cx| {
             cx.has_active_span()
                 .then(|| TraceContext::from(cx.span().span_context()))
         });
-
         let config = provider.config();
-        let processors = provider.log_processors();
-        let num_processors = processors.len();
-
-        for (i, processor) in processors.iter().enumerate() {
-            let record = if i < num_processors - 1 {
-                record.clone()
-            } else {
-                record
-            };
-
-            let mut record_to_pass = record; // This line is added to move the value
-
+        for processor in provider.log_processors() {
+            let mut record = record.clone();
             if let Some(ref trace_context) = trace_context {
-                record_to_pass.trace_context = Some(trace_context.clone());
+                record.trace_context = Some(trace_context.clone())
             }
-
             let data = LogData {
-                record: record_to_pass,
+                record,
                 resource: config.resource.clone(),
                 instrumentation: self.instrumentation_library().clone(),
             };
-
             processor.emit(data);
         }
     }
-    
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, level: Severity, target: &str) -> bool {

--- a/opentelemetry-stdout/src/logs/transform.rs
+++ b/opentelemetry-stdout/src/logs/transform.rs
@@ -1,9 +1,6 @@
 use std::{borrow::Cow, collections::HashMap, time::SystemTime};
 
-use crate::common::{
-    as_human_readable, as_opt_human_readable, as_opt_unix_nano, as_unix_nano, KeyValue, Resource,
-    Scope, Value,
-};
+use crate::common::{as_opt_human_readable, as_opt_unix_nano, KeyValue, Resource, Scope, Value};
 use opentelemetry_sdk::AttributeSet;
 use serde::Serialize;
 
@@ -76,10 +73,10 @@ struct LogRecord {
     time_unix_nano: Option<SystemTime>,
     #[serde(serialize_with = "as_opt_human_readable")]
     time: Option<SystemTime>,
-    #[serde(serialize_with = "as_unix_nano")]
-    observed_time_unix_nano: SystemTime,
-    #[serde(serialize_with = "as_human_readable")]
-    observed_time: SystemTime,
+    #[serde(serialize_with = "as_opt_unix_nano")]
+    observed_time_unix_nano: Option<SystemTime>,
+    #[serde(serialize_with = "as_opt_human_readable")]
+    observed_time: Option<SystemTime>,
     severity_number: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     severity_text: Option<Cow<'static, str>>,

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -197,10 +197,12 @@ impl UserEventsExporter {
 
                 // populate CS PartA
                 let mut cs_a_count = 0;
-                let event_time: SystemTime = log_data
-                    .record
-                    .timestamp
-                    .unwrap_or(log_data.record.observed_timestamp);
+                let event_time: SystemTime = log_data.record.timestamp.unwrap_or(
+                    log_data
+                        .record
+                        .observed_timestamp
+                        .unwrap_or(SystemTime::now()),
+                );
                 cs_a_count += 1; // for event_time
                 eb.add_struct("PartA", cs_a_count, 0);
                 {

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use std::{borrow::Cow, time::SystemTime};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 /// LogRecord represents all data carried by a log record, and
 /// is provided to `LogExporter`s as input.
@@ -13,7 +13,7 @@ pub struct LogRecord {
     pub timestamp: Option<SystemTime>,
 
     /// Timestamp for when the record was observed by OpenTelemetry
-    pub observed_timestamp: SystemTime,
+    pub observed_timestamp: Option<SystemTime>,
 
     /// Trace context for logs associated with spans
     pub trace_context: Option<TraceContext>,
@@ -28,20 +28,6 @@ pub struct LogRecord {
 
     /// Additional attributes associated with this record
     pub attributes: Option<Vec<(Key, AnyValue)>>,
-}
-
-impl Default for LogRecord {
-    fn default() -> Self {
-        LogRecord {
-            timestamp: None,
-            observed_timestamp: SystemTime::now(),
-            trace_context: None,
-            severity_text: None,
-            severity_number: None,
-            body: None,
-            attributes: None,
-        }
-    }
 }
 
 impl LogRecord {
@@ -262,120 +248,85 @@ impl LogRecordBuilder {
     }
 
     /// Assign timestamp
-    pub fn with_timestamp(self, timestamp: SystemTime) -> Self {
-        Self {
-            record: LogRecord {
-                timestamp: Some(timestamp),
-                ..self.record
-            },
-        }
+    pub fn with_timestamp(&mut self, timestamp: SystemTime) -> &mut Self {
+        self.record.timestamp = Some(timestamp);
+        self
     }
 
     /// Assign observed timestamp
-    pub fn with_observed_timestamp(self, timestamp: SystemTime) -> Self {
-        Self {
-            record: LogRecord {
-                observed_timestamp: timestamp,
-                ..self.record
-            },
-        }
+    pub fn with_observed_timestamp(&mut self, timestamp: SystemTime) -> &mut Self {
+        self.record.observed_timestamp = Some(timestamp);
+        self
     }
 
     /// Assign the record's [`TraceContext`]
-    pub fn with_span_context(self, span_context: &SpanContext) -> Self {
-        Self {
-            record: LogRecord {
-                trace_context: Some(TraceContext {
-                    span_id: span_context.span_id(),
-                    trace_id: span_context.trace_id(),
-                    trace_flags: Some(span_context.trace_flags()),
-                }),
-                ..self.record
-            },
-        }
+    pub fn with_span_context(&mut self, span_context: &SpanContext) -> &mut Self {
+        self.record.trace_context = Some(TraceContext {
+            span_id: span_context.span_id(),
+            trace_id: span_context.trace_id(),
+            trace_flags: Some(span_context.trace_flags()),
+        });
+        self
     }
 
     /// Assign the record's [`TraceContext`] from a `TraceContextExt` trait
-    pub fn with_context<T>(self, context: &T) -> Self
+    pub fn with_context<T>(&mut self, context: &T) -> &mut Self
     where
         T: TraceContextExt,
     {
         if context.has_active_span() {
-            self.with_span_context(context.span().span_context())
-        } else {
-            self
+            self.with_span_context(context.span().span_context());
         }
+        self
     }
 
     /// Assign severity text
-    pub fn with_severity_text<T>(self, severity: T) -> Self
+    pub fn with_severity_text<T>(&mut self, severity: T) -> &mut Self
     where
         T: Into<Cow<'static, str>>,
     {
-        Self {
-            record: LogRecord {
-                severity_text: Some(severity.into()),
-                ..self.record
-            },
-        }
+        self.record.severity_text = Some(severity.into());
+        self
     }
 
     /// Assign severity number
-    pub fn with_severity_number(self, severity: Severity) -> Self {
-        Self {
-            record: LogRecord {
-                severity_number: Some(severity),
-                ..self.record
-            },
-        }
+    pub fn with_severity_number(&mut self, severity: Severity) -> &mut Self {
+        self.record.severity_number = Some(severity);
+        self
     }
 
     /// Assign body
-    pub fn with_body(self, body: AnyValue) -> Self {
-        Self {
-            record: LogRecord {
-                body: Some(body),
-                ..self.record
-            },
-        }
+    pub fn with_body(&mut self, body: AnyValue) -> &mut Self {
+        self.record.body = Some(body);
+        self
     }
 
     /// Assign attributes.
     /// The SDK doesn't carry on any deduplication on these attributes.
-    pub fn with_attributes(self, attributes: Vec<(Key, AnyValue)>) -> Self {
-        Self {
-            record: LogRecord {
-                attributes: Some(attributes),
-                ..self.record
-            },
-        }
+    pub fn with_attributes(&mut self, attributes: Vec<(Key, AnyValue)>) -> &mut Self {
+        self.record.attributes = Some(attributes);
+        self
     }
 
     /// Set a single attribute for this record.
     /// The SDK doesn't carry on any deduplication on these attributes.
-    pub fn with_attribute<K, V>(mut self, key: K, value: V) -> Self
+    pub fn with_attribute<K, V>(&mut self, key: K, value: V) -> &mut Self
     where
         K: Into<Key>,
         V: Into<AnyValue>,
     {
-        if let Some(ref mut vec) = self.record.attributes {
-            vec.push((key.into(), value.into()));
-        } else {
-            let vec = vec![(key.into(), value.into())];
-            self.record.attributes = Some(vec);
-        }
-
+        self.record
+            .attributes
+            .get_or_insert_with(Vec::new)
+            .push((key.into(), value.into()));
         self
     }
 
     /// Build the record, consuming the Builder
-    pub fn build(self) -> LogRecord {
+    pub fn build(mut self) -> LogRecord {
+        if self.record.observed_timestamp.is_none() {
+            self.record.observed_timestamp = Some(SystemTime::now());
+        }
         self.record
-    }
-}
-
-impl Default for LogRecordBuilder {
-    fn default() -> Self {
-        Self::new()
     }
 }


### PR DESCRIPTION
## Changes

Opening this PR for discussion, as I am not fully sure if the proposed approach has any drawbacks.

This PR refactors the `LogRecordBuilder` struct methods to modify the `LogRecord` object in place. All methods that previously consumed `self` and returned a new `Self` instance have been updated to operate in-place by taking a `&mut self` parameter.

So.
```rust
    pub fn with_timestamp(self, timestamp: SystemTime) -> Self {
        Self {
            record: LogRecord {
                timestamp: Some(timestamp),
                ..self.record
            },
        }
    }
```

is changed to 

```rust
    pub fn with_timestamp(&mut self, timestamp: SystemTime) -> &mut Self {
        self.record.timestamp = Some(timestamp);
        self
   }
```
The motivation behind this change 

- is to improve the performance of building LogRecord by avoiding object creation and memory allocation within these methods. The in-place modification provides a more efficient way to update LogRecordBuilder. While the existing approach creates the new LogRecord on the stack, and only does the shallow copy, there are still improved perf numbers for `opentelemetry-appender-log` with the above changes when the properties are substantial.

-  allow using `LogRecordBuilder` for `opentelemetry-appender-tracing` where method chaining is not possible. There won't be perf improvement with this change as direct updating LogRecord is always much faster. However, I didn't see performance degrade either, and this allows us to add abstraction over the internal implementation of the LogRecord structure.

The downside is it is not consistent with [SpanBuilder](https://github.com/open-telemetry/opentelemetry-rust/blob/b6e91a9baf4474571b92693ec87f65835eb45385/opentelemetry/src/trace/tracer.rs#L279) which returns and uses `Self` instant, instead of `&mut Self`. Feel free to comment if this approach doesn't align with idiomatic Rust practices.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
