### PR TITLE
Add await to async trace documentation

### DIFF
--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -151,6 +151,7 @@
 //! use opentelemetry::{Context, global, trace::{FutureExt, TraceContextExt, Tracer}};
 //!
 //! async fn some_work() { }
+//! # async fn in_an_async_context() {
 //!
 //! // Get a tracer
 //! let tracer = global::tracer("my_tracer");
@@ -159,7 +160,8 @@
 //! let span = tracer.start("my_span");
 //!
 //! // Perform some async work with this span as the currently active parent.
-//! some_work().with_context(Context::current_with_span(span));
+//! some_work().with_context(Context::current_with_span(span)).await;
+//! # }
 //! ```
 
 use std::borrow::Cow;


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Add an `await` to the trace module doc section that describes WithContext, as the returned future is #[must_use] and does nothing without being awaited. It might not be apparent to readers that [WithContext&lt;impl Future&gt; is Future](https://docs.rs/opentelemetry/latest/opentelemetry/trace/struct.WithContext.html#impl-Future-for-WithContext%3CT%3E)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
