### PR TITLE
CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@nightly-2024-02-07
         with:
           components: rustfmt
       - name: external-type-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly-2024-02-07
+      - uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: nightly-2024-02-07
           components: rustfmt
       - name: external-type-check
         run: |


### PR DESCRIPTION
## Changes

CI is failing with [error ](https://github.com/open-telemetry/opentelemetry-rust/actions/runs/8701475331/job/23863550076?pr=1663)-
``` 
   Installed package `cargo-check-external-types v0.1.11` (executable `cargo-check-external-types`)
Running rustdoc to produce json doc output...
[/home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-check-external-types-0.1.11/src/main.rs:105:30] err = Error {
    context: "error at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-check-external-types-0.1.11/src/main.rs:175:14",
    source: "The version of rustdoc being used produces JSON format version 29, but this tool requires format version 28. This can happen if the locally installed version of rustdoc doesn't match the rustdoc JSON types from the `rustdoc-types` crate.\n\nIf this occurs with the latest Rust nightly and the latest version of this tool, then this is a bug, and the tool needs to be upgraded to the latest format version.\n\nOtherwise, you'll need to determine a Rust nightly version that matches this tool's supported format version (or vice versa).",
```

Using the rust nightly release which uses the compatible `rustdoc` version as used by the `rustdoc-type` crate. It seems #1655 has somehow overwritten the default nightly version to latest.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
