### PR TITLE
Use consistent style of passing attributes to metrics

### DIFF
--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -80,13 +80,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Record measurements using the histogram instrument.
     histogram.record(
         10.5,
-        [
+        &[
             KeyValue::new("mykey1", "myvalue1"),
             KeyValue::new("mykey2", "myvalue2"),
             KeyValue::new("mykey3", "myvalue3"),
             KeyValue::new("mykey4", "myvalue4"),
-        ]
-        .as_ref(),
+        ],
     );
 
     // Example 2 - Drop unwanted attributes using view.
@@ -98,13 +97,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // attribute.
     counter.add(
         10,
-        [
+        &[
             KeyValue::new("mykey1", "myvalue1"),
             KeyValue::new("mykey2", "myvalue2"),
             KeyValue::new("mykey3", "myvalue3"),
             KeyValue::new("mykey4", "myvalue4"),
-        ]
-        .as_ref(),
+        ],
     );
 
     // Example 3 - Change Aggregation configuration using View.
@@ -122,35 +120,32 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // the change of boundaries.
     histogram2.record(
         1.5,
-        [
+        &[
             KeyValue::new("mykey1", "myvalue1"),
             KeyValue::new("mykey2", "myvalue2"),
             KeyValue::new("mykey3", "myvalue3"),
             KeyValue::new("mykey4", "myvalue4"),
-        ]
-        .as_ref(),
+        ],
     );
 
     histogram2.record(
         1.2,
-        [
+        &[
             KeyValue::new("mykey1", "myvalue1"),
             KeyValue::new("mykey2", "myvalue2"),
             KeyValue::new("mykey3", "myvalue3"),
             KeyValue::new("mykey4", "myvalue4"),
-        ]
-        .as_ref(),
+        ],
     );
 
     histogram2.record(
         1.23,
-        [
+        &[
             KeyValue::new("mykey1", "myvalue1"),
             KeyValue::new("mykey2", "myvalue2"),
             KeyValue::new("mykey3", "myvalue3"),
             KeyValue::new("mykey4", "myvalue4"),
-        ]
-        .as_ref(),
+        ],
     );
 
     // Metrics are exported by default every 30 seconds when using stdout exporter,

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -34,11 +34,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Record measurements using the Counter instrument.
     counter.add(
         10,
-        [
+        &[
             KeyValue::new("mykey1", "myvalue1"),
             KeyValue::new("mykey2", "myvalue2"),
-        ]
-        .as_ref(),
+        ],
     );
 
     // Create a ObservableCounter instrument and register a callback that reports the measurement.
@@ -52,11 +51,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         observer.observe_u64(
             &observable_counter,
             100,
-            [
+            &[
                 KeyValue::new("mykey1", "myvalue1"),
                 KeyValue::new("mykey2", "myvalue2"),
-            ]
-            .as_ref(),
+            ],
         )
     })?;
 
@@ -66,11 +64,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Record measurements using the UpCounter instrument.
     updown_counter.add(
         -10,
-        [
+        &[
             KeyValue::new("mykey1", "myvalue1"),
             KeyValue::new("mykey2", "myvalue2"),
-        ]
-        .as_ref(),
+        ],
     );
 
     // Create a Observable UpDownCounter instrument and register a callback that reports the measurement.
@@ -84,11 +81,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         observer.observe_i64(
             &observable_up_down_counter,
             100,
-            [
+            &[
                 KeyValue::new("mykey1", "myvalue1"),
                 KeyValue::new("mykey2", "myvalue2"),
-            ]
-            .as_ref(),
+            ],
         )
     })?;
 
@@ -101,11 +97,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Record measurements using the histogram instrument.
     histogram.record(
         10.5,
-        [
+        &[
             KeyValue::new("mykey1", "myvalue1"),
             KeyValue::new("mykey2", "myvalue2"),
-        ]
-        .as_ref(),
+        ],
     );
 
     // Note that there is no ObservableHistogram instrument.
@@ -122,11 +117,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
         gauge.record(
             1.0,
-            [
+            &[
                 KeyValue::new("mykey1", "myvalue1"),
                 KeyValue::new("mykey2", "myvalue2"),
-            ]
-            .as_ref(),
+            ],
         );
     }
 
@@ -142,11 +136,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         observer.observe_f64(
             &observable_gauge,
             1.0,
-            [
+            &[
                 KeyValue::new("mykey1", "myvalue1"),
                 KeyValue::new("mykey2", "myvalue2"),
-            ]
-            .as_ref(),
+            ],
         )
     })?;
 

--- a/opentelemetry-otlp/tests/integration_test/src/asserter.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/asserter.rs
@@ -19,7 +19,7 @@ impl TraceAsserter {
         self.assert_resource_span_eq(&self.results, &self.expected);
     }
 
-    fn assert_resource_span_eq(&self, results: &Vec<ResourceSpans>, expected: &Vec<ResourceSpans>) {
+    fn assert_resource_span_eq(&self, results: &[ResourceSpans], expected: &[ResourceSpans]) {
         let mut results_spans = Vec::new();
         let mut expected_spans = Vec::new();
 

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -83,8 +83,7 @@ pub trait MeterProvider {
 /// // Record measurements using the counter instrument add()
 /// u64_counter.add(
 ///     10,
-///     &
-///     [
+///     &[
 ///         KeyValue::new("mykey1", "myvalue1"),
 ///         KeyValue::new("mykey2", "myvalue2"),
 ///     ]
@@ -96,8 +95,7 @@ pub trait MeterProvider {
 /// // Record measurements using the counter instrument add()
 /// f64_counter.add(
 ///     3.15,
-///     &
-///     [
+///     &[
 ///         KeyValue::new("mykey1", "myvalue1"),
 ///         KeyValue::new("mykey2", "myvalue2"),
 ///     ],

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -83,10 +83,11 @@ pub trait MeterProvider {
 /// // Record measurements using the counter instrument add()
 /// u64_counter.add(
 ///     10,
+///     &
 ///     [
 ///         KeyValue::new("mykey1", "myvalue1"),
 ///         KeyValue::new("mykey2", "myvalue2"),
-///     ].as_ref()
+///     ]
 /// );
 ///
 /// // f64 Counter
@@ -95,10 +96,11 @@ pub trait MeterProvider {
 /// // Record measurements using the counter instrument add()
 /// f64_counter.add(
 ///     3.15,
+///     &
 ///     [
 ///         KeyValue::new("mykey1", "myvalue1"),
 ///         KeyValue::new("mykey2", "myvalue2"),
-///     ].as_ref()
+///     ],
 /// );
 ///
 /// // u6 observable counter
@@ -109,10 +111,10 @@ pub trait MeterProvider {
 ///     observer.observe_u64(
 ///         &observable_u4_counter,
 ///         1,
-///         [
+///         &[
 ///             KeyValue::new("mykey1", "myvalue1"),
 ///             KeyValue::new("mykey2", "myvalue2"),
-///         ].as_ref(),
+///         ],
 ///     )
 /// });
 ///
@@ -124,10 +126,10 @@ pub trait MeterProvider {
 ///     observer.observe_f64(
 ///         &observable_f64_counter,
 ///         1.55,
-///         [
+///         &[
 ///             KeyValue::new("mykey1", "myvalue1"),
 ///             KeyValue::new("mykey2", "myvalue2"),
-///         ].as_ref(),
+///         ],
 ///     )
 /// });
 ///
@@ -137,10 +139,11 @@ pub trait MeterProvider {
 /// // Record measurements using the updown counter instrument add()
 /// updown_i64_counter.add(
 ///     -10,
+///     &
 ///     [
 ///         KeyValue::new("mykey1", "myvalue1"),
 ///         KeyValue::new("mykey2", "myvalue2"),
-///     ].as_ref(),
+///     ],
 /// );
 ///
 /// // f64 updown counter
@@ -149,10 +152,11 @@ pub trait MeterProvider {
 /// // Record measurements using the updown counter instrument add()
 /// updown_f64_counter.add(
 ///     -10.67,
+///     &
 ///     [
 ///         KeyValue::new("mykey1", "myvalue1"),
 ///         KeyValue::new("mykey2", "myvalue2"),
-///     ].as_ref(),
+///     ],
 /// );
 ///
 /// // i64 observable updown counter
@@ -163,10 +167,10 @@ pub trait MeterProvider {
 ///     observer.observe_i64(
 ///         &observable_i64_up_down_counter,
 ///         1,
-///         [
+///         &[
 ///             KeyValue::new("mykey1", "myvalue1"),
 ///             KeyValue::new("mykey2", "myvalue2"),
-///         ].as_ref(),
+///         ],
 ///     )
 /// });
 ///
@@ -178,10 +182,10 @@ pub trait MeterProvider {
 ///     observer.observe_f64(
 ///         &observable_f64_up_down_counter,
 ///         1.16,
-///         [
+///         &[
 ///             KeyValue::new("mykey1", "myvalue1"),
 ///             KeyValue::new("mykey2", "myvalue2"),
-///         ].as_ref(),
+///         ],
 ///     )
 /// });
 ///
@@ -193,10 +197,10 @@ pub trait MeterProvider {
 ///     observer.observe_f64(
 ///         &f64_gauge,
 ///         2.32,
-///         [
+///         &[
 ///             KeyValue::new("mykey1", "myvalue1"),
 ///             KeyValue::new("mykey2", "myvalue2"),
-///         ].as_ref(),
+///         ],
 ///     )
 /// });
 ///
@@ -208,10 +212,10 @@ pub trait MeterProvider {
 ///     observer.observe_i64(
 ///         &i64_gauge,
 ///         12,
-///         [
+///         &[
 ///             KeyValue::new("mykey1", "myvalue1"),
 ///             KeyValue::new("mykey2", "myvalue2"),
-///         ].as_ref(),
+///         ],
 ///     )
 /// });
 ///
@@ -223,10 +227,10 @@ pub trait MeterProvider {
 ///     observer.observe_u64(
 ///         &u64_gauge,
 ///         1,
-///         [
+///         &[
 ///             KeyValue::new("mykey1", "myvalue1"),
 ///             KeyValue::new("mykey2", "myvalue2"),
-///         ].as_ref(),
+///         ],
 ///     )
 /// });
 ///
@@ -236,11 +240,10 @@ pub trait MeterProvider {
 /// // Record measurements using the histogram instrument record()
 /// f64_histogram.record(
 ///     10.5,
-///     [
+///     &[
 ///         KeyValue::new("mykey1", "myvalue1"),
 ///         KeyValue::new("mykey2", "myvalue2"),
-///     ]
-///     .as_ref(),
+///     ],
 /// );
 ///
 /// // u64 histogram
@@ -249,11 +252,10 @@ pub trait MeterProvider {
 /// // Record measurements using the histogram instrument record()
 /// u64_histogram.record(
 ///     12,
-///     [
+///     &[
 ///         KeyValue::new("mykey1", "myvalue1"),
 ///         KeyValue::new("mykey2", "myvalue2"),
-///     ]
-///     .as_ref(),
+///     ],
 /// );
 ///
 /// ```


### PR DESCRIPTION
Metric attributes were passed inconsistently throughout the repo. Some used &[] and some used [].as_ref(). This modifies everywhere to use the former, as I believe that is more idiomatic than using as_ref() and more concise too.