### PR TITLE
Use shared slices instead of references to owned vectors as return types

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -28,6 +28,9 @@
   - After `shutdown`, `LogProcessor` will not process any new logs
 - Moving LogRecord implementation to the SDK. [1702](https://github.com/open-telemetry/opentelemetry-rust/pull/1702).
     - Relocated `LogRecord` struct to SDK, as an implementation for the trait in the API.
+- **Breaking** [#1729](https://github.com/open-telemetry/opentelemetry-rust/pull/1729)
+  - Update the return type of `TracerProvider.span_processors()` from `&Vec<Box<dyn SpanProcessor>>` to `&[Box<dyn SpanProcessor>]`.
+  - Update the return type of `LoggerProvider.log_processors()` from `&Vec<Box<dyn LogProcessor>>` to `&[Box<dyn LogProcessor>]`.
 
 ## v0.22.1
 

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -92,7 +92,7 @@ impl LoggerProvider {
     }
 
     /// Log processors associated with this provider.
-    pub fn log_processors(&self) -> &Vec<Box<dyn LogProcessor>> {
+    pub fn log_processors(&self) -> &[Box<dyn LogProcessor>] {
         &self.inner.processors
     }
 

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -62,7 +62,7 @@ impl TracerProvider {
     }
 
     /// Span processors associated with this provider
-    pub fn span_processors(&self) -> &Vec<Box<dyn SpanProcessor>> {
+    pub fn span_processors(&self) -> &[Box<dyn SpanProcessor>] {
         &self.inner.processors
     }
 

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -219,7 +219,7 @@ impl Span {
             data.end_time = opentelemetry::time::now();
         }
 
-        match provider.span_processors().as_slice() {
+        match provider.span_processors() {
             [] => {}
             [processor] => {
                 processor.on_end(build_export_data(


### PR DESCRIPTION
## Changes
- Use shared slices (a more abstract type) instead of references to owned vectors as the return types of `TracerProvider.span_processors()` and `LoggerProvider.log_processors()`
- Shared slices offer enough information for the callers of these methods and hides implementation details

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
