### PR TITLE
Propose Shaun Cox as an approver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,7 @@ For GitHub groups see the [code owners](CODEOWNERS) file.
 * [Cijo Thomas](https://github.com/cijothomas)
 * [Harold Dost](https://github.com/hdost)
 * [Lalit Kumar Bhasin](https://github.com/lalitb)
+* [Shaun Cox](https://github.com/shaun-cox)
 
 ### Emeritus
 


### PR DESCRIPTION
Shaun has been contributing significantly to the project over last few months, and I would like to nominate him to be an [Approver](https://github.com/open-telemetry/community/blob/main/community-membership.md#requirements-2).

**All** current maintainers have to approve this, as per Otel Guidelines.