### PR TITLE
Remove Batch LogRecord&Span Processor configuration via non-standard environment variables

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -31,6 +31,14 @@
 - [#1375](https://github.com/open-telemetry/opentelemetry-rust/pull/1375/) Fix metric collections during PeriodicReader shutdown
 - **Breaking** [#1480](https://github.com/open-telemetry/opentelemetry-rust/pull/1480) Remove fine grained `BatchConfig` configurations from `BatchLogProcessorBuilder` and `BatchSpanProcessorBuilder`. Use `BatchConfigBuilder` to construct a `BatchConfig` instance and pass it using `BatchLogProcessorBuilder::with_batch_config` or `BatchSpanProcessorBuilder::with_batch_config`. 
 - **Breaking** [#1480](https://github.com/open-telemetry/opentelemetry-rust/pull/1480) Remove mutating functions from `BatchConfig`, use `BatchConfigBuilder` to construct a `BatchConfig` instance.
+- **Breaking** [#1495](https://github.com/open-telemetry/opentelemetry-rust/pull/1495) Remove Batch LogRecord&Span Processor configuration via non-standard environment variables. Use the following table to migrate from the no longer supported non-standard environment variables to the standard ones.
+
+| No longer supported             | Standard equivalent       |
+|---------------------------------|---------------------------|
+| OTEL_BLRP_SCHEDULE_DELAY_MILLIS | OTEL_BLRP_SCHEDULE_DELAY  |
+| OTEL_BLRP_EXPORT_TIMEOUT_MILLIS | OTEL_BLRP_EXPORT_TIMEOUT  |
+| OTEL_BSP_SCHEDULE_DELAY_MILLIS  | OTEL_BSP_SCHEDULE_DELAY   |
+| OTEL_BSP_EXPORT_TIMEOUT_MILLIS  | OTEL_BSP_EXPORT_TIMEOUT   |
 
 ## v0.21.2
 

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -316,7 +316,11 @@ pub struct BatchConfigBuilder {
 impl Default for BatchConfigBuilder {
     /// Create a new [`BatchConfigBuilder`] initialized with default batch config values as per the specs.
     /// The values are overriden by environment variables if set.
-    /// For a list of supported environment variables see [Batch LogRecord Processor](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#batch-logrecord-processor).
+    /// The supported environment variables are:
+    /// * `OTEL_BLRP_MAX_QUEUE_SIZE`
+    /// * `OTEL_BLRP_SCHEDULE_DELAY`
+    /// * `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE`
+    /// * `OTEL_BLRP_EXPORT_TIMEOUT`
     fn default() -> Self {
         BatchConfigBuilder {
             max_queue_size: OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT,

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -396,7 +396,6 @@ impl BatchConfigBuilder {
 
         if let Some(scheduled_delay) = env::var(OTEL_BLRP_SCHEDULE_DELAY)
             .ok()
-            .or_else(|| env::var("OTEL_BLRP_SCHEDULE_DELAY_MILLIS").ok())
             .and_then(|delay| u64::from_str(&delay).ok())
         {
             self.scheduled_delay = Duration::from_millis(scheduled_delay);
@@ -404,7 +403,6 @@ impl BatchConfigBuilder {
 
         if let Some(max_export_timeout) = env::var(OTEL_BLRP_EXPORT_TIMEOUT)
             .ok()
-            .or_else(|| env::var("OTEL_BLRP_EXPORT_TIMEOUT_MILLIS").ok())
             .and_then(|s| u64::from_str(&s).ok())
         {
             self.max_export_timeout = Duration::from_millis(max_export_timeout);
@@ -520,44 +518,6 @@ mod tests {
         assert_eq!(config.max_export_timeout, Duration::from_millis(60000));
         assert_eq!(config.max_queue_size, 4096);
         assert_eq!(config.max_export_batch_size, 1024);
-    }
-
-    #[test]
-    fn test_batch_config_configurable_by_env_vars_millis() {
-        let env_vars = vec![
-            ("OTEL_BLRP_SCHEDULE_DELAY_MILLIS", Some("3000")),
-            ("OTEL_BLRP_EXPORT_TIMEOUT_MILLIS", Some("70000")),
-        ];
-
-        let config = temp_env::with_vars(env_vars, BatchConfig::default);
-
-        assert_eq!(config.scheduled_delay, Duration::from_millis(3000));
-        assert_eq!(config.max_export_timeout, Duration::from_millis(70000));
-        assert_eq!(config.max_queue_size, OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT);
-        assert_eq!(
-            config.max_export_batch_size,
-            OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT
-        );
-    }
-
-    #[test]
-    fn test_batch_config_configurable_by_env_vars_precedence() {
-        let env_vars = vec![
-            (OTEL_BLRP_SCHEDULE_DELAY, Some("2000")),
-            ("OTEL_BLRP_SCHEDULE_DELAY_MILLIS", Some("3000")),
-            (OTEL_BLRP_EXPORT_TIMEOUT, Some("60000")),
-            ("OTEL_BLRP_EXPORT_TIMEOUT_MILLIS", Some("70000")),
-        ];
-
-        let config = temp_env::with_vars(env_vars, BatchConfig::default);
-
-        assert_eq!(config.scheduled_delay, Duration::from_millis(2000));
-        assert_eq!(config.max_export_timeout, Duration::from_millis(60000));
-        assert_eq!(config.max_queue_size, OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT);
-        assert_eq!(
-            config.max_export_batch_size,
-            OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT
-        );
     }
 
     #[test]

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -553,7 +553,12 @@ pub struct BatchConfigBuilder {
 impl Default for BatchConfigBuilder {
     /// Create a new [`BatchConfigBuilder`] initialized with default batch config values as per the specs.
     /// The values are overriden by environment variables if set.
-    /// For a list of supported environment variables see [Batch LogRecord Processor](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#batch-span-processor).
+    /// The supported environment variables are:
+    /// * `OTEL_BSP_MAX_QUEUE_SIZE`
+    /// * `OTEL_BSP_SCHEDULE_DELAY`
+    /// * `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`
+    /// * `OTEL_BSP_EXPORT_TIMEOUT`
+    /// * `OTEL_BSP_MAX_CONCURRENT_EXPORTS`
     fn default() -> Self {
         BatchConfigBuilder {
             max_queue_size: OTEL_BSP_MAX_QUEUE_SIZE_DEFAULT,

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -646,7 +646,6 @@ impl BatchConfigBuilder {
 
         if let Some(scheduled_delay) = env::var(OTEL_BSP_SCHEDULE_DELAY)
             .ok()
-            .or_else(|| env::var("OTEL_BSP_SCHEDULE_DELAY_MILLIS").ok())
             .and_then(|delay| u64::from_str(&delay).ok())
         {
             self.scheduled_delay = Duration::from_millis(scheduled_delay);
@@ -667,7 +666,6 @@ impl BatchConfigBuilder {
 
         if let Some(max_export_timeout) = env::var(OTEL_BSP_EXPORT_TIMEOUT)
             .ok()
-            .or_else(|| env::var("OTEL_BSP_EXPORT_TIMEOUT_MILLIS").ok())
             .and_then(|timeout| u64::from_str(&timeout).ok())
         {
             self.max_export_timeout = Duration::from_millis(max_export_timeout);
@@ -813,44 +811,6 @@ mod tests {
         assert_eq!(config.max_export_timeout, Duration::from_millis(60000));
         assert_eq!(config.max_queue_size, 4096);
         assert_eq!(config.max_export_batch_size, 1024);
-    }
-
-    #[test]
-    fn test_batch_config_configurable_by_env_vars_millis() {
-        let env_vars = vec![
-            ("OTEL_BSP_SCHEDULE_DELAY_MILLIS", Some("3000")),
-            ("OTEL_BSP_EXPORT_TIMEOUT_MILLIS", Some("70000")),
-        ];
-
-        let config = temp_env::with_vars(env_vars, BatchConfig::default);
-
-        assert_eq!(config.scheduled_delay, Duration::from_millis(3000));
-        assert_eq!(config.max_export_timeout, Duration::from_millis(70000));
-        assert_eq!(config.max_queue_size, OTEL_BSP_MAX_QUEUE_SIZE_DEFAULT);
-        assert_eq!(
-            config.max_export_batch_size,
-            OTEL_BSP_MAX_EXPORT_BATCH_SIZE_DEFAULT
-        );
-    }
-
-    #[test]
-    fn test_batch_config_configurable_by_env_vars_precedence() {
-        let env_vars = vec![
-            (OTEL_BSP_SCHEDULE_DELAY, Some("2000")),
-            ("OTEL_BSP_SCHEDULE_DELAY_MILLIS", Some("3000")),
-            (OTEL_BSP_EXPORT_TIMEOUT, Some("60000")),
-            ("OTEL_BSP_EXPORT_TIMEOUT_MILLIS", Some("70000")),
-        ];
-
-        let config = temp_env::with_vars(env_vars, BatchConfig::default);
-
-        assert_eq!(config.scheduled_delay, Duration::from_millis(2000));
-        assert_eq!(config.max_export_timeout, Duration::from_millis(60000));
-        assert_eq!(config.max_queue_size, OTEL_BSP_MAX_QUEUE_SIZE_DEFAULT);
-        assert_eq!(
-            config.max_export_batch_size,
-            OTEL_BSP_MAX_EXPORT_BATCH_SIZE_DEFAULT
-        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Removes Batch LogRecord&Span Processor configuration via non-standard environment variables. 

For convenience and discoverability, a mapping table from the no longer supported to the supported environment variables is provided here:

| No longer supported             | Standard equivalent       |
|---------------------------------|---------------------------|
| OTEL_BLRP_SCHEDULE_DELAY_MILLIS | OTEL_BLRP_SCHEDULE_DELAY  |
| OTEL_BLRP_EXPORT_TIMEOUT_MILLIS | OTEL_BLRP_EXPORT_TIMEOUT  |
| OTEL_BSP_SCHEDULE_DELAY_MILLIS  | OTEL_BSP_SCHEDULE_DELAY   |
| OTEL_BSP_EXPORT_TIMEOUT_MILLIS  | OTEL_BSP_EXPORT_TIMEOUT   |

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
