### PR TITLE
chore: fix unused_doc_comments warning

### DIFF
--- a/opentelemetry-stackdriver/src/lib.rs
+++ b/opentelemetry-stackdriver/src/lib.rs
@@ -328,8 +328,8 @@ where
                 ),
                 display_name: Some(to_truncate(span.name.into_owned())),
                 span_id: hex::encode(span.span_context.span_id().to_bytes()),
-                /// From the API docs: If this is a root span,
-                /// then this field must be empty.
+                // From the API docs: If this is a root span,
+                // then this field must be empty.
                 parent_span_id: match span.parent_span_id {
                     SpanId::INVALID => "".to_owned(),
                     _ => hex::encode(span.parent_span_id.to_bytes()),


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Change the document comment to a regular comment.

The warning I got with `cargo check --workspace`:

```
warning: unused doc comment
   --> opentelemetry-stackdriver/src/lib.rs:331:17
    |
331 | /                 /// From the API docs: If this is a root span,
332 | |                 /// then this field must be empty.
    | |__________________________________________________^
333 | /                 parent_span_id: match span.parent_span_id {
334 | |                     SpanId::INVALID => "".to_owned(),
335 | |                     _ => hex::encode(span.parent_span_id.to_bytes()),
336 | |                 },
    | |_________________- rustdoc does not generate documentation for expression fields
    |
    = help: use `//` for a plain comment
    = note: `#[warn(unused_doc_comments)]` on by default

warning: `opentelemetry-stackdriver` (lib) generated 1 warning
```


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
