### PR TITLE
Update msrv version to1.65 in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Registry](https://opentelemetry.io/ecosystem/registry/?language=rust).
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.64. The current OpenTelemetry version is not guaranteed to build
+version is 1.65. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-http/README.md
+++ b/opentelemetry-http/README.md
@@ -18,7 +18,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a HTTP client interface for use by trace exporters, as well as
 helper types to inject and extract key value pairs into/from HTTP headers.
 
-*Compiler support: [requires `rustc` 1.64+][msrv]*
+*Compiler support: [requires `rustc` 1.65+][msrv]*
 
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
 [msrv]: #supported-rust-versions
@@ -26,7 +26,7 @@ helper types to inject and extract key value pairs into/from HTTP headers.
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.64. The current OpenTelemetry version is not guaranteed to build
+version is 1.65. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-jaeger-propagator/README.md
+++ b/opentelemetry-jaeger-propagator/README.md
@@ -19,7 +19,7 @@ generate, collect, and export telemetry data (metrics, logs, and traces) for
 analysis in order to understand your software's performance and behavior. This
 crate provides the ability to create and interact with a Jaeger propagator.
 
-*Compiler support: [requires `rustc` 1.64+][msrv]*
+*Compiler support: [requires `rustc` 1.65+][msrv]*
 
 [`Jaeger`]: https://www.jaegertracing.io/
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
@@ -28,7 +28,7 @@ crate provides the ability to create and interact with a Jaeger propagator.
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.64. The current OpenTelemetry version is not guaranteed to build
+version is 1.65. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-jaeger/README.md
+++ b/opentelemetry-jaeger/README.md
@@ -35,7 +35,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a trace pipeline and exporter for sending span information to a
 Jaeger `agent` or `collector` endpoint for processing and visualization.
 
-*Compiler support: [requires `rustc` 1.64+][msrv]*
+*Compiler support: [requires `rustc` 1.65+][msrv]*
 
 [`Jaeger`]: https://www.jaegertracing.io/
 [jaeger-otlp]: https://medium.com/jaegertracing/introducing-native-support-for-opentelemetry-in-jaeger-eb661be8183c
@@ -167,7 +167,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.64. The current OpenTelemetry version is not guaranteed to build
+version is 1.65. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -30,7 +30,7 @@ can easily instrument your applications or systems, no matter their language,
 infrastructure, or runtime environment. Crucially, the storage and visualization
 of telemetry is intentionally left to other tools.
 
-*Compiler support: [requires `rustc` 1.64+][msrv]*
+*Compiler support: [requires `rustc` 1.65+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
@@ -43,7 +43,7 @@ See [docs](https://docs.rs/opentelemetry-otlp).
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.64. The current OpenTelemetry version is not guaranteed to build
+version is 1.65. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-sdk/README.md
+++ b/opentelemetry-sdk/README.md
@@ -29,7 +29,7 @@ can easily instrument your applications or systems, no matter their language,
 infrastructure, or runtime environment. Crucially, the storage and visualization
 of telemetry is intentionally left to other tools.
 
-*Compiler support: [requires `rustc` 1.64+][msrv]*
+*Compiler support: [requires `rustc` 1.65+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
@@ -104,7 +104,7 @@ See [docs](https://docs.rs/opentelemetry-sdk).
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.64. The current OpenTelemetry version is not guaranteed to build
+version is 1.65. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -1,6 +1,6 @@
 //! Implements the [`SDK`] component of [OpenTelemetry].
 //!
-//! *Compiler support: [requires `rustc` 1.64+][msrv]*
+//! *Compiler support: [requires `rustc` 1.65+][msrv]*
 //!
 //! [`SDK`]: https://opentelemetry.io/docs/specs/otel/overview/#sdk
 //! [OpenTelemetry]: https://opentelemetry.io/docs/what-is-opentelemetry/

--- a/opentelemetry-stdout/README.md
+++ b/opentelemetry-stdout/README.md
@@ -29,7 +29,7 @@ can easily instrument your applications or systems, no matter their language,
 infrastructure, or runtime environment. Crucially, the storage and visualization
 of telemetry is intentionally left to other tools.
 
-*Compiler support: [requires `rustc` 1.64+][msrv]*
+*Compiler support: [requires `rustc` 1.65+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
@@ -50,7 +50,7 @@ See [docs](https://docs.rs/opentelemetry-stdout).
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.64. The current OpenTelemetry version is not guaranteed to build
+version is 1.65. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -21,7 +21,7 @@ analysis in order to understand your software's performance and behavior. This
 crate provides a trace pipeline and exporter for sending span information to a
 Zipkin collector for processing and visualization.
 
-*Compiler support: [requires `rustc` 1.64+][msrv]*
+*Compiler support: [requires `rustc` 1.65+][msrv]*
 
 [`Zipkin`]: https://zipkin.io/
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
@@ -104,12 +104,12 @@ available so be sure to match them appropriately.
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.64. The current OpenTelemetry version is not guaranteed to build on
+version is 1.65. The current OpenTelemetry version is not guaranteed to build on
 Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions before
 it will always be supported. For example, if the current stable compiler version
-is 1.64, the minimum supported version will not be increased past 1.46, three
+is 1.49, the minimum supported version will not be increased past 1.46, three
 minor versions prior. Increasing the minimum supported compiler version is not
 considered a semver breaking change as long as doing so complies with this
 policy.

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -28,7 +28,7 @@ can easily instrument your applications or systems, no matter their language,
 infrastructure, or runtime environment. Crucially, the storage and visualization
 of telemetry is intentionally left to other tools.
 
-*Compiler support: [requires `rustc` 1.64+][msrv]*
+*Compiler support: [requires `rustc` 1.65+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
@@ -133,7 +133,7 @@ See [docs](https://docs.rs/opentelemetry).
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.64. The current OpenTelemetry version is not guaranteed to build
+version is 1.65. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions


### PR DESCRIPTION
## Changes

While we bumped msrv to 1.65 in #1318, the docs are still showing 1.64. Updating it.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
