### PR TITLE
feat: force user to add exporter builder pipeline.

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 - Changed dependency from `opentelemetry_api` to `opentelemetry` as the latter
   is now the API crate. [#1226](https://github.com/open-telemetry/opentelemetry-rust/pull/1226)
+- Make `NoExporterBuilder` a compiling time error [#1271](https://github.com/open-telemetry/opentelemetry-rust/pull/1271)
 
 ## v0.13.0
 

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -213,7 +213,6 @@ pub use crate::span::{
     OtlpTracePipeline, SpanExporter, SpanExporterBuilder, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
 };
-use std::marker::PhantomData;
 
 #[cfg(feature = "metrics")]
 pub use crate::metric::{

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -409,5 +409,4 @@ pub enum Protocol {
 #[derive(Debug, Default)]
 #[doc(hidden)]
 /// Placeholder type when no exporter pipeline has been configured in telemetry pipeline.
-/// Users shouldn't be able to use this type, hence the private PhantomData.
-pub struct NoExporterConfig(PhantomData<()>);
+pub struct NoExporterConfig(());

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -213,6 +213,7 @@ pub use crate::span::{
     OtlpTracePipeline, SpanExporter, SpanExporterBuilder, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
 };
+use std::marker::PhantomData;
 
 #[cfg(feature = "metrics")]
 pub use crate::metric::{
@@ -366,10 +367,6 @@ pub enum Error {
     #[error("the lock of the {0} has been poisoned")]
     PoisonedLock(&'static str),
 
-    /// The pipeline will need a exporter to complete setup. Throw this error if none is provided.
-    #[error("no exporter builder is provided, please provide one using with_exporter() method")]
-    NoExporterBuilder,
-
     /// Unsupported compression algorithm.
     #[error("unsupported compression algorithm '{0}'")]
     UnsupportedCompressionAlgorithm(String),
@@ -408,3 +405,9 @@ pub enum Protocol {
     /// HTTP protocol with binary protobuf
     HttpBinary,
 }
+
+#[derive(Debug, Default)]
+#[doc(hidden)]
+/// Placeholder type when no exporter pipeline has been configured in telemetry pipeline.
+/// Users shouldn't be able to use this type, hence the private PhantomData.
+pub struct NoExporterConfig(PhantomData<()>);

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -13,7 +13,6 @@ use crate::exporter::http::HttpExporterBuilder;
 
 use crate::{NoExporterConfig, OtlpPipeline};
 use async_trait::async_trait;
-use std::marker::PhantomData;
 use std::{borrow::Cow, fmt::Debug};
 
 use opentelemetry::{

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -36,7 +36,7 @@ impl OtlpPipeline {
     pub fn logging(self) -> OtlpLogPipeline<NoExporterConfig> {
         OtlpLogPipeline {
             log_config: None,
-            exporter_builder: NoExporterConfig(PhantomData),
+            exporter_builder: NoExporterConfig(()),
         }
     }
 }

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -116,12 +116,12 @@ impl opentelemetry_sdk::export::logs::LogExporter for LogExporter {
 
 /// Recommended configuration for an OTLP exporter pipeline.
 #[derive(Debug)]
-pub struct OtlpLogPipeline<T> {
-    exporter_builder: T,
+pub struct OtlpLogPipeline<EB> {
+    exporter_builder: EB,
     log_config: Option<opentelemetry_sdk::logs::Config>,
 }
 
-impl<T> OtlpLogPipeline<T> {
+impl<EB> OtlpLogPipeline<EB> {
     /// Set the log provider configuration.
     pub fn with_log_config(mut self, log_config: opentelemetry_sdk::logs::Config) -> Self {
         self.log_config = Some(log_config);

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -24,7 +24,6 @@ use opentelemetry_sdk::{
     Resource,
 };
 use std::fmt::{Debug, Formatter};
-use std::marker::PhantomData;
 use std::time;
 
 #[cfg(feature = "grpc-sys")]

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -51,7 +51,7 @@ impl OtlpPipeline {
             rt,
             aggregator_selector: None,
             temporality_selector: None,
-            exporter_pipeline: NoExporterConfig(PhantomData),
+            exporter_pipeline: NoExporterConfig(()),
             resource: None,
             period: None,
             timeout: None,

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -57,13 +57,13 @@ impl OtlpPipeline {
 /// let tracing_pipeline = opentelemetry_otlp::new_pipeline().tracing();
 /// ```
 #[derive(Debug)]
-pub struct OtlpTracePipeline<T> {
-    exporter_builder: T,
+pub struct OtlpTracePipeline<EB> {
+    exporter_builder: EB,
     trace_config: Option<sdk::trace::Config>,
     batch_config: Option<sdk::trace::BatchConfig>,
 }
 
-impl<T> OtlpTracePipeline<T> {
+impl<EB> OtlpTracePipeline<EB> {
     /// Set the trace provider configuration.
     pub fn with_trace_config(mut self, trace_config: sdk::trace::Config) -> Self {
         self.trace_config = Some(trace_config);

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -42,7 +42,7 @@ impl OtlpPipeline {
     /// Create a OTLP tracing pipeline.
     pub fn tracing(self) -> OtlpTracePipeline<NoExporterConfig> {
         OtlpTracePipeline {
-            exporter_builder: NoExporterConfig(PhantomData),
+            exporter_builder: NoExporterConfig(()),
             trace_config: None,
             batch_config: None,
         }

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -3,7 +3,6 @@
 //! Defines a [SpanExporter] to send trace data via the OpenTelemetry Protocol (OTLP)
 
 use std::fmt::Debug;
-use std::marker::PhantomData;
 
 use futures_core::future::BoxFuture;
 use opentelemetry::{

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -60,7 +60,7 @@ impl Meter {
         let view_cache = Default::default();
 
         Meter {
-            scope: scope.clone(),
+            scope,
             pipes: Arc::clone(&pipes),
             u64_resolver: Resolver::new(Arc::clone(&pipes), Arc::clone(&view_cache)),
             i64_resolver: Resolver::new(Arc::clone(&pipes), Arc::clone(&view_cache)),


### PR DESCRIPTION
Currently, when users don't configure a builder pipeline. We will throw a runtime error. This could be frustrating as user may not realize they forgot to config an exporter until runtime.

Use will not be able to call `build` or `install_*` functions until they configure an exporter with the `with_exporter` function. Existing use case should remain unimpacted 

## Changes
- This change forces the user to call `with_exporter` before building exporters or installing the pipeline and eliminates the `NoExporterBuilder` error. The downside is users cannot call `with_exporter` multiple times to override the exporter pipeline. However, I think this use case is limited and not worth supporting. 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
