### PR TITLE
Remove extra generic from with_http_client

### DIFF
--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Do not set an empty span as the active span when the propagator does not find a remote span.
+- Change type signature of `with_http_client()` to use the provided generic as argument.
 
 ## V0.8.0
 

--- a/opentelemetry-datadog/src/exporter/mod.rs
+++ b/opentelemetry-datadog/src/exporter/mod.rs
@@ -347,10 +347,7 @@ impl DatadogPipelineBuilder {
     }
 
     /// Choose the http client used by uploader
-    pub fn with_http_client<T: HttpClient + 'static>(
-        mut self,
-        client: Arc<dyn HttpClient>,
-    ) -> Self {
+    pub fn with_http_client(mut self, client: Arc<dyn HttpClient>) -> Self {
         self.client = Some(client);
         self
     }


### PR DESCRIPTION
This generic type parameter is not being used anywhere, so when you try to use `with_http_client`, it requires you to specify a dummy type that implements `HttpClient + 'static`.

So this does not work:

```rust
new_pipeline().with_http_client(Arc::new(client))
```

But these work, even though they don't necessarily match the actual type of `client`:

```rust
new_pipeline::<Arc<dyn HttpClient>>().with_http_client(Arc::new(client))

new_pipeline::<reqwest::Client>().with_http_client(Arc::new(client))
```

## Changes

I changed the type signature of `with_http_client` to address this.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
