### PR TITLE
Use static dispatch to validate value types for public APIs

### DIFF
--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -40,6 +40,12 @@ fn attributes_creation(c: &mut Criterion) {
         });
     });
 
+    c.bench_function("CreateTupleKeyValueUsingGenerics", |b| {
+        b.iter(|| {
+            let _v1 = black_box(no_op("attribute1", "value1"));
+        });
+    });
+
     #[allow(clippy::useless_vec)]
     c.bench_function("CreateOtelKeyValueVector", |b| {
         b.iter(|| {
@@ -63,6 +69,17 @@ fn attributes_creation(c: &mut Criterion) {
             ]);
         });
     });
+}
+
+
+trait OTelValueType {}
+
+impl OTelValueType for u32 {}
+
+impl  OTelValueType for &str {}
+
+fn no_op<T : OTelValueType>(key: &'static str, value: T) {
+    black_box("test");
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -40,9 +40,21 @@ fn attributes_creation(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("CreateTupleKeyValueUsingGenerics", |b| {
+    c.bench_function("CreateKeyValueUsingGenericMethod", |b| {
         b.iter(|| {
             let _v1 = black_box(no_op("attribute1", "value1"));
+        });
+    });
+
+    #[allow(clippy::useless_vec)]
+    c.bench_function("CreateKeyValueVectorUsingGenericMethod", |b| {
+        b.iter(|| {
+            let _v1 = black_box(vec![
+                no_op("attribute1", "value1"),
+                no_op("attribute2", "value2"),
+                no_op("attribute3", "value3"),
+                no_op("attribute4", "value4"),
+            ]);
         });
     });
 

--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -40,14 +40,14 @@ fn attributes_creation(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("CreateKeyValueUsingGenericMethod", |b| {
+    c.bench_function("ProvideKeyValueUsingGenericMethod", |b| {
         b.iter(|| {
             let _v1 = black_box(no_op("attribute1", "value1"));
         });
     });
 
     #[allow(clippy::useless_vec)]
-    c.bench_function("CreateKeyValueVectorUsingGenericMethod", |b| {
+    c.bench_function("ProvideMultipleKeyValuesUsingGenericMethod", |b| {
         b.iter(|| {
             let _v1 = black_box(vec![
                 no_op("attribute1", "value1"),


### PR DESCRIPTION
Related to #1642 

## Changes
- Use static dispatch to validate the value types

Here are the benchmark results:
| Benchmark Method | Execution Time|
|-----------------------|-----------------|
|CreateOTelKey_Static|1.8588 ns|
|CreateOTelKey_Owned|45.364 ns|
|CreateOTelKey_Arc|46.610 ns|
|CreateOTelKeyValue|4.3361 ns|
|CreateTupleKeyValue|1.2396 ns|
|**ProvideKeyValueUsingGenericMethod** |**621.28 ps**|
|ProvideMultipleKeyValuesUsingGenericMethod |3.4066 ns|
|CreateOtelKeyValueVector|64.357 ns|
|CreateTupleKeyValueVector|46.892 ns|
