### PR TITLE
deprecation(opentelemetry-jaeger): Add deprecation notice.

### DIFF
--- a/opentelemetry-jaeger/CHANGELOG.md
+++ b/opentelemetry-jaeger/CHANGELOG.md
@@ -1,16 +1,23 @@
 # Changelog
 
+## Deprecation Notice
+
+Starting with [Jaeger v1.38](https://github.com/jaegertracing/jaeger/releases/tag/v1.38.0) Jaeger supports the OpenTelemetry Protocol (OTLP).
+[OpenTelemetry has recommended](https://opentelemetry.io/blog/2022/jaeger-native-otlp/) migrating to OTLP.
+
+Please check the [README](https://crates.io/crates/opentelemetry-jaeger) for more information.
+
 ## vNext
 
 ### Changed
 
-- **Breaking** Remove support for surf HTTP client [#1537](https://github.com/open-telemetry/opentelemetry-rust/pull/1537)
 - Update to tonic 0.11 and prost 0.12 (#1536)
 
-## v0.21.0
+### Removed
 
-### Changed
-- Previously, the opentelemetry-jaeger crate exposed both a Jaeger exporter and a Jaeger propagator. Going forwards, the Jaeger propagator functionality has been moved to a new crate [opentelemetry-jaeger-propagator](../opentelemetry-jaeger-propagator/) to prepare for opentelemetry-jaeger exporter deprecation. Starting with [Jaeger v1.35](https://github.com/jaegertracing/jaeger/releases/tag/v1.35.0), Jaeger supports the OpenTelemetry Protocol (OTLP). [OpenTelemetry has recommended](https://opentelemetry.io/blog/2022/jaeger-native-otlp/) that Jaeger exporters be deprecated from OpenTelemetry SDKs in favor of sending traces to Jaeger clients using OTLP. An example and further discussion of how to consume OpenTelemetry spans with Jaeger can be found at [Introducing native support for OpenTelemetry in Jaeger](https://medium.com/jaegertracing/introducing-native-support-for-opentelemetry-in-jaeger-eb661be8183c).
+- **Breaking** Jaeger propagator functionality has been moved to a new crate [opentelemetry-jaeger-propagator](../opentelemetry-jaeger-propagator/)
+  to prepare for opentelemetry-jaeger exporter deprecation. [#1487](https://github.com/open-telemetry/opentelemetry-rust/pull/1487)
+- **Breaking** Remove support for surf HTTP client [#1537](https://github.com/open-telemetry/opentelemetry-rust/pull/1537)
 
 ## v0.20.0
 

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -15,6 +15,9 @@ license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.65"
 
+[badges]
+maintenance = { status = "deprecated" }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -17,7 +17,7 @@ To prepare for the deprecation of the Jaeger exporter, the Jaeger propagator imp
 The plan is to have 0.22.0 be the last release of the Jaeger exporter. This means that future versions of the OpenTelemetry
 SDK will not work with the exporter.
 
-If you have any questions please comment on the [Jaeger Deprecation Issue].
+If you have any questions please comment on the [Jaeger Deprecation Issue][deprecation-issue].
 
 [`Jaeger`] integration for applications instrumented with [`OpenTelemetry`]. This includes a jaeger exporter and a jaeger propagator.
 
@@ -42,7 +42,7 @@ Jaeger `agent` or `collector` endpoint for processing and visualization.
 [jaeger-deprecation]: https://opentelemetry.io/blog/2022/jaeger-native-otlp/
 [exporting-otlp]: https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples/tracing-jaeger
 [Jaeger 1.35.0]: https://github.com/jaegertracing/jaeger/releases/tag/v1.35.0
-[Jaeger Deprecation Issue]: https://github.com/open-telemetry/opentelemetry-rust/pull/995
+[deprecation-issue]: https://github.com/open-telemetry/opentelemetry-rust/pull/995
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
 [msrv]: #supported-rust-versions
 

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -2,7 +2,22 @@
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png
 
-# OpenTelemetry Jaeger
+# OpenTelemetry Jaeger (Deprecated)
+
+**WARNING**
+As of [Jaeger 1.35.0], released in Sept 2022, ingesting the OpenTelemetry Protocol (OTLP) is stable and
+as a result, language specific Jaeger exporters within OpenTelemetry SDKs are [recommended for deprecation by the OpenTelemetry project][jaeger-deprecation].
+More information and examples of using OTLP with Jaeger can be found in [Introducing native support for OpenTelemetry in Jaeger][jaeger-otlp]
+and [Exporting OTLP traces to Jaeger][exporting-otlp].
+
+The opentelemetry-jaeger crate previously contained both a Jaeger exporter and a Jaeger propagator.
+To prepare for the deprecation of the Jaeger exporter, the Jaeger propagator implementation has been migrated to
+[opentelemetry-jaeger-propagator](../opentelemetry-jaeger-propagator/).
+
+The plan is to have 0.22.0 be the last release of the Jaeger exporter. This means that future versions of the OpenTelemetry
+SDK will not work with the exporter.
+
+If you have any questions please comment on the [Jaeger Deprecation Issue].
 
 [`Jaeger`] integration for applications instrumented with [`OpenTelemetry`]. This includes a jaeger exporter and a jaeger propagator.
 
@@ -11,11 +26,6 @@
 [![LICENSE](https://img.shields.io/crates/l/opentelemetry-jaeger)](./LICENSE)
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
-
-**WARNING**
-[Jaeger](https://www.jaegertracing.io/) supports the OpenTelemetry Protocol (OTLP) as of [v1.35.0](https://github.com/jaegertracing/jaeger/releases/tag/v1.35.0) and as a result, language specific Jaeger exporters within OpenTelemetry SDKs are [recommended for deprecation by the OpenTelemetry project](https://opentelemetry.io/blog/2022/jaeger-native-otlp/). More information and examples of using OTLP with Jaeger can be found in [Introducing native support for OpenTelemetry in Jaeger](https://medium.com/jaegertracing/introducing-native-support-for-opentelemetry-in-jaeger-eb661be8183c) and [Exporting OTLP traces to Jaeger](https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples/tracing-jaeger).
-
-The opentelemetry-jaeger crate previously contained both a Jaeger exporter and a Jaeger propagator. To prepare for the deprecation of the Jaeger exporter, the Jaeger propagator implementation has been migrated to [opentelemetry-jaeger-propagator](../opentelemetry-jaeger-propagator/).
 
 ## Overview
 
@@ -28,6 +38,11 @@ Jaeger `agent` or `collector` endpoint for processing and visualization.
 *Compiler support: [requires `rustc` 1.64+][msrv]*
 
 [`Jaeger`]: https://www.jaegertracing.io/
+[jaeger-otlp]: [jaeger-otlp]: https://medium.com/jaegertracing/introducing-native-support-for-opentelemetry-in-jaeger-eb661be8183c
+[jaeger-deprecation]: https://opentelemetry.io/blog/2022/jaeger-native-otlp/
+[exporting-otlp]: https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples/tracing-jaeger
+[Jaeger 1.35.0]: https://github.com/jaegertracing/jaeger/releases/tag/v1.35.0
+[Jaeger Deprecation Issue]: https://github.com/open-telemetry/opentelemetry-rust/pull/995
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
 [msrv]: #supported-rust-versions
 

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -38,7 +38,7 @@ Jaeger `agent` or `collector` endpoint for processing and visualization.
 *Compiler support: [requires `rustc` 1.64+][msrv]*
 
 [`Jaeger`]: https://www.jaegertracing.io/
-[jaeger-otlp]: [jaeger-otlp]: https://medium.com/jaegertracing/introducing-native-support-for-opentelemetry-in-jaeger-eb661be8183c
+[jaeger-otlp]: https://medium.com/jaegertracing/introducing-native-support-for-opentelemetry-in-jaeger-eb661be8183c
 [jaeger-deprecation]: https://opentelemetry.io/blog/2022/jaeger-native-otlp/
 [exporting-otlp]: https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples/tracing-jaeger
 [Jaeger 1.35.0]: https://github.com/jaegertracing/jaeger/releases/tag/v1.35.0

--- a/opentelemetry-jaeger/examples/actix-udp/src/main.rs
+++ b/opentelemetry-jaeger/examples/actix-udp/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use actix_service::Service;
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpServer};

--- a/opentelemetry-jaeger/src/exporter/config/agent.rs
+++ b/opentelemetry-jaeger/src/exporter/config/agent.rs
@@ -35,6 +35,9 @@ const DEFAULT_AGENT_ENDPOINT_HOST: &str = "127.0.0.1";
 /// Default agent port if none is provided
 const DEFAULT_AGENT_ENDPOINT_PORT: &str = "6831";
 
+/// Deprecation Notice:
+/// Ingestion of OTLP is now supported in Jaeger please check [crates.io] for more details.
+///
 /// AgentPipeline config and build a exporter targeting a jaeger agent using UDP as transport layer protocol.
 ///
 /// ## UDP packet max length
@@ -68,6 +71,7 @@ const DEFAULT_AGENT_ENDPOINT_PORT: &str = "6831";
 /// [`with_max_packet_size`]: AgentPipeline::with_max_packet_size
 /// [UDP packet size]: https://stackoverflow.com/questions/1098897/what-is-the-largest-safe-udp-packet-size-on-the-internet
 /// [why 65000]: https://serverfault.com/questions/246508/how-is-the-mtu-is-65535-in-udp-but-ethernet-does-not-allow-frame-size-more-than
+/// [crates.io]: https://crates.io/crates/opentelemetry-jaeger
 ///
 /// ## Environment variables
 /// The following environment variables are available to configure the agent exporter.
@@ -77,6 +81,10 @@ const DEFAULT_AGENT_ENDPOINT_PORT: &str = "6831";
 /// - `OTEL_EXPORTER_JAEGER_AGENT_PORT`, set the port of the agent. If the `OTEL_EXPORTER_JAEGER_AGENT_HOST`
 /// is not set, the exporter will use 127.0.0.1 as the host.
 #[derive(Debug)]
+#[deprecated(
+    since = "0.21.0",
+    note = "Please Migrate to opentelemetry-otlp exporter."
+)]
 pub struct AgentPipeline {
     transformation_config: TransformationConfig,
     trace_config: Option<Config>,
@@ -123,7 +131,15 @@ impl HasRequiredConfig for AgentPipeline {
 ///
 /// See details for each configurations at [`AgentPipeline`]
 ///
+/// Deprecation Notice:
+/// Ingestion of OTLP is now supported in Jaeger please check [crates.io] for more details.
+///
 /// [`AgentPipeline`]: crate::config::agent::AgentPipeline
+/// [crates.io]: https://crates.io/crates/opentelemetry-jaeger
+#[deprecated(
+    since = "0.21.0",
+    note = "Please Migrate to opentelemetry-otlp exporter."
+)]
 pub fn new_agent_pipeline() -> AgentPipeline {
     AgentPipeline::default()
 }

--- a/opentelemetry-jaeger/src/exporter/config/agent.rs
+++ b/opentelemetry-jaeger/src/exporter/config/agent.rs
@@ -83,7 +83,7 @@ const DEFAULT_AGENT_ENDPOINT_PORT: &str = "6831";
 #[derive(Debug)]
 #[deprecated(
     since = "0.21.0",
-    note = "Please Migrate to opentelemetry-otlp exporter."
+    note = "Please migrate to opentelemetry-otlp exporter."
 )]
 pub struct AgentPipeline {
     transformation_config: TransformationConfig,
@@ -138,7 +138,7 @@ impl HasRequiredConfig for AgentPipeline {
 /// [crates.io]: https://crates.io/crates/opentelemetry-jaeger
 #[deprecated(
     since = "0.21.0",
-    note = "Please Migrate to opentelemetry-otlp exporter."
+    note = "Please migrate to opentelemetry-otlp exporter."
 )]
 pub fn new_agent_pipeline() -> AgentPipeline {
     AgentPipeline::default()

--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -94,7 +94,7 @@ const ENV_PASSWORD: &str = "OTEL_EXPORTER_JAEGER_PASSWORD";
 #[derive(Debug)]
 #[deprecated(
     since = "0.21.0",
-    note = "Please Migrate to opentelemetry-otlp exporter."
+    note = "Please migrate to opentelemetry-otlp exporter."
 )]
 pub struct CollectorPipeline {
     transformation_config: TransformationConfig,
@@ -181,7 +181,7 @@ impl Default for ClientConfig {
 #[cfg(feature = "collector_client")]
 #[deprecated(
     since = "0.21.0",
-    note = "Please Migrate to opentelemetry-otlp exporter."
+    note = "Please migrate to opentelemetry-otlp exporter."
 )]
 pub fn new_collector_pipeline() -> CollectorPipeline {
     CollectorPipeline::default()
@@ -198,7 +198,7 @@ pub fn new_collector_pipeline() -> CollectorPipeline {
 // make sure when collector_cilent and wasm_collector_client are both set. We will create a wasm type client
 #[deprecated(
     since = "0.21.0",
-    note = "Please Migrate to opentelemetry-otlp exporter."
+    note = "Please migrate to opentelemetry-otlp exporter."
 )]
 pub fn new_wasm_collector_pipeline() -> CollectorPipeline {
     let mut pipeline = CollectorPipeline::default();

--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -50,6 +50,9 @@ const ENV_PASSWORD: &str = "OTEL_EXPORTER_JAEGER_PASSWORD";
 
 /// CollectorPipeline config and build a exporter targeting a jaeger collector using HTTP protocol.
 ///
+/// Deprecation Notice:
+/// Ingestion of OTLP is now supported in Jaeger please check [crates.io] for more details.
+///
 /// ## Environment variables
 ///
 /// - `OTEL_EXPORTER_JAEGER_ENDPOINT`: set the endpoint of the collector. Usually starts with `http://` or `https://`
@@ -87,7 +90,12 @@ const ENV_PASSWORD: &str = "OTEL_EXPORTER_JAEGER_PASSWORD";
 ///
 /// [reqwest]: reqwest::Client
 /// [reqwest blocking client]: reqwest::blocking::Client
+/// [crates.io]: https://crates.io/crates/opentelemetry-jaeger
 #[derive(Debug)]
+#[deprecated(
+    since = "0.21.0",
+    note = "Please Migrate to opentelemetry-otlp exporter."
+)]
 pub struct CollectorPipeline {
     transformation_config: TransformationConfig,
     trace_config: Option<Config>,
@@ -165,15 +173,33 @@ impl Default for ClientConfig {
 ///
 /// See details for each configurations at [`CollectorPipeline`].
 ///
+/// Deprecation Notice:
+/// Ingestion of OTLP is now supported in Jaeger please check [crates.io] for more details.
+///
 /// [`CollectorPipeline`]: crate::config::collector::CollectorPipeline
+/// [crates.io]: https://crates.io/crates/opentelemetry-jaeger
 #[cfg(feature = "collector_client")]
+#[deprecated(
+    since = "0.21.0",
+    note = "Please Migrate to opentelemetry-otlp exporter."
+)]
 pub fn new_collector_pipeline() -> CollectorPipeline {
     CollectorPipeline::default()
 }
 
 /// Similar to [`new_collector_pipeline`] but the exporter is configured to run with wasm.
+///
+/// Deprecation Notice:
+/// Ingestion of OTLP is now supported in Jaeger please check [crates.io] for more details.
+///
+/// [crates.io]: https://crates.io/crates/opentelemetry-jaeger
 #[cfg(feature = "wasm_collector_client")]
-#[allow(clippy::field_reassign_with_default)] // make sure when collector_cilent and wasm_collector_client are both set. We will create a wasm type client
+#[allow(clippy::field_reassign_with_default)]
+// make sure when collector_cilent and wasm_collector_client are both set. We will create a wasm type client
+#[deprecated(
+    since = "0.21.0",
+    note = "Please Migrate to opentelemetry-otlp exporter."
+)]
 pub fn new_wasm_collector_pipeline() -> CollectorPipeline {
     let mut pipeline = CollectorPipeline::default();
     pipeline.client_config = ClientConfig::Wasm;

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -53,7 +53,7 @@ const INSTRUMENTATION_LIBRARY_VERSION: &str = "otel.library.version";
 /// [crates.io]: https://crates.io/crates/opentelemetry-jaeger
 #[deprecated(
     since = "0.21.0",
-    note = "Please Migrate to opentelemetry-otlp exporter."
+    note = "Please migrate to opentelemetry-otlp exporter."
 )]
 #[derive(Debug)]
 pub struct Exporter {
@@ -85,7 +85,7 @@ impl Exporter {
 /// [crates.io]: https://crates.io/crates/opentelemetry-jaeger
 #[deprecated(
     since = "0.21.0",
-    note = "Please Migrate to opentelemetry-otlp exporter."
+    note = "Please migrate to opentelemetry-otlp exporter."
 )]
 #[derive(Debug, Default)]
 pub struct Process {

--- a/opentelemetry-jaeger/src/exporter/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/mod.rs
@@ -46,6 +46,15 @@ const INSTRUMENTATION_LIBRARY_NAME: &str = "otel.library.name";
 const INSTRUMENTATION_LIBRARY_VERSION: &str = "otel.library.version";
 
 /// Jaeger span exporter
+///
+/// Deprecation Notice:
+/// Ingestion of OTLP is now supported in Jaeger please check [crates.io] for more details.
+///
+/// [crates.io]: https://crates.io/crates/opentelemetry-jaeger
+#[deprecated(
+    since = "0.21.0",
+    note = "Please Migrate to opentelemetry-otlp exporter."
+)]
 #[derive(Debug)]
 pub struct Exporter {
     /// Whether or not to export instrumentation information.
@@ -69,6 +78,15 @@ impl Exporter {
 }
 
 /// Jaeger process configuration
+///
+/// Deprecation Notice:
+/// Ingestion of OTLP is now supported in Jaeger please check [crates.io] for more details.
+///
+/// [crates.io]: https://crates.io/crates/opentelemetry-jaeger
+#[deprecated(
+    since = "0.21.0",
+    note = "Please Migrate to opentelemetry-otlp exporter."
+)]
 #[derive(Debug, Default)]
 pub struct Process {
     /// Jaeger service name

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -18,7 +18,7 @@ use std::net::ToSocketAddrs;
 #[async_trait]
 #[deprecated(
     since = "0.21.0",
-    note = "Please Migrate to opentelemetry-otlp exporter."
+    note = "Please migrate to opentelemetry-otlp exporter."
 )]
 pub trait JaegerTraceRuntime: RuntimeChannel + std::fmt::Debug {
     /// A communication socket between Jaeger client and agent.

--- a/opentelemetry-jaeger/src/exporter/runtime.rs
+++ b/opentelemetry-jaeger/src/exporter/runtime.rs
@@ -10,8 +10,16 @@ use std::net::ToSocketAddrs;
 
 /// Jaeger Trace Runtime is an extension to [`RuntimeChannel`].
 ///
+/// Deprecation Notice:
+/// Ingestion of OTLP is now supported in Jaeger please check [crates.io] for more details.
+///
 /// [`RuntimeChannel`]: opentelemetry_sdk::runtime::RuntimeChannel
+/// [crates.io]: https://crates.io/crates/opentelemetry-jaeger
 #[async_trait]
+#[deprecated(
+    since = "0.21.0",
+    note = "Please Migrate to opentelemetry-otlp exporter."
+)]
 pub trait JaegerTraceRuntime: RuntimeChannel + std::fmt::Debug {
     /// A communication socket between Jaeger client and agent.
     type Socket: std::fmt::Debug + Send + Sync;

--- a/opentelemetry-jaeger/src/lib.rs
+++ b/opentelemetry-jaeger/src/lib.rs
@@ -303,6 +303,7 @@
     unreachable_pub,
     unused
 )]
+#![allow(deprecated)]
 #![cfg_attr(
     docsrs,
     feature(doc_cfg, doc_auto_cfg),

--- a/opentelemetry-jaeger/tests/integration_test.rs
+++ b/opentelemetry-jaeger/tests/integration_test.rs
@@ -1,3 +1,4 @@
+#[allow(deprecated)]
 #[cfg(feature = "integration_test")]
 mod tests {
     use opentelemetry::{


### PR DESCRIPTION
- Add deprecation flags to the various components to give notices in users compilers.
- Add more definition around the deprecation in the README.
- Add a deprecation badge for crates.io.

Relates #995