### PR TITLE
Prepare for opentelemetry-http release

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 ## vNext
-- Add feature flag enabling users to configure `reqwest` usage to use rustls via `reqwest/rustls-tls` feature flag
+
+## v0.11.1
+
+- Add feature flag enabling users to configure `reqwest` usage to use rustls via
+  `reqwest/rustls-tls` feature flag
+  [1638](https://github.com/open-telemetry/opentelemetry-rust/pull/1638).
 
 ## v0.11.0
 

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-http"
-version = "0.11.0"
+version = "0.11.1"
 description = "Helper implementations for sending HTTP requests. Uses include propagating and extracting context over http, exporting telemetry, requesting sampling strategies."
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"


### PR DESCRIPTION
Attempting to do a one-off release for opentelemetry-http crate alone.
It ~1 month since last release, but we are not quite ready for a full release of all components, hence doing a one-off.