### PR TITLE
Add impl Into to some logs methods

### DIFF
--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -57,18 +57,18 @@ fn log_benchmark_group<F: Fn(&dyn Logger)>(c: &mut Criterion, name: &str, f: F) 
 
 fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "simple-log", |logger| {
-        logger.emit(LogRecord::builder().with_body("simple log".into()).build())
+        logger.emit(LogRecord::builder().with_body("simple log").build())
     });
 
     log_benchmark_group(c, "long-log", |logger| {
-        logger.emit(LogRecord::builder().with_body("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Gravida in fermentum et sollicitudin ac orci phasellus. Ullamcorper dignissim cras tincidunt lobortis feugiat vivamus at augue. Magna etiam tempor orci eu. Sed tempus urna et pharetra pharetra massa.".into()).build())
+        logger.emit(LogRecord::builder().with_body("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Gravida in fermentum et sollicitudin ac orci phasellus. Ullamcorper dignissim cras tincidunt lobortis feugiat vivamus at augue. Magna etiam tempor orci eu. Sed tempus urna et pharetra pharetra massa.").build())
     });
 
     let now = SystemTime::now();
     log_benchmark_group(c, "full-log", |logger| {
         logger.emit(
             LogRecord::builder()
-                .with_body("full log".into())
+                .with_body("full log")
                 .with_timestamp(now)
                 .with_observed_timestamp(now)
                 .with_severity_number(Severity::Warn)
@@ -80,7 +80,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "full-log-with-4-attributes", |logger| {
         logger.emit(
             LogRecord::builder()
-                .with_body("full log".into())
+                .with_body("full log")
                 .with_timestamp(now)
                 .with_observed_timestamp(now)
                 .with_severity_number(Severity::Warn)
@@ -96,7 +96,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "full-log-with-9-attributes", |logger| {
         logger.emit(
             LogRecord::builder()
-                .with_body("full log".into())
+                .with_body("full log")
                 .with_timestamp(now)
                 .with_observed_timestamp(now)
                 .with_severity_number(Severity::Warn)

--- a/opentelemetry/src/global/logs.rs
+++ b/opentelemetry/src/global/logs.rs
@@ -112,7 +112,7 @@ pub fn logger_provider() -> GlobalLoggerProvider {
 /// If `name` is an empty string, the provider will use a default name.
 ///
 /// [`Logger`]: crate::logs::Logger
-pub fn logger(name: Cow<'static, str>) -> BoxedLogger {
+pub fn logger(name: impl Into<Cow<'static, str>>) -> BoxedLogger {
     logger_provider().logger(name)
 }
 

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -331,10 +331,10 @@ impl LogRecordBuilder {
     }
 
     /// Assign body
-    pub fn with_body(self, body: AnyValue) -> Self {
+    pub fn with_body(self, body: impl Into<AnyValue>) -> Self {
         Self {
             record: LogRecord {
-                body: Some(body),
+                body: Some(body.into()),
                 ..self.record
             },
         }


### PR DESCRIPTION
## Changes

This adds `impl Into` to two logs methods, the first to match the equivalent metrics/traces method and the other to make `with_body` more ergonomic so you can do `with_body("hello")`

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
