### PR TITLE
Simpler usage of Observable instruments

### DIFF
--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -43,22 +43,20 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     );
 
     // Create a ObservableCounter instrument and register a callback that reports the measurement.
-    let observable_counter = meter
+    let _observable_counter = meter
         .u64_observable_counter("my_observable_counter")
         .with_description("My observable counter example description")
         .with_unit(Unit::new("myunit"))
+        .with_callback(|observer| {
+            observer.observe(
+                100,
+                &[
+                    KeyValue::new("mykey1", "myvalue1"),
+                    KeyValue::new("mykey2", "myvalue2"),
+                ],
+            )
+        })
         .init();
-
-    meter.register_callback(&[observable_counter.as_any()], move |observer| {
-        observer.observe_u64(
-            &observable_counter,
-            100,
-            &[
-                KeyValue::new("mykey1", "myvalue1"),
-                KeyValue::new("mykey2", "myvalue2"),
-            ],
-        )
-    })?;
 
     // Create a UpCounter Instrument.
     let updown_counter = meter.i64_up_down_counter("my_updown_counter").init();

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -71,22 +71,20 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     );
 
     // Create a Observable UpDownCounter instrument and register a callback that reports the measurement.
-    let observable_up_down_counter = meter
+    let _observable_up_down_counter = meter
         .i64_observable_up_down_counter("my_observable_updown_counter")
         .with_description("My observable updown counter example description")
         .with_unit(Unit::new("myunit"))
+        .with_callback(|observer| {
+            observer.observe(
+                100,
+                &[
+                    KeyValue::new("mykey1", "myvalue1"),
+                    KeyValue::new("mykey2", "myvalue2"),
+                ],
+            )
+        })
         .init();
-
-    meter.register_callback(&[observable_up_down_counter.as_any()], move |observer| {
-        observer.observe_i64(
-            &observable_up_down_counter,
-            100,
-            &[
-                KeyValue::new("mykey1", "myvalue1"),
-                KeyValue::new("mykey2", "myvalue2"),
-            ],
-        )
-    })?;
 
     // Create a Histogram Instrument.
     let histogram = meter
@@ -106,8 +104,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Note that there is no ObservableHistogram instrument.
 
     // Create a Gauge Instrument.
-    {
-        let gauge = meter
+    let gauge = meter
             .f64_gauge("my_gauge")
             .with_description("A gauge set to 1.0")
             .with_unit(Unit::new("myunit"))
@@ -120,26 +117,22 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
                 KeyValue::new("mykey2", "myvalue2"),
             ],
         );
-    }
 
     // Create a ObservableGauge instrument and register a callback that reports the measurement.
-    let observable_gauge = meter
+    let _observable_gauge = meter
         .f64_observable_gauge("my_observable_gauge")
         .with_description("An observable gauge set to 1.0")
         .with_unit(Unit::new("myunit"))
+        .with_callback(|observer| {
+            observer.observe(
+                1.0,
+                &[
+                    KeyValue::new("mykey1", "myvalue1"),
+                    KeyValue::new("mykey2", "myvalue2"),
+                ],
+            )
+        })
         .init();
-
-    // Register a callback that reports the measurement.
-    meter.register_callback(&[observable_gauge.as_any()], move |observer| {
-        observer.observe_f64(
-            &observable_gauge,
-            1.0,
-            &[
-                KeyValue::new("mykey1", "myvalue1"),
-                KeyValue::new("mykey2", "myvalue2"),
-            ],
-        )
-    })?;
 
     // Metrics are exported by default every 30 seconds when using stdout exporter,
     // however shutting down the MeterProvider here instantly flushes

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -105,18 +105,18 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     // Create a Gauge Instrument.
     let gauge = meter
-            .f64_gauge("my_gauge")
-            .with_description("A gauge set to 1.0")
-            .with_unit(Unit::new("myunit"))
-            .init();
+        .f64_gauge("my_gauge")
+        .with_description("A gauge set to 1.0")
+        .with_unit(Unit::new("myunit"))
+        .init();
 
-        gauge.record(
-            1.0,
-            &[
-                KeyValue::new("mykey1", "myvalue1"),
-                KeyValue::new("mykey2", "myvalue2"),
-            ],
-        );
+    gauge.record(
+        1.0,
+        &[
+            KeyValue::new("mykey1", "myvalue1"),
+            KeyValue::new("mykey2", "myvalue2"),
+        ],
+    );
 
     // Create a ObservableGauge instrument and register a callback that reports the measurement.
     let _observable_gauge = meter

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -115,14 +115,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let tracer = global::tracer("ex.com/basic");
     let meter = global::meter("ex.com/basic");
 
-    let gauge = meter
+    let _gauge = meter
         .f64_observable_gauge("ex.com.one")
         .with_description("A gauge set to 1.0")
+        .with_callback(|observer| observer.observe(1.0, COMMON_ATTRIBUTES.as_ref()))
         .init();
-
-    meter.register_callback(&[gauge.as_any()], move |observer| {
-        observer.observe_f64(&gauge, 1.0, COMMON_ATTRIBUTES.as_ref())
-    })?;
 
     let histogram = meter.f64_histogram("ex.com.two").init();
     histogram.record(5.5, COMMON_ATTRIBUTES.as_ref());

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -166,6 +166,91 @@ mod tests {
     // "multi_thread" tokio flavor must be used else flush won't
     // be able to make progress!
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn observable_counter_aggregation() {
+        // Run this test with stdout enabled to see output.
+        // cargo test observable_counter_aggregation --features=metrics,testing -- --nocapture
+
+        // Arrange
+        let exporter = InMemoryMetricsExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+        // Act
+        let meter = meter_provider.meter("test");
+        let _counter = meter
+            .u64_observable_counter("my_observable_counter")
+            .with_unit(Unit::new("my_unit"))
+            .with_callback(|observer| {
+                observer.observe(100, &[KeyValue::new("key1", "value1")]);
+                observer.observe(200, &[KeyValue::new("key1", "value2")]);
+            })
+            .init();
+
+        meter_provider.force_flush().unwrap();
+
+        // Assert
+        let resource_metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics are expected to be exported.");
+        assert!(!resource_metrics.is_empty());
+        let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
+        assert_eq!(metric.name, "my_observable_counter");
+        assert_eq!(metric.unit.as_str(), "my_unit");
+        let sum = metric
+            .data
+            .as_any()
+            .downcast_ref::<data::Sum<u64>>()
+            .expect("Sum aggregation expected for ObservableCounter instruments by default");
+
+        // Expecting 2 time-series.
+        assert_eq!(sum.data_points.len(), 2);
+        assert!(sum.is_monotonic, "Counter should produce monotonic.");
+        assert_eq!(
+            sum.temporality,
+            data::Temporality::Cumulative,
+            "Should produce cumulative by default."
+        );
+
+        // find and validate key1=value1 datapoint
+        let mut data_point1 = None;
+        for datapoint in &sum.data_points {
+            if datapoint
+                .attributes
+                .iter()
+                .any(|(k, v)| k.as_str() == "key1" && v.as_str() == "value1")
+            {
+                data_point1 = Some(datapoint);
+            }
+        }
+        assert_eq!(
+            data_point1
+                .expect("datapoint with key1=value1 expected")
+                .value,
+            100
+        );
+
+        // find and validate key1=value2 datapoint
+        let mut data_point1 = None;
+        for datapoint in &sum.data_points {
+            if datapoint
+                .attributes
+                .iter()
+                .any(|(k, v)| k.as_str() == "key1" && v.as_str() == "value2")
+            {
+                data_point1 = Some(datapoint);
+            }
+        }
+        assert_eq!(
+            data_point1
+                .expect("datapoint with key1=value2 expected")
+                .value,
+            200
+        );
+    }
+
+    // "multi_thread" tokio flavor must be used else flush won't
+    // be able to make progress!
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn counter_duplicate_instrument_merge() {
         // Arrange
         let exporter = InMemoryMetricsExporter::default();

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -428,12 +428,12 @@ mod tests {
         // Act
         let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
         let meter = meter_provider.meter("test");
-        let counter = meter.u64_observable_counter("testcounter").init();
-        meter
-            .register_callback(&[counter.as_any()], move |_| {
+        let _counter = meter
+            .u64_observable_counter("testcounter")
+            .with_callback(move |_| {
                 sender.send(()).expect("channel should still be open");
             })
-            .expect("callback registration should succeed");
+            .init();
 
         _ = meter_provider.force_flush();
 


### PR DESCRIPTION
There are 2 ways today to provide callbacks for Observable Instruments today:
1. As part of instrument creation itself (via `with_callback`) 
2. After instrument creation, via `meter.register_callback`

After careful consideration, I'm leaning towards removing option 2. While it offers flexibility by allowing one callback to be associated with multiple instruments, and the ability to "un-register", it significantly increases complexity and requires more extensive testing to ensure correctness. It also has a lot of public API exposure, so removing this from 1st stable release also allow us to maintain a manageable scope.

In the upcoming PR(s), I'll make changes to modify all examples/tests to utilize option 1 (this PR just adds a single test) If there are no scenarios where option 2 is essential, I'll proceed with its removal in subsequent iterations.

@open-telemetry/rust-approvers Please share your thoughts on removing option2. (To be clear, this is proposed to be removed to **keep scope in control**, as this is not only complex to use, but equally challenging to ensure sufficient test coverage/correctness)

Edit: Updated all examples and tests to use option1. (There is dire shortage of tests overall :( )
