### PR TITLE
Switch from the chrono `clock` feature to `now`

### DIFF
--- a/opentelemetry-stdout/CHANGELOG.md
+++ b/opentelemetry-stdout/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Changed
+
+- Adjusted `chrono` features to reduce number of transitive dependencies. [#1569](https://github.com/open-telemetry/opentelemetry-rust/pull/1569)
+
 ## v0.2.0
 
 ### Changed

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -22,7 +22,7 @@ logs = ["opentelemetry/logs", "opentelemetry_sdk/logs", "async-trait", "thiserro
 
 [dependencies]
 async-trait = { workspace = true, optional = true }
-chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
+chrono = { version = "0.4.34", default-features = false, features = ["now"] }
 thiserror = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 opentelemetry = { version = "0.21", path = "../opentelemetry", default_features = false }


### PR DESCRIPTION
In #1192, `chrono` was added as a dependency of the `opentelemetry-stdout` crate in order to support outputting timestamps in human readable format.

In that PR, all Chrono features were disabled apart from the `clock` feature.

However, since that change landed, `chrono` [v0.4.32](https://github.com/chronotope/chrono/releases/tag/v0.4.32) has added support for an even finer-grained feature named `now`, which is a subset of the `clock` feature - that excludes timezone support, and so avoids pulling in many timezone related crates.

`opentelemetry-stdout` only uses chrono's UTC features, so we can safely switch from using the `clock` feature to using `now` instead.

After this change, the following transitive dependencies are no longer pulled in:

- `android-tzdata`
- `android_system_properties`
- `cc`
- `core-foundation-sys`
- `iana-time-zone`
- `iana-time-zone-haiku`
- `windows-core`
- `windows-targets`
- `windows_aarch64_gnullvm`
- `windows_aarch64_msvc`
- `windows_i686_gnu`
- `windows_i686_msvc`
- `windows_x86_64_gnu`
- `windows_x86_64_gnullvm`
- `windows_x86_64_msvc`

See:
https://github.com/chronotope/chrono/pull/1343
https://github.com/chronotope/chrono/blob/main/README.md#crate-features
