### PR TITLE
feat: allow user to attach resource to every metrics.

### DIFF
--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Added
+
+- Add `ResourceSelector` to allow attaching resource as attributes to metrics [#1608](https://github.com/open-telemetry/opentelemetry-rust/pull/1608)
+
 ## v0.15.0
 
 ### Changed

--- a/opentelemetry-prometheus/src/resource_selector.rs
+++ b/opentelemetry-prometheus/src/resource_selector.rs
@@ -7,11 +7,11 @@ use std::collections::HashSet;
 /// `ResourceSelector` is used to select which resource to export with every metrics.
 ///
 /// By default, the exporter will only export resource as `target_info` metrics but not inline in every
-/// metrics. You can disable this behavior by calling [`ExporterBuilder::without_target_info`].
+/// metrics. You can disable this behavior by calling [`without_target_info`](crate::ExporterBuilder::without_target_info)
 ///
 /// You can add resource to every metrics by set `ResourceSelector` to anything other than `None`.
 ///
-/// By default, ResouceSelector is `None`.
+/// By default, ResourceSelector is `None`, meaning resource will not be attributes of every metrics.
 #[derive(Debug, Default)]
 #[non_exhaustive]
 pub enum ResourceSelector {

--- a/opentelemetry-prometheus/src/resource_selector.rs
+++ b/opentelemetry-prometheus/src/resource_selector.rs
@@ -1,0 +1,43 @@
+use crate::get_attrs;
+use opentelemetry::Key;
+use opentelemetry_sdk::Resource;
+use prometheus::proto::LabelPair;
+use std::collections::HashSet;
+
+/// `ResourceSelector` is used to select which resource to export with every metrics.
+///
+/// By default, the exporter will only export resource as `target_info` metrics but not inline in every
+/// metrics. You can disable this behavior by calling [`ExporterBuilder::without_target_info`].
+///
+/// You can add resource to every metrics by set `ResourceSelector` to anything other than `None`.
+///
+/// By default, ResouceSelector is `None`.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub enum ResourceSelector {
+    /// Export all resource attributes with every metrics.
+    All,
+    /// Do not export any resource attributes with every metrics.
+    #[default]
+    None,
+    /// Export only the resource attributes in the allow list with every metrics.
+    KeyAllowList(HashSet<Key>),
+}
+
+impl From<HashSet<Key>> for ResourceSelector {
+    fn from(keys: HashSet<Key>) -> Self {
+        ResourceSelector::KeyAllowList(keys)
+    }
+}
+
+impl ResourceSelector {
+    pub(crate) fn select(&self, resource: &Resource) -> Vec<LabelPair> {
+        match self {
+            ResourceSelector::All => get_attrs(&mut resource.iter(), &[]),
+            ResourceSelector::None => Vec::new(),
+            ResourceSelector::KeyAllowList(keys) => {
+                get_attrs(&mut resource.iter().filter(|(k, _)| keys.contains(k)), &[])
+            }
+        }
+    }
+}

--- a/opentelemetry-prometheus/tests/data/resource_in_every_metrics.txt
+++ b/opentelemetry-prometheus/tests/data/resource_in_every_metrics.txt
@@ -1,0 +1,9 @@
+# HELP bar_ratio a fun little gauge
+# TYPE bar_ratio gauge
+bar_ratio{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",service_name="prometheus_test",telemetry_sdk_language="rust",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+# HELP target_info Target metadata
+# TYPE target_info gauge
+target_info{service_name="prometheus_test",telemetry_sdk_language="rust",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1

--- a/opentelemetry-prometheus/tests/data/select_resource_in_every_metrics.txt
+++ b/opentelemetry-prometheus/tests/data/select_resource_in_every_metrics.txt
@@ -1,0 +1,9 @@
+# HELP bar_ratio a fun little gauge
+# TYPE bar_ratio gauge
+bar_ratio{A="B",C="D",otel_scope_name="testmeter",otel_scope_version="v0.1.0",service_name="prometheus_test"} 1
+# HELP otel_scope_info Instrumentation Scope metadata
+# TYPE otel_scope_info gauge
+otel_scope_info{otel_scope_name="testmeter",otel_scope_version="v0.1.0"} 1
+# HELP target_info Target metadata
+# TYPE target_info gauge
+target_info{service_name="prometheus_test",telemetry_sdk_language="rust",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="latest"} 1


### PR DESCRIPTION
Fixes #1565 
Design discussion issue (if applicable) #

## Changes

- add a `ResourceSelector` to prometheus exporter so users are allowed to add add resrouce to every metrics

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
