### PR TITLE
Make stress test more realistic

### DIFF
--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -65,12 +65,6 @@ impl LogProcessor for NoOpLogProcessor {
 fn main() {
     // LoggerProvider with a no-op processor.
     let provider: LoggerProvider = LoggerProvider::builder()
-        .with_config(
-            Config::default().with_resource(Resource::new(vec![KeyValue::new(
-                "service.name",
-                "log-appender-tracing-example",
-            )])),
-        )
         .with_log_processor(NoOpLogProcessor {})
         .build();
 

--- a/stress/src/traces.rs
+++ b/stress/src/traces.rs
@@ -1,17 +1,38 @@
 use lazy_static::lazy_static;
 use opentelemetry::{
-    trace::{Span, SpanBuilder, Tracer, TracerProvider as _},
-    KeyValue,
+    trace::{Span, SpanBuilder, TraceResult, Tracer, TracerProvider as _}, Context, KeyValue
 };
-use opentelemetry_sdk::trace as sdktrace;
+use opentelemetry_sdk::{export::trace::SpanData, trace::{self as sdktrace, SpanProcessor}};
 
 mod throughput;
 
 lazy_static! {
     static ref PROVIDER: sdktrace::TracerProvider = sdktrace::TracerProvider::builder()
         .with_config(sdktrace::config().with_sampler(sdktrace::Sampler::AlwaysOn))
+        .with_span_processor(NoOpSpanProcessor {})
         .build();
     static ref TRACER: sdktrace::Tracer = PROVIDER.tracer("stress");
+}
+
+#[derive(Debug)]
+pub struct NoOpSpanProcessor;
+
+impl SpanProcessor for NoOpSpanProcessor {
+    fn on_start(&self, _span: &mut opentelemetry_sdk::trace::Span, _cx: &Context) {
+        // No-op
+    }
+
+    fn on_end(&self, _span: SpanData) {
+        // No-op
+    }
+
+    fn force_flush(&self) -> TraceResult<()> {
+        Ok(())
+    }
+
+    fn shutdown(&mut self) -> TraceResult<()> {
+        Ok(())
+    }
 }
 
 fn main() {


### PR DESCRIPTION
For logs - removes the custom Resource, and let the default resource be automatically added. There isn't a super easy way to keep the default + add my own attribute, as setting my Resource overrides the default! Will fix this later.
This will make it consistent across traces and metrics which all use default Resources only.

For traces - adds a noop processor. Without processor, we are not measuring the real SDK cost. (We could alternatively use a processor with noop exporter as well)