### PR TITLE
[Metric SDK] - Avoid exposing AttributeSet to exporters - Part1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ members = [
     "examples/*",
     "stress",
 ]
-# Any deleted crates with remaining README
-exclude = []
+# Crates temporarily excluded from the workspace
+exclude = ["opentelemetry-prometheus"]
 resolver = "2"
 
 [profile.bench]

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -97,7 +97,7 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Sum<T> {
 pub struct DataPoint<T> {
     /// Attributes is the set of key value pairs that uniquely identify the
     /// time series.
-    pub attributes: AttributeSet,
+    pub attributes: Vec<KeyValue>,
     /// The time when the time series was started.
     pub start_time: Option<SystemTime>,
     /// The time when the time series was recorded.

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -143,7 +143,7 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Histogram<T> {
 #[derive(Debug)]
 pub struct HistogramDataPoint<T> {
     /// The set of key value pairs that uniquely identify the time series.
-    pub attributes: AttributeSet,
+    pub attributes: Vec<KeyValue>,
     /// The time when the time series was started.
     pub start_time: SystemTime,
     /// The time when the time series was recorded.

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -339,7 +339,7 @@ mod tests {
                 .explicit_bucket_histogram(vec![1.0], true, true);
             let mut a = Histogram {
                 data_points: vec![HistogramDataPoint {
-                    attributes: AttributeSet::from(&[KeyValue::new("a2", 2)][..]),
+                    attributes: vec![KeyValue::new("a1", 1)],
                     start_time: SystemTime::now(),
                     time: SystemTime::now(),
                     count: 2,
@@ -365,10 +365,7 @@ mod tests {
             assert!(new_agg.is_none());
             assert_eq!(a.temporality, temporality);
             assert_eq!(a.data_points.len(), 1);
-            assert_eq!(
-                a.data_points[0].attributes,
-                AttributeSet::from(&new_attributes[..])
-            );
+            assert_eq!(a.data_points[0].attributes, new_attributes.to_vec());
             assert_eq!(a.data_points[0].count, 1);
             assert_eq!(a.data_points[0].bounds, vec![1.0]);
             assert_eq!(a.data_points[0].bucket_counts, vec![0, 1]);

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -226,7 +226,7 @@ mod tests {
         let (measure, agg) = AggregateBuilder::<u64>::new(None, None).last_value();
         let mut a = Gauge {
             data_points: vec![DataPoint {
-                attributes: AttributeSet::from(&[KeyValue::new("a", 1)][..]),
+                attributes: vec![KeyValue::new("a", 1)],
                 start_time: Some(SystemTime::now()),
                 time: Some(SystemTime::now()),
                 value: 1u64,
@@ -241,10 +241,7 @@ mod tests {
         assert_eq!(count, 1);
         assert!(new_agg.is_none());
         assert_eq!(a.data_points.len(), 1);
-        assert_eq!(
-            a.data_points[0].attributes,
-            AttributeSet::from(&new_attributes[..])
-        );
+        assert_eq!(a.data_points[0].attributes, new_attributes.to_vec());
         assert_eq!(a.data_points[0].value, 2);
     }
 
@@ -256,14 +253,14 @@ mod tests {
             let mut a = Sum {
                 data_points: vec![
                     DataPoint {
-                        attributes: AttributeSet::from(&[KeyValue::new("a1", 1)][..]),
+                        attributes: vec![KeyValue::new("a1", 1)],
                         start_time: Some(SystemTime::now()),
                         time: Some(SystemTime::now()),
                         value: 1u64,
                         exemplars: vec![],
                     },
                     DataPoint {
-                        attributes: AttributeSet::from(&[KeyValue::new("a2", 2)][..]),
+                        attributes: vec![KeyValue::new("a2", 1)],
                         start_time: Some(SystemTime::now()),
                         time: Some(SystemTime::now()),
                         value: 2u64,
@@ -287,10 +284,7 @@ mod tests {
             assert_eq!(a.temporality, temporality);
             assert!(a.is_monotonic);
             assert_eq!(a.data_points.len(), 1);
-            assert_eq!(
-                a.data_points[0].attributes,
-                AttributeSet::from(&new_attributes[..])
-            );
+            assert_eq!(a.data_points[0].attributes, new_attributes.to_vec());
             assert_eq!(a.data_points[0].value, 3);
         }
     }
@@ -302,14 +296,14 @@ mod tests {
             let mut a = Sum {
                 data_points: vec![
                     DataPoint {
-                        attributes: AttributeSet::from(&[KeyValue::new("a1", 1)][..]),
+                        attributes: vec![KeyValue::new("a1", 1)],
                         start_time: Some(SystemTime::now()),
                         time: Some(SystemTime::now()),
                         value: 1u64,
                         exemplars: vec![],
                     },
                     DataPoint {
-                        attributes: AttributeSet::from(&[KeyValue::new("a2", 2)][..]),
+                        attributes: vec![KeyValue::new("a2", 1)],
                         start_time: Some(SystemTime::now()),
                         time: Some(SystemTime::now()),
                         value: 2u64,
@@ -333,10 +327,7 @@ mod tests {
             assert_eq!(a.temporality, temporality);
             assert!(a.is_monotonic);
             assert_eq!(a.data_points.len(), 1);
-            assert_eq!(
-                a.data_points[0].attributes,
-                AttributeSet::from(&new_attributes[..])
-            );
+            assert_eq!(a.data_points[0].attributes, new_attributes.to_vec());
             assert_eq!(a.data_points[0].value, 3);
         }
     }

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Mutex, time::SystemTime};
 
 use crate::metrics::data::{self, Aggregation, Temporality};
 use crate::{attributes::AttributeSet, metrics::data::HistogramDataPoint};
+use opentelemetry::KeyValue;
 use opentelemetry::{global, metrics::MetricsError};
 
 use super::{
@@ -165,7 +166,10 @@ impl<T: Number<T>> Histogram<T> {
 
         for (a, b) in values.drain() {
             h.data_points.push(HistogramDataPoint {
-                attributes: a,
+                attributes: a
+                    .iter()
+                    .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
+                    .collect(),
                 start_time: start,
                 time: t,
                 count: b.count,
@@ -236,7 +240,10 @@ impl<T: Number<T>> Histogram<T> {
         // overload the system.
         for (a, b) in values.iter() {
             h.data_points.push(HistogramDataPoint {
-                attributes: a.clone(),
+                attributes: a
+                    .iter()
+                    .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
+                    .collect(),
                 start_time: start,
                 time: t,
                 count: b.count,

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{attributes::AttributeSet, metrics::data::DataPoint};
-use opentelemetry::{global, metrics::MetricsError};
+use opentelemetry::{global, metrics::MetricsError, KeyValue};
 
 use super::{
     aggregate::{is_under_cardinality_limit, STREAM_OVERFLOW_ATTRIBUTE_SET},
@@ -66,7 +66,10 @@ impl<T: Number<T>> LastValue<T> {
 
         for (attrs, value) in values.drain() {
             dest.push(DataPoint {
-                attributes: attrs,
+                attributes: attrs
+                    .iter()
+                    .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
+                    .collect(),
                 time: Some(value.timestamp),
                 value: value.value,
                 start_time: None,

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::vec;
 use std::{
     collections::{hash_map::Entry, HashMap},
     sync::Mutex,
@@ -7,6 +8,7 @@ use std::{
 
 use crate::attributes::AttributeSet;
 use crate::metrics::data::{self, Aggregation, DataPoint, Temporality};
+use opentelemetry::KeyValue;
 use opentelemetry::{global, metrics::MetricsError};
 
 use super::{
@@ -131,7 +133,7 @@ impl<T: Number<T>> Sum<T> {
             .swap(false, Ordering::AcqRel)
         {
             s_data.data_points.push(DataPoint {
-                attributes: AttributeSet::default(),
+                attributes: vec![],
                 start_time: Some(prev_start),
                 time: Some(t),
                 value: self.value_map.no_attribute_value.get_and_reset_value(),
@@ -141,7 +143,10 @@ impl<T: Number<T>> Sum<T> {
 
         for (attrs, value) in values.drain() {
             s_data.data_points.push(DataPoint {
-                attributes: attrs,
+                attributes: attrs
+                    .iter()
+                    .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
+                    .collect(),
                 start_time: Some(prev_start),
                 time: Some(t),
                 value,
@@ -201,7 +206,7 @@ impl<T: Number<T>> Sum<T> {
             .load(Ordering::Acquire)
         {
             s_data.data_points.push(DataPoint {
-                attributes: AttributeSet::default(),
+                attributes: vec![],
                 start_time: Some(prev_start),
                 time: Some(t),
                 value: self.value_map.no_attribute_value.get_value(),
@@ -215,7 +220,10 @@ impl<T: Number<T>> Sum<T> {
         // overload the system.
         for (attrs, value) in values.iter() {
             s_data.data_points.push(DataPoint {
-                attributes: attrs.clone(),
+                attributes: attrs
+                    .iter()
+                    .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
+                    .collect(),
                 start_time: Some(prev_start),
                 time: Some(t),
                 value: *value,
@@ -297,7 +305,7 @@ impl<T: Number<T>> PrecomputedSum<T> {
             .swap(false, Ordering::AcqRel)
         {
             s_data.data_points.push(DataPoint {
-                attributes: AttributeSet::default(),
+                attributes: vec![],
                 start_time: Some(prev_start),
                 time: Some(t),
                 value: self.value_map.no_attribute_value.get_and_reset_value(),
@@ -312,7 +320,10 @@ impl<T: Number<T>> PrecomputedSum<T> {
                 new_reported.insert(attrs.clone(), value);
             }
             s_data.data_points.push(DataPoint {
-                attributes: attrs.clone(),
+                attributes: attrs
+                    .iter()
+                    .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
+                    .collect(),
                 start_time: Some(prev_start),
                 time: Some(t),
                 value: delta,
@@ -379,7 +390,7 @@ impl<T: Number<T>> PrecomputedSum<T> {
             .load(Ordering::Acquire)
         {
             s_data.data_points.push(DataPoint {
-                attributes: AttributeSet::default(),
+                attributes: vec![],
                 start_time: Some(prev_start),
                 time: Some(t),
                 value: self.value_map.no_attribute_value.get_value(),
@@ -394,7 +405,10 @@ impl<T: Number<T>> PrecomputedSum<T> {
                 new_reported.insert(attrs.clone(), *value);
             }
             s_data.data_points.push(DataPoint {
-                attributes: attrs.clone(),
+                attributes: attrs
+                    .iter()
+                    .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
+                    .collect(),
                 start_time: Some(prev_start),
                 time: Some(t),
                 value: delta,

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -166,7 +166,7 @@ mod tests {
             if datapoint
                 .attributes
                 .iter()
-                .any(|(k, v)| k.as_str() == "key1" && v.as_str() == "value1")
+                .any(|kv| kv.key.as_str() == "key1" && kv.value.as_str() == "value1")
             {
                 data_point1 = Some(datapoint);
             }
@@ -184,7 +184,7 @@ mod tests {
             if datapoint
                 .attributes
                 .iter()
-                .any(|(k, v)| k.as_str() == "key1" && v.as_str() == "value2")
+                .any(|kv| kv.key.as_str() == "key1" && kv.value.as_str() == "value2")
             {
                 data_point1 = Some(datapoint);
             }
@@ -1000,7 +1000,7 @@ mod tests {
             datapoint
                 .attributes
                 .iter()
-                .any(|(k, v)| k.as_str() == key && v.as_str() == value)
+                .any(|kv| kv.key.as_str() == key && kv.value.as_str() == value)
         })
     }
 

--- a/opentelemetry-stdout/src/metrics/transform.rs
+++ b/opentelemetry-stdout/src/metrics/transform.rs
@@ -230,7 +230,7 @@ impl<T: Into<DataValue> + Copy> From<&data::Sum<T>> for Sum {
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 struct DataPoint {
-    attributes: AttributeSet,
+    attributes: Vec<KeyValue>,
     #[serde(serialize_with = "as_opt_human_readable")]
     start_time: Option<SystemTime>,
     #[serde(serialize_with = "as_opt_human_readable")]
@@ -253,7 +253,7 @@ fn is_zero_u8(v: &u8) -> bool {
 impl<T: Into<DataValue> + Copy> From<&data::DataPoint<T>> for DataPoint {
     fn from(value: &data::DataPoint<T>) -> Self {
         DataPoint {
-            attributes: AttributeSet::from(&value.attributes),
+            attributes: value.attributes.iter().map(Into::into).collect(),
             start_time_unix_nano: value.start_time,
             time_unix_nano: value.time,
             start_time: value.start_time,

--- a/opentelemetry-stdout/src/metrics/transform.rs
+++ b/opentelemetry-stdout/src/metrics/transform.rs
@@ -284,7 +284,7 @@ impl<T: Into<DataValue> + Copy> From<&data::Histogram<T>> for Histogram {
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 struct HistogramDataPoint {
-    attributes: AttributeSet,
+    attributes: Vec<KeyValue>,
     #[serde(serialize_with = "as_unix_nano")]
     start_time_unix_nano: SystemTime,
     #[serde(serialize_with = "as_unix_nano")]
@@ -306,7 +306,7 @@ struct HistogramDataPoint {
 impl<T: Into<DataValue> + Copy> From<&data::HistogramDataPoint<T>> for HistogramDataPoint {
     fn from(value: &data::HistogramDataPoint<T>) -> Self {
         HistogramDataPoint {
-            attributes: AttributeSet::from(&value.attributes),
+            attributes: value.attributes.iter().map(Into::into).collect(),
             start_time_unix_nano: value.start_time,
             time_unix_nano: value.time,
             start_time: value.start_time,

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -16,7 +16,7 @@ if rustup component add clippy; then
                 "opentelemetry-appender-log"
                 "opentelemetry-appender-tracing"
                 "opentelemetry-otlp"
-                "opentelemetry-prometheus"
+                # "opentelemetry-prometheus" - temporarily exlude Prometheus from CI.
                 "opentelemetry-proto"
                 "opentelemetry-sdk"
                 "opentelemetry-semantic-conventions"


### PR DESCRIPTION
`AttributeSet` is how attributes are stored internally for Metric Aggregation, and is also exposed to exporters. This PR exposes only a `Vec<KeyValue>` to exporters (done only for SUM, HISTOGRAM to keep PR's small)

In the next set of PRs, this will be extended to all Aggregations, and then `AttributeSet` can be completely kept pub(crate) instead of exposing it. Also, attributes can be further hidden by just exposing an Iterator only, instead of even a Vec!.

This affects some export authors. Not adding changelog in this PR, as I plan to get it covered in one shot when above are achieved.

Also removed `opentelemetry-prometheus` from CI for now, as it is not planned for the upcoming release : https://github.com/open-telemetry/opentelemetry-rust/issues/1719