### PR TITLE
Use display for standard trace and span id formats

### DIFF
--- a/opentelemetry-contrib/src/trace/propagator/trace_context_response.rs
+++ b/opentelemetry-contrib/src/trace/propagator/trace_context_response.rs
@@ -103,7 +103,7 @@ impl TextMapPropagator for TraceContextResponsePropagator {
         let span_context = span.span_context();
         if span_context.is_valid() {
             let header_value = format!(
-                "{:02x}-{:032x}-{:016x}-{:02x}",
+                "{:02x}-{}-{}-{:02x}",
                 SUPPORTED_VERSION,
                 span_context.trace_id(),
                 span_context.span_id(),

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -559,7 +559,7 @@ mod propagator {
                     0x00
                 };
                 let header_value = format!(
-                    "{:032x}:{:016x}:{:01}:{:01x}",
+                    "{}:{}:{:01}:{:01x}",
                     span_context.trace_id(),
                     span_context.span_id(),
                     DEPRECATED_PARENT_SPAN,

--- a/opentelemetry-sdk/src/propagation/composite.rs
+++ b/opentelemetry-sdk/src/propagation/composite.rs
@@ -143,7 +143,7 @@ mod tests {
             injector.set(
                 "testheader",
                 format!(
-                    "{}-{}-{:02x}",
+                    "{:x}-{:x}-{:02x}",
                     span_context.trace_id(),
                     span_context.span_id(),
                     span_context.trace_flags()

--- a/opentelemetry-sdk/src/propagation/composite.rs
+++ b/opentelemetry-sdk/src/propagation/composite.rs
@@ -143,7 +143,7 @@ mod tests {
             injector.set(
                 "testheader",
                 format!(
-                    "{:x}-{:x}-{:02x}",
+                    "{}-{}-{:02x}",
                     span_context.trace_id(),
                     span_context.span_id(),
                     span_context.trace_flags()

--- a/opentelemetry-sdk/src/propagation/trace_context.rs
+++ b/opentelemetry-sdk/src/propagation/trace_context.rs
@@ -114,7 +114,7 @@ impl TextMapPropagator for TraceContextPropagator {
         let span_context = span.span_context();
         if span_context.is_valid() {
             let header_value = format!(
-                "{:02x}-{:032x}-{:016x}-{:02x}",
+                "{:02x}-{}-{}-{:02x}",
                 SUPPORTED_VERSION,
                 span_context.trace_id(),
                 span_context.span_id(),

--- a/opentelemetry-sdk/src/trace/id_generator/aws.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/aws.rs
@@ -83,7 +83,7 @@ mod tests {
             .unwrap()
             .as_secs();
 
-        let trace_as_hex: String = format!("{:032x}", trace_id);
+        let trace_as_hex = trace_id.to_string();
         let (timestamp, _xray_id) = trace_as_hex.split_at(8_usize);
 
         let trace_time: u64 = u64::from_str_radix(timestamp, 16).unwrap();

--- a/opentelemetry-stdout/src/logs/transform.rs
+++ b/opentelemetry-stdout/src/logs/transform.rs
@@ -102,12 +102,12 @@ impl From<opentelemetry_sdk::export::logs::LogData> for LogRecord {
                 .record
                 .trace_context
                 .as_ref()
-                .map(|c| format!("{:x}", c.trace_id)),
+                .map(|c| c.trace_id.to_string()),
             span_id: value
                 .record
                 .trace_context
                 .as_ref()
-                .map(|c| format!("{:x}", c.span_id)),
+                .map(|c| c.span_id.to_string()),
             flags: value
                 .record
                 .trace_context

--- a/opentelemetry-stdout/src/trace/transform.rs
+++ b/opentelemetry-stdout/src/trace/transform.rs
@@ -93,10 +93,10 @@ struct Span {
 impl From<opentelemetry_sdk::export::trace::SpanData> for Span {
     fn from(value: opentelemetry_sdk::export::trace::SpanData) -> Self {
         Span {
-            trace_id: format!("{:x}", value.span_context.trace_id()),
-            span_id: format!("{:x}", value.span_context.span_id()),
+            trace_id: value.span_context.trace_id().to_string(),
+            span_id: value.span_context.span_id().to_string(),
             trace_state: Some(value.span_context.trace_state().header()).filter(|s| !s.is_empty()),
-            parent_span_id: Some(format!("{:x}", value.parent_span_id))
+            parent_span_id: Some(value.parent_span_id.to_string())
                 .filter(|s| s != "0")
                 .unwrap_or_default(),
             name: value.name,
@@ -180,8 +180,8 @@ struct Link {
 impl From<opentelemetry::trace::Link> for Link {
     fn from(value: opentelemetry::trace::Link) -> Self {
         Link {
-            trace_id: format!("{:x}", value.span_context.trace_id()),
-            span_id: format!("{:x}", value.span_context.span_id()),
+            trace_id: value.span_context.trace_id().to_string(),
+            span_id: value.span_context.span_id().to_string(),
             trace_state: Some(value.span_context.trace_state().header()).filter(|s| !s.is_empty()),
             attributes: value.attributes.into_iter().map(Into::into).collect(),
             dropped_attributes_count: value.dropped_attributes_count,

--- a/opentelemetry-zipkin/src/propagator/mod.rs
+++ b/opentelemetry-zipkin/src/propagator/mod.rs
@@ -228,11 +228,7 @@ impl TextMapPropagator for Propagator {
                 span_context.trace_flags() & TRACE_FLAG_DEFERRED == TRACE_FLAG_DEFERRED;
             let is_debug = span_context.trace_flags() & TRACE_FLAG_DEBUG == TRACE_FLAG_DEBUG;
             if self.inject_encoding.support(&B3Encoding::SingleHeader) {
-                let mut value = format!(
-                    "{:032x}-{:016x}",
-                    span_context.trace_id(),
-                    span_context.span_id(),
-                );
+                let mut value = format!("{}-{}", span_context.trace_id(), span_context.span_id());
                 if !is_deferred {
                     let flag = if is_debug {
                         "d"
@@ -250,14 +246,8 @@ impl TextMapPropagator for Propagator {
                 || self.inject_encoding.support(&B3Encoding::UnSpecified)
             {
                 // if inject_encoding is Unspecified, default to use MultipleHeader
-                injector.set(
-                    B3_TRACE_ID_HEADER,
-                    format!("{:032x}", span_context.trace_id()),
-                );
-                injector.set(
-                    B3_SPAN_ID_HEADER,
-                    format!("{:016x}", span_context.span_id()),
-                );
+                injector.set(B3_TRACE_ID_HEADER, span_context.trace_id().to_string());
+                injector.set(B3_SPAN_ID_HEADER, span_context.span_id().to_string());
 
                 if is_debug {
                     injector.set(B3_DEBUG_FLAG_HEADER, "1".to_string());


### PR DESCRIPTION
As brought up in #1296 not all of the implementations of span and trace id formatting properly pad as required by the spec.

## Changes

Have consistent padding and hex casing by using the `Display` impl of trace and span ids which is in accordance with the [spec].

[spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.26.0/specification/trace/api.md#retrieving-the-traceid-and-spanid

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)