### PR TITLE
chore: add prometheus back with API and SDK pinned at 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,6 @@ members = [
     "examples/*",
     "stress",
 ]
-# Crates temporarily excluded from the workspace
-exclude = ["opentelemetry-prometheus"]
 resolver = "2"
 
 [profile.bench]

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -21,13 +21,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 once_cell = { workspace = true }
-opentelemetry = { version = "0.23", path = "../opentelemetry", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.23", path = "../opentelemetry-sdk", default-features = false, features = ["metrics"] }
+opentelemetry = { version = "0.23", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.23", default-features = false, features = ["metrics"] }
 prometheus = "0.13"
 protobuf = "2.14"
 
 [dev-dependencies]
-opentelemetry-semantic-conventions = { path = "../opentelemetry-semantic-conventions" }
+opentelemetry-semantic-conventions = { version = "0.15" }
 hyper = { workspace = true, features = ["full"] }
 tokio = { workspace = true, features = ["full"] }
 

--- a/opentelemetry-prometheus/README.md
+++ b/opentelemetry-prometheus/README.md
@@ -4,7 +4,10 @@
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png
 
-[`Prometheus`] integration for applications instrumented with [`OpenTelemetry`].
+[`Prometheus`] integration for applications instrumented with [`OpenTelemetry`]. 
+
+**The development of prometheus exporter has halt until the Opentelemetry metrics API and SDK reaches 1.0. Current 
+implementation is based on Opentelemetry API and SDK 0.23**.
 
 [![Crates.io: opentelemetry-prometheus](https://img.shields.io/crates/v/opentelemetry-prometheus.svg)](https://crates.io/crates/opentelemetry-prometheus)
 [![Documentation](https://docs.rs/opentelemetry-prometheus/badge.svg)](https://docs.rs/opentelemetry-prometheus)

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -1,4 +1,7 @@
 //! An OpenTelemetry exporter for [Prometheus] metrics.
+//! 
+//! <div class="warning"> The development of prometheus exporter has halt until the Opentelemetry metrics API and SDK reaches 1.0. Current 
+//! implementation is based on Opentelemetry API and SDK 0.23.</div>
 //!
 //! [Prometheus]: https://prometheus.io
 //!

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -20,7 +20,7 @@
 //!     .with_registry(registry.clone())
 //!     .build()?;
 //!
-//! // set up a meter meter to create instruments
+//! // set up a meter to create instruments
 //! let provider = SdkMeterProvider::builder().with_reader(exporter).build();
 //! let meter = provider.meter("my-app");
 //!

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -1,6 +1,6 @@
 //! An OpenTelemetry exporter for [Prometheus] metrics.
-//! 
-//! <div class="warning"> The development of prometheus exporter has halt until the Opentelemetry metrics API and SDK reaches 1.0. Current 
+//!
+//! <div class="warning"> The development of prometheus exporter has halt until the Opentelemetry metrics API and SDK reaches 1.0. Current
 //! implementation is based on Opentelemetry API and SDK 0.23.</div>
 //!
 //! [Prometheus]: https://prometheus.io

--- a/opentelemetry-stdout/src/lib.rs
+++ b/opentelemetry-stdout/src/lib.rs
@@ -1,5 +1,4 @@
 //! Export telemetry signals to stdout.
-//! 
 //! <div class="warning">This exporter is designed for debugging and learning purposes. It is not
 //! recommended for use in production environments. The output format might not be
 //! exhaustive and is subject to change at any time.

--- a/opentelemetry-stdout/src/lib.rs
+++ b/opentelemetry-stdout/src/lib.rs
@@ -1,4 +1,5 @@
 //! Export telemetry signals to stdout.
+//! 
 //! <div class="warning">This exporter is designed for debugging and learning purposes. It is not
 //! recommended for use in production environments. The output format might not be
 //! exhaustive and is subject to change at any time.

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -16,7 +16,7 @@ if rustup component add clippy; then
                 "opentelemetry-appender-log"
                 "opentelemetry-appender-tracing"
                 "opentelemetry-otlp"
-                # "opentelemetry-prometheus" - temporarily exlude Prometheus from CI.
+                "opentelemetry-prometheus"
                 "opentelemetry-proto"
                 "opentelemetry-sdk"
                 "opentelemetry-semantic-conventions"


### PR DESCRIPTION
## Changes

Keep prometheus exporter with lint checks but depended on fixed version to avoid any breaking changes in SDK and API impacing it

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
