### PR TITLE
Prepare for patch release

### DIFF
--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.14.1
+
 ### Fixed
 
 - Fix UCUM annotation escaping by ignoring unknown instrument units and annotations (#1348)

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-prometheus"
-version = "0.14.0"
+version = "0.14.1"
 description = "Prometheus exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -22,6 +22,8 @@
   `SpanData` now stores `events` as `SpanEvents` instead of `EvictedQueue` where
   `SpanEvents` is a struct with a `Vec` of events and `dropped_count`.
 
+## v0.21.1
+
 ### Fixed
 
 - Fix metric export corruption if gauges have not received a last value. (#1363)

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry_sdk"
-version = "0.21.0"
+version = "0.21.1"
 description = "The SDK for the OpenTelemetry metrics collection and distributed tracing framework"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"


### PR DESCRIPTION
Relase backported bugfixes into [v0.21.x](https://github.com/open-telemetry/opentelemetry-rust/tree/v0.21.x):

* `opentelemetry-prometheus`: 
    * #1348
* `opentelemetry-sdk`: 
    * #1363 
    * #1351