### PR TITLE
feat: make trace state can be propagated  for dropped sampler

### DIFF
--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -265,6 +265,7 @@ mod tests {
                 KeyValue::new("extra_attr_key", "extra_attr_value"),
                 KeyValue::new("record_only_key", "record_only_value")
             ]
-        )
+        );
+        assert_eq!(span.span_context().trace_state().get("foo"), Some("bar"));
     }
 }

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -228,7 +228,7 @@ mod tests {
                 .clone();
             SamplingResult {
                 decision: SamplingDecision::RecordOnly,
-                attributes: Vec::new(),
+                attributes: vec![KeyValue::new("record_only_key", "record_only_value")],
                 trace_state,
             }
         }
@@ -261,7 +261,10 @@ mod tests {
         assert!(!span.span_context().trace_flags().is_sampled());
         assert_eq!(
             span.exported_data().unwrap().attributes,
-            vec![KeyValue::new("extra_attr_key", "extra_attr_value")]
+            vec![
+                KeyValue::new("extra_attr_key", "extra_attr_value"),
+                KeyValue::new("record_only_key", "record_only_value")
+            ]
         )
     }
 }


### PR DESCRIPTION
Fixes #1399 
Design discussion issue (if applicable) #

## Changes

Please provide a brief description of the changes here.
Added a return value (SamplingDecision) for func `make_sampling_decision`, and keep the `TraceState` value when sampling decision is `Drop`.
## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
