### PR TITLE
Use warning in rustdocs for stdout

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -29,7 +29,7 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
                 .tonic()
                 .with_endpoint("http://localhost:4317"),
         )
-        .with_trace_config(sdktrace::config().with_resource(RESOURCE.clone()))
+        .with_trace_config(sdktrace::config().with_resource(RESOURCE.clone()).with_sampler(sampler::AlwaysOn))
         .install_batch(runtime::Tokio)
 }
 

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -29,7 +29,7 @@ fn init_tracer() -> Result<sdktrace::Tracer, TraceError> {
                 .tonic()
                 .with_endpoint("http://localhost:4317"),
         )
-        .with_trace_config(sdktrace::config().with_resource(RESOURCE.clone()).with_sampler(sampler::AlwaysOn))
+        .with_trace_config(sdktrace::config().with_resource(RESOURCE.clone()))
         .install_batch(runtime::Tokio)
 }
 

--- a/opentelemetry-stdout/src/lib.rs
+++ b/opentelemetry-stdout/src/lib.rs
@@ -1,7 +1,8 @@
 //! Export telemetry signals to stdout.
-//! This exporter is designed for debugging and learning purposes. It is not
+//! <div class="warning">This exporter is designed for debugging and learning purposes. It is not
 //! recommended for use in production environments. The output format might not be
 //! exhaustive and is subject to change at any time.
+//! </div>
 //!
 //! # Examples
 //!


### PR DESCRIPTION
Trying to leverage ["Warning"](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html#adding-a-warning-block) in our docs, since https://github.com/rust-lang/rust/pull/106561/files is merged!

Rendered output in local:

<img width="775" alt="image" src="https://github.com/open-telemetry/opentelemetry-rust/assets/5232798/f5baf44b-3cc8-4d2e-b5bd-0a947803f776">
