### PR TITLE
Refactory opentelemetry benchmarks

### DIFF
--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -45,6 +45,10 @@ opentelemetry_sdk = { path = "../opentelemetry-sdk" } # for documentation tests
 criterion = { version = "0.3" }
 
 [[bench]]
-name = "noop_metrics"
+name = "metrics"
 harness = false
 required-features = ["metrics"]
+
+[[bench]]
+name = "attributes"
+harness = false

--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -9,20 +9,15 @@ fn criterion_benchmark(c: &mut Criterion) {
 }
 
 fn attributes_creation(c: &mut Criterion) {
-
     c.bench_function("CreateOTelKeyValue", |b| {
         b.iter(|| {
-            let _v1 = black_box(
-                KeyValue::new("attribute1", "value1")
-            );
+            let _v1 = black_box(KeyValue::new("attribute1", "value1"));
         });
     });
 
     c.bench_function("CreateKeyValueTuple", |b| {
         b.iter(|| {
-            let _v1 = black_box(
-                ("attribute1", "value1")
-            );
+            let _v1 = black_box(("attribute1", "value1"));
         });
     });
 

--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -1,0 +1,56 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use opentelemetry::KeyValue;
+
+// Run this benchmark with:
+// cargo bench --bench attributes
+
+fn criterion_benchmark(c: &mut Criterion) {
+    attributes_creation(c);
+}
+
+fn attributes_creation(c: &mut Criterion) {
+
+    c.bench_function("CreateOTelKeyValue", |b| {
+        b.iter(|| {
+            let _v1 = black_box(
+                KeyValue::new("attribute1", "value1")
+            );
+        });
+    });
+
+    c.bench_function("CreateKeyValueTuple", |b| {
+        b.iter(|| {
+            let _v1 = black_box(
+                ("attribute1", "value1")
+            );
+        });
+    });
+
+    #[allow(clippy::useless_vec)]
+    c.bench_function("CreateVector_KeyValue", |b| {
+        b.iter(|| {
+            let _v1 = black_box(vec![
+                KeyValue::new("attribute1", "value1"),
+                KeyValue::new("attribute2", "value2"),
+                KeyValue::new("attribute3", "value3"),
+                KeyValue::new("attribute4", "value4"),
+            ]);
+        });
+    });
+
+    #[allow(clippy::useless_vec)]
+    c.bench_function("CreateVector_StringPairs", |b| {
+        b.iter(|| {
+            let _v1 = black_box(vec![
+                ("attribute1", "value1"),
+                ("attribute2", "value2"),
+                ("attribute3", "value3"),
+                ("attribute4", "value4"),
+            ]);
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+
+criterion_main!(benches);

--- a/opentelemetry/benches/metrics.rs
+++ b/opentelemetry/benches/metrics.rs
@@ -1,8 +1,11 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::{
     metrics::{noop::NoopMeterProvider, Counter, MeterProvider as _},
     KeyValue,
 };
+
+// Run this benchmark with:
+// cargo bench --bench metrics --features=metrics
 
 fn create_counter() -> Counter<u64> {
     let meter_provider: NoopMeterProvider = NoopMeterProvider::default();
@@ -12,21 +15,21 @@ fn create_counter() -> Counter<u64> {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    noop_counter_add(c);
+    counter_add(c);
 }
 
-fn noop_counter_add(c: &mut Criterion) {
-    let noop_counter = create_counter();
+fn counter_add(c: &mut Criterion) {
+    let counter = create_counter();
 
-    c.bench_function("NoopCounter_NoAttributes", |b| {
+    c.bench_function("Counter_NoAttributes", |b| {
         b.iter(|| {
-            noop_counter.add(1, &[]);
+            counter.add(1, &[]);
         });
     });
 
-    c.bench_function("NoopCounter_AddWithInlineStaticAttributes", |b| {
+    c.bench_function("Counter_AddWithInlineStaticAttributes", |b| {
         b.iter(|| {
-            noop_counter.add(
+            counter.add(
                 1,
                 &[
                     KeyValue::new("attribute1", "value1"),
@@ -38,7 +41,7 @@ fn noop_counter_add(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("NoopCounter_AddWithStaticArray", |b| {
+    c.bench_function("Counter_AddWithStaticArray", |b| {
         b.iter(|| {
             let kv = [
                 KeyValue::new("attribute1", "value1"),
@@ -47,11 +50,11 @@ fn noop_counter_add(c: &mut Criterion) {
                 KeyValue::new("attribute4", "value4"),
             ];
 
-            noop_counter.add(1, &kv);
+            counter.add(1, &kv);
         });
     });
 
-    c.bench_function("NoopCounter_AddWithDynamicAttributes", |b| {
+    c.bench_function("Counter_AddWithDynamicAttributes", |b| {
         b.iter(|| {
             let kv = vec![
                 KeyValue::new("attribute1", "value1"),
@@ -60,31 +63,7 @@ fn noop_counter_add(c: &mut Criterion) {
                 KeyValue::new("attribute4", "value4"),
             ];
 
-            noop_counter.add(1, &kv);
-        });
-    });
-
-    #[allow(clippy::useless_vec)]
-    c.bench_function("CreateVector_KeyValue", |b| {
-        b.iter(|| {
-            let _v1 = black_box(vec![
-                KeyValue::new("attribute1", "value1"),
-                KeyValue::new("attribute2", "value2"),
-                KeyValue::new("attribute3", "value3"),
-                KeyValue::new("attribute4", "value4"),
-            ]);
-        });
-    });
-
-    #[allow(clippy::useless_vec)]
-    c.bench_function("CreateDynamicVector_StringPair", |b| {
-        b.iter(|| {
-            let _v1 = black_box(vec![
-                ("attribute1", "value1"),
-                ("attribute2", "value2"),
-                ("attribute3", "value3"),
-                ("attribute4", "value4"),
-            ]);
+            counter.add(1, &kv);
         });
     });
 }


### PR DESCRIPTION
Separate into metrics and key values. We expect to add more such micro benchmarks to get good understanding of the overhead introduced in `opentelemetry` itself.