### PR TITLE
Nit fixes to md file to reduce warnings

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -25,13 +25,33 @@
     // these are words that are always correct and can be thought of as our
     // workspace dictionary.
     "words": [
+        "actix",
+        "appender",
+        "appenders",
+        "Bhasin",
+        "Cijo",
+        "codecov",
         "deque",
+        "Dirkjan",
         "hasher",
+        "isahc",
+        "Isobel",
+        "jaegertracing",
+        "Kühle",
+        "Kumar",
+        "Lalit",
         "msrv",
+        "Ochtman",
+        "openetelemetry",
         "opentelemetry",
         "OTLP",
+        "protoc",
         "quantile",
+        "Redelmeier",
+        "reqwest",
         "rustc",
+        "Tescher",
+        "Zhongyang",
         "zipkin"
     ],
     "enabledLanguageIds": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
     - main
+    paths-ignore:
+    - '**.md'
 jobs:
   test:
     strategy:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,7 @@
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
+# Code owners file
 
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers
+This file controls who is tagged for review for any given pull request.
+
+For anything not explicitly taken by someone else:
+
+* @open-telemetry/rust-approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # Code owners file
 
-This file controls who is tagged for review for any given pull request.
+## This file controls who is tagged for review for any given pull request.
 
-For anything not explicitly taken by someone else:
+## For anything not explicitly taken by someone else:
 
 * @open-telemetry/rust-approvers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ you're more than welcome to participate!
 
 ### Prerequisites
 
-Crate `opentelemetry-otlp` uses gRPC + Protocol Buffers.<br>
+Crate `opentelemetry-otlp` uses gRPC + Protocol Buffers.
 You can provide the protocol compiler protoc path programmatically (only works with tonic) or build it from source
 
 ```sh
@@ -40,13 +40,13 @@ Everyone is welcome to contribute code to `opentelemetry-rust` via
 GitHub pull requests (PRs).
 
 ```sh
-$ git clone --recurse-submodule https://github.com/open-telemetry/opentelemetry-rust
+git clone --recurse-submodule https://github.com/open-telemetry/opentelemetry-rust
 ```
 
 Enter the newly created directory and add your fork as a new remote:
 
 ```sh
-$ git remote add <YOUR_FORK> git@github.com:<YOUR_GITHUB_USERNAME>/opentelemetry-rust
+git remote add <YOUR_FORK> git@github.com:<YOUR_GITHUB_USERNAME>/opentelemetry-rust
 ```
 
 Check out a new branch, make modifications, run linters and tests, and
@@ -70,25 +70,25 @@ the repo to catch any issues locally.
 
 ### How to Receive Comments
 
-* If the PR is not ready for review, please put `[WIP]` in the title or mark it
+- If the PR is not ready for review, please put `[WIP]` in the title or mark it
   as [`draft`](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
-* Make sure CLA is signed and all required CI checks are clear.
-* Submit small, focused PRs addressing a single concern/issue.
-* Make sure the PR title reflects the contribution.
-* Write a summary that helps understand the change.
-* Include usage examples in the summary, where applicable.
-* Include benchmarks (before/after) in the summary, for contributions that are
+- Make sure CLA is signed and all required CI checks are clear.
+- Submit small, focused PRs addressing a single concern/issue.
+- Make sure the PR title reflects the contribution.
+- Write a summary that helps understand the change.
+- Include usage examples in the summary, where applicable.
+- Include benchmarks (before/after) in the summary, for contributions that are
   performance enhancements.
 
 ### How to Get PRs Merged
 
 A PR is considered to be **ready to merge** when:
 
-* It has received approval from
+- It has received approval from
   [Approvers](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).
   /
   [Maintainers](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
-* Major feedbacks are resolved.
+- Major feedbacks are resolved.
 
 Any Maintainer can merge the PR once it is **ready to merge**. Note, that some
 PRs may not be merged immediately if the repo is in the process of a release and
@@ -124,7 +124,7 @@ For a deeper discussion, see:
 
 ### Error Handling
 
-Currently, the Opentelemetry Rust SDK has two ways to handle errors. In the situation where errors are not allowed to return. One should call global error handler to process the errors. Otherwise, one should return the errors. 
+Currently, the Opentelemetry Rust SDK has two ways to handle errors. In the situation where errors are not allowed to return. One should call global error handler to process the errors. Otherwise, one should return the errors.
 
 The Opentelemetry Rust SDK comes with an error type `openetelemetry::Error`. For different function, one error has been defined. All error returned by trace module MUST be wrapped in `opentelemetry::trace::TraceError`. All errors returned by metrics module MUST be wrapped in `opentelemetry::metrics::MetricsError`.
 
@@ -139,17 +139,17 @@ OpenTelemetry supports multiple ways to configure the API, SDK and other compone
 
 ## Style Guide
 
-* Run `cargo clippy --all` - this will catch common mistakes and improve
+- Run `cargo clippy --all` - this will catch common mistakes and improve
 your Rust code
-* Run `cargo fmt` - this will find and fix code formatting
+- Run `cargo fmt` - this will find and fix code formatting
 issues.
 
 ## Testing and Benchmarking
 
-* Run `cargo test --all` - this will execute code and doc tests for all
+- Run `cargo test --all` - this will execute code and doc tests for all
 projects in this workspace.
-* Run `cargo bench` - this will run benchmarks to show performance
-* Run `cargo bench` - this will run benchmarks to show performance
+- Run `cargo bench` - this will run benchmarks to show performance
+- Run `cargo bench` - this will run benchmarks to show performance
 regressions
 
 ## Approvers and Maintainers
@@ -158,21 +158,21 @@ For GitHub groups see the [code owners](CODEOWNERS) file.
 
 ### Maintainers
 
-* [Harold Dost](https://github.com/hdost)
-* [Julian Tescher](https://github.com/jtescher)
-* [Zhongyang Wu](https://github.com/TommyCpp)
+- [Harold Dost](https://github.com/hdost)
+- [Julian Tescher](https://github.com/jtescher)
+- [Zhongyang Wu](https://github.com/TommyCpp)
 
 ### Approvers
 
-* [Cijo Thomas](https://github.com/cijothomas)
-* [Lalit Kumar Bhasin](https://github.com/lalitb)
-* [Shaun Cox](https://github.com/shaun-cox)
+- [Cijo Thomas](https://github.com/cijothomas)
+- [Lalit Kumar Bhasin](https://github.com/lalitb)
+- [Shaun Cox](https://github.com/shaun-cox)
 
 ### Emeritus
 
-* [Dirkjan Ochtman](https://github.com/djc)
-* [Jan Kühle](https://github.com/frigus02)
-* [Isobel Redelmeier](https://github.com/iredelmeier)
+- [Dirkjan Ochtman](https://github.com/djc)
+- [Jan Kühle](https://github.com/frigus02)
+- [Isobel Redelmeier](https://github.com/iredelmeier)
 
 ### Become an Approver or a Maintainer
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ observability tools.
 [Jaeger]: https://www.jaegertracing.io
 [msrv]: #supported-rust-versions
 
-
 ## Project Status
 
 | Signal  | Status     |
@@ -101,36 +100,36 @@ adapter crates to assist in propagating state and instrumenting applications.
 
 In particular, the following crates are likely to be of interest:
 
-- [`opentelemetry-aws`] provides unofficial propagators for AWS X-ray.
-- [`opentelemetry-datadog`] provides additional exporters to [`Datadog`].
-- [`opentelemetry-dynatrace`] provides additional exporters to Dynatrace.
-- [`opentelemetry-contrib`] provides additional exporters and propagators that
+* [`opentelemetry-aws`] provides unofficial propagators for AWS X-ray.
+* [`opentelemetry-datadog`] provides additional exporters to [`Datadog`].
+* [`opentelemetry-dynatrace`] provides additional exporters to Dynatrace.
+* [`opentelemetry-contrib`] provides additional exporters and propagators that
   are experimental.
-- [`opentelemetry-http`] provides an interface for injecting and extracting
+* [`opentelemetry-http`] provides an interface for injecting and extracting
   trace information from [`http`] headers.
-- [`opentelemetry-jaeger`] provides a pipeline and exporter for sending trace
+* [`opentelemetry-jaeger`] provides a pipeline and exporter for sending trace
   information to [`Jaeger`].
-- [`opentelemetry-otlp`] exporter for sending trace and metric data in the OTLP
+* [`opentelemetry-otlp`] exporter for sending trace and metric data in the OTLP
   format to the OpenTelemetry collector.
-- [`opentelemetry-prometheus`] provides a pipeline and exporter for sending
+* [`opentelemetry-prometheus`] provides a pipeline and exporter for sending
   metrics information to [`Prometheus`].
-- [`opentelemetry-semantic-conventions`] provides standard names and semantic
+* [`opentelemetry-semantic-conventions`] provides standard names and semantic
   otel conventions.
-- [`opentelemetry-stackdriver`] provides an exporter for Google's [Cloud Trace]
+* [`opentelemetry-stackdriver`] provides an exporter for Google's [Cloud Trace]
   (which used to be called StackDriver).
-- [`opentelemetry-zipkin`] provides a pipeline and exporter for sending trace
+* [`opentelemetry-zipkin`] provides a pipeline and exporter for sending trace
   information to [`Zipkin`].
 
 Additionally, there are also several third-party crates which are not
 maintained by the `opentelemetry` project. These include:
 
-- [`tracing-opentelemetry`] provides integration for applications instrumented
+* [`tracing-opentelemetry`] provides integration for applications instrumented
   using the [`tracing`] API and ecosystem.
-- [`actix-web-opentelemetry`] provides integration for the [`actix-web`] web
+* [`actix-web-opentelemetry`] provides integration for the [`actix-web`] web
   server and ecosystem.
-- [`opentelemetry-application-insights`] provides an unofficial [Azure
+* [`opentelemetry-application-insights`] provides an unofficial [Azure
   Application Insights] exporter.
-- [`opentelemetry-tide`] provides integration for the [`Tide`] web server and
+* [`opentelemetry-tide`] provides integration for the [`Tide`] web server and
   ecosystem.
 
 If you're the maintainer of an `opentelemetry` ecosystem crate not listed
@@ -149,7 +148,6 @@ above, please let us know! We'd love to add your project to the list!
 [`opentelemetry-contrib`]: https://crates.io/crates/opentelemetry-contrib
 [`Datadog`]: https://www.datadoghq.com
 [`opentelemetry-datadog`]: https://crates.io/crates/opentelemetry-datadog
-[`Dynatrace`]: https://www.dynatrace.com/
 [`opentelemetry-dynatrace`]: https://crates.io/crates/opentelemetry-dynatrace
 [`opentelemetry-semantic-conventions`]: https://crates.io/crates/opentelemetry-semantic-conventions
 [`http`]: https://crates.io/crates/http
@@ -182,7 +180,7 @@ this policy.
 
 See the [contributing file](CONTRIBUTING.md).
 
-The Rust special interest group (SIG) meets weekly on Tuesdays at 9 AM Pacific
+The Rust special interest group (SIG) meets weekly on Tuesdays at 8 AM Pacific
 Time (16:00 UTC). The meeting is subject to change depending on contributors'
 availability. Check the [OpenTelemetry community
 calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com)

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -151,7 +151,7 @@
 //! You can set it using one of the following methods from highest priority to lowest priority.
 //! 1. [`with_service_name`].
 //! 2. include a `service.name` key value pairs when configure resource using [`with_trace_config`].
-//! 3. set the service name as `OTEL_SERVCE_NAME` environment variable.
+//! 3. set the service name as `OTEL_SERVICE_NAME` environment variable.
 //! 4. set the `service.name` attributes in `OTEL_RESOURCE_ATTRIBUTES`.
 //! 5. if the service name is not provided by the above method. `unknown_service` will be used.
 //!
@@ -207,7 +207,7 @@
 //! ```
 //!
 //! ### Export to collectors
-//! Note that this example requires `collecotr_client` and `isahc_collector_client` feature.
+//! Note that this example requires `collector_client` and `isahc_collector_client` feature.
 //! ```ignore
 //! use opentelemetry::{global, KeyValue, trace::{Tracer, TraceError}};
 //! use opentelemetry_sdk::{trace::{config, RandomIdGenerator, Sampler}, Resource};


### PR DESCRIPTION
I think its good to add CI checks for this (https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/workflows/markdownlint.yml) in the future. As a first step, doing some cleanups in md files.