### PR TITLE
Include diagnosing error messages for userevents metrics exporter

### DIFF
--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - Include error diagnosing messages for registering tracepoint
-    [#1224](https://github.com/open-telemetry/opentelemetry-rust/pull/1224).
+    [#1273](https://github.com/open-telemetry/opentelemetry-rust/pull/1273).
 - Add version, protocol to schema
     [#1224](https://github.com/open-telemetry/opentelemetry-rust/pull/1224).
 

--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Include error diagnosing messages for registering tracepoint
+    [#1224](https://github.com/open-telemetry/opentelemetry-rust/pull/1224).
 - Add version, protocol to schema
     [#1224](https://github.com/open-telemetry/opentelemetry-rust/pull/1224).
 

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -24,10 +24,7 @@ impl MetricsExporter {
         // This is unsafe because if the code is used in a shared object,
         // the event MUST be unregistered before the shared object unloads.
         unsafe {
-            let result = tracepoint::register(trace_point.as_ref());
-            if result == -1 {
-                eprintln!("Tracepoint failed to register.");
-            }
+            let _result = tracepoint::register(trace_point.as_ref());
         }
         MetricsExporter { trace_point }
     }

--- a/opentelemetry-user-events-metrics/src/exporter/mod.rs
+++ b/opentelemetry-user-events-metrics/src/exporter/mod.rs
@@ -24,7 +24,10 @@ impl MetricsExporter {
         // This is unsafe because if the code is used in a shared object,
         // the event MUST be unregistered before the shared object unloads.
         unsafe {
-            let _result = tracepoint::register(trace_point.as_ref());
+            let result = tracepoint::register(trace_point.as_ref());
+            if result == -1 {
+                eprintln!("Tracepoint failed to register.");
+            }
         }
         MetricsExporter { trace_point }
     }

--- a/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
+++ b/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
@@ -85,7 +85,7 @@ pub unsafe fn register(trace_point: Pin<&ehi::TracepointState>) -> i32 {
     // If tracepoint doesn't exist, it will create one automatically
     let result = panic::catch_unwind(|| {
         // CStr::from_bytes_with_nul_unchecked is ok because METRICS_EVENT_DEF ends with "\0".
-        trace_point.register(ffi::CStr::from_bytes_with_nul_unchecked(METRICS_EVENT_DEF));
+        trace_point.register(ffi::CStr::from_bytes_with_nul_unchecked(METRICS_EVENT_DEF))
     });
 
     match result {

--- a/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
+++ b/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
@@ -84,8 +84,7 @@ pub unsafe fn register(trace_point: Pin<&ehi::TracepointState>) -> i32 {
     // If tracepoint doesn't exist, it will create one automatically
     let result = panic::catch_unwind(|| {
         // CStr::from_bytes_with_nul_unchecked is ok because METRICS_EVENT_DEF ends with "\0".
-        trace_point
-            .register(ffi::CStr::from_bytes_with_nul_unchecked(METRICS_EVENT_DEF))
+        trace_point.register(ffi::CStr::from_bytes_with_nul_unchecked(METRICS_EVENT_DEF))
     });
 
     match result {

--- a/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
+++ b/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
@@ -91,6 +91,8 @@ pub unsafe fn register(trace_point: Pin<&ehi::TracepointState>) -> i32 {
     match result {
         Ok(value) => {
             if value == 0 {
+                // Temporary print as a measure for quick testing
+                // will be replaced with proper logging mechanism
                 println!("Tracepoint registered successfully.")
             } else if value == 95 {
                 global::handle_error(MetricsError::Other(

--- a/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
+++ b/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
@@ -104,7 +104,7 @@ pub unsafe fn register(trace_point: Pin<&ehi::TracepointState>) -> i32 {
             value
         }
         // We don't want to ever panic so we catch the error and return a unique code for retry
-        Err(err)=> {
+        Err(err) => {
             global::handle_error(MetricsError::Other(format!(
                 "Tracepoint failed to register: {:?}.",
                 err,

--- a/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
+++ b/opentelemetry-user-events-metrics/src/tracepoint/mod.rs
@@ -98,7 +98,7 @@ pub unsafe fn register(trace_point: Pin<&ehi::TracepointState>) -> i32 {
                 ));
             } else if value == 13 {
                 global::handle_error(MetricsError::Other(
-                    "Insuufficient permissions. You need read/write/execute permissions to user_events tracing directory.".into(),
+                    "Insufficient permissions. You need read/write/execute permissions to user_events tracing directory.".into(),
                 ));
             }
             value


### PR DESCRIPTION
Primarily for when tracepoint fails to register