### PR TITLE
Add tests for tracing appender

### DIFF
--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -24,3 +24,4 @@ opentelemetry-stdout = { path = "../opentelemetry-stdout", features = ["logs"] }
 [features]
 logs_level_enabled = ["opentelemetry/logs_level_enabled", "opentelemetry_sdk/logs_level_enabled"]
 default = ["logs_level_enabled"]
+testing = ["opentelemetry_sdk/testing"]

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -145,9 +145,9 @@ const fn severity_of_level(level: &Level) -> Severity {
 mod tests {
     use crate::layer;
     use opentelemetry::logs::Severity;
-    use opentelemetry::trace::{TraceId, Tracer, TraceContextExt, SpanId, TraceFlags};
-    use opentelemetry::{logs::AnyValue, Key};
     use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry::trace::{SpanId, TraceContextExt, TraceFlags, TraceId, Tracer};
+    use opentelemetry::{logs::AnyValue, Key};
     use opentelemetry_sdk::logs::LoggerProvider;
     use opentelemetry_sdk::testing::logs::InMemoryLogsExporter;
     use opentelemetry_sdk::trace::{config, Sampler, TracerProvider};
@@ -165,12 +165,12 @@ mod tests {
 
         let layer = layer::OpenTelemetryTracingBridge::new(&logger_provider);
         let subscriber = tracing_subscriber::registry().with(layer);
-        
-        // avoiding setting tracing subscriber as global as that does not 
+
+        // avoiding setting tracing subscriber as global as that does not
         // play well with unit tests.
         let _guard = tracing::subscriber::set_default(subscriber);
-        
-        // Act        
+
+        // Act
         error!(name: "my-event-name", target: "my-system", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
         logger_provider.force_flush();
 
@@ -214,7 +214,7 @@ mod tests {
         let layer = layer::OpenTelemetryTracingBridge::new(&logger_provider);
         let subscriber = tracing_subscriber::registry().with(layer);
 
-        // avoiding setting tracing subscriber as global as that does not 
+        // avoiding setting tracing subscriber as global as that does not
         // play well with unit tests.
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -226,8 +226,8 @@ mod tests {
 
         let mut trace_id_expected = TraceId::from_hex("1").unwrap();
         let mut span_id_expected = SpanId::from_hex("1").unwrap();
-        
-        // Act        
+
+        // Act
         tracer.in_span("test-span", |cx| {            
             trace_id_expected = cx.span().span_context().trace_id();
             span_id_expected = cx.span().span_context().span_id();
@@ -253,9 +253,23 @@ mod tests {
 
         // validate trace context.
         assert!(log.record.trace_context.is_some());
-        assert_eq!(log.record.trace_context.as_ref().unwrap().trace_id, trace_id_expected);
-        assert_eq!(log.record.trace_context.as_ref().unwrap().span_id, span_id_expected);
-        assert_eq!(log.record.trace_context.as_ref().unwrap().trace_flags.unwrap(), TraceFlags::SAMPLED);
+        assert_eq!(
+            log.record.trace_context.as_ref().unwrap().trace_id,
+            trace_id_expected
+        );
+        assert_eq!(
+            log.record.trace_context.as_ref().unwrap().span_id,
+            span_id_expected
+        );
+        assert_eq!(
+            log.record
+                .trace_context
+                .as_ref()
+                .unwrap()
+                .trace_flags
+                .unwrap(),
+            TraceFlags::SAMPLED
+        );
 
         // validate attributes.
         let attributes: Vec<(Key, AnyValue)> = log

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -146,7 +146,7 @@ mod tests {
     use crate::layer;
     use opentelemetry::logs::Severity;
     use opentelemetry::trace::TracerProvider as _;
-    use opentelemetry::trace::{SpanId, TraceContextExt, TraceFlags, TraceId, Tracer};
+    use opentelemetry::trace::{TraceContextExt, TraceFlags, Tracer};
     use opentelemetry::{logs::AnyValue, Key};
     use opentelemetry_sdk::logs::LoggerProvider;
     use opentelemetry_sdk::testing::logs::InMemoryLogsExporter;
@@ -224,16 +224,14 @@ mod tests {
             .build();
         let tracer = tracer_provider.tracer("test-tracer");
 
-        let mut trace_id_expected = TraceId::from_hex("1").unwrap();
-        let mut span_id_expected = SpanId::from_hex("1").unwrap();
-
         // Act
-        tracer.in_span("test-span", |cx| {            
-            trace_id_expected = cx.span().span_context().trace_id();
-            span_id_expected = cx.span().span_context().span_id();
+        let (trace_id_expected, span_id_expected) = tracer.in_span("test-span", |cx| {
+            let trace_id = cx.span().span_context().trace_id();
+            let span_id = cx.span().span_context().span_id();
 
             // logging is done inside span context.
             error!(name: "my-event-name", target: "my-system", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
+           (trace_id, span_id)
         });
 
         logger_provider.force_flush();

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -75,7 +75,7 @@ impl From<&SpanContext> for TraceContext {
 }
 
 /// Value types for representing arbitrary values in a log record.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum AnyValue {
     /// An integer value
     Int(i64),


### PR DESCRIPTION
tracing-appender today has zero test coverage. This is adding the basic coverage. I am leveraging `InMemoryExporter`, so this is more than unit tests and indirectly tests the Logging API/SDK as well.

This should make it easier to review PRs like https://github.com/open-telemetry/opentelemetry-rust/pull/1380 and https://github.com/open-telemetry/opentelemetry-rust/pull/1394 as well.

Changes from https://github.com/open-telemetry/opentelemetry-rust/pull/1402 was needed for the tests, so I included that into this PR as @psandana is waiting for Microsoft CLA. (I have messaged him in separately about this)