### PR TITLE
Add tracing tests using inmemoryexporter

### DIFF
--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -47,7 +47,7 @@ mod tests {
     };
 
     #[test]
-    fn tracing_in_span_test() {
+    fn tracing_in_span() {
         // Arrange
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = TracerProvider::builder()
@@ -71,7 +71,7 @@ mod tests {
     }
 
     #[test]
-    fn tracing_tracer_start_test() {
+    fn tracing_tracer_start() {
         // Arrange
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = TracerProvider::builder()

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -39,9 +39,12 @@ mod runtime_tests;
 
 #[cfg(all(test, feature = "testing"))]
 mod tests {
-    use crate::testing::trace::InMemorySpanExporterBuilder;
-    use opentelemetry::{trace::{Tracer, Span, TracerProvider as _}, KeyValue};
     use super::*;
+    use crate::testing::trace::InMemorySpanExporterBuilder;
+    use opentelemetry::{
+        trace::{Span, Tracer, TracerProvider as _},
+        KeyValue,
+    };
 
     #[test]
     fn tracing_in_span_test() {
@@ -50,16 +53,17 @@ mod tests {
         let provider = TracerProvider::builder()
             .with_span_processor(SimpleSpanProcessor::new(Box::new(exporter.clone())))
             .build();
-        
+
         // Act
         let tracer = provider.tracer("test_tracer");
-        tracer.in_span("span_name", |_cx| {
-            });
+        tracer.in_span("span_name", |_cx| {});
 
         provider.force_flush();
 
         // Assert
-        let exported_spans = exporter.get_finished_spans().expect("Spans are expected to be exported.");
+        let exported_spans = exporter
+            .get_finished_spans()
+            .expect("Spans are expected to be exported.");
         assert_eq!(exported_spans.len(), 1);
         let span = &exported_spans[0];
         assert_eq!(span.name, "span_name");
@@ -82,7 +86,9 @@ mod tests {
         provider.force_flush();
 
         // Assert
-        let exported_spans = exporter.get_finished_spans().expect("Spans are expected to be exported.");
+        let exported_spans = exporter
+            .get_finished_spans()
+            .expect("Spans are expected to be exported.");
         assert_eq!(exported_spans.len(), 1);
         let span = &exported_spans[0];
         assert_eq!(span.name, "span_name");


### PR DESCRIPTION
Adding module level tests, which tests the entire tracing api/sdk pipeline. These are not unit tests, but not integration tests either. 
I think this is a good way to test things, and improve coverage. This is pretty close to testing what an end user experiences (minus the actual exporter part, which can be covered by spinning up collectors in the future.)

This was discussed in todays SIG meeting, and opening this PR to get early feedback. If all likes this direction, then I can send follow up PRs greatly improving coverage, and extend it to metrics and logs as well. (Or create issues with "help-wanted" tag inviting more folks to contribute.)

This uses in_memory_exporter which were recently added. If we ourselves don't use it, who else will 🤣 !