### PR TITLE
[Metrics API] InstrumentBuilder modified to take instrumentprovider instead of meter

### DIFF
--- a/opentelemetry-sdk/benches/metric_counter.rs
+++ b/opentelemetry-sdk/benches/metric_counter.rs
@@ -13,8 +13,8 @@ fn create_counter() -> Counter<u64> {
         .with_reader(ManualReader::builder().build())
         .build();
     let meter = meter_provider.meter("benchmarks");
-    let counter = meter.u64_counter("counter_bench").init();
-    counter
+
+    meter.u64_counter("counter_bench").init()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/opentelemetry/benches/metrics.rs
+++ b/opentelemetry/benches/metrics.rs
@@ -6,7 +6,7 @@ use opentelemetry::{global, metrics::Counter, KeyValue};
 
 fn create_counter() -> Counter<u64> {
     let meter = global::meter("benchmarks");
-    
+
     meter.u64_counter("counter_bench").init()
 }
 

--- a/opentelemetry/benches/metrics.rs
+++ b/opentelemetry/benches/metrics.rs
@@ -6,8 +6,8 @@ use opentelemetry::{global, metrics::Counter, KeyValue};
 
 fn create_counter() -> Counter<u64> {
     let meter = global::meter("benchmarks");
-    let counter = meter.u64_counter("counter_bench").init();
-    counter
+    
+    meter.u64_counter("counter_bench").init()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -37,27 +37,23 @@ impl<T> Counter<T> {
     }
 }
 
-impl TryFrom<InstrumentBuilder<'_, Counter<u64>>> for Counter<u64> {
+impl TryFrom<InstrumentBuilder<Counter<u64>>> for Counter<u64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<'_, Counter<u64>>) -> Result<Self, Self::Error> {
-        builder.meter.instrument_provider.u64_counter(
-            builder.name,
-            builder.description,
-            builder.unit,
-        )
+    fn try_from(builder: InstrumentBuilder<Counter<u64>>) -> Result<Self, Self::Error> {
+        builder
+            .instrument_provider
+            .u64_counter(builder.name, builder.description, builder.unit)
     }
 }
 
-impl TryFrom<InstrumentBuilder<'_, Counter<f64>>> for Counter<f64> {
+impl TryFrom<InstrumentBuilder<Counter<f64>>> for Counter<f64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<'_, Counter<f64>>) -> Result<Self, Self::Error> {
-        builder.meter.instrument_provider.f64_counter(
-            builder.name,
-            builder.description,
-            builder.unit,
-        )
+    fn try_from(builder: InstrumentBuilder<Counter<f64>>) -> Result<Self, Self::Error> {
+        builder
+            .instrument_provider
+            .f64_counter(builder.name, builder.description, builder.unit)
     }
 }
 

--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -37,20 +37,20 @@ impl<T> Counter<T> {
     }
 }
 
-impl TryFrom<InstrumentBuilder<Counter<u64>>> for Counter<u64> {
+impl TryFrom<InstrumentBuilder<'_, Counter<u64>>> for Counter<u64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<Counter<u64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<'_, Counter<u64>>) -> Result<Self, Self::Error> {
         builder
             .instrument_provider
             .u64_counter(builder.name, builder.description, builder.unit)
     }
 }
 
-impl TryFrom<InstrumentBuilder<Counter<f64>>> for Counter<f64> {
+impl TryFrom<InstrumentBuilder<'_, Counter<f64>>> for Counter<f64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<Counter<f64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<'_, Counter<f64>>) -> Result<Self, Self::Error> {
         builder
             .instrument_provider
             .f64_counter(builder.name, builder.description, builder.unit)

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -37,30 +37,30 @@ impl<T> Gauge<T> {
     }
 }
 
-impl TryFrom<InstrumentBuilder<Gauge<u64>>> for Gauge<u64> {
+impl TryFrom<InstrumentBuilder<'_, Gauge<u64>>> for Gauge<u64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<Gauge<u64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<'_, Gauge<u64>>) -> Result<Self, Self::Error> {
         builder
             .instrument_provider
             .u64_gauge(builder.name, builder.description, builder.unit)
     }
 }
 
-impl TryFrom<InstrumentBuilder<Gauge<f64>>> for Gauge<f64> {
+impl TryFrom<InstrumentBuilder<'_, Gauge<f64>>> for Gauge<f64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<Gauge<f64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<'_, Gauge<f64>>) -> Result<Self, Self::Error> {
         builder
             .instrument_provider
             .f64_gauge(builder.name, builder.description, builder.unit)
     }
 }
 
-impl TryFrom<InstrumentBuilder<Gauge<i64>>> for Gauge<i64> {
+impl TryFrom<InstrumentBuilder<'_, Gauge<i64>>> for Gauge<i64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<Gauge<i64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<'_, Gauge<i64>>) -> Result<Self, Self::Error> {
         builder
             .instrument_provider
             .i64_gauge(builder.name, builder.description, builder.unit)

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -37,34 +37,31 @@ impl<T> Gauge<T> {
     }
 }
 
-impl TryFrom<InstrumentBuilder<'_, Gauge<u64>>> for Gauge<u64> {
+impl TryFrom<InstrumentBuilder<Gauge<u64>>> for Gauge<u64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<'_, Gauge<u64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<Gauge<u64>>) -> Result<Self, Self::Error> {
         builder
-            .meter
             .instrument_provider
             .u64_gauge(builder.name, builder.description, builder.unit)
     }
 }
 
-impl TryFrom<InstrumentBuilder<'_, Gauge<f64>>> for Gauge<f64> {
+impl TryFrom<InstrumentBuilder<Gauge<f64>>> for Gauge<f64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<'_, Gauge<f64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<Gauge<f64>>) -> Result<Self, Self::Error> {
         builder
-            .meter
             .instrument_provider
             .f64_gauge(builder.name, builder.description, builder.unit)
     }
 }
 
-impl TryFrom<InstrumentBuilder<'_, Gauge<i64>>> for Gauge<i64> {
+impl TryFrom<InstrumentBuilder<Gauge<i64>>> for Gauge<i64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<'_, Gauge<i64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<Gauge<i64>>) -> Result<Self, Self::Error> {
         builder
-            .meter
             .instrument_provider
             .i64_gauge(builder.name, builder.description, builder.unit)
     }

--- a/opentelemetry/src/metrics/instruments/histogram.rs
+++ b/opentelemetry/src/metrics/instruments/histogram.rs
@@ -36,26 +36,22 @@ impl<T> Histogram<T> {
     }
 }
 
-impl TryFrom<InstrumentBuilder<'_, Histogram<f64>>> for Histogram<f64> {
+impl TryFrom<InstrumentBuilder<Histogram<f64>>> for Histogram<f64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<'_, Histogram<f64>>) -> Result<Self, Self::Error> {
-        builder.meter.instrument_provider.f64_histogram(
-            builder.name,
-            builder.description,
-            builder.unit,
-        )
+    fn try_from(builder: InstrumentBuilder<Histogram<f64>>) -> Result<Self, Self::Error> {
+        builder
+            .instrument_provider
+            .f64_histogram(builder.name, builder.description, builder.unit)
     }
 }
 
-impl TryFrom<InstrumentBuilder<'_, Histogram<u64>>> for Histogram<u64> {
+impl TryFrom<InstrumentBuilder<Histogram<u64>>> for Histogram<u64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<'_, Histogram<u64>>) -> Result<Self, Self::Error> {
-        builder.meter.instrument_provider.u64_histogram(
-            builder.name,
-            builder.description,
-            builder.unit,
-        )
+    fn try_from(builder: InstrumentBuilder<Histogram<u64>>) -> Result<Self, Self::Error> {
+        builder
+            .instrument_provider
+            .u64_histogram(builder.name, builder.description, builder.unit)
     }
 }

--- a/opentelemetry/src/metrics/instruments/histogram.rs
+++ b/opentelemetry/src/metrics/instruments/histogram.rs
@@ -36,20 +36,20 @@ impl<T> Histogram<T> {
     }
 }
 
-impl TryFrom<InstrumentBuilder<Histogram<f64>>> for Histogram<f64> {
+impl TryFrom<InstrumentBuilder<'_, Histogram<f64>>> for Histogram<f64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<Histogram<f64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<'_, Histogram<f64>>) -> Result<Self, Self::Error> {
         builder
             .instrument_provider
             .f64_histogram(builder.name, builder.description, builder.unit)
     }
 }
 
-impl TryFrom<InstrumentBuilder<Histogram<u64>>> for Histogram<u64> {
+impl TryFrom<InstrumentBuilder<'_, Histogram<u64>>> for Histogram<u64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<Histogram<u64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<'_, Histogram<u64>>) -> Result<Self, Self::Error> {
         builder
             .instrument_provider
             .u64_histogram(builder.name, builder.description, builder.unit)

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -25,22 +25,22 @@ pub trait AsyncInstrument<T>: Send + Sync {
 }
 
 /// Configuration for building a sync instrument.
-pub struct InstrumentBuilder<T> {
-    instrument_provider: Arc<dyn InstrumentProvider + Send + Sync>,
+pub struct InstrumentBuilder<'a, T> {
+    instrument_provider: &'a dyn InstrumentProvider,
     name: Cow<'static, str>,
     description: Option<Cow<'static, str>>,
     unit: Option<Unit>,
     _marker: marker::PhantomData<T>,
 }
 
-impl<T> InstrumentBuilder<T>
+impl<'a, T> InstrumentBuilder<'a, T>
 where
     T: TryFrom<Self, Error = MetricsError>,
 {
     /// Create a new instrument builder
-    pub(crate) fn new(meter: &Meter, name: Cow<'static, str>) -> Self {
+    pub(crate) fn new(meter: &'a Meter, name: Cow<'static, str>) -> Self {
         InstrumentBuilder {
-            instrument_provider: meter.instrument_provider.clone(),
+            instrument_provider: meter.instrument_provider.as_ref(),
             name,
             description: None,
             unit: None,
@@ -84,7 +84,7 @@ where
     }
 }
 
-impl<T> fmt::Debug for InstrumentBuilder<T> {
+impl<T> fmt::Debug for InstrumentBuilder<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("InstrumentBuilder")
             .field("name", &self.name)

--- a/opentelemetry/src/metrics/instruments/up_down_counter.rs
+++ b/opentelemetry/src/metrics/instruments/up_down_counter.rs
@@ -42,11 +42,11 @@ impl<T> UpDownCounter<T> {
     }
 }
 
-impl TryFrom<InstrumentBuilder<'_, UpDownCounter<i64>>> for UpDownCounter<i64> {
+impl TryFrom<InstrumentBuilder<UpDownCounter<i64>>> for UpDownCounter<i64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<'_, UpDownCounter<i64>>) -> Result<Self, Self::Error> {
-        builder.meter.instrument_provider.i64_up_down_counter(
+    fn try_from(builder: InstrumentBuilder<UpDownCounter<i64>>) -> Result<Self, Self::Error> {
+        builder.instrument_provider.i64_up_down_counter(
             builder.name,
             builder.description,
             builder.unit,
@@ -54,11 +54,11 @@ impl TryFrom<InstrumentBuilder<'_, UpDownCounter<i64>>> for UpDownCounter<i64> {
     }
 }
 
-impl TryFrom<InstrumentBuilder<'_, UpDownCounter<f64>>> for UpDownCounter<f64> {
+impl TryFrom<InstrumentBuilder<UpDownCounter<f64>>> for UpDownCounter<f64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<'_, UpDownCounter<f64>>) -> Result<Self, Self::Error> {
-        builder.meter.instrument_provider.f64_up_down_counter(
+    fn try_from(builder: InstrumentBuilder<UpDownCounter<f64>>) -> Result<Self, Self::Error> {
+        builder.instrument_provider.f64_up_down_counter(
             builder.name,
             builder.description,
             builder.unit,

--- a/opentelemetry/src/metrics/instruments/up_down_counter.rs
+++ b/opentelemetry/src/metrics/instruments/up_down_counter.rs
@@ -42,10 +42,10 @@ impl<T> UpDownCounter<T> {
     }
 }
 
-impl TryFrom<InstrumentBuilder<UpDownCounter<i64>>> for UpDownCounter<i64> {
+impl TryFrom<InstrumentBuilder<'_, UpDownCounter<i64>>> for UpDownCounter<i64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<UpDownCounter<i64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<'_, UpDownCounter<i64>>) -> Result<Self, Self::Error> {
         builder.instrument_provider.i64_up_down_counter(
             builder.name,
             builder.description,
@@ -54,10 +54,10 @@ impl TryFrom<InstrumentBuilder<UpDownCounter<i64>>> for UpDownCounter<i64> {
     }
 }
 
-impl TryFrom<InstrumentBuilder<UpDownCounter<f64>>> for UpDownCounter<f64> {
+impl TryFrom<InstrumentBuilder<'_, UpDownCounter<f64>>> for UpDownCounter<f64> {
     type Error = MetricsError;
 
-    fn try_from(builder: InstrumentBuilder<UpDownCounter<f64>>) -> Result<Self, Self::Error> {
+    fn try_from(builder: InstrumentBuilder<'_, UpDownCounter<f64>>) -> Result<Self, Self::Error> {
         builder.instrument_provider.f64_up_down_counter(
             builder.name,
             builder.description,

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -273,7 +273,7 @@ impl Meter {
     pub fn u64_counter(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<'_, Counter<u64>> {
+    ) -> InstrumentBuilder<Counter<u64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -281,7 +281,7 @@ impl Meter {
     pub fn f64_counter(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<'_, Counter<f64>> {
+    ) -> InstrumentBuilder<Counter<f64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -305,7 +305,7 @@ impl Meter {
     pub fn i64_up_down_counter(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<'_, UpDownCounter<i64>> {
+    ) -> InstrumentBuilder<UpDownCounter<i64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -313,7 +313,7 @@ impl Meter {
     pub fn f64_up_down_counter(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<'_, UpDownCounter<f64>> {
+    ) -> InstrumentBuilder<UpDownCounter<f64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -334,26 +334,17 @@ impl Meter {
     }
 
     /// creates an instrument builder for recording independent values.
-    pub fn u64_gauge(
-        &self,
-        name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<'_, Gauge<u64>> {
+    pub fn u64_gauge(&self, name: impl Into<Cow<'static, str>>) -> InstrumentBuilder<Gauge<u64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
     /// creates an instrument builder for recording independent values.
-    pub fn f64_gauge(
-        &self,
-        name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<'_, Gauge<f64>> {
+    pub fn f64_gauge(&self, name: impl Into<Cow<'static, str>>) -> InstrumentBuilder<Gauge<f64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
     /// creates an instrument builder for recording independent values.
-    pub fn i64_gauge(
-        &self,
-        name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<'_, Gauge<i64>> {
+    pub fn i64_gauge(&self, name: impl Into<Cow<'static, str>>) -> InstrumentBuilder<Gauge<i64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -385,7 +376,7 @@ impl Meter {
     pub fn f64_histogram(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<'_, Histogram<f64>> {
+    ) -> InstrumentBuilder<Histogram<f64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -393,7 +384,7 @@ impl Meter {
     pub fn u64_histogram(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<'_, Histogram<u64>> {
+    ) -> InstrumentBuilder<Histogram<u64>> {
         InstrumentBuilder::new(self, name.into())
     }
 

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -273,7 +273,7 @@ impl Meter {
     pub fn u64_counter(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<Counter<u64>> {
+    ) -> InstrumentBuilder<'_, Counter<u64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -281,7 +281,7 @@ impl Meter {
     pub fn f64_counter(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<Counter<f64>> {
+    ) -> InstrumentBuilder<'_, Counter<f64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -305,7 +305,7 @@ impl Meter {
     pub fn i64_up_down_counter(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<UpDownCounter<i64>> {
+    ) -> InstrumentBuilder<'_, UpDownCounter<i64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -313,7 +313,7 @@ impl Meter {
     pub fn f64_up_down_counter(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<UpDownCounter<f64>> {
+    ) -> InstrumentBuilder<'_, UpDownCounter<f64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -334,17 +334,26 @@ impl Meter {
     }
 
     /// creates an instrument builder for recording independent values.
-    pub fn u64_gauge(&self, name: impl Into<Cow<'static, str>>) -> InstrumentBuilder<Gauge<u64>> {
+    pub fn u64_gauge(
+        &self,
+        name: impl Into<Cow<'static, str>>,
+    ) -> InstrumentBuilder<'_, Gauge<u64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
     /// creates an instrument builder for recording independent values.
-    pub fn f64_gauge(&self, name: impl Into<Cow<'static, str>>) -> InstrumentBuilder<Gauge<f64>> {
+    pub fn f64_gauge(
+        &self,
+        name: impl Into<Cow<'static, str>>,
+    ) -> InstrumentBuilder<'_, Gauge<f64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
     /// creates an instrument builder for recording independent values.
-    pub fn i64_gauge(&self, name: impl Into<Cow<'static, str>>) -> InstrumentBuilder<Gauge<i64>> {
+    pub fn i64_gauge(
+        &self,
+        name: impl Into<Cow<'static, str>>,
+    ) -> InstrumentBuilder<'_, Gauge<i64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -376,7 +385,7 @@ impl Meter {
     pub fn f64_histogram(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<Histogram<f64>> {
+    ) -> InstrumentBuilder<'_, Histogram<f64>> {
         InstrumentBuilder::new(self, name.into())
     }
 
@@ -384,7 +393,7 @@ impl Meter {
     pub fn u64_histogram(
         &self,
         name: impl Into<Cow<'static, str>>,
-    ) -> InstrumentBuilder<Histogram<u64>> {
+    ) -> InstrumentBuilder<'_, Histogram<u64>> {
         InstrumentBuilder::new(self, name.into())
     }
 


### PR DESCRIPTION
`InstrumentBuilder` modified to store `InstrumentProvider` instead of `Meter`. There is no need to keep anything from `Meter` other than the `InstrumentProvider` anyway, so this just reduced on indirection. Tried only for sync instruments - if this is good, I'll update the async-instruments too with the same pattern.