### PR TITLE
Metric stress test with unsorted attributes.

### DIFF
--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -13,9 +13,8 @@ lazy_static! {
     static ref PROVIDER: SdkMeterProvider = SdkMeterProvider::builder()
         .with_reader(ManualReader::builder().build())
         .build();
-    static ref ATTRIBUTE_VALUES: [&'static str; 10] = [
-        "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
-        "value10"
+    static ref ATTRIBUTE_VALUES: [&'static str; 6] = [
+        "value1", "value2", "value3", "value4", "value5", "value6"
     ];
     static ref COUNTER: Counter<u64> = PROVIDER
         .meter(<&str as Into<Cow<'static, str>>>::into("test"))
@@ -33,14 +32,17 @@ fn test_counter() {
     let index_first_attribute = rng.gen_range(0..len);
     let index_second_attribute = rng.gen_range(0..len);
     let index_third_attribute = rng.gen_range(0..len);
+    let index_fourth_attribute = rng.gen_range(0..len);
 
-    // each attribute has 10 possible values, so there are 1000 possible combinations (time-series)
+    // each attribute has 6 possible values, so there are 1286 possible combinations (time-series)
     COUNTER.add(
         1,
         &[
-            KeyValue::new("attribute1", ATTRIBUTE_VALUES[index_first_attribute]),
+            // Make sure attributes are unsorted to test sorting cost
+            KeyValue::new("attribute4", ATTRIBUTE_VALUES[index_fourth_attribute]),
             KeyValue::new("attribute2", ATTRIBUTE_VALUES[index_second_attribute]),
             KeyValue::new("attribute3", ATTRIBUTE_VALUES[index_third_attribute]),
+            KeyValue::new("attribute1", ATTRIBUTE_VALUES[index_first_attribute]),
         ],
     );
 }

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -13,9 +13,8 @@ lazy_static! {
     static ref PROVIDER: SdkMeterProvider = SdkMeterProvider::builder()
         .with_reader(ManualReader::builder().build())
         .build();
-    static ref ATTRIBUTE_VALUES: [&'static str; 6] = [
-        "value1", "value2", "value3", "value4", "value5", "value6"
-    ];
+    static ref ATTRIBUTE_VALUES: [&'static str; 6] =
+        ["value1", "value2", "value3", "value4", "value5", "value6"];
     static ref COUNTER: Counter<u64> = PROVIDER
         .meter(<&str as Into<Cow<'static, str>>>::into("test"))
         .u64_counter("hello")


### PR DESCRIPTION
## Changes

To better account for sorting cost, don't pass in attributes pre-sorted, as that's unlikely to be done in real applications.  Likewise, add a fourth attribute for better sorting accountability.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
