### PR TITLE
OTLPMetricPipeline fixed to no longer set global provider

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Add "metrics", "logs" to default features. With this, default feature list is
   "trace", "metrics" and "logs".
+- `OtlpMetricPipeline.build()` no longer invoke the
+  `global::set_meter_provider`. User who setup the pipeline must do it
+  themselves using `global::set_meter_provider(meter_provider.clone());`.
 
 ## v0.16.0
 

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -85,6 +85,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         result.err()
     );
     let meter_provider = result.unwrap();
+    global::set_meter_provider(meter_provider.clone());
 
     // Initialize logs and save the logger_provider.
     let logger_provider = init_logs().unwrap();

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -1,12 +1,12 @@
 //! OTEL metric exporter
 //!
-//! Defines a [MetricsExporter] to send metric data to backend via OTEL protocol.
+//! Defines a [MetricsExporter] to send metric data to backend via OTLP protocol.
 //!
 
 use crate::{NoExporterConfig, OtlpPipeline};
 use async_trait::async_trait;
 use core::fmt;
-use opentelemetry::{global, metrics::Result};
+use opentelemetry::metrics::Result;
 
 #[cfg(feature = "grpc-tonic")]
 use crate::exporter::tonic::TonicExporterBuilder;
@@ -240,9 +240,6 @@ where
         }
 
         let provider = provider.build();
-
-        global::set_meter_provider(provider.clone());
-
         Ok(provider)
     }
 }


### PR DESCRIPTION
Towards #1592 
## Changes

This PR modifies the `OTLPMetricPipeleine` so that it does not setup the global meter provider itself.
End users must use the returned provider (a clone of it, if they cannot give up ownership), and call `global::set_meter_provider()` themselves, if they want to set a global meter provider.

This behavior is now consistent with logs. Next step is to cleanup traces too, so that all remain consistent and correct with no side effects. (Traces need 2 change - one is the same idea as this PR. But it also need to creating tracers itself. Hence traces will be a separate PR)

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
