### PR TITLE
Moving LogRecord implementation to SDK

### DIFF
--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -96,7 +96,7 @@
 
 use log::{Level, Metadata, Record};
 use opentelemetry::{
-    logs::{AnyValue, LogRecordBuilder, Logger, LoggerProvider, Severity},
+    logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
     Key,
 };
 use std::borrow::Cow;
@@ -126,14 +126,11 @@ where
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            let log_record = self
-                .logger
-                .create_log_record()
-                .with_severity_number(severity_of_level(record.level()))
-                .with_severity_text(record.level().as_str().into())
-                .with_body(AnyValue::from(record.args().to_string()))
-                .with_attributes(log_attributes(record.key_values()))
-                .build();
+            let mut log_record = self.logger.create_log_record();
+            log_record.set_severity_number(severity_of_level(record.level()));
+            log_record.set_severity_text(record.level().as_str().into());
+            log_record.set_body(AnyValue::from(record.args().to_string()));
+            log_record.set_attributes(log_attributes(record.key_values()));
 
             self.logger.emit(log_record);
         }

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -1,5 +1,5 @@
 use log::{Level, Metadata, Record};
-use opentelemetry::logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity};
+use opentelemetry::logs::{AnyValue, LogRecordBuilder, Logger, LoggerProvider, Severity};
 use std::borrow::Cow;
 
 pub struct OpenTelemetryLogBridge<P, L>
@@ -27,10 +27,13 @@ where
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            let mut log_record = self.logger.create_log_record();
-            log_record.set_severity_number(severity_of_level(record.level()));
-            log_record.set_severity_text(Some(record.level().as_str().into()));
-            log_record.set_body(Some(AnyValue::from(record.args().to_string())));
+            let log_record = self
+                .logger
+                .create_log_record()
+                .with_severity_number(severity_of_level(record.level()))
+                .with_severity_text(record.level().as_str().into())
+                .with_body(AnyValue::from(record.args().to_string()))
+                .build();
 
             self.logger.emit(log_record);
         }

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -1,5 +1,5 @@
 use log::{Level, Metadata, Record};
-use opentelemetry::logs::{AnyValue, LogRecordBuilder, Logger, LoggerProvider, Severity};
+use opentelemetry::logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity};
 use std::borrow::Cow;
 
 pub struct OpenTelemetryLogBridge<P, L>
@@ -27,15 +27,12 @@ where
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            self.logger.emit(
-                LogRecordBuilder::new()
-                    .with_severity_number(severity_of_level(record.level()))
-                    .with_severity_text(record.level().as_str())
-                    // Not populating ObservedTimestamp, instead relying on OpenTelemetry
-                    // API to populate it with current time.
-                    .with_body(AnyValue::from(record.args().to_string()))
-                    .build(),
-            );
+            let mut log_record = self.logger.create_log_record();
+            log_record.set_severity_number(severity_of_level(record.level()));
+            log_record.set_severity_text(Some(record.level().as_str().into()));
+            log_record.set_body(Some(AnyValue::from(record.args().to_string())));
+
+            self.logger.emit(log_record);
         }
     }
 

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -130,7 +130,7 @@ where
             log_record.set_severity_number(severity_of_level(record.level()));
             log_record.set_severity_text(record.level().as_str().into());
             log_record.set_body(AnyValue::from(record.args().to_string()));
-            log_record.set_attributes(log_attributes(record.key_values()));
+            log_record.add_attributes(log_attributes(record.key_values()));
 
             self.logger.emit(log_record);
         }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -71,9 +71,11 @@ impl EventVisitor {
         }
     }
 
-    fn push_to_otel_log_record(self, log_record: &mut LogRecord) {
-        log_record.body = self.log_record_body;
-        log_record.attributes = Some(self.log_record_attributes);
+    fn push_to_otel_log_record<LR: LogRecord>(self, log_record: &mut LR) {
+        log_record.set_body(self.log_record_body);
+        log_record.set_attributes(self.log_record_attributes);
+        //log_record.body = self.log_record_body;
+        //log_record.attributes = Some(self.log_record_attributes);
     }
 }
 
@@ -166,9 +168,12 @@ where
         #[cfg(not(feature = "experimental_metadata_attributes"))]
         let meta = event.metadata();
 
-        let mut log_record: LogRecord = LogRecord::default();
-        log_record.severity_number = Some(severity_of_level(meta.level()));
-        log_record.severity_text = Some(meta.level().to_string().into());
+        //let mut log_record: LogRecord = LogRecord::default();
+        let mut log_record = self.logger.create_log_record();
+        log_record.set_severity_number(severity_of_level(meta.level()));
+        log_record.set_severity_text(Some(meta.level().to_string().into()));
+        //log_record.severity_number = Some(severity_of_level(meta.level()));
+        //log_record.severity_text = Some(meta.level().to_string().into());
 
         // Not populating ObservedTimestamp, instead relying on OpenTelemetry
         // API to populate it with current time.

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -75,7 +75,7 @@ impl EventVisitor {
         if let Some(body) = self.log_record_body {
             log_record.set_body(body);
         }
-        log_record.set_attributes(self.log_record_attributes);
+        log_record.add_attributes(self.log_record_attributes);
     }
 }
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -72,7 +72,9 @@ impl EventVisitor {
     }
 
     fn push_to_otel_log_record<LR: LogRecord>(self, log_record: &mut LR) {
-        log_record.set_body(self.log_record_body.unwrap()); // unwrap should be safe, as value is always there
+        if let Some(body) = self.log_record_body {
+            log_record.set_body(body);
+        }        
         log_record.set_attributes(self.log_record_attributes);
     }
 }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -74,7 +74,7 @@ impl EventVisitor {
     fn push_to_otel_log_record<LR: LogRecord>(self, log_record: &mut LR) {
         if let Some(body) = self.log_record_body {
             log_record.set_body(body);
-        }        
+        }
         log_record.set_attributes(self.log_record_attributes);
     }
 }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{
-    logs::{AnyValue, LogRecord, LogRecordBuilder, Logger, LoggerProvider, Severity},
+    logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
     Key,
 };
 use std::borrow::Cow;
@@ -169,12 +169,9 @@ where
         let meta = event.metadata();
 
         //let mut log_record: LogRecord = LogRecord::default();
-        let mut log_record = self
-            .logger
-            .create_log_record()
-            .with_severity_number(severity_of_level(meta.level()))
-            .with_severity_text(meta.level().to_string().into())
-            .build();
+        let mut log_record = self.logger.create_log_record();
+        log_record.set_severity_number(severity_of_level(meta.level()));
+        log_record.set_severity_text(meta.level().to_string().into());
 
         let mut visitor = EventVisitor::default();
         visitor.visit_metadata(meta);

--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -50,8 +50,8 @@ pub mod tonic {
         }
     }
 
-    impl From<opentelemetry_sdk::logs::SdkLogRecord> for LogRecord {
-        fn from(log_record: opentelemetry_sdk::logs::SdkLogRecord) -> Self {
+    impl From<opentelemetry_sdk::logs::LogRecord> for LogRecord {
+        fn from(log_record: opentelemetry_sdk::logs::LogRecord) -> Self {
             let trace_context = log_record.trace_context.as_ref();
             let severity_number = match log_record.severity_number {
                 Some(Severity::Trace) => SeverityNumber::Trace,

--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -50,8 +50,8 @@ pub mod tonic {
         }
     }
 
-    impl From<opentelemetry::logs::LogRecord> for LogRecord {
-        fn from(log_record: opentelemetry::logs::LogRecord) -> Self {
+    impl From<opentelemetry_sdk::logs::SdkLogRecord> for LogRecord {
+        fn from(log_record: opentelemetry_sdk::logs::SdkLogRecord) -> Self {
             let trace_context = log_record.trace_context.as_ref();
             let severity_number = match log_record.severity_number {
                 Some(Severity::Trace) => SeverityNumber::Trace,
@@ -83,7 +83,7 @@ pub mod tonic {
 
             LogRecord {
                 time_unix_nano: log_record.timestamp.map(to_nanos).unwrap_or_default(),
-                observed_time_unix_nano: to_nanos(log_record.observed_timestamp),
+                observed_time_unix_nano: to_nanos(log_record.observed_timestamp.unwrap()),
                 severity_number: severity_number.into(),
                 severity_text: log_record.severity_text.map(Into::into).unwrap_or_default(),
                 body: log_record.body.map(Into::into),

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -26,6 +26,8 @@
   - `shutdown` methods in `LoggerProvider` and `LogProcessor` now takes a immutable reference
   - After `shutdown`, `LoggerProvider` will return noop `Logger`
   - After `shutdown`, `LogProcessor` will not process any new logs
+- Moving LogRecord implementation to the SDK. [1702](https://github.com/open-telemetry/opentelemetry-rust/pull/1702).
+    - Relocated `LogRecord` struct to SDK, as an implementation for the trait in the API.
 
 ## v0.22.1
 

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -4,12 +4,14 @@ use std::time::SystemTime;
 use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use opentelemetry::logs::{AnyValue, LogRecord, Logger as _, LogResult, LoggerProvider as _, Severity};
+use opentelemetry::logs::{
+    AnyValue, LogRecord, LogRecordBuilder, LogResult, Logger as _, LoggerProvider as _, Severity,
+};
 use opentelemetry::trace::Tracer;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::Key;
 use opentelemetry_sdk::export::logs::{LogData, LogExporter};
-use opentelemetry_sdk::logs::{LoggerProvider, Logger};
+use opentelemetry_sdk::logs::{Logger, LoggerProvider};
 use opentelemetry_sdk::trace::{config, Sampler, TracerProvider};
 
 #[derive(Debug)]
@@ -22,7 +24,7 @@ impl LogExporter for VoidExporter {
     }
 }
 
-fn log_benchmark_group<F: Fn(& Logger)>(c: &mut Criterion, name: &str, f: F) {
+fn log_benchmark_group<F: Fn(&Logger)>(c: &mut Criterion, name: &str, f: F) {
     let mut group = c.benchmark_group(name);
 
     group.bench_function("no-context", |b| {
@@ -59,14 +61,19 @@ fn log_benchmark_group<F: Fn(& Logger)>(c: &mut Criterion, name: &str, f: F) {
 
 fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "simple-log", |logger| {
-        let record :&_ = logger.create_log_record().set_body(Some("simple log".into()));
-        logger.emit(*record);
+        logger.emit(
+            logger
+                .create_log_record()
+                .with_body("simple log".into())
+                .build(),
+        );
     });
 
     log_benchmark_group(c, "simple-log-with-int", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("simple log")
+            logger
+                .create_log_record()
+                .with_body("simple log".into())
                 .with_attribute("testint", 2)
                 .build(),
         )
@@ -74,12 +81,9 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     log_benchmark_group(c, "simple-log-with-double", |logger| {
         logger.emit(
-            logger.create_log_record()
-                .with_body("simple log")
-                .with_attribute("testdouble", 2.2)
-                .build(),
-            LogRecord::builder()
-                .with_body("simple log")
+            logger
+                .create_log_record()
+                .with_body("simple log".into())
                 .with_attribute("testdouble", 2.2)
                 .build(),
         )
@@ -87,8 +91,9 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     log_benchmark_group(c, "simple-log-with-string", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("simple log")
+            logger
+                .create_log_record()
+                .with_body("simple log".into())
                 .with_attribute("teststring", "test")
                 .build(),
         )
@@ -96,8 +101,9 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     log_benchmark_group(c, "simple-log-with-bool", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("simple log")
+            logger
+                .create_log_record()
+                .with_body("simple log".into())
                 .with_attribute("testbool", AnyValue::Boolean(true))
                 .build(),
         )
@@ -106,8 +112,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     let bytes = AnyValue::Bytes(vec![25u8, 30u8, 40u8]);
     log_benchmark_group(c, "simple-log-with-bytes", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("simple log")
+            logger
+                .create_log_record()
+                .with_body("simple log".into())
                 .with_attribute("testbytes", bytes.clone())
                 .build(),
         )
@@ -123,8 +130,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     ]);
     log_benchmark_group(c, "simple-log-with-a-lot-of-bytes", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("simple log")
+            logger
+                .create_log_record()
+                .with_body("simple log".into())
                 .with_attribute("testbytes", bytes.clone())
                 .build(),
         )
@@ -133,8 +141,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     let vec_any_values = AnyValue::ListAny(vec![AnyValue::Int(25), "test".into(), true.into()]);
     log_benchmark_group(c, "simple-log-with-vec-any-value", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("simple log")
+            logger
+                .create_log_record()
+                .with_body("simple log".into())
                 .with_attribute("testvec", vec_any_values.clone())
                 .build(),
         )
@@ -149,8 +158,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     ]);
     log_benchmark_group(c, "simple-log-with-inner-vec-any-value", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("simple log")
+            logger
+                .create_log_record()
+                .with_body("simple log".into())
                 .with_attribute("testvec", vec_any_values.clone())
                 .build(),
         )
@@ -163,8 +173,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     ]));
     log_benchmark_group(c, "simple-log-with-map-any-value", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("simple log")
+            logger
+                .create_log_record()
+                .with_body("simple log".into())
                 .with_attribute("testmap", map_any_values.clone())
                 .build(),
         )
@@ -183,38 +194,41 @@ fn criterion_benchmark(c: &mut Criterion) {
     ]));
     log_benchmark_group(c, "simple-log-with-inner-map-any-value", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("simple log")
+            logger
+                .create_log_record()
+                .with_body("simple log".into())
                 .with_attribute("testmap", map_any_values.clone())
                 .build(),
         )
     });
 
     log_benchmark_group(c, "long-log", |logger| {
-        logger.emit(LogRecord::builder().with_body("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Gravida in fermentum et sollicitudin ac orci phasellus. Ullamcorper dignissim cras tincidunt lobortis feugiat vivamus at augue. Magna etiam tempor orci eu. Sed tempus urna et pharetra pharetra massa.").build())
+        logger.emit(logger.create_log_record().with_body("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Gravida in fermentum et sollicitudin ac orci phasellus. Ullamcorper dignissim cras tincidunt lobortis feugiat vivamus at augue. Magna etiam tempor orci eu. Sed tempus urna et pharetra pharetra massa.".into()).build())
     });
 
     let now = SystemTime::now();
     log_benchmark_group(c, "full-log", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("full log")
+            logger
+                .create_log_record()
+                .with_body("full log".into())
                 .with_timestamp(now)
                 .with_observed_timestamp(now)
                 .with_severity_number(Severity::Warn)
-                .with_severity_text(Severity::Warn.name())
+                .with_severity_text(Severity::Warn.name().into())
                 .build(),
         )
     });
 
     log_benchmark_group(c, "full-log-with-4-attributes", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("full log")
+            logger
+                .create_log_record()
+                .with_body("full log".into())
                 .with_timestamp(now)
                 .with_observed_timestamp(now)
                 .with_severity_number(Severity::Warn)
-                .with_severity_text(Severity::Warn.name())
+                .with_severity_text(Severity::Warn.name().into())
                 .with_attribute("name", "my-event-name")
                 .with_attribute("event.id", 20)
                 .with_attribute("user.name", "otel")
@@ -225,12 +239,13 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     log_benchmark_group(c, "full-log-with-9-attributes", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("full log")
+            logger
+                .create_log_record()
+                .with_body("full log".into())
                 .with_timestamp(now)
                 .with_observed_timestamp(now)
                 .with_severity_number(Severity::Warn)
-                .with_severity_text(Severity::Warn.name())
+                .with_severity_text(Severity::Warn.name().into())
                 .with_attribute("name", "my-event-name")
                 .with_attribute("event.id", 20)
                 .with_attribute("user.name", "otel")
@@ -266,12 +281,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     ];
     log_benchmark_group(c, "full-log-with-attributes", |logger| {
         logger.emit(
-            LogRecord::builder()
-                .with_body("full log")
+            logger
+                .create_log_record()
+                .with_body("full log".into())
                 .with_timestamp(now)
                 .with_observed_timestamp(now)
                 .with_severity_number(Severity::Warn)
-                .with_severity_text(Severity::Warn.name())
+                .with_severity_text(Severity::Warn.name().into())
                 .with_attributes(attributes.clone())
                 .build(),
         )

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -69,28 +69,28 @@ fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "simple-log-with-int", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());
-        log_record.set_attribute("testint", 2);
+        log_record.add_attribute("testint", 2);
         logger.emit(log_record);
     });
 
     log_benchmark_group(c, "simple-log-with-double", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());
-        log_record.set_attribute("testdouble", 2.2);
+        log_record.add_attribute("testdouble", 2.2);
         logger.emit(log_record);
     });
 
     log_benchmark_group(c, "simple-log-with-string", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());
-        log_record.set_attribute("teststring", "test");
+        log_record.add_attribute("teststring", "test");
         logger.emit(log_record);
     });
 
     log_benchmark_group(c, "simple-log-with-bool", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());
-        log_record.set_attribute("testbool", AnyValue::Boolean(true));
+        log_record.add_attribute("testbool", AnyValue::Boolean(true));
         logger.emit(log_record);
     });
 
@@ -98,7 +98,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "simple-log-with-bytes", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());
-        log_record.set_attribute("testbytes", bytes.clone());
+        log_record.add_attribute("testbytes", bytes.clone());
         logger.emit(log_record);
     });
 
@@ -113,7 +113,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "simple-log-with-a-lot-of-bytes", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());
-        log_record.set_attribute("testbytes", bytes.clone());
+        log_record.add_attribute("testbytes", bytes.clone());
         logger.emit(log_record);
     });
 
@@ -121,7 +121,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "simple-log-with-vec-any-value", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());
-        log_record.set_attribute("testvec", vec_any_values.clone());
+        log_record.add_attribute("testvec", vec_any_values.clone());
         logger.emit(log_record);
     });
 
@@ -135,7 +135,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "simple-log-with-inner-vec-any-value", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());
-        log_record.set_attribute("testvec", vec_any_values.clone());
+        log_record.add_attribute("testvec", vec_any_values.clone());
         logger.emit(log_record);
     });
 
@@ -147,7 +147,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "simple-log-with-map-any-value", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());
-        log_record.set_attribute("testmap", map_any_values.clone());
+        log_record.add_attribute("testmap", map_any_values.clone());
         logger.emit(log_record);
     });
 
@@ -165,7 +165,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "simple-log-with-inner-map-any-value", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());
-        log_record.set_attribute("testmap", map_any_values.clone());
+        log_record.add_attribute("testmap", map_any_values.clone());
         logger.emit(log_record);
     });
 
@@ -193,10 +193,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         log_record.set_observed_timestamp(now);
         log_record.set_severity_number(Severity::Warn);
         log_record.set_severity_text(Severity::Warn.name().into());
-        log_record.set_attribute("name", "my-event-name");
-        log_record.set_attribute("event.id", 20);
-        log_record.set_attribute("user.name", "otel");
-        log_record.set_attribute("user.email", "otel@opentelemetry.io");
+        log_record.add_attribute("name", "my-event-name");
+        log_record.add_attribute("event.id", 20);
+        log_record.add_attribute("user.name", "otel");
+        log_record.add_attribute("user.email", "otel@opentelemetry.io");
         logger.emit(log_record);
     });
 
@@ -207,15 +207,15 @@ fn criterion_benchmark(c: &mut Criterion) {
         log_record.set_observed_timestamp(now);
         log_record.set_severity_number(Severity::Warn);
         log_record.set_severity_text(Severity::Warn.name().into());
-        log_record.set_attribute("name", "my-event-name");
-        log_record.set_attribute("event.id", 20);
-        log_record.set_attribute("user.name", "otel");
-        log_record.set_attribute("user.email", "otel@opentelemetry.io");
-        log_record.set_attribute("code.filename", "log.rs");
-        log_record.set_attribute("code.filepath", "opentelemetry_sdk/benches/log.rs");
-        log_record.set_attribute("code.lineno", 96);
-        log_record.set_attribute("code.namespace", "opentelemetry_sdk::benches::log");
-        log_record.set_attribute("log.target", "opentelemetry_sdk::benches::log");
+        log_record.add_attribute("name", "my-event-name");
+        log_record.add_attribute("event.id", 20);
+        log_record.add_attribute("user.name", "otel");
+        log_record.add_attribute("user.email", "otel@opentelemetry.io");
+        log_record.add_attribute("code.filename", "log.rs");
+        log_record.add_attribute("code.filepath", "opentelemetry_sdk/benches/log.rs");
+        log_record.add_attribute("code.lineno", 96);
+        log_record.add_attribute("code.namespace", "opentelemetry_sdk::benches::log");
+        log_record.add_attribute("log.target", "opentelemetry_sdk::benches::log");
         logger.emit(log_record);
     });
 
@@ -246,7 +246,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         log_record.set_observed_timestamp(now);
         log_record.set_severity_number(Severity::Warn);
         log_record.set_severity_text(Severity::Warn.name().into());
-        log_record.set_attributes(attributes.clone());
+        log_record.add_attributes(attributes.clone());
         logger.emit(log_record);
     });
 }

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use opentelemetry::logs::{
-    AnyValue, LogRecordBuilder, LogResult, Logger as _, LoggerProvider as _, Severity,
+    AnyValue, LogRecord as _, LogResult, Logger as _, LoggerProvider as _, Severity,
 };
 use opentelemetry::trace::Tracer;
 use opentelemetry::trace::TracerProvider as _;
@@ -61,63 +61,45 @@ fn log_benchmark_group<F: Fn(&Logger)>(c: &mut Criterion, name: &str, f: F) {
 
 fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "simple-log", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("simple log".into())
-                .build(),
-        );
+        let mut log_record = logger.create_log_record();
+        log_record.set_body(AnyValue::String("simple log".into()));
+        logger.emit(log_record);
     });
 
     log_benchmark_group(c, "simple-log-with-int", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("simple log".into())
-                .with_attribute("testint", 2)
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("simple log".into());
+        log_record.set_attribute("testint", 2);
+        logger.emit(log_record);
     });
 
     log_benchmark_group(c, "simple-log-with-double", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("simple log".into())
-                .with_attribute("testdouble", 2.2)
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("simple log".into());
+        log_record.set_attribute("testdouble", 2.2);
+        logger.emit(log_record);
     });
 
     log_benchmark_group(c, "simple-log-with-string", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("simple log".into())
-                .with_attribute("teststring", "test")
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("simple log".into());
+        log_record.set_attribute("teststring", "test");
+        logger.emit(log_record);
     });
 
     log_benchmark_group(c, "simple-log-with-bool", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("simple log".into())
-                .with_attribute("testbool", AnyValue::Boolean(true))
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("simple log".into());
+        log_record.set_attribute("testbool", AnyValue::Boolean(true));
+        logger.emit(log_record);
     });
 
     let bytes = AnyValue::Bytes(vec![25u8, 30u8, 40u8]);
     log_benchmark_group(c, "simple-log-with-bytes", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("simple log".into())
-                .with_attribute("testbytes", bytes.clone())
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("simple log".into());
+        log_record.set_attribute("testbytes", bytes.clone());
+        logger.emit(log_record);
     });
 
     let bytes = AnyValue::Bytes(vec![
@@ -129,24 +111,18 @@ fn criterion_benchmark(c: &mut Criterion) {
         30u8, 40u8, 30u8, 40u8, 30u8, 40u8, 30u8, 40u8, 30u8, 40u8,
     ]);
     log_benchmark_group(c, "simple-log-with-a-lot-of-bytes", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("simple log".into())
-                .with_attribute("testbytes", bytes.clone())
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("simple log".into());
+        log_record.set_attribute("testbytes", bytes.clone());
+        logger.emit(log_record);
     });
 
     let vec_any_values = AnyValue::ListAny(vec![AnyValue::Int(25), "test".into(), true.into()]);
     log_benchmark_group(c, "simple-log-with-vec-any-value", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("simple log".into())
-                .with_attribute("testvec", vec_any_values.clone())
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("simple log".into());
+        log_record.set_attribute("testvec", vec_any_values.clone());
+        logger.emit(log_record);
     });
 
     let vec_any_values = AnyValue::ListAny(vec![AnyValue::Int(25), "test".into(), true.into()]);
@@ -157,13 +133,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         vec_any_values,
     ]);
     log_benchmark_group(c, "simple-log-with-inner-vec-any-value", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("simple log".into())
-                .with_attribute("testvec", vec_any_values.clone())
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("simple log".into());
+        log_record.set_attribute("testvec", vec_any_values.clone());
+        logger.emit(log_record);
     });
 
     let map_any_values = AnyValue::Map(HashMap::from([
@@ -172,13 +145,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         ("teststring".into(), "test".into()),
     ]));
     log_benchmark_group(c, "simple-log-with-map-any-value", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("simple log".into())
-                .with_attribute("testmap", map_any_values.clone())
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("simple log".into());
+        log_record.set_attribute("testmap", map_any_values.clone());
+        logger.emit(log_record);
     });
 
     let map_any_values = AnyValue::Map(HashMap::from([
@@ -193,70 +163,60 @@ fn criterion_benchmark(c: &mut Criterion) {
         ("testmap".into(), map_any_values),
     ]));
     log_benchmark_group(c, "simple-log-with-inner-map-any-value", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("simple log".into())
-                .with_attribute("testmap", map_any_values.clone())
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("simple log".into());
+        log_record.set_attribute("testmap", map_any_values.clone());
+        logger.emit(log_record);
     });
 
     log_benchmark_group(c, "long-log", |logger| {
-        logger.emit(logger.create_log_record().with_body("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Gravida in fermentum et sollicitudin ac orci phasellus. Ullamcorper dignissim cras tincidunt lobortis feugiat vivamus at augue. Magna etiam tempor orci eu. Sed tempus urna et pharetra pharetra massa.".into()).build())
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Gravida in fermentum et sollicitudin ac orci phasellus. Ullamcorper dignissim cras tincidunt lobortis feugiat vivamus at augue. Magna etiam tempor orci eu. Sed tempus urna et pharetra pharetra massa.".into());
+        logger.emit(log_record);
     });
 
     let now = SystemTime::now();
     log_benchmark_group(c, "full-log", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("full log".into())
-                .with_timestamp(now)
-                .with_observed_timestamp(now)
-                .with_severity_number(Severity::Warn)
-                .with_severity_text(Severity::Warn.name().into())
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("full log".into());
+        log_record.set_timestamp(now);
+        log_record.set_observed_timestamp(now);
+        log_record.set_severity_number(Severity::Warn);
+        log_record.set_severity_text(Severity::Warn.name().into());
+        logger.emit(log_record);
     });
 
     log_benchmark_group(c, "full-log-with-4-attributes", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("full log".into())
-                .with_timestamp(now)
-                .with_observed_timestamp(now)
-                .with_severity_number(Severity::Warn)
-                .with_severity_text(Severity::Warn.name().into())
-                .with_attribute("name", "my-event-name")
-                .with_attribute("event.id", 20)
-                .with_attribute("user.name", "otel")
-                .with_attribute("user.email", "otel@opentelemetry.io")
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("full log".into());
+        log_record.set_timestamp(now);
+        log_record.set_observed_timestamp(now);
+        log_record.set_severity_number(Severity::Warn);
+        log_record.set_severity_text(Severity::Warn.name().into());
+        log_record.set_attribute("name", "my-event-name");
+        log_record.set_attribute("event.id", 20);
+        log_record.set_attribute("user.name", "otel");
+        log_record.set_attribute("user.email", "otel@opentelemetry.io");
+        logger.emit(log_record);
     });
 
     log_benchmark_group(c, "full-log-with-9-attributes", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("full log".into())
-                .with_timestamp(now)
-                .with_observed_timestamp(now)
-                .with_severity_number(Severity::Warn)
-                .with_severity_text(Severity::Warn.name().into())
-                .with_attribute("name", "my-event-name")
-                .with_attribute("event.id", 20)
-                .with_attribute("user.name", "otel")
-                .with_attribute("user.email", "otel@opentelemetry.io")
-                .with_attribute("code.filename", "log.rs")
-                .with_attribute("code.filepath", "opentelemetry_sdk/benches/log.rs")
-                .with_attribute("code.lineno", 96)
-                .with_attribute("code.namespace", "opentelemetry_sdk::benches::log")
-                .with_attribute("log.target", "opentelemetry_sdk::benches::log")
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("full log".into());
+        log_record.set_timestamp(now);
+        log_record.set_observed_timestamp(now);
+        log_record.set_severity_number(Severity::Warn);
+        log_record.set_severity_text(Severity::Warn.name().into());
+        log_record.set_attribute("name", "my-event-name");
+        log_record.set_attribute("event.id", 20);
+        log_record.set_attribute("user.name", "otel");
+        log_record.set_attribute("user.email", "otel@opentelemetry.io");
+        log_record.set_attribute("code.filename", "log.rs");
+        log_record.set_attribute("code.filepath", "opentelemetry_sdk/benches/log.rs");
+        log_record.set_attribute("code.lineno", 96);
+        log_record.set_attribute("code.namespace", "opentelemetry_sdk::benches::log");
+        log_record.set_attribute("log.target", "opentelemetry_sdk::benches::log");
+        logger.emit(log_record);
     });
 
     let attributes: Vec<(Key, AnyValue)> = vec![
@@ -280,17 +240,14 @@ fn criterion_benchmark(c: &mut Criterion) {
         ),
     ];
     log_benchmark_group(c, "full-log-with-attributes", |logger| {
-        logger.emit(
-            logger
-                .create_log_record()
-                .with_body("full log".into())
-                .with_timestamp(now)
-                .with_observed_timestamp(now)
-                .with_severity_number(Severity::Warn)
-                .with_severity_text(Severity::Warn.name().into())
-                .with_attributes(attributes.clone())
-                .build(),
-        )
+        let mut log_record = logger.create_log_record();
+        log_record.set_body("full log".into());
+        log_record.set_timestamp(now);
+        log_record.set_observed_timestamp(now);
+        log_record.set_severity_number(Severity::Warn);
+        log_record.set_severity_text(Severity::Warn.name().into());
+        log_record.set_attributes(attributes.clone());
+        logger.emit(log_record);
     });
 }
 

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use opentelemetry::logs::{
-    AnyValue, LogRecord, LogRecordBuilder, LogResult, Logger as _, LoggerProvider as _, Severity,
+    AnyValue, LogRecordBuilder, LogResult, Logger as _, LoggerProvider as _, Severity,
 };
 use opentelemetry::trace::Tracer;
 use opentelemetry::trace::TracerProvider as _;

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -62,7 +62,7 @@ fn log_benchmark_group<F: Fn(&Logger)>(c: &mut Criterion, name: &str, f: F) {
 fn criterion_benchmark(c: &mut Criterion) {
     log_benchmark_group(c, "simple-log", |logger| {
         let mut log_record = logger.create_log_record();
-        log_record.set_body(AnyValue::String("simple log".into()));
+        log_record.set_body("simple log".into());
         logger.emit(log_record);
     });
 

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -1,5 +1,5 @@
 //! Log exporters
-use crate::logs::SdkLogRecord;
+use crate::logs::LogRecord;
 use crate::Resource;
 use async_trait::async_trait;
 #[cfg(feature = "logs_level_enabled")]
@@ -30,7 +30,7 @@ pub trait LogExporter: Send + Sync + Debug {
 #[derive(Clone, Debug)]
 pub struct LogData {
     /// Log record
-    pub record: SdkLogRecord,
+    pub record: LogRecord,
     /// Instrumentation details for the emitter who produced this `LogEvent`.
     pub instrumentation: InstrumentationLibrary,
 }

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -1,4 +1,5 @@
 //! Log exporters
+use crate::logs::SdkLogRecord;
 use crate::Resource;
 use async_trait::async_trait;
 #[cfg(feature = "logs_level_enabled")]
@@ -7,7 +8,6 @@ use opentelemetry::{
     logs::{LogError, LogResult},
     InstrumentationLibrary,
 };
-use crate::logs::SdkLogRecord;
 use std::fmt::Debug;
 
 /// `LogExporter` defines the interface that log exporters should implement.

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -4,9 +4,10 @@ use async_trait::async_trait;
 #[cfg(feature = "logs_level_enabled")]
 use opentelemetry::logs::Severity;
 use opentelemetry::{
-    logs::{LogError, LogRecord, LogResult},
+    logs::{LogError, LogResult},
     InstrumentationLibrary,
 };
+use crate::logs::SdkLogRecord;
 use std::fmt::Debug;
 
 /// `LogExporter` defines the interface that log exporters should implement.
@@ -29,7 +30,7 @@ pub trait LogExporter: Send + Sync + Debug {
 #[derive(Clone, Debug)]
 pub struct LogData {
     /// Log record
-    pub record: LogRecord,
+    pub record: SdkLogRecord,
     /// Instrumentation details for the emitter who produced this `LogEvent`.
     pub instrumentation: InstrumentationLibrary,
 }

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -1,11 +1,11 @@
-use super::{BatchLogProcessor, Config, LogProcessor, SimpleLogProcessor};
+use super::{BatchLogProcessor, Config, LogProcessor, SdkLogRecord, SimpleLogProcessor, TraceContext};
 use crate::{
     export::logs::{LogData, LogExporter},
     runtime::RuntimeChannel,
 };
 use opentelemetry::{
     global::{self},
-    logs::{LogRecord, LogResult, TraceContext},
+    logs::LogResult,
     trace::TraceContextExt,
     Context, InstrumentationLibrary,
 };
@@ -222,8 +222,14 @@ impl Logger {
 }
 
 impl opentelemetry::logs::Logger for Logger {
+    type LogRecord = SdkLogRecord;
+
+    fn create_log_record(&self) -> Self::LogRecord {
+        SdkLogRecord::default()
+    }
+
     /// Emit a `LogRecord`.
-    fn emit(&self, record: LogRecord) {
+    fn emit(&self, record: Self::LogRecord) {
         let provider = self.provider();
         let processors = provider.log_processors();
         let trace_context = Context::map_current(|cx| {
@@ -462,17 +468,17 @@ mod tests {
 
         let logger1 = logger_provider.logger("test-logger1");
         let logger2 = logger_provider.logger("test-logger2");
-        logger1.emit(LogRecord::default());
-        logger2.emit(LogRecord::default());
+        logger1.emit(logger1.create_log_record());
+        logger2.emit(logger1.create_log_record());
 
         let logger3 = logger_provider.logger("test-logger3");
         let handle = thread::spawn(move || {
-            logger3.emit(LogRecord::default());
+            logger3.emit(logger3.create_log_record());
         });
         handle.join().expect("thread panicked");
 
         let _ = logger_provider.shutdown();
-        logger1.emit(LogRecord::default());
+        logger1.emit(logger1.create_log_record());
 
         assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 3);
     }
@@ -495,8 +501,8 @@ mod tests {
         let logger2 = logger_provider.logger("test-logger2");
 
         // Acts
-        logger1.emit(LogRecord::default());
-        logger2.emit(LogRecord::default());
+        logger1.emit(logger1.create_log_record());
+        logger2.emit(logger1.create_log_record());
 
         // explicitly calling shutdown on logger_provider. This will
         // indeed do the shutdown, even if there are loggers still alive.

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -1,4 +1,7 @@
-use super::{BatchLogProcessor, Config, LogProcessor, SdkLogRecord, SimpleLogProcessor, TraceContext};
+use super::{
+    BatchLogProcessor, Config, LogProcessor, SdkLogRecord, SdkLogRecordBuilder, SimpleLogProcessor,
+    TraceContext,
+};
 use crate::{
     export::logs::{LogData, LogExporter},
     runtime::RuntimeChannel,
@@ -223,9 +226,10 @@ impl Logger {
 
 impl opentelemetry::logs::Logger for Logger {
     type LogRecord = SdkLogRecord;
+    type LogRecordBuilder = SdkLogRecordBuilder;
 
-    fn create_log_record(&self) -> Self::LogRecord {
-        SdkLogRecord::default()
+    fn create_log_record(&self) -> Self::LogRecordBuilder {
+        SdkLogRecordBuilder::default()
     }
 
     /// Emit a `LogRecord`.
@@ -276,7 +280,7 @@ mod tests {
 
     use super::*;
     use opentelemetry::logs::Logger;
-    use opentelemetry::logs::LoggerProvider as _;
+    use opentelemetry::logs::{LogRecordBuilder as _, LoggerProvider as _};
     use opentelemetry::{Key, KeyValue, Value};
     use std::fmt::{Debug, Formatter};
     use std::sync::atomic::AtomicU64;
@@ -468,17 +472,17 @@ mod tests {
 
         let logger1 = logger_provider.logger("test-logger1");
         let logger2 = logger_provider.logger("test-logger2");
-        logger1.emit(logger1.create_log_record());
-        logger2.emit(logger1.create_log_record());
+        logger1.emit(logger1.create_log_record().build());
+        logger2.emit(logger1.create_log_record().build());
 
         let logger3 = logger_provider.logger("test-logger3");
         let handle = thread::spawn(move || {
-            logger3.emit(logger3.create_log_record());
+            logger3.emit(logger3.create_log_record().build());
         });
         handle.join().expect("thread panicked");
 
         let _ = logger_provider.shutdown();
-        logger1.emit(logger1.create_log_record());
+        logger1.emit(logger1.create_log_record().build());
 
         assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 3);
     }
@@ -501,8 +505,8 @@ mod tests {
         let logger2 = logger_provider.logger("test-logger2");
 
         // Acts
-        logger1.emit(logger1.create_log_record());
-        logger2.emit(logger1.create_log_record());
+        logger1.emit(logger1.create_log_record().build());
+        logger2.emit(logger1.create_log_record().build());
 
         // explicitly calling shutdown on logger_provider. This will
         // indeed do the shutdown, even if there are loggers still alive.

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -1,6 +1,4 @@
-use super::{
-    BatchLogProcessor, Config, LogProcessor, SdkLogRecord, SimpleLogProcessor, TraceContext,
-};
+use super::{BatchLogProcessor, Config, LogProcessor, LogRecord, SimpleLogProcessor, TraceContext};
 use crate::{
     export::logs::{LogData, LogExporter},
     runtime::RuntimeChannel,
@@ -224,10 +222,10 @@ impl Logger {
 }
 
 impl opentelemetry::logs::Logger for Logger {
-    type LogRecord = SdkLogRecord;
+    type LogRecord = LogRecord;
 
     fn create_log_record(&self) -> Self::LogRecord {
-        SdkLogRecord::default()
+        LogRecord::default()
     }
 
     /// Emit a `LogRecord`.

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -11,7 +11,8 @@ pub use log_processor::{
     BatchConfig, BatchConfigBuilder, BatchLogProcessor, BatchLogProcessorBuilder, LogProcessor,
     SimpleLogProcessor,
 };
-pub use record::{SdkLogRecord, TraceContext};
+pub use opentelemetry::logs::LogRecordBuilder;
+pub use record::{SdkLogRecord, SdkLogRecordBuilder, TraceContext};
 
 #[cfg(all(test, feature = "testing"))]
 mod tests {
@@ -30,14 +31,15 @@ mod tests {
 
         // Act
         let logger = logger_provider.logger("test-logger");
-        let mut log_record=  logger.create_log_record();
-        log_record.severity_number = Some(Severity::Error);
-        log_record.severity_text = Some("Error".into());
-        let attributes = vec![
-            (Key::new("key1"), "value1".into()),
-            (Key::new("key2"), "value2".into()),
-        ];
-        log_record.attributes = Some(attributes);
+        let log_record = logger
+            .create_log_record()
+            .with_severity_number(Severity::Error)
+            .with_severity_text("Error".into())
+            .with_attributes(vec![
+                (Key::new("key1"), "value1".into()),
+                (Key::new("key2"), "value2".into()),
+            ])
+            .build();
         logger.emit(log_record);
 
         // Assert

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -3,6 +3,7 @@
 mod config;
 mod log_emitter;
 mod log_processor;
+mod record;
 
 pub use config::{config, Config};
 pub use log_emitter::{Builder, Logger, LoggerProvider};
@@ -10,12 +11,13 @@ pub use log_processor::{
     BatchConfig, BatchConfigBuilder, BatchLogProcessor, BatchLogProcessorBuilder, LogProcessor,
     SimpleLogProcessor,
 };
+pub use record::{SdkLogRecord, TraceContext};
 
 #[cfg(all(test, feature = "testing"))]
 mod tests {
     use super::*;
     use crate::testing::logs::InMemoryLogsExporter;
-    use opentelemetry::logs::{LogRecord, Logger, LoggerProvider as _, Severity};
+    use opentelemetry::logs::{Logger, LoggerProvider as _, Severity};
     use opentelemetry::{logs::AnyValue, Key, KeyValue};
 
     #[test]
@@ -28,7 +30,7 @@ mod tests {
 
         // Act
         let logger = logger_provider.logger("test-logger");
-        let mut log_record: LogRecord = LogRecord::default();
+        let mut log_record=  logger.create_log_record();
         log_record.severity_number = Some(Severity::Error);
         log_record.severity_text = Some("Error".into());
         let attributes = vec![

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -11,13 +11,13 @@ pub use log_processor::{
     BatchConfig, BatchConfigBuilder, BatchLogProcessor, BatchLogProcessorBuilder, LogProcessor,
     SimpleLogProcessor,
 };
-pub use opentelemetry::logs::LogRecord;
-pub use record::{SdkLogRecord, TraceContext};
+pub use record::{LogRecord, TraceContext};
 
 #[cfg(all(test, feature = "testing"))]
 mod tests {
     use super::*;
     use crate::testing::logs::InMemoryLogsExporter;
+    use opentelemetry::logs::LogRecord;
     use opentelemetry::logs::{Logger, LoggerProvider as _, Severity};
     use opentelemetry::{logs::AnyValue, Key, KeyValue};
 

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -11,8 +11,8 @@ pub use log_processor::{
     BatchConfig, BatchConfigBuilder, BatchLogProcessor, BatchLogProcessorBuilder, LogProcessor,
     SimpleLogProcessor,
 };
-pub use opentelemetry::logs::LogRecordBuilder;
-pub use record::{SdkLogRecord, SdkLogRecordBuilder, TraceContext};
+pub use opentelemetry::logs::LogRecord;
+pub use record::{SdkLogRecord, TraceContext};
 
 #[cfg(all(test, feature = "testing"))]
 mod tests {
@@ -31,15 +31,13 @@ mod tests {
 
         // Act
         let logger = logger_provider.logger("test-logger");
-        let log_record = logger
-            .create_log_record()
-            .with_severity_number(Severity::Error)
-            .with_severity_text("Error".into())
-            .with_attributes(vec![
-                (Key::new("key1"), "value1".into()),
-                (Key::new("key2"), "value2".into()),
-            ])
-            .build();
+        let mut log_record = logger.create_log_record();
+        log_record.set_severity_number(Severity::Error);
+        log_record.set_severity_text("Error".into());
+        log_record.set_attributes(vec![
+            (Key::new("key1"), "value1".into()),
+            (Key::new("key2"), "value2".into()),
+        ]);
         logger.emit(log_record);
 
         // Assert

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -34,7 +34,7 @@ mod tests {
         let mut log_record = logger.create_log_record();
         log_record.set_severity_number(Severity::Error);
         log_record.set_severity_text("Error".into());
-        log_record.set_attributes(vec![
+        log_record.add_attributes(vec![
             (Key::new("key1"), "value1".into()),
             (Key::new("key2"), "value2".into()),
         ]);

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{
-    logs::{AnyValue, LogRecord, Severity},
+    logs::{AnyValue, Severity},
     trace::{SpanContext, SpanId, TraceFlags, TraceId},
     Key,
 };
@@ -9,7 +9,7 @@ use std::{borrow::Cow, time::SystemTime};
 #[non_exhaustive]
 /// LogRecord represents all data carried by a log record, and
 /// is provided to `LogExporter`s as input.
-pub struct SdkLogRecord {
+pub struct LogRecord {
     /// Record timestamp
     pub timestamp: Option<SystemTime>,
 
@@ -31,7 +31,7 @@ pub struct SdkLogRecord {
     pub attributes: Option<Vec<(Key, AnyValue)>>,
 }
 
-impl LogRecord for SdkLogRecord {
+impl opentelemetry::logs::LogRecord for LogRecord {
     fn set_timestamp(&mut self, timestamp: SystemTime) {
         self.timestamp = Some(timestamp);
     }
@@ -103,7 +103,7 @@ impl From<&SpanContext> for TraceContext {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::logs::{AnyValue, LogRecord, Severity};
+    use opentelemetry::logs::{AnyValue, LogRecord as _, Severity};
     use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceId};
     use std::borrow::Cow;
     use std::time::SystemTime;
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn test_set_timestamp() {
-        let mut log_record = SdkLogRecord::default();
+        let mut log_record = LogRecord::default();
         let now = SystemTime::now();
         log_record.set_timestamp(now);
         assert_eq!(log_record.timestamp, Some(now));
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn test_set_observed_timestamp() {
-        let mut log_record = SdkLogRecord::default();
+        let mut log_record = LogRecord::default();
         let now = SystemTime::now();
         log_record.set_observed_timestamp(now);
         assert_eq!(log_record.observed_timestamp, Some(now));
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn test_set_span_context() {
-        let mut log_record = SdkLogRecord::default();
+        let mut log_record = LogRecord::default();
         let span_context = SpanContext::new(
             trace_id_from_u128(123),
             span_id_from_u64(456),
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn test_set_severity_text() {
-        let mut log_record = SdkLogRecord::default();
+        let mut log_record = LogRecord::default();
         let severity_text: Cow<'static, str> = "ERROR".into(); // Explicitly typed
         log_record.set_severity_text(severity_text);
         assert_eq!(log_record.severity_text, Some(Cow::Borrowed("ERROR")));
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn test_set_severity_number() {
-        let mut log_record = SdkLogRecord::default();
+        let mut log_record = LogRecord::default();
         let severity_number = Severity::Error;
         log_record.set_severity_number(severity_number);
         assert_eq!(log_record.severity_number, Some(Severity::Error));
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn test_set_body() {
-        let mut log_record = SdkLogRecord::default();
+        let mut log_record = LogRecord::default();
         let body = AnyValue::String("Test body".into());
         log_record.set_body(body.clone());
         assert_eq!(log_record.body, Some(body));
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_set_attributes() {
-        let mut log_record = SdkLogRecord::default();
+        let mut log_record = LogRecord::default();
         let attributes = vec![(Key::new("key"), AnyValue::String("value".into()))];
         log_record.set_attributes(attributes.clone());
         assert_eq!(log_record.attributes, Some(attributes));
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_set_attribute() {
-        let mut log_record = SdkLogRecord::default();
+        let mut log_record = LogRecord::default();
         log_record.set_attribute("key", "value");
         assert_eq!(
             log_record.attributes,

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -1,92 +1,156 @@
 use opentelemetry::{
-    trace::{SpanContext, SpanId, TraceFlags, TraceId},
+    logs::{AnyValue, LogRecord, LogRecordBuilder, Severity},
+    trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId},
     Key,
-    logs::{LogRecord, AnyValue, Severity},
 };
 use std::{borrow::Cow, time::SystemTime};
-    
-    #[derive(Debug, Clone, Default)]
-    #[non_exhaustive]
-    /// LogRecord represents all data carried by a log record, and
-    /// is provided to `LogExporter`s as input.
-    pub struct SdkLogRecord {
-        /// Record timestamp
-        pub timestamp: Option<SystemTime>,
-    
-        /// Timestamp for when the record was observed by OpenTelemetry
-        pub observed_timestamp: Option<SystemTime>,
-    
-        /// Trace context for logs associated with spans
-        pub trace_context: Option<TraceContext>,
-    
-        /// The original severity string from the source
-        pub severity_text: Option<Cow<'static, str>>,
-        /// The corresponding severity value, normalized
-        pub severity_number: Option<Severity>,
-    
-        /// Record body
-        pub body: Option<AnyValue>,
-    
-        /// Additional attributes associated with this record
-        pub attributes: Option<Vec<(Key, AnyValue)>>,
-    }
-    
-    impl LogRecord for SdkLogRecord {     
-        fn set_timestamp(&mut self, timestamp: SystemTime) -> &mut Self{
-            self.timestamp = Some(timestamp);
-            self
-        }
-    
-        fn set_observed_timestamp(&mut self, timestamp: SystemTime) -> &mut Self{
-            self.observed_timestamp = Some(timestamp);
-            self
-        }
-    
-        fn set_span_context(&mut self, span_context: &SpanContext) -> &mut Self{
-            self.trace_context =  Some(TraceContext {
-                span_id: span_context.span_id(),
-                trace_id: span_context.trace_id(),
-                trace_flags: Some(span_context.trace_flags()),
-            });
-            self
-        }
-    
-        fn set_severity_text(&mut self, severity_text: Option<Cow<'static, str>>) -> &mut Self{
-            self.severity_text = severity_text.into();
-            self
-        }
-    
-        fn set_severity_number(&mut self, severity_number: Severity) -> &mut Self{
-            self.severity_number = Some(severity_number);
-            self
-        }
-    
-        fn set_body(&mut self, body: Option<AnyValue>) -> &mut Self{
-            self.body = body;
-            self
-        }
-    
-        fn set_attributes(&mut self, attributes: Vec<(Key, AnyValue)>) -> &mut Self{
-            self.attributes = Some(attributes);
-            self
-        }
-    
-        fn set_attribute<K,V>(&mut self, key: K, value: V) -> &mut Self
-        where
-            K: Into<Key>,
-            V: Into<AnyValue>,
-        {
-            if self.attributes.is_none() {
-                self.attributes = Some(Vec::new());
-            }
-            if let Some(ref mut attributes) = self.attributes {
-                attributes.push((key.into(), value.into()));
-            }
-            self
-        }
+
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+/// LogRecord represents all data carried by a log record, and
+/// is provided to `LogExporter`s as input.
+pub struct SdkLogRecord {
+    /// Record timestamp
+    pub timestamp: Option<SystemTime>,
+
+    /// Timestamp for when the record was observed by OpenTelemetry
+    pub observed_timestamp: Option<SystemTime>,
+
+    /// Trace context for logs associated with spans
+    pub trace_context: Option<TraceContext>,
+
+    /// The original severity string from the source
+    pub severity_text: Option<Cow<'static, str>>,
+    /// The corresponding severity value, normalized
+    pub severity_number: Option<Severity>,
+
+    /// Record body
+    pub body: Option<AnyValue>,
+
+    /// Additional attributes associated with this record
+    pub attributes: Option<Vec<(Key, AnyValue)>>,
+}
+
+impl LogRecord for SdkLogRecord {
+    fn set_timestamp(&mut self, timestamp: SystemTime) {
+        self.timestamp = Some(timestamp);
     }
 
+    fn set_observed_timestamp(&mut self, timestamp: SystemTime) {
+        self.observed_timestamp = Some(timestamp);
+    }
 
+    fn set_span_context(&mut self, span_context: &SpanContext) {
+        self.trace_context = Some(TraceContext {
+            span_id: span_context.span_id(),
+            trace_id: span_context.trace_id(),
+            trace_flags: Some(span_context.trace_flags()),
+        });
+    }
+
+    fn set_severity_text(&mut self, severity_text: Cow<'static, str>) {
+        self.severity_text = Some(severity_text);
+    }
+
+    fn set_severity_number(&mut self, severity_number: Severity) {
+        self.severity_number = Some(severity_number);
+    }
+
+    fn set_body(&mut self, body: AnyValue) {
+        self.body = Some(body);
+    }
+
+    fn set_attributes(&mut self, attributes: Vec<(Key, AnyValue)>) {
+        self.attributes = Some(attributes);
+    }
+
+    fn set_attribute<K, V>(&mut self, key: K, value: V)
+    where
+        K: Into<Key>,
+        V: Into<AnyValue>,
+    {
+        if self.attributes.is_none() {
+            self.attributes = Some(Vec::new());
+        }
+        if let Some(ref mut attributes) = self.attributes {
+            attributes.push((key.into(), value.into()));
+        }
+    }
+}
+
+/// Implementation for LogRecordBuilder
+#[derive(Debug, Default)]
+pub struct SdkLogRecordBuilder {
+    record: SdkLogRecord,
+}
+impl LogRecordBuilder for SdkLogRecordBuilder {
+    type LogRecord = SdkLogRecord;
+
+    fn with_timestamp(mut self, timestamp: SystemTime) -> Self {
+        self.record.set_timestamp(timestamp);
+        self
+    }
+
+    fn with_observed_timestamp(mut self, timestamp: SystemTime) -> Self {
+        self.record.observed_timestamp = Some(timestamp);
+        self
+    }
+
+    fn with_span_context(mut self, context: &SpanContext) -> Self {
+        self.record.trace_context = Some(TraceContext {
+            span_id: context.span_id(),
+            trace_id: context.trace_id(),
+            trace_flags: Some(context.trace_flags()),
+        });
+        self
+    }
+
+    fn with_severity_text(mut self, text: Cow<'static, str>) -> Self {
+        self.record.severity_text = Some(text);
+        self
+    }
+
+    fn with_severity_number(mut self, number: Severity) -> Self {
+        self.record.severity_number = Some(number);
+        self
+    }
+
+    fn with_body(mut self, body: AnyValue) -> Self {
+        self.record.body = Some(body);
+        self
+    }
+
+    fn with_attributes(mut self, attributes: Vec<(Key, AnyValue)>) -> Self {
+        self.record.attributes = Some(attributes);
+        self
+    }
+
+    fn with_attribute<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: Into<Key>,
+        V: Into<AnyValue>,
+    {
+        if self.record.attributes.is_none() {
+            self.record.attributes = Some(Vec::new());
+        }
+        if let Some(ref mut attributes) = self.record.attributes {
+            attributes.push((key.into(), value.into()));
+        }
+        self
+    }
+
+    fn with_context<T>(mut self, context: &T) -> Self
+    where
+        T: TraceContextExt,
+    {
+        self.record.set_context(context);
+        self
+    }
+
+    fn build(&self) -> Self::LogRecord {
+        self.record.clone()
+    }
+}
 /// TraceContext stores the trace data for logs that have an associated
 /// span.
 #[derive(Debug, Clone)]

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -77,7 +77,7 @@ impl opentelemetry::logs::LogRecord for LogRecord {
     }
 }
 
-/// TraceContext stores the trace data for logs that have an associated
+/// TraceContext stores the trace context for logs that have an associated
 /// span.
 #[derive(Debug, Clone)]
 #[non_exhaustive]

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -1,0 +1,111 @@
+use opentelemetry::{
+    trace::{SpanContext, SpanId, TraceFlags, TraceId},
+    Key,
+    logs::{LogRecord, AnyValue, Severity},
+};
+use std::{borrow::Cow, time::SystemTime};
+    
+    #[derive(Debug, Clone, Default)]
+    #[non_exhaustive]
+    /// LogRecord represents all data carried by a log record, and
+    /// is provided to `LogExporter`s as input.
+    pub struct SdkLogRecord {
+        /// Record timestamp
+        pub timestamp: Option<SystemTime>,
+    
+        /// Timestamp for when the record was observed by OpenTelemetry
+        pub observed_timestamp: Option<SystemTime>,
+    
+        /// Trace context for logs associated with spans
+        pub trace_context: Option<TraceContext>,
+    
+        /// The original severity string from the source
+        pub severity_text: Option<Cow<'static, str>>,
+        /// The corresponding severity value, normalized
+        pub severity_number: Option<Severity>,
+    
+        /// Record body
+        pub body: Option<AnyValue>,
+    
+        /// Additional attributes associated with this record
+        pub attributes: Option<Vec<(Key, AnyValue)>>,
+    }
+    
+    impl LogRecord for SdkLogRecord {     
+        fn set_timestamp(&mut self, timestamp: SystemTime) -> &mut Self{
+            self.timestamp = Some(timestamp);
+            self
+        }
+    
+        fn set_observed_timestamp(&mut self, timestamp: SystemTime) -> &mut Self{
+            self.observed_timestamp = Some(timestamp);
+            self
+        }
+    
+        fn set_span_context(&mut self, span_context: &SpanContext) -> &mut Self{
+            self.trace_context =  Some(TraceContext {
+                span_id: span_context.span_id(),
+                trace_id: span_context.trace_id(),
+                trace_flags: Some(span_context.trace_flags()),
+            });
+            self
+        }
+    
+        fn set_severity_text(&mut self, severity_text: Option<Cow<'static, str>>) -> &mut Self{
+            self.severity_text = severity_text.into();
+            self
+        }
+    
+        fn set_severity_number(&mut self, severity_number: Severity) -> &mut Self{
+            self.severity_number = Some(severity_number);
+            self
+        }
+    
+        fn set_body(&mut self, body: Option<AnyValue>) -> &mut Self{
+            self.body = body;
+            self
+        }
+    
+        fn set_attributes(&mut self, attributes: Vec<(Key, AnyValue)>) -> &mut Self{
+            self.attributes = Some(attributes);
+            self
+        }
+    
+        fn set_attribute<K,V>(&mut self, key: K, value: V) -> &mut Self
+        where
+            K: Into<Key>,
+            V: Into<AnyValue>,
+        {
+            if self.attributes.is_none() {
+                self.attributes = Some(Vec::new());
+            }
+            if let Some(ref mut attributes) = self.attributes {
+                attributes.push((key.into(), value.into()));
+            }
+            self
+        }
+    }
+
+
+/// TraceContext stores the trace data for logs that have an associated
+/// span.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct TraceContext {
+    /// Trace id
+    pub trace_id: TraceId,
+    /// Span Id
+    pub span_id: SpanId,
+    /// Trace flags
+    pub trace_flags: Option<TraceFlags>,
+}
+
+impl From<&SpanContext> for TraceContext {
+    fn from(span_context: &SpanContext) -> Self {
+        TraceContext {
+            trace_id: span_context.trace_id(),
+            span_id: span_context.span_id(),
+            trace_flags: Some(span_context.trace_flags()),
+        }
+    }
+}

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -50,7 +50,7 @@ impl Default for InMemoryLogsExporter {
     }
 }
 
-/// `LogDataWithResource` associates a [`LogRecord`] with a [`Resource`] and
+/// `LogDataWithResource` associates a [`SdkLogRecord`] with a [`Resource`] and
 /// [`InstrumentationLibrary`].
 #[derive(Clone, Debug)]
 pub struct LogDataWithResource {

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -50,7 +50,7 @@ impl Default for InMemoryLogsExporter {
     }
 }
 
-/// `LogDataWithResource` associates a [`SdkLogRecord`] with a [`Resource`] and
+/// `LogDataWithResource` associates a [`LogRecord`] with a [`Resource`] and
 /// [`InstrumentationLibrary`].
 #[derive(Clone, Debug)]
 pub struct LogDataWithResource {

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -1,5 +1,5 @@
 use crate::export::logs::{LogData, LogExporter};
-use crate::logs::SdkLogRecord;
+use crate::logs::LogRecord;
 use crate::Resource;
 use async_trait::async_trait;
 use opentelemetry::logs::{LogError, LogResult};
@@ -55,7 +55,7 @@ impl Default for InMemoryLogsExporter {
 #[derive(Clone, Debug)]
 pub struct LogDataWithResource {
     /// Log record
-    pub record: SdkLogRecord,
+    pub record: LogRecord,
     /// Instrumentation details for the emitter who produced this `LogData`.
     pub instrumentation: InstrumentationLibrary,
     /// Resource for the emitter who produced this `LogData`.

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -1,7 +1,8 @@
 use crate::export::logs::{LogData, LogExporter};
 use crate::Resource;
 use async_trait::async_trait;
-use opentelemetry::logs::{LogError, LogRecord, LogResult};
+use opentelemetry::logs::{LogError, LogResult};
+use crate::logs::SdkLogRecord;
 use opentelemetry::InstrumentationLibrary;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
@@ -54,7 +55,7 @@ impl Default for InMemoryLogsExporter {
 #[derive(Clone, Debug)]
 pub struct LogDataWithResource {
     /// Log record
-    pub record: LogRecord,
+    pub record: SdkLogRecord,
     /// Instrumentation details for the emitter who produced this `LogData`.
     pub instrumentation: InstrumentationLibrary,
     /// Resource for the emitter who produced this `LogData`.

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -1,8 +1,8 @@
 use crate::export::logs::{LogData, LogExporter};
+use crate::logs::SdkLogRecord;
 use crate::Resource;
 use async_trait::async_trait;
 use opentelemetry::logs::{LogError, LogResult};
-use crate::logs::SdkLogRecord;
 use opentelemetry::InstrumentationLibrary;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};

--- a/opentelemetry-stdout/src/logs/transform.rs
+++ b/opentelemetry-stdout/src/logs/transform.rs
@@ -125,8 +125,8 @@ impl From<opentelemetry_sdk::export::logs::LogData> for LogRecord {
                 .unwrap_or_default(),
             time_unix_nano: value.record.timestamp,
             time: value.record.timestamp,
-            observed_time_unix_nano: value.record.observed_timestamp,
-            observed_time: value.record.observed_timestamp,
+            observed_time_unix_nano: value.record.observed_timestamp.unwrap(),
+            observed_time: value.record.observed_timestamp.unwrap(),
             severity_number: value
                 .record
                 .severity_number

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -25,6 +25,10 @@
 ### Changed
 
 - Deprecate `versioned_logger()` in favor of `logger_builder()` [1567](https://github.com/open-telemetry/opentelemetry-rust/pull/1567).
+- **BREAKING** Moving LogRecord implementation to the SDK. [1702](https://github.com/open-telemetry/opentelemetry-rust/pull/1702).
+    - Relocated `LogRecord` struct to SDK.
+    - Introduced the `LogRecord` trait in the API for populating log records. This trait is implemented by the SDK.
+    This is the breaking change for the authors of Log Appenders. Refer to the [opentelemetry-appender-tracing](https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-tracing) for more details.
 
 Before:
 

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -15,10 +15,9 @@ pub trait Logger {
     fn create_log_record(&self) -> Self::LogRecord;
 
     /// Emit a [`LogRecord`]. If there is active current thread's [`Context`],
-    ///  the logger will set the record's [`TraceContext`] to the active trace context,
+    ///  the logger will set the record's `TraceContext` to the active trace context,
     ///
     /// [`Context`]: crate::Context
-    /// [`TraceContext`]: crate::logs::TraceContext
     fn emit(&self, record: Self::LogRecord);
 
     #[cfg(feature = "logs_level_enabled")]

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -1,9 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
-use crate::{
-    logs::LogRecord, logs::LogRecordBuilder, InstrumentationLibrary, InstrumentationLibraryBuilder,
-    KeyValue,
-};
+use crate::{logs::LogRecord, InstrumentationLibrary, InstrumentationLibraryBuilder, KeyValue};
 
 #[cfg(feature = "logs_level_enabled")]
 use super::Severity;
@@ -14,11 +11,8 @@ pub trait Logger {
     /// Specifies the `LogRecord` type associated with this logger.
     type LogRecord: LogRecord;
 
-    /// Specifies the `LogRecordBuilder` type for constructing log records.
-    type LogRecordBuilder: LogRecordBuilder<LogRecord = Self::LogRecord>;
-
     /// Creates a new log record builder.
-    fn create_log_record(&self) -> Self::LogRecordBuilder;
+    fn create_log_record(&self) -> Self::LogRecord;
 
     /// Emit a [`LogRecord`]. If there is active current thread's [`Context`],
     ///  the logger will set the record's [`TraceContext`] to the active trace context,

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
-use crate::{logs::{LogRecord, LogRecordBuilder}, InstrumentationLibrary, InstrumentationLibraryBuilder, KeyValue};
+use crate::{logs::LogRecord, InstrumentationLibrary, InstrumentationLibraryBuilder, KeyValue};
 
 #[cfg(feature = "logs_level_enabled")]
 use super::Severity;
@@ -10,10 +10,9 @@ use super::Severity;
 pub trait Logger {
 
     type LogRecord: LogRecord;
-    type LogRecordBuilder: LogRecordBuilder<Record=Self::LogRecord>;
 
     /// Creates a new log record builder.
-    fn create_log_record(&self) -> Self::LogRecordBuilder;
+    fn create_log_record(&self) -> Self::LogRecord;
 
     /// Emit a [`LogRecord`]. If there is active current thread's [`Context`],
     ///  the logger will set the record's [`TraceContext`] to the active trace context,

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
-use crate::{logs::LogRecord, InstrumentationLibrary, InstrumentationLibraryBuilder, KeyValue};
+use crate::{logs::{LogRecord, LogRecordBuilder}, InstrumentationLibrary, InstrumentationLibraryBuilder, KeyValue};
 
 #[cfg(feature = "logs_level_enabled")]
 use super::Severity;
@@ -8,12 +8,19 @@ use super::Severity;
 /// The interface for emitting [`LogRecord`]s.
 
 pub trait Logger {
+
+    type LogRecord: LogRecord;
+    type LogRecordBuilder: LogRecordBuilder<Record=Self::LogRecord>;
+
+    /// Creates a new log record builder.
+    fn create_log_record(&self) -> Self::LogRecordBuilder;
+
     /// Emit a [`LogRecord`]. If there is active current thread's [`Context`],
     ///  the logger will set the record's [`TraceContext`] to the active trace context,
     ///
     /// [`Context`]: crate::Context
     /// [`TraceContext`]: crate::logs::TraceContext
-    fn emit(&self, record: LogRecord);
+    fn emit(&self, record: Self::LogRecord);
 
     #[cfg(feature = "logs_level_enabled")]
     /// Check if the given log level is enabled.

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -1,6 +1,9 @@
 use std::{borrow::Cow, sync::Arc};
 
-use crate::{logs::LogRecord, InstrumentationLibrary, InstrumentationLibraryBuilder, KeyValue};
+use crate::{
+    logs::LogRecord, logs::LogRecordBuilder, InstrumentationLibrary, InstrumentationLibraryBuilder,
+    KeyValue,
+};
 
 #[cfg(feature = "logs_level_enabled")]
 use super::Severity;
@@ -8,11 +11,14 @@ use super::Severity;
 /// The interface for emitting [`LogRecord`]s.
 
 pub trait Logger {
-
+    /// Specifies the `LogRecord` type associated with this logger.
     type LogRecord: LogRecord;
 
+    /// Specifies the `LogRecordBuilder` type for constructing log records.
+    type LogRecordBuilder: LogRecordBuilder<LogRecord = Self::LogRecord>;
+
     /// Creates a new log record builder.
-    fn create_log_record(&self) -> Self::LogRecord;
+    fn create_log_record(&self) -> Self::LogRecordBuilder;
 
     /// Emit a [`LogRecord`]. If there is active current thread's [`Context`],
     ///  the logger will set the record's [`TraceContext`] to the active trace context,

--- a/opentelemetry/src/logs/mod.rs
+++ b/opentelemetry/src/logs/mod.rs
@@ -12,7 +12,7 @@ mod record;
 
 pub use logger::{Logger, LoggerProvider};
 pub use noop::NoopLoggerProvider;
-pub use record::{AnyValue, LogRecord, LogRecordBuilder, Severity};
+pub use record::{AnyValue, LogRecord, Severity};
 
 /// Describe the result of operations in log SDK.
 pub type LogResult<T> = Result<T, LogError>;

--- a/opentelemetry/src/logs/mod.rs
+++ b/opentelemetry/src/logs/mod.rs
@@ -12,7 +12,7 @@ mod record;
 
 pub use logger::{Logger, LoggerProvider};
 pub use noop::NoopLoggerProvider;
-pub use record::{AnyValue, LogRecord, Severity};
+pub use record::{AnyValue, LogRecord, LogRecordBuilder, Severity};
 
 /// Describe the result of operations in log SDK.
 pub type LogResult<T> = Result<T, LogError>;

--- a/opentelemetry/src/logs/mod.rs
+++ b/opentelemetry/src/logs/mod.rs
@@ -10,9 +10,9 @@ mod logger;
 mod noop;
 mod record;
 
-pub use logger::{Logger, LoggerProvider, LogRecordBuilder};
+pub use logger::{Logger, LoggerProvider};
 pub use noop::NoopLoggerProvider;
-pub use record::{AnyValue, LogRecord, LogRecordBuilder, Severity};
+pub use record::{AnyValue, LogRecord, Severity};
 
 /// Describe the result of operations in log SDK.
 pub type LogResult<T> = Result<T, LogError>;

--- a/opentelemetry/src/logs/mod.rs
+++ b/opentelemetry/src/logs/mod.rs
@@ -10,9 +10,9 @@ mod logger;
 mod noop;
 mod record;
 
-pub use logger::{Logger, LoggerProvider};
+pub use logger::{Logger, LoggerProvider, LogRecordBuilder};
 pub use noop::NoopLoggerProvider;
-pub use record::{AnyValue, LogRecord, LogRecordBuilder, Severity, TraceContext};
+pub use record::{AnyValue, LogRecord, LogRecordBuilder, Severity};
 
 /// Describe the result of operations in log SDK.
 pub type LogResult<T> = Result<T, LogError>;

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -2,7 +2,6 @@ use std::{borrow::Cow, sync::Arc, time::SystemTime};
 
 use crate::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    trace::SpanContext,
     InstrumentationLibrary, Key, KeyValue,
 };
 
@@ -46,26 +45,18 @@ impl LogRecord for NoopLogRecord {
     #[inline]
     fn set_observed_timestamp(&mut self, _timestamp: SystemTime) {}
     #[inline]
-    fn set_span_context(&mut self, _context: &SpanContext) {}
-    #[inline]
     fn set_severity_text(&mut self, _text: Cow<'static, str>) {}
     #[inline]
     fn set_severity_number(&mut self, _number: Severity) {}
     #[inline]
     fn set_body(&mut self, _body: AnyValue) {}
     #[inline]
-    fn set_attributes(&mut self, _attributes: Vec<(Key, AnyValue)>) {}
+    fn add_attributes(&mut self, _attributes: Vec<(Key, AnyValue)>) {}
     #[inline]
-    fn set_attribute<K, V>(&mut self, _key: K, _value: V)
+    fn add_attribute<K, V>(&mut self, _key: K, _value: V)
     where
         K: Into<Key>,
         V: Into<AnyValue>,
-    {
-    }
-    #[inline]
-    fn set_context<T>(&mut self, _context: &T)
-    where
-        T: crate::trace::TraceContextExt,
     {
     }
 }

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -34,6 +34,21 @@ impl LoggerProvider for NoopLoggerProvider {
     }
 }
 
+/// No-operation implementation of LogRecord.
+pub struct NoopLogRecord;
+
+impl LogRecord for NoopLogRecord {
+    // Implement the LogRecord trait methods with empty bodies.
+    fn set_timestamp(&mut self, _timestamp: SystemTime) {}
+    fn set_observed_timestamp(&mut self, _timestamp: SystemTime) {}
+    fn set_span_context(&mut self, _context: &SpanContext) {}
+    fn set_severity_text(&mut self, _text: &str) {}
+    fn set_severity_number(&mut self, _number: Severity) {}
+    fn set_body(&mut self, _body: AnyValue) {}
+    fn set_attributes(&mut self, _attributes: Vec<(Key, AnyValue)>) {}
+}
+
+
 /// A no-op implementation of a [`Logger`]
 #[derive(Clone, Debug)]
 pub struct NoopLogger(());

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -1,9 +1,9 @@
 use std::{borrow::Cow, sync::Arc, time::SystemTime};
 
 use crate::{
-    logs::{LogRecord, Logger, LoggerProvider, AnyValue, Severity},
-    InstrumentationLibrary, KeyValue, Key,
-    trace::SpanContext
+    logs::{AnyValue, LogRecord, LogRecordBuilder, Logger, LoggerProvider, Severity},
+    trace::SpanContext,
+    InstrumentationLibrary, Key, KeyValue,
 };
 
 /// A no-op implementation of a [`LoggerProvider`].
@@ -41,18 +41,78 @@ pub struct NoopLogRecord;
 
 impl LogRecord for NoopLogRecord {
     // Implement the LogRecord trait methods with empty bodies.
-    fn set_timestamp(&mut self, _timestamp: SystemTime) -> &mut Self {self}
-    fn set_observed_timestamp(&mut self, _timestamp: SystemTime) -> &mut Self {self}
-    fn set_span_context(&mut self, _context: &SpanContext) ->  &mut Self {self}
-    fn set_severity_text(&mut self, _text: Option<Cow<'static, str>>) -> &mut Self {self}
-    fn set_severity_number(&mut self, _number: Severity) -> &mut Self {self}
-    fn set_body(&mut self, _body: Option<AnyValue>) -> &mut Self {self}
-    fn set_attributes(&mut self, _attributes: Vec<(Key, AnyValue)>) -> &mut Self {self}
-    fn set_attribute<K,V>(&mut self, _key: K, _value: V) -> &mut Self
-        where
-            K: Into<Key>,
-            V: Into<AnyValue> {self}
-    fn set_context<T>(&mut self, _context: &T) -> &mut Self where T: crate::trace::TraceContextExt  {self}
+    fn set_timestamp(&mut self, _timestamp: SystemTime) {}
+    fn set_observed_timestamp(&mut self, _timestamp: SystemTime) {}
+    fn set_span_context(&mut self, _context: &SpanContext) {}
+    fn set_severity_text(&mut self, _text: Cow<'static, str>) {}
+    fn set_severity_number(&mut self, _number: Severity) {}
+    fn set_body(&mut self, _body: AnyValue) {}
+    fn set_attributes(&mut self, _attributes: Vec<(Key, AnyValue)>) {}
+    fn set_attribute<K, V>(&mut self, _key: K, _value: V)
+    where
+        K: Into<Key>,
+        V: Into<AnyValue>,
+    {
+    }
+    fn set_context<T>(&mut self, _context: &T)
+    where
+        T: crate::trace::TraceContextExt,
+    {
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NoopLogRecordBuilder;
+
+impl LogRecordBuilder for NoopLogRecordBuilder {
+    type LogRecord = NoopLogRecord;
+
+    fn with_timestamp(self, _timestamp: SystemTime) -> Self {
+        self
+    }
+
+    fn with_observed_timestamp(self, _timestamp: SystemTime) -> Self {
+        self
+    }
+
+    fn with_span_context(self, _context: &SpanContext) -> Self {
+        self
+    }
+
+    fn with_severity_text(self, _text: Cow<'static, str>) -> Self {
+        self
+    }
+
+    fn with_severity_number(self, _number: Severity) -> Self {
+        self
+    }
+
+    fn with_body(self, _body: AnyValue) -> Self {
+        self
+    }
+
+    fn with_attributes(self, _attributes: Vec<(Key, AnyValue)>) -> Self {
+        self
+    }
+
+    fn with_attribute<K, V>(self, _key: K, _value: V) -> Self
+    where
+        K: Into<Key>,
+        V: Into<AnyValue>,
+    {
+        self
+    }
+
+    fn with_context<T>(self, _context: &T) -> Self
+    where
+        T: crate::trace::TraceContextExt,
+    {
+        self
+    }
+
+    fn build(&self) -> Self::LogRecord {
+        NoopLogRecord
+    }
 }
 
 /// A no-op implementation of a [`Logger`]
@@ -61,8 +121,10 @@ pub struct NoopLogger(());
 
 impl Logger for NoopLogger {
     type LogRecord = NoopLogRecord;
-    fn create_log_record(&self) -> Self::LogRecord {
-        NoopLogRecord
+    type LogRecordBuilder = NoopLogRecordBuilder;
+
+    fn create_log_record(&self) -> Self::LogRecordBuilder {
+        NoopLogRecordBuilder {}
     }
     fn emit(&self, _record: Self::LogRecord) {}
     #[cfg(feature = "logs_level_enabled")]

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -1,8 +1,9 @@
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, sync::Arc, time::SystemTime};
 
 use crate::{
-    logs::{LogRecord, Logger, LoggerProvider},
-    InstrumentationLibrary, KeyValue,
+    logs::{LogRecord, Logger, LoggerProvider, AnyValue, Severity},
+    InstrumentationLibrary, KeyValue, Key,
+    trace::SpanContext
 };
 
 /// A no-op implementation of a [`LoggerProvider`].
@@ -34,27 +35,36 @@ impl LoggerProvider for NoopLoggerProvider {
     }
 }
 
-/// No-operation implementation of LogRecord.
+#[derive(Debug, Clone, Default)]
+/// A no-operation log record that implements the LogRecord trait.
 pub struct NoopLogRecord;
 
 impl LogRecord for NoopLogRecord {
     // Implement the LogRecord trait methods with empty bodies.
-    fn set_timestamp(&mut self, _timestamp: SystemTime) {}
-    fn set_observed_timestamp(&mut self, _timestamp: SystemTime) {}
-    fn set_span_context(&mut self, _context: &SpanContext) {}
-    fn set_severity_text(&mut self, _text: &str) {}
-    fn set_severity_number(&mut self, _number: Severity) {}
-    fn set_body(&mut self, _body: AnyValue) {}
-    fn set_attributes(&mut self, _attributes: Vec<(Key, AnyValue)>) {}
+    fn set_timestamp(&mut self, _timestamp: SystemTime) -> &mut Self {self}
+    fn set_observed_timestamp(&mut self, _timestamp: SystemTime) -> &mut Self {self}
+    fn set_span_context(&mut self, _context: &SpanContext) ->  &mut Self {self}
+    fn set_severity_text(&mut self, _text: Option<Cow<'static, str>>) -> &mut Self {self}
+    fn set_severity_number(&mut self, _number: Severity) -> &mut Self {self}
+    fn set_body(&mut self, _body: Option<AnyValue>) -> &mut Self {self}
+    fn set_attributes(&mut self, _attributes: Vec<(Key, AnyValue)>) -> &mut Self {self}
+    fn set_attribute<K,V>(&mut self, _key: K, _value: V) -> &mut Self
+        where
+            K: Into<Key>,
+            V: Into<AnyValue> {self}
+    fn set_context<T>(&mut self, _context: &T) -> &mut Self where T: crate::trace::TraceContextExt  {self}
 }
-
 
 /// A no-op implementation of a [`Logger`]
 #[derive(Clone, Debug)]
 pub struct NoopLogger(());
 
 impl Logger for NoopLogger {
-    fn emit(&self, _record: LogRecord) {}
+    type LogRecord = NoopLogRecord;
+    fn create_log_record(&self) -> Self::LogRecord {
+        NoopLogRecord
+    }
+    fn emit(&self, _record: Self::LogRecord) {}
     #[cfg(feature = "logs_level_enabled")]
     fn event_enabled(&self, _level: super::Severity, _target: &str) -> bool {
         false

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -41,19 +41,28 @@ pub struct NoopLogRecord;
 
 impl LogRecord for NoopLogRecord {
     // Implement the LogRecord trait methods with empty bodies.
+    #[inline]
     fn set_timestamp(&mut self, _timestamp: SystemTime) {}
+    #[inline]
     fn set_observed_timestamp(&mut self, _timestamp: SystemTime) {}
+    #[inline]
     fn set_span_context(&mut self, _context: &SpanContext) {}
+    #[inline]
     fn set_severity_text(&mut self, _text: Cow<'static, str>) {}
+    #[inline]
     fn set_severity_number(&mut self, _number: Severity) {}
+    #[inline]
     fn set_body(&mut self, _body: AnyValue) {}
+    #[inline]
     fn set_attributes(&mut self, _attributes: Vec<(Key, AnyValue)>) {}
+    #[inline]
     fn set_attribute<K, V>(&mut self, _key: K, _value: V)
     where
         K: Into<Key>,
         V: Into<AnyValue>,
     {
     }
+    #[inline]
     fn set_context<T>(&mut self, _context: &T)
     where
         T: crate::trace::TraceContextExt,

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, sync::Arc, time::SystemTime};
 
 use crate::{
-    logs::{AnyValue, LogRecord, LogRecordBuilder, Logger, LoggerProvider, Severity},
+    logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
     trace::SpanContext,
     InstrumentationLibrary, Key, KeyValue,
 };
@@ -61,70 +61,15 @@ impl LogRecord for NoopLogRecord {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct NoopLogRecordBuilder;
-
-impl LogRecordBuilder for NoopLogRecordBuilder {
-    type LogRecord = NoopLogRecord;
-
-    fn with_timestamp(self, _timestamp: SystemTime) -> Self {
-        self
-    }
-
-    fn with_observed_timestamp(self, _timestamp: SystemTime) -> Self {
-        self
-    }
-
-    fn with_span_context(self, _context: &SpanContext) -> Self {
-        self
-    }
-
-    fn with_severity_text(self, _text: Cow<'static, str>) -> Self {
-        self
-    }
-
-    fn with_severity_number(self, _number: Severity) -> Self {
-        self
-    }
-
-    fn with_body(self, _body: AnyValue) -> Self {
-        self
-    }
-
-    fn with_attributes(self, _attributes: Vec<(Key, AnyValue)>) -> Self {
-        self
-    }
-
-    fn with_attribute<K, V>(self, _key: K, _value: V) -> Self
-    where
-        K: Into<Key>,
-        V: Into<AnyValue>,
-    {
-        self
-    }
-
-    fn with_context<T>(self, _context: &T) -> Self
-    where
-        T: crate::trace::TraceContextExt,
-    {
-        self
-    }
-
-    fn build(&self) -> Self::LogRecord {
-        NoopLogRecord
-    }
-}
-
 /// A no-op implementation of a [`Logger`]
 #[derive(Clone, Debug)]
 pub struct NoopLogger(());
 
 impl Logger for NoopLogger {
     type LogRecord = NoopLogRecord;
-    type LogRecordBuilder = NoopLogRecordBuilder;
 
-    fn create_log_record(&self) -> Self::LogRecordBuilder {
-        NoopLogRecordBuilder {}
+    fn create_log_record(&self) -> Self::LogRecord {
+        NoopLogRecord {}
     }
     fn emit(&self, _record: Self::LogRecord) {}
     #[cfg(feature = "logs_level_enabled")]

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -26,7 +26,6 @@ pub trait LogRecord {
             }
             self
         }
-    
 }
 
 /// Value types for representing arbitrary values in a log record.

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -7,7 +7,7 @@ use std::{borrow::Cow, collections::HashMap, time::SystemTime};
 /// Abstract interface for managing log records. The implementation is provided by the SDK
 /// Abstract interface for log records in an observability framework.
 pub trait LogRecord {
-    /// Sets the creation timestamp.
+    /// Sets the time when the event occurred measured by the origin clock, i.e. the time at the source.
     fn set_timestamp(&mut self, timestamp: SystemTime);
 
     /// Sets the observed event timestamp.

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -1,20 +1,13 @@
-use crate::{
-    trace::{SpanContext, TraceContextExt},
-    Array, Key, StringValue, Value,
-};
+use crate::{Array, Key, StringValue, Value};
 use std::{borrow::Cow, collections::HashMap, time::SystemTime};
 
-/// Abstract interface for managing log records. The implementation is provided by the SDK
-/// Abstract interface for log records in an observability framework.
+/// SDK implemented trait for managing log records
 pub trait LogRecord {
     /// Sets the time when the event occurred measured by the origin clock, i.e. the time at the source.
     fn set_timestamp(&mut self, timestamp: SystemTime);
 
     /// Sets the observed event timestamp.
     fn set_observed_timestamp(&mut self, timestamp: SystemTime);
-
-    /// Associates a span context.
-    fn set_span_context(&mut self, context: &SpanContext);
 
     /// Sets severity as text.
     fn set_severity_text(&mut self, text: Cow<'static, str>);
@@ -26,23 +19,13 @@ pub trait LogRecord {
     fn set_body(&mut self, body: AnyValue);
 
     /// Adds multiple attributes.
-    fn set_attributes(&mut self, attributes: Vec<(Key, AnyValue)>);
+    fn add_attributes(&mut self, attributes: Vec<(Key, AnyValue)>);
 
-    /// Adds or updates a single attribute.
-    fn set_attribute<K, V>(&mut self, key: K, value: V)
+    /// Adds a single attribute.
+    fn add_attribute<K, V>(&mut self, key: K, value: V)
     where
         K: Into<Key>,
         V: Into<AnyValue>;
-
-    /// Sets the trace context, pulling from the active span if available.
-    fn set_context<T>(&mut self, context: &T)
-    where
-        T: TraceContextExt,
-    {
-        if context.has_active_span() {
-            self.set_span_context(context.span().span_context())
-        }
-    }
 }
 
 /// Value types for representing arbitrary values in a log record.

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -40,50 +40,9 @@ pub trait LogRecord {
         T: TraceContextExt,
     {
         if context.has_active_span() {
-            self.set_span_context(context.span().span_context());
+            self.set_span_context(context.span().span_context())
         }
     }
-}
-
-/// Builder trait for constructing `LogRecord` instances.
-pub trait LogRecordBuilder {
-    /// Specifies the `LogRecord` type this builder creates.
-    type LogRecord: LogRecord;
-
-    /// Sets the timestamp when the log was created.
-    fn with_timestamp(self, timestamp: SystemTime) -> Self;
-
-    /// Sets the timestamp when the event was observed.
-    fn with_observed_timestamp(self, timestamp: SystemTime) -> Self;
-
-    /// Associates a span context with the log record.
-    fn with_span_context(self, context: &SpanContext) -> Self;
-
-    /// Specifies severity as text.
-    fn with_severity_text(self, text: Cow<'static, str>) -> Self;
-
-    /// Specifies severity as a numeric value.
-    fn with_severity_number(self, number: Severity) -> Self;
-
-    /// Sets the body of the log record.
-    fn with_body(self, body: AnyValue) -> Self;
-
-    /// Adds multiple attributes to the log record.
-    fn with_attributes(self, attributes: Vec<(Key, AnyValue)>) -> Self;
-
-    /// Adds or updates a single attribute.
-    fn with_attribute<K, V>(self, key: K, value: V) -> Self
-    where
-        K: Into<Key>,
-        V: Into<AnyValue>;
-
-    /// Sets the trace context, pulling from the active span from context if available.
-    fn with_context<T>(self, context: &T) -> Self
-    where
-        T: TraceContextExt;
-
-    /// Builds and returns the `LogRecord`.
-    fn build(&self) -> Self::LogRecord;
 }
 
 /// Value types for representing arbitrary values in a log record.

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -2,80 +2,31 @@ use crate::{
     trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId},
     Array, Key, StringValue, Value,
 };
-use std::{borrow::Cow, collections::HashMap, time::SystemTime};
+use std::{borrow::Cow, collections::HashMap, time::SystemTime, sync::Arc};
 
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-/// LogRecord represents all data carried by a log record, and
-/// is provided to `LogExporter`s as input.
-pub struct LogRecord {
-    /// Event name. Optional as not all the logging API support it.
-    pub event_name: Option<Cow<'static, str>>,
-
-    /// Record timestamp
-    pub timestamp: Option<SystemTime>,
-
-    /// Timestamp for when the record was observed by OpenTelemetry
-    pub observed_timestamp: SystemTime,
-
-    /// Trace context for logs associated with spans
-    pub trace_context: Option<TraceContext>,
-
-    /// The original severity string from the source
-    pub severity_text: Option<Cow<'static, str>>,
-    /// The corresponding severity value, normalized
-    pub severity_number: Option<Severity>,
-
-    /// Record body
-    pub body: Option<AnyValue>,
-
-    /// Additional attributes associated with this record
-    pub attributes: Option<Vec<(Key, AnyValue)>>,
+/// Abstract interface for log records.
+pub trait LogRecord {
+    fn set_timestamp(&mut self, timestamp: SystemTime);
+    fn set_observed_timestamp(&mut self, timestamp: SystemTime);
+    fn set_span_context(&mut self, context: &SpanContext);
+    fn set_severity_text(&mut self, text: &str);
+    fn set_severity_number(&mut self, number: Severity);
+    fn set_body(&mut self, body: AnyValue);
+    fn set_attributes(&mut self, attributes: Vec<(Key, AnyValue)>);
 }
 
-impl Default for LogRecord {
-    fn default() -> Self {
-        LogRecord {
-            event_name: None,
-            timestamp: None,
-            observed_timestamp: SystemTime::now(),
-            trace_context: None,
-            severity_text: None,
-            severity_number: None,
-            body: None,
-            attributes: None,
-        }
-    }
-}
+/// Builder for creating log records.
+pub trait LogRecordBuilder {
+    type Record: LogRecord;
 
-impl LogRecord {
-    /// Create a [`LogRecordBuilder`] to create a new Log Record
-    pub fn builder() -> LogRecordBuilder {
-        LogRecordBuilder::new()
-    }
-}
-
-/// TraceContext stores the trace data for logs that have an associated
-/// span.
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct TraceContext {
-    /// Trace id
-    pub trace_id: TraceId,
-    /// Span Id
-    pub span_id: SpanId,
-    /// Trace flags
-    pub trace_flags: Option<TraceFlags>,
-}
-
-impl From<&SpanContext> for TraceContext {
-    fn from(span_context: &SpanContext) -> Self {
-        TraceContext {
-            trace_id: span_context.trace_id(),
-            span_id: span_context.span_id(),
-            trace_flags: Some(span_context.trace_flags()),
-        }
-    }
+    fn with_timestamp(&mut self, timestamp: SystemTime) -> &mut Self;
+    fn with_observed_timestamp(&mut self, timestamp: SystemTime) -> &mut Self;
+    fn with_span_context(&mut self, context: &SpanContext) -> &mut Self;
+    fn with_severity_text(&mut self, text: &str) -> &mut Self;
+    fn with_severity_number(&mut self, number: Severity) -> &mut Self;
+    fn with_body(&mut self, body: AnyValue) -> &mut Self;
+    fn with_attributes(&mut self, attributes: Vec<(Key, AnyValue)>) -> &mut Self;
+    fn build(&self) -> Arc<Self::Record>;
 }
 
 /// Value types for representing arbitrary values in a log record.
@@ -248,151 +199,5 @@ impl Severity {
             Severity::Fatal3 => "FATAL3",
             Severity::Fatal4 => "FATAL4",
         }
-    }
-}
-
-/// A builder for [`LogRecord`] values.
-#[derive(Debug, Clone)]
-pub struct LogRecordBuilder {
-    record: LogRecord,
-}
-
-impl LogRecordBuilder {
-    /// Create a new LogRecordBuilder
-    pub fn new() -> Self {
-        Self {
-            record: Default::default(),
-        }
-    }
-
-    /// Assign timestamp
-    pub fn with_timestamp(self, timestamp: SystemTime) -> Self {
-        Self {
-            record: LogRecord {
-                timestamp: Some(timestamp),
-                ..self.record
-            },
-        }
-    }
-
-    /// Assign observed timestamp
-    pub fn with_observed_timestamp(self, timestamp: SystemTime) -> Self {
-        Self {
-            record: LogRecord {
-                observed_timestamp: timestamp,
-                ..self.record
-            },
-        }
-    }
-
-    /// Assign the record's [`TraceContext`]
-    pub fn with_span_context(self, span_context: &SpanContext) -> Self {
-        Self {
-            record: LogRecord {
-                trace_context: Some(TraceContext {
-                    span_id: span_context.span_id(),
-                    trace_id: span_context.trace_id(),
-                    trace_flags: Some(span_context.trace_flags()),
-                }),
-                ..self.record
-            },
-        }
-    }
-
-    /// Assign the record's [`TraceContext`] from a `TraceContextExt` trait
-    pub fn with_context<T>(self, context: &T) -> Self
-    where
-        T: TraceContextExt,
-    {
-        if context.has_active_span() {
-            self.with_span_context(context.span().span_context())
-        } else {
-            self
-        }
-    }
-
-    /// Assign severity text
-    pub fn with_severity_text<T>(self, severity: T) -> Self
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        Self {
-            record: LogRecord {
-                severity_text: Some(severity.into()),
-                ..self.record
-            },
-        }
-    }
-
-    /// Assign severity number
-    pub fn with_severity_number(self, severity: Severity) -> Self {
-        Self {
-            record: LogRecord {
-                severity_number: Some(severity),
-                ..self.record
-            },
-        }
-    }
-
-    /// Assign body
-    pub fn with_body(self, body: impl Into<AnyValue>) -> Self {
-        Self {
-            record: LogRecord {
-                body: Some(body.into()),
-                ..self.record
-            },
-        }
-    }
-
-    /// Assign attributes.
-    /// The SDK doesn't carry on any deduplication on these attributes.
-    pub fn with_attributes(self, attributes: Vec<(Key, AnyValue)>) -> Self {
-        Self {
-            record: LogRecord {
-                attributes: Some(attributes),
-                ..self.record
-            },
-        }
-    }
-
-    /// Set a single attribute for this record.
-    /// The SDK doesn't carry on any deduplication on these attributes.
-    pub fn with_attribute<K, V>(mut self, key: K, value: V) -> Self
-    where
-        K: Into<Key>,
-        V: Into<AnyValue>,
-    {
-        if let Some(ref mut vec) = self.record.attributes {
-            vec.push((key.into(), value.into()));
-        } else {
-            let vec = vec![(key.into(), value.into())];
-            self.record.attributes = Some(vec);
-        }
-
-        self
-    }
-
-    /// Sets the `event_name` of a record.
-    pub fn with_name<T>(self, name: T) -> Self
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        Self {
-            record: LogRecord {
-                event_name: Some(name.into()),
-                ..self.record
-            },
-        }
-    }
-
-    /// Build the record, consuming the Builder
-    pub fn build(self) -> LogRecord {
-        self.record
-    }
-}
-
-impl Default for LogRecordBuilder {
-    fn default() -> Self {
-        Self::new()
     }
 }


### PR DESCRIPTION
Fixes #1189 

## Changes

Opening as draft to get the initial feedback. The changes are:
 - Created `LogRecord`  traits in the API.
 - Added corresponding struct `LogRecord` with implementation in the SDK.

**Earlier:**
```rust
        logger.emit(
            LogRecord::builder()
                .with_body("full log")
                .with_timestamp(now)
                .with_observed_timestamp(now)
                .with_severity_number(Severity::Warn)
                .with_severity_text(Severity::Warn.name())
                .with_attribute("name", "my-event-name")
                .with_attribute("event.id", 20)
                .with_attribute("user.name", "otel")
                .with_attribute("user.email", "otel@opentelemetry.io")
                .with_attribute("code.filename", "log.rs")
                .with_attribute("code.filepath", "opentelemetry_sdk/benches/log.rs")
                .with_attribute("code.lineno", 96)
                .with_attribute("code.namespace", "opentelemetry_sdk::benches::log")
                .with_attribute("log.target", "opentelemetry_sdk::benches::log")
                .build(),
        )

```

**With PR:**
```rust
        let mut log_record = logger.create_log_record();
        log_record.set_body("full log".into());
        log_record.set_timestamp(now);
        log_record.set_observed_timestamp(now);
        log_record.set_severity_number(Severity::Warn);
        log_record.set_severity_text(Severity::Warn.name().into());
        log_record.add_attribute("name", "my-event-name");
        log_record.add_attribute("event.id", 20);
        log_record.add_attribute("user.name", "otel");
        log_record.add_attribute("user.email", "otel@opentelemetry.io");
        log_record.add_attribute("code.filename", "log.rs");
        log_record.add_attribute("code.filepath", "opentelemetry_sdk/benches/log.rs");
        log_record.add_attribute("code.lineno", 96);
        log_record.add_attribute("code.namespace", "opentelemetry_sdk::benches::log");
        log_record.add_attribute("log.target", "opentelemetry_sdk::benches::log");
        logger.emit(log_record);
```

Note - with the new design, the log record creation through chaining required cloning eventually while emitting, so haven't implemented the chaining. The tracing appender also doesn't require chaining as all these log data are populated separately.

This allows us to change the internal SDK implementation for LogRecord without breaking the Bridge API. While there are no current perf benefits with the approach, it enables us to add more optimizations in the SDK to optionally allow the serialization of the log records in the export format without any intermediate allocations within the SDK. I plan to add those optimizations in subsequent PRs once this is finalized. 

**Benchmark**

| Test Name                                        | Main                            | PR                             |
|--------------------------------------------------|---------------------------------|--------------------------------|
| simple-log/no-context                           | [105.28 ns]                     | [89.896 ns]                    |
| simple-log/with-context time                    | [115.49 ns]                     | [90.293 ns]                    |
| simple-log-with-int/no-context                  | [141.40 ns]                     | [123.36 ns]                    |
| simple-log-with-int/with-context                | [147.15 ns]                     | [123.61 ns]                    |
| simple-log-with-double/no-context               | [145.43 ns]                     | [123.32 ns]                    |
| simple-log-with-double/with-context             | [153.33 ns]                     | [122.28 ns]                    |
| simple-log-with-string/no-context               | [144.01 ns]                     | [122.61 ns]                    |
| simple-log-with-string/with-context             | [149.85 ns]                     | [123.61 ns]                    |
| simple-log-with-bool/no-context                 | [146.57 ns]                     | [121.77 ns]                    |
| simple-log-with-bool/with-context               | [152.56 ns]                     | [123.12 ns]                    |
| simple-log-with-bytes/no-context                | [161.11 ns]                     | [139.43 ns]                    |
| simple-log-with-bytes/with-context              | [171.69 ns]                     | [140.73 ns]                    |
| simple-log-with-a-lot-of-bytes/no-context       | [164.77 ns]                     | [140.72 ns]                    |
| simple-log-with-a-lot-of-bytes/with-context     | [172.50 ns]                     | [142.45 ns]                    |
| simple-log-with-vec-any-value/no-context        | [205.88 ns]                     | [194.93 ns]                    |
| simple-log-with-vec-any-value/with-context      | [214.82 ns]                     | [194.06 ns]                    |
| simple-log-with-inner-vec-any-value/no-context  | [275.55 ns]                     | [256.61 ns]                    |
| simple-log-with-inner-vec-any-value/with-context| [280.79 ns]                     | [255.82 ns]                    |
| simple-log-with-map-any-value/no-context        | [234.09 ns]                     | [207.90 ns]                    |
| simple-log-with-map-any-value/with-context      | [244.29 ns]                     | [207.57 ns]                    |
| simple-log-with-inner-map-any-value/no-context  | [335.55 ns]                     | [303.23 ns]                    |
| simple-log-with-inner-map-any-value/with-context| [344.18 ns]                     | [304.65 ns]                    |
| long-log/no-context                             | [106.17 ns]                     | [89.779 ns]                    |
| long-log/with-context                           | [118.93 ns]                     | [91.673 ns]                    |
| full-log/no-context                             | [143.31 ns]                     | [95.529 ns]                    |
| full-log/with-context                           | [145.20 ns]                     | [96.720 ns]                    |
| full-log-with-4-attributes/no-context           | [315.31 ns]                     | [227.49 ns]                    |
| full-log-with-4-attributes/with-context         | [312.81 ns]                     | [235.11 ns]                    |
| full-log-with-9-attributes/no-context           | [548.88 ns]                     | [406.99 ns]                    |
| full-log-with-9-attributes/with-context         | [501.88 ns]                     | [418.26 ns]                    |
| full-log-with-attributes/no-context             | [322.71 ns]                     | [277.63 ns]                    |
| full-log-with-attributes/with-context           | [328.19 ns]                     | [279.08 ns]                    |


**Stress Test** (20 threads)
Main: ~35 million iterations/sec
PR:    ~39 million iterations/sec


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
