### PR TITLE
fix(proto): add `serde(default)` to `Events` and `Status`

### DIFF
--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.trace.v1.rs
@@ -198,6 +198,7 @@ pub mod span {
     #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
     #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+    #[cfg_attr(feature = "with-serde", serde(default))]
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Event {

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -82,6 +82,7 @@ fn build_tonic() {
         "trace.v1.ResourceSpans",
         "common.v1.InstrumentationScope",
         "resource.v1.Resource",
+        "trace.v1.Span.Event",
     ] {
         builder = builder.type_attribute(
             path,

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -83,6 +83,7 @@ fn build_tonic() {
         "common.v1.InstrumentationScope",
         "resource.v1.Resource",
         "trace.v1.Span.Event",
+        "trace.v1.Span.Status",
     ] {
         builder = builder.type_attribute(
             path,

--- a/opentelemetry-proto/tests/json_deserialize.rs
+++ b/opentelemetry-proto/tests/json_deserialize.rs
@@ -3,6 +3,7 @@ mod json_deserialize {
     use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
     use opentelemetry_proto::tonic::common::v1::any_value::Value;
     use opentelemetry_proto::tonic::common::v1::KeyValue;
+    use opentelemetry_proto::tonic::trace::v1::span::Event;
 
     // copied from example json file
     // see https://github.com/open-telemetry/opentelemetry-proto/blob/v1.0.0/examples/trace.json
@@ -67,6 +68,13 @@ mod json_deserialize {
               "stringValue": "my.service"
             }
           }
+    "#;
+
+    const EVENT_JSON: &str = r#"
+    {
+        "name": "my_event",
+        "time_unix_nano": 1234567890
+    }
     "#;
 
     #[test]
@@ -138,5 +146,12 @@ mod json_deserialize {
             keyvalue.value.unwrap().value.unwrap(),
             Value::StringValue("my.service".to_string())
         );
+    }
+
+    #[test]
+    fn test_event() {
+        let event_json: Event = serde_json::from_str(EVENT_JSON).unwrap();
+        assert_eq!(event_json.name, "my_event".to_string());
+        assert_eq!(event_json.attributes.len(), 0);
     }
 }


### PR DESCRIPTION
This should allow all fields in event to be optional, which is needed to decode JSON strings

## Changes
- add `serde(default)` to `Events` for tonic generated types
- add `serde(default)` to `Status` for tonic generated types

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
