### PR TITLE
Add macos-latest in CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         # test both stable and beta versions of Rust on ubuntu-latest
         os: [ubuntu-latest]
         rust: [stable, beta]
-        # test only stable version of Rust on Windows
+        # test only stable version of Rust on Windows and MacOS
         include:
           - rust: stable
-            os: windows-latest
+            os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Free disk space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
         # test only stable version of Rust on Windows and MacOS
         include:
           - rust: stable
-            os: [windows-latest, macos-latest]
+            os: windows-latest
+          - rust: stable
+            os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
     - name: Free disk space


### PR DESCRIPTION
## Changes

Noticed that we are not testing on `macos-latest`, so added a test on it with the stable version of Rust. Keeping it lean, and not adding for msrv and others (unless it is recommended)

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
