### PR TITLE
Add benchmarks to show cost of random generation

### DIFF
--- a/opentelemetry-sdk/benches/metric_counter.rs
+++ b/opentelemetry-sdk/benches/metric_counter.rs
@@ -67,6 +67,17 @@ fn counter_add(c: &mut Criterion) {
             );
         });
     });
+
+    c.bench_function("Random_Generator_5", |b| {
+        b.iter(|| {
+            let mut rng = SmallRng::from_entropy();
+            let _i1 = rng.gen_range(0..4);
+            let _i2 = rng.gen_range(0..4);
+            let _i3 = rng.gen_range(0..10);
+            let _i4 = rng.gen_range(0..10);
+            let _i5 = rng.gen_range(0..10);
+        });
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/opentelemetry/benches/metrics.rs
+++ b/opentelemetry/benches/metrics.rs
@@ -38,11 +38,11 @@ fn counter_add(c: &mut Criterion) {
     });
 
     let kv = [
-                KeyValue::new("attribute1", "value1"),
-                KeyValue::new("attribute2", "value2"),
-                KeyValue::new("attribute3", "value3"),
-                KeyValue::new("attribute4", "value4"),
-            ];
+        KeyValue::new("attribute1", "value1"),
+        KeyValue::new("attribute2", "value2"),
+        KeyValue::new("attribute3", "value3"),
+        KeyValue::new("attribute4", "value4"),
+    ];
 
     c.bench_function("Counter_AddWithStaticArray", |b| {
         b.iter(|| {

--- a/opentelemetry/benches/metrics.rs
+++ b/opentelemetry/benches/metrics.rs
@@ -37,15 +37,15 @@ fn counter_add(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("Counter_AddWithStaticArray", |b| {
-        b.iter(|| {
-            let kv = [
+    let kv = [
                 KeyValue::new("attribute1", "value1"),
                 KeyValue::new("attribute2", "value2"),
                 KeyValue::new("attribute3", "value3"),
                 KeyValue::new("attribute4", "value4"),
             ];
 
+    c.bench_function("Counter_AddWithStaticArray", |b| {
+        b.iter(|| {
             counter.add(1, &kv);
         });
     });

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -19,12 +19,17 @@ name = "traces"
 path = "src/traces.rs"
 doc = false
 
+[[bin]] # Bin to run the stress tests to show the cost of random number generation
+name = "random"
+path = "src/random.rs"
+doc = false
+
 [dependencies]
 ctrlc = "3.2.5"
 lazy_static = "1.4.0"
 num_cpus = "1.15.0"
-opentelemetry = { path = "../opentelemetry", features = ["metrics", "logs", "trace"] }
-opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics", "logs", "trace"] }
+opentelemetry = { path = "../opentelemetry", features = ["metrics", "logs", "trace", "logs_level_enabled"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics", "logs", "trace", "logs_level_enabled"] }
 opentelemetry-appender-tracing = { path = "../opentelemetry-appender-tracing"}
 rand = { version = "0.8.4", features = ["small_rng"] }
 tracing = { workspace = true, features = ["std"]}

--- a/stress/src/random.rs
+++ b/stress/src/random.rs
@@ -1,0 +1,14 @@
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+
+mod throughput;
+
+fn main() {
+    throughput::test_throughput(test_random_generation);
+}
+
+fn test_random_generation() {
+    let mut rng = SmallRng::from_entropy();
+    let _index_first_attribute = rng.gen_range(0..10);
+    let _index_second_attribute = rng.gen_range(0..10);
+    let _index_third_attribute = rng.gen_range(0..10);
+}


### PR DESCRIPTION
Metric benchmarks and stress test includes the cost of random generation in it. This adds a dedicated test to tell how much of the overall cost is arising from the random generation itself, so we get a more realistic idea of the real cost of actual otel code.

Example run:

Counter_Add_Sorted       time:   [796.38 ns 812.20 ns 830.03 ns]
Counter_Add_Unsorted   time:   [772.11 ns 789.88 ns 810.13 ns]
Random_Generator_5      time:   [301.08 ns 307.36 ns 314.33 ns]