### PR TITLE
Fix periodic reader to trigger first exporter at the interval

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp-http/README.md
@@ -36,14 +36,14 @@ On Unix based systems use:
 
 ```shell
 # From the current directory, run `opentelemetry-collector`
-docker run --rm -it -p 4317:4317 -v $(pwd):/cfg otel/opentelemetry-collector:latest --config=/cfg/otel-collector-config.yaml
+docker run --rm -it -p 4318:4318 -v $(pwd):/cfg otel/opentelemetry-collector:latest --config=/cfg/otel-collector-config.yaml
 ```
 
 On Windows use:
 
 ```shell
 # From the current directory, run `opentelemetry-collector`
-docker run --rm -it -p 4317:4317 -v "%cd%":/cfg otel/opentelemetry-collector:latest --config=/cfg/otel-collector-config.yaml
+docker run --rm -it -p 4318:4318 -v "%cd%":/cfg otel/opentelemetry-collector:latest --config=/cfg/otel-collector-config.yaml
 ```
 
 Run the app which exports logs, metrics and traces via OTLP to the collector

--- a/opentelemetry-otlp/examples/basic-otlp-http/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp-http/README.md
@@ -32,12 +32,24 @@ docker-compose down
 If you don't want to use `docker-compose`, you can manually run the `otel/opentelemetry-collector` container
 and inspect the logs to see traces being transferred.
 
+On Unix based systems use:
+
 ```shell
 # From the current directory, run `opentelemetry-collector`
-$ docker run --rm -it -p 4318:4318 -v $(pwd):/cfg otel/opentelemetry-collector:latest --config=/cfg/otel-collector-config.yaml
+docker run --rm -it -p 4317:4317 -v $(pwd):/cfg otel/opentelemetry-collector:latest --config=/cfg/otel-collector-config.yaml
+```
 
-# Run the app which exports logs, metrics and traces via OTLP to the collector.
-$ cargo run
+On Windows use:
+
+```shell
+# From the current directory, run `opentelemetry-collector`
+docker run --rm -it -p 4317:4317 -v "%cd%":/cfg otel/opentelemetry-collector:latest --config=/cfg/otel-collector-config.yaml
+```
+
+Run the app which exports logs, metrics and traces via OTLP to the collector
+
+```shell
+cargo run
 ```
 
 ## View results

--- a/opentelemetry-otlp/examples/basic-otlp/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp/README.md
@@ -32,12 +32,24 @@ docker-compose down
 If you don't want to use `docker-compose`, you can manually run the `otel/opentelemetry-collector` container
 and inspect the logs to see traces being transferred.
 
+On Unix based systems use:
+
 ```shell
 # From the current directory, run `opentelemetry-collector`
-$ docker run --rm -it -p 4317:4317 -v $(pwd):/cfg otel/opentelemetry-collector:latest --config=/cfg/otel-collector-config.yaml
+docker run --rm -it -p 4317:4317 -v $(pwd):/cfg otel/opentelemetry-collector:latest --config=/cfg/otel-collector-config.yaml
+```
 
-# Run the app which exports logs, metrics and traces via OTLP to the collector.
-$ cargo run
+On Windows use:
+
+```shell
+# From the current directory, run `opentelemetry-collector`
+docker run --rm -it -p 4317:4317 -v "%cd%":/cfg otel/opentelemetry-collector:latest --config=/cfg/otel-collector-config.yaml
+```
+
+Run the app which exports logs, metrics and traces via OTLP to the collector
+
+```shell
+cargo run
 ```
 
 ## View results

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -114,7 +114,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     for _ in 0..10 {
         counter.add(1, &[KeyValue::new("test_key", "test_value")]);
     }
-    counter.add(1, &[KeyValue::new("test_key", "test_value")]);
 
     tracer.in_span("Main operation", |cx| {
         let span = cx.span();

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -7,6 +7,9 @@
   [1612](https://github.com/open-telemetry/opentelemetry-rust/pull/1612/files)
 - [#1422](https://github.com/open-telemetry/opentelemetry-rust/pull/1422)
   Fix metrics aggregation bug when using Views to drop attributes.
+- [#1766](https://github.com/open-telemetry/opentelemetry-rust/pull/1766)
+  Fix Metrics PeriodicReader to trigger first collect/export at the first interval
+  instead of doing it right away.
 - [#1623](https://github.com/open-telemetry/opentelemetry-rust/pull/1623) Add Drop implementation for SdkMeterProvider,
   which shuts down metricreaders, thereby allowing metrics still in memory to be flushed out.
 - **Breaking** [#1624](https://github.com/open-telemetry/opentelemetry-rust/pull/1624) Remove `OsResourceDetector` and

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -268,20 +268,17 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
     async fn process_message(&mut self, message: Message) -> bool {
         match message {
             Message::Export => {
-                println!("Export called");
                 if let Err(err) = self.collect_and_export().await {
                     global::handle_error(err)
                 }
             }
             Message::Flush(ch) => {
-                println!("Flush called");
                 let res = self.collect_and_export().await;
                 if ch.send(res).is_err() {
                     global::handle_error(MetricsError::Other("flush channel closed".into()))
                 }
             }
             Message::Shutdown(ch) => {
-                println!("Shutdown called");
                 let res = self.collect_and_export().await;
                 let _ = self.reader.exporter.shutdown();
                 if ch.send(res).is_err() {

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -132,6 +132,7 @@ where
             let ticker = self
                 .runtime
                 .interval(self.interval)
+                .skip(1) // The ticker is fired immediately, so we should skip the first one to align with the interval.
                 .map(|_| Message::Export);
 
             let messages = Box::pin(stream::select(message_receiver, ticker));
@@ -267,17 +268,20 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
     async fn process_message(&mut self, message: Message) -> bool {
         match message {
             Message::Export => {
+                println!("Export called");
                 if let Err(err) = self.collect_and_export().await {
                     global::handle_error(err)
                 }
             }
             Message::Flush(ch) => {
+                println!("Flush called");
                 let res = self.collect_and_export().await;
                 if ch.send(res).is_err() {
                     global::handle_error(MetricsError::Other("flush channel closed".into()))
                 }
             }
             Message::Shutdown(ch) => {
+                println!("Shutdown called");
                 let res = self.collect_and_export().await;
                 let _ = self.reader.exporter.shutdown();
                 if ch.send(res).is_err() {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-rust/issues/1559

`PeriodicReader` makes the first export right away, instead of waiting for the interval. This is mostly unobservable/no-impact in real systems, but this is causing instability in the tests, as tests rely on force_flush() and expect results from a single export, not the result from multiple exports. With this change, the tests, when all [were run together](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-sdk/src/metrics/mod.rs#L82-L83) locally, passes 100% of the time. Before this PR, almost every time, there is at least 1-3 failures. Naturally, the CI flakiness should be gone as well.

Separately, we should be able to leverage `ManualReader` for the tests to get predictable behavior and avoid needing `tokio::test`. Will fix it later, as that requires larger refactoring.

(This issue is visible, if running the opentelemetry-otlp examples too - instead of seeing one metric, resulting from the drop triggered shutdown, one would have seen two metrics without this fix. Also added windows specific instructions to test this in OTLP+ Collector)
