### PR TITLE
Add feature webkpi-roots for reqwest and tonic exporter backends

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- Add `reqwest-rustls-webkpi-roots` feature flag to configure `reqwest` to use embedded `webkpi-roots`.
+- Add `reqwest-rustls-webkpi-roots` feature flag to configure [`reqwest`](https://docs.rs/reqwest/0.11.27/reqwest/index.html#optional-features) to use embedded `webkpi-roots`.
 
 ## v0.11.1
 

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Add `reqwest-rustls-webkpi-roots` feature flag to configure `reqwest` to use embedded `webkpi-roots`.
+
 ## v0.11.1
 
 - Add feature flag enabling users to configure `reqwest` usage to use rustls via

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.65"
 
 [features]
 reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
+reqwest-rustls-webkpi-roots = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - Added `DeltaTemporalitySelector` ([#1568])
+- Add `webkpi-roots` features to `reqwest` and `tonic` backends
 
 [#1568]: https://github.com/open-telemetry/opentelemetry-rust/pull/1568
 

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -67,12 +67,14 @@ grpc-tonic = ["tonic", "prost", "http", "tokio", "opentelemetry-proto/gen-tonic"
 gzip-tonic = ["tonic/gzip"]
 tls = ["tonic/tls"]
 tls-roots = ["tls", "tonic/tls-roots"]
+tls-webkpi-roots = ["tls", "tonic/tls-webpki-roots"]
 
 # http binary
 http-proto = ["prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "http", "trace", "metrics"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
+reqwest-rustls-webkpi-roots = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
 
 # test
 integration-testing = ["tonic", "prost", "tokio/full", "trace"]

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -73,8 +73,8 @@ tls-webkpi-roots = ["tls", "tonic/tls-webpki-roots"]
 http-proto = ["prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "http", "trace", "metrics"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
-reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
-reqwest-rustls-webkpi-roots = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
+reqwest-rustls = ["reqwest", "opentelemetry-http/reqwest-rustls"]
+reqwest-rustls-webkpi-roots = ["reqwest", "opentelemetry-http/reqwest-rustls-webkpi-roots"]
 
 # test
 integration-testing = ["tonic", "prost", "tokio/full", "trace"]

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -97,13 +97,15 @@
 //! * `gzip-tonic`: Use gzip compression for `tonic` grpc layer.
 //! * `tls-tonic`: Enable TLS.
 //! * `tls-roots`: Adds system trust roots to rustls-based gRPC clients using the rustls-native-certs crate
+//! * `tls-webkpi-roots`: Embeds Mozilla's trust roots to rustls-based gRPC clients using the webkpi-roots crate
 //!
 //! The following feature flags offer additional configurations on http:
 //!
 //! * `http-proto`: Use http as transport layer, protobuf as body format.
 //! * `reqwest-blocking-client`: Use reqwest blocking http client.
 //! * `reqwest-client`: Use reqwest http client.
-//! * `reqwest-rustls`: Use reqwest with TLS.
+//! * `reqwest-rustls`: Use reqwest with TLS with system trust roots via `rustls-native-certs` crate.
+//! * `reqwest-rustls-webkpi-roots`: Use reqwest with TLS with Mozilla's trust roots via `webkpi-roots` crate.
 //!
 //! # Kitchen Sink Full Configuration
 //!


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Add features to enable selection of webkpi-roots for TLS trust roots in reqwest and tonic exporter backends.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
