### PR TITLE
Add semver check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,19 @@ jobs:
         env:
           CARGO_INCREMENTAL: '0'
           RUSTDOCFLAGS: -Dwarnings
+  semver:
+    runs-on: ubuntu-latest
+    name: semver
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install stable
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+    - name: cargo-semver-checks
+      uses: obi1kenobi/cargo-semver-checks-action@v2.3
   coverage:
     continue-on-error: true
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
         env:
           CARGO_INCREMENTAL: '0'
           RUSTDOCFLAGS: -Dwarnings
-  semver:
+  semver: # This job uses the latest published crate as baseline for comparison.
     runs-on: ubuntu-latest
     name: semver
     steps:


### PR DESCRIPTION
## Changes
- Add Semver check to CI (Based on https://github.com/obi1kenobi/cargo-semver-checks)
- This would help us identify breaking changes to Semver compatibility to our packages

I created another [PR](https://github.com/utpilla/opentelemetry-rust/pull/2) on my fork where I intentionally make a breaking change to a public enum variant to ensure that this check catches it: https://github.com/utpilla/opentelemetry-rust/actions/runs/9166338802/job/25201536158?pr=2#step:4:59