### PR TITLE
Test to validate identical instruments are merged

### DIFF
--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -156,4 +156,54 @@ mod tests {
             3
         );
     }
+
+    // "multi_thread" tokio flavor must be used else flush won't
+    // be able to make progress!
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn counter_duplicate_instrument_merge() {
+        // Arrange
+        let exporter = InMemoryMetricsExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+        // Act
+        let meter = meter_provider.meter("test");
+        let counter = meter
+            .u64_counter("my_counter")
+            .with_unit(Unit::new("my_unit"))
+            .with_description("my_description")
+            .init();
+
+        let counter_duplicated = meter
+            .u64_counter("my_counter")
+            .with_unit(Unit::new("my_unit"))
+            .with_description("my_description")
+            .init();
+
+        let attribute = vec![KeyValue::new("key1", "value1")];
+        counter.add(10, &attribute);
+        counter_duplicated.add(5, &attribute);
+
+        meter_provider.force_flush().unwrap();
+
+        // Assert
+        let resource_metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics are expected to be exported.");
+        assert!(resource_metrics[0].scope_metrics[0].metrics.len() == 1, "There should be single metric merging duplicate instruments");
+        let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
+        assert_eq!(metric.name, "my_counter");
+        assert_eq!(metric.unit.as_str(), "my_unit");
+        let sum = metric
+            .data
+            .as_any()
+            .downcast_ref::<data::Sum<u64>>()
+            .expect("Sum aggregation expected for Counter instruments by default");
+
+        // Expecting 1 time-series.
+        assert_eq!(sum.data_points.len(), 1);
+
+        let datapoint = &sum.data_points[0];
+        assert_eq!(datapoint.value, 15);
+    }
 }

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -190,7 +190,10 @@ mod tests {
         let resource_metrics = exporter
             .get_finished_metrics()
             .expect("metrics are expected to be exported.");
-        assert!(resource_metrics[0].scope_metrics[0].metrics.len() == 1, "There should be single metric merging duplicate instruments");
+        assert!(
+            resource_metrics[0].scope_metrics[0].metrics.len() == 1,
+            "There should be single metric merging duplicate instruments"
+        );
         let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
         assert_eq!(metric.name, "my_counter");
         assert_eq!(metric.unit.as_str(), "my_unit");


### PR DESCRIPTION
Continuing from https://github.com/open-telemetry/opentelemetry-rust/pull/1382, this adds one more test, validating a different aspect - instruments with matching identity must be merged to produce same metric stream.

I may add few more of similar tests (testing diff. aspects like view/callbacks etc.), and once all is done, we can identify common parts of these tests and move common code to helpers as opposed to duplicating a lot of code in each test. Also it'll be possible to test multiple things in single test.