### PR TITLE
Disable default features on reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ prost = "0.12"
 prost-build = "0.12"
 prost-types = "0.12"
 rand = "0.8"
-reqwest = "0.11"
+reqwest = { version = "0.11", default-features = false }
 serde = "1.0"
 serde_json = "1.0"
 temp-env = "0.3.6"


### PR DESCRIPTION
reqwest's default features cause openssl to be linked in, and defeats the point
of supporting rustls feature flags. Disable default features to avoid this.

This was a regression from the migration to workspace dep versions.