### PR TITLE
Add missing event timestamps to `opentelemetry-stdout`

### DIFF
--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -37,6 +37,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tracer = tracer_provider.tracer("stdout-test");
     let mut span = tracer.start("test_span");
     span.set_attribute(KeyValue::new("test_key", "test_value"));
+    span.add_event(
+        "test_event",
+        vec![KeyValue::new("test_event_key", "test_event_value")],
+    );
     span.end();
 
     let meter = meter_provider.meter("stdout-test");

--- a/opentelemetry-stdout/src/trace/transform.rs
+++ b/opentelemetry-stdout/src/trace/transform.rs
@@ -154,6 +154,10 @@ struct Event {
     name: Cow<'static, str>,
     attributes: Vec<KeyValue>,
     dropped_attributes_count: u32,
+    #[serde(serialize_with = "as_unix_nano")]
+    time_unix_nano: SystemTime,
+    #[serde(serialize_with = "as_human_readable")]
+    time: SystemTime,
 }
 
 impl From<opentelemetry::trace::Event> for Event {
@@ -162,6 +166,8 @@ impl From<opentelemetry::trace::Event> for Event {
             name: value.name,
             attributes: value.attributes.into_iter().map(Into::into).collect(),
             dropped_attributes_count: value.dropped_attributes_count,
+            time_unix_nano: value.timestamp,
+            time: value.timestamp,
         }
     }
 }


### PR DESCRIPTION
Fixes #1390

## Changes

Adds timestamps to events in `opentelemetry-stdout`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
