### PR TITLE
Avoid enabling the transport feature of tonic if not needed

### DIFF
--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -48,7 +48,7 @@ with-schemars = ["schemars"]
 with-serde = ["serde", "hex"]
 
 [dependencies]
-tonic = { workspace = true, optional = true, features = ["codegen", "prost"] }
+tonic = { workspace = true, optional = true, default-features = false, features = ["codegen", "prost"] }
 prost = { workspace = true, optional = true }
 opentelemetry = { version = "0.22", default-features = false, path = "../opentelemetry" }
 opentelemetry_sdk = { version = "0.22", default-features = false, path = "../opentelemetry-sdk" }


### PR DESCRIPTION
## Changes

This disables the default features of `tonic` in `opentelemetry-proto`, so that the `transport` feature doesn't get enabled by default.
This shrinks the dependency tree when using `opentelemetry-otlp` with only the HTTP transport not the GRPC one.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* N/A Unit tests added/updated (if applicable)
* N/A Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* N/A Changes in public API reviewed (if applicable)
