### PR TITLE
[WIP] Suppress nested traces from instrumented dependencies

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 [dependencies]
 once_cell = "1.17"
 opentelemetry = { path = "../../../opentelemetry" }
-opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "metrics", "logs"] }
+opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "metrics", "logs", "logs_level_enabled"] }
 opentelemetry-otlp = { path = "../..", features = ["http-proto", "reqwest-client", "logs"] }
-opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}
+opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing"}
 opentelemetry-semantic-conventions = { path = "../../../opentelemetry-semantic-conventions" }
 
 tokio = { version = "1.0", features = ["full"] }

--- a/opentelemetry-otlp/src/exporter/http/logs.rs
+++ b/opentelemetry-otlp/src/exporter/http/logs.rs
@@ -4,12 +4,14 @@ use async_trait::async_trait;
 use http::{header::CONTENT_TYPE, Method};
 use opentelemetry::logs::{LogError, LogResult};
 use opentelemetry_sdk::export::logs::{LogData, LogExporter};
+use opentelemetry_sdk::suppression::Supression;
 
 use super::OtlpHttpClient;
 
 #[async_trait]
 impl LogExporter for OtlpHttpClient {
     async fn export(&mut self, batch: Vec<LogData>) -> LogResult<()> {
+        let _guard = Suppression::new();
         let client = self
             .client
             .lock()

--- a/opentelemetry-otlp/src/exporter/http/logs.rs
+++ b/opentelemetry-otlp/src/exporter/http/logs.rs
@@ -3,15 +3,18 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use http::{header::CONTENT_TYPE, Method};
 use opentelemetry::logs::{LogError, LogResult};
-use opentelemetry_sdk::export::logs::{LogData, LogExporter};
-use opentelemetry_sdk::suppression::Supression;
+use opentelemetry_sdk::{
+    export::logs::{LogData, LogExporter},
+    suppression::SuppressionGuard,
+};
+//use opentelemetry_sdk::suppression::Supression;
 
 use super::OtlpHttpClient;
 
 #[async_trait]
 impl LogExporter for OtlpHttpClient {
     async fn export(&mut self, batch: Vec<LogData>) -> LogResult<()> {
-        let _guard = Suppression::new();
+        let _guard = SuppressionGuard::new();
         let client = self
             .client
             .lock()

--- a/opentelemetry-otlp/src/exporter/http/logs.rs
+++ b/opentelemetry-otlp/src/exporter/http/logs.rs
@@ -5,7 +5,7 @@ use http::{header::CONTENT_TYPE, Method};
 use opentelemetry::logs::{LogError, LogResult};
 use opentelemetry_sdk::{
     export::logs::{LogData, LogExporter},
-    suppression::SuppressionGuard,
+    suppression::with_suppression,
 };
 //use opentelemetry_sdk::suppression::Supression;
 
@@ -14,31 +14,33 @@ use super::OtlpHttpClient;
 #[async_trait]
 impl LogExporter for OtlpHttpClient {
     async fn export(&mut self, batch: Vec<LogData>) -> LogResult<()> {
-        let _guard = SuppressionGuard::new();
-        let client = self
-            .client
-            .lock()
-            .map_err(|e| LogError::Other(e.to_string().into()))
-            .and_then(|g| match &*g {
-                Some(client) => Ok(Arc::clone(client)),
-                _ => Err(LogError::Other("exporter is already shut down".into())),
-            })?;
+        with_suppression(async {
+            let client = self
+                .client
+                .lock()
+                .map_err(|e| LogError::Other(e.to_string().into()))
+                .and_then(|g| match &*g {
+                    Some(client) => Ok(Arc::clone(client)),
+                    _ => Err(LogError::Other("exporter is already shut down".into())),
+                })?;
 
-        let (body, content_type) = build_body(batch)?;
-        let mut request = http::Request::builder()
-            .method(Method::POST)
-            .uri(&self.collector_endpoint)
-            .header(CONTENT_TYPE, content_type)
-            .body(body)
-            .map_err(|e| crate::Error::RequestFailed(Box::new(e)))?;
+            let (body, content_type) = build_body(batch)?;
+            let mut request = http::Request::builder()
+                .method(Method::POST)
+                .uri(&self.collector_endpoint)
+                .header(CONTENT_TYPE, content_type)
+                .body(body)
+                .map_err(|e| crate::Error::RequestFailed(Box::new(e)))?;
 
-        for (k, v) in &self.headers {
-            request.headers_mut().insert(k.clone(), v.clone());
-        }
+            for (k, v) in &self.headers {
+                request.headers_mut().insert(k.clone(), v.clone());
+            }
 
-        client.send(request).await?;
+            client.send(request).await?;
 
-        Ok(())
+            Ok(())
+        })
+        .await
     }
 
     fn shutdown(&mut self) {

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -30,6 +30,7 @@ url = { version = "2.2", optional = true }
 tokio = { version = "1.0", default-features = false, features = ["rt", "time"], optional = true }
 tokio-stream = { version = "0.1.1", optional = true }
 http = { version = "0.2", optional = true }
+pin-project-lite = { version = "0.2" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -125,6 +125,7 @@ pub mod metrics;
 pub mod propagation;
 pub mod resource;
 pub mod runtime;
+pub mod suppression;
 #[cfg(any(feature = "testing", test))]
 #[doc(hidden)]
 pub mod testing;

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -125,6 +125,7 @@ pub mod metrics;
 pub mod propagation;
 pub mod resource;
 pub mod runtime;
+/// doc
 pub mod suppression;
 #[cfg(any(feature = "testing", test))]
 #[doc(hidden)]

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -133,8 +133,7 @@ impl<R: RuntimeChannel<BatchMessage>> LogProcessor for BatchLogProcessor<R> {
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        let suppress = SuppressionGuard::is_logging_suppressed();
-        !suppress
+        !SuppressionGuard::is_logging_suppressed()
     }
 
     fn force_flush(&self) -> LogResult<()> {

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -1,6 +1,7 @@
 use crate::{
     export::logs::{ExportResult, LogData, LogExporter},
     runtime::{RuntimeChannel, TrySend},
+    suppression::Suppression,
 };
 use futures_channel::oneshot;
 use futures_util::{
@@ -103,7 +104,7 @@ impl LogProcessor for SimpleLogProcessor {
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        true
+        !Suppression::is_logging_suppressed()
     }
 }
 
@@ -132,7 +133,7 @@ impl<R: RuntimeChannel<BatchMessage>> LogProcessor for BatchLogProcessor<R> {
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        true
+        !Suppression::is_logging_suppressed()
     }
 
     fn force_flush(&self) -> LogResult<()> {

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -1,7 +1,7 @@
 use crate::{
     export::logs::{ExportResult, LogData, LogExporter},
     runtime::{RuntimeChannel, TrySend},
-    suppression::SuppressionGuard,
+    suppression::is_suppressed,
 };
 use futures_channel::oneshot;
 use futures_util::{
@@ -104,7 +104,7 @@ impl LogProcessor for SimpleLogProcessor {
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        !SuppressionGuard::is_logging_suppressed()
+        !is_suppressed()
     }
 }
 
@@ -133,7 +133,7 @@ impl<R: RuntimeChannel<BatchMessage>> LogProcessor for BatchLogProcessor<R> {
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        !SuppressionGuard::is_logging_suppressed()
+        !is_suppressed()
     }
 
     fn force_flush(&self) -> LogResult<()> {

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -1,7 +1,7 @@
 use crate::{
     export::logs::{ExportResult, LogData, LogExporter},
     runtime::{RuntimeChannel, TrySend},
-    suppression::Suppression,
+    suppression::SuppressionGuard,
 };
 use futures_channel::oneshot;
 use futures_util::{
@@ -104,7 +104,7 @@ impl LogProcessor for SimpleLogProcessor {
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        !Suppression::is_logging_suppressed()
+        !SuppressionGuard::is_logging_suppressed()
     }
 }
 
@@ -133,7 +133,8 @@ impl<R: RuntimeChannel<BatchMessage>> LogProcessor for BatchLogProcessor<R> {
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        !Suppression::is_logging_suppressed()
+        let suppress = SuppressionGuard::is_logging_suppressed();
+        !suppress
     }
 
     fn force_flush(&self) -> LogResult<()> {

--- a/opentelemetry-sdk/src/suppression.rs
+++ b/opentelemetry-sdk/src/suppression.rs
@@ -1,0 +1,33 @@
+
+use opentelemetry::Context;
+use std::any::{Any, TypeId};
+use std::sync::Arc;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+struct SuppressionKey(bool); // true means logging is suppressed
+
+pub struct Suppression;
+
+impl Suppression {
+    pub fn new() -> Self {
+        // Suppress logging when a new Suppression instance is created
+        let mut new_context = Context::current();
+        new_context.entries.insert(TypeId::of::<SuppressionKey>(), Arc::new(SuppressionKey(true)));
+        new_context.attach();
+
+        Suppression
+    }
+
+    pub fn is_logging_suppressed() -> bool {
+        Context::current().get::<SuppressionKey>().cloned().unwrap_or(SuppressionKey(false)).0
+    }
+}
+
+impl Drop for Suppression {
+    fn drop(&mut self) {
+        // Resume logging when the Suppression instance is dropped
+        let mut new_context = Context::current();
+        new_context.entries.insert(TypeId::of::<SuppressionKey>(), Arc::new(SuppressionKey(false)));
+        new_context.attach();
+    }
+}

--- a/opentelemetry-sdk/src/suppression.rs
+++ b/opentelemetry-sdk/src/suppression.rs
@@ -3,47 +3,62 @@ use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context as TaskContext, Poll};
-use std::thread;
-use tokio::task;
+use tokio::task_local;
 
-thread_local! {
-    static SUPPRESSION_ENABLED: RefCell<bool> = RefCell::new(false)
+task_local! {
+    static SUPPRESSION_ENABLED: RefCell<bool>
 }
 
 #[derive(Clone, Copy, Debug)]
+///suppression context
 pub struct SuppressionContext;
 
 impl SuppressionContext {
+    ///current
     pub fn current() -> Self {
         SuppressionContext
     }
 
+    ///attach
     pub fn attach(self) -> Guard {
-        let was_suppressed = SUPPRESSION_ENABLED.with(|suppressed| {
-            let was_suppressed = *suppressed.borrow();
-            *suppressed.borrow_mut() = true;
-            was_suppressed
-        });
+        let was_suppressed = SUPPRESSION_ENABLED
+            .try_with(|suppressed| {
+                let was_suppressed = *suppressed.borrow();
+                *suppressed.borrow_mut() = true;
+                was_suppressed
+            })
+            .unwrap_or_else(|_| {
+                SUPPRESSION_ENABLED.with(|suppressed| {
+                    *suppressed.borrow_mut() = true;
+                    false // was_suppressed is false since it was not previously initialized
+                })
+            });
         Guard { was_suppressed }
     }
-
+    ///is_suppressed
     pub fn is_suppressed() -> bool {
-        let is_suppressed = SUPPRESSION_ENABLED.with(|suppressed| *suppressed.borrow());
-        is_suppressed
+        SUPPRESSION_ENABLED
+            .try_with(|suppressed| *suppressed.borrow())
+            .unwrap_or(false)
     }
 }
 
+/// Guard
+#[derive(Debug)]
 pub struct Guard {
     was_suppressed: bool,
 }
 
 impl Drop for Guard {
     fn drop(&mut self) {
-        SUPPRESSION_ENABLED.with(|suppressed| *suppressed.borrow_mut() = self.was_suppressed);
+        let _ = SUPPRESSION_ENABLED.try_with(|suppressed| {
+            *suppressed.borrow_mut() = self.was_suppressed;
+        });
     }
 }
 
 pin_project! {
+    /// WithSuppContext
     #[derive(Clone, Debug)]
     pub struct WithSuppContext<T> {
         #[pin]
@@ -62,6 +77,20 @@ impl<T: Future> Future for WithSuppContext<T> {
     }
 }
 
+/// with_init_suppression
+pub async fn with_init_suppression<F, Fut>(func: F)
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    SUPPRESSION_ENABLED
+        .scope(RefCell::new(true), async {
+            func().await;
+        })
+        .await;
+}
+
+/// with_suppression
 pub fn with_suppression<T>(inner: T) -> WithSuppContext<T> {
     WithSuppContext {
         inner,
@@ -69,6 +98,7 @@ pub fn with_suppression<T>(inner: T) -> WithSuppContext<T> {
     }
 }
 
+/// is_suppressed
 pub fn is_suppressed() -> bool {
     SuppressionContext::is_suppressed()
 }

--- a/opentelemetry-sdk/src/suppression.rs
+++ b/opentelemetry-sdk/src/suppression.rs
@@ -1,31 +1,74 @@
-use tokio::task_local;
+use pin_project_lite::pin_project;
+use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context as TaskContext, Poll};
+use std::thread;
+use tokio::task;
 
-// Define the async local storage for suppression.
-task_local! {
-    static SUPPRESSION_FLAG: bool;
+thread_local! {
+    static SUPPRESSION_ENABLED: RefCell<bool> = RefCell::new(false)
 }
 
-/// Represents a scope within which logging is suppressed.
-/// Logging is suppressed for the duration of the guard's lifetime.
-#[derive(Debug)]
-pub struct SuppressionGuard(bool); // Capture the original state
+#[derive(Clone, Copy, Debug)]
+pub struct SuppressionContext;
 
-impl SuppressionGuard {
-    /// doc1
-    pub fn new() -> Self {
-        let original_state = SUPPRESSION_FLAG.try_with(|&flag| flag).unwrap_or(false);
-        SUPPRESSION_FLAG.scope(true, async {});
-        SuppressionGuard(original_state)
+impl SuppressionContext {
+    pub fn current() -> Self {
+        SuppressionContext
     }
 
-    /// doc2
-    pub fn is_logging_suppressed() -> bool {
-        SUPPRESSION_FLAG.try_with(|&flag| flag).unwrap_or(false)
+    pub fn attach(self) -> Guard {
+        let was_suppressed = SUPPRESSION_ENABLED.with(|suppressed| {
+            let was_suppressed = *suppressed.borrow();
+            *suppressed.borrow_mut() = true;
+            was_suppressed
+        });
+        Guard { was_suppressed }
+    }
+
+    pub fn is_suppressed() -> bool {
+        let is_suppressed = SUPPRESSION_ENABLED.with(|suppressed| *suppressed.borrow());
+        is_suppressed
     }
 }
 
-impl Drop for SuppressionGuard {
+pub struct Guard {
+    was_suppressed: bool,
+}
+
+impl Drop for Guard {
     fn drop(&mut self) {
-        SUPPRESSION_FLAG.scope(self.0, async {}); // Restore the original state
+        SUPPRESSION_ENABLED.with(|suppressed| *suppressed.borrow_mut() = self.was_suppressed);
     }
+}
+
+pin_project! {
+    #[derive(Clone, Debug)]
+    pub struct WithSuppContext<T> {
+        #[pin]
+        inner: T,
+        supp_cx: SuppressionContext,
+    }
+}
+
+impl<T: Future> Future for WithSuppContext<T> {
+    type Output = T::Output;
+
+    fn poll(self: Pin<&mut Self>, task_cx: &mut TaskContext<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let _guard = this.supp_cx.attach();
+        this.inner.poll(task_cx)
+    }
+}
+
+pub fn with_suppression<T>(inner: T) -> WithSuppContext<T> {
+    WithSuppContext {
+        inner,
+        supp_cx: SuppressionContext::current(),
+    }
+}
+
+pub fn is_suppressed() -> bool {
+    SuppressionContext::is_suppressed()
 }


### PR DESCRIPTION
Fixes #1171 

Need few changes before making it ready for review.
 - The SuppressionGuard struct should be runtime agnostic. As of now, it is using task-local from tokio runtime.
 - Need to add suppression logic across traces and logs, and OTLP-gRPC and OTLP-HTTP exporters.
Future change : As of now, Context uses thread-local storage. It can also optionally support task-local storage as supported by otel-js, otel-dotnet. And then Context can be leveraged for suppression.

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
