### PR TITLE
Remove SDK's attributeset usage in stdout, add tests

### DIFF
--- a/opentelemetry-sdk/src/attributes/set.rs
+++ b/opentelemetry-sdk/src/attributes/set.rs
@@ -150,12 +150,12 @@ mod tests {
 
         let kv1 = HashKeyValue(KeyValue::new("key", 1.0));
         let kv2 = HashKeyValue(KeyValue::new("key", 1.01));
-        assert_ne!(kv1, kv2);        
-        
+        assert_ne!(kv1, kv2);
+
         let kv1 = HashKeyValue(KeyValue::new("key", std::f64::NAN));
         let kv2 = HashKeyValue(KeyValue::new("key", std::f64::NAN));
         assert_eq!(kv1, kv2);
-        
+
         let kv1 = HashKeyValue(KeyValue::new("key", std::f64::INFINITY));
         let kv2 = HashKeyValue(KeyValue::new("key", std::f64::INFINITY));
         assert_eq!(kv1, kv2);

--- a/opentelemetry-sdk/src/attributes/set.rs
+++ b/opentelemetry-sdk/src/attributes/set.rs
@@ -8,8 +8,6 @@ use std::{
 use opentelemetry::{Array, Key, KeyValue, Value};
 use ordered_float::OrderedFloat;
 
-use crate::Resource;
-
 #[derive(Clone, Debug)]
 struct HashKeyValue(KeyValue);
 
@@ -87,17 +85,6 @@ impl From<&[KeyValue]> for AttributeSet {
     }
 }
 
-impl From<&Resource> for AttributeSet {
-    fn from(values: &Resource) -> Self {
-        let vec = values
-            .iter()
-            .map(|(key, value)| HashKeyValue(KeyValue::new(key.clone(), value.clone())))
-            .collect::<Vec<_>>();
-
-        AttributeSet::new(vec)
-    }
-}
-
 fn calculate_hash(values: &[HashKeyValue]) -> u64 {
     let mut hasher = DefaultHasher::new();
     values.iter().fold(&mut hasher, |mut hasher, item| {
@@ -144,5 +131,54 @@ impl AttributeSet {
 impl Hash for AttributeSet {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write_u64(self.1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::hash::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    use crate::attributes::set::HashKeyValue;
+    use opentelemetry::KeyValue;
+
+    #[test]
+    fn equality_kv_float() {
+        let kv1 = HashKeyValue(KeyValue::new("key", 1.0));
+        let kv2 = HashKeyValue(KeyValue::new("key", 1.0));
+        assert_eq!(kv1, kv2);
+
+        let kv1 = HashKeyValue(KeyValue::new("key", 1.0));
+        let kv2 = HashKeyValue(KeyValue::new("key", 1.01));
+        assert_ne!(kv1, kv2);        
+        
+        let kv1 = HashKeyValue(KeyValue::new("key", std::f64::NAN));
+        let kv2 = HashKeyValue(KeyValue::new("key", std::f64::NAN));
+        assert_eq!(kv1, kv2);
+        
+        let kv1 = HashKeyValue(KeyValue::new("key", std::f64::INFINITY));
+        let kv2 = HashKeyValue(KeyValue::new("key", std::f64::INFINITY));
+        assert_eq!(kv1, kv2);
+    }
+
+    #[test]
+    fn hash_kv_float() {
+        let kv1 = HashKeyValue(KeyValue::new("key", 1.0));
+        let kv2 = HashKeyValue(KeyValue::new("key", 1.0));
+        assert_eq!(hash_helper(&kv1), hash_helper(&kv2));
+
+        let kv1 = HashKeyValue(KeyValue::new("key", std::f64::NAN));
+        let kv2 = HashKeyValue(KeyValue::new("key", std::f64::NAN));
+        assert_eq!(hash_helper(&kv1), hash_helper(&kv2));
+
+        let kv1 = HashKeyValue(KeyValue::new("key", std::f64::INFINITY));
+        let kv2 = HashKeyValue(KeyValue::new("key", std::f64::INFINITY));
+        assert_eq!(hash_helper(&kv1), hash_helper(&kv2));
+    }
+
+    fn hash_helper<T: Hash>(item: &T) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        item.hash(&mut hasher);
+        hasher.finish()
     }
 }

--- a/opentelemetry-stdout/src/logs/transform.rs
+++ b/opentelemetry-stdout/src/logs/transform.rs
@@ -1,10 +1,9 @@
 use std::{borrow::Cow, collections::HashMap, time::SystemTime};
 
 use crate::common::{
-    as_human_readable, as_opt_human_readable, as_opt_unix_nano, as_unix_nano, KeyValue, Resource,
-    Scope, Value,
+    as_human_readable, as_opt_human_readable, as_opt_unix_nano, as_unix_nano, AttributeSet,
+    KeyValue, Resource, Scope, Value,
 };
-use opentelemetry_sdk::AttributeSet;
 use serde::Serialize;
 
 /// Transformed logs data that can be serialized.

--- a/opentelemetry-stdout/src/trace/transform.rs
+++ b/opentelemetry-stdout/src/trace/transform.rs
@@ -1,5 +1,4 @@
-use crate::common::{as_human_readable, as_unix_nano, KeyValue, Resource, Scope};
-use opentelemetry_sdk::AttributeSet;
+use crate::common::{as_human_readable, as_unix_nano, AttributeSet, KeyValue, Resource, Scope};
 use serde::{Serialize, Serializer};
 use std::{borrow::Cow, collections::HashMap, time::SystemTime};
 


### PR DESCRIPTION
`AttributeSet` is designed for Metric aggregation. It looks like it got accidentally used for stdout exporter. stdout already has its own `AttributeSet` and don't need the one from Metric module. I think `AttributeSet` from SDK can be made internal only, after I do another round of cleanup.

Also added some tests for Eq,Hash as we provide custom implementation. Ideally, we should test for all types, but just added for Float only as we use OrderedFloat to get Hash/Eq etc.