### PR TITLE
Add jaeger tracing example to main examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "examples/logs-basic",
     "examples/traceresponse",
     "examples/tracing-grpc",
+    "examples/tracing-jaeger",
     "stress",
 ]
 resolver = "2"

--- a/examples/tracing-jaeger/Cargo.toml
+++ b/examples/tracing-jaeger/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tracing-jaeger"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+opentelemetry = { path = "../../opentelemetry" }
+opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }
+opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio"] }
+opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic", "metrics", "logs"] }
+tokio = { version = "1.0", features = ["full"] }

--- a/examples/tracing-jaeger/Cargo.toml
+++ b/examples/tracing-jaeger/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 opentelemetry = { path = "../../opentelemetry" }
 opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio"] }
-opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic", "metrics", "logs"] }
+opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/tracing-jaeger/README.md
+++ b/examples/tracing-jaeger/README.md
@@ -1,14 +1,14 @@
 # Exporting traces to Jaeger
 
-This example shows how to export spans to Jaeger agent using OTLP.
+This example shows how to export spans to Jaeger agent using OTLPExporter.
 
 ## Usage
 
-Launch the application:
+Launch the example app with Jaeger running in background via docker:
 
 ```shell
 
-# Run jaeger in background
+# Run jaeger in background with native OTLP Ingestion
 $ docker run -d -p16686:16686 -p4317:4317 -e COLLECTOR_OTLP_ENABLED=true jaegertracing/all-in-one:latest
 
 # Run the app

--- a/examples/tracing-jaeger/README.md
+++ b/examples/tracing-jaeger/README.md
@@ -1,0 +1,19 @@
+# Exporting traces to Jaeger
+
+This example shows how to export spans to Jaeger agent using OTLP.
+
+## Usage
+
+Launch the application:
+
+```shell
+
+# Run jaeger in background
+$ docker run -d -p16686:16686 -p4317:4317 -e COLLECTOR_OTLP_ENABLED=true jaegertracing/all-in-one:latest
+
+# Run the app
+$ cargo run
+
+# View spans
+$ firefox http://localhost:16686/
+```

--- a/examples/tracing-jaeger/src/main.rs
+++ b/examples/tracing-jaeger/src/main.rs
@@ -1,0 +1,47 @@
+use opentelemetry::{
+    global,
+    trace::{TraceContextExt, TraceError, Tracer},
+    Key, KeyValue,
+};
+use opentelemetry_sdk::{runtime, trace as sdktrace, Resource};
+use opentelemetry_otlp::WithExportConfig;
+use std::error::Error;
+use opentelemetry::global::shutdown_tracer_provider;
+
+fn init_tracer() -> Result<opentelemetry_sdk::trace::Tracer, TraceError> {
+    opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(
+            opentelemetry_otlp::new_exporter()
+                .tonic()
+                .with_endpoint("http://localhost:4317"),
+        )
+        .with_trace_config(
+            sdktrace::config().with_resource(Resource::new(vec![KeyValue::new(
+                "service.name",
+                "tracing-jaeger",
+            )])),
+        )
+        .install_batch(runtime::Tokio)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let _tracer = init_tracer().expect("Failed to initialize tracer.");
+
+    let tracer = global::tracer("ex.com/basic");
+    tracer.in_span("operation", |cx| {
+        let span = cx.span();
+        span.add_event(
+            "Nice operation!".to_string(),
+            vec![Key::new("bogons").i64(100)],
+        );
+        tracer.in_span("Sub operation...", |cx| {
+            let span = cx.span();
+            span.add_event("Sub span event", vec![]);
+        });
+    });
+
+    shutdown_tracer_provider();
+    Ok(())
+}


### PR DESCRIPTION
As discussed in https://github.com/open-telemetry/opentelemetry-rust/pull/1323#issuecomment-1792886516, trying to start with a working example for using OTLP to export to jaeger.

We had added an example previously in https://github.com/open-telemetry/opentelemetry-rust/pull/1022, but it got lost in refactoring. This PR is adding a top-level example using Jaeger with OTLP Exporter.

Good examples are a pre-req for achieving https://github.com/open-telemetry/opentelemetry-rust/issues/995