### PR TITLE
Remove unnecessary flush from tests

### DIFF
--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -38,8 +38,6 @@ mod tests {
         log_record.attributes = Some(attributes);
         logger.emit(log_record);
 
-        logger_provider.force_flush();
-
         // Assert
         let exported_logs = exporter
             .get_emitted_logs()

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -110,7 +110,10 @@ mod tests {
         span.set_attribute(KeyValue::new("attribute1", "value1"));
         span.add_event("test-event".to_string(), vec![]);
         span.set_status(Status::error("cancelled"));
-        drop(span);
+        span.end();
+
+        // After span end, further operations should not have any effect
+        span.update_name("span_name_updated");
 
         // Assert
         let exported_spans = exporter

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -80,8 +80,6 @@ mod tests {
             span.add_event("test-event".to_string(), vec![]);
         });
 
-        provider.force_flush();
-
         // Assert
         let exported_spans = exporter
             .get_finished_spans()
@@ -112,8 +110,8 @@ mod tests {
         span.set_attribute(KeyValue::new("attribute1", "value1"));
         span.add_event("test-event".to_string(), vec![]);
         span.set_status(Status::error("cancelled"));
-        drop(span);
         provider.force_flush();
+        drop(span);
 
         // Assert
         let exported_spans = exporter
@@ -150,7 +148,6 @@ mod tests {
         span.add_event("test-event".to_string(), vec![]);
         span.set_status(Status::Ok);
         drop(span);
-        provider.force_flush();
 
         // Assert
         let exported_spans = exporter
@@ -197,7 +194,6 @@ mod tests {
         let span_builder = SpanBuilder::from_name("span_name").with_links(links);
         let mut span = tracer.build(span_builder);
         span.end();
-        provider.force_flush();
 
         // Assert
         let exported_spans = exporter
@@ -233,7 +229,6 @@ mod tests {
         span.add_event("test event again, after span builder", Vec::new());
         span.add_event("test event once again, after span builder", Vec::new());
         span.end();
-        provider.force_flush();
 
         // Assert
         let exported_spans = exporter

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -110,7 +110,6 @@ mod tests {
         span.set_attribute(KeyValue::new("attribute1", "value1"));
         span.add_event("test-event".to_string(), vec![]);
         span.set_status(Status::error("cancelled"));
-        provider.force_flush();
         drop(span);
 
         // Assert


### PR DESCRIPTION
SimpleProcessor is used in tests, and flush is not required.