### PR TITLE
Metrics examples to stop using global shutdown

### DIFF
--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -8,7 +8,7 @@ use opentelemetry_sdk::metrics::{
 use opentelemetry_sdk::{runtime, Resource};
 use std::error::Error;
 
-fn init_meter_provider() {
+fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
     // for example 1
     let my_view_rename_and_unit = |i: &Instrument| {
         if i.name == "my_histogram" {
@@ -61,12 +61,13 @@ fn init_meter_provider() {
         .with_view(my_view_drop_attributes)
         .with_view(my_view_change_aggregation)
         .build();
-    global::set_meter_provider(provider);
+    global::set_meter_provider(provider.clone());
+    provider
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    init_meter_provider();
+    let meter_provider = init_meter_provider();
     let meter = global::meter("mylibraryname");
 
     // Example 1 - Rename metric using View.
@@ -153,6 +154,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Metrics are exported by default every 30 seconds when using stdout exporter,
     // however shutting down the MeterProvider here instantly flushes
     // the metrics, instead of waiting for the 30 sec interval.
-    global::shutdown_meter_provider();
+    meter_provider.shutdown()?;
     Ok(())
 }

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -138,7 +138,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Metrics are exported by default every 30 seconds when using stdout exporter,
     // however shutting down the MeterProvider here instantly flushes
     // the metrics, instead of waiting for the 30 sec interval.
-    // global::shutdown_meter_provider();
     meter_provider.shutdown()?;
     Ok(())
 }

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -397,13 +397,13 @@ mod tests {
         let provider = super::SdkMeterProvider::builder()
             .with_reader(reader.clone())
             .build();
-        global::set_meter_provider(provider);
+        global::set_meter_provider(provider.clone());
         assert!(!reader.is_shutdown());
         // create a meter and an instrument
         let meter = global::meter("test");
         let counter = meter.u64_counter("test_counter").init();
         // no need to drop a meter for meter_provider shutdown
-        global::shutdown_meter_provider();
+        provider.shutdown().unwrap();
         assert!(reader.is_shutdown());
         // TODO Fix: the instrument is still available, and can be used.
         // While the reader is shutdown, and no collect is happening


### PR DESCRIPTION
Continuing from https://github.com/open-telemetry/opentelemetry-rust/pull/1739.
Looks like we can remove the global:shutdown for metrics and resolve https://github.com/open-telemetry/opentelemetry-rust/issues/1679 in the next PR?