### PR TITLE
test: increase Telemetry resource testing coverage

### DIFF
--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -368,8 +368,6 @@ mod tests {
                 resource: Cow::Owned(Resource::empty()),
             })
             .build();
-
-        assert_resource(&no_service_name, SERVICE_NAME, None);
         assert_eq!(no_service_name.config().resource.len(), 0);
     }
 

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -302,6 +302,7 @@ mod tests {
             })
             .build();
         assert_resource(&custom_config_provider, SERVICE_NAME, Some("test_service"));
+        assert_eq!(custom_config_provider.config().resource.len(), 1);
 
         // If `OTEL_RESOURCE_ATTRIBUTES` is set, read them automatically
         temp_env::with_var(
@@ -367,6 +368,7 @@ mod tests {
             .build();
 
         assert_resource(&no_service_name, SERVICE_NAME, None);
+        assert_eq!(no_service_name.config().resource.len(), 0);
     }
 
     #[test]

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -284,13 +284,15 @@ mod tests {
         };
 
         // If users didn't provide a resource and there isn't a env var set. Use default one.
-        let default_config_provider = super::LoggerProvider::builder().build();
-        assert_resource(
-            &default_config_provider,
-            SERVICE_NAME,
-            Some("unknown_service"),
-        );
-        assert_telemetry_resource(&default_config_provider);
+        temp_env::with_var_unset("OTEL_RESOURCE_ATTRIBUTES", || {
+            let default_config_provider = super::LoggerProvider::builder().build();
+            assert_resource(
+                &default_config_provider,
+                SERVICE_NAME,
+                Some("unknown_service"),
+            );
+            assert_telemetry_resource(&default_config_provider);
+        });
 
         // If user provided a resource, use that.
         let custom_config_provider = super::LoggerProvider::builder()

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -333,6 +333,7 @@ mod tests {
                     .with_config(Config {
                         resource: Cow::Owned(Resource::default().merge(&mut Resource::new(vec![
                             KeyValue::new("my-custom-key", "my-custom-value"),
+                            KeyValue::new("my-custom-key2", "my-custom-value2"),
                         ]))),
                     })
                     .build();
@@ -348,6 +349,11 @@ mod tests {
                 );
                 assert_resource(
                     &user_provided_resource_config_provider,
+                    "my-custom-key2",
+                    Some("my-custom-value2"),
+                );
+                assert_resource(
+                    &user_provided_resource_config_provider,
                     "k2",
                     Some("value2"),
                 );
@@ -357,7 +363,7 @@ mod tests {
                         .config()
                         .resource
                         .len(),
-                    6
+                    7
                 );
             },
         );

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -299,7 +299,6 @@ mod tests {
                     SERVICE_NAME,
                     "test_service",
                 )])),
-                ..Default::default()
             })
             .build();
         assert_resource(&custom_config_provider, SERVICE_NAME, Some("test_service"));
@@ -332,7 +331,6 @@ mod tests {
                         resource: Cow::Owned(Resource::default().merge(&mut Resource::new(vec![
                             KeyValue::new("my-custom-key", "my-custom-value"),
                         ]))),
-                        ..Default::default()
                     })
                     .build();
                 assert_resource(
@@ -365,7 +363,6 @@ mod tests {
         let no_service_name = super::LoggerProvider::builder()
             .with_config(Config {
                 resource: Cow::Owned(Resource::empty()),
-                ..Default::default()
             })
             .build();
 

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -239,11 +239,138 @@ impl opentelemetry::logs::Logger for Logger {
 
 #[cfg(test)]
 mod tests {
+    use crate::resource::{
+        SERVICE_NAME, TELEMETRY_SDK_LANGUAGE, TELEMETRY_SDK_NAME, TELEMETRY_SDK_VERSION,
+    };
+    use crate::Resource;
+
     use super::*;
     use opentelemetry::global::{logger, set_logger_provider, shutdown_logger_provider};
     use opentelemetry::logs::Logger;
+    use opentelemetry::{Key, KeyValue, Value};
     use std::sync::{Arc, Mutex};
     use std::thread;
+
+    #[test]
+    fn test_logger_provider_default_resource() {
+        let assert_resource = |provider: &super::LoggerProvider,
+                               resource_key: &'static str,
+                               expect: Option<&'static str>| {
+            assert_eq!(
+                provider
+                    .config()
+                    .resource
+                    .get(Key::from_static_str(resource_key))
+                    .map(|v| v.to_string()),
+                expect.map(|s| s.to_string())
+            );
+        };
+        let assert_telemetry_resource = |provider: &super::LoggerProvider| {
+            assert_eq!(
+                provider
+                    .config()
+                    .resource
+                    .get(TELEMETRY_SDK_LANGUAGE.into()),
+                Some(Value::from("rust"))
+            );
+            assert_eq!(
+                provider.config().resource.get(TELEMETRY_SDK_NAME.into()),
+                Some(Value::from("opentelemetry"))
+            );
+            assert_eq!(
+                provider.config().resource.get(TELEMETRY_SDK_VERSION.into()),
+                Some(Value::from(env!("CARGO_PKG_VERSION")))
+            );
+        };
+
+        // If users didn't provide a resource and there isn't a env var set. Use default one.
+        let default_config_provider = super::LoggerProvider::builder().build();
+        assert_resource(
+            &default_config_provider,
+            SERVICE_NAME,
+            Some("unknown_service"),
+        );
+        assert_telemetry_resource(&default_config_provider);
+
+        // If user provided a resource, use that.
+        let custom_config_provider = super::LoggerProvider::builder()
+            .with_config(Config {
+                resource: Cow::Owned(Resource::new(vec![KeyValue::new(
+                    SERVICE_NAME,
+                    "test_service",
+                )])),
+                ..Default::default()
+            })
+            .build();
+        assert_resource(&custom_config_provider, SERVICE_NAME, Some("test_service"));
+
+        // If `OTEL_RESOURCE_ATTRIBUTES` is set, read them automatically
+        temp_env::with_var(
+            "OTEL_RESOURCE_ATTRIBUTES",
+            Some("key1=value1, k2, k3=value2"),
+            || {
+                let env_resource_provider = super::LoggerProvider::builder().build();
+                assert_resource(
+                    &env_resource_provider,
+                    SERVICE_NAME,
+                    Some("unknown_service"),
+                );
+                assert_resource(&env_resource_provider, "key1", Some("value1"));
+                assert_resource(&env_resource_provider, "k3", Some("value2"));
+                assert_telemetry_resource(&env_resource_provider);
+                assert_eq!(env_resource_provider.config().resource.len(), 6);
+            },
+        );
+
+        // When `OTEL_RESOURCE_ATTRIBUTES` is set and also user provided config
+        temp_env::with_var(
+            "OTEL_RESOURCE_ATTRIBUTES",
+            Some("my-custom-key=env-val,k2=value2"),
+            || {
+                let user_provided_resource_config_provider = super::LoggerProvider::builder()
+                    .with_config(Config {
+                        resource: Cow::Owned(Resource::default().merge(&mut Resource::new(vec![
+                            KeyValue::new("my-custom-key", "my-custom-value"),
+                        ]))),
+                        ..Default::default()
+                    })
+                    .build();
+                assert_resource(
+                    &user_provided_resource_config_provider,
+                    SERVICE_NAME,
+                    Some("unknown_service"),
+                );
+                assert_resource(
+                    &user_provided_resource_config_provider,
+                    "my-custom-key",
+                    Some("my-custom-value"),
+                );
+                assert_resource(
+                    &user_provided_resource_config_provider,
+                    "k2",
+                    Some("value2"),
+                );
+                assert_telemetry_resource(&user_provided_resource_config_provider);
+                assert_eq!(
+                    user_provided_resource_config_provider
+                        .config()
+                        .resource
+                        .len(),
+                    6
+                );
+            },
+        );
+
+        // If user provided a resource, it takes priority during collision.
+        let no_service_name = super::LoggerProvider::builder()
+            .with_config(Config {
+                resource: Cow::Owned(Resource::empty()),
+                ..Default::default()
+            })
+            .build();
+
+        assert_resource(&no_service_name, SERVICE_NAME, None);
+    }
 
     #[test]
     fn shutdown_test() {

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -257,17 +257,20 @@ mod tests {
                 Some(Value::from(env!("CARGO_PKG_VERSION")))
             );
         };
+
         // If users didn't provide a resource and there isn't a env var set. Use default one.
-        let reader = TestMetricReader::new();
-        let default_meter_provider = super::SdkMeterProvider::builder()
-            .with_reader(reader)
-            .build();
-        assert_resource(
-            &default_meter_provider,
-            SERVICE_NAME,
-            Some("unknown_service"),
-        );
-        assert_telemetry_resource(&default_meter_provider);
+        temp_env::with_var_unset("OTEL_RESOURCE_ATTRIBUTES", || {
+            let reader = TestMetricReader::new();
+            let default_meter_provider = super::SdkMeterProvider::builder()
+                .with_reader(reader)
+                .build();
+            assert_resource(
+                &default_meter_provider,
+                SERVICE_NAME,
+                Some("unknown_service"),
+            );
+            assert_telemetry_resource(&default_meter_provider);
+        });
 
         // If user provided a resource, use that.
         let reader2 = TestMetricReader::new();

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -349,7 +349,6 @@ mod tests {
             .with_resource(Resource::empty())
             .build();
 
-        assert_resource(&no_service_name, SERVICE_NAME, None);
         assert_eq!(no_service_name.pipes.0[0].resource.len(), 0)
     }
 

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -315,6 +315,7 @@ mod tests {
                     .with_reader(reader4)
                     .with_resource(Resource::default().merge(&mut Resource::new(vec![
                         KeyValue::new("my-custom-key", "my-custom-value"),
+                        KeyValue::new("my-custom-key2", "my-custom-value2"),
                     ])))
                     .build();
                 assert_resource(
@@ -329,6 +330,11 @@ mod tests {
                 );
                 assert_resource(
                     &user_provided_resource_config_provider,
+                    "my-custom-key2",
+                    Some("my-custom-value2"),
+                );
+                assert_resource(
+                    &user_provided_resource_config_provider,
                     "k2",
                     Some("value2"),
                 );
@@ -337,7 +343,7 @@ mod tests {
                     user_provided_resource_config_provider.pipes.0[0]
                         .resource
                         .len(),
-                    6
+                    7
                 );
             },
         );

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -279,6 +279,7 @@ mod tests {
             )]))
             .build();
         assert_resource(&custom_meter_provider, SERVICE_NAME, Some("test_service"));
+        assert_eq!(custom_meter_provider.pipes.0[0].resource.len(), 1);
 
         temp_env::with_var(
             "OTEL_RESOURCE_ATTRIBUTES",
@@ -346,6 +347,7 @@ mod tests {
             .build();
 
         assert_resource(&no_service_name, SERVICE_NAME, None);
+        assert_eq!(no_service_name.pipes.0[0].resource.len(), 0)
     }
 
     #[test]

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -217,42 +217,68 @@ impl fmt::Debug for MeterProviderBuilder {
 }
 #[cfg(test)]
 mod tests {
+    use crate::resource::{
+        SERVICE_NAME, TELEMETRY_SDK_LANGUAGE, TELEMETRY_SDK_NAME, TELEMETRY_SDK_VERSION,
+    };
     use crate::testing::metrics::metric_reader::TestMetricReader;
     use crate::Resource;
     use opentelemetry::global;
-    use opentelemetry::Key;
-    use opentelemetry::KeyValue;
+    use opentelemetry::{Key, KeyValue, Value};
     use std::env;
 
     #[test]
     fn test_meter_provider_resource() {
-        // If users didn't provide a resource and there isn't a env var set. Use default one.
-        let assert_service_name = |provider: super::SdkMeterProvider,
-                                   expect: Option<&'static str>| {
+        let assert_resource = |provider: &super::SdkMeterProvider,
+                               resource_key: &'static str,
+                               expect: Option<&'static str>| {
             assert_eq!(
                 provider.pipes.0[0]
                     .resource
-                    .get(Key::from_static_str("service.name"))
+                    .get(Key::from_static_str(resource_key))
                     .map(|v| v.to_string()),
                 expect.map(|s| s.to_string())
             );
         };
+        let assert_telemetry_resource = |provider: &super::SdkMeterProvider| {
+            assert_eq!(
+                provider.pipes.0[0]
+                    .resource
+                    .get(TELEMETRY_SDK_LANGUAGE.into()),
+                Some(Value::from("rust"))
+            );
+            assert_eq!(
+                provider.pipes.0[0].resource.get(TELEMETRY_SDK_NAME.into()),
+                Some(Value::from("opentelemetry"))
+            );
+            assert_eq!(
+                provider.pipes.0[0]
+                    .resource
+                    .get(TELEMETRY_SDK_VERSION.into()),
+                Some(Value::from(env!("CARGO_PKG_VERSION")))
+            );
+        };
+        // If users didn't provide a resource and there isn't a env var set. Use default one.
         let reader = TestMetricReader::new();
         let default_meter_provider = super::SdkMeterProvider::builder()
             .with_reader(reader)
             .build();
-        assert_service_name(default_meter_provider, Some("unknown_service"));
+        assert_resource(
+            &default_meter_provider,
+            SERVICE_NAME,
+            Some("unknown_service"),
+        );
+        assert_telemetry_resource(&default_meter_provider);
 
         // If user provided a resource, use that.
         let reader2 = TestMetricReader::new();
         let custom_meter_provider = super::SdkMeterProvider::builder()
             .with_reader(reader2)
             .with_resource(Resource::new(vec![KeyValue::new(
-                "service.name",
+                SERVICE_NAME,
                 "test_service",
             )]))
             .build();
-        assert_service_name(custom_meter_provider, Some("test_service"));
+        assert_resource(&custom_meter_provider, SERVICE_NAME, Some("test_service"));
 
         temp_env::with_var(
             "OTEL_RESOURCE_ATTRIBUTES",
@@ -263,17 +289,15 @@ mod tests {
                 let env_resource_provider = super::SdkMeterProvider::builder()
                     .with_reader(reader3)
                     .build();
-                assert_eq!(
-                    env_resource_provider.pipes.0[0].resource,
-                    Resource::new(vec![
-                        KeyValue::new("telemetry.sdk.name", "opentelemetry"),
-                        KeyValue::new("telemetry.sdk.version", env!("CARGO_PKG_VERSION")),
-                        KeyValue::new("telemetry.sdk.language", "rust"),
-                        KeyValue::new("key1", "value1"),
-                        KeyValue::new("k3", "value2"),
-                        KeyValue::new("service.name", "unknown_service"),
-                    ])
+                assert_resource(
+                    &env_resource_provider,
+                    SERVICE_NAME,
+                    Some("unknown_service"),
                 );
+                assert_resource(&env_resource_provider, "key1", Some("value1"));
+                assert_resource(&env_resource_provider, "k3", Some("value2"));
+                assert_telemetry_resource(&env_resource_provider);
+                assert_eq!(env_resource_provider.pipes.0[0].resource.len(), 6);
             },
         );
 
@@ -289,16 +313,27 @@ mod tests {
                         KeyValue::new("my-custom-key", "my-custom-value"),
                     ])))
                     .build();
+                assert_resource(
+                    &user_provided_resource_config_provider,
+                    SERVICE_NAME,
+                    Some("unknown_service"),
+                );
+                assert_resource(
+                    &user_provided_resource_config_provider,
+                    "my-custom-key",
+                    Some("my-custom-value"),
+                );
+                assert_resource(
+                    &user_provided_resource_config_provider,
+                    "k2",
+                    Some("value2"),
+                );
+                assert_telemetry_resource(&user_provided_resource_config_provider);
                 assert_eq!(
-                    user_provided_resource_config_provider.pipes.0[0].resource,
-                    Resource::new(vec![
-                        KeyValue::new("telemetry.sdk.name", "opentelemetry"),
-                        KeyValue::new("telemetry.sdk.version", env!("CARGO_PKG_VERSION")),
-                        KeyValue::new("telemetry.sdk.language", "rust"),
-                        KeyValue::new("my-custom-key", "my-custom-value"),
-                        KeyValue::new("k2", "value2"),
-                        KeyValue::new("service.name", "unknown_service"),
-                    ])
+                    user_provided_resource_config_provider.pipes.0[0]
+                        .resource
+                        .len(),
+                    6
                 );
             },
         );
@@ -310,7 +345,7 @@ mod tests {
             .with_resource(Resource::empty())
             .build();
 
-        assert_service_name(no_service_name, None);
+        assert_resource(&no_service_name, SERVICE_NAME, None);
     }
 
     #[test]

--- a/opentelemetry-sdk/src/trace/id_generator/aws.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/aws.rs
@@ -26,7 +26,7 @@ use std::time::{Duration, UNIX_EPOCH};
 /// use opentelemetry_sdk::trace::{self, TracerProvider, XrayIdGenerator};
 ///
 /// let _provider: TracerProvider = TracerProvider::builder()
-///     .with_config(trace::config().with_id_generator(XrayIdGenerator::default()))
+///     .with_config(trace::Config::default().with_id_generator(XrayIdGenerator::default()))
 ///     .build();
 /// ```
 ///

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -244,7 +244,7 @@ mod tests {
     fn trace_state_for_dropped_sampler() {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = TracerProvider::builder()
-            .with_config(config().with_sampler(Sampler::AlwaysOff))
+            .with_config(Config::default().with_sampler(Sampler::AlwaysOff))
             .with_span_processor(SimpleSpanProcessor::new(Box::new(exporter.clone())))
             .build();
 
@@ -297,7 +297,7 @@ mod tests {
     fn trace_state_for_record_only_sampler() {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = TracerProvider::builder()
-            .with_config(config().with_sampler(TestRecordOnlySampler::default()))
+            .with_config(Config::default().with_sampler(TestRecordOnlySampler::default()))
             .with_span_processor(SimpleSpanProcessor::new(Box::new(exporter.clone())))
             .build();
 

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -309,13 +309,15 @@ mod tests {
         };
 
         // If users didn't provide a resource and there isn't a env var set. Use default one.
-        let default_config_provider = super::TracerProvider::builder().build();
-        assert_resource(
-            &default_config_provider,
-            SERVICE_NAME,
-            Some("unknown_service"),
-        );
-        assert_telemetry_resource(&default_config_provider);
+        temp_env::with_var_unset("OTEL_RESOURCE_ATTRIBUTES", || {
+            let default_config_provider = super::TracerProvider::builder().build();
+            assert_resource(
+                &default_config_provider,
+                SERVICE_NAME,
+                Some("unknown_service"),
+            );
+            assert_telemetry_resource(&default_config_provider);
+        });
 
         // If user provided a resource, use that.
         let custom_config_provider = super::TracerProvider::builder()

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -328,6 +328,7 @@ mod tests {
             })
             .build();
         assert_resource(&custom_config_provider, SERVICE_NAME, Some("test_service"));
+        assert_eq!(custom_config_provider.config().resource.len(), 1);
 
         // If `OTEL_RESOURCE_ATTRIBUTES` is set, read them automatically
         temp_env::with_var(
@@ -395,5 +396,6 @@ mod tests {
             .build();
 
         assert_resource(&no_service_name, SERVICE_NAME, None);
+        assert_eq!(no_service_name.config().resource.len(), 0)
     }
 }

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -223,11 +223,14 @@ impl Builder {
 #[cfg(test)]
 mod tests {
     use crate::export::trace::SpanData;
+    use crate::resource::{
+        SERVICE_NAME, TELEMETRY_SDK_LANGUAGE, TELEMETRY_SDK_NAME, TELEMETRY_SDK_VERSION,
+    };
     use crate::trace::provider::TracerProviderInner;
     use crate::trace::{Config, Span, SpanProcessor};
     use crate::Resource;
     use opentelemetry::trace::{TraceError, TraceResult};
-    use opentelemetry::{Context, Key, KeyValue};
+    use opentelemetry::{Context, Key, KeyValue, Value};
     use std::borrow::Cow;
     use std::env;
     use std::sync::Arc;
@@ -275,32 +278,56 @@ mod tests {
 
     #[test]
     fn test_tracer_provider_default_resource() {
-        // If users didn't provide a resource and there isn't a env var set. Use default one.
-        let assert_service_name = |provider: super::TracerProvider,
-                                   expect: Option<&'static str>| {
+        let assert_resource = |provider: &super::TracerProvider,
+                               resource_key: &'static str,
+                               expect: Option<&'static str>| {
             assert_eq!(
                 provider
                     .config()
                     .resource
-                    .get(Key::from_static_str("service.name"))
+                    .get(Key::from_static_str(resource_key))
                     .map(|v| v.to_string()),
                 expect.map(|s| s.to_string())
             );
         };
+        let assert_telemetry_resource = |provider: &super::TracerProvider| {
+            assert_eq!(
+                provider
+                    .config()
+                    .resource
+                    .get(TELEMETRY_SDK_LANGUAGE.into()),
+                Some(Value::from("rust"))
+            );
+            assert_eq!(
+                provider.config().resource.get(TELEMETRY_SDK_NAME.into()),
+                Some(Value::from("opentelemetry"))
+            );
+            assert_eq!(
+                provider.config().resource.get(TELEMETRY_SDK_VERSION.into()),
+                Some(Value::from(env!("CARGO_PKG_VERSION")))
+            );
+        };
+
+        // If users didn't provide a resource and there isn't a env var set. Use default one.
         let default_config_provider = super::TracerProvider::builder().build();
-        assert_service_name(default_config_provider, Some("unknown_service"));
+        assert_resource(
+            &default_config_provider,
+            SERVICE_NAME,
+            Some("unknown_service"),
+        );
+        assert_telemetry_resource(&default_config_provider);
 
         // If user provided a resource, use that.
         let custom_config_provider = super::TracerProvider::builder()
             .with_config(Config {
                 resource: Cow::Owned(Resource::new(vec![KeyValue::new(
-                    "service.name",
+                    SERVICE_NAME,
                     "test_service",
                 )])),
                 ..Default::default()
             })
             .build();
-        assert_service_name(custom_config_provider, Some("test_service"));
+        assert_resource(&custom_config_provider, SERVICE_NAME, Some("test_service"));
 
         // If `OTEL_RESOURCE_ATTRIBUTES` is set, read them automatically
         temp_env::with_var(
@@ -308,17 +335,15 @@ mod tests {
             Some("key1=value1, k2, k3=value2"),
             || {
                 let env_resource_provider = super::TracerProvider::builder().build();
-                assert_eq!(
-                    env_resource_provider.config().resource,
-                    Cow::Owned(Resource::new(vec![
-                        KeyValue::new("telemetry.sdk.name", "opentelemetry"),
-                        KeyValue::new("telemetry.sdk.version", env!("CARGO_PKG_VERSION")),
-                        KeyValue::new("telemetry.sdk.language", "rust"),
-                        KeyValue::new("key1", "value1"),
-                        KeyValue::new("k3", "value2"),
-                        KeyValue::new("service.name", "unknown_service"),
-                    ]))
+                assert_resource(
+                    &env_resource_provider,
+                    SERVICE_NAME,
+                    Some("unknown_service"),
                 );
+                assert_resource(&env_resource_provider, "key1", Some("value1"));
+                assert_resource(&env_resource_provider, "k3", Some("value2"));
+                assert_telemetry_resource(&env_resource_provider);
+                assert_eq!(env_resource_provider.config().resource.len(), 6);
             },
         );
 
@@ -335,16 +360,28 @@ mod tests {
                         ..Default::default()
                     })
                     .build();
+                assert_resource(
+                    &user_provided_resource_config_provider,
+                    SERVICE_NAME,
+                    Some("unknown_service"),
+                );
+                assert_resource(
+                    &user_provided_resource_config_provider,
+                    "my-custom-key",
+                    Some("my-custom-value"),
+                );
+                assert_resource(
+                    &user_provided_resource_config_provider,
+                    "k2",
+                    Some("value2"),
+                );
+                assert_telemetry_resource(&user_provided_resource_config_provider);
                 assert_eq!(
-                    user_provided_resource_config_provider.config().resource,
-                    Cow::Owned(Resource::new(vec![
-                        KeyValue::new("telemetry.sdk.name", "opentelemetry"),
-                        KeyValue::new("telemetry.sdk.version", env!("CARGO_PKG_VERSION")),
-                        KeyValue::new("telemetry.sdk.language", "rust"),
-                        KeyValue::new("my-custom-key", "my-custom-value"),
-                        KeyValue::new("k2", "value2"),
-                        KeyValue::new("service.name", "unknown_service"),
-                    ]))
+                    user_provided_resource_config_provider
+                        .config()
+                        .resource
+                        .len(),
+                    6
                 );
             },
         );
@@ -357,6 +394,6 @@ mod tests {
             })
             .build();
 
-        assert_service_name(no_service_name, None);
+        assert_resource(&no_service_name, SERVICE_NAME, None);
     }
 }

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -359,6 +359,7 @@ mod tests {
                     .with_config(Config {
                         resource: Cow::Owned(Resource::default().merge(&mut Resource::new(vec![
                             KeyValue::new("my-custom-key", "my-custom-value"),
+                            KeyValue::new("my-custom-key2", "my-custom-value2"),
                         ]))),
                         ..Default::default()
                     })
@@ -375,6 +376,11 @@ mod tests {
                 );
                 assert_resource(
                     &user_provided_resource_config_provider,
+                    "my-custom-key2",
+                    Some("my-custom-value2"),
+                );
+                assert_resource(
+                    &user_provided_resource_config_provider,
                     "k2",
                     Some("value2"),
                 );
@@ -384,7 +390,7 @@ mod tests {
                         .config()
                         .resource
                         .len(),
-                    6
+                    7
                 );
             },
         );

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -397,7 +397,6 @@ mod tests {
             })
             .build();
 
-        assert_resource(&no_service_name, SERVICE_NAME, None);
         assert_eq!(no_service_name.config().resource.len(), 0)
     }
 }


### PR DESCRIPTION
Fixes # https://github.com/open-telemetry/opentelemetry-rust/pull/1624#discussion_r1527556881

## Changes

- Test that all default providers (traces, logs, metrics) contain the corresponding Telemetry resource attributes (TELEMETRY_SDK_LANGUAGE, TELEMETRY_SDK_NAME, TELEMETRY_SDK_VERSION).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
