### PR TITLE
Modify main readme and contrib guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 The Rust special interest group (SIG) meets weekly on Tuesdays at 9 AM Pacific
 Time. The meeting is subject to change depending on contributors'
 availability. Check the [OpenTelemetry community
-calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com)
+calendar](https://github.com/open-telemetry/community?tab=readme-ov-file#calendar)
 for specific dates and for Zoom meeting links. "OTel Rust SIG" is the name of
 meeting for this group.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,15 @@ regardless of your experience level. Whether you're a seasoned OpenTelemetry
 developer, just starting your journey, or simply curious about the work we do,
 you're more than welcome to participate!
 
+Even though, anybody can contribute, there are benefits of being a member of our
+community. See to the [community membership
+document](https://github.com/open-telemetry/community/blob/main/community-membership.md)
+on how to become a
+[**Member**](https://github.com/open-telemetry/community/blob/main/community-membership.md#member),
+[**Approver**](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver)
+and
+[**Maintainer**](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
+
 ## Pull Requests
 
 ### Prerequisites
@@ -172,38 +181,6 @@ projects in this workspace.
 - Run `cargo bench` - this will run benchmarks to show performance
 - Run `cargo bench` - this will run benchmarks to show performance
 regressions
-
-## Approvers and Maintainers
-
-For GitHub groups see the [code owners](CODEOWNERS) file.
-
-### Maintainers
-
-* [Cijo Thomas](https://github.com/cijothomas)
-* [Harold Dost](https://github.com/hdost)
-* [Julian Tescher](https://github.com/jtescher)
-* [Zhongyang Wu](https://github.com/TommyCpp)
-
-### Approvers
-
-* [Lalit Kumar Bhasin](https://github.com/lalitb)
-* [Shaun Cox](https://github.com/shaun-cox)
-
-### Emeritus
-
-- [Dirkjan Ochtman](https://github.com/djc)
-- [Jan Kühle](https://github.com/frigus02)
-- [Isobel Redelmeier](https://github.com/iredelmeier)
-- [Mike Goldsmith](https://github.com/MikeGoldsmith)
-
-### Become an Approver or a Maintainer
-
-See the [community membership document in OpenTelemetry community
-repo](https://github.com/open-telemetry/community/blob/master/community-membership.md).
-
-### Thanks to all the people who have contributed
-
-[![contributors](https://contributors-img.web.app/image?repo=open-telemetry/opentelemetry-rust)](https://github.com/open-telemetry/opentelemetry-rust/graphs/contributors)
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-![OpenTelemetry — An observability framework for cloud-native software.][splash]
-
-[splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png
-
 # OpenTelemetry Rust
 
 The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
@@ -12,10 +8,6 @@ The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![codecov](https://codecov.io/gh/open-telemetry/opentelemetry-rust/branch/main/graph/badge.svg)](https://codecov.io/gh/open-telemetry/opentelemetry-rust)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
-
-[Website](https://opentelemetry.io/) |
-[Slack](https://cloud-native.slack.com/archives/C03GDP0H023) |
-[Documentation](https://docs.rs/opentelemetry)
 
 ## Overview
 
@@ -48,7 +40,6 @@ available:
 
 * [opentelemetry-appender-log](opentelemetry-appender-log/README.md)
 * [opentelemetry-appender-tracing](opentelemetry-appender-tracing/README.md)
-* opentelemetry-appender-slog // TODO: Add link once available
 
 If you already use the logging APIs from above, continue to use them, and use
 the appenders above to bridge the logs to OpenTelemetry. If you are using a
@@ -91,88 +82,64 @@ The example above requires the following packages:
 ```toml
 # Cargo.toml
 [dependencies]
-opentelemetry = "0.21"
-opentelemetry_sdk = "0.21"
-opentelemetry-stdout = { version = "0.2", features = ["trace"] }
+opentelemetry = "0.22"
+opentelemetry_sdk = "0.22"
+opentelemetry-stdout = { version = "0.3", features = ["trace"] }
 ```
 
 See the [examples](./examples) directory for different integration patterns.
 
-## Ecosystem
+## Overview of crates
 
-### Related Crates
+The following crates are maintained in this repo:
 
-In addition to `opentelemetry`, the [`open-telemetry/opentelemetry-rust`]
-repository contains several additional crates designed to be used with the
-`opentelemetry` ecosystem. This includes a collection of trace `SpanExporter`
-and metrics pull and push controller implementations, as well as utility and
-adapter crates to assist in propagating state and instrumenting applications.
-
-In particular, the following crates are likely to be of interest:
-
-* [`opentelemetry-aws`] provides unofficial propagators for AWS X-ray.
-* [`opentelemetry-datadog`] provides additional exporters to [`Datadog`].
-* [`opentelemetry-dynatrace`] provides additional exporters to Dynatrace.
-* [`opentelemetry-contrib`] provides additional exporters and propagators that
-  are experimental.
-* [`opentelemetry-http`] provides an interface for injecting and extracting
-  trace information from [`http`] headers.
-* [`opentelemetry-jaeger`] provides context propagation using [jaeger propagation format](https://www.jaegertracing.io/docs/1.18/client-libraries/#propagation-format).
-* [`opentelemetry-otlp`] exporter for sending trace and metric data in the OTLP
-  format to the OpenTelemetry collector.
+* [`opentelemetry`] This is the OpenTelemetry API crate, and is the crate
+  required to instrument libraries and applications. It contains Logging Bridge
+  API, Metrics API, and Tracing API.
+* [`opentelemetry-sdk`] This is the OpenTelemetry SDK crate, and contains the
+  official OpenTelemetry SDK implementation. It contains Logging SDK, Metrics
+  SDK, and Tracing SDK.
+* [`opentelemetry-otlp`] exporter for sending logs, metrics and traces in the
+  OTLP format to an endpoint accepting OTLP, typically the OpenTelemetry
+  collector.
+* [`opentelemetry-stdout`] exporter for sending logs, metrics and traces to
+  stdout, for learning/debugging purposes.  
+* [`opentelemetry-http`] This crate contains utility functions to help with
+  exporting telemetry, propagation, over [`http`].
+* [`opentelemetry-appender-log`] This crate provides logging appender to route
+  logs emitted using the `log` crate to opentelemetry.
+* [`opentelemetry-appender-tracing`] This crate provides logging appender to route
+  logs emitted using the `tracing` crate to opentelemetry.  
+* [`opentelemetry-jaeger-propagator`] provides context propagation using [jaeger
+  propagation
+  format](https://www.jaegertracing.io/docs/1.18/client-libraries/#propagation-format).
 * [`opentelemetry-prometheus`] provides a pipeline and exporter for sending
-  metrics information to [`Prometheus`].
+  metrics to [`Prometheus`].
 * [`opentelemetry-semantic-conventions`] provides standard names and semantic
   otel conventions.
-* [`opentelemetry-stackdriver`] provides an exporter for Google's [Cloud Trace]
-  (which used to be called StackDriver).
-* [`opentelemetry-zipkin`] provides a pipeline and exporter for sending trace
-  information to [`Zipkin`].
+* [`opentelemetry-zipkin`] provides a pipeline and exporter for sending traces
+  to [`Zipkin`].
 
-Additionally, there are also several third-party crates which are not
-maintained by the `opentelemetry` project. These include:
+In addition, there are several other useful crates in the [OTel Rust Contrib
+repo](https://github.com/open-telemetry/opentelemetry-rust-contrib). A lot of
+crates maintained outside OpenTelemetry owned repos can be found in the
+[OpenTelemetry
+Registry](https://opentelemetry.io/ecosystem/registry/?language=rust).
 
-* [`tracing-opentelemetry`] provides integration for applications instrumented
-  using the [`tracing`] API and ecosystem.
-* [`actix-web-opentelemetry`] provides integration for the [`actix-web`] web
-  server and ecosystem.
-* [`opentelemetry-application-insights`] provides an unofficial [Azure
-  Application Insights] exporter.
-* [`opentelemetry-tide`] provides integration for the [`Tide`] web server and
-  ecosystem.
-* [`trillium-opentelemetry`] provides metrics instrumentation for [`trillium`] http servers following [semantic-conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-metrics.md).
-
-If you're the maintainer of an `opentelemetry` ecosystem crate not listed
-above, please let us know! We'd love to add your project to the list!
-
-[`open-telemetry/opentelemetry-rust`]: https://github.com/open-telemetry/opentelemetry-rust
-[`opentelemetry-jaeger`]: https://crates.io/crates/opentelemetry-jaeger
-[`opentelemetry-otlp`]: https://crates.io/crates/opentelemetry-otlp
+[`opentelemetry`]: https://crates.io/crates/opentelemetry
+[`opentelemetry-sdk`]: https://crates.io/crates/opentelemetry-sdk
+[`opentelemetry-appender-log`]: https://crates.io/crates/opentelemetry-appender-log
+[`opentelemetry-appender-tracing`]: https://crates.io/crates/opentelemetry-appender-tracing
 [`opentelemetry-http`]: https://crates.io/crates/opentelemetry-http
+[`opentelemetry-otlp`]: https://crates.io/crates/opentelemetry-otlp
+[`opentelemetry-stdout`]: https://crates.io/crates/opentelemetry-stdout
+[`opentelemetry-jaeger-propagator`]: https://crates.io/crates/opentelemetry-jaeger-propagator
 [`opentelemetry-prometheus`]: https://crates.io/crates/opentelemetry-prometheus
-[`opentelemetry-aws`]: https://crates.io/crates/opentelemetry-aws
 [`Prometheus`]: https://prometheus.io
 [`opentelemetry-zipkin`]: https://crates.io/crates/opentelemetry-zipkin
 [`Zipkin`]: https://zipkin.io
-[`opentelemetry-contrib`]: https://crates.io/crates/opentelemetry-contrib
-[`Datadog`]: https://www.datadoghq.com
-[`opentelemetry-datadog`]: https://crates.io/crates/opentelemetry-datadog
-[`opentelemetry-dynatrace`]: https://crates.io/crates/opentelemetry-dynatrace
 [`opentelemetry-semantic-conventions`]: https://crates.io/crates/opentelemetry-semantic-conventions
 [`http`]: https://crates.io/crates/http
-
-[`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry
-[`tracing`]: https://crates.io/crates/tracing
-[`actix-web-opentelemetry`]: https://crates.io/crates/actix-web-opentelemetry
-[`actix-web`]: https://crates.io/crates/actix-web
-[`opentelemetry-application-insights`]: https://crates.io/crates/opentelemetry-application-insights
-[Azure Application Insights]: https://docs.microsoft.com/azure/azure-monitor/app/app-insights-overview
-[`opentelemetry-tide`]: https://crates.io/crates/opentelemetry-tide
-[`Tide`]: https://crates.io/crates/tide
-[`opentelemetry-stackdriver`]: https://crates.io/crates/opentelemetry-stackdriver
-[Cloud Trace]: https://cloud.google.com/trace/
-[`trillium-opentelemetry`]: https://github.com/trillium-rs/trillium-opentelemetry
-[`trillium`]: https://github.com/trillium-rs/trillium
 
 ## Supported Rust Versions
 
@@ -207,3 +174,30 @@ The meeting is open for all to join. We invite everyone to join our meeting,
 regardless of your experience level. Whether you're a seasoned OpenTelemetry
 developer, just starting your journey, or simply curious about the work we do,
 you're more than welcome to participate!
+
+## Approvers and Maintainers
+
+For GitHub groups see the [code owners](CODEOWNERS) file.
+
+### Maintainers
+
+* [Cijo Thomas](https://github.com/cijothomas)
+* [Harold Dost](https://github.com/hdost)
+* [Julian Tescher](https://github.com/jtescher)
+* [Zhongyang Wu](https://github.com/TommyCpp)
+
+### Approvers
+
+* [Lalit Kumar Bhasin](https://github.com/lalitb)
+* [Shaun Cox](https://github.com/shaun-cox)
+
+### Emeritus
+
+- [Dirkjan Ochtman](https://github.com/djc)
+- [Jan Kühle](https://github.com/frigus02)
+- [Isobel Redelmeier](https://github.com/iredelmeier)
+- [Mike Goldsmith](https://github.com/MikeGoldsmith)
+
+### Thanks to all the people who have contributed
+
+[![contributors](https://contributors-img.web.app/image?repo=open-telemetry/opentelemetry-rust)](https://github.com/open-telemetry/opentelemetry-rust/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -193,10 +193,10 @@ For GitHub groups see the [code owners](CODEOWNERS) file.
 
 ### Emeritus
 
-- [Dirkjan Ochtman](https://github.com/djc)
-- [Jan Kühle](https://github.com/frigus02)
-- [Isobel Redelmeier](https://github.com/iredelmeier)
-- [Mike Goldsmith](https://github.com/MikeGoldsmith)
+* [Dirkjan Ochtman](https://github.com/djc)
+* [Jan Kühle](https://github.com/frigus02)
+* [Isobel Redelmeier](https://github.com/iredelmeier)
+* [Mike Goldsmith](https://github.com/MikeGoldsmith)
 
 ### Thanks to all the people who have contributed
 


### PR DESCRIPTION
A lot of changes are done to make it more consistent with other languages in OTel.
Also cleaned up main readme to remove the ecosystem part, and lists the components from this repo directlyn and recommends using registry/contrib repo for other crates.

The getting started part is only for tracing, I expect to enhance that in a subsequent PR. (That code also has a bug, as it never sets anything to global provider, but still calls shutdown on global.. Fixes coming up next)