### PR TITLE
Bump the MSRV to 1.65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: 1.64.0
+        toolchain: 1.65.0
         override: true
     - name: Patch dependencies versions # some dependencies bump MSRV without major version bump
       run: ./scripts/patch_dependencies.sh

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ analysis in order to understand your software's performance and behavior. You
 can export and analyze them using [Prometheus], [Jaeger], and other
 observability tools.
 
-*Compiler support: [requires `rustc` 1.64+][msrv]*
+*Compiler support: [requires `rustc` 1.65+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io

--- a/opentelemetry-appender-log/CHANGELOG.md
+++ b/opentelemetry-appender-log/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Changed
+
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
+
 ### Fixed
 
 - Add log appender versions to loggers (#1182).

--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/ope
 readme = "README.md"
 keywords = ["opentelemetry", "log", "logs"]
 license = "Apache-2.0"
-rust-version = "1.64"
+rust-version = "1.65"
 edition = "2021"
 
 [dependencies]

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+### Changed
+
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
+
+### Added
+
 - Add log appender versions to loggers (#1182)
 
 ## v0.1.0

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/ope
 readme = "README.md"
 keywords = ["opentelemetry", "log", "logs", "tracing"]
 license = "Apache-2.0"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["logs"] }

--- a/opentelemetry-aws/CHANGELOG.md
+++ b/opentelemetry-aws/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ## v0.8.0

--- a/opentelemetry-aws/Cargo.toml
+++ b/opentelemetry-aws/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-contrib/CHANGELOG.md
+++ b/opentelemetry-contrib/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ## v0.12.0

--- a/opentelemetry-contrib/Cargo.toml
+++ b/opentelemetry-contrib/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-datadog/CHANGELOG.md
+++ b/opentelemetry-datadog/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ### Fixed
@@ -22,7 +23,7 @@
 - Fix the array encoding length of datadog version 05 exporter #1002
 
 ## v0.7.0
-  
+
 ### Added
 - [Breaking] Add support for unified tagging [#931](https://github.com/open-telemetry/opentelemetry-rust/pull/931).
 

--- a/opentelemetry-datadog/Cargo.toml
+++ b/opentelemetry-datadog/Cargo.toml
@@ -12,7 +12,7 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-dynatrace/CHANGELOG.md
+++ b/opentelemetry-dynatrace/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Add deprecation note to Dynatrace exporter
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 

--- a/opentelemetry-dynatrace/Cargo.toml
+++ b/opentelemetry-dynatrace/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "metrics", "dynatrace"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ## v0.9.0

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 keywords = ["opentelemetry", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 async-trait = "0.1"

--- a/opentelemetry-jaeger/CHANGELOG.md
+++ b/opentelemetry-jaeger/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ## v0.19.0

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "jaeger", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 - Changed dependency from `opentelemetry_api` to `opentelemetry` as the latter
   is now the API crate. [#1226](https://github.com/open-telemetry/opentelemetry-rust/pull/1226)

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 autotests = false
 
 [[test]]

--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - allow custom units in prometheus suffix [#1188](https://github.com/open-telemetry/opentelemetry-rust/pull/1188)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "prometheus", "metrics", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ### Fixed

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 autotests = false
 
 [lib]

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Default Resource (the one used when no other Resource is explicitly provided) now includes `TelemetryResourceDetector`,
   populating "telemetry.sdk.*" attributes.
   [#1066](https://github.com/open-telemetry/opentelemetry-rust/pull/1193).
@@ -33,22 +34,22 @@
   [#1293](https://github.com/open-telemetry/opentelemetry-rust/issues/1293)
   makes few breaking changes with respect to how Span attributes are stored to
   achieve performance gains. See below for details:
-  
+
   *Behavior Change*:
-  
+
   SDK will no longer perform de-duplication of Span attribute Keys. Please share
   [feedback
   here](https://github.com/open-telemetry/opentelemetry-rust/issues/1300), if
   you are affected.
-  
+
   *Breaking Change Affecting Exporter authors*:
-  
+
    `SpanData` now stores `attributes` as `Vec<KeyValue>` instead of
   `EvictedHashMap`. `SpanData` now expose `dropped_attributes_count` as a
   separate field.
-  
+
   *Breaking Change Affecting Sampler authors*:
-  
+
   `should_sample` changes `attributes` from `OrderMap<Key, Value>` to
   `Vec<KeyValue>`.
 

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 opentelemetry = { version = "0.21", path = "../opentelemetry/" }

--- a/opentelemetry-semantic-conventions/CHANGELOG.md
+++ b/opentelemetry-semantic-conventions/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ## v0.12.0

--- a/opentelemetry-semantic-conventions/Cargo.toml
+++ b/opentelemetry-semantic-conventions/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-stackdriver/CHANGELOG.md
+++ b/opentelemetry-stackdriver/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ## v0.17.0

--- a/opentelemetry-stackdriver/Cargo.toml
+++ b/opentelemetry-stackdriver/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust"
 license = "Apache-2.0"
 edition = "2021"
 exclude = ["/proto"]
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 async-trait = "0.1.48"

--- a/opentelemetry-stdout/CHANGELOG.md
+++ b/opentelemetry-stdout/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNext
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Timestamp is additionally exported in user-friendly format.
   [#1192](https://github.com/open-telemetry/opentelemetry-rust/pull/1192).
 - MetricExporter - Temporality is exported in user-friendly format.

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "tracing", "metrics", "logs"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [features]
 trace = ["opentelemetry/trace", "opentelemetry_sdk/trace", "futures-util"]

--- a/opentelemetry-user-events-logs/CHANGELOG.md
+++ b/opentelemetry-user-events-logs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
+
 ## v0.1.0
 
 ### Added

--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-user-events-logs"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-user-events-logs"
 readme = "README.md"
-rust-version = "1.68.0"
+rust-version = "1.65.0"
 keywords = ["opentelemetry", "log", "trace", "user_events"]
 license = "Apache-2.0"
 

--- a/opentelemetry-user-events-metrics/CHANGELOG.md
+++ b/opentelemetry-user-events-metrics/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Include error diagnosing messages for registering tracepoint
     [#1273](https://github.com/open-telemetry/opentelemetry-rust/pull/1273).
 - Add version, protocol to schema

--- a/opentelemetry-user-events-metrics/Cargo.toml
+++ b/opentelemetry-user-events-metrics/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 keywords = ["opentelemetry", "metrics", "user-events"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["metrics"] }

--- a/opentelemetry-zipkin/CHANGELOG.md
+++ b/opentelemetry-zipkin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 
 ## v0.17.0

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-zpages/CHANGELOG.md
+++ b/opentelemetry-zpages/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 - Use tonic based generated files [#1214](https://github.com/open-telemetry/opentelemetry-rust/pull/1214)
 

--- a/opentelemetry-zpages/Cargo.toml
+++ b/opentelemetry-zpages/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Changed
 
+- Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
-- `opentelemetry` crate now only carries the API types #1186. Use the `opentelemetry_sdk` crate for the SDK types. 
+- `opentelemetry` crate now only carries the API types #1186. Use the `opentelemetry_sdk` crate for the SDK types.
 - `trace::noop::NoopSpan` no longer implements `Default` and instead exposes
   a `const DEFAULT` value. [#1270](https://github.com/open-telemetry/opentelemetry-rust/pull/1270)
 - Updated crate documentation and examples.

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -14,7 +14,7 @@ categories = [
 keywords = ["opentelemetry", "logging", "tracing", "metrics", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
The goal of this is to enable GATs https://blog.rust-lang.org/2022/10/28/gats-stabilization.html

Relates to #1314

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
