### PR TITLE
Prepare for SDK 0.22.1 hotfix release

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.22.1
+
 ### Fixed
 
 - [#1576](https://github.com/open-telemetry/opentelemetry-rust/pull/1576)

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry_sdk"
-version = "0.22.0"
+version = "0.22.1"
 description = "The SDK for the OpenTelemetry metrics collection and distributed tracing framework"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"


### PR DESCRIPTION
A .1 release as 0.22.0 had a regression for a basic scenario.