### PR TITLE
Remove old global meter provider shutdown method

### DIFF
--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -58,30 +58,29 @@ impl SdkMeterProvider {
     /// use opentelemetry_sdk::metrics::SdkMeterProvider;
     ///
     /// fn init_metrics() -> SdkMeterProvider {
+    ///     // Setup metric pipelines with readers + views, default has no
+    ///     // readers so nothing is exported.
     ///     let provider = SdkMeterProvider::default();
     ///
     ///     // Set provider to be used as global meter provider
     ///     let _ = global::set_meter_provider(provider.clone());
     ///
-    ///     // Setup metric pipelines with readers + views
-    ///
     ///     provider
     /// }
     ///
-    /// fn main() {
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let provider = init_metrics();
     ///
     ///     // create instruments + record measurements
     ///
     ///     // force all instruments to flush
-    ///     provider.force_flush().unwrap();
+    ///     provider.force_flush()?;
     ///
     ///     // record more measurements..
     ///
-    ///     // dropping provider and shutting down global provider ensure all
-    ///     // remaining metrics data are exported
-    ///     drop(provider);
-    ///     global::shutdown_meter_provider();
+    ///     // shutting down meter provider ensure all remaining metrics data
+    ///     // are exported
+    ///     provider.shutdown()?;
     /// }
     /// ```
     pub fn force_flush(&self) -> Result<()> {

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -10,8 +10,9 @@ of entries, so moving from `IndexMap` to `HashMap` offers slight performance
 gains, and avoids `IndexMap` dependency. This affects `body` and `attributes` of
 `LogRecord`.
 [#1353](https://github.com/open-telemetry/opentelemetry-rust/pull/1353)
-
 - Add `TextMapCompositePropagator` [#1373](https://github.com/open-telemetry/opentelemetry-rust/pull/1373)
+- Remove `global::shutdown_meter_provider`, use `SdkMeterProvider::shutdown`
+  directly instead.
 
 ### Removed
 

--- a/opentelemetry/src/global/metrics.rs
+++ b/opentelemetry/src/global/metrics.rs
@@ -98,14 +98,6 @@ where
     *global_provider = GlobalMeterProvider::new(new_provider);
 }
 
-/// Shut down the current meter global meter provider.
-pub fn shutdown_meter_provider() {
-    let mut global_provider = GLOBAL_METER_PROVIDER
-        .write()
-        .expect("GLOBAL_METER_PROVIDER RwLock poisoned");
-    *global_provider = GlobalMeterProvider::new(metrics::noop::NoopMeterProvider::new());
-}
-
 /// Returns an instance of the currently configured global [`MeterProvider`]
 /// through [`GlobalMeterProvider`].
 pub fn meter_provider() -> GlobalMeterProvider {


### PR DESCRIPTION
## Changes

This change removes the old `global::shutdown_meter_provider` method which is not part of the metrics API spec, and properly documents the `SdkMeterProvider::shutdown` method which is spec compliant.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
