### PR TITLE
Fix feature flags

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -7,6 +7,7 @@
 - URL encoded values in `OTEL_EXPORTER_OTLP_HEADERS` are now correctly decoded. [#1578](https://github.com/open-telemetry/opentelemetry-rust/pull/1578)
 - OTLP exporter will not change the URL added through `ExportConfig` [#1706](https://github.com/open-telemetry/opentelemetry-rust/pull/1706)
 - Default grpc endpoint will not have path based on signal(e.g `/v1/traces`) [#1706](https://github.com/open-telemetry/opentelemetry-rust/pull/1706)
+- Fix feature flags for `OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT` [#1746](https://github.com/open-telemetry/opentelemetry-rust/pull/1746)
 
 ### Added
 

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -31,10 +31,7 @@ pub const OTEL_EXPORTER_OTLP_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_COMPRESSION
 #[cfg(feature = "http-json")]
 /// Default protocol, using http-json.
 pub const OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT: &str = OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_JSON;
-#[cfg(all(
-    feature = "http-proto",
-    not(any(feature = "grpc-tonic", feature = "http-json"))
-))]
+#[cfg(all(feature = "http-proto", not(feature = "http-json")))]
 /// Default protocol, using http-proto.
 pub const OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT: &str = OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF;
 #[cfg(all(

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update protobuf definitions to v1.2.0 [#1668](https://github.com/open-telemetry/opentelemetry-rust/pull/1668)
 - Update protobuf definitions to v1.3.1 [#1721](https://github.com/open-telemetry/opentelemetry-rust/pull/1721)
+- Fix the feature flag condition of `opentelemetry-proto/src/transform/logs.rs` [#1746](https://github.com/open-telemetry/opentelemetry-rust/pull/1746)
 
 ## v0.5.0
 

--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "gen-tonic")]
+#[cfg(feature = "gen-tonic-messages")]
 pub mod tonic {
     use crate::{
         tonic::{


### PR DESCRIPTION
# Fixes

Fix feature flags of opentelemetry-otlp and opentelemetry-proto.

```sh
$ cargo check -p opentelemetry-otlp -F http-proto
    Checking opentelemetry-otlp v0.15.0 (/home/SENSETIME/jiangshenghu1/opentelemetry-rust/opentelemetry-otlp)
error[E0432]: unresolved import `crate::exporter::OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT`
   --> opentelemetry-otlp/src/lib.rs:247:5
    |
247 |     OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT, OTEL_EXPORTER_OTLP_TIMEOUT,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
    |     no `OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT` in `exporter`
    |     help: a similar name exists in the module: `OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT`
    |
...
```

```sh
$ cargo check -p opentelemetry-otlp --no-default-features -F http-json,logs
    Checking opentelemetry-otlp v0.15.0 (/home/SENSETIME/jiangshenghu1/opentelemetry-rust/opentelemetry-otlp)
error[E0277]: the trait bound `ResourceLogs: From<(LogData, &ResourceAttributesWithSchema)>` is not satisfied
   --> opentelemetry-otlp/src/exporter/http/mod.rs:335:52
    |
335 |             .map(|log_event| (log_event, resource).into())
    |                                                    ^^^^ the trait `From<(LogData, &ResourceAttributesWithSchema)>` is not implemented for `ResourceLogs`, which is required by `(LogData, &ResourceAttributesWithSchema): Into<_>`
    |
    = note: required for `(LogData, &ResourceAttributesWithSchema)` to implement `Into<ResourceLogs>`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `opentelemetry-otlp` (lib) due to 1 previous error
```

## Changes

- Update compilation conditions of `OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT` in `opentelemetry-otlp/src/exporter/mod.rs` to fix `cargo check -p opentelemetry-otlp -F http-proto`.
- Change the feature flag condition of `opentelemetry-proto/src/transform/logs.rs` from `gen-tonic` to `gen-tonic-messages` to fix `cargo check -p opentelemetry-otlp --no-default-features -F http-json,logs`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* Unit tests added/updated (if applicable)
  * Related to building. `cargo-all-features` can be added to CI to check with different combinations of feature flags.
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* Changes in public API reviewed (if applicable)
  * No change in public API.