### PR TITLE
Use FnOnce instead of Fn in contrib APIs

### DIFF
--- a/opentelemetry-contrib/src/trace/context.rs
+++ b/opentelemetry-contrib/src/trace/context.rs
@@ -30,7 +30,7 @@ use std::{
 /// }
 /// ```
 pub fn new_span_if_parent_sampled(
-    builder_fn: impl Fn() -> SpanBuilder,
+    builder_fn: impl FnOnce() -> SpanBuilder,
     tracer: TracerSource<'_>,
 ) -> Option<Context> {
     Context::map_current(|current| {
@@ -64,7 +64,7 @@ pub fn new_span_if_parent_sampled(
 /// }
 /// ```
 pub fn new_span_if_recording(
-    builder_fn: impl Fn() -> SpanBuilder,
+    builder_fn: impl FnOnce() -> SpanBuilder,
     tracer: TracerSource<'_>,
 ) -> Option<Context> {
     Context::map_current(|current| {


### PR DESCRIPTION
## Changes

The callback is only called once, so use `FnOnce` instead of `Fn` so that lambdas which capture moved values can be used.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
