### PR TITLE
prometheus: Ignore unknown instrument units

### DIFF
--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Fixed
+
+- Fix UCUM annotation escaping by ignoring unknown instrument units and annotations (#1348)
+
 ## v0.14.0
 
 ### Changed

--- a/opentelemetry-prometheus/src/utils.rs
+++ b/opentelemetry-prometheus/src/utils.rs
@@ -36,7 +36,9 @@ pub(crate) fn get_unit_suffixes(unit: &Unit) -> Option<Cow<'static, str>> {
         };
     }
 
-    Some(Cow::Owned(unit.as_str().to_string()))
+    // Unmatched units and annotations are ignored
+    // e.g. "{request}"
+    None
 }
 
 fn get_prom_units(unit: &str) -> Option<&'static str> {
@@ -49,9 +51,9 @@ fn get_prom_units(unit: &str) -> Option<&'static str> {
         "ms" => Some("milliseconds"),
         "us" => Some("microseconds"),
         "ns" => Some("nanoseconds"),
-        "By" => Some("bytes"),
 
         // Bytes
+        "By" => Some("bytes"),
         "KiBy" => Some("kibibytes"),
         "MiBy" => Some("mebibytes"),
         "GiBy" => Some("gibibytes"),
@@ -79,7 +81,6 @@ fn get_prom_units(unit: &str) -> Option<&'static str> {
         "Hz" => Some("hertz"),
         "1" => Some("ratio"),
         "%" => Some("percent"),
-        "$" => Some("dollars"),
         _ => None,
     }
 }
@@ -185,10 +186,12 @@ mod tests {
             ("1/y", Some(Cow::Owned("per_year".to_owned()))),
             ("m/s", Some(Cow::Owned("meters_per_second".to_owned()))),
             // No match
-            ("invalid", Some(Cow::Owned("invalid".to_string()))),
+            ("invalid", None),
             ("invalid/invalid", None),
-            ("seconds", Some(Cow::Owned("seconds".to_string()))),
+            ("seconds", None),
             ("", None),
+            // annotations
+            ("{request}", None),
         ];
         for (unit_str, expected_suffix) in test_cases {
             let unit = Unit::new(unit_str);


### PR DESCRIPTION
## Motivation

The [metric unit semantic conventions] suggest that integer counts should use annotations (e.g. `{packet}`), which breaks the current unit appending logic as they are not properly escaped.

[metric unit semantic conventions]: https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/general/metrics.md#instrument-units

## Solution

Ignore unknown units (including annotations) as other language implementations currently do. This change also removes the `$` mapping as it is not UCUM.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
