### PR TITLE
Add Rust TLS Feature Flag For `opentelemetry-http`

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNext
+- Add feature flag enabling users to configure `reqwest` usage to use rustls via `reqwest/rustls-tls` feature flag
 
 ## v0.11.0
 

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.65"
 
+[features]
+reqwest-rustls = ["reqwest", "reqwest/rustls-tls"]
+
 [dependencies]
 async-trait = { workspace = true }
 bytes = { workspace = true }

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [features]
-reqwest-rustls = ["reqwest", "reqwest/rustls-tls"]
+reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
 
 [dependencies]
 async-trait = { workspace = true }


### PR DESCRIPTION
Relates #472
Design discussion issue (if applicable) #

## Changes
Similar issue to what https://github.com/open-telemetry/opentelemetry-rust/issues/472 but for opentelemetry-http
Please provide a brief description of the changes here.
Added new feature flag for the `opentelemetry-http` crate to enable rustls instead of openssl

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
