### PR TITLE
Upgrade opentelemetry-proto v1.3.1

### DIFF
--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## vNext
 
-- Update protobuf definitions to v1.1.0 [#1668](https://github.com/open-telemetry/opentelemetry-rust/pull/1668)
+- Update protobuf definitions to v1.2.0 [#1668](https://github.com/open-telemetry/opentelemetry-rust/pull/1668)
+- Update protobuf definitions to v1.3.1 [#1721](https://github.com/open-telemetry/opentelemetry-rust/pull/1721)
 
 ## v0.5.0
 


### PR DESCRIPTION
## Changes

upgrade opentelemetry-proto from `v1.2.0` to` v1.3.1`.  Release desc- https://github.com/open-telemetry/opentelemetry-proto/releases
Easiest of the upgrades, as there are no proto files changes for the three signals (trace, metric, logs). The new release only brings the proto files for [profiling ](https://github.com/open-telemetry/oteps/pull/212)- probably some work we need to do in otel-rust to support this in future.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
