### PR TITLE
Fix metric_counter bench

### DIFF
--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -66,6 +66,7 @@ harness = false
 [[bench]]
 name = "metric_counter"
 harness = false
+required-features = ["metrics"]
 
 [[bench]]
 name = "attribute_set"

--- a/opentelemetry-sdk/benches/metric_counter.rs
+++ b/opentelemetry-sdk/benches/metric_counter.rs
@@ -7,7 +7,7 @@ use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 // Run this benchmark with:
-// cargo bench --bench metric_counter --features=metrics,testing
+// cargo bench --bench metric_counter --features=metrics
 fn create_counter() -> Counter<u64> {
     let meter_provider: SdkMeterProvider = SdkMeterProvider::builder()
         .with_reader(ManualReader::builder().build())


### PR DESCRIPTION
Fixes #

metric_counter bench doesn't work because of metrics feature was not enables.

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
