### PR TITLE
Metric attributes need sort with keys only

### DIFF
--- a/opentelemetry-sdk/src/attributes/set.rs
+++ b/opentelemetry-sdk/src/attributes/set.rs
@@ -39,47 +39,7 @@ impl PartialOrd for HashKeyValue {
 
 impl Ord for HashKeyValue {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.0.key.cmp(&other.0.key) {
-            Ordering::Equal => match type_order(&self.0.value).cmp(&type_order(&other.0.value)) {
-                Ordering::Equal => match (&self.0.value, &other.0.value) {
-                    (Value::F64(f), Value::F64(of)) => OrderedFloat(*f).cmp(&OrderedFloat(*of)),
-                    (Value::Array(Array::Bool(b)), Value::Array(Array::Bool(ob))) => b.cmp(ob),
-                    (Value::Array(Array::I64(i)), Value::Array(Array::I64(oi))) => i.cmp(oi),
-                    (Value::Array(Array::String(s)), Value::Array(Array::String(os))) => s.cmp(os),
-                    (Value::Array(Array::F64(f)), Value::Array(Array::F64(of))) => {
-                        match f.len().cmp(&of.len()) {
-                            Ordering::Equal => f
-                                .iter()
-                                .map(|x| OrderedFloat(*x))
-                                .collect::<Vec<_>>()
-                                .cmp(&of.iter().map(|x| OrderedFloat(*x)).collect()),
-                            other => other,
-                        }
-                    }
-                    (Value::Bool(b), Value::Bool(ob)) => b.cmp(ob),
-                    (Value::I64(i), Value::I64(oi)) => i.cmp(oi),
-                    (Value::String(s), Value::String(os)) => s.cmp(os),
-                    _ => Ordering::Equal,
-                },
-                other => other, // 2nd order by value types
-            },
-            other => other, // 1st order by key
-        }
-    }
-}
-
-fn type_order(v: &Value) -> u8 {
-    match v {
-        Value::Bool(_) => 1,
-        Value::I64(_) => 2,
-        Value::F64(_) => 3,
-        Value::String(_) => 4,
-        Value::Array(a) => match a {
-            Array::Bool(_) => 5,
-            Array::I64(_) => 6,
-            Array::F64(_) => 7,
-            Array::String(_) => 8,
-        },
+        self.0.key.cmp(&other.0.key)
     }
 }
 


### PR DESCRIPTION
`HashKeyValue` is a simple wrapper around `KeyValue` to provide hash, eq, ord implementations.
The `Ord` implementation is required to ensure that attributes are treated the same irrespective of the order in which they are passed. This only requires a sort with the `Key` alone.

This PR simplifies the `Ord` implementation to be based of the `Key` part alone from the `KeyValue`. Also added tests to validate that all measurements aggregate to the same point, irrespective of the order in which KeyValue pairs are passed.

(This is part of a somewhat big refactor of Metrics SDK to significantly improve performance - offering short PRs to make reviews easy. Also intentionally keeping the tests modelled like integration tests, instead of unit tests - this is to reduce churn when refactoring, as lot of internals are expected to change, but the end user facing API need to be relatively stable, as we move towards beta release.)