### PR TITLE
Remove span_builder from Tracer

### DIFF
--- a/examples/traceresponse/src/client.rs
+++ b/examples/traceresponse/src/client.rs
@@ -1,9 +1,10 @@
 use hyper::http::HeaderValue;
 use hyper::{body::Body, Client};
+use opentelemetry::trace::SpanBuilder;
 use opentelemetry::{
     global,
     propagation::TextMapPropagator,
-    trace::{SpanKind, TraceContextExt, Tracer},
+    trace::{SpanKind, TraceContextExt},
     Context, KeyValue,
 };
 use opentelemetry_contrib::trace::propagator::trace_context_response::TraceContextResponsePropagator;
@@ -29,8 +30,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sy
 
     let client = Client::new();
     let tracer = global::tracer("example/client");
-    let span = tracer
-        .span_builder("say hello")
+    let span = SpanBuilder::from_name("say hello")
         .with_kind(SpanKind::Client)
         .start(&tracer);
     let cx = Context::current_with_span(span);

--- a/examples/traceresponse/src/server.rs
+++ b/examples/traceresponse/src/server.rs
@@ -5,7 +5,7 @@ use hyper::{
 use opentelemetry::{
     global,
     propagation::TextMapPropagator,
-    trace::{SpanKind, TraceContextExt, Tracer},
+    trace::{SpanBuilder, SpanKind, TraceContextExt},
     Context,
 };
 use opentelemetry_contrib::trace::propagator::trace_context_response::TraceContextResponsePropagator;
@@ -21,8 +21,7 @@ async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     let _cx_guard = parent_cx.attach();
 
     let tracer = global::tracer("example/server");
-    let span = tracer
-        .span_builder("say hello")
+    let span = SpanBuilder::from_name("say hello")
         .with_kind(SpanKind::Server)
         .start(&tracer);
 

--- a/opentelemetry-otlp/tests/smoke.rs
+++ b/opentelemetry-otlp/tests/smoke.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use opentelemetry::global::shutdown_tracer_provider;
-use opentelemetry::trace::{Span, SpanBuilder, SpanKind, Tracer};
+use opentelemetry::trace::{Span, SpanBuilder, SpanKind};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_proto::tonic::collector::trace::v1::{
     trace_service_server::{TraceService, TraceServiceServer},

--- a/opentelemetry-otlp/tests/smoke.rs
+++ b/opentelemetry-otlp/tests/smoke.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use opentelemetry::global::shutdown_tracer_provider;
-use opentelemetry::trace::{Span, SpanKind, Tracer};
+use opentelemetry::trace::{Span, SpanBuilder, SpanKind, Tracer};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_proto::tonic::collector::trace::v1::{
     trace_service_server::{TraceService, TraceServiceServer},
@@ -102,8 +102,7 @@ async fn smoke_tracer() {
             .expect("failed to install");
 
         println!("Sending span...");
-        let mut span = tracer
-            .span_builder("my-test-span")
+        let mut span = SpanBuilder::from_name("my-test-span")
             .with_kind(SpanKind::Server)
             .start(&tracer);
         span.add_event("my-test-event", vec![]);

--- a/opentelemetry-sdk/benches/span_builder.rs
+++ b/opentelemetry-sdk/benches/span_builder.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use futures_util::future::BoxFuture;
 use opentelemetry::{
-    trace::{Span, SpanBuilder, Tracer, TracerProvider},
+    trace::{Span, SpanBuilder, TracerProvider},
     KeyValue,
 };
 use opentelemetry_sdk::{

--- a/opentelemetry-sdk/benches/span_builder.rs
+++ b/opentelemetry-sdk/benches/span_builder.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use futures_util::future::BoxFuture;
 use opentelemetry::{
-    trace::{Span, Tracer, TracerProvider},
+    trace::{Span, SpanBuilder, Tracer, TracerProvider},
     KeyValue,
 };
 use opentelemetry_sdk::{
@@ -20,15 +20,14 @@ fn span_builder_benchmark_group(c: &mut Criterion) {
     group.bench_function("simplest", |b| {
         let (_provider, tracer) = not_sampled_provider();
         b.iter(|| {
-            let mut span = tracer.span_builder("span").start(&tracer);
+            let mut span = SpanBuilder::from_name("span").start(&tracer);
             span.end();
         })
     });
     group.bench_function(BenchmarkId::new("with_attributes", "1"), |b| {
         let (_provider, tracer) = not_sampled_provider();
         b.iter(|| {
-            let mut span = tracer
-                .span_builder("span")
+            let mut span = SpanBuilder::from_name("span")
                 .with_attributes([KeyValue::new(MAP_KEYS[0], "value")])
                 .start(&tracer);
             span.end();
@@ -37,8 +36,7 @@ fn span_builder_benchmark_group(c: &mut Criterion) {
     group.bench_function(BenchmarkId::new("with_attributes", "4"), |b| {
         let (_provider, tracer) = not_sampled_provider();
         b.iter(|| {
-            let mut span = tracer
-                .span_builder("span")
+            let mut span = SpanBuilder::from_name("span")
                 .with_attributes([
                     KeyValue::new(MAP_KEYS[0], "value"),
                     KeyValue::new(MAP_KEYS[1], "value"),

--- a/opentelemetry-sdk/src/testing/trace/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/trace/in_memory_exporter.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 /// using the `get_finished_spans` method.
 /// # Example
 /// ```
-///# use opentelemetry::trace::{SpanKind, TraceContextExt};
+///# use opentelemetry::trace::{SpanKind, SpanBuilder, TraceContextExt};
 ///# use opentelemetry::{global, trace::Tracer, Context};
 ///# use opentelemetry_sdk::propagation::TraceContextPropagator;
 ///# use opentelemetry_sdk::runtime;

--- a/opentelemetry-sdk/src/testing/trace/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/trace/in_memory_exporter.rs
@@ -27,8 +27,7 @@ use std::sync::{Arc, Mutex};
 ///     global::set_tracer_provider(provider.clone());
 ///
 ///     let tracer = global::tracer("example/in_memory_exporter");
-///     let span = tracer
-///         .span_builder("say hello")
+///     let span = SpanBuilder::from_name("say hello")
 ///         .with_kind(SpanKind::Server)
 ///         .start(&tracer);
 ///

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -568,7 +568,7 @@ mod tests {
         let event2 = event1.clone();
 
         // add event when build
-        let span_builder = tracer.span_builder("test").with_events(vec![event1]);
+        let span_builder = SpanBuilder::from_name("test").with_events(vec![event1]);
         let mut span = tracer.build(span_builder);
 
         // add event after build
@@ -609,7 +609,7 @@ mod tests {
                 .push(KeyValue::new(format!("key {}", i), i.to_string()));
         }
 
-        let span_builder = tracer.span_builder("test").with_links(vec![link]);
+        let span_builder = SpanBuilder::from_name("test").with_links(vec![link]);
         let span = tracer.build(span_builder);
         let link_queue = span
             .data
@@ -643,7 +643,7 @@ mod tests {
             ))
         }
 
-        let span_builder = tracer.span_builder("test").with_links(links);
+        let span_builder = SpanBuilder::from_name("test").with_links(links);
         let span = tracer.build(span_builder);
         let link_queue = span
             .data
@@ -668,7 +668,7 @@ mod tests {
         }
 
         // add events via span builder
-        let span_builder = tracer.span_builder("test").with_events(events);
+        let span_builder = SpanBuilder::from_name("test").with_events(events);
         let mut span = tracer.build(span_builder);
 
         // add events using span api after building the span

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -306,8 +306,8 @@ mod tests {
     };
     use opentelemetry::{
         trace::{
-            Link, SamplingDecision, SamplingResult, Span, SpanContext, SpanId, SpanKind,
-            TraceContextExt, TraceFlags, TraceId, TraceState, Tracer, TracerProvider,
+            Link, SamplingDecision, SamplingResult, Span, SpanBuilder, SpanContext, SpanId,
+            SpanKind, TraceContextExt, TraceFlags, TraceId, TraceState, Tracer, TracerProvider,
         },
         Context, KeyValue,
     };

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -390,7 +390,7 @@ mod tests {
         let tracer = tracer_provider.tracer("test");
 
         let _attached = Context::current_with_span(TestSpan(SpanContext::empty_context())).attach();
-        let span = tracer.span_builder("must_not_be_sampled").start(&tracer);
+        let span = SpanBuilder::from_name("must_not_be_sampled").start(&tracer);
         assert!(!span.span_context().is_sampled());
 
         let context = Context::map_current(|cx| {
@@ -403,7 +403,7 @@ mod tests {
             ))
         });
         let _attached = context.attach();
-        let span = tracer.span_builder("must_not_be_sampled").start(&tracer);
+        let span = SpanBuilder::from_name("must_not_be_sampled").start(&tracer);
 
         assert!(!span.span_context().is_sampled());
     }

--- a/opentelemetry-semantic-conventions/scripts/templates/header_trace.rs
+++ b/opentelemetry-semantic-conventions/scripts/templates/header_trace.rs
@@ -12,8 +12,7 @@
 //! use opentelemetry_semantic_conventions as semcov;
 //!
 //! let tracer = global::tracer("my-component");
-//! let _span = tracer
-//!     .span_builder("span-name")
+//! let _span = SpanBuilder::from_name("span-name")
 //!     .with_attributes(vec![
 //!         semcov::trace::NET_PEER_NAME.string("example.org"),
 //!         semcov::trace::NET_PEER_PORT.i64(80),

--- a/opentelemetry-semantic-conventions/src/trace.rs
+++ b/opentelemetry-semantic-conventions/src/trace.rs
@@ -14,7 +14,7 @@
 //! ## Usage
 //!
 //! ```
-//! use opentelemetry::{global, trace::Tracer as _};
+//! use opentelemetry::{global, trace::Tracer as _, SpanBuilder};
 //! use opentelemetry_semantic_conventions as semcov;
 //!
 //! let tracer = global::tracer("my-component");

--- a/opentelemetry-semantic-conventions/src/trace.rs
+++ b/opentelemetry-semantic-conventions/src/trace.rs
@@ -14,7 +14,7 @@
 //! ## Usage
 //!
 //! ```
-//! use opentelemetry::{global, trace::Tracer as _, SpanBuilder};
+//! use opentelemetry::{global, trace::Tracer as _, trace::SpanBuilder};
 //! use opentelemetry_semantic_conventions as semcov;
 //!
 //! let tracer = global::tracer("my-component");

--- a/opentelemetry-semantic-conventions/src/trace.rs
+++ b/opentelemetry-semantic-conventions/src/trace.rs
@@ -18,8 +18,7 @@
 //! use opentelemetry_semantic_conventions as semcov;
 //!
 //! let tracer = global::tracer("my-component");
-//! let _span = tracer
-//!     .span_builder("span-name")
+//! let _span = SpanBuilder::from_name("span-name")
 //!     .with_attributes(vec![
 //!         semcov::trace::NET_PEER_NAME.string("example.org"),
 //!         semcov::trace::NET_PEER_PORT.i64(80),

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -17,6 +17,10 @@ Removed `OrderMap` type as there was no requirement to use this over regular
 `HashMap`.
 [#1353](https://github.com/open-telemetry/opentelemetry-rust/pull/1353)
 
+Removed `span_builder` from `Tracer`. Use `SpanBuilder::from_name` to obtain
+`SpanBuilder`.
+[#1360](https://github.com/open-telemetry/opentelemetry-rust/pull/1360)
+
 ## [v0.21.0](https://github.com/open-telemetry/opentelemetry-rust/compare/v0.20.0...v0.21.0)
 
 This release should been seen as 1.0-rc4 following 1.0-rc3 in v0.20.0. Refer to CHANGELOG.md in individual creates for details on changes made in different creates.

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -19,7 +19,7 @@ Removed `OrderMap` type as there was no requirement to use this over regular
 
 Removed `span_builder` from `Tracer`. Use `SpanBuilder::from_name` to obtain
 `SpanBuilder`.
-[#1360](https://github.com/open-telemetry/opentelemetry-rust/pull/1360)
+[#1361](https://github.com/open-telemetry/opentelemetry-rust/pull/1361)
 
 ## [v0.21.0](https://github.com/open-telemetry/opentelemetry-rust/compare/v0.20.0...v0.21.0)
 

--- a/opentelemetry/src/trace/noop.rs
+++ b/opentelemetry/src/trace/noop.rs
@@ -160,7 +160,7 @@ impl TextMapPropagator for NoopTextMapPropagator {
 mod tests {
     use super::*;
     use crate::testing::trace::TestSpan;
-    use crate::trace::{self, Span, TraceState, Tracer};
+    use crate::trace::{self, Span, SpanBuilder, TraceState, Tracer};
 
     fn valid_span_context() -> trace::SpanContext {
         trace::SpanContext::new(
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn noop_tracer_propagates_valid_span_context_from_builder() {
         let tracer = NoopTracer::new();
-        let builder = tracer.span_builder("foo");
+        let builder = SpanBuilder::from_name("foo");
         let span = tracer.build_with_context(
             builder,
             &Context::new().with_span(TestSpan(valid_span_context())),

--- a/opentelemetry/src/trace/tracer.rs
+++ b/opentelemetry/src/trace/tracer.rs
@@ -155,17 +155,6 @@ pub trait Tracer {
         self.build_with_context(SpanBuilder::from_name(name), parent_cx)
     }
 
-    /// Creates a span builder.
-    ///
-    /// [`SpanBuilder`]s allow you to specify all attributes of a [`Span`] before
-    /// the span is started.
-    fn span_builder<T>(&self, name: T) -> SpanBuilder
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        SpanBuilder::from_name(name)
-    }
-
     /// Start a [`Span`] from a [`SpanBuilder`].
     fn build(&self, builder: SpanBuilder) -> Self::Span {
         Context::map_current(|cx| self.build_with_context(builder, cx))
@@ -233,8 +222,7 @@ pub trait Tracer {
 /// });
 ///
 /// // Or used with builder pattern
-/// let _span = tracer
-///     .span_builder("example-span-name")
+/// let _span = SpanBuilder::from_name("example-span-name")
 ///     .with_kind(SpanKind::Server)
 ///     .start(&tracer);
 /// ```


### PR DESCRIPTION
## Changes

Removed `span_builder` from `Tracer`. The returned `SpanBuilder` was anyway not connected to the `Tracer`, so users still had to provide a `Tracer` to the `start` method! Removed the method in favor of just using `SpanBuilder`'s associated method to get one!

I am thinking of this as a necessary cleanup of unnecessary public APIs. If there is a desire in the future to bring back this method, we can do so, but this time, it should be linked to Tracer automatically, so there won't be any need to pass it to the "start" !

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
