### PR TITLE
Run opentelemetry-jaeger tests consecutively

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,6 +11,6 @@ cargo test --manifest-path=opentelemetry/Cargo.toml --no-default-features
 cargo test --manifest-path=opentelemetry/Cargo.toml --all-features -- --ignored --test-threads=1
 
 cargo test --manifest-path=opentelemetry/Cargo.toml --all-features
-cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --all-features
+cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --all-features -- --test-threads=1
 cargo test --manifest-path=opentelemetry-otlp/Cargo.toml --features "trace,grpc-sys" --no-default-features
 cargo test --manifest-path=opentelemetry-zipkin/Cargo.toml --all-features


### PR DESCRIPTION
## Design discussion issue 

There are random [failures](https://github.com/open-telemetry/opentelemetry-rust/actions/runs/6915742069/job/18815025248) during `opentelemetry-jaeger` tests, due to environment variable updates from parallel tests
If you run this command line multiple times, you should be able to reproduce it (`test_resolve_timeout` and `test_resolve_endpoint` are updating some environment variables)
```shell
cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --all-features collector -- --test-threads=5
```
output
```shell
    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running unittests src/lib.rs (target/debug/deps/opentelemetry_jaeger-4c618f55e33f8568)

running 5 tests
test exporter::config::collector::tests::test_resolve_timeout ... ok
test exporter::config::collector::tests::test_resolve_endpoint ... ok
test exporter::config::collector::http_client::collector_client_tests::test_bring_your_own_client ... FAILED
test exporter::config::collector::tests::test_collector_exporter ... FAILED
test exporter::config::collector::tests::test_set_collector_endpoint ... FAILED

failures:

---- exporter::config::collector::http_client::collector_client_tests::test_bring_your_own_client stdout ----
Error: ExportFailed(ConfigError { pipeline_name: "collector", config_name: "collector_endpoint", reason: "invalid uri from environment variable, invalid uri character" })

---- exporter::config::collector::tests::test_collector_exporter stdout ----
thread 'exporter::config::collector::tests::test_collector_exporter' panicked at opentelemetry-jaeger/src/exporter/config/collector/mod.rs:578:9:
assertion failed: exporter.is_ok()

---- exporter::config::collector::tests::test_set_collector_endpoint stdout ----
thread 'exporter::config::collector::tests::test_set_collector_endpoint' panicked at opentelemetry-jaeger/src/exporter/config/collector/mod.rs:558:9:
assertion failed: invalid_uri.is_err()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    exporter::config::collector::http_client::collector_client_tests::test_bring_your_own_client
    exporter::config::collector::tests::test_collector_exporter
    exporter::config::collector::tests::test_set_collector_endpoint

test result: FAILED. 2 passed; 3 failed; 0 ignored; 0 measured; 17 filtered out; finished in 0.00s
```

## Changes

The easy fix is to limit threads to 1 (to force tests to run consecutively) but it's probably better to consider something like [temp-env](https://github.com/open-telemetry/opentelemetry-rust/issues/1383)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
