### PR TITLE
Run a stress thread for each logical core

### DIFF
--- a/stress/src/throughput.rs
+++ b/stress/src/throughput.rs
@@ -26,7 +26,7 @@ where
         STOP.store(true, Ordering::SeqCst);
     })
     .expect("Error setting Ctrl-C handler");
-    let num_threads = num_cpus::get_physical();
+    let num_threads = num_cpus::get();
     println!("Number of threads: {}", num_threads);
     let mut handles = Vec::with_capacity(num_threads);
     let func_arc = Arc::new(func);


### PR DESCRIPTION
Fixes #1405
Design discussion issue (if applicable) #

Currently the stress test run a thread for each physical core with physical core reserved for the main loop. For CPU with hyper-thread enabled, this actually will take less than 50% CPU time for the whole stress run. Fix this by spawning the number of threads as the number of logical cores, but still reserve one logical core for main loop.

Task Manager shows the CPU usage as 100% and stable.

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
