### PR TITLE
Span events stored as Vector instead of EvictedQueue

### DIFF
--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -195,7 +195,7 @@ pub(crate) mod tests {
     };
     use opentelemetry_sdk::{
         self,
-        trace::{SpanLinks, SpanEvents},
+        trace::{SpanEvents, SpanLinks},
         InstrumentationLibrary, Resource,
     };
     use std::borrow::Cow;
@@ -217,7 +217,6 @@ pub(crate) mod tests {
         let start_time = SystemTime::UNIX_EPOCH;
         let end_time = start_time.checked_add(Duration::from_secs(1)).unwrap();
 
-        let capacity = 3;
         let attributes = vec![KeyValue::new("span.type", "web")];
         let events = SpanEvents::default();
         let links = SpanLinks::default();

--- a/opentelemetry-datadog/src/exporter/model/mod.rs
+++ b/opentelemetry-datadog/src/exporter/model/mod.rs
@@ -195,7 +195,7 @@ pub(crate) mod tests {
     };
     use opentelemetry_sdk::{
         self,
-        trace::{EvictedQueue, SpanLinks},
+        trace::{SpanLinks, SpanEvents},
         InstrumentationLibrary, Resource,
     };
     use std::borrow::Cow;
@@ -219,7 +219,7 @@ pub(crate) mod tests {
 
         let capacity = 3;
         let attributes = vec![KeyValue::new("span.type", "web")];
-        let events = EvictedQueue::new(capacity);
+        let events = SpanEvents::default();
         let links = SpanLinks::default();
         let resource = Resource::new(vec![KeyValue::new("host.name", "test")]);
 

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -19,12 +19,12 @@ use opentelemetry::{
     trace::{Event, Link, SpanKind, Status},
     InstrumentationLibrary, Key, KeyValue,
 };
+use opentelemetry_sdk::trace::SpanEvents;
 use opentelemetry_sdk::{
     export::{
         trace::{ExportResult, SpanData, SpanExporter},
         ExportError,
     },
-    trace::EvictedQueue,
 };
 
 use crate::exporter::uploader::Uploader;
@@ -255,7 +255,7 @@ impl UserOverrides {
     }
 }
 
-fn events_to_logs(events: EvictedQueue<Event>) -> Option<Vec<jaeger::Log>> {
+fn events_to_logs(events: SpanEvents) -> Option<Vec<jaeger::Log>> {
     if events.is_empty() {
         None
     } else {

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -19,13 +19,11 @@ use opentelemetry::{
     trace::{Event, Link, SpanKind, Status},
     InstrumentationLibrary, Key, KeyValue,
 };
-use opentelemetry_sdk::trace::SpanEvents;
-use opentelemetry_sdk::{
-    export::{
-        trace::{ExportResult, SpanData, SpanExporter},
-        ExportError,
-    },
+use opentelemetry_sdk::export::{
+    trace::{ExportResult, SpanData, SpanExporter},
+    ExportError,
 };
+use opentelemetry_sdk::trace::SpanEvents;
 
 use crate::exporter::uploader::Uploader;
 

--- a/opentelemetry-proto/src/transform/trace.rs
+++ b/opentelemetry-proto/src/transform/trace.rs
@@ -82,7 +82,7 @@ pub mod tonic {
                         end_time_unix_nano: to_nanos(source_span.end_time),
                         dropped_attributes_count: source_span.dropped_attributes_count,
                         attributes: Attributes::from(source_span.attributes).0,
-                        dropped_events_count: source_span.events.dropped_count(),
+                        dropped_events_count: source_span.events.dropped_count,
                         events: source_span
                             .events
                             .into_iter()
@@ -193,7 +193,7 @@ pub mod grpcio {
                         end_time_unix_nano: to_nanos(source_span.end_time),
                         dropped_attributes_count: source_span.dropped_attributes_count,
                         attributes: Attributes::from(source_span.attributes).0,
-                        dropped_events_count: source_span.events.dropped_count(),
+                        dropped_events_count: source_span.events.dropped_count,
                         events: source_span
                             .events
                             .into_iter()

--- a/opentelemetry-sdk/src/export/trace.rs
+++ b/opentelemetry-sdk/src/export/trace.rs
@@ -1,7 +1,7 @@
 //! Trace exporters
 use crate::Resource;
 use futures_util::future::BoxFuture;
-use opentelemetry::trace::{Event, SpanContext, SpanId, SpanKind, Status, TraceError};
+use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceError};
 use opentelemetry::KeyValue;
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -87,7 +87,7 @@ pub struct SpanData {
     /// dropped.
     pub dropped_attributes_count: u32,
     /// Span events
-    pub events: crate::trace::EvictedQueue<Event>,
+    pub events: crate::trace::SpanEvents,
     /// Span Links
     pub links: crate::trace::SpanLinks,
     /// Span status

--- a/opentelemetry-sdk/src/testing/trace/mod.rs
+++ b/opentelemetry-sdk/src/testing/trace/mod.rs
@@ -7,7 +7,7 @@ use crate::{
         trace::{ExportResult, SpanData, SpanExporter},
         ExportError,
     },
-    trace::{Config, EvictedQueue, SpanLinks},
+    trace::{Config, SpanEvents, SpanLinks},
     InstrumentationLibrary,
 };
 use async_trait::async_trait;
@@ -36,7 +36,7 @@ pub fn new_test_export_span_data() -> SpanData {
         end_time: opentelemetry::time::now(),
         attributes: Vec::new(),
         dropped_attributes_count: 0,
-        events: EvictedQueue::new(config.span_limits.max_events_per_span),
+        events: SpanEvents::default(),
         links: SpanLinks::default(),
         status: Status::Unset,
         resource: config.resource,

--- a/opentelemetry-sdk/src/trace/events.rs
+++ b/opentelemetry-sdk/src/trace/events.rs
@@ -1,0 +1,37 @@
+//! # Span Events
+
+use std::ops::Deref;
+
+use opentelemetry::trace::Event;
+/// Stores span events along with dropped count.
+#[derive(Clone, Debug, Default, PartialEq)]
+#[non_exhaustive]
+pub struct SpanEvents {
+    /// The events stored as a vector. Could be empty if there are no events.
+    pub events: Vec<Event>,
+    /// The number of Events dropped from the span.
+    pub dropped_count: u32,
+}
+
+impl Deref for SpanEvents {
+    type Target = [Event];
+
+    fn deref(&self) -> &Self::Target {
+        &self.events
+    }
+}
+
+impl IntoIterator for SpanEvents {
+    type Item = Event;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.events.into_iter()
+    }
+}
+
+impl SpanEvents {
+    pub(crate) fn add_event(&mut self, event: Event) {
+        self.events.push(event);
+    }
+}

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -7,6 +7,7 @@
 //! current operation execution.
 //! * The [`TracerProvider`] struct which configures and produces [`Tracer`]s.
 mod config;
+mod events;
 mod evicted_hash_map;
 mod evicted_queue;
 mod id_generator;
@@ -19,6 +20,7 @@ mod span_processor;
 mod tracer;
 
 pub use config::{config, Config};
+pub use events::SpanEvents;
 pub use evicted_hash_map::EvictedHashMap;
 pub use evicted_queue::EvictedQueue;
 pub use id_generator::{aws::XrayIdGenerator, IdGenerator, RandomIdGenerator};

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -721,7 +721,7 @@ mod tests {
     use crate::testing::trace::{
         new_test_export_span_data, new_test_exporter, new_tokio_test_exporter,
     };
-    use crate::trace::{BatchConfig, EvictedQueue, SpanLinks};
+    use crate::trace::{BatchConfig, SpanEvents, SpanLinks};
     use async_trait::async_trait;
     use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status};
     use std::fmt::Debug;
@@ -750,7 +750,7 @@ mod tests {
             end_time: opentelemetry::time::now(),
             attributes: Vec::new(),
             dropped_attributes_count: 0,
-            events: EvictedQueue::new(0),
+            events: SpanEvents::default(),
             links: SpanLinks::default(),
             status: Status::Unset,
             resource: Default::default(),

--- a/opentelemetry-stdout/src/trace/transform.rs
+++ b/opentelemetry-stdout/src/trace/transform.rs
@@ -107,7 +107,7 @@ impl From<opentelemetry_sdk::export::trace::SpanData> for Span {
             end_time: value.end_time,
             dropped_attributes_count: value.dropped_attributes_count,
             attributes: value.attributes.into_iter().map(Into::into).collect(),
-            dropped_events_count: value.events.dropped_count(),
+            dropped_events_count: value.events.dropped_count,
             events: value.events.into_iter().map(Into::into).collect(),
             dropped_links_count: value.links.dropped_count,
             links: value.links.iter().map(Into::into).collect(),

--- a/opentelemetry-zipkin/src/exporter/model/span.rs
+++ b/opentelemetry-zipkin/src/exporter/model/span.rs
@@ -60,7 +60,7 @@ mod tests {
     use crate::exporter::model::span::{Kind, Span};
     use crate::exporter::model::{into_zipkin_span, OTEL_ERROR_DESCRIPTION, OTEL_STATUS_CODE};
     use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId};
-    use opentelemetry_sdk::trace::{SpanLinks, SpanEvents};
+    use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
     use opentelemetry_sdk::{export::trace::SpanData, Resource};
     use std::borrow::Cow;
     use std::collections::HashMap;

--- a/opentelemetry-zipkin/src/exporter/model/span.rs
+++ b/opentelemetry-zipkin/src/exporter/model/span.rs
@@ -60,8 +60,8 @@ mod tests {
     use crate::exporter::model::span::{Kind, Span};
     use crate::exporter::model::{into_zipkin_span, OTEL_ERROR_DESCRIPTION, OTEL_STATUS_CODE};
     use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId};
-    use opentelemetry_sdk::trace::SpanLinks;
-    use opentelemetry_sdk::{export::trace::SpanData, trace::EvictedQueue, Resource};
+    use opentelemetry_sdk::trace::{SpanLinks, SpanEvents};
+    use opentelemetry_sdk::{export::trace::SpanData, Resource};
     use std::borrow::Cow;
     use std::collections::HashMap;
     use std::net::Ipv4Addr;
@@ -163,7 +163,7 @@ mod tests {
                 end_time: SystemTime::now(),
                 attributes: Vec::new(),
                 dropped_attributes_count: 0,
-                events: EvictedQueue::new(20),
+                events: SpanEvents::default(),
                 links: SpanLinks::default(),
                 status,
                 resource: Cow::Owned(Resource::default()),


### PR DESCRIPTION
Continuing from https://github.com/open-telemetry/opentelemetry-rust/pull/1313/files, this one for Events.