### PR TITLE
Metric SDK - remove de-duplicating attributes for perf gain

### DIFF
--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -373,7 +373,7 @@ impl prometheus::core::Collector for Collector {
 /// Maps attributes into Prometheus-style label pairs.
 ///
 /// It sanitizes invalid characters and handles duplicate keys (due to
-/// sanitization or when user provides duplicate keys) by sorting and 
+/// sanitization or when user provides duplicate keys) by sorting and
 /// concatenating the values following the spec.
 fn get_attrs(kvs: &mut dyn Iterator<Item = (&Key, &Value)>, extra: &[LabelPair]) -> Vec<LabelPair> {
     let mut keys_map = BTreeMap::<String, Vec<String>>::new();

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -373,7 +373,8 @@ impl prometheus::core::Collector for Collector {
 /// Maps attributes into Prometheus-style label pairs.
 ///
 /// It sanitizes invalid characters and handles duplicate keys (due to
-/// sanitization) by sorting and concatenating the values following the spec.
+/// sanitization or when user provides duplicate keys) by sorting and 
+/// concatenating the values following the spec.
 fn get_attrs(kvs: &mut dyn Iterator<Item = (&Key, &Value)>, extra: &[LabelPair]) -> Vec<LabelPair> {
     let mut keys_map = BTreeMap::<String, Vec<String>>::new();
     for (key, value) in kvs {

--- a/opentelemetry-prometheus/tests/data/sanitized_labels.txt
+++ b/opentelemetry-prometheus/tests/data/sanitized_labels.txt
@@ -1,6 +1,6 @@
 # HELP foo_total a sanitary counter
 # TYPE foo_total counter
-foo_total{A_B="Q",C_D="Y;Z",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
+foo_total{A_B="Q;X",C_D="Y;Z",otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 24.3
 # HELP otel_scope_info Instrumentation Scope metadata
 # TYPE otel_scope_info gauge
 otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -135,7 +135,13 @@ fn prometheus_exporter_integration() {
             builder: ExporterBuilder::default().without_units(),
             record_metrics: Box::new(|meter| {
                 let attrs = vec![
-                    // exact match, value should be overwritten
+                    // exact match, SDK will not do de-duplication,
+                    // values should be concatenated.
+                    // The order X;Q vs Q:X is not guaranteed.
+                    // We expect end-users to not produce duplicates in the
+                    // first place, but if that cannot be done,
+                    // we can offer a opt-in feature in SDK to do it.
+                    // https://github.com/open-telemetry/opentelemetry-rust/issues/1300
                     Key::new("A.B").string("X"),
                     Key::new("A.B").string("Q"),
                     // unintended match due to sanitization, values should be concatenated

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -24,6 +24,12 @@
 - **Breaking** Remove `TextMapCompositePropagator` [#1373](https://github.com/open-telemetry/opentelemetry-rust/pull/1373). Use `TextMapCompositePropagator` in opentelemetry API.
 
 - [#1375](https://github.com/open-telemetry/opentelemetry-rust/pull/1375/) Fix metric collections during PeriodicReader shutdown
+- **Breaking**
+  [#1397](https://github.com/open-telemetry/opentelemetry-rust/issues/1397)
+  Removes de-duplication of Metric attribute keys to achieve performance gains.
+  Please share [feedback
+  here](https://github.com/open-telemetry/opentelemetry-rust/issues/1300), if
+  you are affected.
 
 ## v0.21.1
 

--- a/opentelemetry-sdk/src/attributes/set.rs
+++ b/opentelemetry-sdk/src/attributes/set.rs
@@ -111,7 +111,7 @@ impl From<&[KeyValue]> for AttributeSet {
         let mut vec = values
             .iter()
             .rev()
-            .filter_map(|kv| Some(HashKeyValue(kv.clone())))
+            .map(|kv| HashKeyValue(kv.clone()))
             .collect::<Vec<_>>();
         vec.sort_unstable();
 

--- a/opentelemetry-sdk/src/attributes/set.rs
+++ b/opentelemetry-sdk/src/attributes/set.rs
@@ -111,9 +111,7 @@ impl From<&[KeyValue]> for AttributeSet {
         let mut vec = values
             .iter()
             .rev()
-            .filter_map(|kv| {
-                Some(HashKeyValue(kv.clone()))
-            })
+            .filter_map(|kv| Some(HashKeyValue(kv.clone())))
             .collect::<Vec<_>>();
         vec.sort_unstable();
 

--- a/opentelemetry-sdk/src/attributes/set.rs
+++ b/opentelemetry-sdk/src/attributes/set.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::{
     cmp::Ordering,
     hash::{Hash, Hasher},
@@ -109,16 +108,11 @@ pub struct AttributeSet(Vec<HashKeyValue>);
 
 impl From<&[KeyValue]> for AttributeSet {
     fn from(values: &[KeyValue]) -> Self {
-        let mut seen_keys = HashSet::with_capacity(values.len());
         let mut vec = values
             .iter()
             .rev()
             .filter_map(|kv| {
-                if seen_keys.insert(kv.key.clone()) {
-                    Some(HashKeyValue(kv.clone()))
-                } else {
-                    None
-                }
+                Some(HashKeyValue(kv.clone()))
             })
             .collect::<Vec<_>>();
         vec.sort_unstable();

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -226,9 +226,8 @@ mod tests {
             .iter()
             .any(|(k, v)| k.as_str() == "key1" && v.as_str() == "value2");
 
-        assert_eq!(
+        assert!(
             key_value1_found && key_value2_found,
-            true,
             "Should have found both key1=value1 and key1=value2 attributes as does not dedup"
         );
     }

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -160,6 +160,66 @@ mod tests {
     // "multi_thread" tokio flavor must be used else flush won't
     // be able to make progress!
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn counter_aggregation_duplicate_attributes() {
+        // Run this test with stdout enabled to see output.
+        // cargo test counter_aggregation_duplicate_attributes --features=metrics,testing
+
+        // Arrange
+        let exporter = InMemoryMetricsExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+        // Act
+        let meter = meter_provider.meter("test");
+        let counter = meter
+            .u64_counter("my_counter")
+            .with_unit(Unit::new("my_unit"))
+            .init();
+        counter.add(1, &[KeyValue::new("key1", "value1"),KeyValue::new("key1", "value2")]);
+        counter.add(1, &[KeyValue::new("key1", "value1"),KeyValue::new("key1", "value2")]);
+
+        meter_provider.force_flush().unwrap();
+
+        // Assert
+        let resource_metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics are expected to be exported.");
+        assert!(!resource_metrics.is_empty());
+        let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
+        assert_eq!(metric.name, "my_counter");
+        assert_eq!(metric.unit.as_str(), "my_unit");
+        let sum = metric
+            .data
+            .as_any()
+            .downcast_ref::<data::Sum<u64>>()
+            .expect("Sum aggregation expected for Counter instruments by default");
+
+        // Expecting 1 time-series.
+        assert_eq!(sum.data_points.len(), 1);
+
+        // find and validate key1=value1,key1=value2 datapoint        
+        let data_point = &sum.data_points[0];
+        assert_eq!(
+            data_point
+                .value,
+            2
+        );
+        assert_eq!(data_point.attributes.len(), 2, "Should have 2 attributes as sdk is not deduplicating attributes");
+        let key_value1_found = data_point
+            .attributes
+            .iter()
+            .any(|(k, v)| k.as_str() == "key1" && v.as_str() == "value1");
+        let key_value2_found = data_point
+            .attributes
+            .iter()
+            .any(|(k, v)| k.as_str() == "key1" && v.as_str() == "value2");
+
+        assert_eq!(key_value1_found && key_value2_found, true, "Should have found both key1=value1 and key1=value2 attributes as does not dedup");
+    }
+
+    // "multi_thread" tokio flavor must be used else flush won't
+    // be able to make progress!
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn counter_duplicate_instrument_merge() {
         // Arrange
         let exporter = InMemoryMetricsExporter::default();

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -175,8 +175,20 @@ mod tests {
             .u64_counter("my_counter")
             .with_unit(Unit::new("my_unit"))
             .init();
-        counter.add(1, &[KeyValue::new("key1", "value1"),KeyValue::new("key1", "value2")]);
-        counter.add(1, &[KeyValue::new("key1", "value1"),KeyValue::new("key1", "value2")]);
+        counter.add(
+            1,
+            &[
+                KeyValue::new("key1", "value1"),
+                KeyValue::new("key1", "value2"),
+            ],
+        );
+        counter.add(
+            1,
+            &[
+                KeyValue::new("key1", "value1"),
+                KeyValue::new("key1", "value2"),
+            ],
+        );
 
         meter_provider.force_flush().unwrap();
 
@@ -197,14 +209,14 @@ mod tests {
         // Expecting 1 time-series.
         assert_eq!(sum.data_points.len(), 1);
 
-        // find and validate key1=value1,key1=value2 datapoint        
+        // find and validate key1=value1,key1=value2 datapoint
         let data_point = &sum.data_points[0];
+        assert_eq!(data_point.value, 2);
         assert_eq!(
-            data_point
-                .value,
-            2
+            data_point.attributes.len(),
+            2,
+            "Should have 2 attributes as sdk is not deduplicating attributes"
         );
-        assert_eq!(data_point.attributes.len(), 2, "Should have 2 attributes as sdk is not deduplicating attributes");
         let key_value1_found = data_point
             .attributes
             .iter()
@@ -214,7 +226,11 @@ mod tests {
             .iter()
             .any(|(k, v)| k.as_str() == "key1" && v.as_str() == "value2");
 
-        assert_eq!(key_value1_found && key_value2_found, true, "Should have found both key1=value1 and key1=value2 attributes as does not dedup");
+        assert_eq!(
+            key_value1_found && key_value2_found,
+            true,
+            "Should have found both key1=value1 and key1=value2 attributes as does not dedup"
+        );
     }
 
     // "multi_thread" tokio flavor must be used else flush won't


### PR DESCRIPTION
Fixes #1098. This adds to the gains achieved from https://github.com/open-telemetry/opentelemetry-rust/pull/1379!

Similar to [Tracing ](https://github.com/open-telemetry/opentelemetry-rust/pull/1293)and Logs, this PR removes the attribute de-duplication from the SDK. Changelog is advising users to https://github.com/open-telemetry/opentelemetry-rust/issues/1300, feedback from which can be used to evaluate if we need to bring this back as a opt-in feature in OTel SDK.

## Changes
Remove de-deduplication of metric attributes from SDK.
Add test to validate the behavior and assert that it is a conscious choice.
Prometheus Exporter already handles this (when duplicates arise when sanitizing), but order is not guaranteed. Tests are modified to account for this.

## Performance gains
20% gain for Counter.Add() hot path, when 4 attributes are used. More attributes will show more gains.
Numbers from my machine:

main branch
```
Counter_Add_Sorted      time:   [650.97 ns 659.10 ns 668.39 ns]
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

Counter_Add_Unsorted    time:   [645.21 ns 650.88 ns 656.56 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
```

This PR
```
Counter_Add_Sorted      time:   [527.00 ns 531.73 ns 537.88 ns]
                        change: [-18.633% -15.611% -11.545%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe

Counter_Add_Unsorted    time:   [532.62 ns 537.23 ns 542.44 ns]
                        change: [-19.127% -17.803% -16.416%] (p = 0.00 < 0.05)
                        Performance has improved.
```

main branch
50% boost in the time needed for making AttributeSet from slice!
```
AttributeSet_without_duplicates
                        time:   [217.74 ns 220.07 ns 222.85 ns]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

AttributeSet_with_duplicates
                        time:   [219.37 ns 229.60 ns 241.22 ns]
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) high mild
  13 (13.00%) high severe
```

This PR:
```
AttributeSet_without_duplicates
                        time:   [99.515 ns 100.37 ns 101.33 ns]
                        change: [-54.598% -53.572% -52.608%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

AttributeSet_with_duplicates
                        time:   [105.90 ns 107.11 ns 108.55 ns]
                        change: [-54.672% -52.847% -51.089%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Stress Tests:
main branch
```
Number of threads: 4
Throughput: 7,660,800 iterations/sec
Throughput: 7,904,400 iterations/sec
Throughput: 7,685,400 iterations/sec
Throughput: 7,048,800 iterations/sec
Throughput: 7,251,000 iterations/sec
```

this PR
```
Number of threads: 4
Throughput: 8,148,800 iterations/sec
Throughput: 8,265,800 iterations/sec
Throughput: 8,422,600 iterations/sec
Throughput: 8,420,600 iterations/sec
Throughput: 8,473,200 iterations/sec
```

Stress tests use only 3 attributes, so the improvement seems smaller compared
to benchmarks which uses 4 attributes!

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
