### PR TITLE
CI failure fix for external-type-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-10-10
+          toolchain: nightly-2024-02-07
           components: rustfmt
           override: true
       - name: external-type-check


### PR DESCRIPTION
## Error

CI checks are failing with error - https://github.com/open-telemetry/opentelemetry-rust/actions/runs/7909832162/job/21591506906?pr=1526

``
error at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-check-external-types-0.1.11/src/main.rs:175:14: The version of rustdoc being used produces JSON format version 27, but this tool requires format version 28. This can happen if the locally installed version of rustdoc doesn't match the rustdoc JSON types from the `rustdoc-types` crate.
``

## Changes

The latest version of cargo-check-external-types (v0.1.11) depends on Rust nightly-2024-02-07 as mentioned [here](https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.1.11). Updating the version accordingly.

Another solution to prevent the issue from recurring is to lock the version of cargo-check-external-types in CI.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
