### PR TITLE
Fix observable counter cumulative aggregation

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -26,6 +26,7 @@
   - `shutdown` methods in `LoggerProvider` and `LogProcessor` now takes a immutable reference
   - After `shutdown`, `LoggerProvider` will return noop `Logger`
   - After `shutdown`, `LogProcessor` will not process any new logs
+- [#1644](https://github.com/open-telemetry/opentelemetry-rust/pull/1644) Fix cumulative aggregation for observable counters.
 
 ## v0.22.1
 

--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -82,7 +82,7 @@ impl<T> fmt::Debug for ObservableCounter<T> {
 }
 
 impl<T> ObservableCounter<T> {
-    /// Records an increment to the counter.
+    /// Records the absolute value of the counter.
     ///
     /// It is only valid to call this within a callback. If called outside of the
     /// registered callback it should have no effect on the instrument, and an

--- a/opentelemetry/src/metrics/instruments/up_down_counter.rs
+++ b/opentelemetry/src/metrics/instruments/up_down_counter.rs
@@ -88,7 +88,7 @@ impl<T> ObservableUpDownCounter<T> {
         ObservableUpDownCounter(inner)
     }
 
-    /// Records the increment or decrement to the counter.
+    /// Records the absolute value of the counter.
     ///
     /// It is only valid to call this within a callback. If called outside of the
     /// registered callback it should have no effect on the instrument, and an


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-rust/issues/1517 (incorrect cumulative aggregation for observable counters).

## Changes

The observable counters rely on `PrecomputedSum` that was using the same `ValueMap` implementation as `Sum` (its counterpart for synchronous counters), effectively adding all observations (also drastically reducing the counter range).

This PR specializes `ValueMap` with an `O` (operation) parameter so that observations can be performed with the correct semantics (`AddAssign` for synchronous counters, `Assign` for observable ones). It also updates the `PrecomputedSum::cumulative` aggregation to return the current value.

The tests (`observable_counter_delta` and `observable_counter_cumulative`) are from https://github.com/open-telemetry/opentelemetry-rust/pull/1516 with tiny fixes.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (none)
