### PR TITLE
Remove jaeger crate from tracing example deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ In particular, the following crates are likely to be of interest:
   are experimental.
 * [`opentelemetry-http`] provides an interface for injecting and extracting
   trace information from [`http`] headers.
-* [`opentelemetry-jaeger`] provides a pipeline and exporter for sending trace
-  information to [`Jaeger`].
+* [`opentelemetry-jaeger`] provides context propagation using [jaeger propagation format](https://www.jaegertracing.io/docs/1.18/client-libraries/#propagation-format).
 * [`opentelemetry-otlp`] exporter for sending trace and metric data in the OTLP
   format to the OpenTelemetry collector.
 * [`opentelemetry-prometheus`] provides a pipeline and exporter for sending

--- a/examples/tracing-jaeger/Cargo.toml
+++ b/examples/tracing-jaeger/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [dependencies]
 opentelemetry = { path = "../../opentelemetry" }
-opentelemetry-jaeger = { path = "../../opentelemetry-jaeger" }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio"] }
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic"] }
 tokio = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-rust/issues/995

## Changes

Removed unwanted dependency from example. The example was already using OTLPExporter!
Minor wording change to indicate opentelemetry-jaeger is to be used for jaeger propagators, not for exporters.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
