### PR TITLE
Modify metrics example to shutdown without global shutdown method

### DIFF
--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -5,7 +5,7 @@ use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::{runtime, Resource};
 use std::error::Error;
 
-fn init_meter_provider() {
+fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
     let exporter = opentelemetry_stdout::MetricsExporterBuilder::default()
         // uncomment the below lines to pretty print output.
         //  .with_encoder(|writer, data|
@@ -19,13 +19,14 @@ fn init_meter_provider() {
             "metrics-basic-example",
         )]))
         .build();
-    global::set_meter_provider(provider);
+    global::set_meter_provider(provider.clone());
+    provider
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Initialize the MeterProvider with the stdout Exporter.
-    init_meter_provider();
+    let meter_provider = init_meter_provider();
 
     // Create a meter from the above MeterProvider.
     let meter = global::meter("mylibraryname");
@@ -137,6 +138,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Metrics are exported by default every 30 seconds when using stdout exporter,
     // however shutting down the MeterProvider here instantly flushes
     // the metrics, instead of waiting for the 30 sec interval.
-    global::shutdown_meter_provider();
+    // global::shutdown_meter_provider();
+    meter_provider.shutdown()?;
     Ok(())
 }


### PR DESCRIPTION
To see if we need to keep global::shutdown() for metrics.