### PR TITLE
Add Lalit as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,11 @@ For GitHub groups see the [code owners](CODEOWNERS) file.
 * [Cijo Thomas](https://github.com/cijothomas)
 * [Harold Dost](https://github.com/hdost)
 * [Julian Tescher](https://github.com/jtescher)
+* [Lalit Kumar Bhasin](https://github.com/lalitb)
 * [Zhongyang Wu](https://github.com/TommyCpp)
 
 ### Approvers
 
-* [Lalit Kumar Bhasin](https://github.com/lalitb)
 * [Shaun Cox](https://github.com/shaun-cox)
 
 ### Emeritus


### PR DESCRIPTION
Lalit has been helping this project for ~1 year, and several months as an approver. He has been contributing to all areas of the project, and actively reviewing PRs, issues and many more! 
The project will greatly benefit with Lalit stepping up as a maintainer.

