### PR TITLE
Fix max_scale validation of exponential histogram configuration

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Fixed
 
 - Fix delta aggregation metric reuse. (#1434)
+- Fix `max_scale` validation of exponential histogram configuration. (#1452)
 
 ## v0.21.1
 

--- a/opentelemetry-sdk/src/metrics/aggregation.rs
+++ b/opentelemetry-sdk/src/metrics/aggregation.rs
@@ -134,7 +134,7 @@ impl Aggregation {
                         max_scale,
                     )));
                 }
-                if *max_scale < -EXPO_MIN_SCALE {
+                if *max_scale < EXPO_MIN_SCALE {
                     return Err(MetricsError::Config(format!(
                         "aggregation: exponential histogram: max scale ({}) is less than -10",
                         max_scale,


### PR DESCRIPTION
`metrics::Aggregation::validate()` has a bug that limits `max_scale` of a `Base2ExponentialHistogram` to the interval `[10, 20]` instead of the expected `[-10, 20]`.

## Changes

Fix the double negation so that the function validates correctly. I've also added some tests that exercise the entire validation function.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [X] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
