### PR TITLE
Move a changelog entry to the correct version

### DIFF
--- a/opentelemetry-stdout/CHANGELOG.md
+++ b/opentelemetry-stdout/CHANGELOG.md
@@ -9,12 +9,12 @@
 - The default feature now includes logs, metrics and trace.
 - Update `opentelemetry` dependency version to 0.23
 - Update `opentelemetry_sdk` dependency version to 0.23
+- TraceExporter fixed to print InstrumentationScope's attributes.
 
 ## v0.3.0
 
 ### Changed
 
-- TraceExporter fixed to print InstrumentationScope's attributes.
 - Fix StatusCode in stdout exporter [#1454](https://github.com/open-telemetry/opentelemetry-rust/pull/1454)
 - Add missing event timestamps [#1391](https://github.com/open-telemetry/opentelemetry-rust/pull/1391)
 - Adjusted `chrono` features to reduce number of transitive dependencies. [#1569](https://github.com/open-telemetry/opentelemetry-rust/pull/1569)


### PR DESCRIPTION
## Changes

This moves a changelog entry that was added under the wrong version. See #1747.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
