### PR TITLE
Enhance LogRecord Deserialization with Default Values for Missing Fields

### DIFF
--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
@@ -27,6 +27,7 @@ pub struct LogsData {
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResourceLogs {
@@ -49,6 +50,7 @@ pub struct ResourceLogs {
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScopeLogs {
@@ -72,6 +74,7 @@ pub struct ScopeLogs {
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LogRecord {

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -53,6 +53,9 @@ fn build_tonic() {
         "resource.v1.Resource",
         "trace.v1.Span.Event",
         "trace.v1.Status",
+        "logs.v1.LogRecord",
+        "logs.v1.ScopeLogs",
+        "logs.v1.ResourceLogs",
     ] {
         builder = builder.type_attribute(
             path,


### PR DESCRIPTION
## Changes

Creating separate PRs for the small issues I am finding while doing integration tests for logs. 

As of now, deserialization of LogRecords fails if certain fields are missing in the JSON input. By introducing default values for these fields, we ensure the deserialization process handles missing fields gracefully, similar to the current behavior of the traces deserialization.



Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
