### PR TITLE
make current context optional

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -29,6 +29,7 @@
         "opentelemetry",
         "OTLP",
         "quantile",
+        "Runtimes",
         "zipkin"
     ],
     "enabledLanguageIds": [

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -214,7 +214,8 @@ impl opentelemetry::logs::Logger for Logger {
         let trace_context = Context::map_current(|cx| {
             cx.has_active_span()
                 .then(|| TraceContext::from(cx.span().span_context()))
-        });
+        })
+        .flatten();
         let config = provider.config();
         for processor in provider.log_processors() {
             let mut record = record.clone();

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -368,7 +368,7 @@ mod tests {
         let span = tracer.span_builder("must_not_be_sampled").start(&tracer);
         assert!(!span.span_context().is_sampled());
 
-        let context = Context::map_current(|cx| {
+        let context = Context::with_current_or_default(|cx| {
             cx.with_remote_span_context(SpanContext::new(
                 TraceId::from_u128(1),
                 SpanId::from_u64(1),

--- a/opentelemetry/src/baggage.rs
+++ b/opentelemetry/src/baggage.rs
@@ -308,9 +308,7 @@ pub trait BaggageExt {
     /// ```
     /// use opentelemetry::{baggage::BaggageExt, Context, KeyValue, Value};
     ///
-    /// let cx = Context::map_current(|cx| {
-    ///     cx.with_baggage(vec![KeyValue::new("my-name", "my-value")])
-    /// });
+    /// let cx = Context::new().with_baggage(vec![KeyValue::new("my-name", "my-value")]);
     ///
     /// assert_eq!(
     ///     cx.baggage().get("my-name"),
@@ -347,7 +345,7 @@ pub trait BaggageExt {
     /// ```
     /// use opentelemetry::{baggage::BaggageExt, Context, KeyValue, Value};
     ///
-    /// let cx = Context::map_current(|cx| cx.with_cleared_baggage());
+    /// let cx = Context::current().with_cleared_baggage();
     ///
     /// assert_eq!(cx.baggage().len(), 0);
     /// ```
@@ -378,7 +376,7 @@ impl BaggageExt for Context {
     }
 
     fn current_with_baggage<T: IntoIterator<Item = I>, I: Into<KeyValueMetadata>>(kvs: T) -> Self {
-        Context::map_current(|cx| cx.with_baggage(kvs))
+        Context::current().with_baggage(kvs)
     }
 
     fn with_cleared_baggage(&self) -> Self {

--- a/opentelemetry/src/propagation/text_map_propagator.rs
+++ b/opentelemetry/src/propagation/text_map_propagator.rs
@@ -18,7 +18,7 @@ pub trait TextMapPropagator: Debug {
     /// [`Context`]: crate::Context
     /// [`Injector`]: crate::propagation::Injector
     fn inject(&self, injector: &mut dyn Injector) {
-        Context::map_current(|cx| self.inject_context(cx, injector))
+        Context::map_current(|cx| self.inject_context(cx, injector));
     }
 
     /// Properly encodes the values of the [`Context`] and injects them into the
@@ -35,7 +35,7 @@ pub trait TextMapPropagator: Debug {
     /// [`Context`]: crate::Context
     /// [`Injector`]: crate::propagation::Extractor
     fn extract(&self, extractor: &dyn Extractor) -> Context {
-        Context::map_current(|cx| self.extract_with_context(cx, extractor))
+        Context::with_current_or_default(|cx| self.extract_with_context(cx, extractor))
     }
 
     /// Retrieves encoded data using the provided [`Extractor`]. If no data for this

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -241,7 +241,7 @@ pub trait TraceContextExt {
     /// ```
     /// use opentelemetry::{trace::TraceContextExt, Context};
     ///
-    /// assert!(!Context::map_current(|cx| cx.has_active_span()));
+    /// assert!(!Context::map_current(|cx| cx.has_active_span()).unwrap_or_default());
     /// ```
     fn has_active_span(&self) -> bool;
 
@@ -349,7 +349,7 @@ pub fn get_active_span<F, T>(f: F) -> T
 where
     F: FnOnce(SpanRef<'_>) -> T,
 {
-    Context::map_current(|cx| f(cx.span()))
+    Context::with_current_or_default(|cx| f(cx.span()))
 }
 
 pin_project! {

--- a/opentelemetry/src/trace/tracer.rs
+++ b/opentelemetry/src/trace/tracer.rs
@@ -136,7 +136,7 @@ pub trait Tracer {
     where
         T: Into<Cow<'static, str>>,
     {
-        Context::map_current(|cx| self.start_with_context(name, cx))
+        Context::with_current_or_default(|cx| self.start_with_context(name, cx))
     }
 
     /// Starts a new [`Span`] with a given context.
@@ -169,7 +169,7 @@ pub trait Tracer {
 
     /// Start a [`Span`] from a [`SpanBuilder`].
     fn build(&self, builder: SpanBuilder) -> Self::Span {
-        Context::map_current(|cx| self.build_with_context(builder, cx))
+        Context::with_current_or_default(|cx| self.build_with_context(builder, cx))
     }
 
     /// Start a span from a [`SpanBuilder`] with a parent context.
@@ -382,7 +382,7 @@ impl SpanBuilder {
 
     /// Builds a span with the given tracer from this configuration.
     pub fn start<T: Tracer>(self, tracer: &T) -> T::Span {
-        Context::map_current(|cx| tracer.build_with_context(self, cx))
+        Context::with_current_or_default(|cx| tracer.build_with_context(self, cx))
     }
 
     /// Builds a span with the given tracer from this configuration and parent.


### PR DESCRIPTION
Performance improvement related to accessing the current context.

## Changes

```rust
    static CURRENT_CONTEXT: RefCell<Context> = RefCell::new(Context::default());
```
becomes
```rust
    static CURRENT_CONTEXT: RefCell<Option<Context>> = const { RefCell::new(None) }
```
The current thread-local context is now initialized with a constant `None`, avoiding the need for a run-time initializer and the need for a run-time check to be sure that initializer has run before every access to the current context.

This turn out to be an improvement generally for amd64, but surprisingly a regression on arm64, for reasons I cannot identify yet.  So will probably hold off on this for now.

```text
amd64:

context/has_active_span/in-cx/alt
                        time:   [6.2645 ns 6.2747 ns 6.2870 ns]
                        thrpt:  [159.06 Melem/s 159.37 Melem/s 159.63 Melem/s]
                 change:
                        time:   [-3.2338% -2.9862% -2.7412%] (p = 0.00 < 0.05)
                        thrpt:  [+2.8184% +3.0781% +3.3419%]
                        Performance has improved.
context/is_sampled/in-cx/alt
                        time:   [8.0346 ns 8.0479 ns 8.0620 ns]
                        thrpt:  [124.04 Melem/s 124.26 Melem/s 124.46 Melem/s]
                 change:
                        time:   [+0.5039% +0.8413% +1.1377%] (p = 0.00 < 0.05)
                        thrpt:  [-1.1249% -0.8343% -0.5014%]
                        Change within noise threshold.
context/is_recording/in-cx/alt
                        time:   [8.4486 ns 8.4626 ns 8.4786 ns]
                        thrpt:  [117.94 Melem/s 118.17 Melem/s 118.36 Melem/s]
                 change:
                        time:   [+2.5777% +3.0760% +3.5538%] (p = 0.00 < 0.05)
                        thrpt:  [-3.4318% -2.9842% -2.5130%]
                        Performance has regressed.
context/has_active_span/in-cx/spec
                        time:   [84.993 ns 85.517 ns 86.022 ns]
                        thrpt:  [11.625 Melem/s 11.694 Melem/s 11.766 Melem/s]
                 change:
                        time:   [+2.7741% +5.7107% +8.8178%] (p = 0.00 < 0.05)
                        thrpt:  [-8.1033% -5.4022% -2.6992%]
                        Performance has regressed.
context/is_sampled/in-cx/spec
                        time:   [84.037 ns 85.620 ns 86.746 ns]
                        thrpt:  [11.528 Melem/s 11.680 Melem/s 11.900 Melem/s]
                 change:
                        time:   [-8.8682% -6.9420% -4.8259%] (p = 0.00 < 0.05)
                        thrpt:  [+5.0706% +7.4599% +9.7311%]
                        Performance has improved.
context/is_recording/in-cx/spec
                        time:   [84.530 ns 85.055 ns 85.602 ns]
                        thrpt:  [11.682 Melem/s 11.757 Melem/s 11.830 Melem/s]
                 change:
                        time:   [-7.7509% -6.2732% -4.5596%] (p = 0.00 < 0.05)
                        thrpt:  [+4.7774% +6.6931% +8.4021%]
                        Performance has improved.
context/has_active_span/no-cx/alt
                        time:   [2.0758 ns 2.0786 ns 2.0812 ns]
                        thrpt:  [480.50 Melem/s 481.09 Melem/s 481.74 Melem/s]
                 change:
                        time:   [-42.517% -42.315% -42.078%] (p = 0.00 < 0.05)
                        thrpt:  [+72.646% +73.355% +73.966%]
                        Performance has improved.
context/is_sampled/no-cx/alt
                        time:   [2.0620 ns 2.0662 ns 2.0703 ns]
                        thrpt:  [483.03 Melem/s 483.97 Melem/s 484.97 Melem/s]
                 change:
                        time:   [-57.996% -57.904% -57.808%] (p = 0.00 < 0.05)
                        thrpt:  [+137.01% +137.55% +138.07%]
                        Performance has improved.
context/is_recording/no-cx/alt
                        time:   [2.0084 ns 2.0131 ns 2.0174 ns]
                        thrpt:  [495.69 Melem/s 496.75 Melem/s 497.90 Melem/s]
                 change:
                        time:   [-58.994% -58.874% -58.762%] (p = 0.00 < 0.05)
                        thrpt:  [+142.50% +143.15% +143.87%]
                        Performance has improved.
context/has_active_span/no-cx/spec
                        time:   [4.3785 ns 4.3931 ns 4.4061 ns]
                        thrpt:  [226.96 Melem/s 227.63 Melem/s 228.39 Melem/s]
                 change:
                        time:   [-30.002% -29.839% -29.680%] (p = 0.00 < 0.05)
                        thrpt:  [+42.207% +42.530% +42.860%]
                        Performance has improved.
context/is_sampled/no-cx/spec
                        time:   [6.3858 ns 6.3932 ns 6.4015 ns]
                        thrpt:  [156.21 Melem/s 156.42 Melem/s 156.60 Melem/s]
                 change:
                        time:   [-17.400% -17.217% -17.038%] (p = 0.00 < 0.05)
                        thrpt:  [+20.537% +20.797% +21.065%]
                        Performance has improved.
context/is_recording/no-cx/spec
                        time:   [6.3925 ns 6.4006 ns 6.4095 ns]
                        thrpt:  [156.02 Melem/s 156.23 Melem/s 156.43 Melem/s]
                 change:
                        time:   [-17.186% -16.873% -16.651%] (p = 0.00 < 0.05)
                        thrpt:  [+19.978% +20.297% +20.752%]
                        Performance has improved.
context/has_active_span/no-sdk/alt
                        time:   [2.0526 ns 2.0545 ns 2.0568 ns]
                        thrpt:  [486.20 Melem/s 486.74 Melem/s 487.20 Melem/s]
                 change:
                        time:   [-43.715% -43.606% -43.493%] (p = 0.00 < 0.05)
                        thrpt:  [+76.968% +77.325% +77.669%]
                        Performance has improved.
context/is_sampled/no-sdk/alt
                        time:   [2.0409 ns 2.0429 ns 2.0453 ns]
                        thrpt:  [488.94 Melem/s 489.51 Melem/s 489.99 Melem/s]
                 change:
                        time:   [-58.027% -57.928% -57.832%] (p = 0.00 < 0.05)
                        thrpt:  [+137.15% +137.69% +138.25%]
                        Performance has improved.
context/is_recording/no-sdk/alt
                        time:   [1.9791 ns 1.9813 ns 1.9838 ns]
                        thrpt:  [504.08 Melem/s 504.71 Melem/s 505.27 Melem/s]
                 change:
                        time:   [-58.651% -58.570% -58.488%] (p = 0.00 < 0.05)
                        thrpt:  [+140.89% +141.37% +141.85%]
                        Performance has improved.
context/has_active_span/no-sdk/spec
                        time:   [4.3322 ns 4.3364 ns 4.3409 ns]
                        thrpt:  [230.37 Melem/s 230.60 Melem/s 230.83 Melem/s]
                 change:
                        time:   [-31.582% -30.860% -30.417%] (p = 0.00 < 0.05)
                        thrpt:  [+43.713% +44.634% +46.160%]
                        Performance has improved.
context/is_sampled/no-sdk/spec
                        time:   [6.3813 ns 6.3869 ns 6.3931 ns]
                        thrpt:  [156.42 Melem/s 156.57 Melem/s 156.71 Melem/s]
                 change:
                        time:   [-17.742% -17.608% -17.481%] (p = 0.00 < 0.05)
                        thrpt:  [+21.184% +21.371% +21.568%]
                        Performance has improved.
context/is_recording/no-sdk/spec
                        time:   [6.3825 ns 6.3908 ns 6.3999 ns]
                        thrpt:  [156.25 Melem/s 156.48 Melem/s 156.68 Melem/s]
                 change:
                        time:   [-18.223% -18.096% -17.961%] (p = 0.00 < 0.05)
                        thrpt:  [+21.893% +22.095% +22.283%]
                        Performance has improved.

new_span/if_parent_sampled/in-cx/alt
                        time:   [475.78 ns 478.19 ns 480.94 ns]
                        thrpt:  [2.0793 Melem/s 2.0912 Melem/s 2.1018 Melem/s]
                 change:
                        time:   [-2.6163% -1.4468% -0.5691%] (p = 0.00 < 0.05)
                        thrpt:  [+0.5724% +1.4680% +2.6866%]
                        Change within noise threshold.
new_span/if_recording/in-cx/alt
                        time:   [15.584 ns 15.603 ns 15.625 ns]
                        thrpt:  [63.999 Melem/s 64.092 Melem/s 64.167 Melem/s]
                 change:
                        time:   [+29.307% +29.616% +29.915%] (p = 0.00 < 0.05)
                        thrpt:  [-23.027% -22.849% -22.665%]
                        Performance has regressed.
new_span/if_parent_sampled/in-cx/spec
                        time:   [456.77 ns 457.70 ns 458.82 ns]
                        thrpt:  [2.1795 Melem/s 2.1849 Melem/s 2.1893 Melem/s]
                 change:
                        time:   [-2.3257% -1.9278% -1.5780%] (p = 0.00 < 0.05)
                        thrpt:  [+1.6033% +1.9657% +2.3811%]
                        Performance has improved.
new_span/if_recording/in-cx/spec
                        time:   [90.915 ns 91.325 ns 91.725 ns]
                        thrpt:  [10.902 Melem/s 10.950 Melem/s 10.999 Melem/s]
                 change:
                        time:   [+3.5867% +5.4784% +7.6966%] (p = 0.00 < 0.05)
                        thrpt:  [-7.1466% -5.1938% -3.4625%]
                        Performance has regressed.
new_span/if_parent_sampled/no-cx/alt
                        time:   [6.4172 ns 6.4292 ns 6.4420 ns]
                        thrpt:  [155.23 Melem/s 155.54 Melem/s 155.83 Melem/s]
                 change:
                        time:   [-27.266% -27.102% -26.949%] (p = 0.00 < 0.05)
                        thrpt:  [+36.891% +37.178% +37.487%]
                        Performance has improved.
new_span/if_recording/no-cx/alt
                        time:   [6.3985 ns 6.4068 ns 6.4160 ns]
                        thrpt:  [155.86 Melem/s 156.09 Melem/s 156.29 Melem/s]
                 change:
                        time:   [-28.434% -28.145% -27.888%] (p = 0.00 < 0.05)
                        thrpt:  [+38.673% +39.170% +39.732%]
                        Performance has improved.
new_span/if_parent_sampled/no-cx/spec
                        time:   [183.48 ns 183.77 ns 184.08 ns]
                        thrpt:  [5.4323 Melem/s 5.4416 Melem/s 5.4501 Melem/s]
                 change:
                        time:   [-9.1118% -8.6668% -8.2447%] (p = 0.00 < 0.05)
                        thrpt:  [+8.9855% +9.4892% +10.025%]
                        Performance has improved.
new_span/if_recording/no-cx/spec
                        time:   [7.5257 ns 7.5350 ns 7.5451 ns]
                        thrpt:  [132.54 Melem/s 132.71 Melem/s 132.88 Melem/s]
                 change:
                        time:   [-17.887% -17.199% -16.749%] (p = 0.00 < 0.05)
                        thrpt:  [+20.119% +20.772% +21.783%]
                        Performance has improved.
new_span/if_parent_sampled/no-sdk/alt
                        time:   [6.4109 ns 6.4219 ns 6.4333 ns]
                        thrpt:  [155.44 Melem/s 155.72 Melem/s 155.98 Melem/s]
                 change:
                        time:   [-27.421% -27.163% -26.945%] (p = 0.00 < 0.05)
                        thrpt:  [+36.882% +37.293% +37.781%]
                        Performance has improved.
new_span/if_recording/no-sdk/alt
                        time:   [6.3984 ns 6.4077 ns 6.4176 ns]
                        thrpt:  [155.82 Melem/s 156.06 Melem/s 156.29 Melem/s]
                 change:
                        time:   [-27.401% -27.275% -27.140%] (p = 0.00 < 0.05)
                        thrpt:  [+37.249% +37.505% +37.743%]
                        Performance has improved.
new_span/if_parent_sampled/no-sdk/spec
                        time:   [97.772 ns 97.930 ns 98.089 ns]
                        thrpt:  [10.195 Melem/s 10.211 Melem/s 10.228 Melem/s]
                 change:
                        time:   [-8.9761% -8.6445% -8.3115%] (p = 0.00 < 0.05)
                        thrpt:  [+9.0649% +9.4625% +9.8613%]
                        Performance has improved.
new_span/if_recording/no-sdk/spec
                        time:   [7.8574 ns 7.8814 ns 7.9116 ns]
                        thrpt:  [126.40 Melem/s 126.88 Melem/s 127.27 Melem/s]
                 change:
                        time:   [-12.811% -12.606% -12.401%] (p = 0.00 < 0.05)
                        thrpt:  [+14.156% +14.424% +14.693%]
                        Performance has improved.
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
