### PR TITLE
Show working example for OTLP Http

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -9,11 +9,10 @@ publish = false
 once_cell = { workspace = true }
 opentelemetry = { path = "../../../opentelemetry" }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "metrics", "logs"] }
-opentelemetry-otlp = { path = "../..", features = ["http-proto", "http-json", "reqwest-client", "logs"] }
+opentelemetry-otlp = { path = "../..", features = ["http-proto", "reqwest-client", "logs"] }
 opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}
 opentelemetry-semantic-conventions = { path = "../../../opentelemetry-semantic-conventions" }
 
 tokio = { workspace = true, features = ["full"] }
-tracing-subscriber = { workspace = true, features = ["registry", "std"] }
-tracing = { workspace = true, features = ["std"] }
-tracing-core = { workspace = true }
+opentelemetry-appender-log = { path = "../../../opentelemetry-appender-log", default-features = false}
+log = { workspace = true }

--- a/opentelemetry-otlp/examples/basic-otlp-http/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp-http/README.md
@@ -2,9 +2,9 @@
 
 This example shows how to setup OpenTelemetry OTLP exporter for logs, metrics
 and traces to exports them to the [OpenTelemetry
-Collector](https://github.com/open-telemetry/opentelemetry-collector) via OTLP over HTTP.
-The Collector then sends the data to the appropriate backend, in this case,
-the logging Exporter, which displays data to console.
+Collector](https://github.com/open-telemetry/opentelemetry-collector) via OTLP
+over HTTP/protobuf. The Collector then sends the data to the appropriate
+backend, in this case, the logging Exporter, which displays data to console.
 
 ## Usage
 
@@ -47,203 +47,124 @@ You should be able to see something similar below with different time and ID in 
 ### Span
 
 ```text
-2023-09-08T21:50:35.884Z        info    ResourceSpans #0
+...
+2024-05-14T02:15:56.827Z        info    ResourceSpans #0
 Resource SchemaURL:
 Resource attributes:
-     -> service.name: Str(basic-otlp-tracing-example)
+     -> service.name: Str(basic-otlp-example)
 ScopeSpans #0
 ScopeSpans SchemaURL:
-InstrumentationScope ex.com/basic
+InstrumentationScope basic
+InstrumentationScope attributes:
+     -> scope-key: Str(scope-value)
 Span #0
-    Trace ID       : f8e7ea4dcab43689cea14f708309d682
-    Parent ID      : 8b560e2e7238eab5
-    ID             : 9e36b48dc07b32fe
+    Trace ID       : 4467894e2d8d0c4165df1218160bc260
+    Parent ID      : 589ea953b6ec03a9
+    ID             : b2aa3c3a9c21e0d0
     Name           : Sub operation...
     Kind           : Internal
-    Start time     : 2023-09-08 21:50:35.872800345 +0000 UTC
-    End time       : 2023-09-08 21:50:35.87282574 +0000 UTC
+    Start time     : 2024-05-14 02:15:56.824239163 +0000 UTC
+    End time       : 2024-05-14 02:15:56.824244315 +0000 UTC
     Status code    : Unset
     Status message :
 Attributes:
-     -> lemons: Str(five)
+     -> another.key: Str(yes)
 Events:
 SpanEvent #0
      -> Name: Sub span event
-     -> Timestamp: 2023-09-08 21:50:35.872808684 +0000 UTC
+     -> Timestamp: 2024-05-14 02:15:56.82424188 +0000 UTC
      -> DroppedAttributesCount: 0
 ResourceSpans #1
 Resource SchemaURL:
 Resource attributes:
-     -> service.name: Str(basic-otlp-tracing-example)
+     -> service.name: Str(basic-otlp-example)
 ScopeSpans #0
 ScopeSpans SchemaURL:
-InstrumentationScope ex.com/basic
+InstrumentationScope basic
+InstrumentationScope attributes:
+     -> scope-key: Str(scope-value)
 Span #0
-    Trace ID       : f8e7ea4dcab43689cea14f708309d682
+    Trace ID       : 4467894e2d8d0c4165df1218160bc260
     Parent ID      :
-    ID             : 8b560e2e7238eab5
-    Name           : operation
+    ID             : 589ea953b6ec03a9
+    Name           : Main operation
     Kind           : Internal
-    Start time     : 2023-09-08 21:50:35.872735497 +0000 UTC
-    End time       : 2023-09-08 21:50:35.872832026 +0000 UTC
+    Start time     : 2024-05-14 02:15:56.824194899 +0000 UTC
+    End time       : 2024-05-14 02:15:56.824251136 +0000 UTC
     Status code    : Unset
     Status message :
 Attributes:
-     -> ex.com/another: Str(yes)
+     -> another.key: Str(yes)
 Events:
 SpanEvent #0
      -> Name: Nice operation!
-     -> Timestamp: 2023-09-08 21:50:35.872750123 +0000 UTC
+     -> Timestamp: 2024-05-14 02:15:56.824201397 +0000 UTC
      -> DroppedAttributesCount: 0
      -> Attributes::
           -> bogons: Int(100)
         {"kind": "exporter", "data_type": "traces", "name": "logging"}
+...
 ```
 
 ### Metric
 
 ```text
-2023-09-08T19:14:12.522Z        info    ResourceMetrics #0
+...
+2024-05-14T02:15:56.827Z        info    ResourceMetrics #0
 Resource SchemaURL:
 Resource attributes:
-     -> service.name: Str(basic-otlp-metrics-example)
+     -> service.name: Str(basic-otlp-example)
 ScopeMetrics #0
-ScopeMetrics SchemaURL:
-InstrumentationScope ex.com/basic
+ScopeMetrics SchemaURL: schema_url
+InstrumentationScope basic v1.0
+InstrumentationScope attributes:
+     -> scope-key: Str(scope-value)
 Metric #0
 Descriptor:
-     -> Name: ex.com.one
-     -> Description: A gauge set to 1.0
-     -> Unit:
-     -> DataType: Gauge
+     -> Name: test_counter
+     -> Description: a simple counter for demo purposes.
+     -> Unit: my_unit
+     -> DataType: Sum
+     -> IsMonotonic: true
+     -> AggregationTemporality: Cumulative
 NumberDataPoints #0
 Data point attributes:
-     -> A: Str(1)
-     -> B: Str(2)
-     -> C: Str(3)
-     -> lemons: Int(10)
-StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
-Timestamp: 2023-09-08 19:14:12.468030127 +0000 UTC
-Value: 1.000000
-Metric #1
-Descriptor:
-     -> Name: ex.com.two
-     -> Description:
-     -> Unit:
-     -> DataType: Histogram
-     -> AggregationTemporality: Cumulative
-HistogramDataPoints #0
-Data point attributes:
-     -> A: Str(1)
-     -> B: Str(2)
-     -> C: Str(3)
-     -> lemons: Int(10)
-StartTimestamp: 2023-09-08 19:14:12.466896812 +0000 UTC
-Timestamp: 2023-09-08 19:14:12.468052807 +0000 UTC
-Count: 1
-Sum: 5.500000
-Min: 5.500000
-Max: 5.500000
-ExplicitBounds #0: 0.000000
-ExplicitBounds #1: 5.000000
-ExplicitBounds #2: 10.000000
-ExplicitBounds #3: 25.000000
-ExplicitBounds #4: 50.000000
-ExplicitBounds #5: 75.000000
-ExplicitBounds #6: 100.000000
-ExplicitBounds #7: 250.000000
-ExplicitBounds #8: 500.000000
-ExplicitBounds #9: 750.000000
-ExplicitBounds #10: 1000.000000
-ExplicitBounds #11: 2500.000000
-ExplicitBounds #12: 5000.000000
-ExplicitBounds #13: 7500.000000
-ExplicitBounds #14: 10000.000000
-Buckets #0, Count: 0
-Buckets #1, Count: 0
-Buckets #2, Count: 1
-Buckets #3, Count: 0
-Buckets #4, Count: 0
-Buckets #5, Count: 0
-Buckets #6, Count: 0
-Buckets #7, Count: 0
-Buckets #8, Count: 0
-Buckets #9, Count: 0
-Buckets #10, Count: 0
-Buckets #11, Count: 0
-Buckets #12, Count: 0
-Buckets #13, Count: 0
-Buckets #14, Count: 0
-Buckets #15, Count: 0
-HistogramDataPoints #1
-StartTimestamp: 2023-09-08 19:14:12.466896812 +0000 UTC
-Timestamp: 2023-09-08 19:14:12.468052807 +0000 UTC
-Count: 1
-Sum: 1.300000
-Min: 1.300000
-Max: 1.300000
-ExplicitBounds #0: 0.000000
-ExplicitBounds #1: 5.000000
-ExplicitBounds #2: 10.000000
-ExplicitBounds #3: 25.000000
-ExplicitBounds #4: 50.000000
-ExplicitBounds #5: 75.000000
-ExplicitBounds #6: 100.000000
-ExplicitBounds #7: 250.000000
-ExplicitBounds #8: 500.000000
-ExplicitBounds #9: 750.000000
-ExplicitBounds #10: 1000.000000
-ExplicitBounds #11: 2500.000000
-ExplicitBounds #12: 5000.000000
-ExplicitBounds #13: 7500.000000
-ExplicitBounds #14: 10000.000000
-Buckets #0, Count: 0
-Buckets #1, Count: 1
-Buckets #2, Count: 0
-Buckets #3, Count: 0
-Buckets #4, Count: 0
-Buckets #5, Count: 0
-Buckets #6, Count: 0
-Buckets #7, Count: 0
-Buckets #8, Count: 0
-Buckets #9, Count: 0
-Buckets #10, Count: 0
-Buckets #11, Count: 0
-Buckets #12, Count: 0
-Buckets #13, Count: 0
-Buckets #14, Count: 0
-Buckets #15, Count: 0
-        {"kind": "exporter", "data_type": "metrics", "name": "logging"}
+     -> test_key: Str(test_value)
+StartTimestamp: 2024-05-14 02:15:56.824127393 +0000 UTC
+Timestamp: 2024-05-14 02:15:56.825354918 +0000 UTC
+Value: 11
+...
 ```
 
 ### Logs
 
 ```text
-2023-09-08T21:50:35.884Z        info    ResourceLog #0
+...
+2024-05-14T02:15:56.828Z        info    ResourceLog #0
 Resource SchemaURL:
 Resource attributes:
-     -> service.name: Str(basic-otlp-logging-example)
+     -> service.name: Str(basic-otlp-example)
 ScopeLogs #0
 ScopeLogs SchemaURL:
-InstrumentationScope opentelemetry-log-appender 0.1.0
+InstrumentationScope opentelemetry-log-appender 0.3.0
 LogRecord #0
-ObservedTimestamp: 2023-09-08 21:50:35.872759168 +0000 UTC
+ObservedTimestamp: 2024-05-14 02:15:56.824218088 +0000 UTC
 Timestamp: 1970-01-01 00:00:00 +0000 UTC
 SeverityText: INFO
 SeverityNumber: Info(9)
 Body: Str(hello from banana. My price is 2.99. I am also inside a Span!)
-Trace ID: f8e7ea4dcab43689cea14f708309d682
-Span ID: 8b560e2e7238eab5
+Trace ID: 4467894e2d8d0c4165df1218160bc260
+Span ID: 589ea953b6ec03a9
 Flags: 1
 ResourceLog #1
 Resource SchemaURL:
 Resource attributes:
-     -> service.name: Str(basic-otlp-logging-example)
+     -> service.name: Str(basic-otlp-example)
 ScopeLogs #0
 ScopeLogs SchemaURL:
-InstrumentationScope opentelemetry-log-appender 0.1.0
+InstrumentationScope opentelemetry-log-appender 0.3.0
 LogRecord #0
-ObservedTimestamp: 2023-09-08 21:50:35.872833713 +0000 UTC
+ObservedTimestamp: 2024-05-14 02:15:56.824254268 +0000 UTC
 Timestamp: 1970-01-01 00:00:00 +0000 UTC
 SeverityText: INFO
 SeverityNumber: Info(9)
@@ -251,4 +172,5 @@ Body: Str(hello from apple. My price is 1.99)
 Trace ID:
 Span ID:
 Flags: 0
+...
 ```

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -7,7 +7,7 @@
 //! order to support open-source telemetry data formats (e.g. Jaeger,
 //! Prometheus, etc.) sending to multiple open-source or commercial back-ends.
 //!
-//! Currently, this crate only support sending tracing data or metrics in OTLP
+//! Currently, this crate only support sending telemetry in OTLP
 //! via grpc and http (in binary format). Supports for other format and protocol
 //! will be added in the future. The details of what's currently offering in this
 //! crate can be found in this doc.
@@ -18,7 +18,7 @@
 //! you want to send data to:
 //!
 //! ```shell
-//! $ docker run -p 4317:4317 otel/opentelemetry-collector-dev:latest
+//! $ docker run -p 4317:4317 otel/opentelemetry-collector:latest
 //! ```
 //!
 //! Then install a new pipeline with the recommended defaults to start exporting


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-rust/issues/1659
Based on https://github.com/open-telemetry/opentelemetry-rust/pull/1752#issuecomment-2109116504, the example for otlp-http is modified to use HTTP/protobuf instead of json.
Also modified the example to use log appenger instead of tracing appender, as `tracing` causes https://github.com/open-telemetry/opentelemetry-rust/issues/761, and cannot be used without fixing.