### PR TITLE
Move codeowners to a single place

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 
 ## This file controls who is tagged for review for any given pull request.
 
-## For anything not explicitly taken by someone else:
+## For anything not explicitly taken by someone else
 
 * @open-telemetry/rust-approvers

--- a/README.md
+++ b/README.md
@@ -192,8 +192,6 @@ you're more than welcome to participate!
 
 ## Approvers and Maintainers
 
-For GitHub groups see the [code owners](CODEOWNERS) file.
-
 ### Maintainers
 
 * [Cijo Thomas](https://github.com/cijothomas)

--- a/opentelemetry-appender-log/CODEOWNERS
+++ b/opentelemetry-appender-log/CODEOWNERS
@@ -1,5 +1,0 @@
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers

--- a/opentelemetry-appender-tracing/CODEOWNERS
+++ b/opentelemetry-appender-tracing/CODEOWNERS
@@ -1,5 +1,0 @@
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers

--- a/opentelemetry-http/CODEOWNERS
+++ b/opentelemetry-http/CODEOWNERS
@@ -1,5 +1,0 @@
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers

--- a/opentelemetry-otlp/CODEOWNERS
+++ b/opentelemetry-otlp/CODEOWNERS
@@ -1,6 +1,0 @@
- 
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers 

--- a/opentelemetry-prometheus/CODEOWNERS
+++ b/opentelemetry-prometheus/CODEOWNERS
@@ -1,5 +1,0 @@
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers

--- a/opentelemetry-proto/CODEOWNERS
+++ b/opentelemetry-proto/CODEOWNERS
@@ -1,6 +1,0 @@
- 
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers 

--- a/opentelemetry-sdk/CODEOWNERS
+++ b/opentelemetry-sdk/CODEOWNERS
@@ -1,5 +1,0 @@
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers

--- a/opentelemetry-semantic-conventions/CODEOWNERS
+++ b/opentelemetry-semantic-conventions/CODEOWNERS
@@ -1,5 +1,0 @@
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers

--- a/opentelemetry-stdout/CODEOWNERS
+++ b/opentelemetry-stdout/CODEOWNERS
@@ -1,6 +1,0 @@
- 
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers 

--- a/opentelemetry-zipkin/CODEOWNERS
+++ b/opentelemetry-zipkin/CODEOWNERS
@@ -1,5 +1,0 @@
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers

--- a/opentelemetry/CODEOWNERS
+++ b/opentelemetry/CODEOWNERS
@@ -1,5 +1,0 @@
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-
-# For anything not explicitly taken by someone else:
-*  @open-telemetry/rust-approvers


### PR DESCRIPTION
Since non-spec components are already moved to contrib repo, we don't have the need to maintain per component owners file. This PR remove all codeowners file in individual components.
Also moves the main codeowners from root to ./github folder, which is recognized by Github. This makes the top level directly leaner.