### PR TITLE
Update serialization format for LogRecord fields.

### DIFF
--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
@@ -79,6 +79,13 @@ pub struct LogRecord {
     /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
     /// Value of 0 indicates unknown or missing timestamp.
     #[prost(fixed64, tag = "1")]
+    #[cfg_attr(
+        feature = "with-serde",
+        serde(
+            serialize_with = "crate::proto::serializers::serialize_u64_to_string",
+            deserialize_with = "crate::proto::serializers::deserialize_string_to_u64"
+        )
+    )]
     pub time_unix_nano: u64,
     /// Time when the event was observed by the collection system.
     /// For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
@@ -96,6 +103,13 @@ pub struct LogRecord {
     /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
     /// Value of 0 indicates unknown or missing timestamp.
     #[prost(fixed64, tag = "11")]
+    #[cfg_attr(
+        feature = "with-serde",
+        serde(
+            serialize_with = "crate::proto::serializers::serialize_u64_to_string",
+            deserialize_with = "crate::proto::serializers::deserialize_string_to_u64"
+        )
+    )]
     pub observed_time_unix_nano: u64,
     /// Numerical value of the severity, normalized to values described in Log Data Model.
     /// \[Optional\].
@@ -136,6 +150,13 @@ pub struct LogRecord {
     ///    - the field is not present,
     ///    - the field contains an invalid value.
     #[prost(bytes = "vec", tag = "9")]
+    #[cfg_attr(
+        feature = "with-serde",
+        serde(
+            serialize_with = "crate::proto::serializers::serialize_to_hex_string",
+            deserialize_with = "crate::proto::serializers::deserialize_from_hex_string"
+        )
+    )]
     pub trace_id: ::prost::alloc::vec::Vec<u8>,
     /// A unique identifier for a span within a trace, assigned when the span
     /// is created. The ID is an 8-byte array. An ID with all zeroes OR of length
@@ -150,6 +171,13 @@ pub struct LogRecord {
     ///    - the field is not present,
     ///    - the field contains an invalid value.
     #[prost(bytes = "vec", tag = "10")]
+    #[cfg_attr(
+        feature = "with-serde",
+        serde(
+            serialize_with = "crate::proto::serializers::serialize_to_hex_string",
+            deserialize_with = "crate::proto::serializers::deserialize_from_hex_string"
+        )
+    )]
     pub span_id: ::prost::alloc::vec::Vec<u8>,
 }
 /// Possible values for LogRecord.SeverityNumber.

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -68,6 +68,8 @@ fn build_tonic() {
         "trace.v1.Span.trace_id",
         "trace.v1.Span.span_id",
         "trace.v1.Span.parent_span_id",
+        "logs.v1.LogRecord.span_id",
+        "logs.v1.LogRecord.trace_id",
     ] {
         builder = builder
             .field_attribute(path, "#[cfg_attr(feature = \"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_to_hex_string\", deserialize_with = \"crate::proto::serializers::deserialize_from_hex_string\"))]")
@@ -81,6 +83,8 @@ fn build_tonic() {
         "trace.v1.Span.start_time_unix_nano",
         "trace.v1.Span.end_time_unix_nano",
         "trace.v1.Span.Event.time_unix_nano",
+        "logs.v1.LogRecord.time_unix_nano",
+        "logs.v1.LogRecord.observed_time_unix_nano",
     ] {
         builder = builder
             .field_attribute(path, "#[cfg_attr(feature = \"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_u64_to_string\", deserialize_with = \"crate::proto::serializers::deserialize_string_to_u64\"))]")


### PR DESCRIPTION
## Changes

- timestamp  (u64) should be converted to a string as per [proto-json mapping ](https://protobuf.dev/programming-guides/proto3/#scalar)
- trace_id and span_id (sequence of bytes) should be converted to hex string as per the [otlp specs](https://github.com/open-telemetry/opentelemetry-proto/blob/v1.3.1/docs/specification.md#json-protobuf-encoding)

This is also consistent with SpanData encoding.


This would be eventually tested through #1759.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
