### PR TITLE
Chore/1489 deprecate aws id generator

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## Deprecation Notice
-
-XrayIdGenerator has been migrated to the opentelemetry-aws crate starting from 0.10.0. [#33](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/33)
-
 
 ## vNext
 
+
+### Deprecated
+
+- XrayIdGenerator in the opentelemetry-sdk has been deprecated and moved to version 0.10.0 of the opentelemetry-aws crate.
 
 ### Added
 
@@ -18,7 +18,6 @@ XrayIdGenerator has been migrated to the opentelemetry-aws crate starting from 0
 Performance Improvement : Creating Spans and LogRecords are now faster, by avoiding expensive cloning of `Resource` for every Span/LogRecord.
 
 ### Changed
-- XrayIdGenerator in the opentelemetry-sdk has been deprecated. XrayIdGenerator has been added to the opentelemetry-aws crate starting from version 0.10.0.
 - **Breaking**
 [#1313](https://github.com/open-telemetry/opentelemetry-rust/pull/1313)
 [#1350](https://github.com/open-telemetry/opentelemetry-rust/pull/1350)

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
+## Deprecation Notice
+
+XrayIdGenerator has been migrated to the opentelemetry-aws crate starting from 0.10.0. [#33](https://github.com/open-telemetry/opentelemetry-rust-contrib/pull/33)
+
+
 ## vNext
+
 
 ### Added
 
@@ -12,7 +18,7 @@
 Performance Improvement : Creating Spans and LogRecords are now faster, by avoiding expensive cloning of `Resource` for every Span/LogRecord.
 
 ### Changed
-
+- XrayIdGenerator in the opentelemetry-sdk has been deprecated. XrayIdGenerator has been added to the opentelemetry-aws crate starting from version 0.10.0.
 - **Breaking**
 [#1313](https://github.com/open-telemetry/opentelemetry-rust/pull/1313)
 [#1350](https://github.com/open-telemetry/opentelemetry-rust/pull/1350)

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -137,6 +137,8 @@ pub mod runtime;
 #[cfg(any(feature = "testing", test))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "testing", test))))]
 pub mod testing;
+
+#[allow(deprecated)]
 #[cfg(feature = "trace")]
 #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
 pub mod trace;

--- a/opentelemetry-sdk/src/trace/id_generator/aws.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/aws.rs
@@ -35,7 +35,7 @@ use std::time::{Duration, UNIX_EPOCH};
 /// [xray-trace-id]: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids
 #[derive(Debug, Default)]
 #[deprecated(
-    since = "0.21.0",
+    since = "0.21.3",
     note = "XrayId Generator has been migrated to the opentelemetry-aws crate"
 )]
 pub struct XrayIdGenerator {

--- a/opentelemetry-sdk/src/trace/id_generator/aws.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/aws.rs
@@ -37,7 +37,7 @@ use std::time::{Duration, UNIX_EPOCH};
 #[deprecated(
     since = "0.21.0",
     note = "XrayId Generator has been migrated to the opentelemetry-aws crate"
-    )]
+)]
 pub struct XrayIdGenerator {
     sdk_default_generator: RandomIdGenerator,
 }

--- a/opentelemetry-sdk/src/trace/id_generator/aws.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/aws.rs
@@ -34,6 +34,10 @@ use std::time::{Duration, UNIX_EPOCH};
 /// [xray-exporter]: https://godoc.org/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
 /// [xray-trace-id]: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids
 #[derive(Debug, Default)]
+#[deprecated(
+    since = "0.21.0",
+    note = "XrayId Generator has been migrated to the opentelemetry-aws crate"
+    )]
 pub struct XrayIdGenerator {
     sdk_default_generator: RandomIdGenerator,
 }

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -21,7 +21,7 @@ pub use config::{config, Config};
 pub use events::SpanEvents;
 
 #[deprecated(
-    since = "0.21.0",
+    since = "0.21.3",
     note = "XrayId Generator has been migrated to the opentelemetry-aws crate"
 )]
 pub use id_generator::aws::XrayIdGenerator;

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -19,7 +19,13 @@ mod tracer;
 
 pub use config::{config, Config};
 pub use events::SpanEvents;
-pub use id_generator::{aws::XrayIdGenerator, IdGenerator, RandomIdGenerator};
+
+#[deprecated(
+    since = "0.21.0",
+    note = "XrayId Generator has been migrated to the opentelemetry-aws crate"
+)]
+pub use id_generator::aws::XrayIdGenerator;
+pub use id_generator::{IdGenerator, RandomIdGenerator};
 pub use links::SpanLinks;
 pub use provider::{Builder, TracerProvider};
 pub use sampler::{Sampler, ShouldSample};


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes
Deprecates the XrayIdGenerator in the opentelemetry core sdk. 
Relates [#1489](https://github.com/open-telemetry/opentelemetry-rust/issues/1489)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
