### PR TITLE
Replace regex crate with glob crate 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         df -h
         sudo apt-get remove -y '^dotnet-.*'
         sudo apt-get remove -y powershell mono-devel
-        sudo apt-get autoremove -y
+        sudo apt-get autoremove -y --fix-missing
         sudo apt-get clean
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /usr/share/dotnet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
     - name: Free disk space
       run: |
         df -h
-        sudo apt-get remove -y '^ghc-8.*'
         sudo apt-get remove -y '^dotnet-.*'
         sudo apt-get remove -y powershell mono-devel
         sudo apt-get autoremove -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ jobs:
     - name: Free disk space
       run: |
         df -h
-        sudo apt-get remove -y '^dotnet-.*' --fix-missing
-        sudo apt-get remove -y powershell mono-devel
-        sudo apt-get autoremove -y
-        sudo apt-get clean
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /usr/share/dotnet
         df -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,17 @@ jobs:
         rust: [stable, beta]
     runs-on: ubuntu-latest
     steps:
+    - name: Free disk space
+      run:
+        df -h
+        sudo apt-get remove -y '^ghc-8.*'
+        sudo apt-get remove -y '^dotnet-.*'
+        sudo apt-get remove -y powershell mono-devel
+        sudo apt-get autoremove -y
+        sudo apt-get clean
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/dotnet
+        df -h
     - uses: actions/checkout@v1
       with:
         submodules: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Free disk space
-      run:
+      run: |
         df -h
         sudo apt-get remove -y '^ghc-8.*'
         sudo apt-get remove -y '^dotnet-.*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     - name: Free disk space
       run: |
         df -h
-        sudo apt-get remove -y '^dotnet-.*'
+        sudo apt-get remove -y '^dotnet-.*' --fix-missing
         sudo apt-get remove -y powershell mono-devel
-        sudo apt-get autoremove -y --fix-missing
+        sudo apt-get autoremove -y
         sudo apt-get clean
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /usr/share/dotnet

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Increase instrument name maximum length from 63 to 255 (#1269)
 - Updated crate documentation and examples.
   [#1256](https://github.com/open-telemetry/opentelemetry-rust/issues/1256)
+- Replace regex with glob (#1301)
+
 
 ### Removed
 

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -22,7 +22,7 @@ once_cell = "1.10"
 ordered-float = "4.0"
 percent-encoding = { version = "2.0", optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
-glob = {version = "0.3.1"}
+glob = {version = "0.3.1", optional =true}
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1", optional = true }
 thiserror = "1"
@@ -47,7 +47,7 @@ trace = ["opentelemetry/trace", "crossbeam-channel", "rand", "async-trait", "per
 jaeger_remote_sampler = ["trace", "opentelemetry-http", "http", "serde", "serde_json", "url"]
 logs = ["opentelemetry/logs", "crossbeam-channel", "async-trait", "serde_json"]
 logs_level_enabled = ["logs", "opentelemetry/logs_level_enabled"]
-metrics = ["opentelemetry/metrics", "regex", "async-trait"]
+metrics = ["opentelemetry/metrics", "glob", "async-trait"]
 testing = ["opentelemetry/testing", "trace", "metrics", "logs", "rt-async-std", "rt-tokio", "rt-tokio-current-thread", "tokio/macros", "tokio/rt-multi-thread"]
 rt-tokio = ["tokio", "tokio-stream"]
 rt-tokio-current-thread = ["tokio", "tokio-stream"]

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -22,6 +22,7 @@ once_cell = "1.10"
 ordered-float = "4.0"
 percent-encoding = { version = "2.0", optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
+glob = {version = "0.3.1"}
 regex = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1", optional = true }

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -23,7 +23,6 @@ ordered-float = "4.0"
 percent-encoding = { version = "2.0", optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
 glob = {version = "0.3.1"}
-regex = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1", optional = true }
 thiserror = "1"

--- a/opentelemetry-sdk/src/metrics/view.rs
+++ b/opentelemetry-sdk/src/metrics/view.rs
@@ -172,3 +172,37 @@ pub fn new_view(criteria: Instrument, mask: Stream) -> Result<Box<dyn View>> {
         }
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::Aggregation;
+    use crate::metrics::Instrument;
+    use std::error::Error;
+    use std::result::Result;
+    #[test]
+    fn test_new_view() -> Result<(), Box<dyn Error>> {
+        let criteria = Instrument::new().name("counter");
+        let mask = Stream::new().aggregation(Aggregation::Sum);
+        let view = new_view(criteria, mask)?;
+
+        assert!(view
+            .match_inst(&Instrument::new().name("counter"))
+            .is_some());
+        assert!(view
+            .match_inst(&Instrument::new().name("counter2"))
+            .is_none());
+        assert!(view.match_inst(&Instrument::new().name("*")).is_some());
+        assert!(view
+            .match_inst(&Instrument::new().name("counter*"))
+            .is_some());
+        assert!(view
+            .match_inst(&Instrument::new().name("counter?"))
+            .is_some());
+        assert!(view
+            .match_inst(&Instrument::new().name("counter?*"))
+            .is_some());
+        assert!(view.match_inst(&Instrument::new().name("c*r")).is_some());
+        Ok(())
+    }
+}

--- a/opentelemetry-sdk/src/metrics/view.rs
+++ b/opentelemetry-sdk/src/metrics/view.rs
@@ -189,9 +189,6 @@ mod tests {
         assert!(view
             .match_inst(&Instrument::new().name("counter"))
             .is_some());
-        assert!(view
-            .match_inst(&Instrument::new().name("counter2"))
-            .is_none());
         assert!(view.match_inst(&Instrument::new().name("*")).is_some());
         assert!(view
             .match_inst(&Instrument::new().name("counter*"))
@@ -203,6 +200,9 @@ mod tests {
             .match_inst(&Instrument::new().name("counter?*"))
             .is_some());
         assert!(view.match_inst(&Instrument::new().name("c*r")).is_some());
+        assert!(view
+            .match_inst(&Instrument::new().name("counter2"))
+            .is_none());
         Ok(())
     }
 }


### PR DESCRIPTION
## Changes

replace regex crate with glob crate to fix CI failure due to msrv issue:

``
error: package `regex-syntax v0.8.1` cannot be built because it requires rustc 1.65 or newer, while the currently active rustc version is 1.64.0 Error: Process completed with exit code 101.
``
## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
