### PR TITLE
Requesting Maintainership for h.dost

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,13 +132,13 @@ For GitHub groups see the [code owners](CODEOWNERS) file.
 ### Maintainers
 
 * [Dirkjan Ochtman](https://github.com/djc)
+* [Harold Dost](https://github.com/hdost)
 * [Julian Tescher](https://github.com/jtescher)
 * [Zhongyang Wu](https://github.com/TommyCpp)
 
 ### Approvers
 
 * [Cijo Thomas](https://github.com/cijothomas)
-* [Harold Dost](https://github.com/hdost)
 * [Lalit Kumar Bhasin](https://github.com/lalitb)
 * [Shaun Cox](https://github.com/shaun-cox)
 


### PR DESCRIPTION
As per the [guidelines](https://github.com/open-telemetry/community/blob/main/community-membership.md#becoming-a-maintainer) for the OpenTelemetry project. I am requesting maintainership.

> Unless stated otherwise in a SIG charter ratified by the Technical Committee, a new maintainer is elected by vote of the existing maintainers of the SIG. The vote is officially started when a pull request to add a new maintainer is opened, and ends when the pull request is merged. The pull request may be merged when the following conditions are met:
>
>    - The person being nominated has accepted the nomination by approving the pull request
>    - All maintainers have approved the pull request OR a majority of maintainers have approved the pull request and no maintainer has objected by requesting changes on the pull request. In the case that all maintainers have not given approval, the pull request should stay open for a minimum of 5 days before merging.
>
> The nominee is considered a maintainer after the pull request is merged.