### PR TITLE
Update semantic convention to v1.24.0

### DIFF
--- a/opentelemetry-semantic-conventions/CHANGELOG.md
+++ b/opentelemetry-semantic-conventions/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+### Changed
+
+- Update to v1.24.0 spec 
+  [#1596](https://github.com/open-telemetry/opentelemetry-rust/pull/1596)
+
 ## v0.14.0
 
 ### Changed

--- a/opentelemetry-semantic-conventions/CHANGELOG.md
+++ b/opentelemetry-semantic-conventions/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Update to v1.24.0 spec 
+- Update to [v1.24.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.24.0) of the semantic conventions.
   [#1596](https://github.com/open-telemetry/opentelemetry-rust/pull/1596)
 
 ## v0.14.0

--- a/opentelemetry-semantic-conventions/scripts/generate-consts-from-spec.sh
+++ b/opentelemetry-semantic-conventions/scripts/generate-consts-from-spec.sh
@@ -5,8 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CRATE_DIR="${SCRIPT_DIR}/../"
 
 # freeze the spec version and generator version to make generation reproducible
-SPEC_VERSION=1.21.0
-SEMCOVGEN_VERSION=0.19.0
+SPEC_VERSION=1.24.0
+SEMCOVGEN_VERSION=0.23.0
 
 cd "$CRATE_DIR"
 

--- a/opentelemetry-semantic-conventions/src/lib.rs
+++ b/opentelemetry-semantic-conventions/src/lib.rs
@@ -20,4 +20,4 @@ pub mod trace;
 
 /// The schema URL that matches the version of the semantic conventions that
 /// this crate defines.
-pub const SCHEMA_URL: &str = "https://opentelemetry.io/schemas/1.21.0";
+pub const SCHEMA_URL: &str = "https://opentelemetry.io/schemas/1.24.0";

--- a/opentelemetry-semantic-conventions/src/resource.rs
+++ b/opentelemetry-semantic-conventions/src/resource.rs
@@ -26,49 +26,6 @@
 //!     .build();
 //! ```
 
-/// Array of brand name and version separated by a space.
-///
-/// This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.brands`).
-///
-/// # Examples
-///
-/// - ` Not A;Brand 99`
-/// - `Chromium 99`
-/// - `Chrome 99`
-pub const BROWSER_BRANDS: &str = "browser.brands";
-
-/// The platform on which the browser is running.
-///
-/// This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.platform`). If unavailable, the legacy `navigator.platform` API SHOULD NOT be used instead and this attribute SHOULD be left unset in order for the values to be consistent.
-/// The list of possible values is defined in the [W3C User-Agent Client Hints specification](https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform). Note that some (but not all) of these values can overlap with values in the [`os.type` and `os.name` attributes](./os.md). However, for consistency, the values in the `browser.platform` attribute should capture the exact value that the user agent provides.
-///
-/// # Examples
-///
-/// - `Windows`
-/// - `macOS`
-/// - `Android`
-pub const BROWSER_PLATFORM: &str = "browser.platform";
-
-/// A boolean that is true if the browser is running on a mobile device.
-///
-/// This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.mobile`). If unavailable, this attribute SHOULD be left unset.
-pub const BROWSER_MOBILE: &str = "browser.mobile";
-
-/// Preferred language of the user using the browser.
-///
-/// This value is intended to be taken from the Navigator API `navigator.language`.
-///
-/// # Examples
-///
-/// - `en`
-/// - `en-US`
-/// - `fr`
-/// - `fr-FR`
-pub const BROWSER_LANGUAGE: &str = "browser.language";
-
-/// Name of the cloud provider.
-pub const CLOUD_PROVIDER: &str = "cloud.provider";
-
 /// The cloud account ID the resource is assigned to.
 ///
 /// # Examples
@@ -76,43 +33,6 @@ pub const CLOUD_PROVIDER: &str = "cloud.provider";
 /// - `111111111111`
 /// - `opentelemetry`
 pub const CLOUD_ACCOUNT_ID: &str = "cloud.account.id";
-
-/// The geographical region the resource is running.
-///
-/// Refer to your provider&#39;s docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), [Google Cloud regions](https://cloud.google.com/about/locations), or [Tencent Cloud regions](https://www.tencentcloud.com/document/product/213/6091).
-///
-/// # Examples
-///
-/// - `us-central1`
-/// - `us-east-1`
-pub const CLOUD_REGION: &str = "cloud.region";
-
-/// Cloud provider-specific native identifier of the monitored cloud resource (e.g. an [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) on AWS, a [fully qualified resource ID](https://learn.microsoft.com/en-us/rest/api/resources/resources/get-by-id) on Azure, a [full resource name](https://cloud.google.com/apis/design/resource_names#full_resource_name) on GCP).
-///
-/// On some cloud providers, it may not be possible to determine the full ID at startup,
-/// so it may be necessary to set `cloud.resource_id` as a span attribute instead.
-///
-/// The exact value to use for `cloud.resource_id` depends on the cloud provider.
-/// The following well-known definitions MUST be used if you set this attribute and they apply:
-///
-/// * **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
-///   Take care not to use the &#34;invoked ARN&#34; directly but replace any
-///   [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html)
-///   with the resolved function version, as the same runtime instance may be invokable with
-///   multiple different aliases.
-/// * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names)
-/// * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id) of the invoked function,
-///   *not* the function app, having the form
-///   `/subscriptions/&lt;SUBSCIPTION_GUID&gt;/resourceGroups/&lt;RG&gt;/providers/Microsoft.Web/sites/&lt;FUNCAPP&gt;/functions/&lt;FUNC&gt;`.
-///   This means that a span attribute MUST be used, as an Azure function app can host multiple functions that would usually share
-///   a TracerProvider.
-///
-/// # Examples
-///
-/// - `arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function`
-/// - `//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID`
-/// - `/subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>`
-pub const CLOUD_RESOURCE_ID: &str = "cloud.resource_id";
 
 /// Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
 ///
@@ -128,12 +48,622 @@ pub const CLOUD_AVAILABILITY_ZONE: &str = "cloud.availability_zone";
 /// The prefix of the service SHOULD match the one specified in `cloud.provider`.
 pub const CLOUD_PLATFORM: &str = "cloud.platform";
 
-/// The Amazon Resource Name (ARN) of an [ECS container instance](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html).
+/// Name of the cloud provider.
+pub const CLOUD_PROVIDER: &str = "cloud.provider";
+
+/// The geographical region the resource is running.
+///
+/// Refer to your provider&#39;s docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/global-infrastructure/geographies/), [Google Cloud regions](https://cloud.google.com/about/locations), or [Tencent Cloud regions](https://www.tencentcloud.com/document/product/213/6091).
 ///
 /// # Examples
 ///
-/// - `arn:aws:ecs:us-west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9`
-pub const AWS_ECS_CONTAINER_ARN: &str = "aws.ecs.container.arn";
+/// - `us-central1`
+/// - `us-east-1`
+pub const CLOUD_REGION: &str = "cloud.region";
+
+/// Cloud provider-specific native identifier of the monitored cloud resource (e.g. an [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) on AWS, a [fully qualified resource ID](https://learn.microsoft.com/rest/api/resources/resources/get-by-id) on Azure, a [full resource name](https://cloud.google.com/apis/design/resource_names#full_resource_name) on GCP).
+///
+/// On some cloud providers, it may not be possible to determine the full ID at startup,
+/// so it may be necessary to set `cloud.resource_id` as a span attribute instead.
+///
+/// The exact value to use for `cloud.resource_id` depends on the cloud provider.
+/// The following well-known definitions MUST be used if you set this attribute and they apply:
+///
+/// * **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
+///   Take care not to use the &#34;invoked ARN&#34; directly but replace any
+///   [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html)
+///   with the resolved function version, as the same runtime instance may be invokable with
+///   multiple different aliases.
+/// * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names)
+/// * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/rest/api/resources/resources/get-by-id) of the invoked function,
+///   *not* the function app, having the form
+///   `/subscriptions/&lt;SUBSCIPTION_GUID&gt;/resourceGroups/&lt;RG&gt;/providers/Microsoft.Web/sites/&lt;FUNCAPP&gt;/functions/&lt;FUNC&gt;`.
+///   This means that a span attribute MUST be used, as an Azure function app can host multiple functions that would usually share
+///   a TracerProvider.
+///
+/// # Examples
+///
+/// - `arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function`
+/// - `//run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID`
+/// - `/subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>`
+pub const CLOUD_RESOURCE_ID: &str = "cloud.resource_id";
+
+/// The command used to run the container (i.e. the command name).
+///
+/// If using embedded credentials or sensitive data, it is recommended to remove them to prevent potential leakage.
+///
+/// # Examples
+///
+/// - `otelcontribcol`
+pub const CONTAINER_COMMAND: &str = "container.command";
+
+/// All the command arguments (including the command/executable itself) run by the container.
+///
+/// # Examples
+///
+/// - `otelcontribcol, --config, config.yaml`
+pub const CONTAINER_COMMAND_ARGS: &str = "container.command_args";
+
+/// The full command run by the container as a single string representing the full command.
+///
+/// # Examples
+///
+/// - `otelcontribcol --config config.yaml`
+pub const CONTAINER_COMMAND_LINE: &str = "container.command_line";
+
+/// Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated.
+///
+/// # Examples
+///
+/// - `a3bf90e006b2`
+pub const CONTAINER_ID: &str = "container.id";
+
+/// Runtime specific image identifier. Usually a hash algorithm followed by a UUID.
+///
+/// Docker defines a sha256 of the image id; `container.image.id` corresponds to the `Image` field from the Docker container inspect [API](https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerInspect) endpoint.
+/// K8s defines a link to the container registry repository with digest `&#34;imageID&#34;: &#34;registry.azurecr.io /namespace/service/dockerfile@sha256:bdeabd40c3a8a492eaf9e8e44d0ebbb84bac7ee25ac0cf8a7159d25f62555625&#34;`.
+/// The ID is assinged by the container runtime and can vary in different environments. Consider using `oci.manifest.digest` if it is important to identify the same image in different environments/runtimes.
+///
+/// # Examples
+///
+/// - `sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f`
+pub const CONTAINER_IMAGE_ID: &str = "container.image.id";
+
+/// Name of the image the container was built on.
+///
+/// # Examples
+///
+/// - `gcr.io/opentelemetry/operator`
+pub const CONTAINER_IMAGE_NAME: &str = "container.image.name";
+
+/// Repo digests of the container image as provided by the container runtime.
+///
+/// [Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect) and [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238) report those under the `RepoDigests` field.
+///
+/// # Examples
+///
+/// - `example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb`
+/// - `internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578`
+pub const CONTAINER_IMAGE_REPO_DIGESTS: &str = "container.image.repo_digests";
+
+/// Container image tags. An example can be found in [Docker Image Inspect](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect). Should be only the `&lt;tag&gt;` section of the full name for example from `registry.example.com/my-org/my-image:&lt;tag&gt;`.
+///
+/// # Examples
+///
+/// - `v1.27.1`
+/// - `3.5.7-0`
+pub const CONTAINER_IMAGE_TAGS: &str = "container.image.tags";
+
+/// Container name used by container runtime.
+///
+/// # Examples
+///
+/// - `opentelemetry-autoconf`
+pub const CONTAINER_NAME: &str = "container.name";
+
+/// The container runtime managing this container.
+///
+/// # Examples
+///
+/// - `docker`
+/// - `containerd`
+/// - `rkt`
+pub const CONTAINER_RUNTIME: &str = "container.runtime";
+
+/// A unique identifier representing the device.
+///
+/// The device identifier MUST only be defined using the values outlined below. This value is not an advertising identifier and MUST NOT be used as such. On iOS (Swift or Objective-C), this value MUST be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). On Android (Java or Kotlin), this value MUST be equal to the Firebase Installation ID or a globally unique UUID which is persisted across sessions in your application. More information can be found [here](https://developer.android.com/training/articles/user-data-ids) on best practices and exact implementation details. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
+///
+/// # Examples
+///
+/// - `2ab2916d-a51f-4ac8-80ee-45ac31a28092`
+pub const DEVICE_ID: &str = "device.id";
+
+/// The name of the device manufacturer.
+///
+/// The Android OS provides this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER). iOS apps SHOULD hardcode the value `Apple`.
+///
+/// # Examples
+///
+/// - `Apple`
+/// - `Samsung`
+pub const DEVICE_MANUFACTURER: &str = "device.manufacturer";
+
+/// The model identifier for the device.
+///
+/// It&#39;s recommended this value represents a machine-readable version of the model identifier rather than the market or consumer-friendly name of the device.
+///
+/// # Examples
+///
+/// - `iPhone3,4`
+/// - `SM-G920F`
+pub const DEVICE_MODEL_IDENTIFIER: &str = "device.model.identifier";
+
+/// The marketing name for the device model.
+///
+/// It&#39;s recommended this value represents a human-readable version of the device model rather than a machine-readable alternative.
+///
+/// # Examples
+///
+/// - `iPhone 6s Plus`
+/// - `Samsung Galaxy S6`
+pub const DEVICE_MODEL_NAME: &str = "device.model.name";
+
+/// The CPU architecture the host system is running on.
+pub const HOST_ARCH: &str = "host.arch";
+
+/// The amount of level 2 memory cache available to the processor (in Bytes).
+///
+/// # Examples
+///
+/// - `12288000`
+pub const HOST_CPU_CACHE_L2_SIZE: &str = "host.cpu.cache.l2.size";
+
+/// Family or generation of the CPU.
+///
+/// # Examples
+///
+/// - `6`
+/// - `PA-RISC 1.1e`
+pub const HOST_CPU_FAMILY: &str = "host.cpu.family";
+
+/// Model identifier. It provides more granular information about the CPU, distinguishing it from other CPUs within the same family.
+///
+/// # Examples
+///
+/// - `6`
+/// - `9000/778/B180L`
+pub const HOST_CPU_MODEL_ID: &str = "host.cpu.model.id";
+
+/// Model designation of the processor.
+///
+/// # Examples
+///
+/// - `11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz`
+pub const HOST_CPU_MODEL_NAME: &str = "host.cpu.model.name";
+
+/// Stepping or core revisions.
+///
+/// # Examples
+///
+/// - `1`
+pub const HOST_CPU_STEPPING: &str = "host.cpu.stepping";
+
+/// Processor manufacturer identifier. A maximum 12-character string.
+///
+/// [CPUID](https://wiki.osdev.org/CPUID) command returns the vendor ID string in EBX, EDX and ECX registers. Writing these to memory in this order results in a 12-character string.
+///
+/// # Examples
+///
+/// - `GenuineIntel`
+pub const HOST_CPU_VENDOR_ID: &str = "host.cpu.vendor.id";
+
+/// Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system.
+///
+/// # Examples
+///
+/// - `fdbf79e8af94cb7f9e8df36789187052`
+pub const HOST_ID: &str = "host.id";
+
+/// VM image ID or host OS image ID. For Cloud, this value is from the provider.
+///
+/// # Examples
+///
+/// - `ami-07b06b442921831e5`
+pub const HOST_IMAGE_ID: &str = "host.image.id";
+
+/// Name of the VM image or OS install the host was instantiated from.
+///
+/// # Examples
+///
+/// - `infra-ami-eks-worker-node-7d4ec78312`
+/// - `CentOS-8-x86_64-1905`
+pub const HOST_IMAGE_NAME: &str = "host.image.name";
+
+/// The version string of the VM image or host OS as defined in [Version Attributes](/docs/resource/README.md#version-attributes).
+///
+/// # Examples
+///
+/// - `0.1`
+pub const HOST_IMAGE_VERSION: &str = "host.image.version";
+
+/// Available IP addresses of the host, excluding loopback interfaces.
+///
+/// IPv4 Addresses MUST be specified in dotted-quad notation. IPv6 addresses MUST be specified in the [RFC 5952](https://www.rfc-editor.org/rfc/rfc5952.html) format.
+///
+/// # Examples
+///
+/// - `192.168.1.140`
+/// - `fe80::abc2:4a28:737a:609e`
+pub const HOST_IP: &str = "host.ip";
+
+/// Available MAC addresses of the host, excluding loopback interfaces.
+///
+/// MAC Addresses MUST be represented in [IEEE RA hexadecimal form](https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf): as hyphen-separated octets in uppercase hexadecimal form from most to least significant.
+///
+/// # Examples
+///
+/// - `AC-DE-48-23-45-67`
+/// - `AC-DE-48-23-45-67-01-9F`
+pub const HOST_MAC: &str = "host.mac";
+
+/// Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user.
+///
+/// # Examples
+///
+/// - `opentelemetry-test`
+pub const HOST_NAME: &str = "host.name";
+
+/// Type of host. For Cloud, this must be the machine type.
+///
+/// # Examples
+///
+/// - `n1-standard-1`
+pub const HOST_TYPE: &str = "host.type";
+
+/// The name of the cluster.
+///
+/// # Examples
+///
+/// - `opentelemetry-cluster`
+pub const K8S_CLUSTER_NAME: &str = "k8s.cluster.name";
+
+/// A pseudo-ID for the cluster, set to the UID of the `kube-system` namespace.
+///
+/// K8s doesn&#39;t have support for obtaining a cluster ID. If this is ever
+/// added, we will recommend collecting the `k8s.cluster.uid` through the
+/// official APIs. In the meantime, we are able to use the `uid` of the
+/// `kube-system` namespace as a proxy for cluster ID. Read on for the
+/// rationale.
+///
+/// Every object created in a K8s cluster is assigned a distinct UID. The
+/// `kube-system` namespace is used by Kubernetes itself and will exist
+/// for the lifetime of the cluster. Using the `uid` of the `kube-system`
+/// namespace is a reasonable proxy for the K8s ClusterID as it will only
+/// change if the cluster is rebuilt. Furthermore, Kubernetes UIDs are
+/// UUIDs as standardized by
+/// [ISO/IEC 9834-8 and ITU-T X.667](https://www.itu.int/ITU-T/studygroups/com17/oid.html).
+/// Which states:
+///
+/// &gt; If generated according to one of the mechanisms defined in Rec.
+///   ITU-T X.667 | ISO/IEC 9834-8, a UUID is either guaranteed to be
+///   different from all other UUIDs generated before 3603 A.D., or is
+///   extremely likely to be different (depending on the mechanism chosen).
+///
+/// Therefore, UIDs between clusters should be extremely unlikely to
+/// conflict.
+///
+/// # Examples
+///
+/// - `218fc5a9-a5f1-4b54-aa05-46717d0ab26d`
+pub const K8S_CLUSTER_UID: &str = "k8s.cluster.uid";
+
+/// The name of the Container from Pod specification, must be unique within a Pod. Container runtime usually uses different globally unique name (`container.name`).
+///
+/// # Examples
+///
+/// - `redis`
+pub const K8S_CONTAINER_NAME: &str = "k8s.container.name";
+
+/// Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec.
+///
+/// # Examples
+///
+/// - `0`
+/// - `2`
+pub const K8S_CONTAINER_RESTART_COUNT: &str = "k8s.container.restart_count";
+
+/// The name of the CronJob.
+///
+/// # Examples
+///
+/// - `opentelemetry`
+pub const K8S_CRONJOB_NAME: &str = "k8s.cronjob.name";
+
+/// The UID of the CronJob.
+///
+/// # Examples
+///
+/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
+pub const K8S_CRONJOB_UID: &str = "k8s.cronjob.uid";
+
+/// The name of the DaemonSet.
+///
+/// # Examples
+///
+/// - `opentelemetry`
+pub const K8S_DAEMONSET_NAME: &str = "k8s.daemonset.name";
+
+/// The UID of the DaemonSet.
+///
+/// # Examples
+///
+/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
+pub const K8S_DAEMONSET_UID: &str = "k8s.daemonset.uid";
+
+/// The name of the Deployment.
+///
+/// # Examples
+///
+/// - `opentelemetry`
+pub const K8S_DEPLOYMENT_NAME: &str = "k8s.deployment.name";
+
+/// The UID of the Deployment.
+///
+/// # Examples
+///
+/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
+pub const K8S_DEPLOYMENT_UID: &str = "k8s.deployment.uid";
+
+/// The name of the Job.
+///
+/// # Examples
+///
+/// - `opentelemetry`
+pub const K8S_JOB_NAME: &str = "k8s.job.name";
+
+/// The UID of the Job.
+///
+/// # Examples
+///
+/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
+pub const K8S_JOB_UID: &str = "k8s.job.uid";
+
+/// The name of the namespace that the pod is running in.
+///
+/// # Examples
+///
+/// - `default`
+pub const K8S_NAMESPACE_NAME: &str = "k8s.namespace.name";
+
+/// The name of the Node.
+///
+/// # Examples
+///
+/// - `node-1`
+pub const K8S_NODE_NAME: &str = "k8s.node.name";
+
+/// The UID of the Node.
+///
+/// # Examples
+///
+/// - `1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2`
+pub const K8S_NODE_UID: &str = "k8s.node.uid";
+
+/// The name of the Pod.
+///
+/// # Examples
+///
+/// - `opentelemetry-pod-autoconf`
+pub const K8S_POD_NAME: &str = "k8s.pod.name";
+
+/// The UID of the Pod.
+///
+/// # Examples
+///
+/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
+pub const K8S_POD_UID: &str = "k8s.pod.uid";
+
+/// The name of the ReplicaSet.
+///
+/// # Examples
+///
+/// - `opentelemetry`
+pub const K8S_REPLICASET_NAME: &str = "k8s.replicaset.name";
+
+/// The UID of the ReplicaSet.
+///
+/// # Examples
+///
+/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
+pub const K8S_REPLICASET_UID: &str = "k8s.replicaset.uid";
+
+/// The name of the StatefulSet.
+///
+/// # Examples
+///
+/// - `opentelemetry`
+pub const K8S_STATEFULSET_NAME: &str = "k8s.statefulset.name";
+
+/// The UID of the StatefulSet.
+///
+/// # Examples
+///
+/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
+pub const K8S_STATEFULSET_UID: &str = "k8s.statefulset.uid";
+
+/// The digest of the OCI image manifest. For container images specifically is the digest by which the container image is known.
+///
+/// Follows [OCI Image Manifest Specification](https://github.com/opencontainers/image-spec/blob/main/manifest.md), and specifically the [Digest property](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests).
+/// An example can be found in [Example Image Manifest](https://docs.docker.com/registry/spec/manifest-v2-2/#example-image-manifest).
+///
+/// # Examples
+///
+/// - `sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4`
+pub const OCI_MANIFEST_DIGEST: &str = "oci.manifest.digest";
+
+/// Unique identifier for a particular build or compilation of the operating system.
+///
+/// # Examples
+///
+/// - `TQ3C.230805.001.B2`
+/// - `20E247`
+/// - `22621`
+pub const OS_BUILD_ID: &str = "os.build_id";
+
+/// Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands.
+///
+/// # Examples
+///
+/// - `Microsoft Windows [Version 10.0.18363.778]`
+/// - `Ubuntu 18.04.1 LTS`
+pub const OS_DESCRIPTION: &str = "os.description";
+
+/// Human readable operating system name.
+///
+/// # Examples
+///
+/// - `iOS`
+/// - `Android`
+/// - `Ubuntu`
+pub const OS_NAME: &str = "os.name";
+
+/// The operating system type.
+pub const OS_TYPE: &str = "os.type";
+
+/// The version string of the operating system as defined in [Version Attributes](/docs/resource/README.md#version-attributes).
+///
+/// # Examples
+///
+/// - `14.2.1`
+/// - `18.04.1`
+pub const OS_VERSION: &str = "os.version";
+
+/// The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`.
+///
+/// # Examples
+///
+/// - `cmd/otelcol`
+pub const PROCESS_COMMAND: &str = "process.command";
+
+/// All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`.
+///
+/// # Examples
+///
+/// - `cmd/otecol`
+/// - `--config=config.yaml`
+pub const PROCESS_COMMAND_ARGS: &str = "process.command_args";
+
+/// The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead.
+///
+/// # Examples
+///
+/// - `C:\cmd\otecol --config="my directory\config.yaml"`
+pub const PROCESS_COMMAND_LINE: &str = "process.command_line";
+
+/// The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`.
+///
+/// # Examples
+///
+/// - `otelcol`
+pub const PROCESS_EXECUTABLE_NAME: &str = "process.executable.name";
+
+/// The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`.
+///
+/// # Examples
+///
+/// - `/usr/bin/cmd/otelcol`
+pub const PROCESS_EXECUTABLE_PATH: &str = "process.executable.path";
+
+/// The username of the user that owns the process.
+///
+/// # Examples
+///
+/// - `root`
+pub const PROCESS_OWNER: &str = "process.owner";
+
+/// Parent Process identifier (PPID).
+///
+/// # Examples
+///
+/// - `111`
+pub const PROCESS_PARENT_PID: &str = "process.parent_pid";
+
+/// Process identifier (PID).
+///
+/// # Examples
+///
+/// - `1234`
+pub const PROCESS_PID: &str = "process.pid";
+
+/// An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment.
+///
+/// # Examples
+///
+/// - `Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0`
+pub const PROCESS_RUNTIME_DESCRIPTION: &str = "process.runtime.description";
+
+/// The name of the runtime of this process. For compiled native binaries, this SHOULD be the name of the compiler.
+///
+/// # Examples
+///
+/// - `OpenJDK Runtime Environment`
+pub const PROCESS_RUNTIME_NAME: &str = "process.runtime.name";
+
+/// The version of the runtime of this process, as returned by the runtime without modification.
+///
+/// # Examples
+///
+/// - `14.0.2`
+pub const PROCESS_RUNTIME_VERSION: &str = "process.runtime.version";
+
+/// Uniquely identifies the framework API revision offered by a version (`os.version`) of the android operating system. More information can be found [here](https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels).
+///
+/// # Examples
+///
+/// - `33`
+/// - `32`
+pub const ANDROID_OS_API_LEVEL: &str = "android.os.api_level";
+
+/// Array of brand name and version separated by a space.
+///
+/// This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.brands`).
+///
+/// # Examples
+///
+/// - ` Not A;Brand 99`
+/// - `Chromium 99`
+/// - `Chrome 99`
+pub const BROWSER_BRANDS: &str = "browser.brands";
+
+/// Preferred language of the user using the browser.
+///
+/// This value is intended to be taken from the Navigator API `navigator.language`.
+///
+/// # Examples
+///
+/// - `en`
+/// - `en-US`
+/// - `fr`
+/// - `fr-FR`
+pub const BROWSER_LANGUAGE: &str = "browser.language";
+
+/// A boolean that is true if the browser is running on a mobile device.
+///
+/// This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.mobile`). If unavailable, this attribute SHOULD be left unset.
+pub const BROWSER_MOBILE: &str = "browser.mobile";
+
+/// The platform on which the browser is running.
+///
+/// This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.platform`). If unavailable, the legacy `navigator.platform` API SHOULD NOT be used instead and this attribute SHOULD be left unset in order for the values to be consistent.
+/// The list of possible values is defined in the [W3C User-Agent Client Hints specification](https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform). Note that some (but not all) of these values can overlap with values in the [`os.type` and `os.name` attributes](./os.md). However, for consistency, the values in the `browser.platform` attribute should capture the exact value that the user agent provides.
+///
+/// # Examples
+///
+/// - `Windows`
+/// - `macOS`
+/// - `Android`
+pub const BROWSER_PLATFORM: &str = "browser.platform";
 
 /// The ARN of an [ECS cluster](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html).
 ///
@@ -141,6 +671,13 @@ pub const AWS_ECS_CONTAINER_ARN: &str = "aws.ecs.container.arn";
 ///
 /// - `arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster`
 pub const AWS_ECS_CLUSTER_ARN: &str = "aws.ecs.cluster.arn";
+
+/// The Amazon Resource Name (ARN) of an [ECS container instance](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html).
+///
+/// # Examples
+///
+/// - `arn:aws:ecs:us-west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9`
+pub const AWS_ECS_CONTAINER_ARN: &str = "aws.ecs.container.arn";
 
 /// The [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html) for an ECS task.
 pub const AWS_ECS_LAUNCHTYPE: &str = "aws.ecs.launchtype";
@@ -174,6 +711,15 @@ pub const AWS_ECS_TASK_REVISION: &str = "aws.ecs.task.revision";
 /// - `arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster`
 pub const AWS_EKS_CLUSTER_ARN: &str = "aws.eks.cluster.arn";
 
+/// The Amazon Resource Name(s) (ARN) of the AWS log group(s).
+///
+/// See the [log group ARN format documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format).
+///
+/// # Examples
+///
+/// - `arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*`
+pub const AWS_LOG_GROUP_ARNS: &str = "aws.log.group.arns";
+
 /// The name(s) of the AWS log group(s) an application is writing to.
 ///
 /// Multiple log groups must be supported for cases like multi-container applications, where a single application has sidecar containers, and each write to their own log group.
@@ -184,22 +730,6 @@ pub const AWS_EKS_CLUSTER_ARN: &str = "aws.eks.cluster.arn";
 /// - `opentelemetry-service`
 pub const AWS_LOG_GROUP_NAMES: &str = "aws.log.group.names";
 
-/// The Amazon Resource Name(s) (ARN) of the AWS log group(s).
-///
-/// See the [log group ARN format documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format).
-///
-/// # Examples
-///
-/// - `arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*`
-pub const AWS_LOG_GROUP_ARNS: &str = "aws.log.group.arns";
-
-/// The name(s) of the AWS log stream(s) an application is writing to.
-///
-/// # Examples
-///
-/// - `logs/main/10838bed-421f-43ef-870a-f43feacbbb5b`
-pub const AWS_LOG_STREAM_NAMES: &str = "aws.log.stream.names";
-
 /// The ARN(s) of the AWS log stream(s).
 ///
 /// See the [log stream ARN format documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format). One log group can contain several log streams, so these ARNs necessarily identify both a log group and a log stream.
@@ -208,6 +738,13 @@ pub const AWS_LOG_STREAM_NAMES: &str = "aws.log.stream.names";
 ///
 /// - `arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:log-stream:logs/main/10838bed-421f-43ef-870a-f43feacbbb5b`
 pub const AWS_LOG_STREAM_ARNS: &str = "aws.log.stream.arns";
+
+/// The name(s) of the AWS log stream(s) an application is writing to.
+///
+/// # Examples
+///
+/// - `logs/main/10838bed-421f-43ef-870a-f43feacbbb5b`
+pub const AWS_LOG_STREAM_NAMES: &str = "aws.log.stream.names";
 
 /// The name of the Cloud Run [execution](https://cloud.google.com/run/docs/managing/job-executions) being run for the Job, as set by the [`CLOUD_RUN_EXECUTION`](https://cloud.google.com/run/docs/container-contract#jobs-env-vars) environment variable.
 ///
@@ -225,14 +762,6 @@ pub const GCP_CLOUD_RUN_JOB_EXECUTION: &str = "gcp.cloud_run.job.execution";
 /// - `1`
 pub const GCP_CLOUD_RUN_JOB_TASK_INDEX: &str = "gcp.cloud_run.job.task_index";
 
-/// The instance name of a GCE instance. This is the value provided by `host.name`, the visible name of the instance in the Cloud Console UI, and the prefix for the default hostname of the instance as defined by the [default internal DNS name](https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names).
-///
-/// # Examples
-///
-/// - `instance-1`
-/// - `my-vm-name`
-pub const GCP_GCE_INSTANCE_NAME: &str = "gcp.gce.instance.name";
-
 /// The hostname of a GCE instance. This is the full value of the default or [custom hostname](https://cloud.google.com/compute/docs/instances/custom-hostname-vm).
 ///
 /// # Examples
@@ -241,19 +770,13 @@ pub const GCP_GCE_INSTANCE_NAME: &str = "gcp.gce.instance.name";
 /// - `sample-vm.us-west1-b.c.my-project.internal`
 pub const GCP_GCE_INSTANCE_HOSTNAME: &str = "gcp.gce.instance.hostname";
 
-/// Time and date the release was created.
+/// The instance name of a GCE instance. This is the value provided by `host.name`, the visible name of the instance in the Cloud Console UI, and the prefix for the default hostname of the instance as defined by the [default internal DNS name](https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names).
 ///
 /// # Examples
 ///
-/// - `2022-10-23T18:00:42Z`
-pub const HEROKU_RELEASE_CREATION_TIMESTAMP: &str = "heroku.release.creation_timestamp";
-
-/// Commit hash for the current release.
-///
-/// # Examples
-///
-/// - `e6134959463efd8966b20e75b913cafe3f5ec`
-pub const HEROKU_RELEASE_COMMIT: &str = "heroku.release.commit";
+/// - `instance-1`
+/// - `my-vm-name`
+pub const GCP_GCE_INSTANCE_NAME: &str = "gcp.gce.instance.name";
 
 /// Unique identifier for the application.
 ///
@@ -262,78 +785,29 @@ pub const HEROKU_RELEASE_COMMIT: &str = "heroku.release.commit";
 /// - `2daa2797-e42b-4624-9322-ec3f968df4da`
 pub const HEROKU_APP_ID: &str = "heroku.app.id";
 
-/// Container name used by container runtime.
+/// Commit hash for the current release.
 ///
 /// # Examples
 ///
-/// - `opentelemetry-autoconf`
-pub const CONTAINER_NAME: &str = "container.name";
+/// - `e6134959463efd8966b20e75b913cafe3f5ec`
+pub const HEROKU_RELEASE_COMMIT: &str = "heroku.release.commit";
 
-/// Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/reference/run/#container-identification). The UUID might be abbreviated.
+/// Time and date the release was created.
 ///
 /// # Examples
 ///
-/// - `a3bf90e006b2`
-pub const CONTAINER_ID: &str = "container.id";
+/// - `2022-10-23T18:00:42Z`
+pub const HEROKU_RELEASE_CREATION_TIMESTAMP: &str = "heroku.release.creation_timestamp";
 
-/// The container runtime managing this container.
+/// Name of the [deployment environment](https://wikipedia.org/wiki/Deployment_environment) (aka deployment tier).
 ///
-/// # Examples
+/// `deployment.environment` does not affect the uniqueness constraints defined through
+/// the `service.namespace`, `service.name` and `service.instance.id` resource attributes.
+/// This implies that resources carrying the following attribute combinations MUST be
+/// considered to be identifying the same service:
 ///
-/// - `docker`
-/// - `containerd`
-/// - `rkt`
-pub const CONTAINER_RUNTIME: &str = "container.runtime";
-
-/// Name of the image the container was built on.
-///
-/// # Examples
-///
-/// - `gcr.io/opentelemetry/operator`
-pub const CONTAINER_IMAGE_NAME: &str = "container.image.name";
-
-/// Container image tag.
-///
-/// # Examples
-///
-/// - `0.1`
-pub const CONTAINER_IMAGE_TAG: &str = "container.image.tag";
-
-/// Runtime specific image identifier. Usually a hash algorithm followed by a UUID.
-///
-/// Docker defines a sha256 of the image id; `container.image.id` corresponds to the `Image` field from the Docker container inspect [API](https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerInspect) endpoint.
-/// K8s defines a link to the container registry repository with digest `&#34;imageID&#34;: &#34;registry.azurecr.io /namespace/service/dockerfile@sha256:bdeabd40c3a8a492eaf9e8e44d0ebbb84bac7ee25ac0cf8a7159d25f62555625&#34;`.
-/// OCI defines a digest of manifest.
-///
-/// # Examples
-///
-/// - `sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f`
-pub const CONTAINER_IMAGE_ID: &str = "container.image.id";
-
-/// The command used to run the container (i.e. the command name).
-///
-/// If using embedded credentials or sensitive data, it is recommended to remove them to prevent potential leakage.
-///
-/// # Examples
-///
-/// - `otelcontribcol`
-pub const CONTAINER_COMMAND: &str = "container.command";
-
-/// The full command run by the container as a single string representing the full command.
-///
-/// # Examples
-///
-/// - `otelcontribcol --config config.yaml`
-pub const CONTAINER_COMMAND_LINE: &str = "container.command_line";
-
-/// All the command arguments (including the command/executable itself) run by the container.
-///
-/// # Examples
-///
-/// - `otelcontribcol, --config, config.yaml`
-pub const CONTAINER_COMMAND_ARGS: &str = "container.command_args";
-
-/// Name of the [deployment environment](https://en.wikipedia.org/wiki/Deployment_environment) (aka deployment tier).
+/// * `service.name=frontend`, `deployment.environment=production`
+/// * `service.name=frontend`, `deployment.environment=staging`.
 ///
 /// # Examples
 ///
@@ -341,51 +815,30 @@ pub const CONTAINER_COMMAND_ARGS: &str = "container.command_args";
 /// - `production`
 pub const DEPLOYMENT_ENVIRONMENT: &str = "deployment.environment";
 
-/// A unique identifier representing the device.
+/// The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version.
 ///
-/// The device identifier MUST only be defined using the values outlined below. This value is not an advertising identifier and MUST NOT be used as such. On iOS (Swift or Objective-C), this value MUST be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). On Android (Java or Kotlin), this value MUST be equal to the Firebase Installation ID or a globally unique UUID which is persisted across sessions in your application. More information can be found [here](https://developer.android.com/training/articles/user-data-ids) on best practices and exact implementation details. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
+/// * **AWS Lambda:** Use the (full) log stream name.
 ///
 /// # Examples
 ///
-/// - `2ab2916d-a51f-4ac8-80ee-45ac31a28092`
-pub const DEVICE_ID: &str = "device.id";
+/// - `2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de`
+pub const FAAS_INSTANCE: &str = "faas.instance";
 
-/// The model identifier for the device.
+/// The amount of memory available to the serverless function converted to Bytes.
 ///
-/// It&#39;s recommended this value represents a machine readable version of the model identifier rather than the market or consumer-friendly name of the device.
-///
-/// # Examples
-///
-/// - `iPhone3,4`
-/// - `SM-G920F`
-pub const DEVICE_MODEL_IDENTIFIER: &str = "device.model.identifier";
-
-/// The marketing name for the device model.
-///
-/// It&#39;s recommended this value represents a human readable version of the device model rather than a machine readable alternative.
+/// It&#39;s recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information (which must be multiplied by 1,048,576).
 ///
 /// # Examples
 ///
-/// - `iPhone 6s Plus`
-/// - `Samsung Galaxy S6`
-pub const DEVICE_MODEL_NAME: &str = "device.model.name";
-
-/// The name of the device manufacturer.
-///
-/// The Android OS provides this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER). iOS apps SHOULD hardcode the value `Apple`.
-///
-/// # Examples
-///
-/// - `Apple`
-/// - `Samsung`
-pub const DEVICE_MANUFACTURER: &str = "device.manufacturer";
+/// - `134217728`
+pub const FAAS_MAX_MEMORY: &str = "faas.max_memory";
 
 /// The name of the single function that this runtime instance executes.
 ///
 /// This is the name of the function as configured/deployed on the FaaS
 /// platform and is usually different from the name of the callback
 /// function (which may be stored in the
-/// [`code.namespace`/`code.function`](/docs/general/general-attributes.md#source-code-attributes)
+/// [`code.namespace`/`code.function`](/docs/general/attributes.md#source-code-attributes)
 /// span attributes).
 ///
 /// For some cloud providers, the above definition is ambiguous. The following
@@ -423,347 +876,6 @@ pub const FAAS_NAME: &str = "faas.name";
 /// - `pinkfroid-00002`
 pub const FAAS_VERSION: &str = "faas.version";
 
-/// The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version.
-///
-/// * **AWS Lambda:** Use the (full) log stream name.
-///
-/// # Examples
-///
-/// - `2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de`
-pub const FAAS_INSTANCE: &str = "faas.instance";
-
-/// The amount of memory available to the serverless function converted to Bytes.
-///
-/// It&#39;s recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information (which must be multiplied by 1,048,576).
-///
-/// # Examples
-///
-/// - `134217728`
-pub const FAAS_MAX_MEMORY: &str = "faas.max_memory";
-
-/// Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system.
-///
-/// # Examples
-///
-/// - `fdbf79e8af94cb7f9e8df36789187052`
-pub const HOST_ID: &str = "host.id";
-
-/// Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user.
-///
-/// # Examples
-///
-/// - `opentelemetry-test`
-pub const HOST_NAME: &str = "host.name";
-
-/// Type of host. For Cloud, this must be the machine type.
-///
-/// # Examples
-///
-/// - `n1-standard-1`
-pub const HOST_TYPE: &str = "host.type";
-
-/// The CPU architecture the host system is running on.
-pub const HOST_ARCH: &str = "host.arch";
-
-/// Name of the VM image or OS install the host was instantiated from.
-///
-/// # Examples
-///
-/// - `infra-ami-eks-worker-node-7d4ec78312`
-/// - `CentOS-8-x86_64-1905`
-pub const HOST_IMAGE_NAME: &str = "host.image.name";
-
-/// VM image ID or host OS image ID. For Cloud, this value is from the provider.
-///
-/// # Examples
-///
-/// - `ami-07b06b442921831e5`
-pub const HOST_IMAGE_ID: &str = "host.image.id";
-
-/// The version string of the VM image or host OS as defined in [Version Attributes](README.md#version-attributes).
-///
-/// # Examples
-///
-/// - `0.1`
-pub const HOST_IMAGE_VERSION: &str = "host.image.version";
-
-/// The name of the cluster.
-///
-/// # Examples
-///
-/// - `opentelemetry-cluster`
-pub const K8S_CLUSTER_NAME: &str = "k8s.cluster.name";
-
-/// A pseudo-ID for the cluster, set to the UID of the `kube-system` namespace.
-///
-/// K8s does not have support for obtaining a cluster ID. If this is ever
-/// added, we will recommend collecting the `k8s.cluster.uid` through the
-/// official APIs. In the meantime, we are able to use the `uid` of the
-/// `kube-system` namespace as a proxy for cluster ID. Read on for the
-/// rationale.
-///
-/// Every object created in a K8s cluster is assigned a distinct UID. The
-/// `kube-system` namespace is used by Kubernetes itself and will exist
-/// for the lifetime of the cluster. Using the `uid` of the `kube-system`
-/// namespace is a reasonable proxy for the K8s ClusterID as it will only
-/// change if the cluster is rebuilt. Furthermore, Kubernetes UIDs are
-/// UUIDs as standardized by
-/// [ISO/IEC 9834-8 and ITU-T X.667](https://www.itu.int/ITU-T/studygroups/com17/oid.html).
-/// Which states:
-///
-/// &gt; If generated according to one of the mechanisms defined in Rec.
-///   ITU-T X.667 | ISO/IEC 9834-8, a UUID is either guaranteed to be
-///   different from all other UUIDs generated before 3603 A.D., or is
-///   extremely likely to be different (depending on the mechanism chosen).
-///
-/// Therefore, UIDs between clusters should be extremely unlikely to
-/// conflict.
-///
-/// # Examples
-///
-/// - `218fc5a9-a5f1-4b54-aa05-46717d0ab26d`
-pub const K8S_CLUSTER_UID: &str = "k8s.cluster.uid";
-
-/// The name of the Node.
-///
-/// # Examples
-///
-/// - `node-1`
-pub const K8S_NODE_NAME: &str = "k8s.node.name";
-
-/// The UID of the Node.
-///
-/// # Examples
-///
-/// - `1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2`
-pub const K8S_NODE_UID: &str = "k8s.node.uid";
-
-/// The name of the namespace that the pod is running in.
-///
-/// # Examples
-///
-/// - `default`
-pub const K8S_NAMESPACE_NAME: &str = "k8s.namespace.name";
-
-/// The UID of the Pod.
-///
-/// # Examples
-///
-/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
-pub const K8S_POD_UID: &str = "k8s.pod.uid";
-
-/// The name of the Pod.
-///
-/// # Examples
-///
-/// - `opentelemetry-pod-autoconf`
-pub const K8S_POD_NAME: &str = "k8s.pod.name";
-
-/// The name of the Container from Pod specification, must be unique within a Pod. Container runtime usually uses different globally unique name (`container.name`).
-///
-/// # Examples
-///
-/// - `redis`
-pub const K8S_CONTAINER_NAME: &str = "k8s.container.name";
-
-/// Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec.
-///
-/// # Examples
-///
-/// - `0`
-/// - `2`
-pub const K8S_CONTAINER_RESTART_COUNT: &str = "k8s.container.restart_count";
-
-/// The UID of the ReplicaSet.
-///
-/// # Examples
-///
-/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
-pub const K8S_REPLICASET_UID: &str = "k8s.replicaset.uid";
-
-/// The name of the ReplicaSet.
-///
-/// # Examples
-///
-/// - `opentelemetry`
-pub const K8S_REPLICASET_NAME: &str = "k8s.replicaset.name";
-
-/// The UID of the Deployment.
-///
-/// # Examples
-///
-/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
-pub const K8S_DEPLOYMENT_UID: &str = "k8s.deployment.uid";
-
-/// The name of the Deployment.
-///
-/// # Examples
-///
-/// - `opentelemetry`
-pub const K8S_DEPLOYMENT_NAME: &str = "k8s.deployment.name";
-
-/// The UID of the StatefulSet.
-///
-/// # Examples
-///
-/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
-pub const K8S_STATEFULSET_UID: &str = "k8s.statefulset.uid";
-
-/// The name of the StatefulSet.
-///
-/// # Examples
-///
-/// - `opentelemetry`
-pub const K8S_STATEFULSET_NAME: &str = "k8s.statefulset.name";
-
-/// The UID of the DaemonSet.
-///
-/// # Examples
-///
-/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
-pub const K8S_DAEMONSET_UID: &str = "k8s.daemonset.uid";
-
-/// The name of the DaemonSet.
-///
-/// # Examples
-///
-/// - `opentelemetry`
-pub const K8S_DAEMONSET_NAME: &str = "k8s.daemonset.name";
-
-/// The UID of the Job.
-///
-/// # Examples
-///
-/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
-pub const K8S_JOB_UID: &str = "k8s.job.uid";
-
-/// The name of the Job.
-///
-/// # Examples
-///
-/// - `opentelemetry`
-pub const K8S_JOB_NAME: &str = "k8s.job.name";
-
-/// The UID of the CronJob.
-///
-/// # Examples
-///
-/// - `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff`
-pub const K8S_CRONJOB_UID: &str = "k8s.cronjob.uid";
-
-/// The name of the CronJob.
-///
-/// # Examples
-///
-/// - `opentelemetry`
-pub const K8S_CRONJOB_NAME: &str = "k8s.cronjob.name";
-
-/// The operating system type.
-pub const OS_TYPE: &str = "os.type";
-
-/// Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands.
-///
-/// # Examples
-///
-/// - `Microsoft Windows [Version 10.0.18363.778]`
-/// - `Ubuntu 18.04.1 LTS`
-pub const OS_DESCRIPTION: &str = "os.description";
-
-/// Human readable operating system name.
-///
-/// # Examples
-///
-/// - `iOS`
-/// - `Android`
-/// - `Ubuntu`
-pub const OS_NAME: &str = "os.name";
-
-/// The version string of the operating system as defined in [Version Attributes](/docs/resource/README.md#version-attributes).
-///
-/// # Examples
-///
-/// - `14.2.1`
-/// - `18.04.1`
-pub const OS_VERSION: &str = "os.version";
-
-/// Process identifier (PID).
-///
-/// # Examples
-///
-/// - `1234`
-pub const PROCESS_PID: &str = "process.pid";
-
-/// Parent Process identifier (PID).
-///
-/// # Examples
-///
-/// - `111`
-pub const PROCESS_PARENT_PID: &str = "process.parent_pid";
-
-/// The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`.
-///
-/// # Examples
-///
-/// - `otelcol`
-pub const PROCESS_EXECUTABLE_NAME: &str = "process.executable.name";
-
-/// The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`.
-///
-/// # Examples
-///
-/// - `/usr/bin/cmd/otelcol`
-pub const PROCESS_EXECUTABLE_PATH: &str = "process.executable.path";
-
-/// The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`.
-///
-/// # Examples
-///
-/// - `cmd/otelcol`
-pub const PROCESS_COMMAND: &str = "process.command";
-
-/// The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead.
-///
-/// # Examples
-///
-/// - `C:\cmd\otecol --config="my directory\config.yaml"`
-pub const PROCESS_COMMAND_LINE: &str = "process.command_line";
-
-/// All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`.
-///
-/// # Examples
-///
-/// - `cmd/otecol`
-/// - `--config=config.yaml`
-pub const PROCESS_COMMAND_ARGS: &str = "process.command_args";
-
-/// The username of the user that owns the process.
-///
-/// # Examples
-///
-/// - `root`
-pub const PROCESS_OWNER: &str = "process.owner";
-
-/// The name of the runtime of this process. For compiled native binaries, this SHOULD be the name of the compiler.
-///
-/// # Examples
-///
-/// - `OpenJDK Runtime Environment`
-pub const PROCESS_RUNTIME_NAME: &str = "process.runtime.name";
-
-/// The version of the runtime of this process, as returned by the runtime without modification.
-///
-/// # Examples
-///
-/// - `14.0.2`
-pub const PROCESS_RUNTIME_VERSION: &str = "process.runtime.version";
-
-/// An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment.
-///
-/// # Examples
-///
-/// - `Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0`
-pub const PROCESS_RUNTIME_DESCRIPTION: &str = "process.runtime.description";
-
 /// Logical name of the service.
 ///
 /// MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md#process), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
@@ -781,15 +893,6 @@ pub const SERVICE_NAME: &str = "service.name";
 /// - `a01dbef8a`
 pub const SERVICE_VERSION: &str = "service.version";
 
-/// A namespace for `service.name`.
-///
-/// A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
-///
-/// # Examples
-///
-/// - `Shop`
-pub const SERVICE_NAMESPACE: &str = "service.namespace";
-
 /// The string ID of the service instance.
 ///
 /// MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations).
@@ -799,6 +902,18 @@ pub const SERVICE_NAMESPACE: &str = "service.namespace";
 /// - `my-k8s-pod-deployment-1`
 /// - `627cc493-f310-47de-96bd-71410b7dec09`
 pub const SERVICE_INSTANCE_ID: &str = "service.instance.id";
+
+/// A namespace for `service.name`.
+///
+/// A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+///
+/// # Examples
+///
+/// - `Shop`
+pub const SERVICE_NAMESPACE: &str = "service.namespace";
+
+/// The language of the telemetry SDK.
+pub const TELEMETRY_SDK_LANGUAGE: &str = "telemetry.sdk.language";
 
 /// The name of the telemetry SDK as defined above.
 ///
@@ -814,9 +929,6 @@ pub const SERVICE_INSTANCE_ID: &str = "service.instance.id";
 /// - `opentelemetry`
 pub const TELEMETRY_SDK_NAME: &str = "telemetry.sdk.name";
 
-/// The language of the telemetry SDK.
-pub const TELEMETRY_SDK_LANGUAGE: &str = "telemetry.sdk.language";
-
 /// The version string of the telemetry SDK.
 ///
 /// # Examples
@@ -824,12 +936,29 @@ pub const TELEMETRY_SDK_LANGUAGE: &str = "telemetry.sdk.language";
 /// - `1.2.3`
 pub const TELEMETRY_SDK_VERSION: &str = "telemetry.sdk.version";
 
-/// The version string of the auto instrumentation agent, if used.
+/// The name of the auto instrumentation agent or distribution, if used.
+///
+/// Official auto instrumentation agents and distributions SHOULD set the `telemetry.distro.name` attribute to
+/// a string starting with `opentelemetry-`, e.g. `opentelemetry-java-instrumentation`.
+///
+/// # Examples
+///
+/// - `parts-unlimited-java`
+pub const TELEMETRY_DISTRO_NAME: &str = "telemetry.distro.name";
+
+/// The version string of the auto instrumentation agent or distribution, if used.
 ///
 /// # Examples
 ///
 /// - `1.2.3`
-pub const TELEMETRY_AUTO_VERSION: &str = "telemetry.auto.version";
+pub const TELEMETRY_DISTRO_VERSION: &str = "telemetry.distro.version";
+
+/// Additional description of the web engine (e.g. detailed version and edition information).
+///
+/// # Examples
+///
+/// - `WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final`
+pub const WEBENGINE_DESCRIPTION: &str = "webengine.description";
 
 /// The name of the web engine.
 ///
@@ -844,13 +973,6 @@ pub const WEBENGINE_NAME: &str = "webengine.name";
 ///
 /// - `21.0.0`
 pub const WEBENGINE_VERSION: &str = "webengine.version";
-
-/// Additional description of the web engine (e.g. detailed version and edition information).
-///
-/// # Examples
-///
-/// - `WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final`
-pub const WEBENGINE_DESCRIPTION: &str = "webengine.description";
 
 /// The name of the instrumentation scope - (`InstrumentationScope.Name` in OTLP).
 ///

--- a/opentelemetry-semantic-conventions/src/trace.rs
+++ b/opentelemetry-semantic-conventions/src/trace.rs
@@ -28,39 +28,580 @@
 //!     .start(&tracer);
 //! ```
 
-/// Client address - unix domain socket name, IPv4 or IPv6 address.
+/// The name of the invoked function.
 ///
-/// When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent client address behind any intermediaries (e.g. proxies) if it&#39;s available.
+/// SHOULD be equal to the `faas.name` resource attribute of the invoked function.
 ///
 /// # Examples
 ///
-/// - `/tmp/my.sock`
+/// - `my-function`
+pub const FAAS_INVOKED_NAME: &str = "faas.invoked_name";
+
+/// The cloud provider of the invoked function.
+///
+/// SHOULD be equal to the `cloud.provider` resource attribute of the invoked function.
+pub const FAAS_INVOKED_PROVIDER: &str = "faas.invoked_provider";
+
+/// The cloud region of the invoked function.
+///
+/// SHOULD be equal to the `cloud.region` resource attribute of the invoked function.
+///
+/// # Examples
+///
+/// - `eu-central-1`
+pub const FAAS_INVOKED_REGION: &str = "faas.invoked_region";
+
+/// Type of the trigger which caused this function invocation.
+pub const FAAS_TRIGGER: &str = "faas.trigger";
+
+/// The [`service.name`](/docs/resource/README.md#service) of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any.
+///
+/// # Examples
+///
+/// - `AuthTokenCache`
+pub const PEER_SERVICE: &str = "peer.service";
+
+/// Username or client_id extracted from the access token or [Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) header in the inbound request from outside the system.
+///
+/// # Examples
+///
+/// - `username`
+pub const ENDUSER_ID: &str = "enduser.id";
+
+/// Actual/assumed role the client is making the request under extracted from token or application security context.
+///
+/// # Examples
+///
+/// - `admin`
+pub const ENDUSER_ROLE: &str = "enduser.role";
+
+/// Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an [OAuth 2.0 Access Token](https://tools.ietf.org/html/rfc6749#section-3.3) or an attribute value in a [SAML 2.0 Assertion](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html).
+///
+/// # Examples
+///
+/// - `read:message, write:files`
+pub const ENDUSER_SCOPE: &str = "enduser.scope";
+
+/// Identifies the class / type of event.
+///
+/// Event names are subject to the same rules as [attribute names](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.26.0/specification/common/attribute-naming.md). Notably, event names are namespaced to avoid collisions and provide a clean separation of semantics for events in separate domains like browser, mobile, and kubernetes.
+///
+/// # Examples
+///
+/// - `browser.mouse.click`
+/// - `device.app.lifecycle`
+pub const EVENT_NAME: &str = "event.name";
+
+/// A unique identifier for the Log Record.
+///
+/// If an id is provided, other log records with the same id will be considered duplicates and can be removed safely. This means, that two distinguishable log records MUST have different values.
+/// The id MAY be an [Universally Unique Lexicographically Sortable Identifier (ULID)](https://github.com/ulid/spec), but other identifiers (e.g. UUID) may be used as needed.
+///
+/// # Examples
+///
+/// - `01ARZ3NDEKTSV4RRFFQ69G5FAV`
+pub const LOG_RECORD_UID: &str = "log.record.uid";
+
+/// The stream associated with the log. See below for a list of well-known values.
+pub const LOG_IOSTREAM: &str = "log.iostream";
+
+/// The basename of the file.
+///
+/// # Examples
+///
+/// - `audit.log`
+pub const LOG_FILE_NAME: &str = "log.file.name";
+
+/// The basename of the file, with symlinks resolved.
+///
+/// # Examples
+///
+/// - `uuid.log`
+pub const LOG_FILE_NAME_RESOLVED: &str = "log.file.name_resolved";
+
+/// The full path to the file.
+///
+/// # Examples
+///
+/// - `/var/log/mysql/audit.log`
+pub const LOG_FILE_PATH: &str = "log.file.path";
+
+/// The full path to the file, with symlinks resolved.
+///
+/// # Examples
+///
+/// - `/var/lib/docker/uuid.log`
+pub const LOG_FILE_PATH_RESOLVED: &str = "log.file.path_resolved";
+
+/// This attribute represents the state the application has transitioned into at the occurrence of the event.
+///
+/// The iOS lifecycle states are defined in the [UIApplicationDelegate documentation](https://developer.apple.com/documentation/uikit/uiapplicationdelegate#1656902), and from which the `OS terminology` column values are derived.
+pub const IOS_STATE: &str = "ios.state";
+
+/// This attribute represents the state the application has transitioned into at the occurrence of the event.
+///
+/// The Android lifecycle states are defined in [Activity lifecycle callbacks](https://developer.android.com/guide/components/activities/activity-lifecycle#lc), and from which the `OS identifiers` are derived.
+pub const ANDROID_STATE: &str = "android.state";
+
+/// The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn&#39;t provide a name, then the [db.connection_string](/docs/database/database-spans.md#connection-level-attributes) should be used.
+///
+/// # Examples
+///
+/// - `myDataSource`
+pub const POOL_NAME: &str = "pool.name";
+
+/// The state of a connection in the pool.
+///
+/// # Examples
+///
+/// - `idle`
+pub const STATE: &str = "state";
+
+/// Full type name of the [`IExceptionHandler`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.diagnostics.iexceptionhandler) implementation that handled the exception.
+///
+/// # Examples
+///
+/// - `Contoso.MyHandler`
+pub const ASPNETCORE_DIAGNOSTICS_HANDLER_TYPE: &str = "aspnetcore.diagnostics.handler.type";
+
+/// Rate limiting policy name.
+///
+/// # Examples
+///
+/// - `fixed`
+/// - `sliding`
+/// - `token`
+pub const ASPNETCORE_RATE_LIMITING_POLICY: &str = "aspnetcore.rate_limiting.policy";
+
+/// Rate-limiting result, shows whether the lease was acquired or contains a rejection reason.
+///
+/// # Examples
+///
+/// - `acquired`
+/// - `request_canceled`
+pub const ASPNETCORE_RATE_LIMITING_RESULT: &str = "aspnetcore.rate_limiting.result";
+
+/// Flag indicating if request was handled by the application pipeline.
+///
+/// # Examples
+///
+/// - `True`
+pub const ASPNETCORE_REQUEST_IS_UNHANDLED: &str = "aspnetcore.request.is_unhandled";
+
+/// A value that indicates whether the matched route is a fallback route.
+///
+/// # Examples
+///
+/// - `True`
+pub const ASPNETCORE_ROUTING_IS_FALLBACK: &str = "aspnetcore.routing.is_fallback";
+
+/// SignalR HTTP connection closure status.
+///
+/// # Examples
+///
+/// - `app_shutdown`
+/// - `timeout`
+pub const SIGNALR_CONNECTION_STATUS: &str = "signalr.connection.status";
+
+/// [SignalR transport type](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md).
+///
+/// # Examples
+///
+/// - `web_sockets`
+/// - `long_polling`
+pub const SIGNALR_TRANSPORT: &str = "signalr.transport";
+
+/// Name of the buffer pool.
+///
+/// Pool names are generally obtained via [BufferPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName()).
+///
+/// # Examples
+///
+/// - `mapped`
+/// - `direct`
+pub const JVM_BUFFER_POOL_NAME: &str = "jvm.buffer.pool.name";
+
+/// Name of the memory pool.
+///
+/// Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).
+///
+/// # Examples
+///
+/// - `G1 Old Gen`
+/// - `G1 Eden space`
+/// - `G1 Survivor Space`
+pub const JVM_MEMORY_POOL_NAME: &str = "jvm.memory.pool.name";
+
+/// The type of memory.
+///
+/// # Examples
+///
+/// - `heap`
+/// - `non_heap`
+pub const JVM_MEMORY_TYPE: &str = "jvm.memory.type";
+
+/// The device identifier.
+///
+/// # Examples
+///
+/// - `(identifier)`
+pub const SYSTEM_DEVICE: &str = "system.device";
+
+/// The logical CPU number [0..n-1].
+///
+/// # Examples
+///
+/// - `1`
+pub const SYSTEM_CPU_LOGICAL_NUMBER: &str = "system.cpu.logical_number";
+
+/// The state of the CPU.
+///
+/// # Examples
+///
+/// - `idle`
+/// - `interrupt`
+pub const SYSTEM_CPU_STATE: &str = "system.cpu.state";
+
+/// The memory state.
+///
+/// # Examples
+///
+/// - `free`
+/// - `cached`
+pub const SYSTEM_MEMORY_STATE: &str = "system.memory.state";
+
+/// The paging access direction.
+///
+/// # Examples
+///
+/// - `in`
+pub const SYSTEM_PAGING_DIRECTION: &str = "system.paging.direction";
+
+/// The memory paging state.
+///
+/// # Examples
+///
+/// - `free`
+pub const SYSTEM_PAGING_STATE: &str = "system.paging.state";
+
+/// The memory paging type.
+///
+/// # Examples
+///
+/// - `minor`
+pub const SYSTEM_PAGING_TYPE: &str = "system.paging.type";
+
+/// The filesystem mode.
+///
+/// # Examples
+///
+/// - `rw, ro`
+pub const SYSTEM_FILESYSTEM_MODE: &str = "system.filesystem.mode";
+
+/// The filesystem mount path.
+///
+/// # Examples
+///
+/// - `/mnt/data`
+pub const SYSTEM_FILESYSTEM_MOUNTPOINT: &str = "system.filesystem.mountpoint";
+
+/// The filesystem state.
+///
+/// # Examples
+///
+/// - `used`
+pub const SYSTEM_FILESYSTEM_STATE: &str = "system.filesystem.state";
+
+/// The filesystem type.
+///
+/// # Examples
+///
+/// - `ext4`
+pub const SYSTEM_FILESYSTEM_TYPE: &str = "system.filesystem.type";
+
+/// A stateless protocol MUST NOT set this attribute.
+///
+/// # Examples
+///
+/// - `close_wait`
+pub const SYSTEM_NETWORK_STATE: &str = "system.network.state";
+
+/// The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES).
+///
+/// # Examples
+///
+/// - `running`
+pub const SYSTEM_PROCESSES_STATUS: &str = "system.processes.status";
+
+/// Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+///
+/// When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent the client address behind any intermediaries,  for example proxies, if it&#39;s available.
+///
+/// # Examples
+///
+/// - `client.example.com`
 /// - `10.1.2.80`
+/// - `/tmp/my.sock`
 pub const CLIENT_ADDRESS: &str = "client.address";
 
 /// Client port number.
 ///
-/// When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent client port behind any intermediaries (e.g. proxies) if it&#39;s available.
+/// When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent the client port behind any intermediaries,  for example proxies, if it&#39;s available.
 ///
 /// # Examples
 ///
 /// - `65123`
 pub const CLIENT_PORT: &str = "client.port";
 
-/// Immediate client peer address - unix domain socket name, IPv4 or IPv6 address.
+/// The column number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
 ///
 /// # Examples
 ///
-/// - `/tmp/my.sock`
-/// - `127.0.0.1`
-pub const CLIENT_SOCKET_ADDRESS: &str = "client.socket.address";
+/// - `16`
+pub const CODE_COLUMN: &str = "code.column";
 
-/// Immediate client peer port number.
+/// The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).
 ///
 /// # Examples
 ///
-/// - `35555`
-pub const CLIENT_SOCKET_PORT: &str = "client.socket.port";
+/// - `/usr/local/MyApplication/content_root/app/index.php`
+pub const CODE_FILEPATH: &str = "code.filepath";
+
+/// The method or function name, or equivalent (usually rightmost part of the code unit&#39;s name).
+///
+/// # Examples
+///
+/// - `serveRequest`
+pub const CODE_FUNCTION: &str = "code.function";
+
+/// The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
+///
+/// # Examples
+///
+/// - `42`
+pub const CODE_LINENO: &str = "code.lineno";
+
+/// The &#34;namespace&#34; within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit.
+///
+/// # Examples
+///
+/// - `com.example.MyHttpService`
+pub const CODE_NAMESPACE: &str = "code.namespace";
+
+/// A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
+///
+/// # Examples
+///
+/// - `at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)`
+pub const CODE_STACKTRACE: &str = "code.stacktrace";
+
+/// The consistency level of the query. Based on consistency values from [CQL](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html).
+pub const DB_CASSANDRA_CONSISTENCY_LEVEL: &str = "db.cassandra.consistency_level";
+
+/// The data center of the coordinating node for a query.
+///
+/// # Examples
+///
+/// - `us-west-2`
+pub const DB_CASSANDRA_COORDINATOR_DC: &str = "db.cassandra.coordinator.dc";
+
+/// The ID of the coordinating node for a query.
+///
+/// # Examples
+///
+/// - `be13faa2-8574-4d71-926d-27f16cf8a7af`
+pub const DB_CASSANDRA_COORDINATOR_ID: &str = "db.cassandra.coordinator.id";
+
+/// Whether or not the query is idempotent.
+pub const DB_CASSANDRA_IDEMPOTENCE: &str = "db.cassandra.idempotence";
+
+/// The fetch size used for paging, i.e. how many rows will be returned at once.
+///
+/// # Examples
+///
+/// - `5000`
+pub const DB_CASSANDRA_PAGE_SIZE: &str = "db.cassandra.page_size";
+
+/// The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
+///
+/// # Examples
+///
+/// - `0`
+/// - `2`
+pub const DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT: &str =
+    "db.cassandra.speculative_execution_count";
+
+/// The name of the primary Cassandra table that the operation is acting upon, including the keyspace name (if applicable).
+///
+/// This mirrors the db.sql.table attribute but references cassandra rather than sql. It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+///
+/// # Examples
+///
+/// - `mytable`
+pub const DB_CASSANDRA_TABLE: &str = "db.cassandra.table";
+
+/// The connection string used to connect to the database. It is recommended to remove embedded credentials.
+///
+/// # Examples
+///
+/// - `Server=(localdb)\v11.0;Integrated Security=true;`
+pub const DB_CONNECTION_STRING: &str = "db.connection_string";
+
+/// Unique Cosmos client instance id.
+///
+/// # Examples
+///
+/// - `3ba4827d-4422-483f-b59f-85b74211c11d`
+pub const DB_COSMOSDB_CLIENT_ID: &str = "db.cosmosdb.client_id";
+
+/// Cosmos client connection mode.
+pub const DB_COSMOSDB_CONNECTION_MODE: &str = "db.cosmosdb.connection_mode";
+
+/// Cosmos DB container name.
+///
+/// # Examples
+///
+/// - `anystring`
+pub const DB_COSMOSDB_CONTAINER: &str = "db.cosmosdb.container";
+
+/// CosmosDB Operation Type.
+pub const DB_COSMOSDB_OPERATION_TYPE: &str = "db.cosmosdb.operation_type";
+
+/// RU consumed for that operation.
+///
+/// # Examples
+///
+/// - `46.18`
+/// - `1.0`
+pub const DB_COSMOSDB_REQUEST_CHARGE: &str = "db.cosmosdb.request_charge";
+
+/// Request payload size in bytes.
+pub const DB_COSMOSDB_REQUEST_CONTENT_LENGTH: &str = "db.cosmosdb.request_content_length";
+
+/// Cosmos DB status code.
+///
+/// # Examples
+///
+/// - `200`
+/// - `201`
+pub const DB_COSMOSDB_STATUS_CODE: &str = "db.cosmosdb.status_code";
+
+/// Cosmos DB sub status code.
+///
+/// # Examples
+///
+/// - `1000`
+/// - `1002`
+pub const DB_COSMOSDB_SUB_STATUS_CODE: &str = "db.cosmosdb.sub_status_code";
+
+/// Represents the identifier of an Elasticsearch cluster.
+///
+/// # Examples
+///
+/// - `e9106fc68e3044f0b1475b04bf4ffd5f`
+pub const DB_ELASTICSEARCH_CLUSTER_NAME: &str = "db.elasticsearch.cluster.name";
+
+/// Represents the human-readable identifier of the node/instance to which a request was routed.
+///
+/// # Examples
+///
+/// - `instance-0000000001`
+pub const DB_ELASTICSEARCH_NODE_NAME: &str = "db.elasticsearch.node.name";
+
+/// An identifier (address, unique name, or any other identifier) of the database instance that is executing queries or mutations on the current connection. This is useful in cases where the database is running in a clustered environment and the instrumentation is able to record the node executing the query. The client may obtain this value in databases like MySQL using queries like `select @@hostname`.
+///
+/// # Examples
+///
+/// - `mysql-e26b99z.example.com`
+pub const DB_INSTANCE_ID: &str = "db.instance.id";
+
+/// The fully-qualified class name of the [Java Database Connectivity (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to connect.
+///
+/// # Examples
+///
+/// - `org.postgresql.Driver`
+/// - `com.microsoft.sqlserver.jdbc.SQLServerDriver`
+pub const DB_JDBC_DRIVER_CLASSNAME: &str = "db.jdbc.driver_classname";
+
+/// The MongoDB collection being accessed within the database stated in `db.name`.
+///
+/// # Examples
+///
+/// - `customers`
+/// - `products`
+pub const DB_MONGODB_COLLECTION: &str = "db.mongodb.collection";
+
+/// The Microsoft SQL Server [instance name](https://docs.microsoft.com/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15) connecting to. This name is used to determine the port of a named instance.
+///
+/// If setting a `db.mssql.instance_name`, `server.port` is no longer required (but still recommended if non-standard).
+///
+/// # Examples
+///
+/// - `MSSQLSERVER`
+pub const DB_MSSQL_INSTANCE_NAME: &str = "db.mssql.instance_name";
+
+/// This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails).
+///
+/// In some SQL databases, the database name to be used is called &#34;schema name&#34;. In case there are multiple layers that could be considered for database name (e.g. Oracle instance name and schema name), the database name to be used is the more specific layer (e.g. Oracle schema name).
+///
+/// # Examples
+///
+/// - `customers`
+/// - `main`
+pub const DB_NAME: &str = "db.name";
+
+/// The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`, or the SQL keyword.
+///
+/// When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
+///
+/// # Examples
+///
+/// - `findAndModify`
+/// - `HMSET`
+/// - `SELECT`
+pub const DB_OPERATION: &str = "db.operation";
+
+/// The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` attribute.
+///
+/// # Examples
+///
+/// - `0`
+/// - `1`
+/// - `15`
+pub const DB_REDIS_DATABASE_INDEX: &str = "db.redis.database_index";
+
+/// The name of the primary table that the operation is acting upon, including the database name (if applicable).
+///
+/// It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
+///
+/// # Examples
+///
+/// - `public.users`
+/// - `customers`
+pub const DB_SQL_TABLE: &str = "db.sql.table";
+
+/// The database statement being executed.
+///
+/// # Examples
+///
+/// - `SELECT * FROM wuser_table`
+/// - `SET mykey "WuValue"`
+pub const DB_STATEMENT: &str = "db.statement";
+
+/// An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers.
+pub const DB_SYSTEM: &str = "db.system";
+
+/// Username for accessing the database.
+///
+/// # Examples
+///
+/// - `readonly_user`
+/// - `reporting_user`
+pub const DB_USER: &str = "db.user";
+
+/// Deprecated, use `network.protocol.name` instead.
+#[deprecated]
+pub const HTTP_FLAVOR: &str = "http.flavor";
 
 /// Deprecated, use `http.request.method` instead.
 ///
@@ -72,13 +613,21 @@ pub const CLIENT_SOCKET_PORT: &str = "client.socket.port";
 #[deprecated]
 pub const HTTP_METHOD: &str = "http.method";
 
-/// Deprecated, use `http.response.status_code` instead.
+/// Deprecated, use `http.request.header.content-length` instead.
 ///
 /// # Examples
 ///
-/// - `200`
+/// - `3495`
 #[deprecated]
-pub const HTTP_STATUS_CODE: &str = "http.status_code";
+pub const HTTP_REQUEST_CONTENT_LENGTH: &str = "http.request_content_length";
+
+/// Deprecated, use `http.response.header.content-length` instead.
+///
+/// # Examples
+///
+/// - `3495`
+#[deprecated]
+pub const HTTP_RESPONSE_CONTENT_LENGTH: &str = "http.response_content_length";
 
 /// Deprecated, use `url.scheme` instead.
 ///
@@ -89,13 +638,13 @@ pub const HTTP_STATUS_CODE: &str = "http.status_code";
 #[deprecated]
 pub const HTTP_SCHEME: &str = "http.scheme";
 
-/// Deprecated, use `url.full` instead.
+/// Deprecated, use `http.response.status_code` instead.
 ///
 /// # Examples
 ///
-/// - `https://www.foo.bar/search?q=OpenTelemetry#SemConv`
+/// - `200`
 #[deprecated]
-pub const HTTP_URL: &str = "http.url";
+pub const HTTP_STATUS_CODE: &str = "http.status_code";
 
 /// Deprecated, use `url.path` and `url.query` instead.
 ///
@@ -105,61 +654,22 @@ pub const HTTP_URL: &str = "http.url";
 #[deprecated]
 pub const HTTP_TARGET: &str = "http.target";
 
-/// Deprecated, use `http.request.body.size` instead.
+/// Deprecated, use `url.full` instead.
 ///
 /// # Examples
 ///
-/// - `3495`
+/// - `https://www.foo.bar/search?q=OpenTelemetry#SemConv`
 #[deprecated]
-pub const HTTP_REQUEST_CONTENT_LENGTH: &str = "http.request_content_length";
+pub const HTTP_URL: &str = "http.url";
 
-/// Deprecated, use `http.response.body.size` instead.
+/// Deprecated, use `user_agent.original` instead.
 ///
 /// # Examples
 ///
-/// - `3495`
+/// - `CERN-LineMode/2.15 libwww/2.17b3`
+/// - `Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1`
 #[deprecated]
-pub const HTTP_RESPONSE_CONTENT_LENGTH: &str = "http.response_content_length";
-
-/// Deprecated, use `server.socket.domain` on client spans.
-///
-/// # Examples
-///
-/// - `/var/my.sock`
-#[deprecated]
-pub const NET_SOCK_PEER_NAME: &str = "net.sock.peer.name";
-
-/// Deprecated, use `server.socket.address` on client spans and `client.socket.address` on server spans.
-///
-/// # Examples
-///
-/// - `192.168.0.1`
-#[deprecated]
-pub const NET_SOCK_PEER_ADDR: &str = "net.sock.peer.addr";
-
-/// Deprecated, use `server.socket.port` on client spans and `client.socket.port` on server spans.
-///
-/// # Examples
-///
-/// - `65531`
-#[deprecated]
-pub const NET_SOCK_PEER_PORT: &str = "net.sock.peer.port";
-
-/// Deprecated, use `server.address` on client spans and `client.address` on server spans.
-///
-/// # Examples
-///
-/// - `example.com`
-#[deprecated]
-pub const NET_PEER_NAME: &str = "net.peer.name";
-
-/// Deprecated, use `server.port` on client spans and `client.port` on server spans.
-///
-/// # Examples
-///
-/// - `8080`
-#[deprecated]
-pub const NET_PEER_PORT: &str = "net.peer.port";
+pub const HTTP_USER_AGENT: &str = "http.user_agent";
 
 /// Deprecated, use `server.address`.
 ///
@@ -177,25 +687,21 @@ pub const NET_HOST_NAME: &str = "net.host.name";
 #[deprecated]
 pub const NET_HOST_PORT: &str = "net.host.port";
 
-/// Deprecated, use `server.socket.address`.
+/// Deprecated, use `server.address` on client spans and `client.address` on server spans.
 ///
 /// # Examples
 ///
-/// - `/var/my.sock`
+/// - `example.com`
 #[deprecated]
-pub const NET_SOCK_HOST_ADDR: &str = "net.sock.host.addr";
+pub const NET_PEER_NAME: &str = "net.peer.name";
 
-/// Deprecated, use `server.socket.port`.
+/// Deprecated, use `server.port` on client spans and `client.port` on server spans.
 ///
 /// # Examples
 ///
 /// - `8080`
 #[deprecated]
-pub const NET_SOCK_HOST_PORT: &str = "net.sock.host.port";
-
-/// Deprecated, use `network.transport`.
-#[deprecated]
-pub const NET_TRANSPORT: &str = "net.transport";
+pub const NET_PEER_PORT: &str = "net.peer.port";
 
 /// Deprecated, use `network.protocol.name`.
 ///
@@ -219,23 +725,62 @@ pub const NET_PROTOCOL_VERSION: &str = "net.protocol.version";
 #[deprecated]
 pub const NET_SOCK_FAMILY: &str = "net.sock.family";
 
-/// The domain name of the destination system.
-///
-/// This value may be a host name, a fully qualified domain name, or another host naming format.
+/// Deprecated, use `network.local.address`.
 ///
 /// # Examples
 ///
-/// - `foo.example.com`
-pub const DESTINATION_DOMAIN: &str = "destination.domain";
+/// - `/var/my.sock`
+#[deprecated]
+pub const NET_SOCK_HOST_ADDR: &str = "net.sock.host.addr";
 
-/// Peer address, for example IP address or UNIX socket name.
+/// Deprecated, use `network.local.port`.
 ///
 /// # Examples
 ///
-/// - `10.5.3.2`
+/// - `8080`
+#[deprecated]
+pub const NET_SOCK_HOST_PORT: &str = "net.sock.host.port";
+
+/// Deprecated, use `network.peer.address`.
+///
+/// # Examples
+///
+/// - `192.168.0.1`
+#[deprecated]
+pub const NET_SOCK_PEER_ADDR: &str = "net.sock.peer.addr";
+
+/// Deprecated, no replacement at this time.
+///
+/// # Examples
+///
+/// - `/var/my.sock`
+#[deprecated]
+pub const NET_SOCK_PEER_NAME: &str = "net.sock.peer.name";
+
+/// Deprecated, use `network.peer.port`.
+///
+/// # Examples
+///
+/// - `65531`
+#[deprecated]
+pub const NET_SOCK_PEER_PORT: &str = "net.sock.peer.port";
+
+/// Deprecated, use `network.transport`.
+#[deprecated]
+pub const NET_TRANSPORT: &str = "net.transport";
+
+/// Destination address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+///
+/// When observed from the source side, and when communicating through an intermediary, `destination.address` SHOULD represent the destination address behind any intermediaries, for example proxies, if it&#39;s available.
+///
+/// # Examples
+///
+/// - `destination.example.com`
+/// - `10.1.2.80`
+/// - `/tmp/my.sock`
 pub const DESTINATION_ADDRESS: &str = "destination.address";
 
-/// Peer port number.
+/// Destination port number.
 ///
 /// # Examples
 ///
@@ -243,13 +788,58 @@ pub const DESTINATION_ADDRESS: &str = "destination.address";
 /// - `2888`
 pub const DESTINATION_PORT: &str = "destination.port";
 
-/// The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
+/// The disk IO operation direction.
 ///
 /// # Examples
 ///
-/// - `java.net.ConnectException`
-/// - `OSError`
-pub const EXCEPTION_TYPE: &str = "exception.type";
+/// - `read`
+pub const DISK_IO_DIRECTION: &str = "disk.io.direction";
+
+/// Describes a class of error the operation ended with.
+///
+/// The `error.type` SHOULD be predictable and SHOULD have low cardinality.
+/// Instrumentations SHOULD document the list of errors they report.
+///
+/// The cardinality of `error.type` within one instrumentation library SHOULD be low.
+/// Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+/// should be prepared for `error.type` to have high cardinality at query time when no
+/// additional filters are applied.
+///
+/// If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+///
+/// If a specific domain defines its own set of error identifiers (such as HTTP or gRPC status codes),
+/// it&#39;s RECOMMENDED to:
+///
+/// * Use a domain-specific attribute
+/// * Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
+///
+/// # Examples
+///
+/// - `timeout`
+/// - `java.net.UnknownHostException`
+/// - `server_certificate_invalid`
+/// - `500`
+pub const ERROR_TYPE: &str = "error.type";
+
+/// SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.
+///
+/// An exception is considered to have escaped (or left) the scope of a span,
+/// if that span is ended while the exception is still logically &#34;in flight&#34;.
+/// This may be actually &#34;in flight&#34; in some languages (e.g. if the exception
+/// is passed to a Context manager&#39;s `__exit__` method in Python) but will
+/// usually be caught at the point of recording the exception in most languages.
+///
+/// It is usually not possible to determine at the point where an exception is thrown
+/// whether it will escape the scope of a span.
+/// However, it is trivial to know that an exception
+/// will escape, if one checks for an active exception just before ending the span,
+/// as done in the [example for recording span exceptions](#recording-an-exception).
+///
+/// It follows that an exception may still escape the scope of the span
+/// even if the `exception.escaped` attribute was not set or set to false,
+/// since the event might have been recorded at a time where it was not
+/// clear whether the exception will escape.
+pub const EXCEPTION_ESCAPED: &str = "exception.escaped";
 
 /// The exception message.
 ///
@@ -266,14 +856,28 @@ pub const EXCEPTION_MESSAGE: &str = "exception.message";
 /// - `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)`
 pub const EXCEPTION_STACKTRACE: &str = "exception.stacktrace";
 
+/// The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
+///
+/// # Examples
+///
+/// - `java.net.ConnectException`
+/// - `OSError`
+pub const EXCEPTION_TYPE: &str = "exception.type";
+
+/// The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size.
+///
+/// # Examples
+///
+/// - `3495`
+pub const HTTP_REQUEST_BODY_SIZE: &str = "http.request.body.size";
+
 /// HTTP request method.
 ///
 /// HTTP request method value SHOULD be &#34;known&#34; to the instrumentation.
 /// By default, this convention defines &#34;known&#34; methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
 /// and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
 ///
-/// If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER` and, except if reporting a metric, MUST
-/// set the exact method received in the request line as value of the `http.request.method_original` attribute.
+/// If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
 ///
 /// If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
 /// the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
@@ -291,6 +895,31 @@ pub const EXCEPTION_STACKTRACE: &str = "exception.stacktrace";
 /// - `HEAD`
 pub const HTTP_REQUEST_METHOD: &str = "http.request.method";
 
+/// Original HTTP method sent by the client in the request line.
+///
+/// # Examples
+///
+/// - `GeT`
+/// - `ACL`
+/// - `foo`
+pub const HTTP_REQUEST_METHOD_ORIGINAL: &str = "http.request.method_original";
+
+/// The ordinal number of request resending attempt (for any reason, including redirects).
+///
+/// The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
+///
+/// # Examples
+///
+/// - `3`
+pub const HTTP_REQUEST_RESEND_COUNT: &str = "http.request.resend_count";
+
+/// The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size.
+///
+/// # Examples
+///
+/// - `3495`
+pub const HTTP_RESPONSE_BODY_SIZE: &str = "http.response.body.size";
+
 /// [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).
 ///
 /// # Examples
@@ -298,7 +927,7 @@ pub const HTTP_REQUEST_METHOD: &str = "http.request.method";
 /// - `200`
 pub const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
 
-/// The matched route (path template in the format used by the respective server framework). See note below.
+/// The matched route, that is, the path template in the format used by the respective server framework.
 ///
 /// MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 /// SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
@@ -309,88 +938,411 @@ pub const HTTP_RESPONSE_STATUS_CODE: &str = "http.response.status_code";
 /// - `{controller}/{action}/{id?}`
 pub const HTTP_ROUTE: &str = "http.route";
 
-/// The name identifies the event.
+/// The number of messages sent, received, or processed in the scope of the batching operation.
+///
+/// Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
 ///
 /// # Examples
 ///
-/// - `click`
-/// - `exception`
-pub const EVENT_NAME: &str = "event.name";
+/// - `0`
+/// - `1`
+/// - `2`
+pub const MESSAGING_BATCH_MESSAGE_COUNT: &str = "messaging.batch.message_count";
 
-/// The domain identifies the business context for the events.
-///
-/// Events across different domains may have same `event.name`, yet be
-/// unrelated events.
-pub const EVENT_DOMAIN: &str = "event.domain";
-
-/// A unique identifier for the Log Record.
-///
-/// If an id is provided, other log records with the same id will be considered duplicates and can be removed safely. This means, that two distinguishable log records MUST have different values.
-/// The id MAY be an [Universally Unique Lexicographically Sortable Identifier (ULID)](https://github.com/ulid/spec), but other identifiers (e.g. UUID) may be used as needed.
+/// A unique identifier for the client that consumes or produces a message.
 ///
 /// # Examples
 ///
-/// - `01ARZ3NDEKTSV4RRFFQ69G5FAV`
-pub const LOG_RECORD_UID: &str = "log.record.uid";
+/// - `client-5`
+/// - `myhost@8742@s8083jm`
+pub const MESSAGING_CLIENT_ID: &str = "messaging.client_id";
 
-/// The stream associated with the log. See below for a list of well-known values.
-pub const LOG_IOSTREAM: &str = "log.iostream";
+/// A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).
+pub const MESSAGING_DESTINATION_ANONYMOUS: &str = "messaging.destination.anonymous";
 
-/// The basename of the file.
+/// The message destination name.
+///
+/// Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
+/// the broker doesn&#39;t have such notion, the destination name SHOULD uniquely identify the broker.
 ///
 /// # Examples
 ///
-/// - `audit.log`
-pub const LOG_FILE_NAME: &str = "log.file.name";
+/// - `MyQueue`
+/// - `MyTopic`
+pub const MESSAGING_DESTINATION_NAME: &str = "messaging.destination.name";
 
-/// The full path to the file.
+/// Low cardinality representation of the messaging destination name.
+///
+/// Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
 ///
 /// # Examples
 ///
-/// - `/var/log/mysql/audit.log`
-pub const LOG_FILE_PATH: &str = "log.file.path";
+/// - `/customers/{customerId}`
+pub const MESSAGING_DESTINATION_TEMPLATE: &str = "messaging.destination.template";
 
-/// The basename of the file, with symlinks resolved.
+/// A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed.
+pub const MESSAGING_DESTINATION_TEMPORARY: &str = "messaging.destination.temporary";
+
+/// A boolean that is true if the publish message destination is anonymous (could be unnamed or have auto-generated name).
+pub const MESSAGING_DESTINATION_PUBLISH_ANONYMOUS: &str = "messaging.destination_publish.anonymous";
+
+/// The name of the original destination the message was published to.
+///
+/// The name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
+/// the broker doesn&#39;t have such notion, the original destination name SHOULD uniquely identify the broker.
 ///
 /// # Examples
 ///
-/// - `uuid.log`
-pub const LOG_FILE_NAME_RESOLVED: &str = "log.file.name_resolved";
+/// - `MyQueue`
+/// - `MyTopic`
+pub const MESSAGING_DESTINATION_PUBLISH_NAME: &str = "messaging.destination_publish.name";
 
-/// The full path to the file, with symlinks resolved.
+/// The ordering key for a given message. If the attribute is not present, the message does not have an ordering key.
 ///
 /// # Examples
 ///
-/// - `/var/lib/docker/uuid.log`
-pub const LOG_FILE_PATH_RESOLVED: &str = "log.file.path_resolved";
+/// - `ordering_key`
+pub const MESSAGING_GCP_PUBSUB_MESSAGE_ORDERING_KEY: &str =
+    "messaging.gcp_pubsub.message.ordering_key";
 
-/// The type of memory.
+/// Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
 ///
 /// # Examples
 ///
-/// - `heap`
-/// - `non_heap`
-pub const TYPE: &str = "type";
+/// - `my-group`
+pub const MESSAGING_KAFKA_CONSUMER_GROUP: &str = "messaging.kafka.consumer.group";
 
-/// Name of the memory pool.
-///
-/// Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).
+/// Partition the message is sent to.
 ///
 /// # Examples
 ///
-/// - `G1 Old Gen`
-/// - `G1 Eden space`
-/// - `G1 Survivor Space`
-pub const POOL: &str = "pool";
+/// - `2`
+pub const MESSAGING_KAFKA_DESTINATION_PARTITION: &str = "messaging.kafka.destination.partition";
 
-/// Logical server hostname, matches server FQDN if available, and IP or socket address if FQDN is not known.
+/// Message keys in Kafka are used for grouping alike messages to ensure they&#39;re processed on the same partition. They differ from `messaging.message.id` in that they&#39;re not unique. If the key is `null`, the attribute MUST NOT be set.
+///
+/// If the key type is not string, it&#39;s string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don&#39;t include its value.
+///
+/// # Examples
+///
+/// - `myKey`
+pub const MESSAGING_KAFKA_MESSAGE_KEY: &str = "messaging.kafka.message.key";
+
+/// The offset of a record in the corresponding Kafka partition.
+///
+/// # Examples
+///
+/// - `42`
+pub const MESSAGING_KAFKA_MESSAGE_OFFSET: &str = "messaging.kafka.message.offset";
+
+/// A boolean that is true if the message is a tombstone.
+pub const MESSAGING_KAFKA_MESSAGE_TOMBSTONE: &str = "messaging.kafka.message.tombstone";
+
+/// The size of the message body in bytes.
+///
+/// This can refer to both the compressed or uncompressed body size. If both sizes are known, the uncompressed
+/// body size should be used.
+///
+/// # Examples
+///
+/// - `1439`
+pub const MESSAGING_MESSAGE_BODY_SIZE: &str = "messaging.message.body.size";
+
+/// The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called &#34;Correlation ID&#34;.
+///
+/// # Examples
+///
+/// - `MyConversationId`
+pub const MESSAGING_MESSAGE_CONVERSATION_ID: &str = "messaging.message.conversation_id";
+
+/// The size of the message body and metadata in bytes.
+///
+/// This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
+/// size should be used.
+///
+/// # Examples
+///
+/// - `2738`
+pub const MESSAGING_MESSAGE_ENVELOPE_SIZE: &str = "messaging.message.envelope.size";
+
+/// A value used by the messaging system as an identifier for the message, represented as a string.
+///
+/// # Examples
+///
+/// - `452a7c7c7c7048c2f887f61572b18fc2`
+pub const MESSAGING_MESSAGE_ID: &str = "messaging.message.id";
+
+/// A string identifying the kind of messaging operation.
+///
+/// If a custom value is used, it MUST be of low cardinality.
+pub const MESSAGING_OPERATION: &str = "messaging.operation";
+
+/// RabbitMQ message routing key.
+///
+/// # Examples
+///
+/// - `myKey`
+pub const MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY: &str =
+    "messaging.rabbitmq.destination.routing_key";
+
+/// Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind.
+///
+/// # Examples
+///
+/// - `myConsumerGroup`
+pub const MESSAGING_ROCKETMQ_CLIENT_GROUP: &str = "messaging.rocketmq.client_group";
+
+/// Model of message consumption. This only applies to consumer spans.
+pub const MESSAGING_ROCKETMQ_CONSUMPTION_MODEL: &str = "messaging.rocketmq.consumption_model";
+
+/// The delay time level for delay message, which determines the message delay time.
+///
+/// # Examples
+///
+/// - `3`
+pub const MESSAGING_ROCKETMQ_MESSAGE_DELAY_TIME_LEVEL: &str =
+    "messaging.rocketmq.message.delay_time_level";
+
+/// The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
+///
+/// # Examples
+///
+/// - `1665987217045`
+pub const MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP: &str =
+    "messaging.rocketmq.message.delivery_timestamp";
+
+/// It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group.
+///
+/// # Examples
+///
+/// - `myMessageGroup`
+pub const MESSAGING_ROCKETMQ_MESSAGE_GROUP: &str = "messaging.rocketmq.message.group";
+
+/// Key(s) of message, another way to mark message besides message id.
+///
+/// # Examples
+///
+/// - `keyA`
+/// - `keyB`
+pub const MESSAGING_ROCKETMQ_MESSAGE_KEYS: &str = "messaging.rocketmq.message.keys";
+
+/// The secondary classifier of message besides topic.
+///
+/// # Examples
+///
+/// - `tagA`
+pub const MESSAGING_ROCKETMQ_MESSAGE_TAG: &str = "messaging.rocketmq.message.tag";
+
+/// Type of message.
+pub const MESSAGING_ROCKETMQ_MESSAGE_TYPE: &str = "messaging.rocketmq.message.type";
+
+/// Namespace of RocketMQ resources, resources in different namespaces are individual.
+///
+/// # Examples
+///
+/// - `myNamespace`
+pub const MESSAGING_ROCKETMQ_NAMESPACE: &str = "messaging.rocketmq.namespace";
+
+/// An identifier for the messaging system being used. See below for a list of well-known identifiers.
+pub const MESSAGING_SYSTEM: &str = "messaging.system";
+
+/// The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
+///
+/// # Examples
+///
+/// - `DE`
+pub const NETWORK_CARRIER_ICC: &str = "network.carrier.icc";
+
+/// The mobile carrier country code.
+///
+/// # Examples
+///
+/// - `310`
+pub const NETWORK_CARRIER_MCC: &str = "network.carrier.mcc";
+
+/// The mobile carrier network code.
+///
+/// # Examples
+///
+/// - `001`
+pub const NETWORK_CARRIER_MNC: &str = "network.carrier.mnc";
+
+/// The name of the mobile carrier.
+///
+/// # Examples
+///
+/// - `sprint`
+pub const NETWORK_CARRIER_NAME: &str = "network.carrier.name";
+
+/// This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
+///
+/// # Examples
+///
+/// - `LTE`
+pub const NETWORK_CONNECTION_SUBTYPE: &str = "network.connection.subtype";
+
+/// The internet connection type.
+///
+/// # Examples
+///
+/// - `wifi`
+pub const NETWORK_CONNECTION_TYPE: &str = "network.connection.type";
+
+/// The network IO operation direction.
+///
+/// # Examples
+///
+/// - `transmit`
+pub const NETWORK_IO_DIRECTION: &str = "network.io.direction";
+
+/// Local address of the network connection - IP address or Unix domain socket name.
+///
+/// # Examples
+///
+/// - `10.1.2.80`
+/// - `/tmp/my.sock`
+pub const NETWORK_LOCAL_ADDRESS: &str = "network.local.address";
+
+/// Local port number of the network connection.
+///
+/// # Examples
+///
+/// - `65123`
+pub const NETWORK_LOCAL_PORT: &str = "network.local.port";
+
+/// Peer address of the network connection - IP address or Unix domain socket name.
+///
+/// # Examples
+///
+/// - `10.1.2.80`
+/// - `/tmp/my.sock`
+pub const NETWORK_PEER_ADDRESS: &str = "network.peer.address";
+
+/// Peer port number of the network connection.
+///
+/// # Examples
+///
+/// - `65123`
+pub const NETWORK_PEER_PORT: &str = "network.peer.port";
+
+/// [OSI application layer](https://osi-model.com/application-layer/) or non-OSI equivalent.
+///
+/// The value SHOULD be normalized to lowercase.
+///
+/// # Examples
+///
+/// - `amqp`
+/// - `http`
+/// - `mqtt`
+pub const NETWORK_PROTOCOL_NAME: &str = "network.protocol.name";
+
+/// Version of the protocol specified in `network.protocol.name`.
+///
+/// `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client&#39;s version. If the HTTP client has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+///
+/// # Examples
+///
+/// - `3.1.1`
+pub const NETWORK_PROTOCOL_VERSION: &str = "network.protocol.version";
+
+/// [OSI transport layer](https://osi-model.com/transport-layer/) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication).
+///
+/// The value SHOULD be normalized to lowercase.
+///
+/// Consider always setting the transport when setting a port number, since
+/// a port number is ambiguous without knowing the transport. For example
+/// different processes could be listening on TCP port 12345 and UDP port 12345.
+///
+/// # Examples
+///
+/// - `tcp`
+/// - `udp`
+pub const NETWORK_TRANSPORT: &str = "network.transport";
+
+/// [OSI network layer](https://osi-model.com/network-layer/) or non-OSI equivalent.
+///
+/// The value SHOULD be normalized to lowercase.
+///
+/// # Examples
+///
+/// - `ipv4`
+/// - `ipv6`
+pub const NETWORK_TYPE: &str = "network.type";
+
+/// The [error codes](https://connect.build/docs/protocol/#error-codes) of the Connect request. Error codes are always string values.
+pub const RPC_CONNECT_RPC_ERROR_CODE: &str = "rpc.connect_rpc.error_code";
+
+/// The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request.
+pub const RPC_GRPC_STATUS_CODE: &str = "rpc.grpc.status_code";
+
+/// `error.code` property of response if it is an error response.
+///
+/// # Examples
+///
+/// - `-32700`
+/// - `100`
+pub const RPC_JSONRPC_ERROR_CODE: &str = "rpc.jsonrpc.error_code";
+
+/// `error.message` property of response if it is an error response.
+///
+/// # Examples
+///
+/// - `Parse error`
+/// - `User already exists`
+pub const RPC_JSONRPC_ERROR_MESSAGE: &str = "rpc.jsonrpc.error_message";
+
+/// `id` property of request or response. Since protocol allows id to be int, string, `null` or missing (for notifications), value is expected to be cast to string for simplicity. Use empty string in case of `null` value. Omit entirely if this is a notification.
+///
+/// # Examples
+///
+/// - `10`
+/// - `request-7`
+/// - ``
+pub const RPC_JSONRPC_REQUEST_ID: &str = "rpc.jsonrpc.request_id";
+
+/// Protocol version as in `jsonrpc` property of request/response. Since JSON-RPC 1.0 doesn&#39;t specify this, the value can be omitted.
+///
+/// # Examples
+///
+/// - `2.0`
+/// - `1.0`
+pub const RPC_JSONRPC_VERSION: &str = "rpc.jsonrpc.version";
+
+/// The name of the (logical) method being called, must be equal to the $method part in the span name.
+///
+/// This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
+///
+/// # Examples
+///
+/// - `exampleMethod`
+pub const RPC_METHOD: &str = "rpc.method";
+
+/// The full (logical) name of the service being called, including its package name, if applicable.
+///
+/// This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
+///
+/// # Examples
+///
+/// - `myservice.EchoService`
+pub const RPC_SERVICE: &str = "rpc.service";
+
+/// A string identifying the remoting system. See below for a list of well-known identifiers.
+pub const RPC_SYSTEM: &str = "rpc.system";
+
+/// Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+///
+/// When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it&#39;s available.
 ///
 /// # Examples
 ///
 /// - `example.com`
+/// - `10.1.2.80`
+/// - `/tmp/my.sock`
 pub const SERVER_ADDRESS: &str = "server.address";
 
-/// Logical server port number.
+/// Server port number.
+///
+/// When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it&#39;s available.
 ///
 /// # Examples
 ///
@@ -399,43 +1351,15 @@ pub const SERVER_ADDRESS: &str = "server.address";
 /// - `443`
 pub const SERVER_PORT: &str = "server.port";
 
-/// The domain name of an immediate peer.
+/// Source address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
 ///
-/// Typically observed from the client side, and represents a proxy or other intermediary domain name.
-///
-/// # Examples
-///
-/// - `proxy.example.com`
-pub const SERVER_SOCKET_DOMAIN: &str = "server.socket.domain";
-
-/// Physical server IP address or Unix socket address. If set from the client, should simply use the socket&#39;s peer address, and not attempt to find any actual server IP (i.e., if set from client, this may represent some proxy server instead of the logical server).
+/// When observed from the destination side, and when communicating through an intermediary, `source.address` SHOULD represent the source address behind any intermediaries, for example proxies, if it&#39;s available.
 ///
 /// # Examples
 ///
-/// - `10.5.3.2`
-pub const SERVER_SOCKET_ADDRESS: &str = "server.socket.address";
-
-/// Physical server port.
-///
-/// # Examples
-///
-/// - `16456`
-pub const SERVER_SOCKET_PORT: &str = "server.socket.port";
-
-/// The domain name of the source system.
-///
-/// This value may be a host name, a fully qualified domain name, or another host naming format.
-///
-/// # Examples
-///
-/// - `foo.example.com`
-pub const SOURCE_DOMAIN: &str = "source.domain";
-
-/// Source address, for example IP address or Unix socket name.
-///
-/// # Examples
-///
-/// - `10.5.3.2`
+/// - `source.example.com`
+/// - `10.1.2.80`
+/// - `/tmp/my.sock`
 pub const SOURCE_ADDRESS: &str = "source.address";
 
 /// Source port number.
@@ -445,6 +1369,291 @@ pub const SOURCE_ADDRESS: &str = "source.address";
 /// - `3389`
 /// - `2888`
 pub const SOURCE_PORT: &str = "source.port";
+
+/// Current &#34;managed&#34; thread ID (as opposed to OS thread ID).
+///
+/// # Examples
+///
+/// - `42`
+pub const THREAD_ID: &str = "thread.id";
+
+/// Current thread name.
+///
+/// # Examples
+///
+/// - `main`
+pub const THREAD_NAME: &str = "thread.name";
+
+/// String indicating the [cipher](https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5) used during the current connection.
+///
+/// The values allowed for `tls.cipher` MUST be one of the `Descriptions` of the [registered TLS Cipher Suits](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#table-tls-parameters-4).
+///
+/// # Examples
+///
+/// - `TLS_RSA_WITH_3DES_EDE_CBC_SHA`
+/// - `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`
+pub const TLS_CIPHER: &str = "tls.cipher";
+
+/// PEM-encoded stand-alone certificate offered by the client. This is usually mutually-exclusive of `client.certificate_chain` since this value also exists in that list.
+///
+/// # Examples
+///
+/// - `MII...`
+pub const TLS_CLIENT_CERTIFICATE: &str = "tls.client.certificate";
+
+/// Array of PEM-encoded certificates that make up the certificate chain offered by the client. This is usually mutually-exclusive of `client.certificate` since that value should be the first certificate in the chain.
+///
+/// # Examples
+///
+/// - `MII...`
+/// - `MI...`
+pub const TLS_CLIENT_CERTIFICATE_CHAIN: &str = "tls.client.certificate_chain";
+
+/// Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.
+///
+/// # Examples
+///
+/// - `0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC`
+pub const TLS_CLIENT_HASH_MD5: &str = "tls.client.hash.md5";
+
+/// Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.
+///
+/// # Examples
+///
+/// - `9E393D93138888D288266C2D915214D1D1CCEB2A`
+pub const TLS_CLIENT_HASH_SHA1: &str = "tls.client.hash.sha1";
+
+/// Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.
+///
+/// # Examples
+///
+/// - `0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0`
+pub const TLS_CLIENT_HASH_SHA256: &str = "tls.client.hash.sha256";
+
+/// Distinguished name of [subject](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6) of the issuer of the x.509 certificate presented by the client.
+///
+/// # Examples
+///
+/// - `CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com`
+pub const TLS_CLIENT_ISSUER: &str = "tls.client.issuer";
+
+/// A hash that identifies clients based on how they perform an SSL/TLS handshake.
+///
+/// # Examples
+///
+/// - `d4e5b18d6b55c71272893221c96ba240`
+pub const TLS_CLIENT_JA3: &str = "tls.client.ja3";
+
+/// Date/Time indicating when client certificate is no longer considered valid.
+///
+/// # Examples
+///
+/// - `2021-01-01T00:00:00.000Z`
+pub const TLS_CLIENT_NOT_AFTER: &str = "tls.client.not_after";
+
+/// Date/Time indicating when client certificate is first considered valid.
+///
+/// # Examples
+///
+/// - `1970-01-01T00:00:00.000Z`
+pub const TLS_CLIENT_NOT_BEFORE: &str = "tls.client.not_before";
+
+/// Also called an SNI, this tells the server which hostname to which the client is attempting to connect to.
+///
+/// # Examples
+///
+/// - `opentelemetry.io`
+pub const TLS_CLIENT_SERVER_NAME: &str = "tls.client.server_name";
+
+/// Distinguished name of subject of the x.509 certificate presented by the client.
+///
+/// # Examples
+///
+/// - `CN=myclient, OU=Documentation Team, DC=example, DC=com`
+pub const TLS_CLIENT_SUBJECT: &str = "tls.client.subject";
+
+/// Array of ciphers offered by the client during the client hello.
+///
+/// # Examples
+///
+/// - `"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "..."`
+pub const TLS_CLIENT_SUPPORTED_CIPHERS: &str = "tls.client.supported_ciphers";
+
+/// String indicating the curve used for the given cipher, when applicable.
+///
+/// # Examples
+///
+/// - `secp256r1`
+pub const TLS_CURVE: &str = "tls.curve";
+
+/// Boolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted tunnel.
+///
+/// # Examples
+///
+/// - `True`
+pub const TLS_ESTABLISHED: &str = "tls.established";
+
+/// String indicating the protocol being tunneled. Per the values in the [IANA registry](https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids), this string should be lower case.
+///
+/// # Examples
+///
+/// - `http/1.1`
+pub const TLS_NEXT_PROTOCOL: &str = "tls.next_protocol";
+
+/// Normalized lowercase protocol name parsed from original string of the negotiated [SSL/TLS protocol version](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html#RETURN-VALUES).
+pub const TLS_PROTOCOL_NAME: &str = "tls.protocol.name";
+
+/// Numeric part of the version parsed from the original string of the negotiated [SSL/TLS protocol version](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html#RETURN-VALUES).
+///
+/// # Examples
+///
+/// - `1.2`
+/// - `3`
+pub const TLS_PROTOCOL_VERSION: &str = "tls.protocol.version";
+
+/// Boolean flag indicating if this TLS connection was resumed from an existing TLS negotiation.
+///
+/// # Examples
+///
+/// - `True`
+pub const TLS_RESUMED: &str = "tls.resumed";
+
+/// PEM-encoded stand-alone certificate offered by the server. This is usually mutually-exclusive of `server.certificate_chain` since this value also exists in that list.
+///
+/// # Examples
+///
+/// - `MII...`
+pub const TLS_SERVER_CERTIFICATE: &str = "tls.server.certificate";
+
+/// Array of PEM-encoded certificates that make up the certificate chain offered by the server. This is usually mutually-exclusive of `server.certificate` since that value should be the first certificate in the chain.
+///
+/// # Examples
+///
+/// - `MII...`
+/// - `MI...`
+pub const TLS_SERVER_CERTIFICATE_CHAIN: &str = "tls.server.certificate_chain";
+
+/// Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.
+///
+/// # Examples
+///
+/// - `0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC`
+pub const TLS_SERVER_HASH_MD5: &str = "tls.server.hash.md5";
+
+/// Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.
+///
+/// # Examples
+///
+/// - `9E393D93138888D288266C2D915214D1D1CCEB2A`
+pub const TLS_SERVER_HASH_SHA1: &str = "tls.server.hash.sha1";
+
+/// Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.
+///
+/// # Examples
+///
+/// - `0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0`
+pub const TLS_SERVER_HASH_SHA256: &str = "tls.server.hash.sha256";
+
+/// Distinguished name of [subject](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6) of the issuer of the x.509 certificate presented by the client.
+///
+/// # Examples
+///
+/// - `CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com`
+pub const TLS_SERVER_ISSUER: &str = "tls.server.issuer";
+
+/// A hash that identifies servers based on how they perform an SSL/TLS handshake.
+///
+/// # Examples
+///
+/// - `d4e5b18d6b55c71272893221c96ba240`
+pub const TLS_SERVER_JA3S: &str = "tls.server.ja3s";
+
+/// Date/Time indicating when server certificate is no longer considered valid.
+///
+/// # Examples
+///
+/// - `2021-01-01T00:00:00.000Z`
+pub const TLS_SERVER_NOT_AFTER: &str = "tls.server.not_after";
+
+/// Date/Time indicating when server certificate is first considered valid.
+///
+/// # Examples
+///
+/// - `1970-01-01T00:00:00.000Z`
+pub const TLS_SERVER_NOT_BEFORE: &str = "tls.server.not_before";
+
+/// Distinguished name of subject of the x.509 certificate presented by the server.
+///
+/// # Examples
+///
+/// - `CN=myserver, OU=Documentation Team, DC=example, DC=com`
+pub const TLS_SERVER_SUBJECT: &str = "tls.server.subject";
+
+/// The [URI fragment](https://www.rfc-editor.org/rfc/rfc3986#section-3.5) component.
+///
+/// # Examples
+///
+/// - `SemConv`
+pub const URL_FRAGMENT: &str = "url.fragment";
+
+/// Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986).
+///
+/// For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it SHOULD be included nevertheless.
+/// `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password SHOULD be redacted and attribute&#39;s value SHOULD be `https://REDACTED:REDACTED@www.example.com/`.
+/// `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
+///
+/// # Examples
+///
+/// - `https://www.foo.bar/search?q=OpenTelemetry#SemConv`
+/// - `//localhost`
+pub const URL_FULL: &str = "url.full";
+
+/// The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component.
+///
+/// # Examples
+///
+/// - `/search`
+pub const URL_PATH: &str = "url.path";
+
+/// The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component.
+///
+/// Sensitive content provided in query string SHOULD be scrubbed when instrumentations can identify it.
+///
+/// # Examples
+///
+/// - `q=OpenTelemetry`
+pub const URL_QUERY: &str = "url.query";
+
+/// The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol.
+///
+/// # Examples
+///
+/// - `https`
+/// - `ftp`
+/// - `telnet`
+pub const URL_SCHEME: &str = "url.scheme";
+
+/// Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client.
+///
+/// # Examples
+///
+/// - `CERN-LineMode/2.15 libwww/2.17b3`
+/// - `Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1`
+pub const USER_AGENT_ORIGINAL: &str = "user_agent.original";
+
+/// A unique id to identify a session.
+///
+/// # Examples
+///
+/// - `00112233-4455-6677-8899-aabbccddeeff`
+pub const SESSION_ID: &str = "session.id";
+
+/// The previous `session.id` for this user, when known.
+///
+/// # Examples
+///
+/// - `00112233-4455-6677-8899-aabbccddeeff`
+pub const SESSION_PREVIOUS_ID: &str = "session.previous_id";
 
 /// The full invoked ARN as provided on the `Context` passed to the function (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable).
 ///
@@ -479,6 +1688,13 @@ pub const CLOUDEVENTS_EVENT_SOURCE: &str = "cloudevents.event_source";
 /// - `1.0`
 pub const CLOUDEVENTS_EVENT_SPEC_VERSION: &str = "cloudevents.event_spec_version";
 
+/// The [subject](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject) of the event in the context of the event producer (identified by source).
+///
+/// # Examples
+///
+/// - `mynewfile.jpg`
+pub const CLOUDEVENTS_EVENT_SUBJECT: &str = "cloudevents.event_subject";
+
 /// The [event_type](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type) contains a value describing the type of event related to the originating occurrence.
 ///
 /// # Examples
@@ -487,200 +1703,10 @@ pub const CLOUDEVENTS_EVENT_SPEC_VERSION: &str = "cloudevents.event_spec_version
 /// - `com.example.object.deleted.v2`
 pub const CLOUDEVENTS_EVENT_TYPE: &str = "cloudevents.event_type";
 
-/// The [subject](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject) of the event in the context of the event producer (identified by source).
-///
-/// # Examples
-///
-/// - `mynewfile.jpg`
-pub const CLOUDEVENTS_EVENT_SUBJECT: &str = "cloudevents.event_subject";
-
 /// Parent-child Reference type.
 ///
 /// The causal relationship between a child Span and a parent Span.
 pub const OPENTRACING_REF_TYPE: &str = "opentracing.ref_type";
-
-/// An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers.
-pub const DB_SYSTEM: &str = "db.system";
-
-/// The connection string used to connect to the database. It is recommended to remove embedded credentials.
-///
-/// # Examples
-///
-/// - `Server=(localdb)\v11.0;Integrated Security=true;`
-pub const DB_CONNECTION_STRING: &str = "db.connection_string";
-
-/// Username for accessing the database.
-///
-/// # Examples
-///
-/// - `readonly_user`
-/// - `reporting_user`
-pub const DB_USER: &str = "db.user";
-
-/// The fully-qualified class name of the [Java Database Connectivity (JDBC)](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/) driver used to connect.
-///
-/// # Examples
-///
-/// - `org.postgresql.Driver`
-/// - `com.microsoft.sqlserver.jdbc.SQLServerDriver`
-pub const DB_JDBC_DRIVER_CLASSNAME: &str = "db.jdbc.driver_classname";
-
-/// This attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails).
-///
-/// In some SQL databases, the database name to be used is called &#34;schema name&#34;. In case there are multiple layers that could be considered for database name (e.g. Oracle instance name and schema name), the database name to be used is the more specific layer (e.g. Oracle schema name).
-///
-/// # Examples
-///
-/// - `customers`
-/// - `main`
-pub const DB_NAME: &str = "db.name";
-
-/// The database statement being executed.
-///
-/// # Examples
-///
-/// - `SELECT * FROM wuser_table`
-/// - `SET mykey "WuValue"`
-pub const DB_STATEMENT: &str = "db.statement";
-
-/// The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`, or the SQL keyword.
-///
-/// When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
-///
-/// # Examples
-///
-/// - `findAndModify`
-/// - `HMSET`
-/// - `SELECT`
-pub const DB_OPERATION: &str = "db.operation";
-
-/// The Microsoft SQL Server [instance name](https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15) connecting to. This name is used to determine the port of a named instance.
-///
-/// If setting a `db.mssql.instance_name`, `server.port` is no longer required (but still recommended if non-standard).
-///
-/// # Examples
-///
-/// - `MSSQLSERVER`
-pub const DB_MSSQL_INSTANCE_NAME: &str = "db.mssql.instance_name";
-
-/// The fetch size used for paging, i.e. how many rows will be returned at once.
-///
-/// # Examples
-///
-/// - `5000`
-pub const DB_CASSANDRA_PAGE_SIZE: &str = "db.cassandra.page_size";
-
-/// The consistency level of the query. Based on consistency values from [CQL](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html).
-pub const DB_CASSANDRA_CONSISTENCY_LEVEL: &str = "db.cassandra.consistency_level";
-
-/// The name of the primary table that the operation is acting upon, including the keyspace name (if applicable).
-///
-/// This mirrors the db.sql.table attribute but references cassandra rather than sql. It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
-///
-/// # Examples
-///
-/// - `mytable`
-pub const DB_CASSANDRA_TABLE: &str = "db.cassandra.table";
-
-/// Whether or not the query is idempotent.
-pub const DB_CASSANDRA_IDEMPOTENCE: &str = "db.cassandra.idempotence";
-
-/// The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
-///
-/// # Examples
-///
-/// - `0`
-/// - `2`
-pub const DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT: &str =
-    "db.cassandra.speculative_execution_count";
-
-/// The ID of the coordinating node for a query.
-///
-/// # Examples
-///
-/// - `be13faa2-8574-4d71-926d-27f16cf8a7af`
-pub const DB_CASSANDRA_COORDINATOR_ID: &str = "db.cassandra.coordinator.id";
-
-/// The data center of the coordinating node for a query.
-///
-/// # Examples
-///
-/// - `us-west-2`
-pub const DB_CASSANDRA_COORDINATOR_DC: &str = "db.cassandra.coordinator.dc";
-
-/// The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` attribute.
-///
-/// # Examples
-///
-/// - `0`
-/// - `1`
-/// - `15`
-pub const DB_REDIS_DATABASE_INDEX: &str = "db.redis.database_index";
-
-/// The collection being accessed within the database stated in `db.name`.
-///
-/// # Examples
-///
-/// - `customers`
-/// - `products`
-pub const DB_MONGODB_COLLECTION: &str = "db.mongodb.collection";
-
-/// The name of the primary table that the operation is acting upon, including the database name (if applicable).
-///
-/// It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
-///
-/// # Examples
-///
-/// - `public.users`
-/// - `customers`
-pub const DB_SQL_TABLE: &str = "db.sql.table";
-
-/// Unique Cosmos client instance id.
-///
-/// # Examples
-///
-/// - `3ba4827d-4422-483f-b59f-85b74211c11d`
-pub const DB_COSMOSDB_CLIENT_ID: &str = "db.cosmosdb.client_id";
-
-/// CosmosDB Operation Type.
-pub const DB_COSMOSDB_OPERATION_TYPE: &str = "db.cosmosdb.operation_type";
-
-/// Cosmos client connection mode.
-pub const DB_COSMOSDB_CONNECTION_MODE: &str = "db.cosmosdb.connection_mode";
-
-/// Cosmos DB container name.
-///
-/// # Examples
-///
-/// - `anystring`
-pub const DB_COSMOSDB_CONTAINER: &str = "db.cosmosdb.container";
-
-/// Request payload size in bytes.
-pub const DB_COSMOSDB_REQUEST_CONTENT_LENGTH: &str = "db.cosmosdb.request_content_length";
-
-/// Cosmos DB status code.
-///
-/// # Examples
-///
-/// - `200`
-/// - `201`
-pub const DB_COSMOSDB_STATUS_CODE: &str = "db.cosmosdb.status_code";
-
-/// Cosmos DB sub status code.
-///
-/// # Examples
-///
-/// - `1000`
-/// - `1002`
-pub const DB_COSMOSDB_SUB_STATUS_CODE: &str = "db.cosmosdb.sub_status_code";
-
-/// RU consumed for that operation.
-///
-/// # Examples
-///
-/// - `46.18`
-/// - `1.0`
-pub const DB_COSMOSDB_REQUEST_CHARGE: &str = "db.cosmosdb.request_charge";
 
 /// Name of the code, either &#34;OK&#34; or &#34;ERROR&#34;. MUST NOT be set if the status code is UNSET.
 pub const OTEL_STATUS_CODE: &str = "otel.status_code";
@@ -691,19 +1717,6 @@ pub const OTEL_STATUS_CODE: &str = "otel.status_code";
 ///
 /// - `resource not found`
 pub const OTEL_STATUS_DESCRIPTION: &str = "otel.status_description";
-
-/// Type of the trigger which caused this function invocation.
-///
-/// For the server/consumer span on the incoming side,
-/// `faas.trigger` MUST be set.
-///
-/// Clients invoking FaaS instances usually cannot set `faas.trigger`,
-/// since they would typically need to look in the payload to determine
-/// the event type. If clients set it, it should be the same as the
-/// trigger that corresponding incoming would have (i.e., this has
-/// nothing to do with the underlying transport used to make the API
-/// call to invoke the lambda, which is often HTTP).
-pub const FAAS_TRIGGER: &str = "faas.trigger";
 
 /// The invocation ID of the current function invocation.
 ///
@@ -720,6 +1733,14 @@ pub const FAAS_INVOCATION_ID: &str = "faas.invocation_id";
 /// - `myDbName`
 pub const FAAS_DOCUMENT_COLLECTION: &str = "faas.document.collection";
 
+/// The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name.
+///
+/// # Examples
+///
+/// - `myFile.txt`
+/// - `myTableName`
+pub const FAAS_DOCUMENT_NAME: &str = "faas.document.name";
+
 /// Describes the type of the operation that was performed on the data.
 pub const FAAS_DOCUMENT_OPERATION: &str = "faas.document.operation";
 
@@ -730,13 +1751,12 @@ pub const FAAS_DOCUMENT_OPERATION: &str = "faas.document.operation";
 /// - `2020-01-23T13:47:06Z`
 pub const FAAS_DOCUMENT_TIME: &str = "faas.document.time";
 
-/// The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name.
+/// A string containing the schedule period as [Cron Expression](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm).
 ///
 /// # Examples
 ///
-/// - `myFile.txt`
-/// - `myTableName`
-pub const FAAS_DOCUMENT_NAME: &str = "faas.document.name";
+/// - `0/5 * * * ? *`
+pub const FAAS_CRON: &str = "faas.cron";
 
 /// A string containing the function invocation time in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime).
 ///
@@ -745,38 +1765,8 @@ pub const FAAS_DOCUMENT_NAME: &str = "faas.document.name";
 /// - `2020-01-23T13:47:06Z`
 pub const FAAS_TIME: &str = "faas.time";
 
-/// A string containing the schedule period as [Cron Expression](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm).
-///
-/// # Examples
-///
-/// - `0/5 * * * ? *`
-pub const FAAS_CRON: &str = "faas.cron";
-
 /// A boolean that is true if the serverless function is executed for the first time (aka cold-start).
 pub const FAAS_COLDSTART: &str = "faas.coldstart";
-
-/// The name of the invoked function.
-///
-/// SHOULD be equal to the `faas.name` resource attribute of the invoked function.
-///
-/// # Examples
-///
-/// - `my-function`
-pub const FAAS_INVOKED_NAME: &str = "faas.invoked_name";
-
-/// The cloud provider of the invoked function.
-///
-/// SHOULD be equal to the `cloud.provider` resource attribute of the invoked function.
-pub const FAAS_INVOKED_PROVIDER: &str = "faas.invoked_provider";
-
-/// The cloud region of the invoked function.
-///
-/// SHOULD be equal to the `cloud.region` resource attribute of the invoked function.
-///
-/// # Examples
-///
-/// - `eu-central-1`
-pub const FAAS_INVOKED_REGION: &str = "faas.invoked_region";
 
 /// The unique identifier of the feature flag.
 ///
@@ -810,191 +1800,6 @@ pub const FEATURE_FLAG_PROVIDER_NAME: &str = "feature_flag.provider_name";
 /// - `on`
 pub const FEATURE_FLAG_VARIANT: &str = "feature_flag.variant";
 
-/// [OSI Transport Layer](https://osi-model.com/transport-layer/) or [Inter-process Communication method](https://en.wikipedia.org/wiki/Inter-process_communication). The value SHOULD be normalized to lowercase.
-///
-/// # Examples
-///
-/// - `tcp`
-/// - `udp`
-pub const NETWORK_TRANSPORT: &str = "network.transport";
-
-/// [OSI Network Layer](https://osi-model.com/network-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase.
-///
-/// # Examples
-///
-/// - `ipv4`
-/// - `ipv6`
-pub const NETWORK_TYPE: &str = "network.type";
-
-/// [OSI Application Layer](https://osi-model.com/application-layer/) or non-OSI equivalent. The value SHOULD be normalized to lowercase.
-///
-/// # Examples
-///
-/// - `amqp`
-/// - `http`
-/// - `mqtt`
-pub const NETWORK_PROTOCOL_NAME: &str = "network.protocol.name";
-
-/// Version of the application layer protocol used. See note below.
-///
-/// `network.protocol.version` refers to the version of the protocol used and might be different from the protocol client&#39;s version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
-///
-/// # Examples
-///
-/// - `3.1.1`
-pub const NETWORK_PROTOCOL_VERSION: &str = "network.protocol.version";
-
-/// The internet connection type.
-///
-/// # Examples
-///
-/// - `wifi`
-pub const NETWORK_CONNECTION_TYPE: &str = "network.connection.type";
-
-/// This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
-///
-/// # Examples
-///
-/// - `LTE`
-pub const NETWORK_CONNECTION_SUBTYPE: &str = "network.connection.subtype";
-
-/// The name of the mobile carrier.
-///
-/// # Examples
-///
-/// - `sprint`
-pub const NETWORK_CARRIER_NAME: &str = "network.carrier.name";
-
-/// The mobile carrier country code.
-///
-/// # Examples
-///
-/// - `310`
-pub const NETWORK_CARRIER_MCC: &str = "network.carrier.mcc";
-
-/// The mobile carrier network code.
-///
-/// # Examples
-///
-/// - `001`
-pub const NETWORK_CARRIER_MNC: &str = "network.carrier.mnc";
-
-/// The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
-///
-/// # Examples
-///
-/// - `DE`
-pub const NETWORK_CARRIER_ICC: &str = "network.carrier.icc";
-
-/// The [`service.name`](/docs/resource/README.md#service) of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any.
-///
-/// # Examples
-///
-/// - `AuthTokenCache`
-pub const PEER_SERVICE: &str = "peer.service";
-
-/// Username or client_id extracted from the access token or [Authorization](https://tools.ietf.org/html/rfc7235#section-4.2) header in the inbound request from outside the system.
-///
-/// # Examples
-///
-/// - `username`
-pub const ENDUSER_ID: &str = "enduser.id";
-
-/// Actual/assumed role the client is making the request under extracted from token or application security context.
-///
-/// # Examples
-///
-/// - `admin`
-pub const ENDUSER_ROLE: &str = "enduser.role";
-
-/// Scopes or granted authorities the client currently possesses extracted from token or application security context. The value would come from the scope associated with an [OAuth 2.0 Access Token](https://tools.ietf.org/html/rfc6749#section-3.3) or an attribute value in a [SAML 2.0 Assertion](http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html).
-///
-/// # Examples
-///
-/// - `read:message, write:files`
-pub const ENDUSER_SCOPE: &str = "enduser.scope";
-
-/// Current &#34;managed&#34; thread ID (as opposed to OS thread ID).
-///
-/// # Examples
-///
-/// - `42`
-pub const THREAD_ID: &str = "thread.id";
-
-/// Current thread name.
-///
-/// # Examples
-///
-/// - `main`
-pub const THREAD_NAME: &str = "thread.name";
-
-/// The method or function name, or equivalent (usually rightmost part of the code unit&#39;s name).
-///
-/// # Examples
-///
-/// - `serveRequest`
-pub const CODE_FUNCTION: &str = "code.function";
-
-/// The &#34;namespace&#34; within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit.
-///
-/// # Examples
-///
-/// - `com.example.MyHttpService`
-pub const CODE_NAMESPACE: &str = "code.namespace";
-
-/// The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).
-///
-/// # Examples
-///
-/// - `/usr/local/MyApplication/content_root/app/index.php`
-pub const CODE_FILEPATH: &str = "code.filepath";
-
-/// The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
-///
-/// # Examples
-///
-/// - `42`
-pub const CODE_LINENO: &str = "code.lineno";
-
-/// The column number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
-///
-/// # Examples
-///
-/// - `16`
-pub const CODE_COLUMN: &str = "code.column";
-
-/// Original HTTP method sent by the client in the request line.
-///
-/// # Examples
-///
-/// - `GeT`
-/// - `ACL`
-/// - `foo`
-pub const HTTP_REQUEST_METHOD_ORIGINAL: &str = "http.request.method_original";
-
-/// The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size.
-///
-/// # Examples
-///
-/// - `3495`
-pub const HTTP_REQUEST_BODY_SIZE: &str = "http.request.body.size";
-
-/// The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size.
-///
-/// # Examples
-///
-/// - `3495`
-pub const HTTP_RESPONSE_BODY_SIZE: &str = "http.response.body.size";
-
-/// The ordinal number of request resending attempt (for any reason, including redirects).
-///
-/// The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
-///
-/// # Examples
-///
-/// - `3`
-pub const HTTP_RESEND_COUNT: &str = "http.resend_count";
-
 /// The AWS request ID as returned in the response headers `x-amz-request-id` or `x-amz-requestid`.
 ///
 /// # Examples
@@ -1003,13 +1808,16 @@ pub const HTTP_RESEND_COUNT: &str = "http.resend_count";
 /// - `C9ER4AJX75574TDJ`
 pub const AWS_REQUEST_ID: &str = "aws.request_id";
 
-/// The keys in the `RequestItems` object field.
+/// The value of the `AttributesToGet` request parameter.
 ///
 /// # Examples
 ///
-/// - `Users`
-/// - `Cats`
-pub const AWS_DYNAMODB_TABLE_NAMES: &str = "aws.dynamodb.table_names";
+/// - `lives`
+/// - `id`
+pub const AWS_DYNAMODB_ATTRIBUTES_TO_GET: &str = "aws.dynamodb.attributes_to_get";
+
+/// The value of the `ConsistentRead` request parameter.
+pub const AWS_DYNAMODB_CONSISTENT_READ: &str = "aws.dynamodb.consistent_read";
 
 /// The JSON-serialized value of each item in the `ConsumedCapacity` response field.
 ///
@@ -1018,12 +1826,35 @@ pub const AWS_DYNAMODB_TABLE_NAMES: &str = "aws.dynamodb.table_names";
 /// - `{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "ReadCapacityUnits": number, "Table": { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName": "string", "WriteCapacityUnits": number }`
 pub const AWS_DYNAMODB_CONSUMED_CAPACITY: &str = "aws.dynamodb.consumed_capacity";
 
+/// The value of the `IndexName` request parameter.
+///
+/// # Examples
+///
+/// - `name_to_group`
+pub const AWS_DYNAMODB_INDEX_NAME: &str = "aws.dynamodb.index_name";
+
 /// The JSON-serialized value of the `ItemCollectionMetrics` response field.
 ///
 /// # Examples
 ///
 /// - `{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob, "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" : "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S": "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }`
 pub const AWS_DYNAMODB_ITEM_COLLECTION_METRICS: &str = "aws.dynamodb.item_collection_metrics";
+
+/// The value of the `Limit` request parameter.
+///
+/// # Examples
+///
+/// - `10`
+pub const AWS_DYNAMODB_LIMIT: &str = "aws.dynamodb.limit";
+
+/// The value of the `ProjectionExpression` request parameter.
+///
+/// # Examples
+///
+/// - `Title`
+/// - `Title, Price, Color`
+/// - `Title, Description, RelatedItems, ProductReviews`
+pub const AWS_DYNAMODB_PROJECTION: &str = "aws.dynamodb.projection";
 
 /// The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
 ///
@@ -1041,40 +1872,6 @@ pub const AWS_DYNAMODB_PROVISIONED_READ_CAPACITY: &str = "aws.dynamodb.provision
 /// - `2.0`
 pub const AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY: &str = "aws.dynamodb.provisioned_write_capacity";
 
-/// The value of the `ConsistentRead` request parameter.
-pub const AWS_DYNAMODB_CONSISTENT_READ: &str = "aws.dynamodb.consistent_read";
-
-/// The value of the `ProjectionExpression` request parameter.
-///
-/// # Examples
-///
-/// - `Title`
-/// - `Title, Price, Color`
-/// - `Title, Description, RelatedItems, ProductReviews`
-pub const AWS_DYNAMODB_PROJECTION: &str = "aws.dynamodb.projection";
-
-/// The value of the `Limit` request parameter.
-///
-/// # Examples
-///
-/// - `10`
-pub const AWS_DYNAMODB_LIMIT: &str = "aws.dynamodb.limit";
-
-/// The value of the `AttributesToGet` request parameter.
-///
-/// # Examples
-///
-/// - `lives`
-/// - `id`
-pub const AWS_DYNAMODB_ATTRIBUTES_TO_GET: &str = "aws.dynamodb.attributes_to_get";
-
-/// The value of the `IndexName` request parameter.
-///
-/// # Examples
-///
-/// - `name_to_group`
-pub const AWS_DYNAMODB_INDEX_NAME: &str = "aws.dynamodb.index_name";
-
 /// The value of the `Select` request parameter.
 ///
 /// # Examples
@@ -1082,6 +1879,14 @@ pub const AWS_DYNAMODB_INDEX_NAME: &str = "aws.dynamodb.index_name";
 /// - `ALL_ATTRIBUTES`
 /// - `COUNT`
 pub const AWS_DYNAMODB_SELECT: &str = "aws.dynamodb.select";
+
+/// The keys in the `RequestItems` object field.
+///
+/// # Examples
+///
+/// - `Users`
+/// - `Cats`
+pub const AWS_DYNAMODB_TABLE_NAMES: &str = "aws.dynamodb.table_names";
 
 /// The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.
 ///
@@ -1115,20 +1920,6 @@ pub const AWS_DYNAMODB_TABLE_COUNT: &str = "aws.dynamodb.table_count";
 /// The value of the `ScanIndexForward` request parameter.
 pub const AWS_DYNAMODB_SCAN_FORWARD: &str = "aws.dynamodb.scan_forward";
 
-/// The value of the `Segment` request parameter.
-///
-/// # Examples
-///
-/// - `10`
-pub const AWS_DYNAMODB_SEGMENT: &str = "aws.dynamodb.segment";
-
-/// The value of the `TotalSegments` request parameter.
-///
-/// # Examples
-///
-/// - `100`
-pub const AWS_DYNAMODB_TOTAL_SEGMENTS: &str = "aws.dynamodb.total_segments";
-
 /// The value of the `Count` response parameter.
 ///
 /// # Examples
@@ -1142,6 +1933,20 @@ pub const AWS_DYNAMODB_COUNT: &str = "aws.dynamodb.count";
 ///
 /// - `50`
 pub const AWS_DYNAMODB_SCANNED_COUNT: &str = "aws.dynamodb.scanned_count";
+
+/// The value of the `Segment` request parameter.
+///
+/// # Examples
+///
+/// - `10`
+pub const AWS_DYNAMODB_SEGMENT: &str = "aws.dynamodb.segment";
+
+/// The value of the `TotalSegments` request parameter.
+///
+/// # Examples
+///
+/// - `100`
+pub const AWS_DYNAMODB_TOTAL_SEGMENTS: &str = "aws.dynamodb.total_segments";
 
 /// The JSON-serialized value of each item in the `AttributeDefinitions` request field.
 ///
@@ -1168,6 +1973,31 @@ pub const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES: &str =
 /// - `some-bucket-name`
 pub const AWS_S3_BUCKET: &str = "aws.s3.bucket";
 
+/// The source object (in the form `bucket`/`key`) for the copy operation.
+///
+/// The `copy_source` attribute applies to S3 copy operations and corresponds to the `--copy-source` parameter
+/// of the [copy-object operation within the S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html).
+/// This applies in particular to the following operations:
+///
+/// - [copy-object](https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html)
+/// - [upload-part-copy](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html)
+///
+/// # Examples
+///
+/// - `someFile.yml`
+pub const AWS_S3_COPY_SOURCE: &str = "aws.s3.copy_source";
+
+/// The delete request container that specifies the objects to be deleted.
+///
+/// The `delete` attribute is only applicable to the [delete-object](https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html) operation.
+/// The `delete` attribute corresponds to the `--delete` parameter of the
+/// [delete-objects operation within the S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-objects.html).
+///
+/// # Examples
+///
+/// - `Objects=[{Key=string,VersionId=string},{Key=string,VersionId=string}],Quiet=boolean`
+pub const AWS_S3_DELETE: &str = "aws.s3.delete";
+
 /// The S3 object key the request refers to. Corresponds to the `--key` parameter of the [S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html) operations.
 ///
 /// The `key` attribute is applicable to all object-related S3 operations, i.e. that require the object key as a mandatory parameter.
@@ -1192,19 +2022,17 @@ pub const AWS_S3_BUCKET: &str = "aws.s3.bucket";
 /// - `someFile.yml`
 pub const AWS_S3_KEY: &str = "aws.s3.key";
 
-/// The source object (in the form `bucket`/`key`) for the copy operation.
+/// The part number of the part being uploaded in a multipart-upload operation. This is a positive integer between 1 and 10,000.
 ///
-/// The `copy_source` attribute applies to S3 copy operations and corresponds to the `--copy-source` parameter
-/// of the [copy-object operation within the S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html).
-/// This applies in particular to the following operations:
-///
-/// - [copy-object](https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html)
-/// - [upload-part-copy](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html)
+/// The `part_number` attribute is only applicable to the [upload-part](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html)
+/// and [upload-part-copy](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html) operations.
+/// The `part_number` attribute corresponds to the `--part-number` parameter of the
+/// [upload-part operation within the S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html).
 ///
 /// # Examples
 ///
-/// - `someFile.yml`
-pub const AWS_S3_COPY_SOURCE: &str = "aws.s3.copy_source";
+/// - `3456`
+pub const AWS_S3_PART_NUMBER: &str = "aws.s3.part_number";
 
 /// Upload ID that identifies the multipart upload.
 ///
@@ -1223,28 +2051,14 @@ pub const AWS_S3_COPY_SOURCE: &str = "aws.s3.copy_source";
 /// - `dfRtDYWFbkRONycy.Yxwh66Yjlx.cph0gtNBtJ`
 pub const AWS_S3_UPLOAD_ID: &str = "aws.s3.upload_id";
 
-/// The delete request container that specifies the objects to be deleted.
+/// The GraphQL document being executed.
 ///
-/// The `delete` attribute is only applicable to the [delete-object](https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html) operation.
-/// The `delete` attribute corresponds to the `--delete` parameter of the
-/// [delete-objects operation within the S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-objects.html).
+/// The value may be sanitized to exclude sensitive information.
 ///
 /// # Examples
 ///
-/// - `Objects=[{Key=string,VersionId=string},{Key=string,VersionId=string}],Quiet=boolean`
-pub const AWS_S3_DELETE: &str = "aws.s3.delete";
-
-/// The part number of the part being uploaded in a multipart-upload operation. This is a positive integer between 1 and 10,000.
-///
-/// The `part_number` attribute is only applicable to the [upload-part](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html)
-/// and [upload-part-copy](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html) operations.
-/// The `part_number` attribute corresponds to the `--part-number` parameter of the
-/// [upload-part operation within the S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html).
-///
-/// # Examples
-///
-/// - `3456`
-pub const AWS_S3_PART_NUMBER: &str = "aws.s3.part_number";
+/// - `query findBookById { bookById(id: ?) { name } }`
+pub const GRAPHQL_DOCUMENT: &str = "graphql.document";
 
 /// The name of the operation being executed.
 ///
@@ -1262,347 +2076,16 @@ pub const GRAPHQL_OPERATION_NAME: &str = "graphql.operation.name";
 /// - `subscription`
 pub const GRAPHQL_OPERATION_TYPE: &str = "graphql.operation.type";
 
-/// The GraphQL document being executed.
-///
-/// The value may be sanitized to exclude sensitive information.
-///
-/// # Examples
-///
-/// - `query findBookById { bookById(id: ?) { name } }`
-pub const GRAPHQL_DOCUMENT: &str = "graphql.document";
-
-/// A value used by the messaging system as an identifier for the message, represented as a string.
-///
-/// # Examples
-///
-/// - `452a7c7c7c7048c2f887f61572b18fc2`
-pub const MESSAGING_MESSAGE_ID: &str = "messaging.message.id";
-
-/// The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called &#34;Correlation ID&#34;.
-///
-/// # Examples
-///
-/// - `MyConversationId`
-pub const MESSAGING_MESSAGE_CONVERSATION_ID: &str = "messaging.message.conversation_id";
-
-/// The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
-///
-/// # Examples
-///
-/// - `2738`
-pub const MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES: &str = "messaging.message.payload_size_bytes";
-
-/// The compressed size of the message payload in bytes.
-///
-/// # Examples
-///
-/// - `2048`
-pub const MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES: &str =
-    "messaging.message.payload_compressed_size_bytes";
-
-/// The message destination name.
-///
-/// Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
-/// the broker does not have such notion, the destination name SHOULD uniquely identify the broker.
-///
-/// # Examples
-///
-/// - `MyQueue`
-/// - `MyTopic`
-pub const MESSAGING_DESTINATION_NAME: &str = "messaging.destination.name";
-
-/// Low cardinality representation of the messaging destination name.
-///
-/// Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
-///
-/// # Examples
-///
-/// - `/customers/{customerId}`
-pub const MESSAGING_DESTINATION_TEMPLATE: &str = "messaging.destination.template";
-
-/// A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed.
-pub const MESSAGING_DESTINATION_TEMPORARY: &str = "messaging.destination.temporary";
-
-/// A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).
-pub const MESSAGING_DESTINATION_ANONYMOUS: &str = "messaging.destination.anonymous";
-
-/// A string identifying the messaging system.
-///
-/// # Examples
-///
-/// - `kafka`
-/// - `rabbitmq`
-/// - `rocketmq`
-/// - `activemq`
-/// - `AmazonSQS`
-pub const MESSAGING_SYSTEM: &str = "messaging.system";
-
-/// A string identifying the kind of messaging operation as defined in the [Operation names](#operation-names) section above.
-///
-/// If a custom value is used, it MUST be of low cardinality.
-pub const MESSAGING_OPERATION: &str = "messaging.operation";
-
-/// The number of messages sent, received, or processed in the scope of the batching operation.
-///
-/// Instrumentations SHOULD NOT set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.message_count` for batching APIs and SHOULD NOT use it for single-message APIs.
-///
-/// # Examples
-///
-/// - `0`
-/// - `1`
-/// - `2`
-pub const MESSAGING_BATCH_MESSAGE_COUNT: &str = "messaging.batch.message_count";
-
-/// A unique identifier for the client that consumes or produces a message.
-///
-/// # Examples
-///
-/// - `client-5`
-/// - `myhost@8742@s8083jm`
-pub const MESSAGING_CLIENT_ID: &str = "messaging.client_id";
-
-/// RabbitMQ message routing key.
-///
-/// # Examples
-///
-/// - `myKey`
-pub const MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY: &str =
-    "messaging.rabbitmq.destination.routing_key";
-
-/// Message keys in Kafka are used for grouping alike messages to ensure they&#39;re processed on the same partition. They differ from `messaging.message.id` in that they&#39;re not unique. If the key is `null`, the attribute MUST NOT be set.
-///
-/// If the key type is not string, it&#39;s string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don&#39;t include its value.
-///
-/// # Examples
-///
-/// - `myKey`
-pub const MESSAGING_KAFKA_MESSAGE_KEY: &str = "messaging.kafka.message.key";
-
-/// Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers.
-///
-/// # Examples
-///
-/// - `my-group`
-pub const MESSAGING_KAFKA_CONSUMER_GROUP: &str = "messaging.kafka.consumer.group";
-
-/// Partition the message is sent to.
-///
-/// # Examples
-///
-/// - `2`
-pub const MESSAGING_KAFKA_DESTINATION_PARTITION: &str = "messaging.kafka.destination.partition";
-
-/// The offset of a record in the corresponding Kafka partition.
-///
-/// # Examples
-///
-/// - `42`
-pub const MESSAGING_KAFKA_MESSAGE_OFFSET: &str = "messaging.kafka.message.offset";
-
-/// A boolean that is true if the message is a tombstone.
-pub const MESSAGING_KAFKA_MESSAGE_TOMBSTONE: &str = "messaging.kafka.message.tombstone";
-
-/// Namespace of RocketMQ resources, resources in different namespaces are individual.
-///
-/// # Examples
-///
-/// - `myNamespace`
-pub const MESSAGING_ROCKETMQ_NAMESPACE: &str = "messaging.rocketmq.namespace";
-
-/// Name of the RocketMQ producer/consumer group that is handling the message. The client type is identified by the SpanKind.
-///
-/// # Examples
-///
-/// - `myConsumerGroup`
-pub const MESSAGING_ROCKETMQ_CLIENT_GROUP: &str = "messaging.rocketmq.client_group";
-
-/// The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
-///
-/// # Examples
-///
-/// - `1665987217045`
-pub const MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP: &str =
-    "messaging.rocketmq.message.delivery_timestamp";
-
-/// The delay time level for delay message, which determines the message delay time.
-///
-/// # Examples
-///
-/// - `3`
-pub const MESSAGING_ROCKETMQ_MESSAGE_DELAY_TIME_LEVEL: &str =
-    "messaging.rocketmq.message.delay_time_level";
-
-/// It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group.
-///
-/// # Examples
-///
-/// - `myMessageGroup`
-pub const MESSAGING_ROCKETMQ_MESSAGE_GROUP: &str = "messaging.rocketmq.message.group";
-
-/// Type of message.
-pub const MESSAGING_ROCKETMQ_MESSAGE_TYPE: &str = "messaging.rocketmq.message.type";
-
-/// The secondary classifier of message besides topic.
-///
-/// # Examples
-///
-/// - `tagA`
-pub const MESSAGING_ROCKETMQ_MESSAGE_TAG: &str = "messaging.rocketmq.message.tag";
-
-/// Key(s) of message, another way to mark message besides message id.
-///
-/// # Examples
-///
-/// - `keyA`
-/// - `keyB`
-pub const MESSAGING_ROCKETMQ_MESSAGE_KEYS: &str = "messaging.rocketmq.message.keys";
-
-/// Model of message consumption. This only applies to consumer spans.
-pub const MESSAGING_ROCKETMQ_CONSUMPTION_MODEL: &str = "messaging.rocketmq.consumption_model";
-
-/// A string identifying the remoting system. See below for a list of well-known identifiers.
-pub const RPC_SYSTEM: &str = "rpc.system";
-
-/// The full (logical) name of the service being called, including its package name, if applicable.
-///
-/// This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
-///
-/// # Examples
-///
-/// - `myservice.EchoService`
-pub const RPC_SERVICE: &str = "rpc.service";
-
-/// The name of the (logical) method being called, must be equal to the $method part in the span name.
-///
-/// This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
-///
-/// # Examples
-///
-/// - `exampleMethod`
-pub const RPC_METHOD: &str = "rpc.method";
-
-/// The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request.
-pub const RPC_GRPC_STATUS_CODE: &str = "rpc.grpc.status_code";
-
-/// Protocol version as in `jsonrpc` property of request/response. Since JSON-RPC 1.0 does not specify this, the value can be omitted.
-///
-/// # Examples
-///
-/// - `2.0`
-/// - `1.0`
-pub const RPC_JSONRPC_VERSION: &str = "rpc.jsonrpc.version";
-
-/// `id` property of request or response. Since protocol allows id to be int, string, `null` or missing (for notifications), value is expected to be cast to string for simplicity. Use empty string in case of `null` value. Omit entirely if this is a notification.
-///
-/// # Examples
-///
-/// - `10`
-/// - `request-7`
-/// - ``
-pub const RPC_JSONRPC_REQUEST_ID: &str = "rpc.jsonrpc.request_id";
-
-/// `error.code` property of response if it is an error response.
-///
-/// # Examples
-///
-/// - `-32700`
-/// - `100`
-pub const RPC_JSONRPC_ERROR_CODE: &str = "rpc.jsonrpc.error_code";
-
-/// `error.message` property of response if it is an error response.
-///
-/// # Examples
-///
-/// - `Parse error`
-/// - `User already exists`
-pub const RPC_JSONRPC_ERROR_MESSAGE: &str = "rpc.jsonrpc.error_message";
-
-/// Whether this is a received or sent message.
-pub const MESSAGE_TYPE: &str = "message.type";
+/// Compressed size of the message in bytes.
+pub const MESSAGE_COMPRESSED_SIZE: &str = "message.compressed_size";
 
 /// MUST be calculated as two different counters starting from `1` one for sent messages and one for received message.
 ///
 /// This way we guarantee that the values will be consistent between different implementations.
 pub const MESSAGE_ID: &str = "message.id";
 
-/// Compressed size of the message in bytes.
-pub const MESSAGE_COMPRESSED_SIZE: &str = "message.compressed_size";
+/// Whether this is a received or sent message.
+pub const MESSAGE_TYPE: &str = "message.type";
 
 /// Uncompressed size of the message in bytes.
 pub const MESSAGE_UNCOMPRESSED_SIZE: &str = "message.uncompressed_size";
-
-/// The [error codes](https://connect.build/docs/protocol/#error-codes) of the Connect request. Error codes are always string values.
-pub const RPC_CONNECT_RPC_ERROR_CODE: &str = "rpc.connect_rpc.error_code";
-
-/// SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.
-///
-/// An exception is considered to have escaped (or left) the scope of a span,
-/// if that span is ended while the exception is still logically &#34;in flight&#34;.
-/// This may be actually &#34;in flight&#34; in some languages (e.g. if the exception
-/// is passed to a Context manager&#39;s `__exit__` method in Python) but will
-/// usually be caught at the point of recording the exception in most languages.
-///
-/// It is usually not possible to determine at the point where an exception is thrown
-/// whether it will escape the scope of a span.
-/// However, it is trivial to know that an exception
-/// will escape, if one checks for an active exception just before ending the span,
-/// as done in the [example above](#recording-an-exception).
-///
-/// It follows that an exception may still escape the scope of the span
-/// even if the `exception.escaped` attribute was not set or set to false,
-/// since the event might have been recorded at a time where it was not
-/// clear whether the exception will escape.
-pub const EXCEPTION_ESCAPED: &str = "exception.escaped";
-
-/// The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol.
-///
-/// # Examples
-///
-/// - `https`
-/// - `ftp`
-/// - `telnet`
-pub const URL_SCHEME: &str = "url.scheme";
-
-/// Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986).
-///
-/// For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
-/// `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password should be redacted and attribute&#39;s value should be `https://REDACTED:REDACTED@www.example.com/`.
-/// `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed) and SHOULD NOT be validated or modified except for sanitizing purposes.
-///
-/// # Examples
-///
-/// - `https://www.foo.bar/search?q=OpenTelemetry#SemConv`
-/// - `//localhost`
-pub const URL_FULL: &str = "url.full";
-
-/// The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component.
-///
-/// When missing, the value is assumed to be `/`
-///
-/// # Examples
-///
-/// - `/search`
-pub const URL_PATH: &str = "url.path";
-
-/// The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component.
-///
-/// Sensitive content provided in query string SHOULD be scrubbed when instrumentations can identify it.
-///
-/// # Examples
-///
-/// - `q=OpenTelemetry`
-pub const URL_QUERY: &str = "url.query";
-
-/// The [URI fragment](https://www.rfc-editor.org/rfc/rfc3986#section-3.5) component.
-///
-/// # Examples
-///
-/// - `SemConv`
-pub const URL_FRAGMENT: &str = "url.fragment";
-
-/// Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client.
-///
-/// # Examples
-///
-/// - `CERN-LineMode/2.15 libwww/2.17b3`
-pub const USER_AGENT_ORIGINAL: &str = "user_agent.original";


### PR DESCRIPTION
## Changes

Update semantic convention from (current) v.1.21.0 to v1.24.0 - https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.24.0

Breaking changes across these two versions:

**Trace attributes removed/renamed:**
```bash
$ diff <(grep "pub const" ./trace_1.24.0.rs | sort) <(grep "pub const" ./trace_1.21.0.rs | sort)  | grep "> "
> pub const CLIENT_SOCKET_ADDRESS: &str = "client.socket.address";
> pub const CLIENT_SOCKET_PORT: &str = "client.socket.port";
> pub const DESTINATION_DOMAIN: &str = "destination.domain";
> pub const EVENT_DOMAIN: &str = "event.domain";
> pub const HTTP_RESEND_COUNT: &str = "http.resend_count";
> pub const MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES: &str =
> pub const MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES: &str = "messaging.message.payload_size_bytes";
> pub const POOL: &str = "pool";
> pub const SERVER_SOCKET_ADDRESS: &str = "server.socket.address";
> pub const SERVER_SOCKET_DOMAIN: &str = "server.socket.domain";
> pub const SERVER_SOCKET_PORT: &str = "server.socket.port";
> pub const SOURCE_DOMAIN: &str = "source.domain";
> pub const TYPE: &str = "type";
$
```

**Resource attributes removed/renamed:**
```bash
$ diff <(grep "pub const" ./resource_1.24.0.rs | sort) <(grep "pub const" ./resource_1.21.0.rs | sort)  | grep "> "
> pub const CONTAINER_IMAGE_TAG: &str = "container.image.tag";
> pub const TELEMETRY_AUTO_VERSION: &str = "telemetry.auto.version";
$
```



## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
