### PR TITLE
chore: fix 1.75 linter errors

### DIFF
--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -245,7 +245,7 @@ mod tests {
             .expect("Logs are expected to be exported.");
         assert_eq!(exported_logs.len(), 1);
         let log = exported_logs
-            .get(0)
+            .first()
             .expect("Atleast one log is expected to be present.");
 
         // Validate common fields
@@ -325,7 +325,7 @@ mod tests {
             .expect("Logs are expected to be exported.");
         assert_eq!(exported_logs.len(), 1);
         let log = exported_logs
-            .get(0)
+            .first()
             .expect("Atleast one log is expected to be present.");
 
         // validate common fields.
@@ -409,7 +409,7 @@ mod tests {
             .expect("Logs are expected to be exported.");
         assert_eq!(exported_logs.len(), 1);
         let log = exported_logs
-            .get(0)
+            .first()
             .expect("Atleast one log is expected to be present.");
 
         // Validate common fields
@@ -489,7 +489,7 @@ mod tests {
             .expect("Logs are expected to be exported.");
         assert_eq!(exported_logs.len(), 1);
         let log = exported_logs
-            .get(0)
+            .first()
             .expect("Atleast one log is expected to be present.");
 
         // validate common fields.

--- a/opentelemetry-jaeger/src/exporter/config/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/mod.rs
@@ -82,6 +82,20 @@ fn build_config_and_process(
     (config, Process { service_name, tags })
 }
 
+pub(crate) fn install_tracer_provider_and_get_tracer(
+    tracer_provider: TracerProvider,
+) -> Result<Tracer, TraceError> {
+    let tracer = opentelemetry::trace::TracerProvider::versioned_tracer(
+        &tracer_provider,
+        "opentelemetry-jaeger",
+        Some(env!("CARGO_PKG_VERSION")),
+        Some(semcov::SCHEMA_URL),
+        None,
+    );
+    let _ = global::set_tracer_provider(tracer_provider);
+    Ok(tracer)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::exporter::config::build_config_and_process;
@@ -114,18 +128,4 @@ mod tests {
         assert_eq!(exporter.process.service_name, "test service");
         env::set_var("OTEL_SERVICE_NAME", "")
     }
-}
-
-pub(crate) fn install_tracer_provider_and_get_tracer(
-    tracer_provider: TracerProvider,
-) -> Result<Tracer, TraceError> {
-    let tracer = opentelemetry::trace::TracerProvider::versioned_tracer(
-        &tracer_provider,
-        "opentelemetry-jaeger",
-        Some(env!("CARGO_PKG_VERSION")),
-        Some(semcov::SCHEMA_URL),
-        None,
-    );
-    let _ = global::set_tracer_provider(tracer_provider);
-    Ok(tracer)
 }

--- a/opentelemetry-jaeger/tests/integration_test.rs
+++ b/opentelemetry-jaeger/tests/integration_test.rs
@@ -191,7 +191,7 @@ mod tests {
             .collect::<Vec<&jaeger_api::SpanRef>>();
         if let Some(parent_span) = parent_span {
             assert_eq!(parent.len(), 1);
-            let parent = parent.get(0).unwrap();
+            let parent = parent.first().unwrap();
             assert_eq!(parent.span_id, parent_span.span_id);
             assert_eq!(parent.trace_id, parent_span.trace_id);
         } else {
@@ -217,10 +217,10 @@ mod tests {
             .filter(|kvs| kvs.key == "otel.library.name" || kvs.key == "otel.library.version")
             .collect::<Vec<&jaeger_api::KeyValue>>();
         assert_eq!(library_metadata.len(), 2);
-        if library_metadata.get(0).unwrap().key != "otel.library.name" {
+        if library_metadata.first().unwrap().key != "otel.library.name" {
             library_metadata.swap(0, 1)
         }
-        assert_eq!(library_metadata.get(0).unwrap().v_str, library_name.into());
+        assert_eq!(library_metadata.first().unwrap().v_str, library_name.into());
         assert_eq!(
             library_metadata.get(1).unwrap().v_str,
             library_version.into()

--- a/opentelemetry-otlp/tests/smoke.rs
+++ b/opentelemetry-otlp/tests/smoke.rs
@@ -116,15 +116,15 @@ async fn smoke_tracer() {
     let req = req_rx.recv().await.expect("missing export request");
     let first_span = req
         .resource_spans
-        .get(0)
+        .first()
         .unwrap()
         .scope_spans
-        .get(0)
+        .first()
         .unwrap()
         .spans
-        .get(0)
+        .first()
         .unwrap();
     assert_eq!("my-test-span", first_span.name);
-    let first_event = first_span.events.get(0).unwrap();
+    let first_event = first_span.events.first().unwrap();
     assert_eq!("my-test-event", first_event.name);
 }

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -45,7 +45,7 @@ mod tests {
             .expect("Logs are expected to be exported.");
         assert_eq!(exported_logs.len(), 1);
         let log = exported_logs
-            .get(0)
+            .first()
             .expect("Atleast one log is expected to be present.");
         assert_eq!(log.instrumentation.name, "test-logger");
         assert_eq!(log.record.severity_number, Some(Severity::Error));

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -580,6 +580,7 @@ mod tests {
             .expect("span data should not be empty as we already set it before")
             .events;
         let event_vec: Vec<_> = event_queue.iter().take(2).collect();
+        #[allow(clippy::get_first)] // we want to extract first two elements
         let processed_event_1 = event_vec.get(0).expect("should have at least two events");
         let processed_event_2 = event_vec.get(1).expect("should have at least two events");
         assert_eq!(processed_event_1.attributes.len(), 128);
@@ -617,7 +618,7 @@ mod tests {
             .expect("span data should not be empty as we already set it before")
             .links;
         let link_vec: Vec<_> = link_queue.links;
-        let processed_link = link_vec.get(0).expect("should have at least one link");
+        let processed_link = link_vec.first().expect("should have at least one link");
         assert_eq!(processed_link.attributes.len(), 128);
     }
 

--- a/opentelemetry-stdout/src/common.rs
+++ b/opentelemetry-stdout/src/common.rs
@@ -77,7 +77,7 @@ impl From<opentelemetry::Key> for Key {
 }
 
 #[derive(Debug, Serialize, Clone)]
-#[allow(dead_code)]
+#[allow(dead_code, clippy::enum_variant_names)] // we want to emphasize the *Values are collection
 pub(crate) enum Value {
     #[serde(rename = "boolValue")]
     Bool(bool),


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Fix new clippy warrning comes with rust 1.75 release

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
