### PR TITLE
fix: send propagator error to global error handler

### DIFF
--- a/opentelemetry-jaeger-propagator/CHANGELOG.md
+++ b/opentelemetry-jaeger-propagator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Changed
+
+- Propagation error will be reported to global error handler [#1640](https://github.com/open-telemetry/opentelemetry-rust/pull/1640)
+
 ## v0.1.0
 
 ### Added

--- a/opentelemetry-jaeger-propagator/src/propagator.rs
+++ b/opentelemetry-jaeger-propagator/src/propagator.rs
@@ -1,3 +1,4 @@
+use opentelemetry::propagation::PropagationError;
 use opentelemetry::{
     global::{self, Error},
     propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
@@ -6,7 +7,6 @@ use opentelemetry::{
 };
 use std::borrow::Cow;
 use std::str::FromStr;
-use opentelemetry::propagation::PropagationError;
 
 const JAEGER_HEADER: &str = "uber-trace-id";
 const JAEGER_BAGGAGE_PREFIX: &str = "uberctx-";
@@ -86,14 +86,24 @@ impl Propagator {
             return None;
         }
 
-        // extract trace id
-        let trace_id = self.extract_trace_id(parts[0])?;
-        let span_id = self.extract_span_id(parts[1])?;
-        // Ignore parent span id since it's deprecated.
-        let flags = self.extract_trace_flags(parts[3])?;
-        let state = self.extract_trace_state(extractor)?;
-
-        Some(SpanContext::new(trace_id, span_id, flags, true, state))
+        match (
+            self.extract_trace_id(parts[0]),
+            self.extract_span_id(parts[1]),
+            // Ignore parent span id since it's deprecated.
+            self.extract_trace_flags(parts[3]),
+            self.extract_trace_state(extractor),
+        ) {
+            (Ok(trace_id), Ok(span_id), Ok(flags), Ok(state)) => {
+                Some(SpanContext::new(trace_id, span_id, flags, true, state))
+            }
+            _ => {
+                global::handle_error(Error::Propagation(PropagationError::extract(
+                    "invalid jaeger header format",
+                    "JaegerPropagator",
+                )));
+                None
+            }
+        }
     }
 
     /// Extract trace id from the header.
@@ -193,7 +203,7 @@ impl TextMapPropagator for Propagator {
     fn extract_with_context(&self, cx: &Context, extractor: &dyn Extractor) -> Context {
         self.extract_span_context(extractor)
             .map(|sc| cx.with_remote_span_context(sc))
-            .unwrap_or_else(|_| cx.clone())
+            .unwrap_or_else(|| cx.clone())
     }
 
     fn fields(&self) -> FieldIter<'_> {
@@ -435,7 +445,7 @@ mod tests {
         );
         assert_eq!(
             propagator_with_custom_header.extract_span_context(&map),
-            Ok(SpanContext::new(
+            Some(SpanContext::new(
                 TraceId::from_hex("12345").unwrap(),
                 SpanId::from_hex("54321").unwrap(),
                 TRACE_FLAG_DEBUG | TraceFlags::SAMPLED,
@@ -452,7 +462,7 @@ mod tests {
         );
         assert_eq!(
             propagator_with_custom_header.extract_span_context(&map),
-            Ok(SpanContext::new(
+            Some(SpanContext::new(
                 TraceId::from_hex("12345").unwrap(),
                 SpanId::from_hex("54321").unwrap(),
                 TRACE_FLAG_DEBUG | TraceFlags::SAMPLED,
@@ -468,7 +478,7 @@ mod tests {
         );
         assert_eq!(
             propagator_with_custom_header.extract_span_context(&map),
-            Err(())
+            None,
         );
 
         map.clear();
@@ -478,7 +488,7 @@ mod tests {
         );
         assert_eq!(
             propagator_with_custom_header.extract_span_context(&map),
-            Err(())
+            None,
         );
 
         map.clear();
@@ -488,7 +498,7 @@ mod tests {
         );
         assert_eq!(
             propagator_with_custom_header.extract_span_context(&map),
-            Err(())
+            None,
         );
 
         map.clear();
@@ -498,7 +508,7 @@ mod tests {
         );
         assert_eq!(
             propagator_with_custom_header.extract_span_context(&map),
-            Err(())
+            None,
         );
 
         map.clear();
@@ -511,7 +521,7 @@ mod tests {
         map.set(&too_long_baggage_key, "baggage_value".to_owned());
         assert_eq!(
             propagator_with_custom_header.extract_span_context(&map),
-            Err(())
+            None,
         );
     }
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **Breaking** [#1624](https://github.com/open-telemetry/opentelemetry-rust/pull/1624) Remove `OsResourceDetector` and
   `ProcessResourceDetector` resource detectors, use the
   [`opentelemetry-resource-detector`](https://crates.io/crates/opentelemetry-resource-detectors) instead.
+- Baggage propagation error will be reported to global error handler [#1640](https://github.com/open-telemetry/opentelemetry-rust/pull/1640)
 
 ## v0.22.1
 

--- a/opentelemetry-sdk/src/propagation/mod.rs
+++ b/opentelemetry-sdk/src/propagation/mod.rs
@@ -3,7 +3,4 @@ mod baggage;
 mod trace_context;
 
 pub use baggage::BaggagePropagator;
-use std::fmt::Display;
 pub use trace_context::TraceContextPropagator;
-
-

--- a/opentelemetry-sdk/src/propagation/mod.rs
+++ b/opentelemetry-sdk/src/propagation/mod.rs
@@ -3,4 +3,7 @@ mod baggage;
 mod trace_context;
 
 pub use baggage::BaggagePropagator;
+use std::fmt::Display;
 pub use trace_context::TraceContextPropagator;
+
+

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - [#1623](https://github.com/open-telemetry/opentelemetry-rust/pull/1623) Add global::meter_provider_shutdown
+- [#1640](https://github.com/open-telemetry/opentelemetry-rust/pull/1640) Add `PropagationError`
 
 ### Removed
 

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -8,6 +8,7 @@ use crate::metrics::MetricsError;
 #[cfg(feature = "trace")]
 use crate::trace::TraceError;
 use once_cell::sync::Lazy;
+use crate::propagation::PropagationError;
 
 static GLOBAL_ERROR_HANDLER: Lazy<RwLock<Option<ErrorHandler>>> = Lazy::new(|| RwLock::new(None));
 
@@ -31,6 +32,9 @@ pub enum Error {
     #[error(transparent)]
     /// Failed to export logs.
     Log(#[from] LogError),
+    
+    #[error(transparent)]
+    Propagation(#[from] PropagationError),
 
     #[error("{0}")]
     /// Other types of failures not covered by the variants above.
@@ -61,6 +65,7 @@ pub fn handle_error<T: Into<Error>>(err: T) {
             #[cfg(feature = "logs")]
             #[cfg_attr(docsrs, doc(cfg(feature = "logs")))]
             Error::Log(err) => eprintln!("OpenTelemetry log error occurred. {}", err),
+            Error::Propagation(err) => eprintln!("OpenTelemetry propagation error occurred. {}", err),
             Error::Other(err_msg) => eprintln!("OpenTelemetry error occurred. {}", err_msg),
         },
     }

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -5,10 +5,10 @@ use std::sync::RwLock;
 use crate::logs::LogError;
 #[cfg(feature = "metrics")]
 use crate::metrics::MetricsError;
+use crate::propagation::PropagationError;
 #[cfg(feature = "trace")]
 use crate::trace::TraceError;
 use once_cell::sync::Lazy;
-use crate::propagation::PropagationError;
 
 static GLOBAL_ERROR_HANDLER: Lazy<RwLock<Option<ErrorHandler>>> = Lazy::new(|| RwLock::new(None));
 
@@ -32,8 +32,9 @@ pub enum Error {
     #[error(transparent)]
     /// Failed to export logs.
     Log(#[from] LogError),
-    
+
     #[error(transparent)]
+    /// Error happens when injecting and extracting information using propagators.
     Propagation(#[from] PropagationError),
 
     #[error("{0}")]
@@ -65,7 +66,9 @@ pub fn handle_error<T: Into<Error>>(err: T) {
             #[cfg(feature = "logs")]
             #[cfg_attr(docsrs, doc(cfg(feature = "logs")))]
             Error::Log(err) => eprintln!("OpenTelemetry log error occurred. {}", err),
-            Error::Propagation(err) => eprintln!("OpenTelemetry propagation error occurred. {}", err),
+            Error::Propagation(err) => {
+                eprintln!("OpenTelemetry propagation error occurred. {}", err)
+            }
             Error::Other(err_msg) => eprintln!("OpenTelemetry error occurred. {}", err_msg),
         },
     }

--- a/opentelemetry/src/propagation/mod.rs
+++ b/opentelemetry/src/propagation/mod.rs
@@ -20,7 +20,6 @@
 //! [`Context`]: crate::Context
 
 use std::collections::HashMap;
-use std::fmt::Display;
 use thiserror::Error;
 
 pub mod composite;
@@ -74,7 +73,8 @@ pub struct PropagationError {
     ops: &'static str,
 }
 
-impl PropagationError{
+impl PropagationError {
+    /// Error happens when extracting information
     pub fn extract(message: &'static str, propagator_name: &'static str) -> Self {
         PropagationError {
             message,
@@ -83,11 +83,12 @@ impl PropagationError{
         }
     }
 
+    /// Error happens when extracting information
     pub fn inject(message: &'static str, propagator_name: &'static str) -> Self {
         PropagationError {
             message,
             propagator_name,
-            ops: "inject"
+            ops: "inject",
         }
     }
 }

--- a/opentelemetry/src/propagation/mod.rs
+++ b/opentelemetry/src/propagation/mod.rs
@@ -20,6 +20,8 @@
 //! [`Context`]: crate::Context
 
 use std::collections::HashMap;
+use std::fmt::Display;
+use thiserror::Error;
 
 pub mod composite;
 pub mod text_map_propagator;
@@ -58,6 +60,35 @@ impl<S: std::hash::BuildHasher> Extractor for HashMap<String, String, S> {
     /// Collect all the keys from the HashMap.
     fn keys(&self) -> Vec<&str> {
         self.keys().map(|k| k.as_str()).collect::<Vec<_>>()
+    }
+}
+
+/// Error when extracting or injecting context data(i.e propagating) across application boundaries.
+#[derive(Error, Debug)]
+#[error("Cannot {} from {}, {}", ops, message, propagator_name)]
+pub struct PropagationError {
+    message: &'static str,
+    // which propagator does this error comes from
+    propagator_name: &'static str,
+    // are we extracting or injecting information across application boundaries
+    ops: &'static str,
+}
+
+impl PropagationError{
+    pub fn extract(message: &'static str, propagator_name: &'static str) -> Self {
+        PropagationError {
+            message,
+            propagator_name,
+            ops: "extract",
+        }
+    }
+
+    pub fn inject(message: &'static str, propagator_name: &'static str) -> Self {
+        PropagationError {
+            message,
+            propagator_name,
+            ops: "inject"
+        }
     }
 }
 


### PR DESCRIPTION
One issue with our propagator setup is when there is an error we usually just return default context and throw the error away. 

## Changes

- Add a new error type for `propagator` 
- Export errors from extracting and injecting to global error handler rather then ignore them
- No change made to the result of extract and injec

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
