### PR TITLE
Prepare v0.23 release

### DIFF
--- a/opentelemetry-appender-log/CHANGELOG.md
+++ b/opentelemetry-appender-log/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## vNext
 
+## v0.4.0
+
 - Add log key-values as attributes [#1628](https://github.com/open-telemetry/opentelemetry-rust/pull/1628)
+- Update `opentelemetry` dependency version to 0.23
 
 ## v0.3.0
 

--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-appender-log"
-version = "0.3.0"
+version = "0.4.0"
 description = "An OpenTelemetry appender for the log crate"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-log"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-log"
@@ -11,7 +11,7 @@ rust-version = "1.65"
 edition = "2021"
 
 [dependencies]
-opentelemetry = { version = "0.22", path = "../opentelemetry", features = ["logs"]}
+opentelemetry = { version = "0.23", path = "../opentelemetry", features = ["logs"]}
 log = { workspace = true, features = ["kv", "std"]}
 serde = { workspace = true, optional = true, features = ["std"] }
 

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## vNext
 
+## v0.4.0
+
 - Removed unwanted dependency on opentelemetry-sdk.
+- Update `opentelemetry` dependency version to 0.23
 
 ## v0.3.0
 

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-appender-tracing"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "An OpenTelemetry log appender for the tracing crate"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-tracing"
@@ -13,7 +13,7 @@ rust-version = "1.65"
 [dependencies]
 log = { workspace = true, optional = true }
 once_cell = { workspace = true }
-opentelemetry = { version = "0.22", path = "../opentelemetry", features = ["logs"] }
+opentelemetry = { version = "0.23", path = "../opentelemetry", features = ["logs"] }
 tracing = { workspace = true, features = ["std"]}
 tracing-core = { workspace = true }
 tracing-log = { version = "0.2", optional = true }

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## vNext
 
+## v0.12.0
+
 - Add `reqwest-rustls-webkpi-roots` feature flag to configure [`reqwest`](https://docs.rs/reqwest/0.11.27/reqwest/index.html#optional-features) to use embedded `webkpi-roots`.
+- Update `opentelemetry` dependency version to 0.23
 
 ## v0.11.1
 

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-http"
-version = "0.11.1"
+version = "0.12.0"
 description = "Helper implementations for sending HTTP requests. Uses include propagating and extracting context over http, exporting telemetry, requesting sampling strategies."
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"
@@ -19,6 +19,6 @@ bytes = { workspace = true }
 http = { workspace = true }
 hyper = { workspace = true, features = ["http2", "client", "tcp"], optional = true }
 isahc = { workspace = true, optional = true }
-opentelemetry = { version = "0.22", path = "../opentelemetry", features = ["trace"] }
+opentelemetry = { version = "0.23", path = "../opentelemetry", features = ["trace"] }
 reqwest = { workspace = true, features = ["blocking"], optional = true }
 tokio = { workspace = true, features = ["time"], optional = true }

--- a/opentelemetry-jaeger-propagator/CHANGELOG.md
+++ b/opentelemetry-jaeger-propagator/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## vNext
 
+## v0.2.0
+
 ### Changed
 
 - Propagation error will be reported to global error handler [#1640](https://github.com/open-telemetry/opentelemetry-rust/pull/1640)
+- Update `opentelemetry` dependency version to 0.23
 
 ## v0.1.0
 

--- a/opentelemetry-jaeger-propagator/Cargo.toml
+++ b/opentelemetry-jaeger-propagator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-jaeger-propagator"
-version = "0.1.0"
+version = "0.2.0"
 description = "Jaeger propagator for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger-propagator"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger-propagator"
@@ -20,7 +20,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-opentelemetry = { version = "0.22", default-features = false, features = [
+opentelemetry = { version = "0.23", default-features = false, features = [
     "trace",
 ], path = "../opentelemetry" }
 

--- a/opentelemetry-jaeger/CHANGELOG.md
+++ b/opentelemetry-jaeger/CHANGELOG.md
@@ -7,7 +7,15 @@ Starting with [Jaeger v1.38](https://github.com/jaegertracing/jaeger/releases/ta
 
 Please check the [README](https://crates.io/crates/opentelemetry-jaeger) for more information.
 
-## vNext
+## v0.22.0
+
+- **This is the last release of this crate.**
+  Jaeger propagator is part of [opentelemetry-jaeger-propagator](../opentelemetry-jaeger-propagator/).
+  For exporting to Jaeger, use [opentelemetry-otlp](../opentelemetry-otlp/).
+- Update `opentelemetry` dependency version to 0.23
+- Update `opentelemetry_sdk` dependency version to 0.23
+- Update `opentelemetry-http` dependency version to 0.12
+- Update `opentelemetry-semantic-conventions` dependency version to 0.15
 
 ## v0.21.0
 

--- a/opentelemetry-jaeger/Cargo.toml
+++ b/opentelemetry-jaeger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-jaeger"
-version = "0.21.0"
+version = "0.22.0"
 description = "Jaeger exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger"
@@ -32,10 +32,10 @@ hyper = { workspace = true, features = ["client"], optional = true }
 hyper-tls = { version = "0.5.0", default-features = false, optional = true }
 isahc = { workspace = true, optional = true }
 js-sys = { version = "0.3", optional = true }
-opentelemetry = { version = "0.22", default-features = false, features = ["trace"], path = "../opentelemetry" }
-opentelemetry_sdk = { version = "0.22", default-features = false, features = ["trace"], path = "../opentelemetry-sdk" }
-opentelemetry-http = { version = "0.11", path = "../opentelemetry-http", optional = true }
-opentelemetry-semantic-conventions = { version = "0.14", path = "../opentelemetry-semantic-conventions" }
+opentelemetry = { version = "0.23", default-features = false, features = ["trace"], path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.23", default-features = false, features = ["trace"], path = "../opentelemetry-sdk" }
+opentelemetry-http = { version = "0.12", path = "../opentelemetry-http", optional = true }
+opentelemetry-semantic-conventions = { version = "0.15", path = "../opentelemetry-semantic-conventions" }
 pin-project-lite = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 thrift = "0.17.0"

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -14,7 +14,7 @@ The opentelemetry-jaeger crate previously contained both a Jaeger exporter and a
 To prepare for the deprecation of the Jaeger exporter, the Jaeger propagator implementation has been migrated to
 [opentelemetry-jaeger-propagator](../opentelemetry-jaeger-propagator/).
 
-The plan is to have 0.22.0 be the last release of the Jaeger exporter. This means that future versions of the OpenTelemetry
+The 0.22.0 is the the last release of the Jaeger exporter. This means that future versions of the OpenTelemetry
 SDK will not work with the exporter.
 
 If you have any questions please comment on the [Jaeger Deprecation Issue][deprecation-issue].
@@ -42,7 +42,7 @@ Jaeger `agent` or `collector` endpoint for processing and visualization.
 [jaeger-deprecation]: https://opentelemetry.io/blog/2022/jaeger-native-otlp/
 [exporting-otlp]: https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples/tracing-jaeger
 [Jaeger 1.35.0]: https://github.com/jaegertracing/jaeger/releases/tag/v1.35.0
-[deprecation-issue]: https://github.com/open-telemetry/opentelemetry-rust/pull/995
+[deprecation-issue]: https://github.com/open-telemetry/opentelemetry-rust/issues/995
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
 [msrv]: #supported-rust-versions
 

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.16.0
+
 ### Fixed
 
 - URL encoded values in `OTEL_EXPORTER_OTLP_HEADERS` are now correctly decoded. [#1578](https://github.com/open-telemetry/opentelemetry-rust/pull/1578)
@@ -23,6 +25,11 @@
  - **Breaking** Remove global provider for Logs [#1691](https://github.com/open-telemetry/opentelemetry-rust/pull/1691/)
       - The method OtlpLogPipeline::install_simple() and OtlpLogPipeline::install_batch() now return `LoggerProvider` instead of
       `Logger`. Refer to the [basic-otlp](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-otlp/examples/basic-otlp/src/main.rs) and [basic-otlp-http](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs) examples for how to initialize OTLP Log Exporter to use with OpenTelemetryLogBridge and OpenTelemetryTracingBridge respectively.
+- Update `opentelemetry` dependency version to 0.23
+- Update `opentelemetry_sdk` dependency version to 0.23
+- Update `opentelemetry-http` dependency version to 0.12
+- Update `opentelemetry-proto` dependency version to 0.6
+- Update `opentelemetry-semantic-conventions` dependency version to 0.15
 
 ## v0.15.0
 

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-otlp"
-version = "0.15.0"
+version = "0.16.0"
 description = "Exporter for the OpenTelemetry Collector"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp"
@@ -28,11 +28,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-trait = { workspace = true }
 futures-core = { workspace = true }
-opentelemetry = { version = "0.22", default-features = false, path = "../opentelemetry" }
-opentelemetry_sdk = { version = "0.22", default-features = false, path = "../opentelemetry-sdk" }
-opentelemetry-http = { version = "0.11", path = "../opentelemetry-http", optional = true }
-opentelemetry-proto = { version = "0.5", path = "../opentelemetry-proto", default-features = false }
-opentelemetry-semantic-conventions = { version = "0.14", path = "../opentelemetry-semantic-conventions" }
+opentelemetry = { version = "0.23", default-features = false, path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.23", default-features = false, path = "../opentelemetry-sdk" }
+opentelemetry-http = { version = "0.12", path = "../opentelemetry-http", optional = true }
+opentelemetry-proto = { version = "0.6", path = "../opentelemetry-proto", default-features = false }
+opentelemetry-semantic-conventions = { version = "0.15", path = "../opentelemetry-semantic-conventions" }
 
 prost = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }

--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## vNext
 
+## v0.16.0
+
 ### Added
 
 - Add `ResourceSelector` to allow attaching resource as attributes to metrics [#1608](https://github.com/open-telemetry/opentelemetry-rust/pull/1608)
+
+### Changed
+
+- Update `opentelemetry` dependency version to 0.23
+- Update `opentelemetry_sdk` dependency version to 0.23
 
 ## v0.15.0
 

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-prometheus"
-version = "0.15.0"
+version = "0.16.0"
 description = "Prometheus exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"
@@ -21,8 +21,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 once_cell = { workspace = true }
-opentelemetry = { version = "0.22", path = "../opentelemetry", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.22", path = "../opentelemetry-sdk", default-features = false, features = ["metrics"] }
+opentelemetry = { version = "0.23", path = "../opentelemetry", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.23", path = "../opentelemetry-sdk", default-features = false, features = ["metrics"] }
 prometheus = "0.13"
 protobuf = "2.14"
 

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## vNext
 
+## v0.6.0
+
 - Update protobuf definitions to v1.2.0 [#1668](https://github.com/open-telemetry/opentelemetry-rust/pull/1668)
 - Update protobuf definitions to v1.3.1 [#1721](https://github.com/open-telemetry/opentelemetry-rust/pull/1721)
+- Update `opentelemetry` dependency version to 0.23
+- Update `opentelemetry_sdk` dependency version to 0.23
 
 ## v0.5.0
 

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-proto"
-version = "0.5.0"
+version = "0.6.0"
 description = "Protobuf generated files and transformations."
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto"
@@ -50,8 +50,8 @@ with-serde = ["serde", "hex"]
 [dependencies]
 tonic = { workspace = true, optional = true, features = ["codegen", "prost"] }
 prost = { workspace = true, optional = true }
-opentelemetry = { version = "0.22", default-features = false, path = "../opentelemetry" }
-opentelemetry_sdk = { version = "0.22", default-features = false, path = "../opentelemetry-sdk" }
+opentelemetry = { version = "0.23", default-features = false, path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.23", default-features = false, path = "../opentelemetry-sdk" }
 schemars = { version = "0.8", optional = true }
 serde = { workspace = true, optional = true, features = ["serde_derive"] }
 hex = { version = "0.4.3", optional = true }

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.23.0
+
 - Fix SimpleSpanProcessor to be consistent with log counterpart. Also removed
   dependency on crossbeam-channel.
   [1612](https://github.com/open-telemetry/opentelemetry-rust/pull/1612/files)
@@ -31,6 +33,7 @@
 - **Breaking** [#1729](https://github.com/open-telemetry/opentelemetry-rust/pull/1729)
   - Update the return type of `TracerProvider.span_processors()` from `&Vec<Box<dyn SpanProcessor>>` to `&[Box<dyn SpanProcessor>]`.
   - Update the return type of `LoggerProvider.log_processors()` from `&Vec<Box<dyn LogProcessor>>` to `&[Box<dyn LogProcessor>]`.
+- Update `opentelemetry` dependency version to 0.23
 
 ## v0.22.1
 

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry_sdk"
-version = "0.22.1"
+version = "0.23.0"
 description = "The SDK for the OpenTelemetry metrics collection and distributed tracing framework"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"
@@ -10,7 +10,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-opentelemetry = { version = "0.22", path = "../opentelemetry/" }
+opentelemetry = { version = "0.23", path = "../opentelemetry/" }
 opentelemetry-http = { version = "0.11", path = "../opentelemetry-http", optional = true }
 async-std = { workspace = true, features = ["unstable"], optional = true }
 async-trait = { workspace = true, optional = true }

--- a/opentelemetry-semantic-conventions/CHANGELOG.md
+++ b/opentelemetry-semantic-conventions/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## vNext
 
+## v0.15.0
+
 ### Changed
 
 - Update to [v1.24.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.24.0) of the semantic conventions.
   [#1596](https://github.com/open-telemetry/opentelemetry-rust/pull/1596)
 - Update to [v1.25.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.25.0) of the semantic conventions.
   [#1681](https://github.com/open-telemetry/opentelemetry-rust/pull/1681)
+- Update `opentelemetry` dependency version to 0.23
+- Update `opentelemetry_sdk` dependency version to 0.23
 
 ## v0.14.0
 

--- a/opentelemetry-semantic-conventions/Cargo.toml
+++ b/opentelemetry-semantic-conventions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
+version = "0.15.0"
 description = "Semantic conventions for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-semantic-conventions"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-semantic-conventions"
@@ -20,5 +20,5 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
-opentelemetry = { version = "0.22", default-features = false, path = "../opentelemetry" } # for doctests
-opentelemetry_sdk = { version = "0.22", features = ["trace"], path = "../opentelemetry-sdk" } # for doctests
+opentelemetry = { version = "0.23", default-features = false, path = "../opentelemetry" } # for doctests
+opentelemetry_sdk = { version = "0.23", features = ["trace"], path = "../opentelemetry-sdk" } # for doctests

--- a/opentelemetry-stdout/CHANGELOG.md
+++ b/opentelemetry-stdout/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## vNext
 
+## v0.4.0
+
+### Changed
+
+- The default feature now includes logs, metrics and trace.
+- Update `opentelemetry` dependency version to 0.23
+- Update `opentelemetry_sdk` dependency version to 0.23
+
 ## v0.3.0
 
 ### Changed
@@ -9,7 +17,6 @@
 - Fix StatusCode in stdout exporter [#1454](https://github.com/open-telemetry/opentelemetry-rust/pull/1454)
 - Add missing event timestamps [#1391](https://github.com/open-telemetry/opentelemetry-rust/pull/1391)
 - Adjusted `chrono` features to reduce number of transitive dependencies. [#1569](https://github.com/open-telemetry/opentelemetry-rust/pull/1569)
-- The default feature now includes logs, metrics and trace.
 
 ## v0.2.0
 

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-stdout"
-version = "0.3.0"
+version = "0.4.0"
 description = "An OpenTelemetry exporter for stdout"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-stdout"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-stdout"
@@ -26,8 +26,8 @@ async-trait = { workspace = true, optional = true }
 chrono = { version = "0.4.34", default-features = false, features = ["now"] }
 thiserror = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
-opentelemetry = { version = "0.22", path = "../opentelemetry", default_features = false }
-opentelemetry_sdk = { version = "0.22", path = "../opentelemetry-sdk", default_features = false }
+opentelemetry = { version = "0.23", path = "../opentelemetry", default_features = false }
+opentelemetry_sdk = { version = "0.23", path = "../opentelemetry-sdk", default_features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 ordered-float = { workspace = true }

--- a/opentelemetry-zipkin/CHANGELOG.md
+++ b/opentelemetry-zipkin/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## vNext
 
+## v0.21.0
+
+### Changed
+
+- Update `opentelemetry` dependency version to 0.23
+- Update `opentelemetry_sdk` dependency version to 0.23
+- Update `opentelemetry-http` dependency version to 0.12
+- Update `opentelemetry-semantic-conventions` dependency version to 0.15
+
 ## v0.20.0
 
 ### Changed

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-zipkin"
-version = "0.20.0"
+version = "0.21.0"
 description = "Zipkin exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-zipkin"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-zipkin"
@@ -28,10 +28,10 @@ reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
 [dependencies]
 async-trait = { workspace = true }
 once_cell = { workspace = true }
-opentelemetry = { version = "0.22", path = "../opentelemetry" }
-opentelemetry_sdk = { version = "0.22", path = "../opentelemetry-sdk", features = ["trace"] }
-opentelemetry-http = { version = "0.11", path = "../opentelemetry-http" }
-opentelemetry-semantic-conventions = { version = "0.14", path = "../opentelemetry-semantic-conventions" }
+opentelemetry = { version = "0.23", path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.23", path = "../opentelemetry-sdk", features = ["trace"] }
+opentelemetry-http = { version = "0.12", path = "../opentelemetry-http" }
+opentelemetry-semantic-conventions = { version = "0.15", path = "../opentelemetry-semantic-conventions" }
 serde_json = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 typed-builder = "0.18"

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.23.0
+
 ### Added
 
 - [#1623](https://github.com/open-telemetry/opentelemetry-rust/pull/1623) Add global::meter_provider_shutdown

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry"
-version = "0.22.0"
+version = "0.23.0"
 description = "OpenTelemetry API for Rust"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"


### PR DESCRIPTION
Preparing the next release.
No change in overall [status](https://github.com/open-telemetry/opentelemetry-rust/tree/main?tab=readme-ov-file#project-status) and breaking changes are still expected in next release.

The next release, which is planned for June 30 2024, is expected to update status of [Logs](https://github.com/open-telemetry/opentelemetry-rust/issues/1733), [Metrics](https://github.com/open-telemetry/opentelemetry-rust/issues/1719) to Beta.

Opening as draft to discuss the below in next Community meeting on Tuesday May 14th 9 AM PT.
Blockers to discuss:
1. https://github.com/open-telemetry/opentelemetry-rust/issues/1679
2. In-flight or upcoming PRs that must be part of this release.

