### PR TITLE
fix(sdk, zipkin, otlp): use `temp_env` for testing

### DIFF
--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -52,6 +52,7 @@ opentelemetry_sdk = { features = ["trace", "rt-tokio", "testing"], path = "../op
 time = { version = "0.3", features = ["macros"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 futures-util = { version = "0.3", default-features = false }
+temp-env = "0.3.6"
 
 [features]
 # telemetry pillars and functions

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -38,6 +38,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dev-dependencies]
 indexmap = "2.0"
 criterion = { version = "0.5", features = ["html_reports"] }
+temp-env = "0.3.6"
+
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { version = "0.13", features = ["flamegraph", "criterion"] }
 

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -247,51 +247,54 @@ mod tests {
             .build();
         assert_service_name(custom_meter_provider, Some("test_service"));
 
-        // If `OTEL_RESOURCE_ATTRIBUTES` is set, read them automatically
-        let reader3 = TestMetricReader {};
-        env::set_var("OTEL_RESOURCE_ATTRIBUTES", "key1=value1, k2, k3=value2");
-        let env_resource_provider = super::SdkMeterProvider::builder()
-            .with_reader(reader3)
-            .build();
-        assert_eq!(
-            env_resource_provider.pipes.0[0].resource,
-            Resource::new(vec![
-                KeyValue::new("telemetry.sdk.name", "opentelemetry"),
-                KeyValue::new("telemetry.sdk.version", env!("CARGO_PKG_VERSION")),
-                KeyValue::new("telemetry.sdk.language", "rust"),
-                KeyValue::new("key1", "value1"),
-                KeyValue::new("k3", "value2"),
-                KeyValue::new("service.name", "unknown_service"),
-            ])
+        temp_env::with_var(
+            "OTEL_RESOURCE_ATTRIBUTES",
+            Some("key1=value1, k2, k3=value2"),
+            || {
+                // If `OTEL_RESOURCE_ATTRIBUTES` is set, read them automatically
+                let reader3 = TestMetricReader {};
+                let env_resource_provider = super::SdkMeterProvider::builder()
+                    .with_reader(reader3)
+                    .build();
+                assert_eq!(
+                    env_resource_provider.pipes.0[0].resource,
+                    Resource::new(vec![
+                        KeyValue::new("telemetry.sdk.name", "opentelemetry"),
+                        KeyValue::new("telemetry.sdk.version", env!("CARGO_PKG_VERSION")),
+                        KeyValue::new("telemetry.sdk.language", "rust"),
+                        KeyValue::new("key1", "value1"),
+                        KeyValue::new("k3", "value2"),
+                        KeyValue::new("service.name", "unknown_service"),
+                    ])
+                );
+            },
         );
 
         // When `OTEL_RESOURCE_ATTRIBUTES` is set and also user provided config
-        env::set_var(
+        temp_env::with_var(
             "OTEL_RESOURCE_ATTRIBUTES",
-            "my-custom-key=env-val,k2=value2",
+            Some("my-custom-key=env-val,k2=value2"),
+            || {
+                let reader4 = TestMetricReader {};
+                let user_provided_resource_config_provider = super::SdkMeterProvider::builder()
+                    .with_reader(reader4)
+                    .with_resource(Resource::default().merge(&mut Resource::new(vec![
+                        KeyValue::new("my-custom-key", "my-custom-value"),
+                    ])))
+                    .build();
+                assert_eq!(
+                    user_provided_resource_config_provider.pipes.0[0].resource,
+                    Resource::new(vec![
+                        KeyValue::new("telemetry.sdk.name", "opentelemetry"),
+                        KeyValue::new("telemetry.sdk.version", env!("CARGO_PKG_VERSION")),
+                        KeyValue::new("telemetry.sdk.language", "rust"),
+                        KeyValue::new("my-custom-key", "my-custom-value"),
+                        KeyValue::new("k2", "value2"),
+                        KeyValue::new("service.name", "unknown_service"),
+                    ])
+                );
+            },
         );
-        let reader4 = TestMetricReader {};
-        let user_provided_resource_config_provider = super::SdkMeterProvider::builder()
-            .with_reader(reader4)
-            .with_resource(
-                Resource::default().merge(&mut Resource::new(vec![KeyValue::new(
-                    "my-custom-key",
-                    "my-custom-value",
-                )])),
-            )
-            .build();
-        assert_eq!(
-            user_provided_resource_config_provider.pipes.0[0].resource,
-            Resource::new(vec![
-                KeyValue::new("telemetry.sdk.name", "opentelemetry"),
-                KeyValue::new("telemetry.sdk.version", env!("CARGO_PKG_VERSION")),
-                KeyValue::new("telemetry.sdk.language", "rust"),
-                KeyValue::new("my-custom-key", "my-custom-value"),
-                KeyValue::new("k2", "value2"),
-                KeyValue::new("service.name", "unknown_service"),
-            ])
-        );
-        env::remove_var("OTEL_RESOURCE_ATTRIBUTES");
 
         // If user provided a resource, it takes priority during collision.
         let reader5 = TestMetricReader {};

--- a/opentelemetry-sdk/src/resource/mod.rs
+++ b/opentelemetry-sdk/src/resource/mod.rs
@@ -255,7 +255,7 @@ mod tests {
     use super::*;
     use crate::resource::EnvResourceDetector;
     use std::collections::HashMap;
-    use std::{env, time};
+    use std::time;
 
     #[test]
     fn new_resource() {
@@ -339,20 +339,30 @@ mod tests {
 
     #[test]
     fn detect_resource() {
-        env::set_var("OTEL_RESOURCE_ATTRIBUTES", "key=value, k = v , a= x, a=z");
-        env::set_var("irrelevant".to_uppercase(), "20200810");
-
-        let detector = EnvResourceDetector::new();
-        let resource =
-            Resource::from_detectors(time::Duration::from_secs(5), vec![Box::new(detector)]);
-        assert_eq!(
-            resource,
-            Resource::new(vec![
-                KeyValue::new("key", "value"),
-                KeyValue::new("k", "v"),
-                KeyValue::new("a", "x"),
-                KeyValue::new("a", "z"),
-            ])
+        temp_env::with_vars(
+            [
+                (
+                    "OTEL_RESOURCE_ATTRIBUTES",
+                    Some("key=value, k = v , a= x, a=z"),
+                ),
+                ("IRRELEVANT", Some("20200810")),
+            ],
+            || {
+                let detector = EnvResourceDetector::new();
+                let resource = Resource::from_detectors(
+                    time::Duration::from_secs(5),
+                    vec![Box::new(detector)],
+                );
+                assert_eq!(
+                    resource,
+                    Resource::new(vec![
+                        KeyValue::new("key", "value"),
+                        KeyValue::new("k", "v"),
+                        KeyValue::new("a", "x"),
+                        KeyValue::new("a", "z"),
+                    ])
+                )
+            },
         )
     }
 }

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -47,3 +47,4 @@ bytes = "1"
 futures-util = { version = "0.3", features = ["io"] }
 hyper = "0.14"
 opentelemetry_sdk = { default-features = false, features = ["trace", "testing"], path = "../opentelemetry-sdk" }
+temp-env = "0.3.6"

--- a/opentelemetry-zipkin/src/exporter/env.rs
+++ b/opentelemetry-zipkin/src/exporter/env.rs
@@ -37,21 +37,22 @@ pub(crate) fn get_endpoint() -> String {
 #[test]
 fn test_collector_defaults() {
     // Ensure the variables are undefined.
-    env::remove_var(ENV_TIMEOUT);
-    env::remove_var(ENV_ENDPOINT);
     assert_eq!(DEFAULT_COLLECTOR_TIMEOUT, get_timeout());
     assert_eq!(DEFAULT_COLLECTOR_ENDPOINT, get_endpoint());
 
     // Bad Timeout Value
-    env::set_var(ENV_TIMEOUT, "a");
-    assert_eq!(DEFAULT_COLLECTOR_TIMEOUT, get_timeout());
+    temp_env::with_var(ENV_TIMEOUT, Some("a"), || {
+        assert_eq!(DEFAULT_COLLECTOR_TIMEOUT, get_timeout());
+    });
 
     // Good Timeout Value
-    env::set_var(ENV_TIMEOUT, "777");
-    assert_eq!(Duration::from_millis(777), get_timeout());
+    temp_env::with_var(ENV_TIMEOUT, Some("777"), || {
+        assert_eq!(Duration::from_millis(777), get_timeout());
+    });
 
     // Custom Endpoint
     let custom_endpoint = "https://example.com/api/v2/spans";
-    env::set_var(ENV_ENDPOINT, custom_endpoint);
-    assert_eq!(custom_endpoint, get_endpoint());
+    temp_env::with_var(ENV_ENDPOINT, Some(custom_endpoint), || {
+        assert_eq!(custom_endpoint, get_endpoint());
+    });
 }


### PR DESCRIPTION
Fixes #1383
Design discussion issue (if applicable) #

## Changes

Replace all env locks with `temp-env` create

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
