### PR TITLE
Add benchmark for opentelemetry-appender-tracing

### DIFF
--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -25,8 +25,16 @@ log = { workspace = true }
 opentelemetry-stdout = { path = "../opentelemetry-stdout", features = ["logs"] }
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["logs", "testing"]  }
 tracing-log = "0.2"
+async-trait = "0.1"
+criterion = "0.5.1"
 
 [features]
 experimental_metadata_attributes = ["dep:tracing-log"]
 logs_level_enabled = ["opentelemetry/logs_level_enabled", "opentelemetry_sdk/logs_level_enabled"]
 default = ["logs_level_enabled"]
+
+
+[[bench]]
+name = "logs"
+harness = false
+required-features = ["logs_level_enabled"]

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -1,3 +1,18 @@
+/*
+    The benchmark results:
+    criterion = "0.5.1"
+    OS: Ubuntu 22.04.2 LTS (5.10.102.1-microsoft-standard-WSL2)
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    RAM: 64.0 GB
+    | Test                        | Average time|
+    |-----------------------------|-------------|
+    | log_no_subscriber           | 313 ps      |
+    | noop_layer_disabled         | 12 ns       |
+    | noop_layer_enabled          | 25 ns       |
+    | ot_layer_disabled           | 19 ns       |
+    | ot_layer_enabled           | 561 ns       |
+*/
+
 use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::logs::LogResult;

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -1,0 +1,121 @@
+use async_trait::async_trait;
+use criterion::{criterion_group, criterion_main, Criterion};
+use opentelemetry::logs::LogResult;
+use opentelemetry::KeyValue;
+use opentelemetry_appender_tracing::layer;
+use opentelemetry_sdk::export::logs::LogData;
+use opentelemetry_sdk::{
+    logs::{Config, LoggerProvider},
+    Resource,
+};
+use tracing::info;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::Registry;
+
+#[derive(Debug, Clone)]
+struct VoidExporter {
+    is_enabled: bool,
+}
+
+#[async_trait]
+impl opentelemetry_sdk::export::logs::LogExporter for VoidExporter {
+    async fn export(&mut self, _batch: Vec<LogData>) -> LogResult<()> {
+        LogResult::Ok(())
+    }
+
+    fn event_enabled(
+        &self,
+        _level: opentelemetry::logs::Severity,
+        _target: &str,
+        _name: &str,
+    ) -> bool {
+        self.is_enabled
+    }
+}
+
+// disabled log processor
+#[derive(Debug)]
+struct VoidProcessor {
+    exporter: Box<dyn opentelemetry_sdk::export::logs::LogExporter>,
+}
+
+impl VoidProcessor {
+    fn new(exporter: Box<dyn opentelemetry_sdk::export::logs::LogExporter>) -> Self {
+        VoidProcessor { exporter: exporter }
+    }
+}
+
+impl opentelemetry_sdk::logs::LogProcessor for VoidProcessor {
+    fn emit(&self, _data: LogData) {
+        //  nop
+    }
+    fn force_flush(&self) -> LogResult<()> {
+        Ok(())
+    }
+    fn shutdown(&mut self) -> LogResult<()> {
+        Ok(())
+    }
+    fn event_enabled(
+        &self,
+        _level: opentelemetry::logs::Severity,
+        _target: &str,
+        _name: &str,
+    ) -> bool {
+        self.exporter.event_enabled(_level, _target, _name)
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let exporter1 = VoidExporter { is_enabled: false };
+    let processor1 = VoidProcessor::new(Box::new(exporter1));
+    let provider1: LoggerProvider = LoggerProvider::builder()
+        .with_config(
+            Config::default().with_resource(Resource::new(vec![KeyValue::new(
+                "service.name",
+                "log-appender-tracing-example",
+            )])),
+        )
+        .with_log_processor(processor1)
+        .build();
+
+    c.bench_function("log_no_subscriber", |b| {
+        b.iter(|| {
+            info!("my-event-name");
+        });
+    });
+    let layer1 = layer::OpenTelemetryTracingBridge::new(&provider1);
+    let subscriber1 = Registry::default().with(layer1);
+    tracing::subscriber::with_default(subscriber1, || {
+        c.bench_function("log_subscriber_log_level_disabled", |b| {
+            b.iter(|| {
+                info!("my-event-name");
+            });
+        });
+    });
+    drop(provider1);
+
+    let exporter2 = VoidExporter { is_enabled: true };
+    let processor2 = VoidProcessor::new(Box::new(exporter2));
+    let provider2 = LoggerProvider::builder()
+        .with_config(
+            Config::default().with_resource(Resource::new(vec![KeyValue::new(
+                "service.name",
+                "log-appender-tracing-example",
+            )])),
+        )
+        .with_log_processor(processor2)
+        .build();
+    let layer2 = layer::OpenTelemetryTracingBridge::new(&provider2);
+    let subscriber2 = Registry::default().with(layer2);
+    tracing::subscriber::with_default(subscriber2, || {
+        c.bench_function("log_subscriber_log_level_enabled", |b| {
+            b.iter(|| {
+                info!("my-event-name");
+            });
+        });
+    });
+    drop(provider2);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Fixes #
## Changes

Added basic benchmarks as of now for the below scenarios with results:
  - `log_no_subscriber` - No subscriber registered - `312.83 ps`
  - `log_subscriber_log_level_disabled`  - Subscriber with event_enabled false - `15.016 ns`    
       // tokio::event_enabled() -> processor::event_enabled() -> exporter::event_enabled()
  - `log_subscriber_log_level_enabled`  - Subscriber with event_enabled true -  `380.09 ns`   
        // tokio::event_enabled() -> processor::event_enabled() -> exporter::event_enabled() 
       //+ tracing::info!() -> processor::emit() -> exporter::export()

![image](https://github.com/open-telemetry/opentelemetry-rust/assets/1196320/e95f16d0-d80c-416c-aaf7-2e0fe1811954)
## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
