### PR TITLE
Add experimental synchronous gauge 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ It's important to regularly review and remove the `otel_unstable` flag from the 
 The potential features include:
 
 - Stable and non-experimental features that are included in the specification to minimize compilation size. These could be separate feature flags for signals (like `logs`, `traces`, `metrics`) and runtimes (`rt-tokio`, `rt-tokio-current-thread`, `rt-async-std`).
-- Stable and non-experimental features, although not part of the specification, are crucial for enhancing the tracing/log crate's functionality or boosting performance. Example: `logs_level_enabled`.
+- Stable and non-experimental features, although not part of the specification, are crucial for enhancing the tracing/log crate's functionality or boosting performance. These features are also subject to discussion and approval by the OpenTelemetry Rust Maintainers. An example of such a feature is `logs_level_enabled`.
 
 All such features should adhere to naming convention  `<signal>_<feature_name>`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ It's important to regularly review and remove the `otel_unstable` flag from the 
 
 The potential features include:
 
-- Stable and non-experimental features that are included in the specification to minimize compilation size. These could be separate feature flags for signals (like `logs`, `traces`, `metrics`) and runtimes (`rt-tokio`, `rt-tokio-current-thread`, `rt-async-std`).
+- Stable and non-experimental features that compliant to specification, and have a feature flag to minimize compilation size. Example: feature flags for signals (like `logs`, `traces`, `metrics`) and runtimes (`rt-tokio`, `rt-tokio-current-thread`, `rt-async-std`).
 - Stable and non-experimental features, although not part of the specification, are crucial for enhancing the tracing/log crate's functionality or boosting performance. These features are also subject to discussion and approval by the OpenTelemetry Rust Maintainers. An example of such a feature is `logs_level_enabled`.
 
 All such features should adhere to naming convention  `<signal>_<feature_name>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,19 @@ OpenTelemetry supports multiple ways to configure the API, SDK and other compone
 - Environment variables
 - Compiling time configurations provided in the source code
 
+### Experimental/Unstable features:
+
+Use `otel_unstable` flag for implementation of specification with [experimental](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.27.0/specification/document-status.md) status. This approach ensures clear demarcation and safe integration of new or evolving features. Utilize the following structure:
+
+```rust
+#[cfg(otel_unstable)]
+{
+    // Your feature implementation
+}
+```
+
+It's important to regularly review and remove the `otel_unstable` flag from the code once the feature becomes stable. This cleanup process is crucial to maintain the overall code quality and to ensure that stable features are accurately reflected in the main build.
+
 ## Style Guide
 
 - Run `cargo clippy --all` - this will catch common mistakes and improve

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,16 +139,24 @@ OpenTelemetry supports multiple ways to configure the API, SDK and other compone
 
 ### Experimental/Unstable features:
 
-Use `otel_unstable` flag for implementation of specification with [experimental](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.27.0/specification/document-status.md) status. This approach ensures clear demarcation and safe integration of new or evolving features. Utilize the following structure:
+Use `otel_unstable` feature flag for implementation of specification with [experimental](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.27.0/specification/document-status.md) status. This approach ensures clear demarcation and safe integration of new or evolving features. Utilize the following structure:
 
 ```rust
-#[cfg(otel_unstable)]
+#[cfg(feature = "otel_unstable")]
 {
     // Your feature implementation
 }
 ```
-
 It's important to regularly review and remove the `otel_unstable` flag from the code once the feature becomes stable. This cleanup process is crucial to maintain the overall code quality and to ensure that stable features are accurately reflected in the main build.
+
+### Optional features:
+
+The potential features include:
+
+- Stable and non-experimental features that are included in the specification to minimize compilation size. These could be separate feature flags for signals (like `logs`, `traces`, `metrics`) and runtimes (`rt-tokio`, `rt-tokio-current-thread`, `rt-async-std`).
+- Stable and non-experimental features, although not part of the specification, are crucial for enhancing the tracing/log crate's functionality or boosting performance. Example: `logs_level_enabled`.
+
+All such features should adhere to naming convention  `<signal>_<feature_name>`
 
 ## Style Guide
 

--- a/examples/metrics-basic/Cargo.toml
+++ b/examples/metrics-basic/Cargo.toml
@@ -11,3 +11,7 @@ opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["metrics", "
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["metrics"]}
 tokio = { version = "1.0", features = ["full"] }
 serde_json = {version = "1.0"}
+
+[features]
+default = ["sync-gauge-experimental"]
+sync-gauge-experimental = ["opentelemetry/sync-gauge-experimental"]

--- a/examples/metrics-basic/Cargo.toml
+++ b/examples/metrics-basic/Cargo.toml
@@ -6,12 +6,8 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-opentelemetry = { path = "../../opentelemetry", features = ["metrics", "sync-gauge-experimental"] }
+opentelemetry = { path = "../../opentelemetry", features = ["metrics"] }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["metrics", "rt-tokio"] }
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["metrics"]}
 tokio = { version = "1.0", features = ["full"] }
 serde_json = {version = "1.0"}
-
-[features]
-default = ["sync-gauge-experimental"]
-sync-gauge-experimental = ["opentelemetry/sync-gauge-experimental"]

--- a/examples/metrics-basic/Cargo.toml
+++ b/examples/metrics-basic/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-opentelemetry = { path = "../../opentelemetry", features = ["metrics"] }
+opentelemetry = { path = "../../opentelemetry", features = ["metrics", "sync-gauge-experimental"] }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["metrics", "rt-tokio"] }
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["metrics"]}
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/metrics-basic/Cargo.toml
+++ b/examples/metrics-basic/Cargo.toml
@@ -6,8 +6,12 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-opentelemetry = { path = "../../opentelemetry", features = ["metrics"] }
+opentelemetry = { path = "../../opentelemetry", features = ["metrics", "otel_unstable"] }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["metrics", "rt-tokio"] }
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["metrics"]}
 tokio = { version = "1.0", features = ["full"] }
 serde_json = {version = "1.0"}
+
+[features]
+default = ["otel_unstable"]
+otel_unstable = ["opentelemetry/otel_unstable"]

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -112,21 +112,23 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     // Create a Gauge Instrument.
     // Note that the Gauge instrument is experimental, and can be changed/removed in the future releases.
-    #[cfg(feature = "sync-gauge-experimental")]
-    let gauge = meter
-        .f64_gauge("my_gauge")
-        .with_description("A gauge set to 1.0")
-        .with_unit(Unit::new("myunit"))
-        .init();
-    #[cfg(feature = "sync-gauge-experimental")]
-    gauge.record(
-        1.0,
-        [
-            KeyValue::new("mykey1", "myvalue1"),
-            KeyValue::new("mykey2", "myvalue2"),
-        ]
-        .as_ref(),
-    );
+    #[cfg(otel_unstable)]
+    {
+        let gauge = meter
+            .f64_gauge("my_gauge")
+            .with_description("A gauge set to 1.0")
+            .with_unit(Unit::new("myunit"))
+            .init();
+
+        gauge.record(
+            1.0,
+            [
+                KeyValue::new("mykey1", "myvalue1"),
+                KeyValue::new("mykey2", "myvalue2"),
+            ]
+            .as_ref(),
+        );
+    }
 
     // Create a ObservableGauge instrument and register a callback that reports the measurement.
     let observable_gauge = meter

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -112,7 +112,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     // Create a Gauge Instrument.
     // Note that the Gauge instrument is experimental, and can be changed/removed in the future releases.
-    #[cfg(otel_unstable)]
+    #[cfg(feature = "otel_unstable")]
     {
         let gauge = meter
             .f64_gauge("my_gauge")

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -111,7 +111,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Note that there is no ObservableHistogram instrument.
 
     // Create a Gauge Instrument.
-    // Note that the Guage instrument is experimental, and can be changed/removed in the future releases.
+    // Note that the Gauge instrument is experimental, and can be changed/removed in the future releases.
     #[cfg(feature = "sync-gauge-experimental")]
     let gauge = meter
         .f64_gauge("my_gauge")

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -112,11 +112,13 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     // Create a Gauge Instrument.
     // Note that the Guage instrument is experimental, and can be changed/removed in the future releases.
+    #[cfg(feature = "sync-gauge-experimental")]
     let gauge = meter
         .f64_gauge("my_gauge")
-        .with_description("My gauge example description")
+        .with_description("A gauge set to 1.0")
         .with_unit(Unit::new("myunit"))
         .init();
+    #[cfg(feature = "sync-gauge-experimental")]
     gauge.record(
         1.0,
         [
@@ -129,7 +131,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Create a ObservableGauge instrument and register a callback that reports the measurement.
     let observable_gauge = meter
         .f64_observable_gauge("my_observable_gauge")
-        .with_description("A gauge set to 1.0")
+        .with_description("An observable gauge set to 1.0")
         .with_unit(Unit::new("myunit"))
         .init();
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Added
 
-
 - [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Add experimental synchronous gauge
 
 ### Changed

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+### Added
+
+
+- [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Add experimental synchronous gauge
+
 ### Changed
 
 - **Breaking**

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -5,9 +5,9 @@ use opentelemetry::{
     global,
     metrics::{
         noop::{NoopAsyncInstrument, NoopRegistration},
-        AsyncInstrument, Callback, CallbackRegistration, Counter, Histogram, InstrumentProvider,
-        MetricsError, ObservableCounter, ObservableGauge, ObservableUpDownCounter,
-        Observer as ApiObserver, Result, Unit, UpDownCounter,
+        AsyncInstrument, Callback, CallbackRegistration, Counter, Gauge, Histogram,
+        InstrumentProvider, MetricsError, ObservableCounter, ObservableGauge,
+        ObservableUpDownCounter, Observer as ApiObserver, Result, Unit, UpDownCounter,
     },
     KeyValue,
 };
@@ -297,6 +297,57 @@ impl InstrumentProvider for SdkMeter {
         }
 
         Ok(ObservableUpDownCounter::new(observable))
+    }
+
+    fn u64_gauge(
+        &self,
+        name: Cow<'static, str>,
+        description: Option<Cow<'static, str>>,
+        unit: Option<Unit>,
+    ) -> Result<Gauge<u64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
+        let p = InstrumentResolver::new(self, &self.u64_resolver);
+        p.lookup(
+            InstrumentKind::Gauge,
+            name,
+            description,
+            unit.unwrap_or_default(),
+        )
+        .map(|i| Gauge::new(Arc::new(i)))
+    }
+
+    fn f64_gauge(
+        &self,
+        name: Cow<'static, str>,
+        description: Option<Cow<'static, str>>,
+        unit: Option<Unit>,
+    ) -> Result<Gauge<f64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
+        let p = InstrumentResolver::new(self, &self.f64_resolver);
+        p.lookup(
+            InstrumentKind::Gauge,
+            name,
+            description,
+            unit.unwrap_or_default(),
+        )
+        .map(|i| Gauge::new(Arc::new(i)))
+    }
+
+    fn i64_gauge(
+        &self,
+        name: Cow<'static, str>,
+        description: Option<Cow<'static, str>>,
+        unit: Option<Unit>,
+    ) -> Result<Gauge<i64>> {
+        validate_instrument_config(name.as_ref(), unit.as_ref(), self.validation_policy)?;
+        let p = InstrumentResolver::new(self, &self.i64_resolver);
+        p.lookup(
+            InstrumentKind::Gauge,
+            name,
+            description,
+            unit.unwrap_or_default(),
+        )
+        .map(|i| Gauge::new(Arc::new(i)))
     }
 
     fn u64_observable_gauge(
@@ -784,6 +835,9 @@ mod tests {
                     .f64_observable_up_down_counter(name.into(), None, None, Vec::new())
                     .map(|_| ()),
             );
+            assert(meter.u64_gauge(name.into(), None, None).map(|_| ()));
+            assert(meter.f64_gauge(name.into(), None, None).map(|_| ()));
+            assert(meter.i64_gauge(name.into(), None, None).map(|_| ()));
             assert(
                 meter
                     .u64_observable_gauge(name.into(), None, None, Vec::new())

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -121,6 +121,7 @@ where
 /// * Observable Counter ⇨ Sum
 /// * UpDownCounter ⇨ Sum
 /// * Observable UpDownCounter ⇨ Sum
+/// * Gauge ⇨ LastValue
 /// * Observable Gauge ⇨ LastValue
 /// * Histogram ⇨ ExplicitBucketHistogram
 ///
@@ -144,6 +145,7 @@ impl AggregationSelector for DefaultAggregationSelector {
             | InstrumentKind::UpDownCounter
             | InstrumentKind::ObservableCounter
             | InstrumentKind::ObservableUpDownCounter => Aggregation::Sum,
+            InstrumentKind::Gauge => Aggregation::LastValue,
             InstrumentKind::ObservableGauge => Aggregation::LastValue,
             InstrumentKind::Histogram => Aggregation::ExplicitBucketHistogram {
                 boundaries: vec![

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Add experimental synchronous gauge. This is behind the conditional flag, and can be enabled by setting the environment variable RUSTFLAGS="--cfg=otel_unstable". 
+- [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Add experimental synchronous gauge. This is behind the feature flag, and can be enabled by enabling the feature `otel_unstable` for opentelemetry crate.
 
 - [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Guidelines to add new unstable/experimental features. 
 

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Add experimental synchronous gauge.
+- [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Add experimental synchronous gauge. This is behind the conditional flag, and can be enabled by setting the environment variable RUSTFLAGS="--cfg=otel_unstable". 
 
 - [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Guidelines to add new unstable/experimental features. 
 

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Added
 
-- [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Add experimental synchronous gauge
+- [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Add experimental synchronous gauge.
+
+- [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Guidelines to add new unstable/experimental features. 
 
 ### Changed
 

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Added
+
+- [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Add experimental synchronous gauge
+
 ### Changed
 
 - Modified `AnyValue.Map` to be backed by `HashMap` instead of custom `OrderMap`,

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -38,7 +38,7 @@ metrics = []
 testing = ["trace", "metrics"]
 logs = []
 logs_level_enabled = ["logs"]
-sync-gauge-experimental = []
+unstable = []
 
 [dev-dependencies]
 opentelemetry_sdk = { path = "../opentelemetry-sdk" } # for documentation tests

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -38,7 +38,7 @@ metrics = []
 testing = ["trace", "metrics"]
 logs = []
 logs_level_enabled = ["logs"]
-unstable = []
+otel_unstable = []
 
 [dev-dependencies]
 opentelemetry_sdk = { path = "../opentelemetry-sdk" } # for documentation tests

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -38,6 +38,7 @@ metrics = []
 testing = ["trace", "metrics"]
 logs = []
 logs_level_enabled = ["logs"]
+sync-gauge-experimental = []
 
 [dev-dependencies]
 opentelemetry_sdk = { path = "../opentelemetry-sdk" } # for documentation tests

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -8,7 +8,7 @@ use std::{any::Any, convert::TryFrom};
 
 /// An SDK implemented instrument that records independent values
 pub trait SyncGauge<T> {
-    /// Records an increment to the counter.
+    /// Records an independent value.
     fn record(&self, value: T, attributes: &[KeyValue]);
 }
 
@@ -26,12 +26,12 @@ where
 }
 
 impl<T> Gauge<T> {
-    /// Create a new counter.
+    /// Create a new gauge.
     pub fn new(inner: Arc<dyn SyncGauge<T> + Send + Sync>) -> Self {
         Gauge(inner)
     }
 
-    /// Records an increment to the counter.
+    /// Records an independent value.
     pub fn record(&self, value: T, attributes: &[KeyValue]) {
         self.0.record(value, attributes)
     }

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -1,12 +1,76 @@
 use crate::{
-    metrics::{AsyncInstrument, AsyncInstrumentBuilder, MetricsError},
+    metrics::{AsyncInstrument, AsyncInstrumentBuilder, InstrumentBuilder, MetricsError},
     KeyValue,
 };
 use core::fmt;
 use std::sync::Arc;
 use std::{any::Any, convert::TryFrom};
 
-/// An instrument that records independent readings.
+/// An SDK implemented instrument that records independent values
+pub trait SyncGauge<T> {
+    /// Records an increment to the counter.
+    fn record(&self, value: T, attributes: &[KeyValue]);
+}
+
+/// An instrument that records independent values
+#[derive(Clone)]
+pub struct Gauge<T>(Arc<dyn SyncGauge<T> + Send + Sync>);
+
+impl<T> fmt::Debug for Gauge<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("Gauge<{}>", std::any::type_name::<T>()))
+    }
+}
+
+impl<T> Gauge<T> {
+    /// Create a new counter.
+    pub fn new(inner: Arc<dyn SyncGauge<T> + Send + Sync>) -> Self {
+        Gauge(inner)
+    }
+
+    /// Records an increment to the counter.
+    pub fn record(&self, value: T, attributes: &[KeyValue]) {
+        self.0.record(value, attributes)
+    }
+}
+
+impl TryFrom<InstrumentBuilder<'_, Gauge<u64>>> for Gauge<u64> {
+    type Error = MetricsError;
+
+    fn try_from(builder: InstrumentBuilder<'_, Gauge<u64>>) -> Result<Self, Self::Error> {
+        builder
+            .meter
+            .instrument_provider
+            .u64_gauge(builder.name, builder.description, builder.unit)
+    }
+}
+
+impl TryFrom<InstrumentBuilder<'_, Gauge<f64>>> for Gauge<f64> {
+    type Error = MetricsError;
+
+    fn try_from(builder: InstrumentBuilder<'_, Gauge<f64>>) -> Result<Self, Self::Error> {
+        builder
+            .meter
+            .instrument_provider
+            .f64_gauge(builder.name, builder.description, builder.unit)
+    }
+}
+
+impl TryFrom<InstrumentBuilder<'_, Gauge<i64>>> for Gauge<i64> {
+    type Error = MetricsError;
+
+    fn try_from(builder: InstrumentBuilder<'_, Gauge<i64>>) -> Result<Self, Self::Error> {
+        builder
+            .meter
+            .instrument_provider
+            .i64_gauge(builder.name, builder.description, builder.unit)
+    }
+}
+
+/// An async instrument that records independent readings.
 #[derive(Clone)]
 pub struct ObservableGauge<T>(Arc<dyn AsyncInstrument<T>>);
 

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use crate::metrics::{
-    AsyncInstrumentBuilder, Counter, Histogram, InstrumentBuilder, InstrumentProvider,
+    AsyncInstrumentBuilder, Counter, Gauge, Histogram, InstrumentBuilder, InstrumentProvider,
     ObservableCounter, ObservableGauge, ObservableUpDownCounter, Result, UpDownCounter,
 };
 use crate::KeyValue;
@@ -331,6 +331,36 @@ impl Meter {
         name: impl Into<Cow<'static, str>>,
     ) -> AsyncInstrumentBuilder<'_, ObservableUpDownCounter<f64>, f64> {
         AsyncInstrumentBuilder::new(self, name.into())
+    }
+
+    /// # Experimental
+    /// This method is experimental and can be changed/removed in future releases.
+    /// creates an instrument builder for recording independent values.
+    pub fn u64_gauge(
+        &self,
+        name: impl Into<Cow<'static, str>>,
+    ) -> InstrumentBuilder<'_, Gauge<u64>> {
+        InstrumentBuilder::new(self, name.into())
+    }
+
+    /// # Experimental
+    /// This method is experimental and can be changed/removed in future releases.
+    /// creates an instrument builder for recording independent values.
+    pub fn f64_gauge(
+        &self,
+        name: impl Into<Cow<'static, str>>,
+    ) -> InstrumentBuilder<'_, Gauge<f64>> {
+        InstrumentBuilder::new(self, name.into())
+    }
+
+    /// # Experimental
+    /// This method is experimental and can be changed/removed in future releases.
+    /// creates an instrument builder for recording indenpendent values.
+    pub fn i64_gauge(
+        &self,
+        name: impl Into<Cow<'static, str>>,
+    ) -> InstrumentBuilder<'_, Gauge<i64>> {
+        InstrumentBuilder::new(self, name.into())
     }
 
     /// creates an instrument builder for recording the current value via callback.

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::sync::Arc;
 
-#[cfg(feature = "sync-gauge-experimental")]
+#[cfg(otel_unstable)]
 use crate::metrics::Gauge;
 use crate::metrics::{
     AsyncInstrumentBuilder, Counter, Histogram, InstrumentBuilder, InstrumentProvider,
@@ -338,7 +338,7 @@ impl Meter {
     /// # Experimental
     /// This method is experimental and can be changed/removed in future releases.
     /// creates an instrument builder for recording independent values.
-    #[cfg(feature = "sync-gauge-experimental")]
+    #[cfg(otel_unstable)]
     pub fn u64_gauge(
         &self,
         name: impl Into<Cow<'static, str>>,
@@ -349,7 +349,7 @@ impl Meter {
     /// # Experimental
     /// This method is experimental and can be changed/removed in future releases.
     /// creates an instrument builder for recording independent values.
-    #[cfg(feature = "sync-gauge-experimental")]
+    #[cfg(otel_unstable)]
     pub fn f64_gauge(
         &self,
         name: impl Into<Cow<'static, str>>,

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -3,8 +3,10 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::sync::Arc;
 
+#[cfg(feature = "sync-gauge-experimental")]
+use crate::metrics::Gauge;
 use crate::metrics::{
-    AsyncInstrumentBuilder, Counter, Gauge, Histogram, InstrumentBuilder, InstrumentProvider,
+    AsyncInstrumentBuilder, Counter, Histogram, InstrumentBuilder, InstrumentProvider,
     ObservableCounter, ObservableGauge, ObservableUpDownCounter, Result, UpDownCounter,
 };
 use crate::KeyValue;
@@ -336,6 +338,7 @@ impl Meter {
     /// # Experimental
     /// This method is experimental and can be changed/removed in future releases.
     /// creates an instrument builder for recording independent values.
+    #[cfg(feature = "sync-gauge-experimental")]
     pub fn u64_gauge(
         &self,
         name: impl Into<Cow<'static, str>>,
@@ -346,6 +349,7 @@ impl Meter {
     /// # Experimental
     /// This method is experimental and can be changed/removed in future releases.
     /// creates an instrument builder for recording independent values.
+    #[cfg(feature = "sync-gauge-experimental")]
     pub fn f64_gauge(
         &self,
         name: impl Into<Cow<'static, str>>,
@@ -356,6 +360,7 @@ impl Meter {
     /// # Experimental
     /// This method is experimental and can be changed/removed in future releases.
     /// creates an instrument builder for recording indenpendent values.
+    #[cfg(feature = "sync-gauge-experimental")]
     pub fn i64_gauge(
         &self,
         name: impl Into<Cow<'static, str>>,

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::sync::Arc;
 
-#[cfg(otel_unstable)]
+#[cfg(feature = "otel_unstable")]
 use crate::metrics::Gauge;
 use crate::metrics::{
     AsyncInstrumentBuilder, Counter, Histogram, InstrumentBuilder, InstrumentProvider,
@@ -338,7 +338,7 @@ impl Meter {
     /// # Experimental
     /// This method is experimental and can be changed/removed in future releases.
     /// creates an instrument builder for recording independent values.
-    #[cfg(otel_unstable)]
+    #[cfg(feature = "otel_unstable")]
     pub fn u64_gauge(
         &self,
         name: impl Into<Cow<'static, str>>,
@@ -349,7 +349,7 @@ impl Meter {
     /// # Experimental
     /// This method is experimental and can be changed/removed in future releases.
     /// creates an instrument builder for recording independent values.
-    #[cfg(otel_unstable)]
+    #[cfg(feature = "otel_unstable")]
     pub fn f64_gauge(
         &self,
         name: impl Into<Cow<'static, str>>,
@@ -360,7 +360,7 @@ impl Meter {
     /// # Experimental
     /// This method is experimental and can be changed/removed in future releases.
     /// creates an instrument builder for recording indenpendent values.
-    #[cfg(feature = "sync-gauge-experimental")]
+    #[cfg(feature = "otel_unstable")]
     pub fn i64_gauge(
         &self,
         name: impl Into<Cow<'static, str>>,

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -13,7 +13,7 @@ pub mod noop;
 use crate::ExportError;
 pub use instruments::{
     counter::{Counter, ObservableCounter, SyncCounter},
-    gauge::ObservableGauge,
+    gauge::{Gauge, ObservableGauge, SyncGauge},
     histogram::{Histogram, SyncHistogram},
     up_down_counter::{ObservableUpDownCounter, SyncUpDownCounter, UpDownCounter},
     AsyncInstrument, AsyncInstrumentBuilder, Callback, InstrumentBuilder,
@@ -177,6 +177,36 @@ pub trait InstrumentProvider {
         Ok(ObservableUpDownCounter::new(Arc::new(
             noop::NoopAsyncInstrument::new(),
         )))
+    }
+
+    /// creates an instrument for recording independent values.
+    fn u64_gauge(
+        &self,
+        _name: Cow<'static, str>,
+        _description: Option<Cow<'static, str>>,
+        _unit: Option<Unit>,
+    ) -> Result<Gauge<u64>> {
+        Ok(Gauge::new(Arc::new(noop::NoopSyncInstrument::new())))
+    }
+
+    /// creates an instrument for recording independent values.
+    fn f64_gauge(
+        &self,
+        _name: Cow<'static, str>,
+        _description: Option<Cow<'static, str>>,
+        _unit: Option<Unit>,
+    ) -> Result<Gauge<f64>> {
+        Ok(Gauge::new(Arc::new(noop::NoopSyncInstrument::new())))
+    }
+
+    /// creates an instrument for recording independent values.
+    fn i64_gauge(
+        &self,
+        _name: Cow<'static, str>,
+        _description: Option<Cow<'static, str>>,
+        _unit: Option<Unit>,
+    ) -> Result<Gauge<i64>> {
+        Ok(Gauge::new(Arc::new(noop::NoopSyncInstrument::new())))
     }
 
     /// creates an instrument for recording the current value via callback.

--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -6,7 +6,7 @@
 use crate::{
     metrics::{
         AsyncInstrument, CallbackRegistration, InstrumentProvider, Meter, MeterProvider, Observer,
-        Result, SyncCounter, SyncHistogram, SyncUpDownCounter,
+        Result, SyncCounter, SyncGauge, SyncHistogram, SyncUpDownCounter,
     },
     KeyValue,
 };
@@ -105,6 +105,12 @@ impl<T> SyncUpDownCounter<T> for NoopSyncInstrument {
 }
 
 impl<T> SyncHistogram<T> for NoopSyncInstrument {
+    fn record(&self, _value: T, _attributes: &[KeyValue]) {
+        // Ignored
+    }
+}
+
+impl<T> SyncGauge<T> for NoopSyncInstrument {
     fn record(&self, _value: T, _attributes: &[KeyValue]) {
         // Ignored
     }


### PR DESCRIPTION
Fixes #1242 

## Changes

Adds synchronous gauge, as described in specs - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#gauge.

The feature is experimental in specs, so the API to create the Gauge instrument is behind the feature flag - `otel_unstable`. The feature flag can be removed once the specs are stable.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
