### PR TITLE
Code changes for the new Clippy version and running test on Windows

### DIFF
--- a/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/http_client.rs
@@ -129,6 +129,7 @@ impl CollectorHttpClient {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 pub(crate) mod test_http_client {
     use async_trait::async_trait;
     use bytes::Bytes;

--- a/opentelemetry-jaeger/src/exporter/thrift/agent.rs
+++ b/opentelemetry-jaeger/src/exporter/thrift/agent.rs
@@ -3,7 +3,7 @@
 
 #![allow(unused_imports)]
 #![allow(unused_extern_crates)]
-#![cfg_attr(clippy, allow(clippy::too_many_arguments, clippy::type_complexity))]
+#![allow(clippy::too_many_arguments, clippy::type_complexity)]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 extern crate thrift;

--- a/opentelemetry-jaeger/src/exporter/thrift/jaeger.rs
+++ b/opentelemetry-jaeger/src/exporter/thrift/jaeger.rs
@@ -3,7 +3,7 @@
 
 #![allow(unused_imports)]
 #![allow(unused_extern_crates)]
-#![cfg_attr(clippy, allow(clippy::too_many_arguments, clippy::type_complexity))]
+#![allow(clippy::too_many_arguments, clippy::type_complexity)]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 extern crate thrift;

--- a/opentelemetry-jaeger/src/exporter/thrift/zipkincore.rs
+++ b/opentelemetry-jaeger/src/exporter/thrift/zipkincore.rs
@@ -3,7 +3,7 @@
 
 #![allow(unused_imports)]
 #![allow(unused_extern_crates)]
-#![cfg_attr(clippy, allow(clippy::too_many_arguments, clippy::type_complexity))]
+#![allow(clippy::too_many_arguments, clippy::type_complexity)]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 extern crate thrift;

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -74,8 +74,20 @@ static COMMON_ATTRIBUTES: Lazy<[KeyValue; 4]> = Lazy::new(|| {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    init_tracer()?;
-    init_metrics()?;
+    let result = init_tracer();
+    assert!(
+        result.is_ok(),
+        "Init tracer failed with error: {:?}",
+        result.err()
+    );
+
+    let result = init_metrics();
+    assert!(
+        result.is_ok(),
+        "Init metrics failed with error: {:?}",
+        result.err()
+    );
+    
     // Opentelemetry will not provide a global API to manage the logger provider. Application users must manage the lifecycle of the logger provider on their own. Dropping logger providers will disable log emitting.
     let logger_provider = init_logs().unwrap();
 

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -74,8 +74,8 @@ static COMMON_ATTRIBUTES: Lazy<[KeyValue; 4]> = Lazy::new(|| {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let _ = init_tracer()?;
-    let _ = init_metrics()?;
+    init_tracer()?;
+    init_metrics()?;
     // Opentelemetry will not provide a global API to manage the logger provider. Application users must manage the lifecycle of the logger provider on their own. Dropping logger providers will disable log emitting.
     let logger_provider = init_logs().unwrap();
 

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         "Init metrics failed with error: {:?}",
         result.err()
     );
-    
+
     // Opentelemetry will not provide a global API to manage the logger provider. Application users must manage the lifecycle of the logger provider on their own. Dropping logger providers will disable log emitting.
     let logger_provider = init_logs().unwrap();
 

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -89,8 +89,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // By binding the result to an unused variable, the lifetime of the variable
     // matches the containing block, reporting traces and metrics during the whole
     // execution.
-    let _ = init_tracer()?;
-    let _ = init_metrics()?;
+    init_tracer()?;
+    init_metrics()?;
 
     // Initialize logs, which sets the global loggerprovider.
     let logger_provider = init_logs().unwrap();

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -89,8 +89,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // By binding the result to an unused variable, the lifetime of the variable
     // matches the containing block, reporting traces and metrics during the whole
     // execution.
-    init_tracer()?;
-    init_metrics()?;
+
+    let result = init_tracer();
+    assert!(result.is_ok(), "Init tracer failed with error: {:?}", result.err());
+
+    let result = init_metrics();
+    assert!(result.is_ok(), "Init metrics failed with error: {:?}", result.err());
 
     // Initialize logs, which sets the global loggerprovider.
     let logger_provider = init_logs().unwrap();

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -91,10 +91,18 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // execution.
 
     let result = init_tracer();
-    assert!(result.is_ok(), "Init tracer failed with error: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "Init tracer failed with error: {:?}",
+        result.err()
+    );
 
     let result = init_metrics();
-    assert!(result.is_ok(), "Init metrics failed with error: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "Init metrics failed with error: {:?}",
+        result.err()
+    );
 
     // Initialize logs, which sets the global loggerprovider.
     let logger_provider = init_logs().unwrap();

--- a/opentelemetry-otlp/tests/integration_test/tests/integration_tests.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/integration_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use integration_test_runner::images::Collector;
 use std::fs::File;
 use std::os::unix::fs::PermissionsExt;

--- a/opentelemetry-otlp/tests/integration_test/tests/traces.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/traces.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use integration_test_runner::asserter::{read_spans_from_json, TraceAsserter};
 use opentelemetry::global;
 use opentelemetry::global::shutdown_tracer_provider;

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -822,7 +822,7 @@ fn gather_and_compare_multi(
     let metric_families = registry.gather();
     encoder.encode(&metric_families, &mut output).unwrap();
 
-    let output_string = if cfg!(windows){
+    let output_string = if cfg!(windows) {
         String::from_utf8(output).unwrap().replace('\n', "\r\n")
     } else {
         String::from_utf8(output).unwrap()

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -406,13 +406,18 @@ fn gather_and_compare(registry: prometheus::Registry, expected: String, name: &'
     let metric_families = registry.gather();
     encoder.encode(&metric_families, &mut output).unwrap();
 
-    let output_string = if cfg!(windows) {
-        String::from_utf8(output).unwrap().replace('\n', "\r\n")
-    } else {
-        String::from_utf8(output).unwrap()
-    };
+    let output_string = get_platform_specific_string(String::from_utf8(output).unwrap());
 
     assert_eq!(output_string, expected, "{name}");
+}
+
+///  Returns a String which uses the platform specific new line feed character.
+fn get_platform_specific_string(input: String) -> String {
+    if cfg!(windows) {
+        input.replace('\n', "\r\n")
+    } else {
+        input
+    }
 }
 
 #[test]
@@ -822,11 +827,7 @@ fn gather_and_compare_multi(
     let metric_families = registry.gather();
     encoder.encode(&metric_families, &mut output).unwrap();
 
-    let output_string = if cfg!(windows) {
-        String::from_utf8(output).unwrap().replace('\n', "\r\n")
-    } else {
-        String::from_utf8(output).unwrap()
-    };
+    let output_string = get_platform_specific_string(String::from_utf8(output).unwrap());
 
     assert!(
         expected.contains(&output_string),

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -409,8 +409,7 @@ fn gather_and_compare(registry: prometheus::Registry, expected: String, name: &'
 
     if cfg!(windows) {
         output_string = String::from_utf8(output).unwrap().replace("\n", "\r\n");
-    }
-    else {
+    } else {
         output_string = String::from_utf8(output).unwrap();
     }
 
@@ -828,8 +827,7 @@ fn gather_and_compare_multi(
 
     if cfg!(windows) {
         output_string = String::from_utf8(output).unwrap().replace("\n", "\r\n");
-    }
-    else {
+    } else {
         output_string = String::from_utf8(output).unwrap();
     }
 

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -405,13 +405,12 @@ fn gather_and_compare(registry: prometheus::Registry, expected: String, name: &'
     let encoder = TextEncoder::new();
     let metric_families = registry.gather();
     encoder.encode(&metric_families, &mut output).unwrap();
-    let output_string;
 
-    if cfg!(windows) {
-        output_string = String::from_utf8(output).unwrap().replace("\n", "\r\n");
+    let output_string =if cfg!(windows) {
+        String::from_utf8(output).unwrap().replace('\n', "\r\n")
     } else {
-        output_string = String::from_utf8(output).unwrap();
-    }
+        String::from_utf8(output).unwrap()
+    };
 
     assert_eq!(output_string, expected, "{name}");
 }
@@ -823,13 +822,11 @@ fn gather_and_compare_multi(
     let metric_families = registry.gather();
     encoder.encode(&metric_families, &mut output).unwrap();
 
-    let output_string;
-
-    if cfg!(windows) {
-        output_string = String::from_utf8(output).unwrap().replace("\n", "\r\n");
+    let output_string = if cfg!(windows){
+        String::from_utf8(output).unwrap().replace('\n', "\r\n")
     } else {
-        output_string = String::from_utf8(output).unwrap();
-    }
+        String::from_utf8(output).unwrap()
+    };
 
     assert!(
         expected.contains(&output_string),

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -405,7 +405,14 @@ fn gather_and_compare(registry: prometheus::Registry, expected: String, name: &'
     let encoder = TextEncoder::new();
     let metric_families = registry.gather();
     encoder.encode(&metric_families, &mut output).unwrap();
-    let output_string = String::from_utf8(output).unwrap();
+    let output_string;
+
+    if cfg!(windows) {
+        output_string = String::from_utf8(output).unwrap().replace("\n", "\r\n");
+    }
+    else {
+        output_string = String::from_utf8(output).unwrap();
+    }
 
     assert_eq!(output_string, expected, "{name}");
 }
@@ -816,7 +823,15 @@ fn gather_and_compare_multi(
     let encoder = TextEncoder::new();
     let metric_families = registry.gather();
     encoder.encode(&metric_families, &mut output).unwrap();
-    let output_string = String::from_utf8(output).unwrap();
+
+    let output_string;
+
+    if cfg!(windows) {
+        output_string = String::from_utf8(output).unwrap().replace("\n", "\r\n");
+    }
+    else {
+        output_string = String::from_utf8(output).unwrap();
+    }
 
     assert!(
         expected.contains(&output_string),

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -406,7 +406,7 @@ fn gather_and_compare(registry: prometheus::Registry, expected: String, name: &'
     let metric_families = registry.gather();
     encoder.encode(&metric_families, &mut output).unwrap();
 
-    let output_string =if cfg!(windows) {
+    let output_string = if cfg!(windows) {
         String::from_utf8(output).unwrap().replace('\n', "\r\n")
     } else {
         String::from_utf8(output).unwrap()

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -109,15 +109,15 @@ fn build_content_map(path: impl AsRef<Path>, normalize_line_feed: bool) -> HashM
                 .file_name()
                 .expect("file name should always exist for generated files");
 
-            let file_contents;
-            if normalize_line_feed && cfg!(windows) {
-                file_contents = std::fs::read_to_string(path.clone())
+            let file_contents =  if normalize_line_feed && cfg!(windows) {
+                std::fs::read_to_string(path.clone())
                     .expect("cannot read from existing generated file")
-                    .replace("\n", "\r\n");
+                    .replace('\n', "\r\n")
             } else {
-                file_contents = std::fs::read_to_string(path.clone())
-                    .expect("cannot read from existing generated file");
-            }
+                std::fs::read_to_string(path.clone())
+                    .expect("cannot read from existing generated file")
+            };
+
             (file_name.to_string_lossy().to_string(), file_contents)
         })
         .collect()

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -109,7 +109,7 @@ fn build_content_map(path: impl AsRef<Path>, normalize_line_feed: bool) -> HashM
                 .file_name()
                 .expect("file name should always exist for generated files");
 
-            let file_contents =  if normalize_line_feed && cfg!(windows) {
+            let file_contents = if normalize_line_feed && cfg!(windows) {
                 std::fs::read_to_string(path.clone())
                     .expect("cannot read from existing generated file")
                     .replace('\n', "\r\n")

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -18,7 +18,7 @@ const TONIC_INCLUDES: &[&str] = &["src/proto/opentelemetry-proto", "src/proto"];
 
 #[test]
 fn build_tonic() {
-    let before_build = build_content_map(TONIC_OUT_DIR);
+    let before_build = build_content_map(TONIC_OUT_DIR, false);
 
     let out_dir = TempDir::new().expect("failed to create temp dir to store the generated files");
 
@@ -95,11 +95,11 @@ fn build_tonic() {
         .compile(TONIC_PROTO_FILES, TONIC_INCLUDES)
         .expect("cannot compile protobuf using tonic");
 
-    let after_build = build_content_map(out_dir.path());
+    let after_build = build_content_map(out_dir.path(), true);
     ensure_files_are_same(before_build, after_build, TONIC_OUT_DIR);
 }
 
-fn build_content_map(path: impl AsRef<Path>) -> HashMap<String, String> {
+fn build_content_map(path: impl AsRef<Path>, normalize_line_feed: bool) -> HashMap<String, String> {
     std::fs::read_dir(path)
         .expect("cannot open dictionary of generated files")
         .flatten()
@@ -108,9 +108,18 @@ fn build_content_map(path: impl AsRef<Path>) -> HashMap<String, String> {
             let file_name = path
                 .file_name()
                 .expect("file name should always exist for generated files");
+
+            let file_contents;
+            if normalize_line_feed && cfg!(windows) {
+                file_contents = std::fs::read_to_string(path.clone()).expect("cannot read from existing generated file").replace("\n", "\r\n");
+            }
+            else {
+                file_contents = std::fs::read_to_string(path.clone()).expect("cannot read from existing generated file");
+            }
+            
             (
                 file_name.to_string_lossy().to_string(),
-                std::fs::read_to_string(path).expect("cannot read from existing generated file"),
+                file_contents,
             )
         })
         .collect()

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -109,18 +109,25 @@ fn build_content_map(path: impl AsRef<Path>, normalize_line_feed: bool) -> HashM
                 .file_name()
                 .expect("file name should always exist for generated files");
 
-            let file_contents = if normalize_line_feed && cfg!(windows) {
-                std::fs::read_to_string(path.clone())
-                    .expect("cannot read from existing generated file")
-                    .replace('\n', "\r\n")
-            } else {
-                std::fs::read_to_string(path.clone())
-                    .expect("cannot read from existing generated file")
-            };
+            let mut file_contents = std::fs::read_to_string(path.clone())
+                .expect("cannot read from existing generated file");
+
+            if normalize_line_feed {
+                file_contents = get_platform_specific_string(file_contents);
+            }
 
             (file_name.to_string_lossy().to_string(), file_contents)
         })
         .collect()
+}
+
+///  Returns a String with the platform specific new line feed character.
+fn get_platform_specific_string(input: String) -> String {
+    if cfg!(windows) {
+        input.replace('\n', "\r\n")
+    } else {
+        input
+    }
 }
 
 fn ensure_files_are_same(

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -111,16 +111,14 @@ fn build_content_map(path: impl AsRef<Path>, normalize_line_feed: bool) -> HashM
 
             let file_contents;
             if normalize_line_feed && cfg!(windows) {
-                file_contents = std::fs::read_to_string(path.clone()).expect("cannot read from existing generated file").replace("\n", "\r\n");
+                file_contents = std::fs::read_to_string(path.clone())
+                    .expect("cannot read from existing generated file")
+                    .replace("\n", "\r\n");
+            } else {
+                file_contents = std::fs::read_to_string(path.clone())
+                    .expect("cannot read from existing generated file");
             }
-            else {
-                file_contents = std::fs::read_to_string(path.clone()).expect("cannot read from existing generated file");
-            }
-            
-            (
-                file_name.to_string_lossy().to_string(),
-                file_contents,
-            )
+            (file_name.to_string_lossy().to_string(), file_contents)
         })
         .collect()
 }

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -435,9 +435,11 @@ mod tests {
             })
             .expect("callback registration should succeed");
 
+        _ = meter_provider.force_flush();
+
         // Assert
         receiver
-            .recv_timeout(interval * 2)
+            .try_recv()
             .expect("message should be available in channel, indicating a collection occurred");
     }
 

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -9,7 +9,7 @@ use futures_util::{
     future::{self, Either},
     pin_mut,
     stream::{self, FusedStream},
-    Stream, StreamExt,
+    StreamExt,
 };
 use opentelemetry::{
     global,
@@ -290,7 +290,7 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
         true
     }
 
-    async fn run(mut self, mut messages: impl Stream<Item = Message> + Unpin + FusedStream) {
+    async fn run(mut self, mut messages: impl Unpin + FusedStream<Item = Message>) {
         while let Some(message) = messages.next().await {
             if !self.process_message(message).await {
                 break;

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -165,9 +165,9 @@ impl SdkProducer for Pipeline {
                             // previous aggregation was of a different type
                             prev_agg.data = data;
                         }
-                        prev_agg.name = inst.name.clone();
-                        prev_agg.description = inst.description.clone();
-                        prev_agg.unit = inst.unit.clone();
+                        prev_agg.name.clone_from(&inst.name);
+                        prev_agg.description.clone_from(&inst.description);
+                        prev_agg.unit.clone_from(&inst.unit);
                     }
                     _ => continue,
                 }

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -399,7 +399,7 @@ impl<R: RuntimeChannel> BatchSpanProcessorInternal<R> {
         })
     }
 
-    async fn run(mut self, mut messages: impl Stream<Item = BatchMessage> + Unpin + FusedStream) {
+    async fn run(mut self, mut messages: impl Unpin + FusedStream<Item = BatchMessage>) {
         loop {
             select! {
                 // FuturesUnordered implements Fuse intelligently such that it

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -42,7 +42,7 @@ use futures_util::{
     future::{self, BoxFuture, Either},
     select,
     stream::{self, FusedStream, FuturesUnordered},
-    Stream, StreamExt as _,
+    StreamExt as _,
 };
 use opentelemetry::global;
 use opentelemetry::{


### PR DESCRIPTION
## Changes
- There's a newer version of the rust toolchain which brings in newer clippy lints:
   - https://rust-lang.github.io/rust-clippy/master/index.html#/implied_bounds_in_impls
   - https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones
   - https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_clippy_cfg
   - https://rust-lang.github.io/rust-clippy/master/index.html#/let_unit_value

- Fix some tests to resolve the complaints from `cargo test` on Windows

After these changes, the commands specified in the [test.sh](https://github.com/open-telemetry/opentelemetry-rust/blob/main/scripts/test.sh) file run successfully on Windows:
```sh

cargo test --workspace --all-features "$@" -- --test-threads=1

# See https://github.com/rust-lang/cargo/issues/5364
cargo test --manifest-path=opentelemetry/Cargo.toml --no-default-features

# Run global tracer provider test in single thread
cargo test --manifest-path=opentelemetry/Cargo.toml --all-features -- --ignored --test-threads=1

cargo test --manifest-path=opentelemetry/Cargo.toml --all-features
cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --all-features -- --test-threads=1
cargo test --manifest-path=opentelemetry-zipkin/Cargo.toml --all-features
```
