### PR TITLE
Add http-json warning to OTLP Exporter

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -11,10 +11,6 @@
 
 ### Added
 
-- Aded `http/json` support for all signals ([#1585])
-
-[#1585]: https://github.com/open-telemetry/opentelemetry-rust/pull/1585
-
 - Added `DeltaTemporalitySelector` ([#1568])
 - Add `webkpi-roots` features to `reqwest` and `tonic` backends
 

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -72,7 +72,7 @@ tls-webkpi-roots = ["tls", "tonic/tls-webpki-roots"]
 
 # http binary
 http-proto = ["prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "http", "trace", "metrics"]
-# http json
+# http json This does not work today due to known issue. See https://github.com/open-telemetry/opentelemetry-rust/issues/1763.
 http-json = ["serde_json", "prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "opentelemetry-proto/with-serde", "http", "trace", "metrics"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -102,7 +102,6 @@
 //! The following feature flags offer additional configurations on http:
 //!
 //! * `http-proto`: Use http as transport layer, protobuf as body format.
-//! * `http-json`: Use http as transport layer, JSON as body format.
 //! * `reqwest-blocking-client`: Use reqwest blocking http client.
 //! * `reqwest-client`: Use reqwest http client.
 //! * `reqwest-rustls`: Use reqwest with TLS with system trust roots via `rustls-native-certs` crate.


### PR DESCRIPTION
Supersedes https://github.com/open-telemetry/opentelemetry-rust/pull/1764. 
This removes the changelog and removed the doc, so the feature is not popularized. This is to unblock https://github.com/open-telemetry/opentelemetry-rust/pull/1738 release.