### PR TITLE
chore: remove flaky tests

### DIFF
--- a/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
+++ b/opentelemetry-jaeger/src/exporter/config/collector/mod.rs
@@ -558,42 +558,7 @@ impl CollectorPipeline {
 #[cfg(test)]
 #[cfg(feature = "rt-tokio")]
 mod tests {
-    use opentelemetry_sdk::runtime::Tokio;
-
-    use crate::config::collector::http_client::test_http_client;
-
     use super::*;
-
-    #[test]
-    fn test_set_collector_endpoint() {
-        let invalid_uri = new_collector_pipeline()
-            .with_endpoint("127.0.0.1:14268/api/traces")
-            .with_http_client(test_http_client::TestHttpClient)
-            .build_uploader::<Tokio>();
-        assert!(invalid_uri.is_err());
-        assert_eq!(
-            format!("{:?}", invalid_uri.err().unwrap()),
-            "ConfigError { pipeline_name: \"collector\", config_name: \"collector_endpoint\", reason: \"invalid uri from the builder, invalid format\" }",
-        );
-
-        let valid_uri = new_collector_pipeline()
-            .with_http_client(test_http_client::TestHttpClient)
-            .with_endpoint("http://127.0.0.1:14268/api/traces")
-            .build_uploader::<Tokio>();
-
-        assert!(valid_uri.is_ok());
-    }
-
-    // Ignore this test as it is flaky and the opentelemetry-jaeger is on-track for deprecation
-    #[ignore]
-    #[test]
-    fn test_collector_exporter() {
-        let exporter = new_collector_pipeline()
-            .with_endpoint("http://127.0.0.1:14268/api/traces")
-            .with_http_client(test_http_client::TestHttpClient)
-            .build_collector_exporter::<Tokio>();
-        assert!(exporter.is_ok());
-    }
 
     #[test]
     fn test_resolve_endpoint() {


### PR DESCRIPTION
## Changes

- remove two flaky tests as they are part of a deprecated create and has been causing issues for us

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
