### PR TITLE
Fix appender-tracing features to remove sdk dependency

### DIFF
--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -29,7 +29,7 @@ criterion = "0.5.1"
 
 [features]
 experimental_metadata_attributes = ["dep:tracing-log"]
-logs_level_enabled = ["opentelemetry/logs_level_enabled", "opentelemetry_sdk/logs_level_enabled"]
+logs_level_enabled = ["opentelemetry/logs_level_enabled"]
 default = ["logs_level_enabled"]
 
 


### PR DESCRIPTION
We removed sdk dependency, but the feature was still referring to it.