### PR TITLE
Move MikeGoldsmith to emeritus

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,7 @@ For GitHub groups see the [code owners](CODEOWNERS) file.
 - [Dirkjan Ochtman](https://github.com/djc)
 - [Jan Kühle](https://github.com/frigus02)
 - [Isobel Redelmeier](https://github.com/iredelmeier)
+- [Mike Goldsmith](https://github.com/MikeGoldsmith)
 
 ### Become an Approver or a Maintainer
 


### PR DESCRIPTION
## Changes

I was part of the original group who helped get this project going and such was added as an approver. I haven't been involved in this group for a while so should be removed from the @open-telemetry/rust-approvers group.

This PR moves myself to Emeritus group in Contributing file too.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
