### PR TITLE
Propagate span_id & trace_id in logs records when converting trace events

### DIFF
--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -14,15 +14,15 @@ name = "grpc-client"
 path = "src/client.rs"
 
 [dependencies]
-opentelemetry = { version = "0.20" }
-opentelemetry_sdk = { version = "0.20", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.19", features = ["rt-tokio"] }
+opentelemetry = { path = "../../opentelemetry" }
+opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio"] }
+opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["rt-tokio"] }
 prost = "0.11"
 tokio = { version = "1.28", features = ["full"] }
 tonic = "0.9.2"
 tracing = "0.1"
 tracing-futures = "0.2"
-tracing-opentelemetry = "0.20"
+tracing-opentelemetry = "0.22"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]

--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -14,9 +14,9 @@ name = "grpc-client"
 path = "src/client.rs"
 
 [dependencies]
-opentelemetry = { path = "../../opentelemetry" }
-opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio"] }
-opentelemetry-jaeger = { path = "../../opentelemetry-jaeger", features = ["rt-tokio"] }
+opentelemetry = { version = "0.21" }
+opentelemetry_sdk = { version = "0.21", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.20", features = ["rt-tokio"] }
 prost = "0.11"
 tokio = { version = "1.28", features = ["full"] }
 tonic = "0.9.2"

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Support trace correlation by setting the trace_id and span_id on the log records
+
 ## v0.2.0
 
 ### Changed

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -11,18 +11,19 @@ license = "Apache-2.0"
 rust-version = "1.65"
 
 [dependencies]
-opentelemetry = { path = "../opentelemetry", features = ["logs"] }
-opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["logs"] }
+opentelemetry = { version = "0.21", features = ["logs"] }
+opentelemetry_sdk = { version = "0.21", features = ["logs"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-tracing-opentelemetry = "0.22"
+tracing-opentelemetry = { version = "0.22", optional = true }
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
 once_cell = "1.13.0"
 
 [dev-dependencies]
-opentelemetry-stdout = { path = "../opentelemetry-stdout", features = ["logs"] }
+opentelemetry-stdout = { version = "0.2", features = ["logs"] }
 
 [features]
 logs_level_enabled = ["opentelemetry/logs_level_enabled", "opentelemetry_sdk/logs_level_enabled"]
+tracing = ["tracing-opentelemetry"]
 default = ["logs_level_enabled"]
 testing = ["opentelemetry_sdk/testing"]

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -11,8 +11,8 @@ license = "Apache-2.0"
 rust-version = "1.65"
 
 [dependencies]
-opentelemetry = { version = "0.21", features = ["logs"] }
-opentelemetry_sdk = { version = "0.21", features = ["logs"] }
+opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["logs"] }
+opentelemetry_sdk = { version = "0.21", path = "../opentelemetry-sdk", features = ["logs"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-opentelemetry = { version = "0.22", optional = true }
 tracing-core = "0.1.31"
@@ -20,7 +20,7 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
 once_cell = "1.13.0"
 
 [dev-dependencies]
-opentelemetry-stdout = { version = "0.2", features = ["logs"] }
+opentelemetry-stdout = { version = "0.2", path = "../opentelemetry-stdout", features = ["logs"] }
 
 [features]
 logs_level_enabled = ["opentelemetry/logs_level_enabled", "opentelemetry_sdk/logs_level_enabled"]

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -11,9 +11,10 @@ license = "Apache-2.0"
 rust-version = "1.65"
 
 [dependencies]
-opentelemetry = { version = "0.21", path = "../opentelemetry", features = ["logs"] }
-opentelemetry_sdk = { version = "0.21", path = "../opentelemetry-sdk", features = ["logs"] }
-tracing = {version = "0.1", default-features = false, features = ["std"]}
+opentelemetry = { path = "../opentelemetry", features = ["logs"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["logs"] }
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing-opentelemetry = "0.22"
 tracing-core = "0.1.31"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
 once_cell = "1.13.0"

--- a/opentelemetry-appender-tracing/examples/basic.rs
+++ b/opentelemetry-appender-tracing/examples/basic.rs
@@ -6,7 +6,7 @@ use opentelemetry_sdk::{
     logs::{Config, LoggerProvider},
     Resource,
 };
-use tracing::error;
+use tracing::{error, info, info_span};
 use tracing_subscriber::prelude::*;
 
 fn main() {

--- a/opentelemetry-appender-tracing/examples/basic.rs
+++ b/opentelemetry-appender-tracing/examples/basic.rs
@@ -23,6 +23,10 @@ fn main() {
     let layer = layer::OpenTelemetryTracingBridge::new(&provider);
     tracing_subscriber::registry().with(layer).init();
 
+    info_span!("my-span").in_scope(|| {
+        info!(target: "my-system", "an info log");
+    })
+
     error!(name: "my-event-name", target: "my-system", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
     drop(provider);
 }

--- a/opentelemetry-appender-tracing/examples/basic.rs
+++ b/opentelemetry-appender-tracing/examples/basic.rs
@@ -25,7 +25,7 @@ fn main() {
 
     info_span!("my-span").in_scope(|| {
         info!(target: "my-system", "an info log");
-    })
+    });
 
     error!(name: "my-event-name", target: "my-system", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
     drop(provider);

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,7 +1,11 @@
-use opentelemetry::logs::{LogRecord, Logger, LoggerProvider, Severity};
+use opentelemetry::{
+    logs::{LogRecord, Logger, LoggerProvider, Severity, TraceContext},
+    trace::{SpanContext, TraceFlags, TraceState},
+};
 use std::borrow::Cow;
-use tracing_core::Level;
-use tracing_subscriber::Layer;
+use tracing_core::{Level, Subscriber};
+use tracing_opentelemetry::OtelData;
+use tracing_subscriber::{registry::LookupSpan, Layer};
 
 const INSTRUMENTATION_LIBRARY_NAME: &str = "opentelemetry-appender-tracing";
 
@@ -90,19 +94,30 @@ where
 
 impl<S, P, L> Layer<S> for OpenTelemetryTracingBridge<P, L>
 where
-    S: tracing::Subscriber,
+    S: Subscriber + for<'a> LookupSpan<'a>,
     P: LoggerProvider<Logger = L> + Send + Sync + 'static,
     L: Logger + Send + Sync + 'static,
 {
-    fn on_event(
-        &self,
-        event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) {
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
         let meta = event.metadata();
         let mut log_record: LogRecord = LogRecord::default();
         log_record.severity_number = Some(severity_of_level(meta.level()));
         log_record.severity_text = Some(meta.level().to_string().into());
+
+        // Extract the trace_id & span_id from the opentelemetry extension.
+        if let Some((trace_id, span_id)) = ctx.event_span(event).and_then(|span| {
+            span.extensions()
+                .get::<OtelData>()
+                .and_then(|ext| ext.builder.trace_id.zip(ext.builder.span_id))
+        }) {
+            log_record.trace_context = Some(TraceContext::from(&SpanContext::new(
+                trace_id,
+                span_id,
+                TraceFlags::default(),
+                false,
+                TraceState::default(),
+            )));
+        }
 
         // add the `name` metadata to attributes
         // TBD - Propose this to be part of log_record metadata.

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -105,7 +105,7 @@ where
         log_record.severity_text = Some(meta.level().to_string().into());
 
         // Extract the trace_id & span_id from the opentelemetry extension.
-        if let Some((trace_id, span_id)) = ctx.event_span(event).and_then(|span| {
+        if let Some((trace_id, span_id)) = ctx.lookup_current().and_then(|span| {
             span.extensions()
                 .get::<OtelData>()
                 .and_then(|ext| ext.builder.trace_id.zip(ext.builder.span_id))

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -106,7 +106,7 @@ where
 
         // Extract the trace_id & span_id from the opentelemetry extension.
         #[cfg(feature = "tracing")]
-        inject_trace_context(&mut log_record, &_ctx);
+        set_trace_context(&mut log_record, &_ctx);
 
         // add the `name` metadata to attributes
         // TBD - Propose this to be part of log_record metadata.
@@ -136,10 +136,8 @@ where
 }
 
 #[cfg(feature = "tracing")]
-fn inject_trace_context<S>(
-    log_record: &mut LogRecord,
-    ctx: &tracing_subscriber::layer::Context<'_, S>,
-) where
+fn set_trace_context<S>(log_record: &mut LogRecord, ctx: &tracing_subscriber::layer::Context<'_, S>)
+where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
     use opentelemetry::{


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-rust/issues/1378.

## Changes

Depends on https://github.com/tokio-rs/tracing-opentelemetry/pull/78.

This PR updates the dependency of tracing-opentelemetry to `0.22` and add a support for propagating the trace context when bridging trace events to logs. This is useful when sending otlp log records to tools such as datadog, which would then use the trace_id and span_id to correlate logs and traces.

To do so, I'm pulling the `OtelData` from the current span and converting it to a TraceContext that can be set on the log record.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
