### PR TITLE
Ignore flaky opentelemetry-jaeger tests

### DIFF
--- a/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
@@ -188,6 +188,7 @@ mod collector_client_tests {
     use opentelemetry::trace::TraceError;
     use opentelemetry_sdk::runtime::Tokio;
 
+    // Ignore this test as it is flaky and the opentelemetry-jaeger is on-track for deprecation
     #[ignore]
     #[test]
     fn test_bring_your_own_client() -> Result<(), TraceError> {

--- a/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
@@ -188,6 +188,7 @@ mod collector_client_tests {
     use opentelemetry::trace::TraceError;
     use opentelemetry_sdk::runtime::Tokio;
 
+    #[ignore]
     #[test]
     fn test_bring_your_own_client() -> Result<(), TraceError> {
         let invalid_uri_builder = new_collector_pipeline()

--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -571,6 +571,7 @@ mod tests {
         assert!(valid_uri.is_ok());
     }
 
+    // Ignore this test as it is flaky and the opentelemetry-jaeger is on-track for deprecation
     #[ignore]
     #[test]
     fn test_collector_exporter() {

--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -571,6 +571,7 @@ mod tests {
         assert!(valid_uri.is_ok());
     }
 
+    #[ignore]
     #[test]
     fn test_collector_exporter() {
         let exporter = new_collector_pipeline()


### PR DESCRIPTION
Fixes #1505
Two tests have been intermittently failing from the `opentelemetry-jaeger` crate:
    exporter::config::collector::http_client::collector_client_tests::test_bring_your_own_client
    exporter::config::collector::tests::test_collector_exporter

As the `opentelemetry-jaeger` crate will be removed in the next major release, these tests can be ignored for the time being to alleviate the issue.

## Changes

Ignores tests:
exporter::config::collector::http_client::collector_client_tests::test_bring_your_own_client
exporter::config::collector::tests::test_collector_exporter

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
