### PR TITLE
[WIP] Suppression of nested logs from dependencies

### DIFF
--- a/opentelemetry-jaeger/examples/actix-udp/src/main.rs
+++ b/opentelemetry-jaeger/examples/actix-udp/src/main.rs
@@ -1,9 +1,10 @@
 use actix_service::Service;
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpServer};
+use opentelemetry::FutureExt;
 use opentelemetry::{
     global,
-    trace::{FutureExt, TraceContextExt, TraceError, Tracer},
+    trace::{TraceContextExt, TraceError, Tracer},
     Key, KeyValue,
 };
 use opentelemetry_sdk::{trace::config, Resource};

--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 [dependencies]
 once_cell = "1.17"
 opentelemetry = { path = "../../../opentelemetry" }
-opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "metrics", "logs"] }
+opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "metrics", "logs", "logs_level_enabled"] }
 opentelemetry-otlp = { path = "../..", features = ["http-proto", "reqwest-client", "logs"] }
-opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}
+opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing"}
 opentelemetry-semantic-conventions = { path = "../../../opentelemetry-semantic-conventions" }
 
 tokio = { version = "1.0", features = ["full"] }

--- a/opentelemetry-otlp/src/exporter/http/logs.rs
+++ b/opentelemetry-otlp/src/exporter/http/logs.rs
@@ -2,38 +2,47 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use http::{header::CONTENT_TYPE, Method};
-use opentelemetry::logs::{LogError, LogResult};
+use opentelemetry::{
+    logs::{LogError, LogResult},
+    FutureExt,
+};
 use opentelemetry_sdk::export::logs::{LogData, LogExporter};
 
 use super::OtlpHttpClient;
+use opentelemetry::Context;
+use std::thread;
 
 #[async_trait]
 impl LogExporter for OtlpHttpClient {
     async fn export(&mut self, batch: Vec<LogData>) -> LogResult<()> {
-        let client = self
-            .client
-            .lock()
-            .map_err(|e| LogError::Other(e.to_string().into()))
-            .and_then(|g| match &*g {
-                Some(client) => Ok(Arc::clone(client)),
-                _ => Err(LogError::Other("exporter is already shut down".into())),
-            })?;
+        async {
+            let client = self
+                .client
+                .lock()
+                .map_err(|e| LogError::Other(e.to_string().into()))
+                .and_then(|g| match &*g {
+                    Some(client) => Ok(Arc::clone(client)),
+                    _ => Err(LogError::Other("exporter is already shut down".into())),
+                })?;
 
-        let (body, content_type) = build_body(batch)?;
-        let mut request = http::Request::builder()
-            .method(Method::POST)
-            .uri(&self.collector_endpoint)
-            .header(CONTENT_TYPE, content_type)
-            .body(body)
-            .map_err(|e| crate::Error::RequestFailed(Box::new(e)))?;
+            let (body, content_type) = build_body(batch)?;
+            let mut request = http::Request::builder()
+                .method(Method::POST)
+                .uri(&self.collector_endpoint)
+                .header(CONTENT_TYPE, content_type)
+                .body(body)
+                .map_err(|e| crate::Error::RequestFailed(Box::new(e)))?;
 
-        for (k, v) in &self.headers {
-            request.headers_mut().insert(k.clone(), v.clone());
+            for (k, v) in &self.headers {
+                request.headers_mut().insert(k.clone(), v.clone());
+            }
+
+            client.send(request).await?;
+
+            Ok(())
         }
-
-        client.send(request).await?;
-
-        Ok(())
+        .with_current_context_supp()
+        .await
     }
 
     fn shutdown(&mut self) {

--- a/opentelemetry-otlp/src/exporter/http/logs.rs
+++ b/opentelemetry-otlp/src/exporter/http/logs.rs
@@ -41,7 +41,8 @@ impl LogExporter for OtlpHttpClient {
 
             Ok(())
         }
-        .with_current_context_supp()
+        //.with_current_context_supp()
+        .with_context(Context::current().with_suppression())
         .await
     }
 

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -105,7 +105,7 @@ impl LogProcessor for SimpleLogProcessor {
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        !Context::current().suppress_logs
+        !Context::current().suppression
     }
 }
 
@@ -134,7 +134,7 @@ impl<R: RuntimeChannel<BatchMessage>> LogProcessor for BatchLogProcessor<R> {
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        !Context::current().suppress_logs
+        !Context::current().suppression
     }
 
     fn force_flush(&self) -> LogResult<()> {

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -19,6 +19,8 @@ use std::{
     time::Duration,
 };
 
+use opentelemetry::Context;
+
 /// The interface for plugging into a [`Logger`].
 ///
 /// [`Logger`]: crate::logs::Logger
@@ -103,7 +105,7 @@ impl LogProcessor for SimpleLogProcessor {
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        true
+        !Context::current().suppress_logs
     }
 }
 
@@ -132,7 +134,7 @@ impl<R: RuntimeChannel<BatchMessage>> LogProcessor for BatchLogProcessor<R> {
 
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        true
+        !Context::current().suppress_logs
     }
 
     fn force_flush(&self) -> LogResult<()> {

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -1,12 +1,18 @@
 #[cfg(feature = "trace")]
 use crate::trace::context::SynchronizedSpan;
+use futures_core::stream::Stream;
+use futures_sink::Sink;
+use pin_project_lite::pin_project;
 use std::any::{Any, TypeId};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::{BuildHasherDefault, Hasher};
 use std::marker::PhantomData;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context as TaskContext, Poll};
+use std::thread;
 
 thread_local! {
     static CURRENT_CONTEXT: RefCell<Context> = RefCell::new(Context::default());
@@ -78,6 +84,7 @@ thread_local! {
 pub struct Context {
     #[cfg(feature = "trace")]
     pub(super) span: Option<Arc<SynchronizedSpan>>,
+    pub suppress_logs: bool,
     entries: HashMap<TypeId, Arc<dyn Any + Sync + Send>, BuildHasherDefault<IdHasher>>,
 }
 
@@ -313,6 +320,7 @@ impl Context {
         Context {
             span: Some(Arc::new(value)),
             entries: Context::map_current(|cx| cx.entries.clone()),
+            ..Context::default()
         }
     }
 
@@ -321,6 +329,15 @@ impl Context {
         Context {
             span: Some(Arc::new(value)),
             entries: self.entries.clone(),
+            ..self.clone()
+        }
+    }
+
+    pub(super) fn with_suppression(&self) -> Self {
+        Context {
+            suppress_logs: true,
+            entries: self.entries.clone(),
+            ..self.clone()
         }
     }
 }
@@ -330,6 +347,115 @@ impl fmt::Debug for Context {
         f.debug_struct("Context")
             .field("entries", &self.entries.len())
             .finish()
+    }
+}
+
+pin_project! {
+    /// A future, stream, or sink that has an associated context.
+    #[derive(Clone, Debug)]
+    pub struct WithContext<T> {
+        #[pin]
+        inner: T,
+        otel_cx: Context,
+    }
+}
+
+impl<T: Sized> FutureExt for T {}
+
+impl<T: std::future::Future> std::future::Future for WithContext<T> {
+    type Output = T::Output;
+
+    fn poll(self: Pin<&mut Self>, task_cx: &mut TaskContext<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let _guard = this.otel_cx.clone().attach();
+
+        this.inner.poll(task_cx)
+    }
+}
+
+impl<T: Stream> Stream for WithContext<T> {
+    type Item = T::Item;
+
+    fn poll_next(self: Pin<&mut Self>, task_cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        let _guard = this.otel_cx.clone().attach();
+        T::poll_next(this.inner, task_cx)
+    }
+}
+
+impl<I, T: Sink<I>> Sink<I> for WithContext<T>
+where
+    T: Sink<I>,
+{
+    type Error = T::Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        task_cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        let this = self.project();
+        let _guard = this.otel_cx.clone().attach();
+        T::poll_ready(this.inner, task_cx)
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: I) -> Result<(), Self::Error> {
+        let this = self.project();
+        let _guard = this.otel_cx.clone().attach();
+        T::start_send(this.inner, item)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        task_cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        let this = self.project();
+        let _guard = this.otel_cx.clone().attach();
+        T::poll_flush(this.inner, task_cx)
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        task_cx: &mut TaskContext<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        let this = self.project();
+        let _enter = this.otel_cx.clone().attach();
+        T::poll_close(this.inner, task_cx)
+    }
+}
+
+/// Extension trait allowing futures, streams, and sinks to be traced with a span.
+pub trait FutureExt: Sized {
+    /// Attaches the provided [`Context`] to this type, returning a `WithContext`
+    /// wrapper.
+    ///
+    /// When the wrapped type is a future, stream, or sink, the attached context
+    /// will be set as current while it is being polled.
+    ///
+    /// [`Context`]: crate::Context
+    fn with_context(self, otel_cx: Context) -> WithContext<Self> {
+        WithContext {
+            inner: self,
+            otel_cx,
+        }
+    }
+
+    /// Attaches the current [`Context`] to this type, returning a `WithContext`
+    /// wrapper.
+    ///
+    /// When the wrapped type is a future, stream, or sink, the attached context
+    /// will be set as the default while it is being polled.
+    ///
+    /// [`Context`]: crate::Context
+    fn with_current_context(self) -> WithContext<Self> {
+        let otel_cx = Context::current();
+        self.with_context(otel_cx)
+    }
+
+    /// Attaches the current context [`Context`] to this type, with
+    /// suppression enabled, returning a `WithContext` wrapper.
+    fn with_current_context_supp(self) -> WithContext<Self> {
+        let otel_cx = Context::current().with_suppression();
+        self.with_context(otel_cx)
     }
 }
 

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -208,7 +208,7 @@ pub mod baggage;
 
 mod context;
 
-pub use context::{Context, ContextGuard};
+pub use context::{Context, ContextGuard, FutureExt, WithContext};
 
 mod common;
 

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -4,16 +4,7 @@ use crate::{
     trace::{Span, SpanContext, Status},
     Context, ContextGuard, KeyValue,
 };
-use futures_core::stream::Stream;
-use futures_sink::Sink;
-use pin_project_lite::pin_project;
-use std::{
-    borrow::Cow,
-    error::Error,
-    pin::Pin,
-    sync::Mutex,
-    task::{Context as TaskContext, Poll},
-};
+use std::{borrow::Cow, error::Error, sync::Mutex};
 
 const NOOP_SPAN: SynchronizedSpan = SynchronizedSpan {
     span_context: SpanContext::NONE,
@@ -358,106 +349,4 @@ where
     F: FnOnce(SpanRef<'_>) -> T,
 {
     Context::map_current(|cx| f(cx.span()))
-}
-
-pin_project! {
-    /// A future, stream, or sink that has an associated context.
-    #[derive(Clone, Debug)]
-    pub struct WithContext<T> {
-        #[pin]
-        inner: T,
-        otel_cx: Context,
-    }
-}
-
-impl<T: Sized> FutureExt for T {}
-
-impl<T: std::future::Future> std::future::Future for WithContext<T> {
-    type Output = T::Output;
-
-    fn poll(self: Pin<&mut Self>, task_cx: &mut TaskContext<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        let _guard = this.otel_cx.clone().attach();
-
-        this.inner.poll(task_cx)
-    }
-}
-
-impl<T: Stream> Stream for WithContext<T> {
-    type Item = T::Item;
-
-    fn poll_next(self: Pin<&mut Self>, task_cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.project();
-        let _guard = this.otel_cx.clone().attach();
-        T::poll_next(this.inner, task_cx)
-    }
-}
-
-impl<I, T: Sink<I>> Sink<I> for WithContext<T>
-where
-    T: Sink<I>,
-{
-    type Error = T::Error;
-
-    fn poll_ready(
-        self: Pin<&mut Self>,
-        task_cx: &mut TaskContext<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        let this = self.project();
-        let _guard = this.otel_cx.clone().attach();
-        T::poll_ready(this.inner, task_cx)
-    }
-
-    fn start_send(self: Pin<&mut Self>, item: I) -> Result<(), Self::Error> {
-        let this = self.project();
-        let _guard = this.otel_cx.clone().attach();
-        T::start_send(this.inner, item)
-    }
-
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        task_cx: &mut TaskContext<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        let this = self.project();
-        let _guard = this.otel_cx.clone().attach();
-        T::poll_flush(this.inner, task_cx)
-    }
-
-    fn poll_close(
-        self: Pin<&mut Self>,
-        task_cx: &mut TaskContext<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        let this = self.project();
-        let _enter = this.otel_cx.clone().attach();
-        T::poll_close(this.inner, task_cx)
-    }
-}
-
-/// Extension trait allowing futures, streams, and sinks to be traced with a span.
-pub trait FutureExt: Sized {
-    /// Attaches the provided [`Context`] to this type, returning a `WithContext`
-    /// wrapper.
-    ///
-    /// When the wrapped type is a future, stream, or sink, the attached context
-    /// will be set as current while it is being polled.
-    ///
-    /// [`Context`]: crate::Context
-    fn with_context(self, otel_cx: Context) -> WithContext<Self> {
-        WithContext {
-            inner: self,
-            otel_cx,
-        }
-    }
-
-    /// Attaches the current [`Context`] to this type, returning a `WithContext`
-    /// wrapper.
-    ///
-    /// When the wrapped type is a future, stream, or sink, the attached context
-    /// will be set as the default while it is being polled.
-    ///
-    /// [`Context`]: crate::Context
-    fn with_current_context(self) -> WithContext<Self> {
-        let otel_cx = Context::current();
-        self.with_context(otel_cx)
-    }
 }

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -174,9 +174,7 @@ mod tracer;
 mod tracer_provider;
 
 pub use self::{
-    context::{
-        get_active_span, mark_span_as_active, FutureExt, SpanRef, TraceContextExt, WithContext,
-    },
+    context::{get_active_span, mark_span_as_active, SpanRef, TraceContextExt},
     span::{Span, SpanKind, Status},
     span_context::{SpanContext, SpanId, TraceFlags, TraceId, TraceState},
     tracer::{SamplingDecision, SamplingResult, SpanBuilder, Tracer},


### PR DESCRIPTION
Raising this PR as alternate approach to fix #1171, by extending the Context structure to store the suppression flag. The PR is to discuss this approach. The earlier approach #1315 was based on tokio runtime, and generalizing it would have been difficult.

**Change summary**

1. Move `FutureExt` and `WithContext` constructs from `trace/context.rs` to `context.rs`.
2. Add suppress_logs flag in `Context` struct
```rust
pub struct Context {
    #[cfg(feature = "trace")]
    pub(super) span: Option<Arc<SynchronizedSpan>>,
    pub suppress_logs: bool,
    entries: HashMap<TypeId, Arc<dyn Any + Sync + Send>, BuildHasherDefault<IdHasher>>,
}
```
3. Add  `with_suppression` method in Context to enable suppression:
```rust
impl Context {
  ...
    pub(super) fn with_suppression(&self) -> Self {
        Context {
            suppress_logs: true,
            entries: self.entries.clone(),
            ..self.clone()
        }
    }
}
```

4. Add `with_current_context_supp` method in FutureExt:
```rust
pub trait FutureExt: Sized {
    ...
    fn with_current_context_supp(self) -> WithContext<Self> {
        let otel_cx = Context::current().with_suppression();
        self.with_context(otel_cx)
    }
}
```
5. Suppress in Exporter::export method:
```rust
impl LogExporter for OtlpHttpClient {
    async fn export(&mut self, batch: Vec<LogData>) -> LogResult<()> {
        async {
            // export logic
       }
        .with_current_context_supp()
        .await
    }
```

6. Check if suppression is enabled in LogProcessor:
```rust
impl<R: RuntimeChannel<BatchMessage>> LogProcessor for BatchLogProcessor<R> {
    ...
    #[cfg(feature = "logs_level_enabled")]
    fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
        !Context::current().suppress_logs
    }
}
```

7. How to test:

run opentelemetry-otlp/examples/basic-otlp-http/ example, while collector is running (using docker-compose up).