### PR TITLE
[Tracing Appender] Propagate event name to exporters

### DIFF
--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.65"
 [dependencies]
 opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["logs"] }
 opentelemetry_sdk = { version = "0.21", path = "../opentelemetry-sdk", features = ["logs"] }
-tracing = {version = "0.1.37", default-features = false, features = ["std"]}
+tracing = {version = "0.1", default-features = false, features = ["std"]}
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
 once_cell = "1.13.0"

--- a/opentelemetry-appender-tracing/examples/basic.rs
+++ b/opentelemetry-appender-tracing/examples/basic.rs
@@ -23,6 +23,6 @@ fn main() {
     let layer = layer::OpenTelemetryTracingBridge::new(&provider);
     tracing_subscriber::registry().with(layer).init();
 
-    error!(target: "my-system", event_id = 20, event_name = "my-event_name", user_name = "otel", user_email = "otel@opentelemetry.io");
+    error!(target: "my-system", name: "my-event-name", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
     drop(provider);
 }

--- a/opentelemetry-appender-tracing/examples/basic.rs
+++ b/opentelemetry-appender-tracing/examples/basic.rs
@@ -23,6 +23,6 @@ fn main() {
     let layer = layer::OpenTelemetryTracingBridge::new(&provider);
     tracing_subscriber::registry().with(layer).init();
 
-    error!(target: "my-system", name: "my-event-name", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
+    error!(name: "my-event-name", target: "my-system", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
     drop(provider);
 }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -103,6 +103,11 @@ where
         log_record.severity_number = Some(map_severity_to_otel_severity(meta.level().as_str()));
         log_record.severity_text = Some(meta.level().to_string().into());
 
+        // add the `name` metadata to attributes
+        // TBD - Propose this to be part of log_record metadata.
+        let vec = vec![("name", meta.name())];
+        log_record.attributes = Some(vec.into_iter().map(|(k, v)| (k.into(), v.into())).collect());
+
         // Not populating ObservedTimestamp, instead relying on OpenTelemetry
         // API to populate it with current time.
 

--- a/opentelemetry-user-events-logs/Cargo.toml
+++ b/opentelemetry-user-events-logs/Cargo.toml
@@ -21,7 +21,7 @@ chrono = { version="0.4", default-features = false, features=["std"] }
 
 [dev-dependencies]
 opentelemetry-appender-tracing = { path = "../opentelemetry-appender-tracing" }
-tracing = { version = "0.1.37", default-features = false, features = ["std"] }
+tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
 microbench = "0.5"

--- a/opentelemetry-user-events-logs/examples/basic.rs
+++ b/opentelemetry-user-events-logs/examples/basic.rs
@@ -30,7 +30,7 @@ fn main() {
     // event_id is also passed as an attribute now, there is nothing in metadata where a
     // numeric id can be stored.
     error!(
-        event_name = "my-event-name",
+        name: "my-event-name",
         event_id = 20,
         user_name = "otel user",
         user_email = "otel@opentelemetry.io"

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -52,7 +52,8 @@ pub(crate) struct UserEventsExporter {
 }
 
 const EVENT_ID: &str = "event_id";
-const EVENT_NAME: &str = "event_name";
+const EVENT_NAME_PRIMARY: &str = "event_name";
+const EVENT_NAME_SECONDARY: &str = "name";
 
 //TBD - How to configure provider name and provider group
 impl UserEventsExporter {
@@ -222,9 +223,16 @@ impl UserEventsExporter {
                                 event_id = *value;
                                 continue;
                             }
-                            (EVENT_NAME, AnyValue::String(value)) => {
+                            (EVENT_NAME_PRIMARY, AnyValue::String(value)) => {
                                 is_event_name = true;
                                 event_name = value.as_str();
+                                continue;
+                            }
+                            (EVENT_NAME_SECONDARY, AnyValue::String(value)) => {
+                                println!("Event name sec is {}", value.as_str());
+                                if !is_event_name {
+                                    event_name = value.as_str();
+                                }
                                 continue;
                             }
                             _ => {
@@ -237,6 +245,7 @@ impl UserEventsExporter {
                             }
                         }
                     }
+
                     if is_part_c_present {
                         eb.set_struct_field_count(cs_c_bookmark, cs_c_count);
                     }
@@ -245,7 +254,7 @@ impl UserEventsExporter {
                 let mut cs_b_bookmark: usize = 0;
                 let mut cs_b_count = 0;
                 eb.add_struct_with_bookmark("PartB", 1, 0, &mut cs_b_bookmark);
-                eb.add_str("_typename", "Logs", FieldFormat::Default, 0);
+                eb.add_str("_typeName", "Logs", FieldFormat::Default, 0);
                 cs_b_count += 1;
 
                 if log_data.record.body.is_some() {
@@ -282,7 +291,7 @@ impl UserEventsExporter {
                     eb.add_value("eventId", event_id, FieldFormat::SignedInt, 0);
                     cs_b_count += 1;
                 }
-                if is_event_name {
+                if event_name.len() > 0 {
                     eb.add_str("name", event_name, FieldFormat::Default, 0);
                     cs_b_count += 1;
                 }

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -229,7 +229,6 @@ impl UserEventsExporter {
                                 continue;
                             }
                             (EVENT_NAME_SECONDARY, AnyValue::String(value)) => {
-                                println!("Event name sec is {}", value.as_str());
                                 if !is_event_name {
                                     event_name = value.as_str();
                                 }

--- a/opentelemetry-user-events-logs/src/logs/exporter.rs
+++ b/opentelemetry-user-events-logs/src/logs/exporter.rs
@@ -290,7 +290,7 @@ impl UserEventsExporter {
                     eb.add_value("eventId", event_id, FieldFormat::SignedInt, 0);
                     cs_b_count += 1;
                 }
-                if event_name.len() > 0 {
+                if !event_name.is_empty() {
                     eb.add_str("name", event_name, FieldFormat::Default, 0);
                     cs_b_count += 1;
                 }


### PR DESCRIPTION
As per the recent changes in Tokio Tracing library - https://github.com/tokio-rs/tracing/pull/2699, it now allows setting event name in tracing macros. E.g., in

```rust
error!(name: "my-event-name", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
```

As lots of backends support event/log name (ElasticSearch, Fluentd, Sentry etc), it should be possible for users to specify event name using tracing macros, and export them to these backend through custom otel-exporters.

The PR modifies tracing subscriber to propagates this event-name to exporters by adding it to attributes. And if the attributes already have the key with the same name, that would override the "name" metadata field. Also, modified user_events log exporter to utilize this field. As of now, user_events exporter expect user to provide this field as "event_name" attribute through tracing macros.

TBD - It is also good to have parity across the metadata field in tracing event, and the log-record, at-least log-record structure should optionally have the additive field from the event metadata (and `name` is one such field). I plan to subsequently propose adding this field in LogRecord implementation separately. 