### PR TITLE
Fix errors in changelogs

### DIFF
--- a/opentelemetry-jaeger/CHANGELOG.md
+++ b/opentelemetry-jaeger/CHANGELOG.md
@@ -13,7 +13,7 @@ Please check the [README](https://crates.io/crates/opentelemetry-jaeger) for mor
 
 ### Changed
 
-- Update to tonic 0.11 and prost 0.12 (#1536)
+- Update to tonic 0.11 and prost 0.12 [#1536](https://github.com/open-telemetry/opentelemetry-rust/pull/1536)
 
 ### Removed
 

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 - Changed dependency from `opentelemetry_api` to `opentelemetry` as the latter
   is now the API crate. [#1226](https://github.com/open-telemetry/opentelemetry-rust/pull/1226)
-- Make `NoExporterBuilder` a compiling time error [#1271](https://github.com/open-telemetry/opentelemetry-rust/pull/1271)
+- Make `NoExporterBuilder` a compiling time error [#1272](https://github.com/open-telemetry/opentelemetry-rust/pull/1272)
 
 ## v0.13.0
 

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## v0.15.0
 
+### Added
+
+- Support custom channels in topic exporters  [#1335](https://github.com/open-telemetry/opentelemetry-rust/pull/1335)
+- Allow specifying OTLP Tonic metadata from env variable (#1377)
+
 ### Changed
 - Update to tonic 0.11 and prost 0.12 (#1536)
 
@@ -21,8 +26,6 @@
 - Add `build_{signal}_exporter` methods to client builders (#1187)
 - Add `grpcio` metrics exporter (#1202)
 - Allow specifying OTLP HTTP headers from env variable (#1290)
-- Support custom channels in topic exporters  [#1335](https://github.com/open-telemetry/opentelemetry-rust/pull/1335)
-- Allow specifying OTLP Tonic metadata from env variable (#1377)
 
 ### Changed
 

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -7,25 +7,25 @@
 ### Added
 
 - Support custom channels in topic exporters  [#1335](https://github.com/open-telemetry/opentelemetry-rust/pull/1335)
-- Allow specifying OTLP Tonic metadata from env variable (#1377)
+- Allow specifying OTLP Tonic metadata from env variable [#1377](https://github.com/open-telemetry/opentelemetry-rust/pull/1377)
 
 ### Changed
-- Update to tonic 0.11 and prost 0.12 (#1536)
+- Update to tonic 0.11 and prost 0.12 [#1536](https://github.com/open-telemetry/opentelemetry-rust/pull/1536)
 
 ### Fixed
 - Fix `tonic()` to the use correct port. [#1556](https://github.com/open-telemetry/opentelemetry-rust/pull/1556)
 
 ### Removed
 - **Breaking** Remove support for surf HTTP client [#1537](https://github.com/open-telemetry/opentelemetry-rust/pull/1537)
-- **Breaking** Remove support for grpcio transport (#1534)
+- **Breaking** Remove support for grpcio transport [#1534](https://github.com/open-telemetry/opentelemetry-rust/pull/1534)
 
 ## v0.14.0
 
 ### Added
 
-- Add `build_{signal}_exporter` methods to client builders (#1187)
-- Add `grpcio` metrics exporter (#1202)
-- Allow specifying OTLP HTTP headers from env variable (#1290)
+- Add `build_{signal}_exporter` methods to client builders [#1187](https://github.com/open-telemetry/opentelemetry-rust/pull/1187)
+- Add `grpcio` metrics exporter [#1202](https://github.com/open-telemetry/opentelemetry-rust/pull/1202)
+- Allow specifying OTLP HTTP headers from env variable [#1290](https://github.com/open-telemetry/opentelemetry-rust/pull/1290)
 
 ### Changed
 

--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- Fix UCUM annotation escaping by ignoring unknown instrument units and annotations (#1348)
+- Fix UCUM annotation escaping by ignoring unknown instrument units and annotations [#1348](https://github.com/open-telemetry/opentelemetry-rust/pull/1348)
 
 ## v0.14.0
 

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Added
 
 - Add `schemars::JsonSchema` trait support with `with-schemars` feature (#1419)
-- Update protobuf definitions to v1.1.0 (#1154)
+- Update protobuf definitions to v1.1.0 [#1482](https://github.com/open-telemetry/opentelemetry-rust/pull/1482)
 
 ## v0.4.0
 

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -6,21 +6,21 @@
 
 ### Changed
 
-- Update to tonic 0.11 and prost 0.12 (#1536)
-- **Breaking** Remove support for grpcio transport (#1534)
+- Update to tonic 0.11 and prost 0.12 [#1536](https://github.com/open-telemetry/opentelemetry-rust/pull/1536)
+- **Breaking** Remove support for grpcio transport [#1534](https://github.com/open-telemetry/opentelemetry-rust/pull/1534)
 
 ### Added
 
-- Add `schemars::JsonSchema` trait support with `with-schemars` feature (#1419)
+- Add `schemars::JsonSchema` trait support with `with-schemars` feature [#1419](https://github.com/open-telemetry/opentelemetry-rust/pull/1419)
 - Update protobuf definitions to v1.1.0 [#1482](https://github.com/open-telemetry/opentelemetry-rust/pull/1482)
 
 ## v0.4.0
 
 ### Added
 
-- Implement tonic metrics proto transformations (#1184)
+- Implement tonic metrics proto transformations [#1184](https://github.com/open-telemetry/opentelemetry-rust/pull/1184)
 - Move proto for zPage to tonic [#1214](https://github.com/open-telemetry/opentelemetry-rust/pull/1214)
-- Support exponential histograms (#1267)
+- Support exponential histograms [#1267](https://github.com/open-telemetry/opentelemetry-rust/pull/1267)
 
 ### Changed
 
@@ -29,11 +29,11 @@
 
 ### Fixed
 
-- Rename `traces` feature to the more standard `trace` (#1183)
+- Rename `traces` feature to the more standard `trace` [#1183](https://github.com/open-telemetry/opentelemetry-rust/pull/1183)
 
 ### Changed
 
-- Switch to `prost` for `grpcio` protos. (#1202)
+- Switch to `prost` for `grpcio` protos. [#1202](https://github.com/open-telemetry/opentelemetry-rust/pull/1202)
   The `gen-protoc` feature is accordingly renamed to `gen-grpcio`.
 
 ## v0.3.0

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -65,6 +65,8 @@ Performance Improvement : Creating Spans and LogRecords are now faster, by avoid
     when calling `Counter::add()` and `UpDownCounter::add()` with an empty set of attributes
     (e.g. `counter.Add(5, &[])`)
 
+- **Breaking** Renamed `MeterProvider` and `Meter` to `SdkMeterProvider` and `SdkMeter` respectively to avoid name collision with public API types. [#1328](https://github.com/open-telemetry/opentelemetry-rust/pull/1328)
+
 ### Fixed
 
 - [#1481](https://github.com/open-telemetry/opentelemetry-rust/pull/1481) Fix error message caused by race condition when using PeriodicReader
@@ -95,7 +97,6 @@ Performance Improvement : Creating Spans and LogRecords are now faster, by avoid
 
 ### Changed
 
-- Renamed `MeterProvider` and `Meter` to `SdkMeterProvider` and `SdkMeter` respectively to avoid name collision with public API types. [#1328](https://github.com/open-telemetry/opentelemetry-rust/pull/1328)
 - Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Default Resource (the one used when no other Resource is explicitly provided) now includes `TelemetryResourceDetector`,
   populating "telemetry.sdk.*" attributes.

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -100,7 +100,7 @@ Performance Improvement : Creating Spans and LogRecords are now faster, by avoid
 - Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Default Resource (the one used when no other Resource is explicitly provided) now includes `TelemetryResourceDetector`,
   populating "telemetry.sdk.*" attributes.
-  [#1066](https://github.com/open-telemetry/opentelemetry-rust/pull/1193).
+  [#1194](https://github.com/open-telemetry/opentelemetry-rust/pull/1194).
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 - Add unit/doc tests for MeterProvider #1220
 - Changed dependency from `opentelemetry_api` to `opentelemetry` as the latter
@@ -146,7 +146,7 @@ Performance Improvement : Creating Spans and LogRecords are now faster, by avoid
 
 ### Fixed
 
-- Fix metric instrument name validation to include `_` #1030
+- Fix metric instrument name validation to include `_` [#1274](https://github.com/open-telemetry/opentelemetry-rust/pull/1274)
 
 ## v0.20.0
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -56,12 +56,12 @@ Performance Improvement : Creating Spans and LogRecords are now faster, by avoid
 | OTEL_BSP_SCHEDULE_DELAY_MILLIS  | OTEL_BSP_SCHEDULE_DELAY   |
 | OTEL_BSP_EXPORT_TIMEOUT_MILLIS  | OTEL_BSP_EXPORT_TIMEOUT   |
 
-- **Breaking** [1455](https://github.com/open-telemetry/opentelemetry-rust/pull/1455) Make the LoggerProvider Owned
+- **Breaking** [#1455](https://github.com/open-telemetry/opentelemetry-rust/pull/1455) Make the LoggerProvider Owned
   - `Logger` now takes an Owned Logger instead of a `Weak<LoggerProviderInner>`
   - `LoggerProviderInner` is no longer `pub (crate)`
   - `Logger.provider()` now returns `&LoggerProvider` instead of an `Option<LoggerProvider>`
 
-- [1519](https://github.com/open-telemetry/opentelemetry-rust/pull/1519) Performance improvements
+- [#1519](https://github.com/open-telemetry/opentelemetry-rust/pull/1519) Performance improvements
     when calling `Counter::add()` and `UpDownCounter::add()` with an empty set of attributes
     (e.g. `counter.Add(5, &[])`)
 
@@ -75,25 +75,25 @@ Performance Improvement : Creating Spans and LogRecords are now faster, by avoid
 
 ### Fixed
 
-- Fix delta aggregation metric reuse. (#1434)
-- Fix `max_scale` validation of exponential histogram configuration. (#1452)
+- Fix delta aggregation metric reuse. [#1434](https://github.com/open-telemetry/opentelemetry-rust/pull/1434)
+- Fix `max_scale` validation of exponential histogram configuration. [#1452](https://github.com/open-telemetry/opentelemetry-rust/pull/1452)
 
 ## v0.21.1
 
 ### Fixed
 
-- Fix metric export corruption if gauges have not received a last value. (#1363)
-- Return consistent `Meter` for a given scope from `MeterProvider`. (#1351)
+- Fix metric export corruption if gauges have not received a last value. [#1363](https://github.com/open-telemetry/opentelemetry-rust/pull/1363)
+- Return consistent `Meter` for a given scope from `MeterProvider`. [#1351](https://github.com/open-telemetry/opentelemetry-rust/pull/1351)
 
 ## v0.21.0
 
 ### Added
 
-- Log warning if two instruments have the same name with different (#1266)
+- Log warning if two instruments have the same name with different [#1266](https://github.com/open-telemetry/opentelemetry-rust/pull/1266)
   casing
-- Log warning if view is created with empty criteria (#1266)
-- Add exponential histogram support (#1267)
-- Add `opentelemetry::sdk::logs::config()` for parity with `opentelemetry::sdk::trace::config()` (#1197)
+- Log warning if view is created with empty criteria [#1266](https://github.com/open-telemetry/opentelemetry-rust/pull/1266)
+- Add exponential histogram support [#1267](https://github.com/open-telemetry/opentelemetry-rust/pull/1267)
+- Add `opentelemetry::sdk::logs::config()` for parity with `opentelemetry::sdk::trace::config()` [#1197](https://github.com/open-telemetry/opentelemetry-rust/pull/1197)
 
 ### Changed
 
@@ -102,19 +102,19 @@ Performance Improvement : Creating Spans and LogRecords are now faster, by avoid
   populating "telemetry.sdk.*" attributes.
   [#1194](https://github.com/open-telemetry/opentelemetry-rust/pull/1194).
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
-- Add unit/doc tests for MeterProvider #1220
+- Add unit/doc tests for MeterProvider [#1220](https://github.com/open-telemetry/opentelemetry-rust/pull/1220)
 - Changed dependency from `opentelemetry_api` to `opentelemetry` as the latter
   is now the API crate. [#1226](https://github.com/open-telemetry/opentelemetry-rust/pull/1226)
 - Add in memory span exporter [#1216](https://github.com/open-telemetry/opentelemetry-rust/pull/1216)
 - Add in memory log exporter [#1231](https://github.com/open-telemetry/opentelemetry-rust/pull/1231)
 - Add `Sync` bound to the `SpanExporter` and `LogExporter` traits [#1240](https://github.com/open-telemetry/opentelemetry-rust/pull/1240)
-- Move `MetricsProducer` config to builders to match other config (#1266)
-- Return error earlier if readers are shut down (#1266)
-- Add `/` to valid characters for instrument names (#1269)
-- Increase instrument name maximum length from 63 to 255 (#1269)
+- Move `MetricsProducer` config to builders to match other config [#1266](https://github.com/open-telemetry/opentelemetry-rust/pull/1266)
+- Return error earlier if readers are shut down [#1266](https://github.com/open-telemetry/opentelemetry-rust/pull/1266)
+- Add `/` to valid characters for instrument names [#1269](https://github.com/open-telemetry/opentelemetry-rust/pull/1269)
+- Increase instrument name maximum length from 63 to 255 [#1269](https://github.com/open-telemetry/opentelemetry-rust/pull/1269)
 - Updated crate documentation and examples.
   [#1256](https://github.com/open-telemetry/opentelemetry-rust/issues/1256)
-- Replace regex with glob (#1301)
+- Replace regex with glob [#1301](https://github.com/open-telemetry/opentelemetry-rust/pull/1301)
 - **Breaking**
   [#1293](https://github.com/open-telemetry/opentelemetry-rust/issues/1293)
   makes few breaking changes with respect to how Span attributes are stored to

--- a/opentelemetry-semantic-conventions/CHANGELOG.md
+++ b/opentelemetry-semantic-conventions/CHANGELOG.md
@@ -6,14 +6,13 @@
 
 ### Changed
 
-* **Breaking** Add generated modules that output const &str for tracing compatibility
+- **Breaking** Replaced Key constants with &'static str for tracing compatibility
   [#1334](https://github.com/open-telemetry/opentelemetry-rust/pull/1334)
 
 ## v0.13.0
 
 ### Changed
 
-- Replaced Key constants with &'static str [#1320]
 - Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
 

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -20,7 +20,7 @@ gains, and avoids `IndexMap` dependency. This affects `body` and `attributes` of
 [#1353](https://github.com/open-telemetry/opentelemetry-rust/pull/1353)
 - Add `TextMapCompositePropagator` [#1373](https://github.com/open-telemetry/opentelemetry-rust/pull/1373)
 - Turned off events for `NoopLogger` to save on operations
-  [1455](https://github.com/open-telemetry/opentelemetry-rust/pull/1455)
+  [#1455](https://github.com/open-telemetry/opentelemetry-rust/pull/1455)
 
 ### Removed
 
@@ -29,7 +29,7 @@ gains, and avoids `IndexMap` dependency. This affects `body` and `attributes` of
 [#1353](https://github.com/open-telemetry/opentelemetry-rust/pull/1353)
 - Remove API for Creating Histograms with signed integers. [#1371](https://github.com/open-telemetry/opentelemetry-rust/pull/1371)
 - Remove `global::shutdown_meter_provider`, use `SdkMeterProvider::shutdown`
-  directly instead (#1412).
+  directly instead [#1412](https://github.com/open-telemetry/opentelemetry-rust/pull/1412).
 
 ## [v0.21.0](https://github.com/open-telemetry/opentelemetry-rust/compare/v0.20.0...v0.21.0)
 
@@ -39,7 +39,7 @@ This release should been seen as 1.0-rc4 following 1.0-rc3 in v0.20.0. Refer to 
 
 - Bump MSRV to 1.65 [#1318](https://github.com/open-telemetry/opentelemetry-rust/pull/1318)
 - Bump MSRV to 1.64 [#1203](https://github.com/open-telemetry/opentelemetry-rust/pull/1203)
-- `opentelemetry` crate now only carries the API types #1186. Use the `opentelemetry_sdk` crate for the SDK types.
+- `opentelemetry` crate now only carries the API types [#1186](https://github.com/open-telemetry/opentelemetry-rust/issues/1186). Use the `opentelemetry_sdk` crate for the SDK types.
 - `trace::noop::NoopSpan` no longer implements `Default` and instead exposes
   a `const DEFAULT` value. [#1270](https://github.com/open-telemetry/opentelemetry-rust/pull/1270)
 - Updated crate documentation and examples.


### PR DESCRIPTION
## Changes

This fixes some errors in changelogs for recent releases. Four changelog entries from the most recent releases were incorrectly listed under a prior release, or duplicated under a prior release. This PR moves and combines those. I also found and fixed some instances where the wrong PR number was referenced for a change, and added Markdown links to PR and issue references. These different changes are split across three commits.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
