### PR TITLE
chore: upgrade tonic to 0.10 (and upgrade prost to match)

### DIFF
--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -17,9 +17,9 @@ path = "src/client.rs"
 opentelemetry = { path = "../../opentelemetry" }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio"]}
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["trace"] }
-prost = "0.11"
+prost = "0.12.3"
 tokio = { version = "1.28", features = ["full"] }
-tonic = "0.9.2"
+tonic = "0.10.2"
 
 [build-dependencies]
 tonic-build = "0.9.2"

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -35,8 +35,8 @@ opentelemetry-http = { version = "0.10", path = "../opentelemetry-http", optiona
 opentelemetry-proto = { version = "0.4", path = "../opentelemetry-proto", default-features = false }
 opentelemetry-semantic-conventions = { version = "0.13", path = "../opentelemetry-semantic-conventions" }
 
-prost = { version = "0.11.0", optional = true }
-tonic = { version = "0.9.0", optional = true }
+prost = { version = ">=0.11.0, <0.13", optional = true }
+tonic = { version = ">=0.9.0, <0.11", optional = true }
 tokio = { version = "1.0", features = ["sync", "rt"], optional = true }
 
 reqwest = { version = "0.11", optional = true, default-features = false }

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -46,8 +46,9 @@ with-serde = ["serde"]
 
 [dependencies]
 grpcio = { version = "0.12", optional = true, features = ["prost-codec"] }
-tonic = { version = "0.9.0", default-features = false, optional = true, features = ["codegen", "prost"] }
-prost = { version = "0.11.0", optional = true }
+
+tonic = { version = ">=0.9.0, <0.11", default-features = false, optional = true, features = ["codegen", "prost"] }
+prost = { version = ">=0.11.0, <0.13", optional = true }
 opentelemetry = { version = "0.21", default-features = false, path = "../opentelemetry" }
 opentelemetry_sdk = { version = "0.21", default-features = false, path = "../opentelemetry-sdk" }
 schemars = { version = "0.8", optional = true }


### PR DESCRIPTION
Fix #1458

## Changes

This upgrades tonic to 0.10, and upgrades the prost version to match tonic's version, so that relevant traits are actually implemented for the prost version we use.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
