### PR TITLE
feat: omit empty otel_scope_info and otel_target_info metrics

### DIFF
--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Changed
+
+- Omit empty `otel_scope_info` and `otel_target_info` metrics [#1428](https://github.com/open-telemetry/opentelemetry-rust/pull/1428)
+
 ## v0.14.1
 
 ### Fixed

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -299,17 +299,19 @@ impl prometheus::core::Collector for Collector {
             // Resource should be immutable, we don't need to compute again
             create_info_metric(TARGET_INFO_NAME, TARGET_INFO_DESCRIPTION, &metrics.resource)
         });
-        if !self.disable_target_info {
+        if !self.disable_target_info && !metrics.resource.is_empty() {
             res.push(target_info.clone())
         }
 
         for scope_metrics in metrics.scope_metrics {
             let scope_labels = if !self.disable_scope_info {
-                let scope_info = inner
-                    .scope_infos
-                    .entry(scope_metrics.scope.clone())
-                    .or_insert_with_key(create_scope_info_metric);
-                res.push(scope_info.clone());
+                if !scope_metrics.scope.attributes.is_empty() {
+                    let scope_info = inner
+                        .scope_infos
+                        .entry(scope_metrics.scope.clone())
+                        .or_insert_with_key(create_scope_info_metric);
+                    res.push(scope_info.clone());
+                }
 
                 let mut labels =
                     Vec::with_capacity(1 + scope_metrics.scope.version.is_some() as usize);

--- a/opentelemetry-prometheus/tests/data/empty_resource.txt
+++ b/opentelemetry-prometheus/tests/data/empty_resource.txt
@@ -4,6 +4,3 @@ foo_total{A="B",C="D",E="true",F="42",otel_scope_name="testmeter",otel_scope_ver
 # HELP otel_scope_info Instrumentation Scope metadata
 # TYPE otel_scope_info gauge
 otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
-# HELP target_info Target metadata
-# TYPE target_info gauge
-target_info 1

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -352,8 +352,12 @@ fn prometheus_exporter_integration() {
                 .unwrap(),
             )
             .build();
-        let meter =
-            provider.versioned_meter("testmeter", Some("v0.1.0"), None::<&'static str>, None);
+        let meter = provider.versioned_meter(
+            "testmeter",
+            Some("v0.1.0"),
+            None::<&'static str>,
+            Some(vec![KeyValue::new("k", "v")]),
+        );
         (tc.record_metrics)(meter);
 
         let content = fs::read_to_string(Path::new("./tests/data").join(tc.expected_file))
@@ -401,7 +405,12 @@ fn multiple_scopes() {
         .build();
 
     let foo_counter = provider
-        .versioned_meter("meterfoo", Some("v0.1.0"), None::<&'static str>, None)
+        .versioned_meter(
+            "meterfoo",
+            Some("v0.1.0"),
+            None::<&'static str>,
+            Some(vec![KeyValue::new("k", "v")]),
+        )
         .u64_counter("foo")
         .with_unit(Unit::new("ms"))
         .with_description("meter foo counter")
@@ -409,7 +418,12 @@ fn multiple_scopes() {
     foo_counter.add(100, &[KeyValue::new("type", "foo")]);
 
     let bar_counter = provider
-        .versioned_meter("meterbar", Some("v0.1.0"), None::<&'static str>, None)
+        .versioned_meter(
+            "meterbar",
+            Some("v0.1.0"),
+            None::<&'static str>,
+            Some(vec![KeyValue::new("k", "v")]),
+        )
         .u64_counter("bar")
         .with_unit(Unit::new("ms"))
         .with_description("meter bar counter")
@@ -735,8 +749,18 @@ fn duplicate_metrics() {
             .with_reader(exporter)
             .build();
 
-        let meter_a = provider.versioned_meter("ma", Some("v0.1.0"), None::<&'static str>, None);
-        let meter_b = provider.versioned_meter("mb", Some("v0.1.0"), None::<&'static str>, None);
+        let meter_a = provider.versioned_meter(
+            "ma",
+            Some("v0.1.0"),
+            None::<&'static str>,
+            Some(vec![KeyValue::new("k", "v")]),
+        );
+        let meter_b = provider.versioned_meter(
+            "mb",
+            Some("v0.1.0"),
+            None::<&'static str>,
+            Some(vec![KeyValue::new("k", "v")]),
+        );
 
         (tc.record_metrics)(meter_a, meter_b);
 


### PR DESCRIPTION
Fixes #1282 

## Changes

* omit otel_scope_info and otel_target_info metrics when scope attributes and resource attributes are empty.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
