### PR TITLE
Add External Type Checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
   external-types:
     strategy:
       matrix:
-        example: [opentelemetry, opentelemetry-sdk]
+        example: [opentelemetry, opentelemetry-sdk, opentelemetry-otlp, opentelemetry-zipkin]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/opentelemetry-otlp/allowed-external-types.toml
+++ b/opentelemetry-otlp/allowed-external-types.toml
@@ -1,0 +1,22 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# This is used with cargo-check-external-types to reduce the surface area of downstream crates from
+# the public API. Ideally this can have a few exceptions as possible.
+allowed_external_types = [
+    "opentelemetry::*",
+    "opentelemetry_http::*",
+    "opentelemetry_sdk::*",
+    # http is a pre 1.0 crate
+    "http::uri::InvalidUri",
+    "http::header::name::InvalidHeaderName",
+    "http::header::value::InvalidHeaderValue",
+    # prost is a pre 1.0 crate
+    "prost::error::EncodeError",
+    # tonic is a pre 1.0 crate
+    "tonic::status::Code",
+    "tonic::status::Status",
+    "tonic::metadata::map::MetadataMap",
+    "tonic::transport::channel::Channel",
+    "tonic::transport::error::Error",
+    "tonic::service::interceptor::Interceptor",
+]

--- a/opentelemetry-zipkin/allowed-external-types.toml
+++ b/opentelemetry-zipkin/allowed-external-types.toml
@@ -1,0 +1,12 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# This is used with cargo-check-external-types to reduce the surface area of downstream crates from
+# the public API. Ideally this can have a few exceptions as possible.
+allowed_external_types = [
+    "opentelemetry::*",
+    "opentelemetry_http::*",
+    "opentelemetry_sdk::*",
+    # http is a pre 1.0 crate
+    "http::error::Error",
+    "http::uri::InvalidUri",
+]


### PR DESCRIPTION
The purpose of this is to ensure we understand the API surface area. Anything exposed by a crate like a type can affect the possible compatibility. This means that if we bump an external type it could cause breaking changes. This tracks them to limit this possibility.

Affected Crates:
- opentelemetry-otlp
- opentelemetry-zipkin

Fixes #
Design discussion issue (if applicable) #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
