### PR TITLE
opentelemetry-otlp: Default the port correctly.

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## vNext
 
-- **Breaking** Remove support for surf HTTP client [#1537](https://github.com/open-telemetry/opentelemetry-rust/pull/1537)
+### Fixed
+- Fix `tonic()` to the use correct port. [#1556](https://github.com/open-telemetry/opentelemetry-rust/pull/1556)
+
+### Changed
 - Update to tonic 0.11 and prost 0.12 (#1536)
+
+### Removed
+- **Breaking** Remove support for surf HTTP client [#1537](https://github.com/open-telemetry/opentelemetry-rust/pull/1537)
 - Remove support for grpcio transport (#1534)
 
 ## v0.14.0

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -245,6 +245,28 @@ mod tests {
         )
     }
 
+    #[cfg(feature = "http-proto")]
+    #[test]
+    fn test_default_http_endpoint() {
+        let exporter_builder = crate::new_exporter().http();
+
+        assert_eq!(
+            exporter_builder.exporter_config.endpoint,
+            "http://localhost:4318"
+        );
+    }
+
+    #[cfg(feature = "grpc-tonic")]
+    #[test]
+    fn test_default_tonic_endpoint() {
+        let exporter_builder = crate::new_exporter().tonic();
+
+        assert_eq!(
+            exporter_builder.exporter_config.endpoint,
+            "http://localhost:4317"
+        );
+    }
+
     #[test]
     fn test_parse_header_string() {
         let test_cases = vec![

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -149,6 +149,7 @@ impl Default for TonicExporterBuilder {
         TonicExporterBuilder {
             exporter_config: ExportConfig {
                 protocol: crate::Protocol::Grpc,
+                endpoint: crate::exporter::default_endpoint(crate::Protocol::Grpc),
                 ..Default::default()
             },
             tonic_config,

--- a/opentelemetry-otlp/tests/integration_test/tests/traces.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/traces.rs
@@ -6,7 +6,6 @@ use opentelemetry::{
     trace::{TraceContextExt, Tracer},
     Key, KeyValue,
 };
-use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{runtime, trace as sdktrace, Resource};
 use std::error::Error;
 use std::fs::File;
@@ -15,11 +14,7 @@ use std::os::unix::fs::MetadataExt;
 fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
     opentelemetry_otlp::new_pipeline()
         .tracing()
-        .with_exporter(
-            opentelemetry_otlp::new_exporter()
-                .tonic()
-                .with_endpoint("http://localhost:4317"),
-        )
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic())
         .with_trace_config(
             sdktrace::config().with_resource(Resource::new(vec![KeyValue::new(
                 opentelemetry_semantic_conventions::resource::SERVICE_NAME,


### PR DESCRIPTION
Current behavior uses http-proto port even when there's no desire to use it.

Relates #1509