### PR TITLE
fix: URLs in OTLP exporters

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - URL encoded values in `OTEL_EXPORTER_OTLP_HEADERS` are now correctly decoded. [#1578](https://github.com/open-telemetry/opentelemetry-rust/pull/1578)
+- OTLP exporter will not change the URL added through `ExportConfig` [#1706](https://github.com/open-telemetry/opentelemetry-rust/pull/1706)
+- Default grpc endpoint will not have path based on signal(e.g `/v1/traces`) [#1706](https://github.com/open-telemetry/opentelemetry-rust/pull/1706)
 
 ### Added
 

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -399,7 +399,7 @@ impl<R: RuntimeChannel> BatchSpanProcessorInternal<R> {
         })
     }
 
-    async fn run(mut self, mut messages: impl Stream<Item = BatchMessage> + Unpin + FusedStream) {
+    async fn run(mut self, mut messages: impl Unpin + FusedStream<Item = BatchMessage>) {
         loop {
             select! {
                 // FuturesUnordered implements Fuse intelligently such that it

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -42,7 +42,7 @@ use futures_util::{
     future::{self, BoxFuture, Either},
     select,
     stream::{self, FusedStream, FuturesUnordered},
-     StreamExt as _,
+    StreamExt as _,
 };
 use opentelemetry::global;
 use opentelemetry::{

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -42,7 +42,7 @@ use futures_util::{
     future::{self, BoxFuture, Either},
     select,
     stream::{self, FusedStream, FuturesUnordered},
-    Stream, StreamExt as _,
+     StreamExt as _,
 };
 use opentelemetry::global;
 use opentelemetry::{


### PR DESCRIPTION
Fixes #1618
Design discussion issue (if applicable) #

## Changes

- Clearify the documentation that the `endpoint` in `ExporterConfig` should be complete. i.e exporter will not append signal path onto it.

- Removed the signal path for default grpc endpoints. As in grpc protocol, [path is decided by the package name](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md). Users can still add path if they manually config it
> Path is case-sensitive. Some gRPC implementations may allow the Path format shown above to be overridden, but this functionality is strongly discouraged. gRPC does not go out of its way to break users that are using this kind of override, but we do not actively support it, and some functionality (e.g., service config support) will not work when the path is not of the form shown above.

- Don't append anything if the users add a path in `ExportConfig`. URLs from env vars don't append anything so we should keep them consistent

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
