### PR TITLE
Use custom channel in exporters if configured

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `build_{signal}_exporter` methods to client builders (#1187)
 - Add `grpcio` metrics exporter (#1202)
 - Allow specifying OTLP HTTP headers from env variable (#1290)
+- Support custom channels in topic exporters  [#1335](https://github.com/open-telemetry/opentelemetry-rust/pull/1335)
 
 ### Changed
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-rust/issues/1333

## Changes

Use `custom_channel` if provided in tonic exporters.

The diff is mostly moving code around to avoid unused parsing/values when a channel is provided.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
