### PR TITLE
fix(proto): use camelCase for json (de)serialization.

### DIFF
--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -57,7 +57,6 @@ opentelemetry = { version = "0.21", default-features = false, path = "../opentel
 opentelemetry_sdk = { version = "0.21", default-features = false, path = "../opentelemetry-sdk" }
 schemars = { version = "0.8", optional = true }
 serde = { workspace = true, optional = true, features = ["serde_derive"] }
-serde = { version = "1.0", optional = true, features = ["serde_derive"] }
 hex = { version = "0.4.3", optional = true }
 
 [dev-dependencies]

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -23,6 +23,11 @@ doctest = false
 name = "grpc_build"
 path = "tests/grpc_build.rs"
 
+[[test]]
+name = "json_deserialize"
+path = "tests/json_deserialize.rs"
+
+
 [features]
 default = []
 
@@ -42,7 +47,7 @@ zpages = ["trace"]
 
 # add ons
 with-schemars = ["schemars"]
-with-serde = ["serde"]
+with-serde = ["serde", "hex"]
 
 [dependencies]
 grpcio = { workspace = true, optional = true, features = ["prost-codec"] }
@@ -52,9 +57,12 @@ opentelemetry = { version = "0.21", default-features = false, path = "../opentel
 opentelemetry_sdk = { version = "0.21", default-features = false, path = "../opentelemetry-sdk" }
 schemars = { version = "0.8", optional = true }
 serde = { workspace = true, optional = true, features = ["serde_derive"] }
+serde = { version = "1.0", optional = true, features = ["serde_derive"] }
+hex = { version = "0.4.3", optional = true }
 
 [dev-dependencies]
 grpcio-compiler = { version = "0.12.1", default-features = false, features = ["prost-codec"] }
 tonic-build = { version = "0.9.0" }
 prost-build = { version = "0.11.1" }
 tempfile = "3.3.0"
+serde_json = "1.0"

--- a/opentelemetry-proto/src/proto.rs
+++ b/opentelemetry-proto/src/proto.rs
@@ -1,3 +1,77 @@
+/// provide serde support for proto traceIds and spanIds.
+/// Those are hex encoded strings in the jsons but they are byte arrays in the proto.
+/// See https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding for more details
+#[cfg(all(feature = "with-serde", feature = "gen-tonic-messages"))]
+pub(crate) mod serializers {
+    use crate::tonic::common::v1::any_value::Value;
+    use crate::tonic::common::v1::AnyValue;
+    use serde::de::{self, MapAccess, Visitor};
+    use serde::ser::SerializeStruct;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::fmt;
+
+    // hex string <-> bytes conversion
+
+    pub fn serialize_to_hex_string<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let hex_string = hex::encode(bytes);
+        serializer.serialize_str(&hex_string)
+    }
+
+    pub fn deserialize_from_hex_string<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BytesVisitor;
+
+        impl<'de> Visitor<'de> for BytesVisitor {
+            type Value = Vec<u8>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string representing hex-encoded bytes")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Vec<u8>, E>
+            where
+                E: de::Error,
+            {
+                hex::decode(value).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(BytesVisitor)
+    }
+
+    // AnyValue <-> KeyValue conversion
+    pub fn serialize_to_value<S>(value: &Option<AnyValue>, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        // Serialize any_value::Value using its own implementation
+        // If value is None, it will be serialized as such
+        match value {
+            Some(value) => value.value.serialize(serializer),
+            None => serializer.serialize_none(),
+        }
+
+    }
+
+    pub fn deserialize_from_value<'de, D>(deserializer: D) -> Result<Option<AnyValue>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Deserialize any_value::Value using its own implementation
+        let value = Option::<Value>::deserialize(deserializer)?;
+
+        // Wrap the deserialized value in AnyValue
+        Ok(Some(AnyValue { value }))
+    }
+
+
+}
+
 #[cfg(feature = "gen-tonic-messages")]
 #[path = "proto/tonic"]
 /// Generated files using [`tonic`](https://docs.rs/crate/tonic) and [`prost`](https://docs.rs/crate/prost)

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
@@ -1,5 +1,6 @@
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportLogsServiceRequest {
@@ -15,6 +16,7 @@ pub struct ExportLogsServiceRequest {
 }
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportLogsServiceResponse {
@@ -38,6 +40,7 @@ pub struct ExportLogsServiceResponse {
 }
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportLogsPartialSuccess {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
@@ -1,5 +1,6 @@
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportMetricsServiceRequest {
@@ -15,6 +16,7 @@ pub struct ExportMetricsServiceRequest {
 }
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportMetricsServiceResponse {
@@ -38,6 +40,7 @@ pub struct ExportMetricsServiceResponse {
 }
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportMetricsPartialSuccess {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
@@ -1,5 +1,6 @@
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTraceServiceRequest {
@@ -15,6 +16,7 @@ pub struct ExportTraceServiceRequest {
 }
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTraceServiceResponse {
@@ -38,6 +40,7 @@ pub struct ExportTraceServiceResponse {
 }
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTracePartialSuccess {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
@@ -3,6 +3,7 @@
 /// object containing arrays, key-value lists and primitives.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AnyValue {
@@ -17,6 +18,7 @@ pub mod any_value {
     /// in which case this AnyValue is considered to be "empty".
     #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
     #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
@@ -40,6 +42,7 @@ pub mod any_value {
 /// since oneof in AnyValue does not allow repeated fields.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ArrayValue {
@@ -54,6 +57,7 @@ pub struct ArrayValue {
 /// are semantically equivalent.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyValueList {
@@ -68,18 +72,28 @@ pub struct KeyValueList {
 /// attributes, etc.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyValue {
     #[prost(string, tag = "1")]
     pub key: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
+    #[cfg_attr(
+        feature = "with-serde",
+        serde(
+            serialize_with = "crate::proto::serializers::serialize_to_value",
+            deserialize_with = "crate::proto::serializers::deserialize_from_value"
+        )
+    )]
     pub value: ::core::option::Option<AnyValue>,
 }
 /// InstrumentationScope is a message representing the instrumentation scope information
 /// such as the fully qualified name and version.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstrumentationScope {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
@@ -10,6 +10,7 @@
 /// as well.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LogsData {
@@ -24,6 +25,7 @@ pub struct LogsData {
 /// A collection of ScopeLogs from a Resource.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceLogs {
@@ -42,6 +44,7 @@ pub struct ResourceLogs {
 /// A collection of Logs produced by a Scope.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScopeLogs {
@@ -61,6 +64,7 @@ pub struct ScopeLogs {
 /// <https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md>
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LogRecord {
@@ -144,6 +148,7 @@ pub struct LogRecord {
 /// Possible values for LogRecord.SeverityNumber.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum SeverityNumber {
@@ -248,6 +253,7 @@ impl SeverityNumber {
 ///
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum LogRecordFlags {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
@@ -10,6 +10,7 @@
 /// as well.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MetricsData {
@@ -24,6 +25,7 @@ pub struct MetricsData {
 /// A collection of ScopeMetrics from a Resource.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceMetrics {
@@ -42,6 +44,7 @@ pub struct ResourceMetrics {
 /// A collection of Metrics produced by an Scope.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScopeMetrics {
@@ -144,6 +147,7 @@ pub struct ScopeMetrics {
 /// strongly encouraged.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Metric {
@@ -170,6 +174,7 @@ pub mod metric {
     /// the time interval over which they are reported.
     #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
     #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Data {
@@ -196,6 +201,7 @@ pub mod metric {
 /// "StartTimeUnixNano" is ignored for all data points.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Gauge {
@@ -206,6 +212,7 @@ pub struct Gauge {
 /// reported measurements over a time interval.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Sum {
@@ -223,6 +230,7 @@ pub struct Sum {
 /// as a Histogram of all reported measurements over a time interval.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Histogram {
@@ -237,6 +245,7 @@ pub struct Histogram {
 /// as a ExponentialHistogram of all reported double measurements over a time interval.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExponentialHistogram {
@@ -255,6 +264,7 @@ pub struct ExponentialHistogram {
 /// recommended for new applications.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Summary {
@@ -265,6 +275,7 @@ pub struct Summary {
 /// time-varying scalar value of a metric.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NumberDataPoint {
@@ -306,6 +317,7 @@ pub mod number_data_point {
     /// value fields is not present inside this oneof.
     #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
     #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
@@ -327,6 +339,7 @@ pub mod number_data_point {
 /// "sum" are known.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HistogramDataPoint {
@@ -410,6 +423,7 @@ pub struct HistogramDataPoint {
 ///
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExponentialHistogramDataPoint {
@@ -509,6 +523,7 @@ pub mod exponential_histogram_data_point {
     /// of counts.
     #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
     #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Buckets {
@@ -534,6 +549,7 @@ pub mod exponential_histogram_data_point {
 /// time-varying values of a Summary metric.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SummaryDataPoint {
@@ -590,6 +606,7 @@ pub mod summary_data_point {
     /// <https://github.com/open-telemetry/opentelemetry-proto/issues/125>
     #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
     #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ValueAtQuantile {
@@ -610,6 +627,7 @@ pub mod summary_data_point {
 /// exemplar was recorded.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Exemplar {
@@ -649,6 +667,7 @@ pub mod exemplar {
     /// inside this oneof.
     #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
     #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
@@ -663,6 +682,7 @@ pub mod exemplar {
 /// which they are aggregated.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum AggregationTemporality {
@@ -761,6 +781,7 @@ impl AggregationTemporality {
 ///
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum DataPointFlags {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.resource.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.resource.v1.rs
@@ -1,6 +1,8 @@
 /// Resource information.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Resource {

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.trace.v1.rs
@@ -10,6 +10,7 @@
 /// as well.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TracesData {
@@ -24,6 +25,8 @@ pub struct TracesData {
 /// A collection of ScopeSpans from a Resource.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceSpans {
@@ -42,6 +45,8 @@ pub struct ResourceSpans {
 /// A collection of Spans produced by an InstrumentationScope.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScopeSpans {
@@ -62,6 +67,8 @@ pub struct ScopeSpans {
 /// The next available field id is 17.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Span {
@@ -72,6 +79,13 @@ pub struct Span {
     ///
     /// This field is required.
     #[prost(bytes = "vec", tag = "1")]
+    #[cfg_attr(
+        feature = "with-serde",
+        serde(
+            serialize_with = "crate::proto::serializers::serialize_to_hex_string",
+            deserialize_with = "crate::proto::serializers::deserialize_from_hex_string"
+        )
+    )]
     pub trace_id: ::prost::alloc::vec::Vec<u8>,
     /// A unique identifier for a span within a trace, assigned when the span
     /// is created. The ID is an 8-byte array. An ID with all zeroes OR of length
@@ -80,6 +94,13 @@ pub struct Span {
     ///
     /// This field is required.
     #[prost(bytes = "vec", tag = "2")]
+    #[cfg_attr(
+        feature = "with-serde",
+        serde(
+            serialize_with = "crate::proto::serializers::serialize_to_hex_string",
+            deserialize_with = "crate::proto::serializers::deserialize_from_hex_string"
+        )
+    )]
     pub span_id: ::prost::alloc::vec::Vec<u8>,
     /// trace_state conveys information about request position in multiple distributed tracing graphs.
     /// It is a trace_state in w3c-trace-context format: <https://www.w3.org/TR/trace-context/#tracestate-header>
@@ -89,6 +110,13 @@ pub struct Span {
     /// The `span_id` of this span's parent span. If this is a root span, then this
     /// field must be empty. The ID is an 8-byte array.
     #[prost(bytes = "vec", tag = "4")]
+    #[cfg_attr(
+        feature = "with-serde",
+        serde(
+            serialize_with = "crate::proto::serializers::serialize_to_hex_string",
+            deserialize_with = "crate::proto::serializers::deserialize_from_hex_string"
+        )
+    )]
     pub parent_span_id: ::prost::alloc::vec::Vec<u8>,
     /// A description of the span's operation.
     ///
@@ -169,6 +197,7 @@ pub mod span {
     /// text description and key-value pairs.
     #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
     #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Event {
@@ -197,6 +226,8 @@ pub mod span {
     /// traces or when the handler receives a request from a different project.
     #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
     #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "with-serde", serde(default))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Link {
@@ -226,6 +257,7 @@ pub mod span {
     /// in addition to a parent/child relationship.
     #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
     #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
     #[derive(
         Clone,
         Copy,
@@ -293,6 +325,7 @@ pub mod span {
 /// programming environments, including REST APIs and RPC APIs.
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Status {
@@ -309,6 +342,7 @@ pub mod status {
     /// <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status>
     #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
     #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
     #[derive(
         Clone,
         Copy,

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.tracez.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.tracez.v1.rs
@@ -1,5 +1,6 @@
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TracezCounts {
@@ -15,6 +16,7 @@ pub struct TracezCounts {
 }
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LatencyData {
@@ -40,6 +42,7 @@ pub struct LatencyData {
 }
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RunningData {
@@ -63,6 +66,7 @@ pub struct RunningData {
 }
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ErrorData {

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -54,7 +54,7 @@ fn build_tonic() {
     let out_dir = TempDir::new().expect("failed to create temp dir to store the generated files");
 
     // build the generated files into OUT_DIR for now so we don't have to touch the src unless we have to
-    tonic_build::configure()
+    let mut builder = tonic_build::configure()
         .build_server(true)
         .build_client(true)
         .server_mod_attribute(".", "#[cfg(feature = \"gen-tonic\")]")
@@ -67,6 +67,46 @@ fn build_tonic() {
             ".",
             "#[cfg_attr(feature = \"with-serde\", derive(serde::Serialize, serde::Deserialize))]",
         )
+        .type_attribute(
+            ".",
+            "#[cfg_attr(feature = \"with-serde\", serde(rename_all = \"camelCase\"))]",
+        );
+
+    // optional numeric and String field need to default it to 0 otherwise JSON files without those field
+    // cannot deserialize
+    // we cannot add serde(default) to all generated types because enums cannot be annotated with serde(default)
+    for path in [
+        "trace.v1.Span",
+        "trace.v1.Span.Link",
+        "trace.v1.ScopeSpans",
+        "trace.v1.ResourceSpans",
+        "common.v1.InstrumentationScope",
+        "resource.v1.Resource",
+    ] {
+        builder = builder.type_attribute(
+            path,
+            "#[cfg_attr(feature = \"with-serde\", serde(default))]",
+        )
+    }
+
+    // special serializer and deserializer for traceId and spanId
+    // OTLP/JSON format uses hex string for traceId and spanId
+    // the proto file uses bytes for traceId and spanId
+    // Thus, special serializer and deserializer are needed
+    for path in [
+        "trace.v1.Span.trace_id",
+        "trace.v1.Span.span_id",
+        "trace.v1.Span.parent_span_id",
+    ] {
+        builder = builder
+            .field_attribute(path, "#[cfg_attr(feature = \"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_to_hex_string\", deserialize_with = \"crate::proto::serializers::deserialize_from_hex_string\"))]")
+    }
+
+    // add custom serializer and deserializer for AnyValue
+    builder = builder
+        .field_attribute("common.v1.KeyValue.value", "#[cfg_attr(feature =\"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_to_value\", deserialize_with = \"crate::proto::serializers::deserialize_from_value\"))]");
+
+    builder
         .out_dir(out_dir.path())
         .compile(TONIC_PROTO_FILES, TONIC_INCLUDES)
         .expect("cannot compile protobuf using tonic");

--- a/opentelemetry-proto/tests/json_deserialize.rs
+++ b/opentelemetry-proto/tests/json_deserialize.rs
@@ -1,0 +1,142 @@
+#[cfg(all(feature = "with-serde", feature = "gen-tonic-messages"))]
+mod json_deserialize {
+    use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+    use opentelemetry_proto::tonic::common::v1::any_value::Value;
+    use opentelemetry_proto::tonic::common::v1::KeyValue;
+
+    // copied from example json file
+    // see https://github.com/open-telemetry/opentelemetry-proto/blob/v1.0.0/examples/trace.json
+    const TRACES_JSON: &str = r#"
+    {
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "my.service"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "my.library",
+            "version": "1.0.0",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "some scope attribute"
+                }
+              }
+            ]
+          },
+          "spans": [
+            {
+              "traceId": "5B8EFFF798038103D269B633813FC60C",
+              "spanId": "EEE19B7EC3C1B174",
+              "parentSpanId": "EEE19B7EC3C1B173",
+              "name": "I'm a server span",
+              "startTimeUnixNano": 1544712660000000000,
+              "endTimeUnixNano": 1544712661000000000,
+              "kind": 2,
+              "attributes": [
+                {
+                  "key": "my.span.attr",
+                  "value": {
+                    "stringValue": "some value"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+    "#;
+
+    const KEY_VALUES_JSON: &str = r#"
+    {
+            "key": "service.name",
+            "value": {
+              "stringValue": "my.service"
+            }
+          }
+    "#;
+
+    #[test]
+    fn test_deserialize_traces() {
+        let request: ExportTraceServiceRequest = serde_json::from_str(TRACES_JSON).unwrap();
+        assert_eq!(
+            request.resource_spans[0].scope_spans[0].spans[0].trace_id,
+            hex::decode("5B8EFFF798038103D269B633813FC60C").unwrap()
+        )
+    }
+
+    #[test]
+    fn test_deserialize_values() {
+        // strings
+        {
+            let value: Value = serde_json::from_str(
+                r#"
+            {
+              "stringValue": "my.service"
+            }
+        "#,
+            )
+            .unwrap();
+            assert_eq!(value, Value::StringValue("my.service".to_string()));
+        }
+        // bools
+        {
+            let value: Value = serde_json::from_str(
+                r#"
+            {
+              "boolValue": true
+            }
+        "#,
+            )
+            .unwrap();
+            assert_eq!(value, Value::BoolValue(true));
+        }
+        // ints
+        {
+            let value: Value = serde_json::from_str(
+                r#"
+            {
+              "intValue": 123
+            }"#,
+            )
+            .unwrap();
+            assert_eq!(value, Value::IntValue(123));
+        }
+        // doubles
+        {
+            let value: Value = serde_json::from_str(
+                r#"
+            {
+              "doubleValue": 123.456
+            }"#,
+            )
+            .unwrap();
+            assert_eq!(value, Value::DoubleValue(123.456));
+        }
+        // todo(zhongyang): add tests for arrays and objects(need an example from other language)
+    }
+
+    #[test]
+    fn test_deserialize_key_values() {
+        let keyvalue: KeyValue = serde_json::from_str(KEY_VALUES_JSON).unwrap();
+
+        assert_eq!(keyvalue.key, "service.name".to_string());
+        assert_eq!(
+            keyvalue.value.unwrap().value.unwrap(),
+            Value::StringValue("my.service".to_string())
+        );
+    }
+}


### PR DESCRIPTION
Part of the effort of #1327 as we need  json formats for assertation in integration tests. 

## Changes

- add configuration to serde to deserialize the json in camelCase field name
- add custom (de)serialization for traceId, spanId as they are case-insensitive hex encoded string(see [here](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding))
- add custom (de)serialization for `KeyValue`
- add tests for above, and a test using example json files

## Merge requirement checklist

* [ x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [] Changes in public API reviewed (if applicable)
