### PR TITLE
Reduce public exposure of noops

### DIFF
--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -14,13 +14,13 @@ use std::{any::Any, borrow::Cow, sync::Arc};
 
 /// A no-op instance of a `MetricProvider`
 #[derive(Debug, Default)]
-pub struct NoopMeterProvider {
+pub(crate) struct NoopMeterProvider {
     _private: (),
 }
 
 impl NoopMeterProvider {
     /// Create a new no-op meter provider.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         NoopMeterProvider { _private: () }
     }
 }
@@ -81,13 +81,13 @@ impl CallbackRegistration for NoopRegistration {
 
 /// A no-op sync instrument
 #[derive(Debug, Default)]
-pub struct NoopSyncInstrument {
+pub(crate) struct NoopSyncInstrument {
     _private: (),
 }
 
 impl NoopSyncInstrument {
     /// Create a new no-op sync instrument
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         NoopSyncInstrument { _private: () }
     }
 }


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-rust/issues/1712
A lot of others noops are used by opentelemetry-sdk. I think sdk can find different ways to handle this. Will explore that later.