### PR TITLE
Remove OTLPExporter dependency on sem conventions

### DIFF
--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -32,7 +32,6 @@ opentelemetry = { version = "0.22", default-features = false, path = "../opentel
 opentelemetry_sdk = { version = "0.22", default-features = false, path = "../opentelemetry-sdk" }
 opentelemetry-http = { version = "0.11", path = "../opentelemetry-http", optional = true }
 opentelemetry-proto = { version = "0.5", path = "../opentelemetry-proto", default-features = false }
-opentelemetry-semantic-conventions = { version = "0.14", path = "../opentelemetry-semantic-conventions" }
 
 prost = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -13,7 +13,6 @@ use opentelemetry_sdk::{
     self as sdk,
     export::trace::{ExportResult, SpanData},
 };
-use opentelemetry_semantic_conventions::SCHEMA_URL;
 use sdk::runtime::RuntimeChannel;
 
 #[cfg(feature = "grpc-tonic")]
@@ -143,7 +142,6 @@ fn build_simple_with_exporter(
     let tracer = provider
         .tracer_builder("opentelemetry-otlp")
         .with_version(env!("CARGO_PKG_VERSION"))
-        .with_schema_url(SCHEMA_URL)
         .build();
     let _ = global::set_tracer_provider(provider);
     tracer
@@ -168,7 +166,6 @@ fn build_batch_with_exporter<R: RuntimeChannel>(
     let tracer = provider
         .tracer_builder("opentelemetry-otlp")
         .with_version(env!("CARGO_PKG_VERSION"))
-        .with_schema_url(SCHEMA_URL)
         .build();
     let _ = global::set_tracer_provider(provider);
     tracer


### PR DESCRIPTION
This was never required, and was used to point to a pointless schema url.