### PR TITLE
Move metric validation from api to sdk

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Add `Sync` bound to the `SpanExporter` and `LogExporter` traits [#1240](https://github.com/open-telemetry/opentelemetry-rust/pull/1240)
 - Move `MetricsProducer` config to builders to match other config (#1266)
 - Return error earlier if readers are shut down (#1266)
+- Add `/` to valid characters for instrument names (#1269)
+- Increase instrument name maximum length from 63 to 255 (#1269)
 
 ### Removed
 

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -21,6 +21,16 @@ use crate::metrics::{
     pipeline::{Pipelines, Resolver},
 };
 
+// instrument validation error strings
+const INSTRUMENT_NAME_EMPTY: &str = "instrument name must be non-empty";
+const INSTRUMENT_NAME_LENGTH: &str = "instrument name must be less than 256 characters";
+const INSTRUMENT_NAME_INVALID_CHAR: &str =
+    "characters in instrument name must be ASCII and belong to the alphanumeric characters, '_', '.', '-' and '/'";
+const INSTRUMENT_NAME_FIRST_ALPHABETIC: &str =
+    "instrument name must start with an alphabetic character";
+const INSTRUMENT_UNIT_LENGTH: &str = "instrument unit must be less than 64 characters";
+const INSTRUMENT_UNIT_INVALID_CHAR: &str = "characters in instrument unit must be ASCII";
+
 /// Handles the creation and coordination of all metric instruments.
 ///
 /// A meter represents a single instrumentation scope; all metric telemetry
@@ -36,6 +46,7 @@ pub struct Meter {
     u64_resolver: Resolver<u64>,
     i64_resolver: Resolver<i64>,
     f64_resolver: Resolver<f64>,
+    validation_policy: InstValidationPolicy,
 }
 
 impl Meter {
@@ -48,6 +59,15 @@ impl Meter {
             u64_resolver: Resolver::new(Arc::clone(&pipes), Arc::clone(&view_cache)),
             i64_resolver: Resolver::new(Arc::clone(&pipes), Arc::clone(&view_cache)),
             f64_resolver: Resolver::new(pipes, view_cache),
+            validation_policy: InstValidationPolicy::HandleGlobalAndIgnore,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_validation_policy(self, validation_policy: InstValidationPolicy) -> Self {
+        Self {
+            validation_policy,
+            ..self
         }
     }
 }
@@ -60,6 +80,7 @@ impl InstrumentProvider for Meter {
         description: Option<Cow<'static, str>>,
         unit: Option<Unit>,
     ) -> Result<Counter<u64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.u64_resolver);
         p.lookup(
             InstrumentKind::Counter,
@@ -76,6 +97,7 @@ impl InstrumentProvider for Meter {
         description: Option<Cow<'static, str>>,
         unit: Option<Unit>,
     ) -> Result<Counter<f64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.f64_resolver);
         p.lookup(
             InstrumentKind::Counter,
@@ -93,6 +115,7 @@ impl InstrumentProvider for Meter {
         unit: Option<Unit>,
         callbacks: Vec<Callback<u64>>,
     ) -> Result<ObservableCounter<u64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.u64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableCounter,
@@ -129,6 +152,7 @@ impl InstrumentProvider for Meter {
         unit: Option<Unit>,
         callbacks: Vec<Callback<f64>>,
     ) -> Result<ObservableCounter<f64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.f64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableCounter,
@@ -163,6 +187,7 @@ impl InstrumentProvider for Meter {
         description: Option<Cow<'static, str>>,
         unit: Option<Unit>,
     ) -> Result<UpDownCounter<i64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.i64_resolver);
         p.lookup(
             InstrumentKind::UpDownCounter,
@@ -179,6 +204,7 @@ impl InstrumentProvider for Meter {
         description: Option<Cow<'static, str>>,
         unit: Option<Unit>,
     ) -> Result<UpDownCounter<f64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.f64_resolver);
         p.lookup(
             InstrumentKind::UpDownCounter,
@@ -196,6 +222,7 @@ impl InstrumentProvider for Meter {
         unit: Option<Unit>,
         callbacks: Vec<Callback<i64>>,
     ) -> Result<ObservableUpDownCounter<i64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.i64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableUpDownCounter,
@@ -234,6 +261,7 @@ impl InstrumentProvider for Meter {
         unit: Option<Unit>,
         callbacks: Vec<Callback<f64>>,
     ) -> Result<ObservableUpDownCounter<f64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.f64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableUpDownCounter,
@@ -272,6 +300,7 @@ impl InstrumentProvider for Meter {
         unit: Option<Unit>,
         callbacks: Vec<Callback<u64>>,
     ) -> Result<ObservableGauge<u64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.u64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableGauge,
@@ -308,6 +337,7 @@ impl InstrumentProvider for Meter {
         unit: Option<Unit>,
         callbacks: Vec<Callback<i64>>,
     ) -> Result<ObservableGauge<i64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.i64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableGauge,
@@ -344,6 +374,7 @@ impl InstrumentProvider for Meter {
         unit: Option<Unit>,
         callbacks: Vec<Callback<f64>>,
     ) -> Result<ObservableGauge<f64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.f64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableGauge,
@@ -379,6 +410,7 @@ impl InstrumentProvider for Meter {
         description: Option<Cow<'static, str>>,
         unit: Option<Unit>,
     ) -> Result<Histogram<f64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.f64_resolver);
         p.lookup(
             InstrumentKind::Histogram,
@@ -395,6 +427,7 @@ impl InstrumentProvider for Meter {
         description: Option<Cow<'static, str>>,
         unit: Option<Unit>,
     ) -> Result<Histogram<u64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.u64_resolver);
         p.lookup(
             InstrumentKind::Histogram,
@@ -411,6 +444,7 @@ impl InstrumentProvider for Meter {
         description: Option<Cow<'static, str>>,
         unit: Option<Unit>,
     ) -> Result<Histogram<i64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
         let p = InstProvider::new(self, &self.i64_resolver);
 
         p.lookup(
@@ -477,6 +511,75 @@ impl InstrumentProvider for Meter {
 
         self.pipes.register_multi_callback(move || callback(&reg))
     }
+}
+
+/// Validation policy for instrument
+#[derive(Clone, Copy)]
+enum InstValidationPolicy {
+    HandleGlobalAndIgnore,
+    /// Currently only for test
+    #[cfg(test)]
+    Strict,
+}
+
+fn validate_instrument_config(
+    name: &str,
+    unit: Option<&Unit>,
+    policy: InstValidationPolicy,
+) -> Result<()> {
+    match validate_instrument_name(name).and_then(|_| validate_instrument_unit(unit)) {
+        Ok(_) => Ok(()),
+        Err(err) => match policy {
+            InstValidationPolicy::HandleGlobalAndIgnore => {
+                global::handle_error(err);
+                Ok(())
+            }
+            #[cfg(test)]
+            InstValidationPolicy::Strict => Err(err),
+        },
+    }
+}
+
+fn validate_instrument_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(MetricsError::InvalidInstrumentConfiguration(
+            INSTRUMENT_NAME_EMPTY,
+        ));
+    }
+    if name.len() > 255 {
+        return Err(MetricsError::InvalidInstrumentConfiguration(
+            INSTRUMENT_NAME_LENGTH,
+        ));
+    }
+    if name.starts_with(|c: char| !c.is_ascii_alphabetic()) {
+        return Err(MetricsError::InvalidInstrumentConfiguration(
+            INSTRUMENT_NAME_FIRST_ALPHABETIC,
+        ));
+    }
+    if name.contains(|c: char| {
+        !c.is_ascii_alphanumeric() && c != '_' && c != '.' && c != '-' && c != '/'
+    }) {
+        return Err(MetricsError::InvalidInstrumentConfiguration(
+            INSTRUMENT_NAME_INVALID_CHAR,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_instrument_unit(unit: Option<&Unit>) -> Result<()> {
+    if let Some(unit) = unit {
+        if unit.as_str().len() > 63 {
+            return Err(MetricsError::InvalidInstrumentConfiguration(
+                INSTRUMENT_UNIT_LENGTH,
+            ));
+        }
+        if unit.as_str().contains(|c: char| !c.is_ascii()) {
+            return Err(MetricsError::InvalidInstrumentConfiguration(
+                INSTRUMENT_UNIT_INVALID_CHAR,
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Default)]
@@ -613,5 +716,198 @@ where
         };
 
         self.resolve.measures(inst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use opentelemetry::metrics::{InstrumentProvider, MetricsError, Unit};
+
+    use super::{
+        InstValidationPolicy, Meter, INSTRUMENT_NAME_FIRST_ALPHABETIC,
+        INSTRUMENT_NAME_INVALID_CHAR, INSTRUMENT_NAME_LENGTH, INSTRUMENT_UNIT_INVALID_CHAR,
+        INSTRUMENT_UNIT_LENGTH,
+    };
+    use crate::{metrics::pipeline::Pipelines, Resource, Scope};
+
+    #[test]
+    fn test_instrument_config_validation() {
+        // scope and pipelines are not related to test
+        let meter = Meter::new(
+            Scope::default(),
+            Arc::new(Pipelines::new(Resource::default(), Vec::new(), Vec::new())),
+        )
+        .with_validation_policy(InstValidationPolicy::Strict);
+        // (name, expected error)
+        let instrument_name_test_cases = vec![
+            ("validateName", ""),
+            ("_startWithNoneAlphabet", INSTRUMENT_NAME_FIRST_ALPHABETIC),
+            ("utf8char锈", INSTRUMENT_NAME_INVALID_CHAR),
+            ("a".repeat(255).leak(), ""),
+            ("a".repeat(256).leak(), INSTRUMENT_NAME_LENGTH),
+            ("invalid name", INSTRUMENT_NAME_INVALID_CHAR),
+            // hyphens are now valid characters in the specification.
+            // https://github.com/open-telemetry/opentelemetry-specification/pull/3684
+            ("allow/hyphen", ""),
+        ];
+        for (name, expected_error) in instrument_name_test_cases {
+            let assert = |result: Result<_, MetricsError>| {
+                if expected_error.is_empty() {
+                    assert!(result.is_ok());
+                } else {
+                    assert!(matches!(
+                        result.unwrap_err(),
+                        MetricsError::InvalidInstrumentConfiguration(msg) if msg == expected_error
+                    ));
+                }
+            };
+
+            assert(meter.u64_counter(name.into(), None, None).map(|_| ()));
+            assert(meter.f64_counter(name.into(), None, None).map(|_| ()));
+            assert(
+                meter
+                    .u64_observable_counter(name.into(), None, None, Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .f64_observable_counter(name.into(), None, None, Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .i64_up_down_counter(name.into(), None, None)
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .f64_up_down_counter(name.into(), None, None)
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .i64_observable_up_down_counter(name.into(), None, None, Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .f64_observable_up_down_counter(name.into(), None, None, Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .u64_observable_gauge(name.into(), None, None, Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .i64_observable_gauge(name.into(), None, None, Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .f64_observable_gauge(name.into(), None, None, Vec::new())
+                    .map(|_| ()),
+            );
+            assert(meter.f64_histogram(name.into(), None, None).map(|_| ()));
+            assert(meter.u64_histogram(name.into(), None, None).map(|_| ()));
+            assert(meter.i64_histogram(name.into(), None, None).map(|_| ()));
+        }
+
+        // (unit, expected error)
+        let instrument_unit_test_cases = vec![
+            (
+                "0123456789012345678901234567890123456789012345678901234567890123",
+                INSTRUMENT_UNIT_LENGTH,
+            ),
+            ("utf8char锈", INSTRUMENT_UNIT_INVALID_CHAR),
+            ("kb", ""),
+        ];
+
+        for (unit, expected_error) in instrument_unit_test_cases {
+            let assert = |result: Result<_, MetricsError>| {
+                if expected_error.is_empty() {
+                    assert!(result.is_ok());
+                } else {
+                    assert!(matches!(
+                        result.unwrap_err(),
+                        MetricsError::InvalidInstrumentConfiguration(msg) if msg == expected_error
+                    ));
+                }
+            };
+            let unit = Some(Unit::new(unit));
+            assert(
+                meter
+                    .u64_counter("test".into(), None, unit.clone())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .f64_counter("test".into(), None, unit.clone())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .u64_observable_counter("test".into(), None, unit.clone(), Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .f64_observable_counter("test".into(), None, unit.clone(), Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .i64_up_down_counter("test".into(), None, unit.clone())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .f64_up_down_counter("test".into(), None, unit.clone())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .i64_observable_up_down_counter("test".into(), None, unit.clone(), Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .f64_observable_up_down_counter("test".into(), None, unit.clone(), Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .u64_observable_gauge("test".into(), None, unit.clone(), Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .i64_observable_gauge("test".into(), None, unit.clone(), Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .f64_observable_gauge("test".into(), None, unit.clone(), Vec::new())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .f64_histogram("test".into(), None, unit.clone())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .u64_histogram("test".into(), None, unit.clone())
+                    .map(|_| ()),
+            );
+            assert(
+                meter
+                    .i64_histogram("test".into(), None, unit.clone())
+                    .map(|_| ()),
+            );
+        }
     }
 }

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -21,6 +21,12 @@ use crate::metrics::{
     pipeline::{Pipelines, Resolver},
 };
 
+// maximum length of instrument name
+const INSTRUMENT_NAME_MAX_LENGTH: usize = 255;
+// maximum length of instrument unit name
+const INSTRUMENT_UNIT_NAME_MAX_LENGTH: usize = 63;
+const INSTRUMENT_NAME_ALLOWED_NON_ALPHANUMERIC_CHARS: [char; 4] = ['-', '.', '-', '/'];
+
 // instrument validation error strings
 const INSTRUMENT_NAME_EMPTY: &str = "instrument name must be non-empty";
 const INSTRUMENT_NAME_LENGTH: &str = "instrument name must be less than 256 characters";
@@ -546,7 +552,7 @@ fn validate_instrument_name(name: &str) -> Result<()> {
             INSTRUMENT_NAME_EMPTY,
         ));
     }
-    if name.len() > 255 {
+    if name.len() > INSTRUMENT_NAME_MAX_LENGTH {
         return Err(MetricsError::InvalidInstrumentConfiguration(
             INSTRUMENT_NAME_LENGTH,
         ));
@@ -557,7 +563,7 @@ fn validate_instrument_name(name: &str) -> Result<()> {
         ));
     }
     if name.contains(|c: char| {
-        !c.is_ascii_alphanumeric() && c != '_' && c != '.' && c != '-' && c != '/'
+        !c.is_ascii_alphanumeric() && !INSTRUMENT_NAME_ALLOWED_NON_ALPHANUMERIC_CHARS.contains(&c)
     }) {
         return Err(MetricsError::InvalidInstrumentConfiguration(
             INSTRUMENT_NAME_INVALID_CHAR,
@@ -568,7 +574,7 @@ fn validate_instrument_name(name: &str) -> Result<()> {
 
 fn validate_instrument_unit(unit: Option<&Unit>) -> Result<()> {
     if let Some(unit) = unit {
-        if unit.as_str().len() > 63 {
+        if unit.as_str().len() > INSTRUMENT_UNIT_NAME_MAX_LENGTH {
             return Err(MetricsError::InvalidInstrumentConfiguration(
                 INSTRUMENT_UNIT_LENGTH,
             ));


### PR DESCRIPTION
## Changes
https://github.com/open-telemetry/opentelemetry-rust/issues/1264

* move validation for metrics instrument from api to sdk
* include hyphen in instrument names as valid values
* increase instrument name maximum length from 63 to 255 characters
## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
