### PR TITLE
Use better random generation in benchmark and stress tests

### DIFF
--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -1,7 +1,7 @@
 /*
     The benchmark results:
     criterion = "0.5.1"
-    OS: Ubuntu 22.04.2 LTS (5.10.102.1-microsoft-standard-WSL2)
+    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
     Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
     RAM: 64.0 GB
     | Test                        | Average time|
@@ -10,7 +10,7 @@
     | noop_layer_disabled         | 12 ns       |
     | noop_layer_enabled          | 25 ns       |
     | ot_layer_disabled           | 19 ns       |
-    | ot_layer_enabled           | 561 ns       |
+    | ot_layer_enabled            | 588 ns      |
 */
 
 use async_trait::async_trait;

--- a/opentelemetry-sdk/benches/metric_counter.rs
+++ b/opentelemetry-sdk/benches/metric_counter.rs
@@ -1,10 +1,33 @@
+/*
+    The benchmark results:
+    criterion = "0.5.1"
+    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    RAM: 64.0 GB
+    | Test                           | Average time|
+    |--------------------------------|-------------|
+    | Counter_Add_Sorted             | 586 ns      |
+    | Counter_Add_Unsorted           | 592 ns      |
+    | Random_Generator_5             | 377 ns      |
+    | ThreadLocal_Random_Generator_5 |  43 ns      |
+*/
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::{
     metrics::{Counter, MeterProvider as _},
     KeyValue,
 };
 use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use rand::{
+    rngs::{self, SmallRng},
+    Rng, SeedableRng,
+};
+use std::cell::RefCell;
+
+thread_local! {
+    /// Store random number generator for each thread
+    static CURRENT_RNG: RefCell<rngs::SmallRng> = RefCell::new(rngs::SmallRng::from_entropy());
+}
 
 // Run this benchmark with:
 // cargo bench --bench metric_counter --features=metrics
@@ -30,12 +53,11 @@ fn counter_add(c: &mut Criterion) {
     let counter = create_counter();
     c.bench_function("Counter_Add_Sorted", |b| {
         b.iter(|| {
-            let mut rng = SmallRng::from_entropy();
             // 4*4*10*10 = 1600 time series.
-            let index_first_attribute = rng.gen_range(0..4);
-            let index_second_attribute = rng.gen_range(0..4);
-            let index_third_attribute = rng.gen_range(0..10);
-            let index_forth_attribute = rng.gen_range(0..10);
+            let index_first_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
+            let index_second_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
+            let index_third_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
+            let index_forth_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
             counter.add(
                 1,
                 &[
@@ -50,12 +72,11 @@ fn counter_add(c: &mut Criterion) {
 
     c.bench_function("Counter_Add_Unsorted", |b| {
         b.iter(|| {
-            let mut rng = SmallRng::from_entropy();
             // 4*4*10*10 = 1600 time series.
-            let index_first_attribute = rng.gen_range(0..4);
-            let index_second_attribute = rng.gen_range(0..4);
-            let index_third_attribute = rng.gen_range(0..10);
-            let index_forth_attribute = rng.gen_range(0..10);
+            let index_first_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
+            let index_second_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
+            let index_third_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
+            let index_forth_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
             counter.add(
                 1,
                 &[
@@ -76,6 +97,16 @@ fn counter_add(c: &mut Criterion) {
             let _i3 = rng.gen_range(0..10);
             let _i4 = rng.gen_range(0..10);
             let _i5 = rng.gen_range(0..10);
+        });
+    });
+
+    c.bench_function("ThreadLocal_Random_Generator_5", |b| {
+        b.iter(|| {
+            let _i1 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
+            let _i2 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
+            let _i3 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
+            let _i4 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
+            let _i5 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
         });
     });
 }

--- a/opentelemetry-sdk/benches/metric_counter.rs
+++ b/opentelemetry-sdk/benches/metric_counter.rs
@@ -9,7 +9,7 @@
     | Counter_Add_Sorted             | 586 ns      |
     | Counter_Add_Unsorted           | 592 ns      |
     | Random_Generator_5             | 377 ns      |
-    | ThreadLocal_Random_Generator_5 |  43 ns      |
+    | ThreadLocal_Random_Generator_5 |  37 ns      |
 */
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -54,10 +54,11 @@ fn counter_add(c: &mut Criterion) {
     c.bench_function("Counter_Add_Sorted", |b| {
         b.iter(|| {
             // 4*4*10*10 = 1600 time series.
-            let index_first_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
-            let index_second_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
-            let index_third_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
-            let index_forth_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
+            let rands = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..4), rng.gen_range(0..4), rng.gen_range(0..10), rng.gen_range(0..10)]);
+            let index_first_attribute = rands[0];
+            let index_second_attribute = rands[1];
+            let index_third_attribute = rands[2];
+            let index_forth_attribute = rands[3];
             counter.add(
                 1,
                 &[
@@ -73,10 +74,11 @@ fn counter_add(c: &mut Criterion) {
     c.bench_function("Counter_Add_Unsorted", |b| {
         b.iter(|| {
             // 4*4*10*10 = 1600 time series.
-            let index_first_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
-            let index_second_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
-            let index_third_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
-            let index_forth_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
+            let rands = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..4), rng.gen_range(0..4), rng.gen_range(0..10), rng.gen_range(0..10)]);
+            let index_first_attribute = rands[0];
+            let index_second_attribute = rands[1];
+            let index_third_attribute = rands[2];
+            let index_forth_attribute = rands[3];
             counter.add(
                 1,
                 &[
@@ -102,11 +104,7 @@ fn counter_add(c: &mut Criterion) {
 
     c.bench_function("ThreadLocal_Random_Generator_5", |b| {
         b.iter(|| {
-            let _i1 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
-            let _i2 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..4));
-            let _i3 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
-            let _i4 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
-            let _i5 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
+            let _i1 = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..4),rng.gen_range(0..4),rng.gen_range(0..10), rng.gen_range(0..10), rng.gen_range(0..10)]);
         });
     });
 }

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -1,3 +1,11 @@
+/*
+    Stress test results:
+    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    RAM: 64.0 GB
+    27 M/sec
+*/
+
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::logs::{LogProcessor, LoggerProvider};
 use tracing::error;

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -45,9 +45,10 @@ fn main() {
 
 fn test_counter() {
     let len = ATTRIBUTE_VALUES.len();
-    let index_first_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..len));
-    let index_second_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..len));
-    let index_third_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..len));
+    let rands = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..len), rng.gen_range(0..len), rng.gen_range(0..len)]);
+    let index_first_attribute = rands[0];
+    let index_second_attribute = rands[1];
+    let index_third_attribute = rands[2];
 
     // each attribute has 10 possible values, so there are 1000 possible combinations (time-series)
     COUNTER.add(

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -1,11 +1,22 @@
+/*
+    Stress test results:
+    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    RAM: 64.0 GB
+    3M /sec
+*/
+
 use lazy_static::lazy_static;
 use opentelemetry::{
     metrics::{Counter, MeterProvider as _},
     KeyValue,
 };
 use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
-use rand::{rngs::SmallRng, Rng, SeedableRng};
-use std::borrow::Cow;
+use rand::{
+    rngs::{self},
+    Rng, SeedableRng,
+};
+use std::{borrow::Cow, cell::RefCell};
 
 mod throughput;
 
@@ -23,16 +34,20 @@ lazy_static! {
         .init();
 }
 
+thread_local! {
+    /// Store random number generator for each thread
+    static CURRENT_RNG: RefCell<rngs::SmallRng> = RefCell::new(rngs::SmallRng::from_entropy());
+}
+
 fn main() {
     throughput::test_throughput(test_counter);
 }
 
 fn test_counter() {
-    let mut rng = SmallRng::from_entropy();
     let len = ATTRIBUTE_VALUES.len();
-    let index_first_attribute = rng.gen_range(0..len);
-    let index_second_attribute = rng.gen_range(0..len);
-    let index_third_attribute = rng.gen_range(0..len);
+    let index_first_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..len));
+    let index_second_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..len));
+    let index_third_attribute = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..len));
 
     // each attribute has 10 possible values, so there are 1000 possible combinations (time-series)
     COUNTER.add(

--- a/stress/src/random.rs
+++ b/stress/src/random.rs
@@ -3,7 +3,7 @@
     OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
     Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
     RAM: 64.0 GB
-    953 B/sec
+    1.25 B/sec
 */
 
 use rand::{
@@ -25,7 +25,5 @@ fn main() {
 }
 
 fn test_random_generation() {
-    let _i1 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
-    let _i2 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
-    let _i3 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
+    let _i1 = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..10), rng.gen_range(0..10), rng.gen_range(0..10)]);
 }

--- a/stress/src/random.rs
+++ b/stress/src/random.rs
@@ -1,14 +1,31 @@
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+/*
+    Stress test results:
+    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    RAM: 64.0 GB
+    953 B/sec
+*/
+
+use rand::{
+    rngs::{self},
+    Rng, SeedableRng,
+};
 
 mod throughput;
+
+use std::cell::RefCell;
+
+thread_local! {
+    /// Store random number generator for each thread
+    static CURRENT_RNG: RefCell<rngs::SmallRng> = RefCell::new(rngs::SmallRng::from_entropy());
+}
 
 fn main() {
     throughput::test_throughput(test_random_generation);
 }
 
 fn test_random_generation() {
-    let mut rng = SmallRng::from_entropy();
-    let _index_first_attribute = rng.gen_range(0..10);
-    let _index_second_attribute = rng.gen_range(0..10);
-    let _index_third_attribute = rng.gen_range(0..10);
+    let _i1 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
+    let _i2 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
+    let _i3 = CURRENT_RNG.with(|rng| rng.borrow_mut().gen_range(0..10));
 }

--- a/stress/src/traces.rs
+++ b/stress/src/traces.rs
@@ -1,3 +1,11 @@
+/*
+    Stress test results:
+    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    RAM: 64.0 GB
+    9 M/sec
+*/
+
 use lazy_static::lazy_static;
 use opentelemetry::{
     trace::{Span, SpanBuilder, TraceResult, Tracer, TracerProvider as _},


### PR DESCRIPTION
As shown [here](https://github.com/open-telemetry/opentelemetry-rust/pull/1667), a good amount of time in benchmarks are spend in just generating random numbers. This PR reduces the cost of that to be more manageable, and not significantly polluting the actual cost of our code!
In benchmarks, the random generator cost fell from **377 ns to 50 ns**. The stress test for random moved from **53M/sec to 950M/sec!** 

Despite this, metrics is still stuck at 3M/sec due to heavy contention, which, I'll be addressing very shortly.

Traces stress test is stuck at 9M/sec as it did not get a key [perf fix from Logs](https://github.com/open-telemetry/opentelemetry-rust/pull/1455)!

Logs are hitting 27 M/sec, but there are few in-flight PRs and other ideas @lalitb is working to make this a lot more better.

Also added current numbers in the benchmark/stress test files for easy comparison.