### PR TITLE
Use edition 2021 resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "examples/tracing-grpc",
     "stress",
 ]
+resolver = "2"
 
 [profile.bench]
 # https://doc.rust-lang.org/cargo/reference/profiles.html#bench


### PR DESCRIPTION
Eliminates the following warning when doing cargo update:
```bash
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

For more information, refer to [Cargo docs](https://doc.rust-lang.org/cargo/reference/features.html#feature-resolver-version-2)

## Changes

- add `workspace.resolver = "2"` to virtual workspace `Cargo.toml` file

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
