### PR TITLE
More distinct naming of metrics constructs in the SDK

### DIFF
--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -1,11 +1,13 @@
 use opentelemetry::metrics::Unit;
 use opentelemetry::Key;
 use opentelemetry::{metrics::MeterProvider as _, KeyValue};
-use opentelemetry_sdk::metrics::{Aggregation, Instrument, MeterProvider, PeriodicReader, Stream};
+use opentelemetry_sdk::metrics::{
+    Aggregation, DefaultMeterProvider, Instrument, PeriodicReader, Stream,
+};
 use opentelemetry_sdk::{runtime, Resource};
 use std::error::Error;
 
-fn init_meter_provider() -> MeterProvider {
+fn init_meter_provider() -> DefaultMeterProvider {
     // for example 1
     let my_view_rename_and_unit = |i: &Instrument| {
         if i.name == "my_histogram" {
@@ -48,7 +50,7 @@ fn init_meter_provider() -> MeterProvider {
         //   Ok(serde_json::to_writer_pretty(writer, &data).unwrap()))
         .build();
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
-    MeterProvider::builder()
+    DefaultMeterProvider::builder()
         .with_reader(reader)
         .with_resource(Resource::new(vec![KeyValue::new(
             "service.name",

--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -2,12 +2,12 @@ use opentelemetry::metrics::Unit;
 use opentelemetry::Key;
 use opentelemetry::{metrics::MeterProvider as _, KeyValue};
 use opentelemetry_sdk::metrics::{
-    Aggregation, DefaultMeterProvider, Instrument, PeriodicReader, Stream,
+    Aggregation, Instrument, PeriodicReader, SdkMeterProvider, Stream,
 };
 use opentelemetry_sdk::{runtime, Resource};
 use std::error::Error;
 
-fn init_meter_provider() -> DefaultMeterProvider {
+fn init_meter_provider() -> SdkMeterProvider {
     // for example 1
     let my_view_rename_and_unit = |i: &Instrument| {
         if i.name == "my_histogram" {
@@ -50,7 +50,7 @@ fn init_meter_provider() -> DefaultMeterProvider {
         //   Ok(serde_json::to_writer_pretty(writer, &data).unwrap()))
         .build();
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
-    DefaultMeterProvider::builder()
+    SdkMeterProvider::builder()
         .with_reader(reader)
         .with_resource(Resource::new(vec![KeyValue::new(
             "service.name",

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -1,17 +1,17 @@
 use opentelemetry::metrics::Unit;
 use opentelemetry::{metrics::MeterProvider as _, KeyValue};
-use opentelemetry_sdk::metrics::{MeterProvider, PeriodicReader};
+use opentelemetry_sdk::metrics::{DefaultMeterProvider, PeriodicReader};
 use opentelemetry_sdk::{runtime, Resource};
 use std::error::Error;
 
-fn init_meter_provider() -> MeterProvider {
+fn init_meter_provider() -> DefaultMeterProvider {
     let exporter = opentelemetry_stdout::MetricsExporterBuilder::default()
         // uncomment the below lines to pretty print output.
         //  .with_encoder(|writer, data|
         //    Ok(serde_json::to_writer_pretty(writer, &data).unwrap()))
         .build();
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
-    MeterProvider::builder()
+    DefaultMeterProvider::builder()
         .with_reader(reader)
         .with_resource(Resource::new(vec![KeyValue::new(
             "service.name",

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -1,17 +1,17 @@
 use opentelemetry::metrics::Unit;
 use opentelemetry::{metrics::MeterProvider as _, KeyValue};
-use opentelemetry_sdk::metrics::{DefaultMeterProvider, PeriodicReader};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::{runtime, Resource};
 use std::error::Error;
 
-fn init_meter_provider() -> DefaultMeterProvider {
+fn init_meter_provider() -> SdkMeterProvider {
     let exporter = opentelemetry_stdout::MetricsExporterBuilder::default()
         // uncomment the below lines to pretty print output.
         //  .with_encoder(|writer, data|
         //    Ok(serde_json::to_writer_pretty(writer, &data).unwrap()))
         .build();
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
-    DefaultMeterProvider::builder()
+    SdkMeterProvider::builder()
         .with_reader(reader)
         .with_resource(Resource::new(vec![KeyValue::new(
             "service.name",

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -44,7 +44,7 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
         .install_batch(opentelemetry_sdk::runtime::Tokio)
 }
 
-fn init_metrics() -> metrics::Result<sdkmetrics::MeterProvider> {
+fn init_metrics() -> metrics::Result<sdkmetrics::DefaultMeterProvider> {
     let export_config = opentelemetry_otlp::ExportConfig {
         endpoint: "http://localhost:4318/v1/metrics".to_string(),
         ..opentelemetry_otlp::ExportConfig::default()

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -44,7 +44,7 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
         .install_batch(opentelemetry_sdk::runtime::Tokio)
 }
 
-fn init_metrics() -> metrics::Result<sdkmetrics::DefaultMeterProvider> {
+fn init_metrics() -> metrics::Result<sdkmetrics::SdkMeterProvider> {
     let export_config = opentelemetry_otlp::ExportConfig {
         endpoint: "http://localhost:4318/v1/metrics".to_string(),
         ..opentelemetry_otlp::ExportConfig::default()

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -12,7 +12,7 @@ use opentelemetry::{
 use opentelemetry_appender_log::OpenTelemetryLogBridge;
 use opentelemetry_otlp::{ExportConfig, WithExportConfig};
 use opentelemetry_sdk::logs::Config;
-use opentelemetry_sdk::{metrics::DefaultMeterProvider, runtime, trace as sdktrace, Resource};
+use opentelemetry_sdk::{metrics::SdkMeterProvider, runtime, trace as sdktrace, Resource};
 use std::error::Error;
 
 fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
@@ -32,7 +32,7 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
         .install_batch(runtime::Tokio)
 }
 
-fn init_metrics() -> metrics::Result<DefaultMeterProvider> {
+fn init_metrics() -> metrics::Result<SdkMeterProvider> {
     let export_config = ExportConfig {
         endpoint: "http://localhost:4317".to_string(),
         ..ExportConfig::default()

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -12,7 +12,7 @@ use opentelemetry::{
 use opentelemetry_appender_log::OpenTelemetryLogBridge;
 use opentelemetry_otlp::{ExportConfig, WithExportConfig};
 use opentelemetry_sdk::logs::Config;
-use opentelemetry_sdk::{metrics::MeterProvider, runtime, trace as sdktrace, Resource};
+use opentelemetry_sdk::{metrics::DefaultMeterProvider, runtime, trace as sdktrace, Resource};
 use std::error::Error;
 
 fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
@@ -32,7 +32,7 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
         .install_batch(runtime::Tokio)
 }
 
-fn init_metrics() -> metrics::Result<MeterProvider> {
+fn init_metrics() -> metrics::Result<DefaultMeterProvider> {
     let export_config = ExportConfig {
         endpoint: "http://localhost:4317".to_string(),
         ..ExportConfig::default()

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -18,7 +18,7 @@ use opentelemetry_sdk::{
             AggregationSelector, DefaultAggregationSelector, DefaultTemporalitySelector,
             TemporalitySelector,
         },
-        Aggregation, InstrumentKind, MeterProvider, PeriodicReader,
+        Aggregation, DefaultMeterProvider, InstrumentKind, PeriodicReader,
     },
     runtime::Runtime,
     Resource,
@@ -215,7 +215,7 @@ where
     RT: Runtime,
 {
     /// Build MeterProvider
-    pub fn build(self) -> Result<MeterProvider> {
+    pub fn build(self) -> Result<DefaultMeterProvider> {
         let exporter = self.exporter_pipeline.build_metrics_exporter(
             self.temporality_selector
                 .unwrap_or_else(|| Box::new(DefaultTemporalitySelector::new())),
@@ -234,7 +234,7 @@ where
 
         let reader = builder.build();
 
-        let mut provider = MeterProvider::builder().with_reader(reader);
+        let mut provider = DefaultMeterProvider::builder().with_reader(reader);
 
         if let Some(resource) = self.resource {
             provider = provider.with_resource(resource);

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -18,7 +18,7 @@ use opentelemetry_sdk::{
             AggregationSelector, DefaultAggregationSelector, DefaultTemporalitySelector,
             TemporalitySelector,
         },
-        Aggregation, DefaultMeterProvider, InstrumentKind, PeriodicReader,
+        Aggregation, InstrumentKind, PeriodicReader, SdkMeterProvider,
     },
     runtime::Runtime,
     Resource,
@@ -215,7 +215,7 @@ where
     RT: Runtime,
 {
     /// Build MeterProvider
-    pub fn build(self) -> Result<DefaultMeterProvider> {
+    pub fn build(self) -> Result<SdkMeterProvider> {
         let exporter = self.exporter_pipeline.build_metrics_exporter(
             self.temporality_selector
                 .unwrap_or_else(|| Box::new(DefaultTemporalitySelector::new())),
@@ -234,7 +234,7 @@ where
 
         let reader = builder.build();
 
-        let mut provider = DefaultMeterProvider::builder().with_reader(reader);
+        let mut provider = SdkMeterProvider::builder().with_reader(reader);
 
         if let Some(resource) = self.resource {
             provider = provider.with_resource(resource);

--- a/opentelemetry-prometheus/examples/hyper.rs
+++ b/opentelemetry-prometheus/examples/hyper.rs
@@ -8,7 +8,7 @@ use opentelemetry::{
     metrics::{Counter, Histogram, MeterProvider as _, Unit},
     KeyValue,
 };
-use opentelemetry_sdk::metrics::DefaultMeterProvider;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use prometheus::{Encoder, Registry, TextEncoder};
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -71,9 +71,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let exporter = opentelemetry_prometheus::exporter()
         .with_registry(registry.clone())
         .build()?;
-    let provider = DefaultMeterProvider::builder()
-        .with_reader(exporter)
-        .build();
+    let provider = SdkMeterProvider::builder().with_reader(exporter).build();
 
     let meter = provider.meter("hyper-example");
     let state = Arc::new(AppState {

--- a/opentelemetry-prometheus/examples/hyper.rs
+++ b/opentelemetry-prometheus/examples/hyper.rs
@@ -8,7 +8,7 @@ use opentelemetry::{
     metrics::{Counter, Histogram, MeterProvider as _, Unit},
     KeyValue,
 };
-use opentelemetry_sdk::metrics::MeterProvider;
+use opentelemetry_sdk::metrics::DefaultMeterProvider;
 use prometheus::{Encoder, Registry, TextEncoder};
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -71,7 +71,9 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let exporter = opentelemetry_prometheus::exporter()
         .with_registry(registry.clone())
         .build()?;
-    let provider = MeterProvider::builder().with_reader(exporter).build();
+    let provider = DefaultMeterProvider::builder()
+        .with_reader(exporter)
+        .build();
 
     let meter = provider.meter("hyper-example");
     let state = Arc::new(AppState {

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -3,7 +3,7 @@
 //! [Prometheus]: https://prometheus.io
 //!
 //! ```
-//! use opentelemetry::{metrics::MeterProvider as _, KeyValue};
+//! use opentelemetry::{metrics::MeterProvider, KeyValue};
 //! use opentelemetry_sdk::metrics::SdkMeterProvider;
 //! use prometheus::{Encoder, TextEncoder};
 //!
@@ -18,7 +18,7 @@
 //!     .build()?;
 //!
 //! // set up a meter meter to create instruments
-//! let provider = MeterProvider::builder().with_reader(exporter).build();
+//! let provider = SdkMeterProvider::builder().with_reader(exporter).build();
 //! let meter = provider.meter("my-app");
 //!
 //! // Use two instruments

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ```
 //! use opentelemetry::{metrics::MeterProvider as _, KeyValue};
-//! use opentelemetry_sdk::metrics::DefaultMeterProvider;
+//! use opentelemetry_sdk::metrics::SdkMeterProvider;
 //! use prometheus::{Encoder, TextEncoder};
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ```
 //! use opentelemetry::{metrics::MeterProvider as _, KeyValue};
-//! use opentelemetry_sdk::metrics::MeterProvider;
+//! use opentelemetry_sdk::metrics::DefaultMeterProvider;
 //! use prometheus::{Encoder, TextEncoder};
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -6,7 +6,7 @@ use opentelemetry::metrics::{Meter, MeterProvider as _, Unit};
 use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use opentelemetry_prometheus::ExporterBuilder;
-use opentelemetry_sdk::metrics::{new_view, Aggregation, DefaultMeterProvider, Instrument, Stream};
+use opentelemetry_sdk::metrics::{new_view, Aggregation, Instrument, SdkMeterProvider, Stream};
 use opentelemetry_sdk::resource::{
     EnvResourceDetector, SdkProvidedResourceDetector, TelemetryResourceDetector,
 };
@@ -336,7 +336,7 @@ fn prometheus_exporter_integration() {
             ))
         };
 
-        let provider = DefaultMeterProvider::builder()
+        let provider = SdkMeterProvider::builder()
             .with_resource(res)
             .with_reader(exporter)
             .with_view(
@@ -395,7 +395,7 @@ fn multiple_scopes() {
         TELEMETRY_SDK_VERSION.string("latest"),
     ]));
 
-    let provider = DefaultMeterProvider::builder()
+    let provider = SdkMeterProvider::builder()
         .with_reader(exporter)
         .with_resource(resource)
         .build();
@@ -730,7 +730,7 @@ fn duplicate_metrics() {
             .chain(tc.custom_resource_attrs.into_iter()),
         ));
 
-        let provider = DefaultMeterProvider::builder()
+        let provider = SdkMeterProvider::builder()
             .with_resource(resource)
             .with_reader(exporter)
             .build();

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -6,7 +6,7 @@ use opentelemetry::metrics::{Meter, MeterProvider as _, Unit};
 use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use opentelemetry_prometheus::ExporterBuilder;
-use opentelemetry_sdk::metrics::{new_view, Aggregation, Instrument, MeterProvider, Stream};
+use opentelemetry_sdk::metrics::{new_view, Aggregation, DefaultMeterProvider, Instrument, Stream};
 use opentelemetry_sdk::resource::{
     EnvResourceDetector, SdkProvidedResourceDetector, TelemetryResourceDetector,
 };
@@ -336,7 +336,7 @@ fn prometheus_exporter_integration() {
             ))
         };
 
-        let provider = MeterProvider::builder()
+        let provider = DefaultMeterProvider::builder()
             .with_resource(res)
             .with_reader(exporter)
             .with_view(
@@ -395,7 +395,7 @@ fn multiple_scopes() {
         TELEMETRY_SDK_VERSION.string("latest"),
     ]));
 
-    let provider = MeterProvider::builder()
+    let provider = DefaultMeterProvider::builder()
         .with_reader(exporter)
         .with_resource(resource)
         .build();
@@ -730,7 +730,7 @@ fn duplicate_metrics() {
             .chain(tc.custom_resource_attrs.into_iter()),
         ));
 
-        let provider = MeterProvider::builder()
+        let provider = DefaultMeterProvider::builder()
             .with_resource(resource)
             .with_reader(exporter)
             .build();

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- Renamed `MeterProvider` and `Meter` to `SdkMeterProvider` and `SdkMeter` respectively to avoid name collision with public API types. [#1328](https://github.com/open-telemetry/opentelemetry-rust/pull/1328)
 - Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Default Resource (the one used when no other Resource is explicitly provided) now includes `TelemetryResourceDetector`,
   populating "telemetry.sdk.*" attributes.

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -11,8 +11,8 @@ use opentelemetry_sdk::{
         data::{ResourceMetrics, Temporality},
         new_view,
         reader::{AggregationSelector, MetricReader, TemporalitySelector},
-        Aggregation, DefaultMeterProvider, Instrument, InstrumentKind, ManualReader, Pipeline,
-        Stream, View,
+        Aggregation, Instrument, InstrumentKind, ManualReader, Pipeline, SdkMeterProvider, Stream,
+        View,
     },
     Resource,
 };
@@ -150,7 +150,7 @@ fn bench_counter(view: Option<Box<dyn View>>, temporality: &str) -> (SharedReade
                 .build(),
         ))
     };
-    let mut builder = DefaultMeterProvider::builder().with_reader(rdr.clone());
+    let mut builder = SdkMeterProvider::builder().with_reader(rdr.clone());
     if let Some(view) = view {
         builder = builder.with_view(view);
     }
@@ -367,7 +367,7 @@ fn bench_histogram(bound_count: usize) -> (SharedReader, Histogram<i64>) {
     );
 
     let r = SharedReader(Arc::new(ManualReader::default()));
-    let mut builder = DefaultMeterProvider::builder().with_reader(r.clone());
+    let mut builder = SdkMeterProvider::builder().with_reader(r.clone());
     if let Some(view) = view {
         builder = builder.with_view(view);
     }
@@ -408,7 +408,7 @@ fn histograms(c: &mut Criterion) {
 
 fn benchmark_collect_histogram(b: &mut Bencher, n: usize) {
     let r = SharedReader(Arc::new(ManualReader::default()));
-    let mtr = DefaultMeterProvider::builder()
+    let mtr = SdkMeterProvider::builder()
         .with_reader(r.clone())
         .build()
         .meter("sdk/metric/bench/histogram");

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -11,8 +11,8 @@ use opentelemetry_sdk::{
         data::{ResourceMetrics, Temporality},
         new_view,
         reader::{AggregationSelector, MetricReader, TemporalitySelector},
-        Aggregation, Instrument, InstrumentKind, ManualReader, MeterProvider, Pipeline, Stream,
-        View,
+        Aggregation, DefaultMeterProvider, Instrument, InstrumentKind, ManualReader, Pipeline,
+        Stream, View,
     },
     Resource,
 };
@@ -150,7 +150,7 @@ fn bench_counter(view: Option<Box<dyn View>>, temporality: &str) -> (SharedReade
                 .build(),
         ))
     };
-    let mut builder = MeterProvider::builder().with_reader(rdr.clone());
+    let mut builder = DefaultMeterProvider::builder().with_reader(rdr.clone());
     if let Some(view) = view {
         builder = builder.with_view(view);
     }
@@ -367,7 +367,7 @@ fn bench_histogram(bound_count: usize) -> (SharedReader, Histogram<i64>) {
     );
 
     let r = SharedReader(Arc::new(ManualReader::default()));
-    let mut builder = MeterProvider::builder().with_reader(r.clone());
+    let mut builder = DefaultMeterProvider::builder().with_reader(r.clone());
     if let Some(view) = view {
         builder = builder.with_view(view);
     }
@@ -408,7 +408,7 @@ fn histograms(c: &mut Criterion) {
 
 fn benchmark_collect_histogram(b: &mut Bencher, n: usize) {
     let r = SharedReader(Arc::new(ManualReader::default()));
-    let mtr = MeterProvider::builder()
+    let mtr = DefaultMeterProvider::builder()
         .with_reader(r.clone())
         .build()
         .meter("sdk/metric/bench/histogram");

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -248,11 +248,11 @@ impl InstrumentId {
     }
 }
 
-pub(crate) struct DefaultInstrument<T> {
+pub(crate) struct ResolvedMeasures<T> {
     pub(crate) measures: Vec<Arc<dyn Measure<T>>>,
 }
 
-impl<T: Copy + 'static> SyncCounter<T> for DefaultInstrument<T> {
+impl<T: Copy + 'static> SyncCounter<T> for ResolvedMeasures<T> {
     fn add(&self, val: T, attrs: &[KeyValue]) {
         for measure in &self.measures {
             measure.call(val, AttributeSet::from(attrs))
@@ -260,7 +260,7 @@ impl<T: Copy + 'static> SyncCounter<T> for DefaultInstrument<T> {
     }
 }
 
-impl<T: Copy + 'static> SyncUpDownCounter<T> for DefaultInstrument<T> {
+impl<T: Copy + 'static> SyncUpDownCounter<T> for ResolvedMeasures<T> {
     fn add(&self, val: T, attrs: &[KeyValue]) {
         for measure in &self.measures {
             measure.call(val, AttributeSet::from(attrs))
@@ -268,7 +268,7 @@ impl<T: Copy + 'static> SyncUpDownCounter<T> for DefaultInstrument<T> {
     }
 }
 
-impl<T: Copy + 'static> SyncHistogram<T> for DefaultInstrument<T> {
+impl<T: Copy + 'static> SyncHistogram<T> for ResolvedMeasures<T> {
     fn record(&self, val: T, attrs: &[KeyValue]) {
         for measure in &self.measures {
             measure.call(val, AttributeSet::from(attrs))

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -248,11 +248,11 @@ impl InstrumentId {
     }
 }
 
-pub(crate) struct InstrumentImpl<T> {
+pub(crate) struct DefaultInstrument<T> {
     pub(crate) measures: Vec<Arc<dyn Measure<T>>>,
 }
 
-impl<T: Copy + 'static> SyncCounter<T> for InstrumentImpl<T> {
+impl<T: Copy + 'static> SyncCounter<T> for DefaultInstrument<T> {
     fn add(&self, val: T, attrs: &[KeyValue]) {
         for measure in &self.measures {
             measure.call(val, AttributeSet::from(attrs))
@@ -260,7 +260,7 @@ impl<T: Copy + 'static> SyncCounter<T> for InstrumentImpl<T> {
     }
 }
 
-impl<T: Copy + 'static> SyncUpDownCounter<T> for InstrumentImpl<T> {
+impl<T: Copy + 'static> SyncUpDownCounter<T> for DefaultInstrument<T> {
     fn add(&self, val: T, attrs: &[KeyValue]) {
         for measure in &self.measures {
             measure.call(val, AttributeSet::from(attrs))
@@ -268,7 +268,7 @@ impl<T: Copy + 'static> SyncUpDownCounter<T> for InstrumentImpl<T> {
     }
 }
 
-impl<T: Copy + 'static> SyncHistogram<T> for InstrumentImpl<T> {
+impl<T: Copy + 'static> SyncHistogram<T> for DefaultInstrument<T> {
     fn record(&self, val: T, attrs: &[KeyValue]) {
         for measure in &self.measures {
             measure.call(val, AttributeSet::from(attrs))

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -87,7 +87,7 @@ impl InstrumentProvider for DefaultMeter {
         unit: Option<Unit>,
     ) -> Result<Counter<u64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.u64_resolver);
+        let p = InstrumentResolver::new(self, &self.u64_resolver);
         p.lookup(
             InstrumentKind::Counter,
             name,
@@ -104,7 +104,7 @@ impl InstrumentProvider for DefaultMeter {
         unit: Option<Unit>,
     ) -> Result<Counter<f64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.f64_resolver);
+        let p = InstrumentResolver::new(self, &self.f64_resolver);
         p.lookup(
             InstrumentKind::Counter,
             name,
@@ -122,7 +122,7 @@ impl InstrumentProvider for DefaultMeter {
         callbacks: Vec<Callback<u64>>,
     ) -> Result<ObservableCounter<u64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.u64_resolver);
+        let p = InstrumentResolver::new(self, &self.u64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableCounter,
             name.clone(),
@@ -159,7 +159,7 @@ impl InstrumentProvider for DefaultMeter {
         callbacks: Vec<Callback<f64>>,
     ) -> Result<ObservableCounter<f64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.f64_resolver);
+        let p = InstrumentResolver::new(self, &self.f64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableCounter,
             name.clone(),
@@ -194,7 +194,7 @@ impl InstrumentProvider for DefaultMeter {
         unit: Option<Unit>,
     ) -> Result<UpDownCounter<i64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.i64_resolver);
+        let p = InstrumentResolver::new(self, &self.i64_resolver);
         p.lookup(
             InstrumentKind::UpDownCounter,
             name,
@@ -211,7 +211,7 @@ impl InstrumentProvider for DefaultMeter {
         unit: Option<Unit>,
     ) -> Result<UpDownCounter<f64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.f64_resolver);
+        let p = InstrumentResolver::new(self, &self.f64_resolver);
         p.lookup(
             InstrumentKind::UpDownCounter,
             name,
@@ -229,7 +229,7 @@ impl InstrumentProvider for DefaultMeter {
         callbacks: Vec<Callback<i64>>,
     ) -> Result<ObservableUpDownCounter<i64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.i64_resolver);
+        let p = InstrumentResolver::new(self, &self.i64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableUpDownCounter,
             name.clone(),
@@ -268,7 +268,7 @@ impl InstrumentProvider for DefaultMeter {
         callbacks: Vec<Callback<f64>>,
     ) -> Result<ObservableUpDownCounter<f64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.f64_resolver);
+        let p = InstrumentResolver::new(self, &self.f64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableUpDownCounter,
             name.clone(),
@@ -307,7 +307,7 @@ impl InstrumentProvider for DefaultMeter {
         callbacks: Vec<Callback<u64>>,
     ) -> Result<ObservableGauge<u64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.u64_resolver);
+        let p = InstrumentResolver::new(self, &self.u64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableGauge,
             name.clone(),
@@ -344,7 +344,7 @@ impl InstrumentProvider for DefaultMeter {
         callbacks: Vec<Callback<i64>>,
     ) -> Result<ObservableGauge<i64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.i64_resolver);
+        let p = InstrumentResolver::new(self, &self.i64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableGauge,
             name.clone(),
@@ -381,7 +381,7 @@ impl InstrumentProvider for DefaultMeter {
         callbacks: Vec<Callback<f64>>,
     ) -> Result<ObservableGauge<f64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.f64_resolver);
+        let p = InstrumentResolver::new(self, &self.f64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableGauge,
             name.clone(),
@@ -417,7 +417,7 @@ impl InstrumentProvider for DefaultMeter {
         unit: Option<Unit>,
     ) -> Result<Histogram<f64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.f64_resolver);
+        let p = InstrumentResolver::new(self, &self.f64_resolver);
         p.lookup(
             InstrumentKind::Histogram,
             name,
@@ -434,7 +434,7 @@ impl InstrumentProvider for DefaultMeter {
         unit: Option<Unit>,
     ) -> Result<Histogram<u64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.u64_resolver);
+        let p = InstrumentResolver::new(self, &self.u64_resolver);
         p.lookup(
             InstrumentKind::Histogram,
             name,
@@ -451,7 +451,7 @@ impl InstrumentProvider for DefaultMeter {
         unit: Option<Unit>,
     ) -> Result<Histogram<i64>> {
         validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
-        let p = InstProvider::new(self, &self.i64_resolver);
+        let p = InstrumentResolver::new(self, &self.i64_resolver);
 
         p.lookup(
             InstrumentKind::Histogram,
@@ -679,20 +679,20 @@ impl fmt::Debug for DefaultMeter {
 }
 
 /// Provides all OpenTelemetry instruments.
-struct InstProvider<'a, T> {
+struct InstrumentResolver<'a, T> {
     meter: &'a DefaultMeter,
     resolve: &'a Resolver<T>,
 }
 
-impl<'a, T> InstProvider<'a, T>
+impl<'a, T> InstrumentResolver<'a, T>
 where
     T: Number<T>,
 {
     fn new(meter: &'a DefaultMeter, resolve: &'a Resolver<T>) -> Self {
-        InstProvider { meter, resolve }
+        InstrumentResolver { meter, resolve }
     }
 
-    /// lookup returns the resolved InstrumentImpl.
+    /// lookup returns the resolved DefaultInstrument.
     fn lookup(
         &self,
         kind: InstrumentKind,

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -15,7 +15,7 @@ use opentelemetry::{
 use crate::instrumentation::Scope;
 use crate::metrics::{
     instrument::{
-        Instrument, InstrumentImpl, InstrumentKind, Observable, ObservableId, EMPTY_MEASURE_MSG,
+        DefaultInstrument, Instrument, InstrumentKind, Observable, ObservableId, EMPTY_MEASURE_MSG,
     },
     internal::{self, Number},
     pipeline::{Pipelines, Resolver},
@@ -699,9 +699,9 @@ where
         name: Cow<'static, str>,
         description: Option<Cow<'static, str>>,
         unit: Unit,
-    ) -> Result<InstrumentImpl<T>> {
+    ) -> Result<DefaultInstrument<T>> {
         let aggregators = self.measures(kind, name, description, unit)?;
-        Ok(InstrumentImpl {
+        Ok(DefaultInstrument {
             measures: aggregators,
         })
     }

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -15,7 +15,7 @@ use opentelemetry::{
 use crate::instrumentation::Scope;
 use crate::metrics::{
     instrument::{
-        DefaultInstrument, Instrument, InstrumentKind, Observable, ObservableId, EMPTY_MEASURE_MSG,
+        Instrument, InstrumentKind, Observable, ObservableId, ResolvedMeasures, EMPTY_MEASURE_MSG,
     },
     internal::{self, Number},
     pipeline::{Pipelines, Resolver},
@@ -692,16 +692,16 @@ where
         InstrumentResolver { meter, resolve }
     }
 
-    /// lookup returns the resolved DefaultInstrument.
+    /// lookup returns the resolved measures.
     fn lookup(
         &self,
         kind: InstrumentKind,
         name: Cow<'static, str>,
         description: Option<Cow<'static, str>>,
         unit: Unit,
-    ) -> Result<DefaultInstrument<T>> {
+    ) -> Result<ResolvedMeasures<T>> {
         let aggregators = self.measures(kind, name, description, unit)?;
-        Ok(DefaultInstrument {
+        Ok(ResolvedMeasures {
             measures: aggregators,
         })
     }

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -46,7 +46,7 @@ const INSTRUMENT_UNIT_INVALID_CHAR: &str = "characters in instrument unit must b
 /// See the [Meter API] docs for usage.
 ///
 /// [Meter API]: opentelemetry::metrics::Meter
-pub struct Meter {
+pub struct DefaultMeter {
     scope: Scope,
     pipes: Arc<Pipelines>,
     u64_resolver: Resolver<u64>,
@@ -55,11 +55,11 @@ pub struct Meter {
     validation_policy: InstrumentValidationPolicy,
 }
 
-impl Meter {
+impl DefaultMeter {
     pub(crate) fn new(scope: Scope, pipes: Arc<Pipelines>) -> Self {
         let view_cache = Default::default();
 
-        Meter {
+        DefaultMeter {
             scope,
             pipes: Arc::clone(&pipes),
             u64_resolver: Resolver::new(Arc::clone(&pipes), Arc::clone(&view_cache)),
@@ -79,7 +79,7 @@ impl Meter {
 }
 
 #[doc(hidden)]
-impl InstrumentProvider for Meter {
+impl InstrumentProvider for DefaultMeter {
     fn u64_counter(
         &self,
         name: Cow<'static, str>,
@@ -672,7 +672,7 @@ impl ApiObserver for Observer {
     }
 }
 
-impl fmt::Debug for Meter {
+impl fmt::Debug for DefaultMeter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Meter").field("scope", &self.scope).finish()
     }
@@ -680,7 +680,7 @@ impl fmt::Debug for Meter {
 
 /// Provides all OpenTelemetry instruments.
 struct InstProvider<'a, T> {
-    meter: &'a Meter,
+    meter: &'a DefaultMeter,
     resolve: &'a Resolver<T>,
 }
 
@@ -688,7 +688,7 @@ impl<'a, T> InstProvider<'a, T>
 where
     T: Number<T>,
 {
-    fn new(meter: &'a Meter, resolve: &'a Resolver<T>) -> Self {
+    fn new(meter: &'a DefaultMeter, resolve: &'a Resolver<T>) -> Self {
         InstProvider { meter, resolve }
     }
 
@@ -732,7 +732,7 @@ mod tests {
     use opentelemetry::metrics::{InstrumentProvider, MetricsError, Unit};
 
     use super::{
-        InstrumentValidationPolicy, Meter, INSTRUMENT_NAME_FIRST_ALPHABETIC,
+        DefaultMeter, InstrumentValidationPolicy, INSTRUMENT_NAME_FIRST_ALPHABETIC,
         INSTRUMENT_NAME_INVALID_CHAR, INSTRUMENT_NAME_LENGTH, INSTRUMENT_UNIT_INVALID_CHAR,
         INSTRUMENT_UNIT_LENGTH,
     };
@@ -741,7 +741,7 @@ mod tests {
     #[test]
     fn test_instrument_config_validation() {
         // scope and pipelines are not related to test
-        let meter = Meter::new(
+        let meter = DefaultMeter::new(
             Scope::default(),
             Arc::new(Pipelines::new(Resource::default(), Vec::new(), Vec::new())),
         )

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -46,7 +46,7 @@ const INSTRUMENT_UNIT_INVALID_CHAR: &str = "characters in instrument unit must b
 /// See the [Meter API] docs for usage.
 ///
 /// [Meter API]: opentelemetry::metrics::Meter
-pub struct DefaultMeter {
+pub struct SdkMeter {
     scope: Scope,
     pipes: Arc<Pipelines>,
     u64_resolver: Resolver<u64>,
@@ -55,11 +55,11 @@ pub struct DefaultMeter {
     validation_policy: InstrumentValidationPolicy,
 }
 
-impl DefaultMeter {
+impl SdkMeter {
     pub(crate) fn new(scope: Scope, pipes: Arc<Pipelines>) -> Self {
         let view_cache = Default::default();
 
-        DefaultMeter {
+        SdkMeter {
             scope,
             pipes: Arc::clone(&pipes),
             u64_resolver: Resolver::new(Arc::clone(&pipes), Arc::clone(&view_cache)),
@@ -79,7 +79,7 @@ impl DefaultMeter {
 }
 
 #[doc(hidden)]
-impl InstrumentProvider for DefaultMeter {
+impl InstrumentProvider for SdkMeter {
     fn u64_counter(
         &self,
         name: Cow<'static, str>,
@@ -672,7 +672,7 @@ impl ApiObserver for Observer {
     }
 }
 
-impl fmt::Debug for DefaultMeter {
+impl fmt::Debug for SdkMeter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Meter").field("scope", &self.scope).finish()
     }
@@ -680,7 +680,7 @@ impl fmt::Debug for DefaultMeter {
 
 /// Provides all OpenTelemetry instruments.
 struct InstrumentResolver<'a, T> {
-    meter: &'a DefaultMeter,
+    meter: &'a SdkMeter,
     resolve: &'a Resolver<T>,
 }
 
@@ -688,7 +688,7 @@ impl<'a, T> InstrumentResolver<'a, T>
 where
     T: Number<T>,
 {
-    fn new(meter: &'a DefaultMeter, resolve: &'a Resolver<T>) -> Self {
+    fn new(meter: &'a SdkMeter, resolve: &'a Resolver<T>) -> Self {
         InstrumentResolver { meter, resolve }
     }
 
@@ -732,7 +732,7 @@ mod tests {
     use opentelemetry::metrics::{InstrumentProvider, MetricsError, Unit};
 
     use super::{
-        DefaultMeter, InstrumentValidationPolicy, INSTRUMENT_NAME_FIRST_ALPHABETIC,
+        InstrumentValidationPolicy, SdkMeter, INSTRUMENT_NAME_FIRST_ALPHABETIC,
         INSTRUMENT_NAME_INVALID_CHAR, INSTRUMENT_NAME_LENGTH, INSTRUMENT_UNIT_INVALID_CHAR,
         INSTRUMENT_UNIT_LENGTH,
     };
@@ -741,7 +741,7 @@ mod tests {
     #[test]
     fn test_instrument_config_validation() {
         // scope and pipelines are not related to test
-        let meter = DefaultMeter::new(
+        let meter = SdkMeter::new(
             Scope::default(),
             Arc::new(Pipelines::new(Resource::default(), Vec::new(), Vec::new())),
         )

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -17,7 +17,7 @@ use opentelemetry::{
 
 use crate::{instrumentation::Scope, Resource};
 
-use super::{meter::Meter as SdkMeter, pipeline::Pipelines, reader::MetricReader, view::View};
+use super::{meter::DefaultMeter, pipeline::Pipelines, reader::MetricReader, view::View};
 
 /// Handles the creation and coordination of [Meter]s.
 ///
@@ -127,7 +127,7 @@ impl MeterProvider for DefaultMeterProvider {
         let inst_provider: Arc<dyn InstrumentProvider + Send + Sync> =
             if !self.is_shutdown.load(Ordering::Relaxed) {
                 let scope = Scope::new(name, version, schema_url, attributes);
-                Arc::new(SdkMeter::new(scope, self.pipes.clone()))
+                Arc::new(DefaultMeter::new(scope, self.pipes.clone()))
             } else {
                 Arc::new(NoopMeterCore::new())
             };

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -25,7 +25,7 @@ use super::{meter::DefaultMeter, pipeline::Pipelines, reader::MetricReader, view
 /// [Resource], have the same [View]s applied to them, and have their produced
 /// metric telemetry passed to the configured [MetricReader]s.
 ///
-/// [Meter]: crate::metrics::Meter
+/// [Meter]: opentelemetry::metrics::Meter
 #[derive(Clone, Debug)]
 pub struct DefaultMeterProvider {
     pipes: Arc<Pipelines>,
@@ -56,7 +56,7 @@ impl DefaultMeterProvider {
     ///
     /// ```
     /// use opentelemetry::{global, Context};
-    /// use opentelemetry_sdk::metrics::MeterProvider;
+    /// use opentelemetry_sdk::metrics::DefaultMeterProvider;
     ///
     /// fn init_metrics() -> MeterProvider {
     ///     let provider = MeterProvider::default();
@@ -152,7 +152,7 @@ impl MeterProviderBuilder {
     ///
     /// By default, if this option is not used, the default [Resource] will be used.
     ///
-    /// [Meter]: crate::metrics::Meter
+    /// [Meter]: opentelemetry::metrics::Meter
     pub fn with_resource(mut self, resource: Resource) -> Self {
         self.resource = Some(resource);
         self

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -27,18 +27,18 @@ use super::{meter::DefaultMeter, pipeline::Pipelines, reader::MetricReader, view
 ///
 /// [Meter]: opentelemetry::metrics::Meter
 #[derive(Clone, Debug)]
-pub struct DefaultMeterProvider {
+pub struct SdkMeterProvider {
     pipes: Arc<Pipelines>,
     is_shutdown: Arc<AtomicBool>,
 }
 
-impl Default for DefaultMeterProvider {
+impl Default for SdkMeterProvider {
     fn default() -> Self {
-        DefaultMeterProvider::builder().build()
+        SdkMeterProvider::builder().build()
     }
 }
 
-impl DefaultMeterProvider {
+impl SdkMeterProvider {
     /// Flushes all pending telemetry.
     ///
     /// There is no guaranteed that all telemetry be flushed or all resources have
@@ -56,10 +56,10 @@ impl DefaultMeterProvider {
     ///
     /// ```
     /// use opentelemetry::{global, Context};
-    /// use opentelemetry_sdk::metrics::DefaultMeterProvider;
+    /// use opentelemetry_sdk::metrics::SdkMeterProvider;
     ///
-    /// fn init_metrics() -> MeterProvider {
-    ///     let provider = MeterProvider::default();
+    /// fn init_metrics() -> SdkMeterProvider {
+    ///     let provider = SdkMeterProvider::default();
     ///
     ///     // Set provider to be used as global meter provider
     ///     let _ = global::set_meter_provider(provider.clone());
@@ -116,7 +116,7 @@ impl DefaultMeterProvider {
     }
 }
 
-impl MeterProvider for DefaultMeterProvider {
+impl MeterProvider for SdkMeterProvider {
     fn versioned_meter(
         &self,
         name: impl Into<Cow<'static, str>>,
@@ -180,8 +180,8 @@ impl MeterProviderBuilder {
     }
 
     /// Construct a new [MeterProvider] with this configuration.
-    pub fn build(self) -> DefaultMeterProvider {
-        DefaultMeterProvider {
+    pub fn build(self) -> SdkMeterProvider {
+        SdkMeterProvider {
             pipes: Arc::new(Pipelines::new(
                 self.resource.unwrap_or_default(),
                 self.readers,
@@ -212,7 +212,7 @@ mod tests {
     #[test]
     fn test_meter_provider_resource() {
         // If users didn't provide a resource and there isn't a env var set. Use default one.
-        let assert_service_name = |provider: super::DefaultMeterProvider,
+        let assert_service_name = |provider: super::SdkMeterProvider,
                                    expect: Option<&'static str>| {
             assert_eq!(
                 provider.pipes.0[0]
@@ -223,14 +223,14 @@ mod tests {
             );
         };
         let reader = TestMetricReader {};
-        let default_meter_provider = super::DefaultMeterProvider::builder()
+        let default_meter_provider = super::SdkMeterProvider::builder()
             .with_reader(reader)
             .build();
         assert_service_name(default_meter_provider, Some("unknown_service"));
 
         // If user provided a resource, use that.
         let reader2 = TestMetricReader {};
-        let custom_meter_provider = super::DefaultMeterProvider::builder()
+        let custom_meter_provider = super::SdkMeterProvider::builder()
             .with_reader(reader2)
             .with_resource(Resource::new(vec![KeyValue::new(
                 "service.name",
@@ -242,7 +242,7 @@ mod tests {
         // If `OTEL_RESOURCE_ATTRIBUTES` is set, read them automatically
         let reader3 = TestMetricReader {};
         env::set_var("OTEL_RESOURCE_ATTRIBUTES", "key1=value1, k2, k3=value2");
-        let env_resource_provider = super::DefaultMeterProvider::builder()
+        let env_resource_provider = super::SdkMeterProvider::builder()
             .with_reader(reader3)
             .build();
         assert_eq!(
@@ -263,7 +263,7 @@ mod tests {
             "my-custom-key=env-val,k2=value2",
         );
         let reader4 = TestMetricReader {};
-        let user_provided_resource_config_provider = super::DefaultMeterProvider::builder()
+        let user_provided_resource_config_provider = super::SdkMeterProvider::builder()
             .with_reader(reader4)
             .with_resource(
                 Resource::default().merge(&mut Resource::new(vec![KeyValue::new(
@@ -287,7 +287,7 @@ mod tests {
 
         // If user provided a resource, it takes priority during collision.
         let reader5 = TestMetricReader {};
-        let no_service_name = super::DefaultMeterProvider::builder()
+        let no_service_name = super::SdkMeterProvider::builder()
             .with_reader(reader5)
             .with_resource(Resource::empty())
             .build();

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Configuration
 //!
-//! The metrics SDK configuration is stored with each [MeterProvider].
+//! The metrics SDK configuration is stored with each [DefaultMeterProvider].
 //! Configuration for [Resource]s, [View]s, and [ManualReader] or
 //! [PeriodicReader] instances can be specified.
 //!

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Configuration
 //!
-//! The metrics SDK configuration is stored with each [DefaultMeterProvider].
+//! The metrics SDK configuration is stored with each [SdkMeterProvider].
 //! Configuration for [Resource]s, [View]s, and [ManualReader] or
 //! [PeriodicReader] instances can be specified.
 //!
@@ -10,16 +10,16 @@
 //!
 //! ```
 //! use opentelemetry::{
-//!     metrics::{MeterProvider as _, Unit},
+//!     metrics::{MeterProvider, Unit},
 //!     KeyValue,
 //! };
-//! use opentelemetry_sdk::{metrics::MeterProvider, Resource};
+//! use opentelemetry_sdk::{metrics::SdkMeterProvider, Resource};
 //!
 //! // Generate SDK configuration, resource, views, etc
 //! let resource = Resource::default(); // default attributes about the current process
 //!
 //! // Create a meter provider with the desired config
-//! let provider = MeterProvider::builder().with_resource(resource).build();
+//! let provider = SdkMeterProvider::builder().with_resource(resource).build();
 //!
 //! // Use the meter provider to create meter instances
 //! let meter = provider.meter("my_app");

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -98,7 +98,7 @@ impl Pipeline {
 
         Ok(move |this: &Pipeline| {
             let mut inner = this.inner.lock()?;
-            // can't compare trait objects so use index + toumbstones to drop
+            // can't compare trait objects so use index + tombstones to drop
             inner.multi_callbacks[idx] = None;
             Ok(())
         })

--- a/opentelemetry-sdk/src/metrics/view.rs
+++ b/opentelemetry-sdk/src/metrics/view.rs
@@ -34,7 +34,7 @@ fn empty_view(_inst: &Instrument) -> Option<Stream> {
 /// View is implemented for all `Fn(&Instrument) -> Option<Stream>`.
 ///
 /// ```
-/// use opentelemetry_sdk::metrics::{Instrument, MeterProvider, Stream};
+/// use opentelemetry_sdk::metrics::{Instrument, SdkMeterProvider, Stream};
 ///
 /// // return streams for the given instrument
 /// let my_view = |i: &Instrument| {
@@ -42,7 +42,7 @@ fn empty_view(_inst: &Instrument) -> Option<Stream> {
 ///   None
 /// };
 ///
-/// let provider = MeterProvider::builder().with_view(my_view).build();
+/// let provider = SdkMeterProvider::builder().with_view(my_view).build();
 /// # drop(provider)
 /// ```
 pub trait View: Send + Sync + 'static {

--- a/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
@@ -39,7 +39,7 @@ use std::sync::{Arc, Mutex};
 ///  let exporter = InMemoryMetricsExporter::default();
 ///
 ///  // Create a MeterProvider and register the exporter
-///  let meter_provider = metrics::MeterProvider::builder()
+///  let meter_provider = metrics::SdkMeterProvider::builder()
 ///      .with_reader(PeriodicReader::builder(exporter.clone(), runtime::Tokio).build())
 ///      .build();
 ///

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -8,7 +8,7 @@ use opentelemetry::{
 };
 #[cfg(all(feature = "metrics", feature = "trace"))]
 use opentelemetry_sdk::{
-    metrics::{DefaultMeterProvider, PeriodicReader},
+    metrics::{PeriodicReader, SdkMeterProvider},
     runtime,
     trace::TracerProvider,
 };
@@ -22,10 +22,10 @@ fn init_trace() -> TracerProvider {
 }
 
 #[cfg(all(feature = "metrics", feature = "trace"))]
-fn init_metrics() -> DefaultMeterProvider {
+fn init_metrics() -> SdkMeterProvider {
     let exporter = opentelemetry_stdout::MetricsExporter::default();
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
-    DefaultMeterProvider::builder().with_reader(reader).build()
+    SdkMeterProvider::builder().with_reader(reader).build()
 }
 
 #[tokio::main]

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -8,7 +8,7 @@ use opentelemetry::{
 };
 #[cfg(all(feature = "metrics", feature = "trace"))]
 use opentelemetry_sdk::{
-    metrics::{MeterProvider, PeriodicReader},
+    metrics::{DefaultMeterProvider, PeriodicReader},
     runtime,
     trace::TracerProvider,
 };
@@ -22,10 +22,10 @@ fn init_trace() -> TracerProvider {
 }
 
 #[cfg(all(feature = "metrics", feature = "trace"))]
-fn init_metrics() -> MeterProvider {
+fn init_metrics() -> DefaultMeterProvider {
     let exporter = opentelemetry_stdout::MetricsExporter::default();
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
-    MeterProvider::builder().with_reader(reader).build()
+    DefaultMeterProvider::builder().with_reader(reader).build()
 }
 
 #[tokio::main]

--- a/opentelemetry-stdout/src/lib.rs
+++ b/opentelemetry-stdout/src/lib.rs
@@ -5,11 +5,11 @@
 //! ```no_run
 //! # #[cfg(all(feature = "metrics", feature = "trace"))]
 //! {
-//! use opentelemetry::metrics::MeterProvider as _;
+//! use opentelemetry::metrics::MeterProvider;
 //! use opentelemetry::trace::{Span, Tracer, TracerProvider as _};
 //! use opentelemetry::{Context, KeyValue};
 //!
-//! use opentelemetry_sdk::metrics::{MeterProvider, PeriodicReader};
+//! use opentelemetry_sdk::metrics::{SdkMeterProvider, PeriodicReader};
 //! use opentelemetry_sdk::runtime;
 //! use opentelemetry_sdk::trace::TracerProvider;
 //!
@@ -20,10 +20,10 @@
 //!         .build()
 //! }
 //!
-//! fn init_metrics() -> MeterProvider {
+//! fn init_metrics() -> SdkMeterProvider {
 //!     let exporter = opentelemetry_stdout::MetricsExporter::default();
 //!     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
-//!     MeterProvider::builder().with_reader(reader).build()
+//!     SdkMeterProvider::builder().with_reader(reader).build()
 //! }
 //!
 //! let tracer_provider = init_trace();

--- a/opentelemetry-user-events-metrics/examples/basic.rs
+++ b/opentelemetry-user-events-metrics/examples/basic.rs
@@ -4,14 +4,14 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_sdk::{
-    metrics::{DefaultMeterProvider, PeriodicReader},
+    metrics::{PeriodicReader, SdkMeterProvider},
     runtime, Resource,
 };
 use opentelemetry_user_events_metrics::MetricsExporter;
 
-fn init_metrics(exporter: MetricsExporter) -> DefaultMeterProvider {
+fn init_metrics(exporter: MetricsExporter) -> SdkMeterProvider {
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
-    DefaultMeterProvider::builder()
+    SdkMeterProvider::builder()
         .with_resource(Resource::new(vec![KeyValue::new(
             "service.name",
             "metric-demo",

--- a/opentelemetry-user-events-metrics/examples/basic.rs
+++ b/opentelemetry-user-events-metrics/examples/basic.rs
@@ -4,14 +4,14 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_sdk::{
-    metrics::{MeterProvider, PeriodicReader},
+    metrics::{DefaultMeterProvider, PeriodicReader},
     runtime, Resource,
 };
 use opentelemetry_user_events_metrics::MetricsExporter;
 
-fn init_metrics(exporter: MetricsExporter) -> MeterProvider {
+fn init_metrics(exporter: MetricsExporter) -> DefaultMeterProvider {
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
-    MeterProvider::builder()
+    DefaultMeterProvider::builder()
         .with_resource(Resource::new(vec![KeyValue::new(
             "service.name",
             "metric-demo",

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -3,14 +3,14 @@ use opentelemetry::{
     metrics::{Counter, MeterProvider as _},
     KeyValue,
 };
-use opentelemetry_sdk::metrics::{ManualReader, MeterProvider};
+use opentelemetry_sdk::metrics::{DefaultMeterProvider, ManualReader};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::borrow::Cow;
 
 mod throughput;
 
 lazy_static! {
-    static ref PROVIDER: MeterProvider = MeterProvider::builder()
+    static ref PROVIDER: DefaultMeterProvider = DefaultMeterProvider::builder()
         .with_reader(ManualReader::builder().build())
         .build();
     static ref ATTRIBUTE_VALUES: [&'static str; 10] = [

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -3,14 +3,14 @@ use opentelemetry::{
     metrics::{Counter, MeterProvider as _},
     KeyValue,
 };
-use opentelemetry_sdk::metrics::{DefaultMeterProvider, ManualReader};
+use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::borrow::Cow;
 
 mod throughput;
 
 lazy_static! {
-    static ref PROVIDER: DefaultMeterProvider = DefaultMeterProvider::builder()
+    static ref PROVIDER: SdkMeterProvider = SdkMeterProvider::builder()
         .with_reader(ManualReader::builder().build())
         .build();
     static ref ATTRIBUTE_VALUES: [&'static str; 10] = [


### PR DESCRIPTION
## Fixes Some Naming Confusions

The SDK currently implements some API `trait`s using `struct`s with identical names as the `trait`. This can get confusing and leads sometimes to using aliasing when `use`ing types, which introduces even more names to have to sort out while reading the code.

## Changes

- rename SDK's `MeterProvider` to `SdkMeterProvider`.  This avoids the clash with the API's `MeterProvider` trait, and opens an easy door to implement other (non-default) `MeterProvider`s with distinguishing names.
- rename `Meter` to `SdkMeter`, for similar reasons.
- rename `InstrumentImpl` to `ResolvedMeasures` as that's all it holds and it doesn't implement any instrument-related trait.
- rename `InstProvider` to `InstrumentResolver`. There is an `InstrumentProvider` trait, which this struct does NOT implement, so avoiding that false association makes things a little clearer (IMO).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
