### PR TITLE
fix: broken link in jaeger docs

### DIFF
--- a/opentelemetry-jaeger-propagator/src/propagator.rs
+++ b/opentelemetry-jaeger-propagator/src/propagator.rs
@@ -15,6 +15,9 @@ const DEPRECATED_PARENT_SPAN: &str = "0";
 const TRACE_FLAG_DEBUG: TraceFlags = TraceFlags::new(0x04);
 
 /// `Propagator` implements the [Jaeger propagation format].
+/// See [module level documentation](self#Examples) for examples.
+/// 
+/// [jaeger propagation format]: https://www.jaegertracing.io/docs/1.18/client-libraries/#propagation-format
 #[derive(Clone, Debug)]
 pub struct Propagator {
     baggage_prefix: &'static str,

--- a/opentelemetry-jaeger-propagator/src/propagator.rs
+++ b/opentelemetry-jaeger-propagator/src/propagator.rs
@@ -16,7 +16,7 @@ const TRACE_FLAG_DEBUG: TraceFlags = TraceFlags::new(0x04);
 
 /// `Propagator` implements the [Jaeger propagation format].
 /// See [module level documentation](self#Examples) for examples.
-/// 
+///  
 /// [jaeger propagation format]: https://www.jaegertracing.io/docs/1.18/client-libraries/#propagation-format
 #[derive(Clone, Debug)]
 pub struct Propagator {


### PR DESCRIPTION
## Changes

Current published doc:
![Screenshot from 2024-05-19 16-05-05](https://github.com/open-telemetry/opentelemetry-rust/assets/12531298/5f6741d3-2661-48fa-a033-55bcf9a6fc87)

After the change:
![Screenshot from 2024-05-19 16-06-00](https://github.com/open-telemetry/opentelemetry-rust/assets/12531298/3607190a-b8d7-4302-86d4-29cf31f83ada)

## Merge requirement checklist
* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
