### PR TITLE
Disable compiler optimization for noop benchmark tests

### DIFF
--- a/opentelemetry/benches/noop_metrics.rs
+++ b/opentelemetry/benches/noop_metrics.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use opentelemetry::{
     metrics::{noop::NoopMeterProvider, Counter, MeterProvider as _},
     KeyValue,
@@ -67,24 +67,24 @@ fn noop_counter_add(c: &mut Criterion) {
     #[allow(clippy::useless_vec)]
     c.bench_function("CreateVector_KeyValue", |b| {
         b.iter(|| {
-            let _v1 = vec![
+            let _v1 = black_box(vec![
                 KeyValue::new("attribute1", "value1"),
                 KeyValue::new("attribute2", "value2"),
                 KeyValue::new("attribute3", "value3"),
                 KeyValue::new("attribute4", "value4"),
-            ];
+            ]);
         });
     });
 
     #[allow(clippy::useless_vec)]
     c.bench_function("CreateDynamicVector_StringPair", |b| {
         b.iter(|| {
-            let _v1 = vec![
+            let _v1 = black_box(vec![
                 ("attribute1", "value1"),
                 ("attribute2", "value2"),
                 ("attribute3", "value3"),
                 ("attribute4", "value4"),
-            ];
+            ]);
         });
     });
 }


### PR DESCRIPTION
## Changes
Gives more releastic cost for Vector of string tuple, and Vector of Key-Value.


**_CreateVector_KeyValue:_** 25.731 ns
**_CreateDynamicVector_StringPair:_** 13.419 ns 

Note - should be merged after #1611 

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
