### PR TITLE
Add CI coverage for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
   test:
     strategy:
       matrix:
-        # test all Rust versions on ubuntu-latest
+        # test both stable and beta versions of Rust on ubuntu-latest
         os: [ubuntu-latest]
         rust: [stable, beta]
-        # test stable Rust on Windows
+        # test only stable version of Rust on Windows
         include:
           - rust: stable
             os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,8 @@ jobs:
   external-types:
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-latest ]
         example: [opentelemetry, opentelemetry-sdk, opentelemetry-otlp, opentelemetry-zipkin]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest # TODO: Check if this could be covered on Windows. The step used currently fails on Windows.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -107,10 +106,7 @@ jobs:
         cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --features rt-tokio &&
         cargo test --manifest-path=opentelemetry-zipkin/Cargo.toml
   cargo-deny:
-    strategy:
-      matrix:
-        os: [ windows-latest, ubuntu-latest ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest # This is only supported on Linux
     continue-on-error: true # Prevent sudden announcement of a new advisory from failing ci
     steps:
       - uses: actions/checkout@v4
@@ -161,3 +157,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false
+          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,11 @@ jobs:
     strategy:
       matrix:
         rust: [stable, beta]
-    runs-on: ubuntu-latest
+        os: [ windows-latest, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Free disk space
+      if: ${{ matrix.os == 'ubuntu-latest'}}
       run: |
         df -h
         sudo rm -rf /usr/local/lib/android
@@ -32,9 +34,12 @@ jobs:
       run: rustup set profile minimal
     - uses: arduino/setup-protoc@v3
     - name: Test
-      run: ./scripts/test.sh
+      run: bash ./scripts/test.sh
   lint:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -48,12 +53,13 @@ jobs:
         command: fmt
         args: --all -- --check
     - name: Lint
-      run: ./scripts/lint.sh
+      run: bash ./scripts/lint.sh
   external-types:
     strategy:
       matrix:
+        os: [ windows-latest, ubuntu-latest ]
         example: [opentelemetry, opentelemetry-sdk, opentelemetry-otlp, opentelemetry-zipkin]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -68,8 +74,9 @@ jobs:
   non-default-examples:
     strategy:
       matrix:
+        os: [ windows-latest, ubuntu-latest ]
         example: [opentelemetry-otlp/examples/basic-otlp]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -83,21 +90,27 @@ jobs:
         cd ${{ matrix.example }}
         cargo build --verbose
   msrv:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: true
     - uses: dtolnay/rust-toolchain@1.65.0
     - name: Patch dependencies versions # some dependencies bump MSRV without major version bump
-      run: ./scripts/patch_dependencies.sh
+      run: bash ./scripts/patch_dependencies.sh
     - name: Run tests
       run: cargo --version &&
         cargo test --manifest-path=opentelemetry/Cargo.toml --features trace,metrics,testing &&
         cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --features rt-tokio &&
         cargo test --manifest-path=opentelemetry-zipkin/Cargo.toml
   cargo-deny:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
     continue-on-error: true # Prevent sudden announcement of a new advisory from failing ci
     steps:
       - uses: actions/checkout@v4
@@ -105,8 +118,11 @@ jobs:
         with:
           command: check advisories
   docs:
+    strategy:
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -120,7 +136,10 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
   coverage:
     continue-on-error: true
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         example: [opentelemetry, opentelemetry-sdk, opentelemetry-otlp, opentelemetry-zipkin]
-    runs-on: ubuntu-latest # TODO: Check if this could be covered on Windows. The step used currently fails on Windows.
+    runs-on: ubuntu-latest # TODO: Check if this could be covered for Windows. The step used currently fails on Windows.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -106,7 +106,7 @@ jobs:
         cargo test --manifest-path=opentelemetry-jaeger/Cargo.toml --features rt-tokio &&
         cargo test --manifest-path=opentelemetry-zipkin/Cargo.toml
   cargo-deny:
-    runs-on: ubuntu-latest # This is only supported on Linux
+    runs-on: ubuntu-latest # This uses the step `EmbarkStudios/cargo-deny-action@v1` which is only supported on Linux
     continue-on-error: true # Prevent sudden announcement of a new advisory from failing ci
     steps:
       - uses: actions/checkout@v4
@@ -157,4 +157,3 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false
-          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,7 @@ jobs:
     - name: Test
       run: bash ./scripts/test.sh
   lint:
-    strategy:
-      matrix:
-        os: [ windows-latest, ubuntu-latest ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -114,11 +111,8 @@ jobs:
         with:
           command: check advisories
   docs:
-    strategy:
-      matrix:
-        os: [ windows-latest, ubuntu-latest ]
     continue-on-error: true
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,13 @@ jobs:
   test:
     strategy:
       matrix:
+        # test all Rust versions on ubuntu-latest
+        os: [ubuntu-latest]
         rust: [stable, beta]
-        os: [ windows-latest, ubuntu-latest ]
+        # test stable Rust on Windows
+        include:
+          - rust: stable
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
     - name: Free disk space
@@ -126,10 +131,7 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
   coverage:
     continue-on-error: true
-    strategy:
-      matrix:
-        os: [ windows-latest, ubuntu-latest ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     if: ${{ ! contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Changes
- Update CI workflow to run jobs on Windows as well

Note: Certain jobs from the CI workflow can only be run on Linx for now