### PR TITLE
Fix metric export data for unused gauges

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### Fixed
 
-- Fix metric export corruption if gauges have not received a last value.
+- Fix metric export corruption if gauges have not received a last value. (#1363)
 
 ## v0.21.0
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -13,14 +13,18 @@
   *Behavior Change*: When enforcing `max_links_per_span`, `max_events_per_span`
   from `SpanLimits`, links/events are kept in the first-come order. The previous
   "eviction" based approach is no longer performed.
-  
+
   *Breaking Change Affecting Exporter authors*:
-  
+
   `SpanData` now stores `links` as `SpanLinks` instead of `EvictedQueue` where
   `SpanLinks` is a struct with a `Vec` of links and `dropped_count`.
 
   `SpanData` now stores `events` as `SpanEvents` instead of `EvictedQueue` where
   `SpanEvents` is a struct with a `Vec` of events and `dropped_count`.
+
+### Fixed
+
+- Fix metric export corruption if gauges have not received a last value.
 
 ## v0.21.0
 

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -55,8 +55,12 @@ impl<T: Number<T>> LastValue<T> {
     pub(crate) fn compute_aggregation(&self, dest: &mut Vec<DataPoint<T>>) {
         let mut values = match self.values.lock() {
             Ok(guard) if !guard.is_empty() => guard,
-            _ => return,
+            _ => {
+                dest.clear(); // poisoned or no values recorded yet
+                return;
+            }
         };
+
         let n = values.len();
         if n > dest.capacity() {
             dest.reserve(n - dest.capacity());


### PR DESCRIPTION
Fixes #1360

## Changes

Clears metric data for gauges that have not received any values when aggregating.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
