### PR TITLE
Performance: By using const over static, improve noop span creation performance another 10%

### DIFF
--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 - `opentelemetry` crate now only carries the API types #1186. Use the `opentelemetry_sdk` crate for the SDK types. 
+- `trace::noop::NoopSpan` no longer implements `Default` and instead exposes
+  a `const DEFAULT` value. [#1270](https://github.com/open-telemetry/opentelemetry-rust/pull/1270)
 
 ## [v0.20.0](https://github.com/open-telemetry/opentelemetry-rust/compare/v0.19.0...v0.20.0)
 This release should been seen as 1.0-rc3 following 1.0-rc2 in v0.19.0. Refer to CHANGELOG.md in individual creates for details on changes made in different creates.

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use futures_core::stream::Stream;
 use futures_sink::Sink;
-use once_cell::sync::Lazy;
 use pin_project_lite::pin_project;
 use std::{
     borrow::Cow,
@@ -16,10 +15,10 @@ use std::{
     task::{Context as TaskContext, Poll},
 };
 
-static NOOP_SPAN: Lazy<SynchronizedSpan> = Lazy::new(|| SynchronizedSpan {
-    span_context: SpanContext::empty_context(),
+const NOOP_SPAN: SynchronizedSpan = SynchronizedSpan {
+    span_context: SpanContext::NONE,
     inner: None,
-});
+};
 
 /// A reference to the currently active span in this context.
 #[derive(Debug)]

--- a/opentelemetry/src/trace/span_context.rs
+++ b/opentelemetry/src/trace/span_context.rs
@@ -20,6 +20,14 @@ use thiserror::Error;
 pub struct TraceFlags(u8);
 
 impl TraceFlags {
+    /// Trace flags with the `sampled` flag set to `0`.
+    ///
+    /// Spans that are not sampled will be ignored by most tracing tools.
+    /// See the `sampled` section of the [W3C TraceContext specification] for details.
+    ///
+    /// [W3C TraceContext specification]: https://www.w3.org/TR/trace-context/#sampled-flag
+    pub const NOT_SAMPLED: TraceFlags = TraceFlags(0x00);
+
     /// Trace flags with the `sampled` flag set to `1`.
     ///
     /// Spans that are not sampled will be ignored by most tracing tools.
@@ -216,6 +224,9 @@ impl fmt::LowerHex for SpanId {
 pub struct TraceState(Option<VecDeque<(String, String)>>);
 
 impl TraceState {
+    /// The default `TraceState`, as a constant
+    pub const NONE: TraceState = TraceState(None);
+
     /// Validates that the given `TraceState` list-member key is valid per the [W3 Spec].
     ///
     /// [W3 Spec]: https://www.w3.org/TR/trace-context/#key
@@ -457,15 +468,18 @@ pub struct SpanContext {
 }
 
 impl SpanContext {
+    /// An invalid span context
+    pub const NONE: SpanContext = SpanContext {
+        trace_id: TraceId::INVALID,
+        span_id: SpanId::INVALID,
+        trace_flags: TraceFlags::NOT_SAMPLED,
+        is_remote: false,
+        trace_state: TraceState::NONE,
+    };
+
     /// Create an invalid empty span context
     pub fn empty_context() -> Self {
-        SpanContext::new(
-            TraceId::INVALID,
-            SpanId::INVALID,
-            TraceFlags::default(),
-            false,
-            TraceState::default(),
-        )
+        SpanContext::NONE
     }
 
     /// Construct a new `SpanContext`


### PR DESCRIPTION
Improves performance for span creation when the SDK is not configured another 10%.

(Depends on https://github.com/open-telemetry/opentelemetry-rust/pull/1268 to go first.)

```text
new_span/if_parent_sampled/no-sdk/spec
                        time:   [83.124 ns 83.224 ns 83.312 ns]
                        thrpt:  [12.003 Melem/s 12.016 Melem/s 12.030 Melem/s]
                 change:
                        time:   [-9.3988% -9.2273% -9.0668%] (p = 0.00 < 0.05)
                        thrpt:  [+9.9709% +10.165% +10.374%]
                        Performance has improved.
```

## Changes

- remove branch in `build_with_context` for the noop tracer. the current context's `span()` method already returns &NOOP_SPAN in the case when no active span is present, which already has the right span context value to use.
- changed NOOP_SPAN from a lazy `static` to a `const`
- changed other constituents of span context to use `const` default values too.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
