### PR TITLE
chore(deps): bump tonic, tonic-build and prost

### DIFF
--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -17,13 +17,13 @@ path = "src/client.rs"
 opentelemetry = { version = "0.20" }
 opentelemetry_sdk = { version = "0.20", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.19", features = ["rt-tokio"] }
-prost = "0.11"
+prost = "0.12"
 tokio = { version = "1.28", features = ["full"] }
-tonic = "0.9.2"
+tonic = "0.10"
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-opentelemetry = "0.20"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
-tonic-build = "0.9.2"
+tonic-build = "0.10"

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -41,9 +41,9 @@ tokio = { version = "1.0", features = ["net", "sync"], optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4.18", optional = true }
 
-tonic = { version = "0.9.0", optional = true }
-prost = { version = "0.11.6", optional = true }
-prost-types = { version = "0.11.6", optional = true }
+tonic = { version = "0.10", optional = true }
+prost = { version = "0.12", optional = true }
+prost-types = { version = "0.12", optional = true }
 
 # Futures
 futures-executor = { version = "0.3", default-features = false, features = ["std"], optional = true }

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -35,8 +35,8 @@ opentelemetry_sdk = { version = "0.20", default-features = false, path = "../ope
 opentelemetry-http = { version = "0.9", path = "../opentelemetry-http", optional = true }
 opentelemetry-semantic-conventions = { version = "0.12", path = "../opentelemetry-semantic-conventions" }
 
-prost = { version = "0.11.0", optional = true }
-tonic = { version = "0.9.0", optional = true }
+prost = { version = "0.12", optional = true }
+tonic = { version = "0.10", optional = true }
 tokio = { version = "1.0", features = ["sync", "rt"], optional = true }
 
 reqwest = { version = "0.11", optional = true, default-features = false }

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -44,14 +44,14 @@ with-serde = ["serde"]
 
 [dependencies]
 grpcio = { version = "0.12", optional = true, features = ["prost-codec"] }
-tonic = { version = "0.9.0", default-features = false, optional = true, features = ["codegen", "prost"] }
-prost = { version = "0.11.0", optional = true }
+tonic = { version = "0.10.0", default-features = false, optional = true, features = ["codegen", "prost"] }
+prost = { version = "0.12.0", optional = true }
 opentelemetry = { version = "0.21", default-features = false, path = "../opentelemetry" }
 opentelemetry_sdk = { version = "0.20", default-features = false, path = "../opentelemetry-sdk" }
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 
 [dev-dependencies]
 grpcio-compiler = { version = "0.12.1", default-features = false, features = ["prost-codec"] }
-tonic-build = { version = "0.9.0" }
-prost-build = { version = "0.11.1" }
+tonic-build = { version = "0.10.0" }
+prost-build = { version = "0.12.1" }
 tempfile = "3.3.0"

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -19,10 +19,10 @@ hyper-rustls = { version = "0.24", optional = true }
 opentelemetry = { version = "0.21", path = "../opentelemetry" }
 opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk" }
 opentelemetry-semantic-conventions = { version = "0.12", path = "../opentelemetry-semantic-conventions" }
-prost = "0.11.0"
-prost-types = "0.11.1"
+prost = "0.12"
+prost-types = "0.12"
 thiserror = "1.0.30"
-tonic = { version = "0.9.0", features = ["gzip", "tls", "transport"] }
+tonic = { version = "0.10.0", features = ["gzip", "tls", "transport"] }
 yup-oauth2 = { version = "8.1.0", optional = true }
 
 # Futures
@@ -40,6 +40,6 @@ tls-webpki-roots = ["tonic/tls-webpki-roots"]
 reqwest = "0.11.9"
 tempfile = "3.3.0"
 tokio = "1"
-tonic-build = "0.9.0"
+tonic-build = "0.10.0"
 walkdir = "2.3.2"
 futures-util = {version = "0.3", default-features = false }

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -16,7 +16,7 @@ opentelemetry_sdk = { version = "0.20", path = "../opentelemetry-sdk", features 
 opentelemetry-proto = { version = "0.3", path = "../opentelemetry-proto", features = ["gen-tonic", "metrics"] }
 eventheader = { version = "= 0.3.2" }
 async-trait = "0.1"
-prost = "0.11"
+prost = "0.12"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

This patch bumps tonic and tonic-build to `0.10`, prost to `0.12`

Related to https://github.com/open-telemetry/opentelemetry-rust/pull/1252

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
