### PR TITLE
Reduce cost of no attribute counters

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -46,6 +46,10 @@
   - `LoggerProviderInner` is no longer `pub (crate)`
   - `Logger.provider()` now returns `&LoggerProvider` instead of an `Option<LoggerProvider>`
 
+- [1519](https://github.com/open-telemetry/opentelemetry-rust/pull/1519) Performance improvements 
+    when calling `Counter::add()` and `UpDownCounter::add()` with an empty set of attributes
+    (e.g. `counter.Add(5, &[])`)
+    
 ### Fixed
 
 - [#1481](https://github.com/open-telemetry/opentelemetry-rust/pull/1481) Fix error message caused by race condition when using PeriodicReader

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -172,3 +172,75 @@ impl AtomicallyUpdate<f64> for f64 {
         F64AtomicTracker::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_add_and_get_u64_atomic_value() {
+        let atomic = u64::new_atomic_tracker();
+        atomic.add(15);
+        atomic.add(10);
+
+        let value = atomic.get_value();
+        assert_eq!(value, 25);
+    }
+
+    #[test]
+    fn can_reset_u64_atomic_value() {
+        let atomic = u64::new_atomic_tracker();
+        atomic.add(15);
+
+        let value = atomic.get_and_reset_value();
+        let value2 = atomic.get_value();
+
+        assert_eq!(value, 15, "Incorrect first value");
+        assert_eq!(value2, 0, "Incorrect second value");
+    }
+
+    #[test]
+    fn can_add_and_get_i64_atomic_value() {
+        let atomic = i64::new_atomic_tracker();
+        atomic.add(15);
+        atomic.add(-10);
+
+        let value = atomic.get_value();
+        assert_eq!(value, 5);
+    }
+
+    #[test]
+    fn can_reset_i64_atomic_value() {
+        let atomic = i64::new_atomic_tracker();
+        atomic.add(15);
+
+        let value = atomic.get_and_reset_value();
+        let value2 = atomic.get_value();
+
+        assert_eq!(value, 15, "Incorrect first value");
+        assert_eq!(value2, 0, "Incorrect second value");
+    }
+
+    #[test]
+    fn can_add_and_get_f64_atomic_value() {
+        let atomic = f64::new_atomic_tracker();
+        atomic.add(15.3);
+        atomic.add(10.4);
+
+        let value = atomic.get_value();
+
+        assert!(f64::abs(25.7 - value) < 0.0001);
+    }
+
+    #[test]
+    fn can_reset_f64_atomic_value() {
+        let atomic = f64::new_atomic_tracker();
+        atomic.add(15.5);
+
+        let value = atomic.get_and_reset_value();
+        let value2 = atomic.get_value();
+
+        assert!(f64::abs(15.5 - value) < 0.0001, "Incorrect first value");
+        assert!(f64::abs(0.0 - value2) < 0.0001, "Incorrect second value");
+    }
+}

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -89,71 +89,47 @@ impl Number<f64> for f64 {
     }
 }
 
-pub(crate) struct U64AtomicTracker {
-    atomic: AtomicU64,
-}
-
-impl U64AtomicTracker {
-    fn new() -> Self {
-        U64AtomicTracker {
-            atomic: AtomicU64::new(0),
-        }
-    }
-}
-
-impl AtomicTracker<u64> for U64AtomicTracker {
+impl AtomicTracker<u64> for AtomicU64 {
     fn add(&self, value: u64) {
-        self.atomic.fetch_add(value, Ordering::Relaxed);
+        self.fetch_add(value, Ordering::Relaxed);
     }
 
     fn get_value(&self) -> u64 {
-        self.atomic.load(Ordering::Relaxed)
+        self.load(Ordering::Relaxed)
     }
 
     fn get_and_reset_value(&self) -> u64 {
-        self.atomic.swap(0, Ordering::Relaxed)
+        self.swap(0, Ordering::Relaxed)
     }
 }
 
 impl AtomicallyUpdate<u64> for u64 {
-    type Tracker = U64AtomicTracker;
+    type Tracker = AtomicU64;
 
     fn new_atomic_tracker() -> Self::Tracker {
-        U64AtomicTracker::new()
+        AtomicU64::new(0)
     }
 }
 
-pub(crate) struct I64AtomicTracker {
-    atomic: AtomicI64,
-}
-
-impl I64AtomicTracker {
-    fn new() -> Self {
-        I64AtomicTracker {
-            atomic: AtomicI64::new(0),
-        }
-    }
-}
-
-impl AtomicTracker<i64> for I64AtomicTracker {
+impl AtomicTracker<i64> for AtomicI64 {
     fn add(&self, value: i64) {
-        self.atomic.fetch_add(value, Ordering::Relaxed);
+        self.fetch_add(value, Ordering::Relaxed);
     }
 
     fn get_value(&self) -> i64 {
-        self.atomic.load(Ordering::Relaxed)
+        self.load(Ordering::Relaxed)
     }
 
     fn get_and_reset_value(&self) -> i64 {
-        self.atomic.swap(0, Ordering::Relaxed)
+        self.swap(0, Ordering::Relaxed)
     }
 }
 
 impl AtomicallyUpdate<i64> for i64 {
-    type Tracker = I64AtomicTracker;
+    type Tracker = AtomicI64;
 
     fn new_atomic_tracker() -> Self::Tracker {
-        I64AtomicTracker::new()
+        AtomicI64::new(0)
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -22,8 +22,8 @@ pub(crate) trait AtomicTracker<T>: Sync + Send + 'static {
 
 /// Marks a type that can have an atomic tracker generated for it
 pub(crate) trait AtomicallyUpdate<T> {
-    type Tracker: AtomicTracker<T>;
-    fn new_atomic_tracker() -> Self::Tracker;
+    type AtomicTracker: AtomicTracker<T>;
+    fn new_atomic_tracker() -> Self::AtomicTracker;
 }
 
 pub(crate) trait Number<T>:
@@ -104,9 +104,9 @@ impl AtomicTracker<u64> for AtomicU64 {
 }
 
 impl AtomicallyUpdate<u64> for u64 {
-    type Tracker = AtomicU64;
+    type AtomicTracker = AtomicU64;
 
-    fn new_atomic_tracker() -> Self::Tracker {
+    fn new_atomic_tracker() -> Self::AtomicTracker {
         AtomicU64::new(0)
     }
 }
@@ -126,9 +126,9 @@ impl AtomicTracker<i64> for AtomicI64 {
 }
 
 impl AtomicallyUpdate<i64> for i64 {
-    type Tracker = AtomicI64;
+    type AtomicTracker = AtomicI64;
 
-    fn new_atomic_tracker() -> Self::Tracker {
+    fn new_atomic_tracker() -> Self::AtomicTracker {
         AtomicI64::new(0)
     }
 }
@@ -166,9 +166,9 @@ impl AtomicTracker<f64> for F64AtomicTracker {
 }
 
 impl AtomicallyUpdate<f64> for f64 {
-    type Tracker = F64AtomicTracker;
+    type AtomicTracker = F64AtomicTracker;
 
-    fn new_atomic_tracker() -> Self::Tracker {
+    fn new_atomic_tracker() -> Self::AtomicTracker {
         F64AtomicTracker::new()
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -18,7 +18,7 @@ use super::{
 struct ValueMap<T: Number<T>> {
     values: Mutex<HashMap<AttributeSet, T>>,
     has_no_value_attribute_value: AtomicBool,
-    no_attribute_value: Box<dyn AtomicTracker<T> + Send + Sync + 'static>,
+    no_attribute_value: T::AtomicTracker,
 }
 
 impl<T: Number<T>> Default for ValueMap<T> {
@@ -32,7 +32,7 @@ impl<T: Number<T>> ValueMap<T> {
         ValueMap {
             values: Mutex::new(HashMap::new()),
             has_no_value_attribute_value: AtomicBool::new(false),
-            no_attribute_value: Box::new(T::new_atomic_tracker()),
+            no_attribute_value: T::new_atomic_tracker(),
         }
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -154,7 +154,10 @@ impl<T: Number<T>> Sum<T> {
             *start = t;
         }
 
-        (n, new_agg.map(|a| Box::new(a) as Box<_>))
+        (
+            s_data.data_points.len(),
+            new_agg.map(|a| Box::new(a) as Box<_>),
+        )
     }
 
     pub(crate) fn cumulative(
@@ -220,7 +223,10 @@ impl<T: Number<T>> Sum<T> {
             });
         }
 
-        (n, new_agg.map(|a| Box::new(a) as Box<_>))
+        (
+            s_data.data_points.len(),
+            new_agg.map(|a| Box::new(a) as Box<_>),
+        )
     }
 }
 
@@ -322,7 +328,10 @@ impl<T: Number<T>> PrecomputedSum<T> {
         *reported = new_reported;
         drop(reported); // drop before values guard is dropped
 
-        (n, new_agg.map(|a| Box::new(a) as Box<_>))
+        (
+            s_data.data_points.len(),
+            new_agg.map(|a| Box::new(a) as Box<_>),
+        )
     }
 
     pub(crate) fn cumulative(
@@ -396,6 +405,9 @@ impl<T: Number<T>> PrecomputedSum<T> {
         *reported = new_reported;
         drop(reported); // drop before values guard is dropped
 
-        (n, new_agg.map(|a| Box::new(a) as Box<_>))
+        (
+            s_data.data_points.len(),
+            new_agg.map(|a| Box::new(a) as Box<_>),
+        )
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     collections::{hash_map::Entry, HashMap},
     sync::Mutex,
@@ -10,26 +11,39 @@ use opentelemetry::{global, metrics::MetricsError};
 
 use super::{
     aggregate::{is_under_cardinality_limit, STREAM_OVERFLOW_ATTRIBUTE_SET},
-    Number,
+    AtomicTracker, Number,
 };
 
 /// The storage for sums.
-#[derive(Default)]
 struct ValueMap<T: Number<T>> {
     values: Mutex<HashMap<AttributeSet, T>>,
+    has_no_value_attribute_value: AtomicBool,
+    no_attribute_value: Box<dyn AtomicTracker<T> + Send + Sync + 'static>,
+}
+
+impl<T: Number<T>> Default for ValueMap<T> {
+    fn default() -> Self {
+        ValueMap::new()
+    }
 }
 
 impl<T: Number<T>> ValueMap<T> {
     fn new() -> Self {
         ValueMap {
             values: Mutex::new(HashMap::new()),
+            has_no_value_attribute_value: AtomicBool::new(false),
+            no_attribute_value: Box::new(T::new_atomic_tracker()),
         }
     }
 }
 
 impl<T: Number<T>> ValueMap<T> {
     fn measure(&self, measurement: T, attrs: AttributeSet) {
-        if let Ok(mut values) = self.values.lock() {
+        if attrs.is_empty() {
+            self.no_attribute_value.add(measurement);
+            self.has_no_value_attribute_value
+                .store(true, Ordering::Release);
+        } else if let Ok(mut values) = self.values.lock() {
             let size = values.len();
             match values.entry(attrs) {
                 Entry::Occupied(mut occupied_entry) => {
@@ -103,7 +117,7 @@ impl<T: Number<T>> Sum<T> {
             Err(_) => return (0, None),
         };
 
-        let n = values.len();
+        let n = values.len() + 1;
         if n > s_data.data_points.capacity() {
             s_data
                 .data_points
@@ -111,6 +125,20 @@ impl<T: Number<T>> Sum<T> {
         }
 
         let prev_start = self.start.lock().map(|start| *start).unwrap_or(t);
+        if self
+            .value_map
+            .has_no_value_attribute_value
+            .swap(false, Ordering::AcqRel)
+        {
+            s_data.data_points.push(DataPoint {
+                attributes: AttributeSet::default(),
+                start_time: Some(prev_start),
+                time: Some(t),
+                value: self.value_map.no_attribute_value.get_and_reset_value(),
+                exemplars: vec![],
+            });
+        }
+
         for (attrs, value) in values.drain() {
             s_data.data_points.push(DataPoint {
                 attributes: attrs,
@@ -155,7 +183,7 @@ impl<T: Number<T>> Sum<T> {
             Err(_) => return (0, None),
         };
 
-        let n = values.len();
+        let n = values.len() + 1;
         if n > s_data.data_points.capacity() {
             s_data
                 .data_points
@@ -163,6 +191,21 @@ impl<T: Number<T>> Sum<T> {
         }
 
         let prev_start = self.start.lock().map(|start| *start).unwrap_or(t);
+
+        if self
+            .value_map
+            .has_no_value_attribute_value
+            .load(Ordering::Acquire)
+        {
+            s_data.data_points.push(DataPoint {
+                attributes: AttributeSet::default(),
+                start_time: Some(prev_start),
+                time: Some(t),
+                value: self.value_map.no_attribute_value.get_value(),
+                exemplars: vec![],
+            });
+        }
+
         // TODO: This will use an unbounded amount of memory if there
         // are unbounded number of attribute sets being aggregated. Attribute
         // sets that become "stale" need to be forgotten so this will not
@@ -230,7 +273,7 @@ impl<T: Number<T>> PrecomputedSum<T> {
             Err(_) => return (0, None),
         };
 
-        let n = values.len();
+        let n = values.len() + 1;
         if n > s_data.data_points.capacity() {
             s_data
                 .data_points
@@ -241,6 +284,20 @@ impl<T: Number<T>> PrecomputedSum<T> {
             Ok(r) => r,
             Err(_) => return (0, None),
         };
+
+        if self
+            .value_map
+            .has_no_value_attribute_value
+            .swap(false, Ordering::AcqRel)
+        {
+            s_data.data_points.push(DataPoint {
+                attributes: AttributeSet::default(),
+                start_time: Some(prev_start),
+                time: Some(t),
+                value: self.value_map.no_attribute_value.get_and_reset_value(),
+                exemplars: vec![],
+            });
+        }
 
         let default = T::default();
         for (attrs, value) in values.drain() {
@@ -295,7 +352,7 @@ impl<T: Number<T>> PrecomputedSum<T> {
             Err(_) => return (0, None),
         };
 
-        let n = values.len();
+        let n = values.len() + 1;
         if n > s_data.data_points.capacity() {
             s_data
                 .data_points
@@ -306,6 +363,20 @@ impl<T: Number<T>> PrecomputedSum<T> {
             Ok(r) => r,
             Err(_) => return (0, None),
         };
+
+        if self
+            .value_map
+            .has_no_value_attribute_value
+            .load(Ordering::Acquire)
+        {
+            s_data.data_points.push(DataPoint {
+                attributes: AttributeSet::default(),
+                start_time: Some(prev_start),
+                time: Some(t),
+                value: self.value_map.no_attribute_value.get_value(),
+                exemplars: vec![],
+            });
+        }
 
         let default = T::default();
         for (attrs, value) in values.iter() {

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -578,10 +578,16 @@ mod tests {
         test_context.flush_metrics();
         let _ = test_context.get_aggregation::<data::Sum<u64>>("my_counter", "my_unit");
 
+        counter.add(50, &[KeyValue::new("a", "b")]);
         test_context.flush_metrics();
         let sum = test_context.get_aggregation::<data::Sum<u64>>("my_counter", "my_unit");
 
-        assert_eq!(sum.data_points.len(), 0, "Expected only one data point");
+        let no_attr_data_point = sum.data_points.iter().find(|x| x.attributes.is_empty());
+
+        assert!(
+            no_attr_data_point.is_none(),
+            "Expected no data points with no attributes"
+        );
     }
 
     struct TestContext {

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -61,7 +61,11 @@ pub use view::*;
 #[cfg(all(test, feature = "testing"))]
 mod tests {
     use super::*;
+    use crate::metrics::data::{ResourceMetrics, Temporality};
+    use crate::metrics::reader::TemporalitySelector;
+    use crate::testing::metrics::InMemoryMetricsExporterBuilder;
     use crate::{runtime, testing::metrics::InMemoryMetricsExporter};
+    use opentelemetry::metrics::{Counter, UpDownCounter};
     use opentelemetry::{
         metrics::{MeterProvider as _, Unit},
         KeyValue,
@@ -427,5 +431,255 @@ mod tests {
         // find and validate the single datapoint
         let data_point = &sum.data_points[0];
         assert_eq!(data_point.value, 30);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn no_attr_cumulative_counter() {
+        let mut test_context = TestContext::new(Some(Temporality::Cumulative));
+        let counter = test_context.u64_counter("test", "my_counter", "my_unit");
+
+        counter.add(50, &[]);
+        test_context.flush_metrics();
+
+        let sum = test_context.get_aggregation::<data::Sum<u64>>("my_counter", "my_unit");
+
+        assert_eq!(sum.data_points.len(), 1, "Expected only one data point");
+        assert!(sum.is_monotonic, "Should produce monotonic.");
+        assert_eq!(
+            sum.temporality,
+            Temporality::Cumulative,
+            "Should produce cumulative"
+        );
+
+        let data_point = &sum.data_points[0];
+        assert!(data_point.attributes.is_empty(), "Non-empty attribute set");
+        assert_eq!(data_point.value, 50, "Unexpected data point value");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn no_attr_delta_counter() {
+        let mut test_context = TestContext::new(Some(Temporality::Delta));
+        let counter = test_context.u64_counter("test", "my_counter", "my_unit");
+
+        counter.add(50, &[]);
+        test_context.flush_metrics();
+
+        let sum = test_context.get_aggregation::<data::Sum<u64>>("my_counter", "my_unit");
+
+        assert_eq!(sum.data_points.len(), 1, "Expected only one data point");
+        assert!(sum.is_monotonic, "Should produce monotonic.");
+        assert_eq!(sum.temporality, Temporality::Delta, "Should produce delta");
+
+        let data_point = &sum.data_points[0];
+        assert!(data_point.attributes.is_empty(), "Non-empty attribute set");
+        assert_eq!(data_point.value, 50, "Unexpected data point value");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn no_attr_cumulative_up_down_counter() {
+        let mut test_context = TestContext::new(Some(Temporality::Cumulative));
+        let counter = test_context.i64_up_down_counter("test", "my_counter", "my_unit");
+
+        counter.add(50, &[]);
+        test_context.flush_metrics();
+
+        let sum = test_context.get_aggregation::<data::Sum<i64>>("my_counter", "my_unit");
+
+        assert_eq!(sum.data_points.len(), 1, "Expected only one data point");
+        assert!(!sum.is_monotonic, "Should not produce monotonic.");
+        assert_eq!(
+            sum.temporality,
+            Temporality::Cumulative,
+            "Should produce cumulative"
+        );
+
+        let data_point = &sum.data_points[0];
+        assert!(data_point.attributes.is_empty(), "Non-empty attribute set");
+        assert_eq!(data_point.value, 50, "Unexpected data point value");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn no_attr_delta_up_down_counter() {
+        let mut test_context = TestContext::new(Some(Temporality::Delta));
+        let counter = test_context.i64_up_down_counter("test", "my_counter", "my_unit");
+
+        counter.add(50, &[]);
+        test_context.flush_metrics();
+
+        let sum = test_context.get_aggregation::<data::Sum<i64>>("my_counter", "my_unit");
+
+        assert_eq!(sum.data_points.len(), 1, "Expected only one data point");
+        assert!(!sum.is_monotonic, "Should not produce monotonic.");
+        assert_eq!(sum.temporality, Temporality::Delta, "Should produce Delta");
+
+        let data_point = &sum.data_points[0];
+        assert!(data_point.attributes.is_empty(), "Non-empty attribute set");
+        assert_eq!(data_point.value, 50, "Unexpected data point value");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn no_attr_cumulative_counter_value_added_after_export() {
+        let mut test_context = TestContext::new(Some(Temporality::Cumulative));
+        let counter = test_context.u64_counter("test", "my_counter", "my_unit");
+
+        counter.add(50, &[]);
+        test_context.flush_metrics();
+        let _ = test_context.get_aggregation::<data::Sum<u64>>("my_counter", "my_unit");
+
+        counter.add(5, &[]);
+        test_context.flush_metrics();
+        let sum = test_context.get_aggregation::<data::Sum<u64>>("my_counter", "my_unit");
+
+        assert_eq!(sum.data_points.len(), 1, "Expected only one data point");
+        assert!(sum.is_monotonic, "Should produce monotonic.");
+        assert_eq!(
+            sum.temporality,
+            Temporality::Cumulative,
+            "Should produce cumulative"
+        );
+
+        let data_point = &sum.data_points[0];
+        assert!(data_point.attributes.is_empty(), "Non-empty attribute set");
+        assert_eq!(data_point.value, 55, "Unexpected data point value");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn no_attr_delta_counter_value_reset_after_export() {
+        let mut test_context = TestContext::new(Some(Temporality::Delta));
+        let counter = test_context.u64_counter("test", "my_counter", "my_unit");
+
+        counter.add(50, &[]);
+        test_context.flush_metrics();
+        let _ = test_context.get_aggregation::<data::Sum<u64>>("my_counter", "my_unit");
+
+        counter.add(5, &[]);
+        test_context.flush_metrics();
+        let sum = test_context.get_aggregation::<data::Sum<u64>>("my_counter", "my_unit");
+
+        assert_eq!(sum.data_points.len(), 1, "Expected only one data point");
+        assert!(sum.is_monotonic, "Should produce monotonic.");
+        assert_eq!(
+            sum.temporality,
+            Temporality::Delta,
+            "Should produce cumulative"
+        );
+
+        let data_point = &sum.data_points[0];
+        assert!(data_point.attributes.is_empty(), "Non-empty attribute set");
+        assert_eq!(data_point.value, 5, "Unexpected data point value");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn second_delta_export_does_not_give_no_attr_value_if_add_not_called() {
+        let mut test_context = TestContext::new(Some(Temporality::Delta));
+        let counter = test_context.u64_counter("test", "my_counter", "my_unit");
+
+        counter.add(50, &[]);
+        test_context.flush_metrics();
+        let _ = test_context.get_aggregation::<data::Sum<u64>>("my_counter", "my_unit");
+
+        test_context.flush_metrics();
+        let sum = test_context.get_aggregation::<data::Sum<u64>>("my_counter", "my_unit");
+
+        assert_eq!(sum.data_points.len(), 0, "Expected only one data point");
+    }
+
+    struct TestContext {
+        exporter: InMemoryMetricsExporter,
+        meter_provider: SdkMeterProvider,
+
+        // Saving this on the test context for lifetime simplicity
+        resource_metrics: Vec<ResourceMetrics>,
+    }
+
+    impl TestContext {
+        fn new(temporality: Option<Temporality>) -> Self {
+            struct TestTemporalitySelector(Temporality);
+            impl TemporalitySelector for TestTemporalitySelector {
+                fn temporality(&self, _kind: InstrumentKind) -> Temporality {
+                    self.0
+                }
+            }
+
+            let mut exporter = InMemoryMetricsExporterBuilder::new();
+            if let Some(temporality) = temporality {
+                exporter = exporter.with_temporality_selector(TestTemporalitySelector(temporality));
+            }
+
+            let exporter = exporter.build();
+            let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
+            let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+            TestContext {
+                exporter,
+                meter_provider,
+                resource_metrics: vec![],
+            }
+        }
+
+        fn u64_counter(
+            &self,
+            meter_name: &'static str,
+            counter_name: &'static str,
+            unit_name: &'static str,
+        ) -> Counter<u64> {
+            self.meter_provider
+                .meter(meter_name)
+                .u64_counter(counter_name)
+                .with_unit(Unit::new(unit_name))
+                .init()
+        }
+
+        fn i64_up_down_counter(
+            &self,
+            meter_name: &'static str,
+            counter_name: &'static str,
+            unit_name: &'static str,
+        ) -> UpDownCounter<i64> {
+            self.meter_provider
+                .meter(meter_name)
+                .i64_up_down_counter(counter_name)
+                .with_unit(Unit::new(unit_name))
+                .init()
+        }
+
+        fn flush_metrics(&self) {
+            self.meter_provider.force_flush().unwrap();
+        }
+
+        fn get_aggregation<T: data::Aggregation>(
+            &mut self,
+            counter_name: &str,
+            unit_name: &str,
+        ) -> &T {
+            self.resource_metrics = self
+                .exporter
+                .get_finished_metrics()
+                .expect("metrics expected to be exported");
+
+            assert!(
+                !self.resource_metrics.is_empty(),
+                "no metrics were exported"
+            );
+
+            // Get the latest resource metric in case of multiple flushes/exports
+            let resource_metric = self.resource_metrics.last().unwrap();
+
+            assert!(
+                !resource_metric.scope_metrics.is_empty(),
+                "No scope metrics in latest export"
+            );
+            assert!(!resource_metric.scope_metrics[0].metrics.is_empty());
+
+            let metric = &resource_metric.scope_metrics[0].metrics[0];
+            assert_eq!(metric.name, counter_name);
+            assert_eq!(metric.unit.as_str(), unit_name);
+
+            metric
+                .data
+                .as_any()
+                .downcast_ref::<T>()
+                .expect("Failed to cast aggregation to expected type")
+        }
     }
 }


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

This PR utilizes atomics to make counters fast when an empty set of attributes are passed in.  This atomic bypasses the hashmap lookups and mutex locking.

## Benchmarks

### main
```
Counter/AddNoAttrs      time:   [59.516 ns 59.947 ns 60.457 ns]
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

Counter/AddNoAttrsDelta time:   [62.342 ns 63.361 ns 64.458 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Counter/AddOneAttr      time:   [144.01 ns 146.76 ns 150.11 ns]
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe

Counter/AddOneAttrDelta time:   [144.58 ns 145.39 ns 146.28 ns]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
```

### PR
```
Counter/AddNoAttrs      time:   [30.140 ns 30.390 ns 30.652 ns]
                        change: [-49.181% -48.265% -47.331%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
Counter/AddNoAttrsDelta time:   [29.836 ns 30.040 ns 30.327 ns]
                        change: [-53.397% -52.564% -51.790%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
Counter/AddOneAttr      time:   [145.48 ns 145.84 ns 146.24 ns]
                        change: [-0.3877% +0.8455% +2.1208%] (p = 0.20 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) high mild
  7 (7.00%) high severe
Counter/AddOneAttrDelta time:   [147.37 ns 148.07 ns 148.85 ns]
                        change: [+0.5418% +2.2081% +3.9805%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
```

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [X] Unit tests added/updated (if applicable)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
