### PR TITLE
Modify loggerprovider shutdown, flush to return single Result and handle repeat shutdown calls

### DIFF
--- a/opentelemetry-appender-log/examples/logs-basic.rs
+++ b/opentelemetry-appender-log/examples/logs-basic.rs
@@ -32,5 +32,5 @@ async fn main() {
     warn!("warn!");
     info!("test log!");
 
-    logger_provider.force_flush();
+    let _ = logger_provider.shutdown();
 }

--- a/opentelemetry-appender-tracing/examples/basic.rs
+++ b/opentelemetry-appender-tracing/examples/basic.rs
@@ -24,5 +24,5 @@ fn main() {
     tracing_subscriber::registry().with(layer).init();
 
     error!(name: "my-event-name", target: "my-system", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
-    drop(provider);
+    let _ = provider.shutdown();
 }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,6 +1,6 @@
 use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    Key,
+    Key, KeyValue,
 };
 use std::borrow::Cow;
 use tracing_core::{Level, Metadata};
@@ -143,6 +143,7 @@ where
             logger: provider
                 .logger_builder(INSTRUMENTATION_LIBRARY_NAME)
                 .with_version(Cow::Borrowed(env!("CARGO_PKG_VERSION")))
+                
                 .build(),
             _phantom: Default::default(),
         }
@@ -235,7 +236,7 @@ mod tests {
 
         // Act
         error!(name: "my-event-name", target: "my-system", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
-        let _ = logger_provider.force_flush();
+        logger_provider.force_flush();
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter
@@ -315,7 +316,7 @@ mod tests {
             (trace_id, span_id)
         });
 
-        let _ = logger_provider.force_flush();
+        logger_provider.force_flush();
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter
@@ -399,7 +400,7 @@ mod tests {
 
         // Act
         log::error!("log from log crate");
-        let _ = logger_provider.force_flush();
+        logger_provider.force_flush();
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter
@@ -479,7 +480,7 @@ mod tests {
             (trace_id, span_id)
         });
 
-        let _ = logger_provider.force_flush();
+        logger_provider.force_flush();
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -235,7 +235,7 @@ mod tests {
 
         // Act
         error!(name: "my-event-name", target: "my-system", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
-        logger_provider.force_flush();
+        let _ = logger_provider.force_flush();
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter
@@ -315,7 +315,7 @@ mod tests {
             (trace_id, span_id)
         });
 
-        logger_provider.force_flush();
+        let _ = logger_provider.force_flush();
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter
@@ -399,7 +399,7 @@ mod tests {
 
         // Act
         log::error!("log from log crate");
-        logger_provider.force_flush();
+        let _ = logger_provider.force_flush();
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter
@@ -479,7 +479,7 @@ mod tests {
             (trace_id, span_id)
         });
 
-        logger_provider.force_flush();
+        let _ = logger_provider.force_flush();
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,6 +1,6 @@
 use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    Key, KeyValue,
+    Key,
 };
 use std::borrow::Cow;
 use tracing_core::{Level, Metadata};
@@ -143,7 +143,6 @@ where
             logger: provider
                 .logger_builder(INSTRUMENTATION_LIBRARY_NAME)
                 .with_version(Cow::Borrowed(env!("CARGO_PKG_VERSION")))
-                
                 .build(),
             _phantom: Default::default(),
         }

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -33,7 +33,6 @@
   - Update the return type of `LoggerProvider.log_processors()` from `&Vec<Box<dyn LogProcessor>>` to `&[Box<dyn LogProcessor>]`.
 - **Breaking** [#1750](https://github.com/open-telemetry/opentelemetry-rust/pull/1729)
   - Update the return type of `LoggerProvider.shutdown()` from `Vec<LogResult<()>>` to `LogResult<()>`.
-  - Update the return type of `LoggerProvider.force_flush()` from `Vec<LogResult<()>>` to `LogResult<()>`.
 
 ## v0.22.1
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -31,6 +31,9 @@
 - **Breaking** [#1729](https://github.com/open-telemetry/opentelemetry-rust/pull/1729)
   - Update the return type of `TracerProvider.span_processors()` from `&Vec<Box<dyn SpanProcessor>>` to `&[Box<dyn SpanProcessor>]`.
   - Update the return type of `LoggerProvider.log_processors()` from `&Vec<Box<dyn LogProcessor>>` to `&[Box<dyn LogProcessor>]`.
+- **Breaking** [#1750](https://github.com/open-telemetry/opentelemetry-rust/pull/1729)
+  - Update the return type of `LoggerProvider.shutdown()` from `Vec<LogResult<()>>` to `LogResult<()>`.
+  - Update the return type of `LoggerProvider.force_flush()` from `Vec<LogResult<()>>` to `LogResult<()>`.
 
 ## v0.22.1
 

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -4,8 +4,8 @@ use crate::{
     runtime::RuntimeChannel,
 };
 use opentelemetry::{
-    global::{self},
-    logs::LogResult,
+    global,
+    logs::{LogError, LogResult},
     trace::TraceContextExt,
     Context, InstrumentationLibrary,
 };
@@ -13,7 +13,10 @@ use opentelemetry::{
 #[cfg(feature = "logs_level_enabled")]
 use opentelemetry::logs::Severity;
 
-use std::{borrow::Cow, sync::Arc};
+use std::{
+    borrow::Cow,
+    sync::{atomic::Ordering, Arc},
+};
 use std::{sync::atomic::AtomicBool, time::SystemTime};
 
 use once_cell::sync::Lazy;
@@ -97,25 +100,46 @@ impl LoggerProvider {
     }
 
     /// Force flush all remaining logs in log processors and return results.
-    pub fn force_flush(&self) -> Vec<LogResult<()>> {
-        self.log_processors()
-            .iter()
-            .map(|processor| processor.force_flush())
-            .collect()
+    pub fn force_flush(&self) -> LogResult<()> {
+        // propagate force_flush to processors
+        let mut errs = vec![];
+        for processor in &self.inner.processors {
+            if let Err(err) = processor.force_flush() {
+                errs.push(err);
+            }
+        }
+
+        if errs.is_empty() {
+            Ok(())
+        } else {
+            Err(LogError::Other(format!("{errs:?}").into()))
+        }
     }
 
     /// Shuts down this `LoggerProvider`
-    pub fn shutdown(&self) -> Vec<LogResult<()>> {
-        // mark itself as already shutdown
-        self.is_shutdown
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-        // propagate the shutdown signal to processors
-        // it's up to the processor to properly block new logs after shutdown
-        self.inner
-            .processors
-            .iter()
-            .map(|processor| processor.shutdown())
-            .collect()
+    pub fn shutdown(&self) -> LogResult<()> {
+        if self
+            .is_shutdown
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            // propagate the shutdown signal to processors
+            // it's up to the processor to properly block new logs after shutdown
+            let mut errs = vec![];
+            for processor in &self.inner.processors {
+                if let Err(err) = processor.shutdown() {
+                    errs.push(err);
+                }
+            }
+
+            if errs.is_empty() {
+                Ok(())
+            } else {
+                Err(LogError::Other(format!("{errs:?}").into()))
+            }
+        } else {
+            Err(LogError::Other("logger provider already shut down".into()))
+        }
     }
 }
 
@@ -486,6 +510,25 @@ mod tests {
     }
 
     #[test]
+    fn shutdown_idempotent_test() {
+        let counter = Arc::new(AtomicU64::new(0));
+        let logger_provider = LoggerProvider::builder()
+            .with_log_processor(ShutdownTestLogProcessor::new(counter.clone()))
+            .build();
+
+        let shutdown_res = logger_provider.shutdown();
+        assert!(shutdown_res.is_ok());
+
+        // Subsequent shutdowns should return an error.
+        let shutdown_res = logger_provider.shutdown();
+        assert!(shutdown_res.is_err());
+
+        // Subsequent shutdowns should return an error.
+        let shutdown_res = logger_provider.shutdown();
+        assert!(shutdown_res.is_err());
+    }
+
+    #[test]
     fn global_shutdown_test() {
         // cargo test shutdown_test --features=logs
 
@@ -508,7 +551,7 @@ mod tests {
 
         // explicitly calling shutdown on logger_provider. This will
         // indeed do the shutdown, even if there are loggers still alive.
-        logger_provider.shutdown();
+        let _ = logger_provider.shutdown();
 
         // Assert
 

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -100,20 +100,11 @@ impl LoggerProvider {
     }
 
     /// Force flush all remaining logs in log processors and return results.
-    pub fn force_flush(&self) -> LogResult<()> {
-        // propagate force_flush to processors
-        let mut errs = vec![];
-        for processor in &self.inner.processors {
-            if let Err(err) = processor.force_flush() {
-                errs.push(err);
-            }
-        }
-
-        if errs.is_empty() {
-            Ok(())
-        } else {
-            Err(LogError::Other(format!("{errs:?}").into()))
-        }
+    pub fn force_flush(&self) -> Vec<LogResult<()>> {
+        self.log_processors()
+            .iter()
+            .map(|processor| processor.force_flush())
+            .collect()
     }
 
     /// Shuts down this `LoggerProvider`

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -729,7 +729,7 @@ mod tests {
             ])))
             .build();
         assert_eq!(exporter.get_resource().unwrap().into_iter().count(), 4);
-        provider.shutdown();
+        let _ = provider.shutdown();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     meter_provider.shutdown()?;
 
     #[cfg(feature = "logs")]
-    drop(logger_provider);
+    logger_provider.shutdown()?;
 
     Ok(())
 }


### PR DESCRIPTION
This is consistent with Metrics shutdown.
The overall result contains formatted version of combined errors, if any.
Added test to validate that repeated shutdown calls are handled.