### PR TITLE
Add logs and metrics to default features in api, sdk and otlp crate

### DIFF
--- a/examples/logs-basic/README.md
+++ b/examples/logs-basic/README.md
@@ -1,16 +1,17 @@
-# Log Appender for API -  Example
+# OpenTelemetry Log Appender for log -  Example
 
 This example shows how to use the opentelemetry-appender-log crate, which is a
-[logging appender](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#log-appender--bridge) that bridges logs from the [log crate](https://docs.rs/log/latest/log/) to OpenTelemetry.
-The example setups a LoggerProvider with stdout exporter, so logs are emitted to stdout.
+[logging
+appender](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#log-appender--bridge)
+that bridges logs from the [log crate](https://docs.rs/log/latest/log/) to
+OpenTelemetry. The example setups a LoggerProvider with stdout exporter, so logs
+are emitted to stdout.
 
 ## Usage
 
-Run the following, and Logs emitted using [log](https://docs.rs/log/latest/log/) will be written out to stdout.
+Run the following, and Logs emitted using [log](https://docs.rs/log/latest/log/)
+will be written out to stdout.
 
 ```shell
-$ cargo run
+cargo run
 ```
-
-
-

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- Add "metrics", "logs" to default features. With this, default feature list is
+  "trace", "metrics" and "logs".
+
 ## v0.16.0
 
 ### Fixed

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -60,7 +60,7 @@ logs = ["opentelemetry/logs", "opentelemetry_sdk/logs", "opentelemetry-proto/log
 # add ons
 serialize = ["serde", "serde_json"]
 
-default = ["grpc-tonic", "trace"]
+default = ["grpc-tonic", "trace", "metrics", "logs"]
 
 # grpc using tonic
 grpc-tonic = ["tonic", "prost", "http", "tokio", "opentelemetry-proto/gen-tonic"]

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- Add "metrics", "logs" to default features. With this, default feature list is
+  "trace", "metrics" and "logs".
+
 ## v0.23.0
 
 - Fix SimpleSpanProcessor to be consistent with log counterpart. Also removed

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -44,7 +44,7 @@ temp-env = { workspace = true }
 pprof = { version = "0.13", features = ["flamegraph", "criterion"] }
 
 [features]
-default = ["trace"]
+default = ["trace", "metrics", "logs"]
 trace = ["opentelemetry/trace", "rand", "async-trait", "percent-encoding"]
 jaeger_remote_sampler = ["trace", "opentelemetry-http", "http", "serde", "serde_json", "url"]
 logs = ["opentelemetry/logs", "async-trait", "serde_json"]

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- Add "metrics", "logs" to default features. With this, default feature list is
+  "trace", "metrics" and "logs".
+
 ## v0.23.0
 
 ### Added

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = { workspace = true }
 js-sys = "0.3.63"
 
 [features]
-default = ["trace"]
+default = ["trace", "metrics", "logs"]
 trace = ["pin-project-lite"]
 metrics = []
 testing = ["trace", "metrics"]


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-rust/issues/1709
All 3 signals are planned to reach beta in the next release. This PR is changing the default for api,sdk,otlp crates to include all three signals by default. The separate feature flags are still maintained, so if anyone wants to only pick only, it is still possible.