### PR TITLE
Env over compling time config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,14 @@ The Opentelemetry Rust SDK comes with an error type `openetelemetry::Error`. For
 
 For users that want to implement their own exporters. It's RECOMMENDED to wrap all errors from the exporter into a crate-level error type, and implement `ExporterError` trait.  
 
+### Priority of configurations
+OpenTelemetry supports multiple ways to configure the API, SDK and other components. The priority of configurations is as follows:
+
+- Environment variables
+- Compiling time configurations provided in the source code
+
+
+
 ## Style Guide
 
 * Run `cargo clippy --all` - this will catch common mistakes and improve

--- a/opentelemetry-jaeger/CHANGELOG.md
+++ b/opentelemetry-jaeger/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
+- Prioritize environment variables over compiling time variables [#1323](https://github.com/open-telemetry/opentelemetry-rust/pull/1323)
 
 ## v0.19.0
 

--- a/opentelemetry-jaeger/src/exporter/agent.rs
+++ b/opentelemetry-jaeger/src/exporter/agent.rs
@@ -54,7 +54,7 @@ impl AgentSyncClientUdp {
             TCompactOutputProtocol::new(write),
         );
 
-        let conn = UdpSocket::bind(address_family(&agent_address.as_slice()))?;
+        let conn = UdpSocket::bind(address_family(agent_address.as_slice()))?;
         conn.connect(agent_address.as_slice())?;
 
         Ok(AgentSyncClientUdp {

--- a/opentelemetry-jaeger/src/exporter/agent.rs
+++ b/opentelemetry-jaeger/src/exporter/agent.rs
@@ -1,5 +1,5 @@
 //! # UDP Jaeger Agent Client
-use crate::exporter::addrs_and_family;
+use crate::exporter::address_family;
 use crate::exporter::runtime::JaegerTraceRuntime;
 use crate::exporter::thrift::{
     agent::{self, TAgentSyncClient},
@@ -7,7 +7,7 @@ use crate::exporter::thrift::{
 };
 use crate::exporter::transport::{TBufferChannel, TNoopChannel};
 use std::fmt;
-use std::net::{ToSocketAddrs, UdpSocket};
+use std::net::{SocketAddr, UdpSocket};
 use thrift::{
     protocol::{TCompactInputProtocol, TCompactOutputProtocol},
     transport::{ReadHalf, TIoChannel, WriteHalf},
@@ -43,10 +43,10 @@ pub(crate) struct AgentSyncClientUdp {
 
 impl AgentSyncClientUdp {
     /// Create a new UDP agent client
-    pub(crate) fn new<T: ToSocketAddrs>(
-        agent_endpoint: T,
+    pub(crate) fn new(
         max_packet_size: usize,
         auto_split: bool,
+        agent_address: Vec<SocketAddr>,
     ) -> thrift::Result<Self> {
         let (buffer, write) = TBufferChannel::with_capacity(max_packet_size).split()?;
         let client = agent::AgentSyncClient::new(
@@ -54,9 +54,8 @@ impl AgentSyncClientUdp {
             TCompactOutputProtocol::new(write),
         );
 
-        let (addrs, family) = addrs_and_family(&agent_endpoint)?;
-        let conn = UdpSocket::bind(family)?;
-        conn.connect(addrs.as_slice())?;
+        let conn = UdpSocket::bind(address_family(&agent_address.as_slice()))?;
+        conn.connect(agent_address.as_slice())?;
 
         Ok(AgentSyncClientUdp {
             conn,
@@ -102,11 +101,11 @@ pub(crate) struct AgentAsyncClientUdp<R: JaegerTraceRuntime> {
 
 impl<R: JaegerTraceRuntime> AgentAsyncClientUdp<R> {
     /// Create a new UDP agent client
-    pub(crate) fn new<T: ToSocketAddrs>(
-        agent_endpoint: T,
+    pub(crate) fn new(
         max_packet_size: usize,
         runtime: R,
         auto_split: bool,
+        agent_address: Vec<SocketAddr>,
     ) -> thrift::Result<Self> {
         let (buffer, write) = TBufferChannel::with_capacity(max_packet_size).split()?;
         let client = agent::AgentSyncClient::new(
@@ -114,7 +113,7 @@ impl<R: JaegerTraceRuntime> AgentAsyncClientUdp<R> {
             TCompactOutputProtocol::new(write),
         );
 
-        let conn = runtime.create_socket(agent_endpoint)?;
+        let conn = runtime.create_socket(agent_address.as_slice())?;
 
         Ok(AgentAsyncClientUdp {
             runtime,

--- a/opentelemetry-jaeger/src/exporter/config/agent.rs
+++ b/opentelemetry-jaeger/src/exporter/config/agent.rs
@@ -1,22 +1,22 @@
-use std::{env, net};
 use std::borrow::BorrowMut;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
+use std::{env, net};
 
 use opentelemetry::trace::TraceError;
+use opentelemetry_sdk::trace::{BatchSpanProcessor, Tracer};
 use opentelemetry_sdk::{
     self,
     trace::{BatchConfig, Config, TracerProvider},
 };
-use opentelemetry_sdk::trace::{BatchSpanProcessor, Tracer};
 
-use crate::{Error, Exporter, JaegerTraceRuntime};
 use crate::exporter::agent::{AgentAsyncClientUdp, AgentSyncClientUdp};
 use crate::exporter::config::{
-    build_config_and_process, HasRequiredConfig, install_tracer_provider_and_get_tracer,
+    build_config_and_process, install_tracer_provider_and_get_tracer, HasRequiredConfig,
     TransformationConfig,
 };
 use crate::exporter::uploader::{AsyncUploader, SyncUploader, Uploader};
+use crate::{Error, Exporter, JaegerTraceRuntime};
 
 /// The max size of UDP packet we want to send, synced with jaeger-agent
 const UDP_PACKET_MAX_LENGTH: usize = 65_000;

--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -1,12 +1,3 @@
-use crate::exporter::config::{
-    build_config_and_process, install_tracer_provider_and_get_tracer, HasRequiredConfig,
-    TransformationConfig,
-};
-use crate::exporter::uploader::{AsyncUploader, Uploader};
-use crate::{Exporter, JaegerTraceRuntime};
-use http::Uri;
-use opentelemetry::trace::TraceError;
-use opentelemetry_sdk::trace::{BatchConfig, BatchSpanProcessor, Config, Tracer, TracerProvider};
 use std::borrow::BorrowMut;
 use std::convert::TryFrom;
 use std::env;
@@ -14,16 +5,25 @@ use std::sync::Arc;
 #[cfg(feature = "collector_client")]
 use std::time::Duration;
 
+use http::Uri;
+
+use opentelemetry::trace::TraceError;
 #[cfg(feature = "collector_client")]
 use opentelemetry_http::HttpClient;
+use opentelemetry_sdk::trace::{BatchConfig, BatchSpanProcessor, Config, Tracer, TracerProvider};
 
 #[cfg(feature = "collector_client")]
 use crate::config::collector::http_client::CollectorHttpClient;
-
 #[cfg(feature = "collector_client")]
 use crate::exporter::collector::AsyncHttpClient;
 #[cfg(feature = "wasm_collector_client")]
 use crate::exporter::collector::WasmCollector;
+use crate::exporter::config::{
+    build_config_and_process, install_tracer_provider_and_get_tracer, HasRequiredConfig,
+    TransformationConfig,
+};
+use crate::exporter::uploader::{AsyncUploader, Uploader};
+use crate::{Exporter, JaegerTraceRuntime};
 
 #[cfg(feature = "collector_client")]
 mod http_client;
@@ -43,7 +43,7 @@ const ENV_TIMEOUT: &str = "OTEL_EXPORTER_JAEGER_TIMEOUT";
 const DEFAULT_COLLECTOR_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Username to send as part of "Basic" authentication to the collector endpoint.
-const ENV_USER: &str = "OTEL_EXPORTER_JAEGER_USER";
+const ENV_USERNAME: &str = "OTEL_EXPORTER_JAEGER_USER";
 
 /// Password to send as part of "Basic" authentication to the collector endpoint.
 const ENV_PASSWORD: &str = "OTEL_EXPORTER_JAEGER_PASSWORD";
@@ -97,7 +97,7 @@ pub struct CollectorPipeline {
     #[cfg(feature = "collector_client")]
     collector_timeout: Duration,
     // only used by builtin http clients.
-    collector_endpoint: Option<Result<http::Uri, http::uri::InvalidUri>>,
+    collector_endpoint: Option<String>,
     collector_username: Option<String>,
     collector_password: Option<String>,
 
@@ -106,7 +106,7 @@ pub struct CollectorPipeline {
 
 impl Default for CollectorPipeline {
     fn default() -> Self {
-        let mut pipeline = Self {
+        Self {
             #[cfg(feature = "collector_client")]
             collector_timeout: DEFAULT_COLLECTOR_TIMEOUT,
             collector_endpoint: None,
@@ -116,33 +116,7 @@ impl Default for CollectorPipeline {
             transformation_config: Default::default(),
             trace_config: Default::default(),
             batch_config: Some(Default::default()),
-        };
-
-        #[cfg(feature = "collector_client")]
-        if let Some(timeout) = env::var(ENV_TIMEOUT).ok().filter(|var| !var.is_empty()) {
-            let timeout = match timeout.parse() {
-                Ok(timeout) => Duration::from_millis(timeout),
-                Err(e) => {
-                    eprintln!("{} malformed defaulting to 10000: {}", ENV_TIMEOUT, e);
-                    DEFAULT_COLLECTOR_TIMEOUT
-                }
-            };
-            pipeline = pipeline.with_timeout(timeout);
         }
-
-        if let Some(endpoint) = env::var(ENV_ENDPOINT).ok().filter(|var| !var.is_empty()) {
-            pipeline = pipeline.with_endpoint(endpoint);
-        }
-
-        if let Some(user) = env::var(ENV_USER).ok().filter(|var| !var.is_empty()) {
-            pipeline = pipeline.with_username(user);
-        }
-
-        if let Some(password) = env::var(ENV_PASSWORD).ok().filter(|var| !var.is_empty()) {
-            pipeline = pipeline.with_password(password);
-        }
-
-        pipeline
     }
 }
 
@@ -224,15 +198,9 @@ impl CollectorPipeline {
     /// Set the collector endpoint.
     ///
     /// E.g. "http://localhost:14268/api/traces"
-    pub fn with_endpoint<T>(self, collector_endpoint: T) -> Self
-    where
-        http::Uri: core::convert::TryFrom<T>,
-        <http::Uri as core::convert::TryFrom<T>>::Error: Into<http::uri::InvalidUri>,
-    {
+    pub fn with_endpoint<T: Into<String>>(self, collector_endpoint: T) -> Self {
         Self {
-            collector_endpoint: Some(
-                core::convert::TryFrom::try_from(collector_endpoint).map_err(Into::into),
-            ),
+            collector_endpoint: Some(collector_endpoint.into()),
             ..self
         }
     }
@@ -491,64 +459,95 @@ impl CollectorPipeline {
     where
         R: JaegerTraceRuntime,
     {
-        let endpoint = self
-            .collector_endpoint
-            .transpose()
-            .map_err::<crate::Error, _>(|err| crate::Error::ConfigError {
-                pipeline_name: "collector",
-                config_name: "collector_endpoint",
-                reason: format!("invalid uri, {}", err),
-            })?
-            .unwrap_or_else(|| {
-                Uri::try_from(DEFAULT_ENDPOINT).unwrap() // default endpoint should always valid
-            });
+        let endpoint = self.resolve_endpoint()?;
+        let username = self.resolve_username();
+        let password = self.resolve_password();
+        #[cfg(feature = "collector_client")]
+        let timeout = self.resolve_timeout();
         match self.client_config {
             #[cfg(feature = "collector_client")]
             ClientConfig::Http { client_type } => {
-                let client = client_type.build_client(
-                    self.collector_username,
-                    self.collector_password,
-                    self.collector_timeout,
-                )?;
+                let client = client_type.build_client(username, password, timeout)?;
 
                 let collector = AsyncHttpClient::new(endpoint, client);
                 Ok(Arc::new(AsyncUploader::<R>::Collector(collector)))
             }
             #[cfg(feature = "wasm_collector_client")]
             ClientConfig::Wasm => {
-                let collector =
-                    WasmCollector::new(endpoint, self.collector_username, self.collector_password)
-                        .map_err::<crate::Error, _>(Into::into)?;
+                let collector = WasmCollector::new(endpoint, username, password)
+                    .map_err::<crate::Error, _>(Into::into)?;
                 Ok(Arc::new(AsyncUploader::<R>::WasmCollector(collector)))
             }
         }
+    }
+
+    fn resolve_env_var(env_var: &'static str) -> Option<String> {
+        env::var(env_var).ok().filter(|var| !var.is_empty())
+    }
+
+    // if provided value from environment variable or the builder is invalid, return error
+    fn resolve_endpoint(&self) -> Result<Uri, crate::Error> {
+        let endpoint_from_env = Self::resolve_env_var(ENV_ENDPOINT)
+            .map(|endpoint| {
+                Uri::try_from(endpoint.as_str()).map_err::<crate::Error, _>(|err| {
+                    crate::Error::ConfigError {
+                        pipeline_name: "collector",
+                        config_name: "collector_endpoint",
+                        reason: format!("invalid uri from environment variable, {}", err),
+                    }
+                })
+            })
+            .transpose()?;
+
+        Ok(match endpoint_from_env {
+            Some(endpoint) => endpoint,
+            None => {
+                if let Some(endpoint) = &self.collector_endpoint {
+                    Uri::try_from(endpoint.as_str()).map_err::<crate::Error, _>(|err| {
+                        crate::Error::ConfigError {
+                            pipeline_name: "collector",
+                            config_name: "collector_endpoint",
+                            reason: format!("invalid uri from the builder, {}", err),
+                        }
+                    })?
+                } else {
+                    Uri::try_from(DEFAULT_ENDPOINT).unwrap() // default endpoint should always valid
+                }
+            }
+        })
+    }
+
+    #[cfg(feature = "collector_client")]
+    fn resolve_timeout(&self) -> Duration {
+        match Self::resolve_env_var(ENV_TIMEOUT) {
+            Some(timeout) => match timeout.parse() {
+                Ok(timeout) => Duration::from_millis(timeout),
+                Err(e) => {
+                    eprintln!("{} malformed defaulting to 10s: {}", ENV_TIMEOUT, e);
+                    self.collector_timeout
+                }
+            },
+            None => self.collector_timeout,
+        }
+    }
+
+    fn resolve_username(&self) -> Option<String> {
+        Self::resolve_env_var(ENV_USERNAME).or_else(|| self.collector_username.clone())
+    }
+
+    fn resolve_password(&self) -> Option<String> {
+        Self::resolve_env_var(ENV_PASSWORD).or_else(|| self.collector_password.clone())
     }
 }
 
 #[cfg(test)]
 #[cfg(feature = "rt-tokio")]
 mod tests {
-    use super::*;
-    use crate::config::collector::http_client::test_http_client;
     use opentelemetry_sdk::runtime::Tokio;
 
-    #[test]
-    fn test_collector_defaults() {
-        // No Env Variable
-        std::env::remove_var(ENV_TIMEOUT);
-        let builder = CollectorPipeline::default();
-        assert_eq!(DEFAULT_COLLECTOR_TIMEOUT, builder.collector_timeout);
+    use crate::config::collector::http_client::test_http_client;
 
-        // Bad Env Variable
-        std::env::set_var(ENV_TIMEOUT, "a");
-        let builder = CollectorPipeline::default();
-        assert_eq!(DEFAULT_COLLECTOR_TIMEOUT, builder.collector_timeout);
-
-        // Good Env Variable
-        std::env::set_var(ENV_TIMEOUT, "777");
-        let builder = CollectorPipeline::default();
-        assert_eq!(Duration::from_millis(777), builder.collector_timeout);
-    }
+    use super::*;
 
     #[test]
     fn test_set_collector_endpoint() {

--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -523,7 +523,7 @@ impl CollectorPipeline {
             Some(timeout) => match timeout.parse() {
                 Ok(timeout) => Duration::from_millis(timeout),
                 Err(e) => {
-                    eprintln!("{} malformed defaulting to 10s: {}", ENV_TIMEOUT, e);
+                    eprintln!("{} malformed default to 10s: {}", ENV_TIMEOUT, e);
                     self.collector_timeout
                 }
             },
@@ -558,7 +558,7 @@ mod tests {
         assert!(invalid_uri.is_err());
         assert_eq!(
             format!("{:?}", invalid_uri.err().unwrap()),
-            "ConfigError { pipeline_name: \"collector\", config_name: \"collector_endpoint\", reason: \"invalid uri, invalid format\" }",
+            "ConfigError { pipeline_name: \"collector\", config_name: \"collector_endpoint\", reason: \"invalid uri from the builder, invalid format\" }",
         );
 
         let valid_uri = new_collector_pipeline()

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -6,8 +6,7 @@
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::fmt::Display;
-use std::io;
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -3,6 +3,12 @@
     feature = "rt-tokio",
     feature = "rt-tokio-current-thread"
 ))]
+use crate::exporter::address_family;
+#[cfg(any(
+    feature = "rt-async-std",
+    feature = "rt-tokio",
+    feature = "rt-tokio-current-thread"
+))]
 use async_trait::async_trait;
 use opentelemetry_sdk::runtime::RuntimeChannel;
 use std::net::ToSocketAddrs;

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -4,11 +4,6 @@
     feature = "rt-tokio-current-thread"
 ))]
 use crate::exporter::address_family;
-#[cfg(any(
-    feature = "rt-async-std",
-    feature = "rt-tokio",
-    feature = "rt-tokio-current-thread"
-))]
 use async_trait::async_trait;
 use opentelemetry_sdk::runtime::RuntimeChannel;
 use std::net::ToSocketAddrs;

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -29,8 +29,8 @@ impl JaegerTraceRuntime for opentelemetry_sdk::runtime::Tokio {
     type Socket = tokio::net::UdpSocket;
 
     fn create_socket<T: ToSocketAddrs>(&self, endpoint: T) -> thrift::Result<Self::Socket> {
-        let (addrs, family) = addrs_and_family(&endpoint)?;
-        let conn = std::net::UdpSocket::bind(family)?;
+        let addrs = endpoint.to_socket_addrs()?.collect::<Vec<_>>();
+        let conn = std::net::UdpSocket::bind(address_family(addrs.as_slice()))?;
         conn.connect(addrs.as_slice())?;
         Ok(tokio::net::UdpSocket::from_std(conn)?)
     }
@@ -48,8 +48,8 @@ impl JaegerTraceRuntime for opentelemetry_sdk::runtime::TokioCurrentThread {
     type Socket = tokio::net::UdpSocket;
 
     fn create_socket<T: ToSocketAddrs>(&self, endpoint: T) -> thrift::Result<Self::Socket> {
-        let (addrs, family) = addrs_and_family(&endpoint)?;
-        let conn = std::net::UdpSocket::bind(family)?;
+        let addrs = endpoint.to_socket_addrs()?.collect::<Vec<_>>();
+        let conn = std::net::UdpSocket::bind(address_family(addrs.as_slice()))?;
         conn.connect(addrs.as_slice())?;
         Ok(tokio::net::UdpSocket::from_std(conn)?)
     }
@@ -67,8 +67,8 @@ impl JaegerTraceRuntime for opentelemetry_sdk::runtime::AsyncStd {
     type Socket = async_std::net::UdpSocket;
 
     fn create_socket<T: ToSocketAddrs>(&self, endpoint: T) -> thrift::Result<Self::Socket> {
-        let (addrs, family) = addrs_and_family(&endpoint)?;
-        let conn = std::net::UdpSocket::bind(family)?;
+        let addrs = endpoint.to_socket_addrs()?.collect::<Vec<_>>();
+        let conn = std::net::UdpSocket::bind(address_family(addrs.as_slice()))?;
         conn.connect(addrs.as_slice())?;
         Ok(async_std::net::UdpSocket::from(conn))
     }

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -3,7 +3,6 @@
     feature = "rt-tokio",
     feature = "rt-tokio-current-thread"
 ))]
-use crate::exporter::addrs_and_family;
 use async_trait::async_trait;
 use opentelemetry_sdk::runtime::RuntimeChannel;
 use std::net::ToSocketAddrs;


### PR DESCRIPTION
Fixes #1225 

## Changes

- add document to show we favor env vars over compiling time values
- correct Jaeger exporter builders to use the correct configuration methods

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
