### PR TITLE
fix ci

### DIFF
--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -125,7 +125,7 @@ mod isahc {
     }
 }
 
-#[cfg(any(feature = "hyper", feature = "hyper_tls"))]
+#[cfg(feature = "hyper")]
 pub mod hyper {
     use crate::ResponseExt;
 


### PR DESCRIPTION
## Changes
`hyper_tls` feature flag is no where defined, but still being used. Removing it to fix the [CI failure](https://github.com/open-telemetry/opentelemetry-rust/actions/runs/8980625546/job/24664607276?pr=1718) for it.
```
error: unexpected `cfg` condition value: `hyper_tls`
   --> opentelemetry-http/src/lib.rs:128:30
    |
128 | #[cfg(any(feature = "hyper", feature = "hyper_tls"))]
```
Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
