### PR TITLE
Use semantic conventions in examples

### DIFF
--- a/examples/logs-basic/Cargo.toml
+++ b/examples/logs-basic/Cargo.toml
@@ -10,5 +10,6 @@ opentelemetry = { path = "../../opentelemetry", features = ["logs"] }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["logs"] }
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["logs"]}
 opentelemetry-appender-log = { path = "../../opentelemetry-appender-log", default-features = false}
+opentelemetry-semantic-conventions = { path = "../../opentelemetry-semantic-conventions" }
 log = { workspace = true }
 serde_json = { workspace = true }

--- a/examples/logs-basic/src/main.rs
+++ b/examples/logs-basic/src/main.rs
@@ -3,6 +3,7 @@ use opentelemetry::KeyValue;
 use opentelemetry_appender_log::OpenTelemetryLogBridge;
 use opentelemetry_sdk::logs::{Config, LoggerProvider};
 use opentelemetry_sdk::Resource;
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 
 fn main() {
     // Setup LoggerProvider with a stdout exporter
@@ -14,7 +15,7 @@ fn main() {
     let logger_provider = LoggerProvider::builder()
         .with_config(
             Config::default().with_resource(Resource::new(vec![KeyValue::new(
-                "service.name",
+                SERVICE_NAME,
                 "logs-basic-example",
             )])),
         )

--- a/examples/tracing-jaeger/Cargo.toml
+++ b/examples/tracing-jaeger/Cargo.toml
@@ -9,4 +9,5 @@ publish = false
 opentelemetry = { path = "../../opentelemetry" }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio"] }
 opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["tonic"] }
+opentelemetry-semantic-conventions = { path = "../../opentelemetry-semantic-conventions" }
 tokio = { workspace = true, features = ["full"] }

--- a/examples/tracing-jaeger/src/main.rs
+++ b/examples/tracing-jaeger/src/main.rs
@@ -6,6 +6,8 @@ use opentelemetry::{
 };
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{runtime, trace as sdktrace, Resource};
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+
 use std::error::Error;
 
 fn init_tracer() -> Result<opentelemetry_sdk::trace::Tracer, TraceError> {
@@ -18,7 +20,7 @@ fn init_tracer() -> Result<opentelemetry_sdk::trace::Tracer, TraceError> {
         )
         .with_trace_config(
             sdktrace::config().with_resource(Resource::new(vec![KeyValue::new(
-                "service.name",
+                SERVICE_NAME,
                 "tracing-jaeger",
             )])),
         )


### PR DESCRIPTION

## Changes

Change `"service.name"` to `opentelemetry_semantic_conventions::resource::SERVICE_NAME` in examples
## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
