### PR TITLE
Performance: access current span through its own field of Context, not the generic map

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -25,6 +25,7 @@
     // these are words that are always correct and can be thought of as our
     // workspace dictionary.
     "words": [
+        "hasher",
         "opentelemetry",
         "OTLP",
         "quantile",

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vscode/
 /target/
 */target/
 **/*.rs.bk

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+api = []
 default = []
 base64_format = ["base64", "binary_propagator"]
 binary_propagator = []
@@ -31,17 +32,24 @@ rt-async-std = ["async-std", "opentelemetry_sdk/rt-async-std"]
 async-std = { version = "1.10", optional = true }
 async-trait = { version = "0.1", optional = true }
 base64 = { version = "0.13", optional = true }
+futures-core = { version = "0.3", optional = true }
+futures-util = { version = "0.3", optional = true, default-features = false }
 once_cell = "1.17.1"
 opentelemetry = { version = "0.21", path = "../opentelemetry" }
-opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk" }
-opentelemetry-semantic-conventions = { version = "0.12", path = "../opentelemetry-semantic-conventions", optional = true }
+opentelemetry_sdk = { version = "0.20", optional = true, path = "../opentelemetry-sdk" }
+opentelemetry-semantic-conventions = { version = "0.12", optional = true, path = "../opentelemetry-semantic-conventions" }
 serde_json = { version = "1", optional = true }
 tokio = { version = "1.0", features = ["fs", "io-util"], optional = true }
 
-# futures
-futures-core = { version = "0.3", optional = true }
-futures-util = { version = "0.3", optional = true, default-features = false }
-
 [dev-dependencies]
 base64 = "0.13"
+criterion = { version = "0.5", features = ["html_reports"] }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["trace", "testing"] }
+[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
+pprof = { version = "0.12", features = ["flamegraph", "criterion"] }
+
+[[bench]]
+name = "new_span"
+harness = false
+required-features = ["api"]

--- a/opentelemetry-contrib/src/trace/context.rs
+++ b/opentelemetry-contrib/src/trace/context.rs
@@ -1,0 +1,161 @@
+use super::TracerSource;
+use opentelemetry::{
+    trace::{SpanBuilder, TraceContextExt as _, Tracer as _},
+    Context,
+};
+use std::{
+    fmt::{Debug, Formatter},
+    ops::{Deref, DerefMut},
+};
+
+/// Lazily creates a new span only if the current context has an active span,
+/// which will used as the new span's parent.
+///
+/// This is useful for instrumenting library crates whose activities would be
+/// undesirable to see as root spans, by themselves, outside of any application
+/// context.
+///
+/// # Examples
+///
+/// ```
+/// use opentelemetry::trace::{SpanBuilder};
+/// use opentelemetry_contrib::trace::{new_span_if_parent_sampled, TracerSource};
+///
+/// fn my_lib_fn() {
+///     let _guard = new_span_if_parent_sampled(
+///         || SpanBuilder::from_name("my span"),
+///         TracerSource::lazy(&|| opentelemetry::global::tracer(module_path!())),
+///     )
+///     .map(|cx| cx.attach());
+/// }
+/// ```
+pub fn new_span_if_parent_sampled(
+    builder_fn: impl Fn() -> SpanBuilder,
+    tracer: TracerSource<'_>,
+) -> Option<Context> {
+    Context::map_current(|current| {
+        current.span().span_context().is_sampled().then(|| {
+            let builder = builder_fn();
+            let span = tracer.get().build_with_context(builder, current);
+            current.with_span(span)
+        })
+    })
+}
+
+/// Lazily creates a new span only if the current context has a recording span,
+/// which will used as the new span's parent.
+///
+/// This is useful for instrumenting library crates whose activities would be
+/// undesirable to see as root spans, by themselves, outside of any application
+/// context.
+///
+/// # Examples
+///
+/// ```
+/// use opentelemetry::trace::{SpanBuilder};
+/// use opentelemetry_contrib::trace::{new_span_if_recording, TracerSource};
+///
+/// fn my_lib_fn() {
+///     let _guard = new_span_if_recording(
+///         || SpanBuilder::from_name("my span"),
+///         TracerSource::lazy(&|| opentelemetry::global::tracer(module_path!())),
+///     )
+///     .map(|cx| cx.attach());
+/// }
+/// ```
+pub fn new_span_if_recording(
+    builder_fn: impl Fn() -> SpanBuilder,
+    tracer: TracerSource<'_>,
+) -> Option<Context> {
+    Context::map_current(|current| {
+        current.span().is_recording().then(|| {
+            let builder = builder_fn();
+            let span = tracer.get().build_with_context(builder, current);
+            current.with_span(span)
+        })
+    })
+}
+
+/// Carries anything with an optional `opentelemetry::Context`.
+///
+/// A `Contextualized<T>` is a smart pointer which owns and instance of `T` and
+/// dereferences to it automatically.  The instance of `T` and its associated
+/// optional `Context` can be reacquired using the `Into` trait for the associated
+/// tuple type.
+///
+/// This type is mostly useful when sending `T`'s through channels with logical
+/// context propagation.
+///
+/// # Examples
+///
+/// ```
+/// use opentelemetry::trace::{SpanBuilder, TraceContextExt as _};
+/// use opentelemetry_contrib::trace::{new_span_if_parent_sampled, Contextualized, TracerSource};
+
+/// enum Message{Command};
+/// let (tx, rx) = std::sync::mpsc::channel();
+///
+/// let cx = new_span_if_parent_sampled(
+///     || SpanBuilder::from_name("my command"),
+///     TracerSource::lazy(&|| opentelemetry::global::tracer(module_path!())),
+/// );
+/// tx.send(Contextualized::new(Message::Command, cx));
+///
+/// let msg = rx.recv().unwrap();
+/// let (msg, cx) = msg.into_inner();
+/// let _guard = cx.filter(|cx| cx.has_active_span()).map(|cx| {
+///     cx.span().add_event("command received", vec![]);
+///     cx.attach()
+/// });
+/// ```
+pub struct Contextualized<T>(T, Option<Context>);
+
+impl<T> Contextualized<T> {
+    /// Creates a new instance using the specified value and optional context.
+    pub fn new(value: T, cx: Option<Context>) -> Self {
+        Self(value, cx)
+    }
+
+    /// Creates a new instance using the specified value and current context if
+    /// it has an active span.
+    pub fn pass_thru(value: T) -> Self {
+        Self::new(
+            value,
+            Context::map_current(|current| current.has_active_span().then(|| current.clone())),
+        )
+    }
+
+    /// Convert self into its constituent parts, returning a tuple.
+    pub fn into_inner(self) -> (T, Option<Context>) {
+        (self.0, self.1)
+    }
+}
+
+impl<T: Clone> Clone for Contextualized<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone())
+    }
+}
+
+impl<T: Debug> Debug for Contextualized<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Contextualized")
+            .field(&self.0)
+            .field(&self.1)
+            .finish()
+    }
+}
+
+impl<T> Deref for Contextualized<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Contextualized<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/opentelemetry-contrib/src/trace/mod.rs
+++ b/opentelemetry-contrib/src/trace/mod.rs
@@ -1,5 +1,15 @@
 //! # Opentelemetry trace contrib
 //!
 
+#[cfg(feature = "api")]
+mod context;
+#[cfg(feature = "api")]
+pub use context::{new_span_if_parent_sampled, new_span_if_recording, Contextualized};
+
 pub mod exporter;
 pub mod propagator;
+
+#[cfg(feature = "api")]
+mod tracer_source;
+#[cfg(feature = "api")]
+pub use tracer_source::TracerSource;

--- a/opentelemetry-contrib/src/trace/tracer_source.rs
+++ b/opentelemetry-contrib/src/trace/tracer_source.rs
@@ -1,0 +1,58 @@
+//! Abstracts away details for acquiring a `Tracer` by instrumented libraries.
+use once_cell::sync::OnceCell;
+use opentelemetry::global::BoxedTracer;
+use std::fmt::Debug;
+
+/// Holds either a borrowed `BoxedTracer` or a factory that can produce one when
+/// and if needed.
+///
+/// This unifies handling of obtaining a `Tracer` by library code optimizing for
+/// common cases when it will never be needed.
+#[derive(Debug)]
+pub struct TracerSource<'a> {
+    variant: Variant<'a>,
+    tracer: OnceCell<BoxedTracer>,
+}
+
+enum Variant<'a> {
+    Borrowed(&'a BoxedTracer),
+    Lazy(&'a dyn Fn() -> BoxedTracer),
+}
+
+impl<'a> TracerSource<'a> {
+    /// Construct an instance by borrowing the specified `BoxedTracer`.
+    pub fn borrowed(tracer: &'a BoxedTracer) -> Self {
+        Self {
+            variant: Variant::Borrowed(tracer),
+            tracer: OnceCell::new(),
+        }
+    }
+
+    /// Construct an instance which may lazily produce a `BoxedTracer` using
+    /// the specified factory function.
+    pub fn lazy(factory: &'a dyn Fn() -> BoxedTracer) -> Self {
+        Self {
+            variant: Variant::Lazy(factory),
+            tracer: OnceCell::new(),
+        }
+    }
+
+    /// Get the associated `BoxedTracer`, producing it if necessary.
+    pub fn get(&self) -> &BoxedTracer {
+        use Variant::*;
+        match self.variant {
+            Borrowed(tracer) => tracer,
+            Lazy(factory) => self.tracer.get_or_init(factory),
+        }
+    }
+}
+
+impl<'a> Debug for Variant<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Variant::*;
+        match self {
+            Borrowed(arg0) => f.debug_tuple("Borrowed").field(arg0).finish(),
+            Lazy(_arg0) => f.debug_tuple("Lazy").finish(),
+        }
+    }
+}

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -171,7 +171,7 @@ impl opentelemetry::trace::Tracer for Tracer {
                 .unwrap_or_else(|| config.id_generator.new_trace_id());
         };
 
-        // In order to accomodate use cases like `tracing-opentelemetry` we there is the ability
+        // In order to accommodate use cases like `tracing-opentelemetry` we there is the ability
         // to use pre-sampling. Otherwise, the standard method of sampling is followed.
         let sampling_decision = if let Some(sampling_result) = builder.sampling_result.take() {
             self.process_sampling_result(sampling_result, parent_cx)

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -74,6 +74,7 @@ thread_local! {
 /// ```
 #[derive(Clone, Default)]
 pub struct Context {
+    pub(super) trace: Option<Arc<super::trace::context::SynchronizedSpan>>,
     entries: HashMap<TypeId, Arc<dyn Any + Sync + Send>, BuildHasherDefault<IdHasher>>,
 }
 
@@ -301,6 +302,25 @@ impl Context {
         ContextGuard {
             previous_cx,
             _marker: PhantomData,
+        }
+    }
+
+    pub(super) fn current_with_trace_context(
+        value: super::trace::context::SynchronizedSpan,
+    ) -> Self {
+        Context {
+            trace: Some(Arc::new(value)),
+            entries: Context::map_current(|cx| cx.entries.clone()),
+        }
+    }
+
+    pub(super) fn with_trace_context(
+        &self,
+        value: super::trace::context::SynchronizedSpan,
+    ) -> Self {
+        Context {
+            trace: Some(Arc::new(value)),
+            entries: self.entries.clone(),
         }
     }
 }

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -109,7 +109,7 @@ impl Context {
         Context::map_current(|cx| cx.clone())
     }
 
-    /// Applys a function to the current context returning its value.
+    /// Applies a function to the current context returning its value.
     ///
     /// This can be used to build higher performing algebraic expressions for
     /// optionally creating a new context without the overhead of cloning the

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -166,7 +166,7 @@ use std::borrow::Cow;
 use std::time;
 use thiserror::Error;
 
-mod context;
+pub(super) mod context;
 pub mod noop;
 mod span;
 mod span_context;


### PR DESCRIPTION
This would go in after #1232, but I need the new benchmark there to show the improvement here.  (Review the 2nd commit for now.)

## Changes

Add the `trace` field below:
```rust
pub struct Context {
    pub(super) trace: Option<Arc<super::trace::context::SynchronizedSpan>>,
    entries: HashMap<TypeId, Arc<dyn Any + Sync + Send>, BuildHasherDefault<IdHasher>>,
}
```
so that current span manipulation doesn't have to traverse the expensive HashMap and then get dispatched with virtual function calls.

Further, this keeps the HashMap empty for the common case of just having a span in context and no other types (like baggage).

I get that the opentelemetry specification is trying to be general with its view that `Context` is extensible and can hold anything, but there comes a real performance penalty for handling everything through that abstraction.

Here are preliminary results:
```
new_span/if_parent_sampled/in-cx/alt
                        time:   [443.41 ns 445.05 ns 447.27 ns]
                        thrpt:  [2.2358 Melem/s 2.2469 Melem/s 2.2553 Melem/s]
                 change:
                        time:   [-9.4406% -9.0621% -8.6385%] (p = 0.00 < 0.05)
                        thrpt:  [+9.4553% +9.9651% +10.425%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
new_span/if_recording/in-cx/alt
                        time:   [9.6986 ns 9.7092 ns 9.7208 ns]
                        thrpt:  [102.87 Melem/s 102.99 Melem/s 103.11 Melem/s]
                 change:
                        time:   [-33.193% -33.097% -33.006%] (p = 0.00 < 0.05)
                        thrpt:  [+49.266% +49.470% +49.685%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
new_span/if_parent_sampled/in-cx/spec
                        time:   [406.51 ns 407.03 ns 407.66 ns]
                        thrpt:  [2.4530 Melem/s 2.4568 Melem/s 2.4600 Melem/s]
                 change:
                        time:   [-12.614% -12.249% -11.821%] (p = 0.00 < 0.05)
                        thrpt:  [+13.406% +13.959% +14.435%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
new_span/if_recording/in-cx/spec
                        time:   [16.089 ns 16.116 ns 16.150 ns]
                        thrpt:  [61.920 Melem/s 62.050 Melem/s 62.154 Melem/s]
                 change:
                        time:   [-58.218% -58.148% -58.081%] (p = 0.00 < 0.05)
                        thrpt:  [+138.55% +138.94% +139.34%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
new_span/if_parent_sampled/no-cx/alt
                        time:   [9.0403 ns 9.0478 ns 9.0557 ns]
                        thrpt:  [110.43 Melem/s 110.52 Melem/s 110.62 Melem/s]
                 change:
                        time:   [-14.455% -14.352% -14.255%] (p = 0.00 < 0.05)
                        thrpt:  [+16.625% +16.758% +16.897%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
new_span/if_recording/no-cx/alt
                        time:   [9.5251 ns 9.5388 ns 9.5518 ns]
                        thrpt:  [104.69 Melem/s 104.83 Melem/s 104.99 Melem/s]
                 change:
                        time:   [-13.539% -13.332% -13.137%] (p = 0.00 < 0.05)
                        thrpt:  [+15.124% +15.383% +15.659%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
new_span/if_parent_sampled/no-cx/spec
                        time:   [182.64 ns 182.83 ns 183.08 ns]
                        thrpt:  [5.4621 Melem/s 5.4694 Melem/s 5.4753 Melem/s]
                 change:
                        time:   [-17.834% -16.546% -15.385%] (p = 0.00 < 0.05)
                        thrpt:  [+18.183% +19.826% +21.706%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe
new_span/if_recording/no-cx/spec
                        time:   [11.692 ns 11.713 ns 11.736 ns]
                        thrpt:  [85.205 Melem/s 85.374 Melem/s 85.527 Melem/s]
                 change:
                        time:   [+13.887% +14.200% +14.533%] (p = 0.00 < 0.05)
                        thrpt:  [-12.689% -12.434% -12.193%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
new_span/if_parent_sampled/no-sdk/alt
                        time:   [8.9813 ns 8.9963 ns 9.0120 ns]
                        thrpt:  [110.96 Melem/s 111.16 Melem/s 111.34 Melem/s]
                 change:
                        time:   [-14.718% -14.566% -14.413%] (p = 0.00 < 0.05)
                        thrpt:  [+16.840% +17.050% +17.258%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) low mild
  5 (5.00%) high mild
new_span/if_recording/no-sdk/alt
                        time:   [9.5512 ns 9.5583 ns 9.5660 ns]
                        thrpt:  [104.54 Melem/s 104.62 Melem/s 104.70 Melem/s]
                 change:
                        time:   [-13.348% -13.168% -13.003%] (p = 0.00 < 0.05)
                        thrpt:  [+14.947% +15.165% +15.404%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  5 (5.00%) high mild
  2 (2.00%) high severe
new_span/if_parent_sampled/no-sdk/spec
                        time:   [83.663 ns 83.759 ns 83.879 ns]
                        thrpt:  [11.922 Melem/s 11.939 Melem/s 11.953 Melem/s]
                 change:
                        time:   [-23.079% -22.948% -22.795%] (p = 0.00 < 0.05)
                        thrpt:  [+29.525% +29.782% +30.003%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
new_span/if_recording/no-sdk/spec
                        time:   [11.606 ns 11.617 ns 11.627 ns]
                        thrpt:  [86.010 Melem/s 86.084 Melem/s 86.163 Melem/s]
                 change:
                        time:   [+12.821% +12.973% +13.103%] (p = 0.00 < 0.05)
                        thrpt:  [-11.585% -11.483% -11.364%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) low mild
  2 (2.00%) high mild

```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
