### PR TITLE
[tracing appender] Collect span attributes

### DIFF
--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Removed unwanted dependency on opentelemetry-sdk.
+- Added support to collect attributes from tracing spans.
 
 ## v0.3.0
 


### PR DESCRIPTION
Seems related to #1378

## Changes

Currently, span attributes are not collected by the `OpenTelemetryTracingBridge`. E.g. when using

```
        let my_span =
            tracing::info_span!("my_span", foo = "bar");

        my_span.in_scope(|| {
            tracing::info!(baz = 42, "Log message with metrics");
        });
```

this will emit the log message with attribute `baz = 42`, but without `foo = bar`.

It can still be desirable to emit attribute values, e.g. when not correlating to emitted tracing data.

This PR adds such functionality by adding two flags that control if span attributes are emitted with logs, and if so, if they are flattened or nested.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
