### PR TITLE
Fix Resource dedup logic

### DIFF
--- a/opentelemetry-sdk/src/resource/mod.rs
+++ b/opentelemetry-sdk/src/resource/mod.rs
@@ -385,9 +385,6 @@ mod tests {
 
     #[test]
     fn detect_resource_merge() {
-        env::set_var("OTEL_RESOURCE_ATTRIBUTES", "key=value, k = v , a= x, a=z");
-        env::set_var("irrelevant".to_uppercase(), "20200810");
-
         let resource1 = Resource::new(vec![
             KeyValue::new("a", ""),
             KeyValue::new("b", "2"),

--- a/opentelemetry-sdk/src/resource/mod.rs
+++ b/opentelemetry-sdk/src/resource/mod.rs
@@ -66,7 +66,7 @@ impl Resource {
         }
     }
 
-    /// Insert and entry if it does not exist or is an empty string
+    /// Insert an entry if it does not exist or is an empty string
     fn insert(&mut self, key: Key, value: Value) {
         match self.attrs.entry(key) {
             Entry::Occupied(mut e) if e.get().as_str().is_empty() => {

--- a/opentelemetry-sdk/src/resource/mod.rs
+++ b/opentelemetry-sdk/src/resource/mod.rs
@@ -69,7 +69,7 @@ impl Resource {
     /// Insert and entry if it does not exist or is an empty string
     fn insert(&mut self, key: Key, value: Value) {
         match self.attrs.entry(key) {
-            Entry::Occupied(mut e) if e.get().to_string().is_empty() => {
+            Entry::Occupied(mut e) if e.get().as_str().is_empty() => {
                 e.insert(value);
             }
             Entry::Vacant(e) => {


### PR DESCRIPTION
## Changes

Previously Resource would have last k,v wins when supplied a list of k,v even if it was empty.

This change brings the logic in line with the documentation on Resource::new and also applies the same to `from_detectors`.

## Design
Suspect that the implementation was just an oversight as the existing doc comment seems to describe the desired behaviour.

Users will be able to specify a list of detectors in priority order and expect them to have first non empty value wins.



## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
