### PR TITLE
Reflect status of each component

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,18 @@ observability tools.
 
 ## Project Status
 
-| Signal  | Status     |
-| ------- | ---------- |
-| Logs    | Alpha*     |
-| Metrics | Alpha      |
-| Traces  | Beta       |
+| Signal/Component      | Overall Status     |
+| --------------------  | ------------------ |
+| Logs-API              | Alpha*             |
+| Logs-SDK              | Alpha              |
+| Logs-OTLP Exporter    | Alpha              |
+| Logs-Appender-Tracing | Alpha              |
+| Metrics-API           | Alpha              |
+| Metrics-SDK           | Alpha              |
+| Metrics-OTLP Exporter | Alpha              |
+| Traces-API            | Beta               |
+| Traces-SDK            | Beta               |
+| Traces-OTLP Exporter  | Beta               |
 
 *OpenTelemetry Rust is not introducing a new end user callable Logging API.
 Instead, it provides [Logs Bridge


### PR DESCRIPTION
As discussed in previous community meetings, the main readme is now updated to show the status of individual components as opposed to the overall signal. This gives better transparency, and additionally, we expect API to always stabilize before SDK, so it is easy to reflect them with a breakdown.
Only showing the API/SDK/OTLP Exporter (Plus one appender for logs, without which logs are not really useable) for each signal as we are prioritizing them for initial GA release. (The list could change, and can be updated accordingly)