### PR TITLE
Remove `tracing-opentelemetry` dependency from `tracing-grpc` example

### DIFF
--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 
 [dependencies]
 opentelemetry = { path = "../../opentelemetry" }
-opentelemetry_sdk = { path = "../../opentelemetry-sdk" }
+opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio"]}
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["trace"] }
 prost = "0.11"
 tokio = { version = "1.28", features = ["full"] }

--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -14,16 +14,12 @@ name = "grpc-client"
 path = "src/client.rs"
 
 [dependencies]
-opentelemetry = { version = "0.20" }
-opentelemetry_sdk = { version = "0.20", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.19", features = ["rt-tokio"] }
+opentelemetry = { path = "../../opentelemetry" }
+opentelemetry_sdk = { path = "../../opentelemetry-sdk" }
+opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["trace"] }
 prost = "0.11"
 tokio = { version = "1.28", features = ["full"] }
 tonic = "0.9.2"
-tracing = "0.1"
-tracing-futures = "0.2"
-tracing-opentelemetry = "0.20"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
 tonic-build = "0.9.2"

--- a/examples/tracing-grpc/src/client.rs
+++ b/examples/tracing-grpc/src/client.rs
@@ -1,7 +1,9 @@
 use hello_world::greeter_client::GreeterClient;
 use hello_world::HelloRequest;
 use opentelemetry::{global, propagation::Injector};
-use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::TracerProvider};
+use opentelemetry_sdk::{
+    propagation::TraceContextPropagator, runtime::Tokio, trace::TracerProvider,
+};
 use opentelemetry_stdout::SpanExporter;
 
 use opentelemetry::{
@@ -13,7 +15,7 @@ fn init_tracer() {
     global::set_text_map_propagator(TraceContextPropagator::new());
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     let provider = TracerProvider::builder()
-        .with_simple_exporter(SpanExporter::default())
+        .with_batch_exporter(SpanExporter::default(), Tokio)
         .build();
 
     global::set_tracer_provider(provider);

--- a/examples/tracing-grpc/src/client.rs
+++ b/examples/tracing-grpc/src/client.rs
@@ -1,10 +1,23 @@
 use hello_world::greeter_client::GreeterClient;
 use hello_world::HelloRequest;
 use opentelemetry::{global, propagation::Injector};
-use tracing::*;
-use tracing_futures::Instrument;
-use tracing_opentelemetry::OpenTelemetrySpanExt;
-use tracing_subscriber::prelude::*;
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::TracerProvider};
+use opentelemetry_stdout::SpanExporter;
+
+use opentelemetry::{
+    trace::{SpanKind, TraceContextExt, Tracer},
+    Context,
+};
+
+fn init_tracer() {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+    // Install stdout exporter pipeline to be able to retrieve the collected spans.
+    let provider = TracerProvider::builder()
+        .with_simple_exporter(SpanExporter::default())
+        .build();
+
+    global::set_tracer_provider(provider);
+}
 
 struct MetadataMap<'a>(&'a mut tonic::metadata::MetadataMap);
 
@@ -24,45 +37,32 @@ pub mod hello_world {
     tonic::include_proto!("helloworld");
 }
 
-#[instrument]
 async fn greet() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let mut client = GreeterClient::connect("http://[::1]:50051")
-        .instrument(info_span!("client connect"))
-        .await?;
+    let tracer = global::tracer("example/client");
+    let span = tracer
+        .span_builder(String::from("Greeter/client"))
+        .with_kind(SpanKind::Client)
+        .start(&tracer);
+    let cx = Context::current_with_span(span);
+    let mut client = GreeterClient::connect("http://[::1]:50051").await?;
 
     let mut request = tonic::Request::new(HelloRequest {
         name: "Tonic".into(),
     });
 
     global::get_text_map_propagator(|propagator| {
-        propagator.inject_context(
-            &tracing::Span::current().context(),
-            &mut MetadataMap(request.metadata_mut()),
-        )
+        propagator.inject_context(&cx, &mut MetadataMap(request.metadata_mut()))
     });
 
-    let response = client
-        .say_hello(request)
-        .instrument(info_span!("say_hello"))
-        .await?;
+    let _response = client.say_hello(request).await?;
 
-    info!("Response received: {:?}", response);
     Ok(())
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
-    let tracer = opentelemetry_jaeger::new_agent_pipeline()
-        .with_service_name("grpc-client")
-        .install_simple()?;
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::EnvFilter::new("INFO"))
-        .with(tracing_opentelemetry::layer().with_tracer(tracer))
-        .try_init()?;
-
+    init_tracer();
     greet().await?;
-
     opentelemetry::global::shutdown_tracer_provider();
 
     Ok(())

--- a/examples/tracing-grpc/src/server.rs
+++ b/examples/tracing-grpc/src/server.rs
@@ -5,7 +5,9 @@ use opentelemetry::{
     propagation::Extractor,
     trace::{Span, SpanKind, Tracer},
 };
-use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::TracerProvider};
+use opentelemetry_sdk::{
+    propagation::TraceContextPropagator, runtime::Tokio, trace::TracerProvider,
+};
 use opentelemetry_stdout::SpanExporter;
 use tonic::{transport::Server, Request, Response, Status};
 
@@ -13,7 +15,7 @@ fn init_tracer() {
     global::set_text_map_propagator(TraceContextPropagator::new());
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     let provider = TracerProvider::builder()
-        .with_simple_exporter(SpanExporter::default())
+        .with_batch_exporter(SpanExporter::default(), Tokio)
         .build();
 
     global::set_tracer_provider(provider);

--- a/examples/tracing-grpc/src/server.rs
+++ b/examples/tracing-grpc/src/server.rs
@@ -47,7 +47,6 @@ impl<'a> Extractor for MetadataMap<'a> {
 fn expensive_fn<S: Span>(to_print: String, span: &mut S) {
     std::thread::sleep(std::time::Duration::from_millis(20));
     span.add_event(to_print, vec![]);
-    // info!("{}", to_print);
 }
 
 #[derive(Debug, Default)]

--- a/examples/tracing-grpc/src/server.rs
+++ b/examples/tracing-grpc/src/server.rs
@@ -1,10 +1,23 @@
 use hello_world::greeter_server::{Greeter, GreeterServer};
 use hello_world::{HelloReply, HelloRequest};
-use opentelemetry::{global, propagation::Extractor};
+use opentelemetry::{
+    global,
+    propagation::Extractor,
+    trace::{Span, SpanKind, Tracer},
+};
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::TracerProvider};
+use opentelemetry_stdout::SpanExporter;
 use tonic::{transport::Server, Request, Response, Status};
-use tracing::*;
-use tracing_opentelemetry::OpenTelemetrySpanExt;
-use tracing_subscriber::prelude::*;
+
+fn init_tracer() {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+    // Install stdout exporter pipeline to be able to retrieve the collected spans.
+    let provider = TracerProvider::builder()
+        .with_simple_exporter(SpanExporter::default())
+        .build();
+
+    global::set_tracer_provider(provider);
+}
 
 #[allow(clippy::derive_partial_eq_without_eq)] // tonic don't derive Eq for generated types. We shouldn't manually change it.
 pub mod hello_world {
@@ -31,10 +44,10 @@ impl<'a> Extractor for MetadataMap<'a> {
     }
 }
 
-#[instrument]
-fn expensive_fn(to_print: String) {
+fn expensive_fn<S: Span>(to_print: String, span: &mut S) {
     std::thread::sleep(std::time::Duration::from_millis(20));
-    info!("{}", to_print);
+    span.add_event(to_print, vec![]);
+    // info!("{}", to_print);
 }
 
 #[derive(Debug, Default)]
@@ -42,17 +55,20 @@ pub struct MyGreeter {}
 
 #[tonic::async_trait]
 impl Greeter for MyGreeter {
-    #[instrument]
     async fn say_hello(
         &self,
         request: Request<HelloRequest>, // Accept request of type HelloRequest
     ) -> Result<Response<HelloReply>, Status> {
         let parent_cx =
             global::get_text_map_propagator(|prop| prop.extract(&MetadataMap(request.metadata())));
-        tracing::Span::current().set_parent(parent_cx);
+        let tracer = global::tracer("example/server");
+        let mut span = tracer
+            .span_builder("Greeter/server")
+            .with_kind(SpanKind::Server)
+            .start_with_context(&tracer, &parent_cx);
 
         let name = request.into_inner().name;
-        expensive_fn(format!("Got name: {name:?}"));
+        expensive_fn(format!("Got name: {name:?}"), &mut span);
 
         // Return an instance of type HelloReply
         let reply = hello_world::HelloReply {
@@ -65,14 +81,7 @@ impl Greeter for MyGreeter {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
-    let tracer = opentelemetry_jaeger::new_agent_pipeline()
-        .with_service_name("grpc-server")
-        .install_batch(opentelemetry_sdk::runtime::Tokio)?;
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::EnvFilter::new("INFO"))
-        .with(tracing_opentelemetry::layer().with_tracer(tracer))
-        .try_init()?;
+    init_tracer();
 
     let addr = "[::1]:50051".parse()?;
     let greeter = MyGreeter::default();

--- a/examples/tracing-http-propagator/src/client.rs
+++ b/examples/tracing-http-propagator/src/client.rs
@@ -6,6 +6,7 @@ use opentelemetry::{
 };
 use opentelemetry_http::HeaderInjector;
 use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::TracerProvider};
+use opentelemetry_semantic_conventions;
 use opentelemetry_stdout::SpanExporter;
 
 fn init_tracer() {

--- a/examples/tracing-http-propagator/src/client.rs
+++ b/examples/tracing-http-propagator/src/client.rs
@@ -6,7 +6,6 @@ use opentelemetry::{
 };
 use opentelemetry_http::HeaderInjector;
 use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::TracerProvider};
-use opentelemetry_semantic_conventions;
 use opentelemetry_stdout::SpanExporter;
 
 fn init_tracer() {


### PR DESCRIPTION
Fixes (partially) #1413 

## Changes

A minimalistic version of `tracing-grpc` example without `opentelemetry-jaeger` and `tracing-*` dependencies

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
