### PR TITLE
Expose log batchconfig

### DIFF
--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -135,7 +135,7 @@ impl<EB> OtlpLogPipeline<EB> {
         self
     }
 
-    /// Set the batch span processor configuration, and it will override the env vars.
+    /// Set the batch log processor configuration, and it will override the env vars.
     pub fn with_batch_config(mut self, batch_config: opentelemetry_sdk::logs::BatchConfig) -> Self {
         self.batch_config = Some(batch_config);
         self
@@ -169,7 +169,7 @@ impl OtlpLogPipeline<LogExporterBuilder> {
         ))
     }
 
-    /// Install the configured log exporter and a batch span processor using the
+    /// Install the configured log exporter and a batch log processor using the
     /// specified runtime.
     ///
     /// Returns a [`Logger`] with the name `opentelemetry-otlp` and the current crate version.

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - [#1410](https://github.com/open-telemetry/opentelemetry-rust/pull/1410) Add experimental synchronous gauge
+- [#1471](https://github.com/open-telemetry/opentelemetry-rust/pull/1471) Configure batch log record processor via [`OTEL_BLRP_*`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#batch-logrecord-processor) environment variables and via `OtlpLogPipeline::with_batch_config`
 
 ### Changed
 

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -655,5 +655,4 @@ mod tests {
         assert_eq!(actual.max_export_timeout, Duration::from_millis(3));
         assert_eq!(actual.max_queue_size, 4);
     }
-    
 }

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -317,11 +317,7 @@ impl Default for BatchConfig {
             .ok()
             .and_then(|batch_size| usize::from_str(&batch_size).ok())
         {
-            if max_export_batch_size > config.max_queue_size {
-                config.max_export_batch_size = config.max_queue_size;
-            } else {
-                config.max_export_batch_size = max_export_batch_size;
-            }
+            config.max_export_batch_size = max_export_batch_size;
         }
 
         // max export batch size must be less or equal to max queue size.
@@ -470,7 +466,13 @@ mod tests {
         OTEL_BLRP_MAX_QUEUE_SIZE, OTEL_BLRP_SCHEDULE_DELAY,
     };
     use crate::{
-        logs::{BatchConfig, log_processor::{OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT, OTEL_BLRP_SCHEDULE_DELAY_DEFAULT, OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT, OTEL_BLRP_EXPORT_TIMEOUT_DEFAULT}},
+        logs::{
+            log_processor::{
+                OTEL_BLRP_EXPORT_TIMEOUT_DEFAULT, OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT,
+                OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT, OTEL_BLRP_SCHEDULE_DELAY_DEFAULT,
+            },
+            BatchConfig,
+        },
         runtime,
         testing::logs::InMemoryLogsExporter,
     };
@@ -495,10 +497,19 @@ mod tests {
     fn test_default_batch_config_adheres_to_specification() {
         let config = BatchConfig::default();
 
-        assert_eq!(config.scheduled_delay, Duration::from_millis(OTEL_BLRP_SCHEDULE_DELAY_DEFAULT));
-        assert_eq!(config.max_export_timeout, Duration::from_millis(OTEL_BLRP_EXPORT_TIMEOUT_DEFAULT));
+        assert_eq!(
+            config.scheduled_delay,
+            Duration::from_millis(OTEL_BLRP_SCHEDULE_DELAY_DEFAULT)
+        );
+        assert_eq!(
+            config.max_export_timeout,
+            Duration::from_millis(OTEL_BLRP_EXPORT_TIMEOUT_DEFAULT)
+        );
         assert_eq!(config.max_queue_size, OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT);
-        assert_eq!(config.max_export_batch_size, OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT);
+        assert_eq!(
+            config.max_export_batch_size,
+            OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT
+        );
     }
 
     #[test]
@@ -530,7 +541,10 @@ mod tests {
         assert_eq!(config.scheduled_delay, Duration::from_millis(3000));
         assert_eq!(config.max_export_timeout, Duration::from_millis(70000));
         assert_eq!(config.max_queue_size, OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT);
-        assert_eq!(config.max_export_batch_size, OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT);
+        assert_eq!(
+            config.max_export_batch_size,
+            OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT
+        );
     }
 
     #[test]
@@ -547,7 +561,10 @@ mod tests {
         assert_eq!(config.scheduled_delay, Duration::from_millis(2000));
         assert_eq!(config.max_export_timeout, Duration::from_millis(60000));
         assert_eq!(config.max_queue_size, OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT);
-        assert_eq!(config.max_export_batch_size, OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT);
+        assert_eq!(
+            config.max_export_batch_size,
+            OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT
+        );
     }
 
     #[test]
@@ -561,8 +578,14 @@ mod tests {
 
         assert_eq!(config.max_queue_size, 256);
         assert_eq!(config.max_export_batch_size, 256);
-        assert_eq!(config.scheduled_delay, Duration::from_millis(OTEL_BLRP_SCHEDULE_DELAY_DEFAULT));
-        assert_eq!(config.max_export_timeout, Duration::from_millis(OTEL_BLRP_EXPORT_TIMEOUT_DEFAULT));
+        assert_eq!(
+            config.scheduled_delay,
+            Duration::from_millis(OTEL_BLRP_SCHEDULE_DELAY_DEFAULT)
+        );
+        assert_eq!(
+            config.max_export_timeout,
+            Duration::from_millis(OTEL_BLRP_EXPORT_TIMEOUT_DEFAULT)
+        );
     }
 
     #[test]
@@ -587,8 +610,9 @@ mod tests {
             (OTEL_BLRP_EXPORT_TIMEOUT, Some("2046")),
         ];
         temp_env::with_vars(env_vars.clone(), || {
-            let builder = BatchLogProcessor::builder(InMemoryLogsExporter::default(), runtime::Tokio);
-            
+            let builder =
+                BatchLogProcessor::builder(InMemoryLogsExporter::default(), runtime::Tokio);
+
             assert_eq!(builder.config.max_export_batch_size, 500);
             assert_eq!(
                 builder.config.scheduled_delay,
@@ -607,7 +631,8 @@ mod tests {
         env_vars.push((OTEL_BLRP_MAX_QUEUE_SIZE, Some("120")));
 
         temp_env::with_vars(env_vars, || {
-            let builder = BatchLogProcessor::builder(InMemoryLogsExporter::default(), runtime::Tokio);
+            let builder =
+                BatchLogProcessor::builder(InMemoryLogsExporter::default(), runtime::Tokio);
             assert_eq!(builder.config.max_export_batch_size, 120);
             assert_eq!(builder.config.max_queue_size, 120);
         });

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -342,6 +342,11 @@ where
         BatchLogProcessorBuilder { config, ..self }
     }
 
+    /// Set the BatchConfig for [BatchLogProcessorBuilder]
+    pub fn with_batch_config(self, config: BatchConfig) -> Self {
+        BatchLogProcessorBuilder { config, ..self }
+    }
+
     /// Build a batch processor
     pub fn build(self) -> BatchLogProcessor<R> {
         BatchLogProcessor::new(Box::new(self.exporter), self.config, self.runtime)

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -425,3 +425,18 @@ enum BatchMessage {
     /// Shut down the worker thread, push all logs in buffer to the backend.
     Shutdown(oneshot::Sender<ExportResult>),
 }
+
+#[cfg(all(test, feature="testing", feature="logs"))]
+mod tests{
+    use std::time::Duration;
+
+    #[test]
+    fn test_default_batch_config_adheres_to_specification(){
+        let config = super::BatchConfig::default();
+
+        assert_eq!(config.scheduled_delay, Duration::from_millis(1000));
+        assert_eq!(config.max_export_timeout, Duration::from_millis(30000));
+        assert_eq!(config.max_queue_size, 2048);
+        assert_eq!(config.max_export_batch_size, 512);
+    }
+}

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -521,7 +521,7 @@ mod tests {
             (OTEL_BLRP_MAX_EXPORT_BATCH_SIZE, Some("1024")),
         ];
 
-        let config = temp_env::with_vars(env_vars, || BatchConfig::default());
+        let config = temp_env::with_vars(env_vars, BatchConfig::default);
 
         assert_eq!(config.scheduled_delay, Duration::from_millis(2000));
         assert_eq!(config.max_export_timeout, Duration::from_millis(60000));
@@ -536,7 +536,7 @@ mod tests {
             ("OTEL_BLRP_EXPORT_TIMEOUT_MILLIS", Some("70000")),
         ];
 
-        let config = temp_env::with_vars(env_vars, || BatchConfig::default());
+        let config = temp_env::with_vars(env_vars, BatchConfig::default);
 
         assert_eq!(config.scheduled_delay, Duration::from_millis(3000));
         assert_eq!(config.max_export_timeout, Duration::from_millis(70000));
@@ -556,7 +556,7 @@ mod tests {
             ("OTEL_BLRP_EXPORT_TIMEOUT_MILLIS", Some("70000")),
         ];
 
-        let config = temp_env::with_vars(env_vars, || BatchConfig::default());
+        let config = temp_env::with_vars(env_vars, BatchConfig::default);
 
         assert_eq!(config.scheduled_delay, Duration::from_millis(2000));
         assert_eq!(config.max_export_timeout, Duration::from_millis(60000));
@@ -574,7 +574,7 @@ mod tests {
             (OTEL_BLRP_MAX_EXPORT_BATCH_SIZE, Some("1024")),
         ];
 
-        let config = temp_env::with_vars(env_vars, || BatchConfig::default());
+        let config = temp_env::with_vars(env_vars, BatchConfig::default);
 
         assert_eq!(config.max_queue_size, 256);
         assert_eq!(config.max_export_batch_size, 256);

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -637,4 +637,23 @@ mod tests {
             assert_eq!(builder.config.max_queue_size, 120);
         });
     }
+
+    #[test]
+    fn test_build_batch_log_processor_builder_with_custom_config() {
+        let expected = BatchConfig::default()
+            .with_max_export_batch_size(1)
+            .with_scheduled_delay(Duration::from_millis(2))
+            .with_max_export_timeout(Duration::from_millis(3))
+            .with_max_queue_size(4);
+
+        let builder = BatchLogProcessor::builder(InMemoryLogsExporter::default(), runtime::Tokio)
+            .with_batch_config(expected);
+
+        let actual = &builder.config;
+        assert_eq!(actual.max_export_batch_size, 1);
+        assert_eq!(actual.scheduled_delay, Duration::from_millis(2));
+        assert_eq!(actual.max_export_timeout, Duration::from_millis(3));
+        assert_eq!(actual.max_queue_size, 4);
+    }
+    
 }

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -379,7 +379,7 @@ impl BatchConfig {
     /// Set max_export_batch_size for [`BatchConfig`].
     /// It's the maximum number of logs to process in a single batch. If there are
     /// more than one batch worth of logs then it processes multiple batches
-    /// of logs one batch after the other without any delay. 
+    /// of logs one batch after the other without any delay.
     /// The default value is 512.
     pub fn with_max_export_batch_size(mut self, max_export_batch_size: usize) -> Self {
         self.max_export_batch_size = max_export_batch_size;
@@ -465,21 +465,40 @@ enum BatchMessage {
 
 #[cfg(all(test, feature = "testing", feature = "logs"))]
 mod tests {
-    use std::time::Duration;
-    use crate::logs::BatchConfig;
     use super::{
-        OTEL_BLRP_EXPORT_TIMEOUT, OTEL_BLRP_MAX_EXPORT_BATCH_SIZE, OTEL_BLRP_MAX_QUEUE_SIZE,
-        OTEL_BLRP_SCHEDULE_DELAY,
+        BatchLogProcessor, OTEL_BLRP_EXPORT_TIMEOUT, OTEL_BLRP_MAX_EXPORT_BATCH_SIZE,
+        OTEL_BLRP_MAX_QUEUE_SIZE, OTEL_BLRP_SCHEDULE_DELAY,
     };
+    use crate::{
+        logs::{BatchConfig, log_processor::{OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT, OTEL_BLRP_SCHEDULE_DELAY_DEFAULT, OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT, OTEL_BLRP_EXPORT_TIMEOUT_DEFAULT}},
+        runtime,
+        testing::logs::InMemoryLogsExporter,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn test_default_const_values() {
+        assert_eq!(OTEL_BLRP_SCHEDULE_DELAY, "OTEL_BLRP_SCHEDULE_DELAY");
+        assert_eq!(OTEL_BLRP_SCHEDULE_DELAY_DEFAULT, 1_000);
+        assert_eq!(OTEL_BLRP_EXPORT_TIMEOUT, "OTEL_BLRP_EXPORT_TIMEOUT");
+        assert_eq!(OTEL_BLRP_EXPORT_TIMEOUT_DEFAULT, 30_000);
+        assert_eq!(OTEL_BLRP_MAX_QUEUE_SIZE, "OTEL_BLRP_MAX_QUEUE_SIZE");
+        assert_eq!(OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT, 2_048);
+        assert_eq!(
+            OTEL_BLRP_MAX_EXPORT_BATCH_SIZE,
+            "OTEL_BLRP_MAX_EXPORT_BATCH_SIZE"
+        );
+        assert_eq!(OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT, 512);
+    }
 
     #[test]
     fn test_default_batch_config_adheres_to_specification() {
         let config = BatchConfig::default();
 
-        assert_eq!(config.scheduled_delay, Duration::from_millis(1000));
-        assert_eq!(config.max_export_timeout, Duration::from_millis(30000));
-        assert_eq!(config.max_queue_size, 2048);
-        assert_eq!(config.max_export_batch_size, 512);
+        assert_eq!(config.scheduled_delay, Duration::from_millis(OTEL_BLRP_SCHEDULE_DELAY_DEFAULT));
+        assert_eq!(config.max_export_timeout, Duration::from_millis(OTEL_BLRP_EXPORT_TIMEOUT_DEFAULT));
+        assert_eq!(config.max_queue_size, OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT);
+        assert_eq!(config.max_export_batch_size, OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT);
     }
 
     #[test]
@@ -510,8 +529,8 @@ mod tests {
 
         assert_eq!(config.scheduled_delay, Duration::from_millis(3000));
         assert_eq!(config.max_export_timeout, Duration::from_millis(70000));
-        assert_eq!(config.max_queue_size, 2048);
-        assert_eq!(config.max_export_batch_size, 512);
+        assert_eq!(config.max_queue_size, OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT);
+        assert_eq!(config.max_export_batch_size, OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT);
     }
 
     #[test]
@@ -527,8 +546,8 @@ mod tests {
 
         assert_eq!(config.scheduled_delay, Duration::from_millis(2000));
         assert_eq!(config.max_export_timeout, Duration::from_millis(60000));
-        assert_eq!(config.max_queue_size, 2048);
-        assert_eq!(config.max_export_batch_size, 512);
+        assert_eq!(config.max_queue_size, OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT);
+        assert_eq!(config.max_export_batch_size, OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT);
     }
 
     #[test]
@@ -542,8 +561,8 @@ mod tests {
 
         assert_eq!(config.max_queue_size, 256);
         assert_eq!(config.max_export_batch_size, 256);
-        assert_eq!(config.scheduled_delay, Duration::from_millis(1000));
-        assert_eq!(config.max_export_timeout, Duration::from_millis(30000));
+        assert_eq!(config.scheduled_delay, Duration::from_millis(OTEL_BLRP_SCHEDULE_DELAY_DEFAULT));
+        assert_eq!(config.max_export_timeout, Duration::from_millis(OTEL_BLRP_EXPORT_TIMEOUT_DEFAULT));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1468 
Design discussion issue (if applicable) #

## Changes
Allows configuring the `BatchLogProcessor<T>` with standard environment variables or in code via `OtlpLogPipeline::with_batch_config`.

The change is inspired from [OtlpTracePipeline::with_batch_config](https://github.com/open-telemetry/opentelemetry-rust/blob/ff64e214064df438a09a5c1695ec73866925f981/opentelemetry-otlp/src/span.rs#L77) 

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)

## Extra discussion
* Now that these two methods of configuration has been introduced, do we still need the `with_max_queue_size`, `with_scheduled_delay`, `with_max_timeout` and `with_max_export_batch_size` functions on `BatchLogProcessorBuilder<E, R>`? Same question applies to `BatchSpanProcessorBuilder<E, R>`.
* The invariant that `max_export_batch_size` (`OTEL_BLRP_MAX_EXPORT_BATCH_SIZE`) needs to be less than or equal to `max_queue_size` (`OTEL_BLRP_MAX_QUEUE_SIZE`) is enforced in multiple places: 
  * `BatchConfig` implementation of  the `Default` trait
  * `with_max_export_batch_size` function of `BatchLogProcessorBuilder<E, R>`

and not at all in `BatchConfig` (I did it like this to mirror the setup from the [BatchConfig](https://github.com/open-telemetry/opentelemetry-rust/blob/ff64e214064df438a09a5c1695ec73866925f981/opentelemetry-sdk/src/trace/span_processor.rs#L591) of the SpanProcessor). Would it be a better idea to introduce a `BatchConfigBuilder`?

* The [OtlpTracePipeline::with_batch_config](https://github.com/open-telemetry/opentelemetry-rust/blob/ff64e214064df438a09a5c1695ec73866925f981/opentelemetry-otlp/src/span.rs#L77) also allows configuration from non-standard (to my knowledge) environmental variables, namely `OTEL_BSP_EXPORT_TIMEOUT_MILLIS` and `OTEL_BSP_SCHEDULE_DELAY_MILLIS`. I replicated the same setup in this PR for the sake of consistency. Do we want to allow configuration from non-standard environment variables when standard ones exist?