### PR TITLE
Removes ordered-float dependency, and make own implementation for f64 hashing.

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add "metrics", "logs" to default features. With this, default feature list is
   "trace", "metrics" and "logs".
+- Removed dependency on `ordered-float`.
 
 ## v0.23.0
 

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -18,7 +18,6 @@ futures-channel = "0.3"
 futures-executor = { workspace = true }
 futures-util = { workspace = true, features = ["std", "sink", "async-await-macro"] }
 once_cell = { workspace = true }
-ordered-float = { workspace = true }
 percent-encoding = { version = "2.0", optional = true }
 rand = { workspace = true, features = ["std", "std_rng","small_rng"], optional = true }
 glob = { version = "0.3.1", optional =true}

--- a/opentelemetry-sdk/benches/metric_counter.rs
+++ b/opentelemetry-sdk/benches/metric_counter.rs
@@ -54,7 +54,8 @@ fn counter_add(c: &mut Criterion) {
     c.bench_function("Counter_Add_Sorted", |b| {
         b.iter(|| {
             // 4*4*10*10 = 1600 time series.
-            let rands = CURRENT_RNG.with_borrow_mut(|rng| {
+            let rands = CURRENT_RNG.with(|rng| {
+                let mut rng = rng.borrow_mut();
                 [
                     rng.gen_range(0..4),
                     rng.gen_range(0..4),
@@ -81,7 +82,8 @@ fn counter_add(c: &mut Criterion) {
     c.bench_function("Counter_Add_Unsorted", |b| {
         b.iter(|| {
             // 4*4*10*10 = 1600 time series.
-            let rands = CURRENT_RNG.with_borrow_mut(|rng| {
+            let rands = CURRENT_RNG.with(|rng| {
+                let mut rng = rng.borrow_mut();
                 [
                     rng.gen_range(0..4),
                     rng.gen_range(0..4),
@@ -118,7 +120,8 @@ fn counter_add(c: &mut Criterion) {
 
     c.bench_function("ThreadLocal_Random_Generator_5", |b| {
         b.iter(|| {
-            let _i1 = CURRENT_RNG.with_borrow_mut(|rng| {
+            let __i1 = CURRENT_RNG.with(|rng| {
+                let mut rng = rng.borrow_mut();
                 [
                     rng.gen_range(0..4),
                     rng.gen_range(0..4),

--- a/opentelemetry-sdk/benches/metric_counter.rs
+++ b/opentelemetry-sdk/benches/metric_counter.rs
@@ -54,7 +54,14 @@ fn counter_add(c: &mut Criterion) {
     c.bench_function("Counter_Add_Sorted", |b| {
         b.iter(|| {
             // 4*4*10*10 = 1600 time series.
-            let rands = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..4), rng.gen_range(0..4), rng.gen_range(0..10), rng.gen_range(0..10)]);
+            let rands = CURRENT_RNG.with_borrow_mut(|rng| {
+                [
+                    rng.gen_range(0..4),
+                    rng.gen_range(0..4),
+                    rng.gen_range(0..10),
+                    rng.gen_range(0..10),
+                ]
+            });
             let index_first_attribute = rands[0];
             let index_second_attribute = rands[1];
             let index_third_attribute = rands[2];
@@ -74,7 +81,14 @@ fn counter_add(c: &mut Criterion) {
     c.bench_function("Counter_Add_Unsorted", |b| {
         b.iter(|| {
             // 4*4*10*10 = 1600 time series.
-            let rands = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..4), rng.gen_range(0..4), rng.gen_range(0..10), rng.gen_range(0..10)]);
+            let rands = CURRENT_RNG.with_borrow_mut(|rng| {
+                [
+                    rng.gen_range(0..4),
+                    rng.gen_range(0..4),
+                    rng.gen_range(0..10),
+                    rng.gen_range(0..10),
+                ]
+            });
             let index_first_attribute = rands[0];
             let index_second_attribute = rands[1];
             let index_third_attribute = rands[2];
@@ -91,22 +105,22 @@ fn counter_add(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("Random_Generator_5", |b| {
-        b.iter(|| {
-            let mut rng = SmallRng::from_entropy();
-            let _i1 = rng.gen_range(0..4);
-            let _i2 = rng.gen_range(0..4);
-            let _i3 = rng.gen_range(0..10);
-            let _i4 = rng.gen_range(0..10);
-            let _i5 = rng.gen_range(0..10);
-        });
-    });
+    // c.bench_function("Random_Generator_5", |b| {
+    //     b.iter(|| {
+    //         let mut rng = SmallRng::from_entropy();
+    //         let _i1 = rng.gen_range(0..4);
+    //         let _i2 = rng.gen_range(0..4);
+    //         let _i3 = rng.gen_range(0..10);
+    //         let _i4 = rng.gen_range(0..10);
+    //         let _i5 = rng.gen_range(0..10);
+    //     });
+    // });
 
-    c.bench_function("ThreadLocal_Random_Generator_5", |b| {
-        b.iter(|| {
-            let _i1 = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..4),rng.gen_range(0..4),rng.gen_range(0..10), rng.gen_range(0..10), rng.gen_range(0..10)]);
-        });
-    });
+    // c.bench_function("ThreadLocal_Random_Generator_5", |b| {
+    //     b.iter(|| {
+    //         let _i1 = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..4),rng.gen_range(0..4),rng.gen_range(0..10), rng.gen_range(0..10), rng.gen_range(0..10)]);
+    //     });
+    // });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/opentelemetry-sdk/benches/metric_counter.rs
+++ b/opentelemetry-sdk/benches/metric_counter.rs
@@ -105,22 +105,30 @@ fn counter_add(c: &mut Criterion) {
         });
     });
 
-    // c.bench_function("Random_Generator_5", |b| {
-    //     b.iter(|| {
-    //         let mut rng = SmallRng::from_entropy();
-    //         let _i1 = rng.gen_range(0..4);
-    //         let _i2 = rng.gen_range(0..4);
-    //         let _i3 = rng.gen_range(0..10);
-    //         let _i4 = rng.gen_range(0..10);
-    //         let _i5 = rng.gen_range(0..10);
-    //     });
-    // });
+    c.bench_function("Random_Generator_5", |b| {
+        b.iter(|| {
+            let mut rng = SmallRng::from_entropy();
+            let _i1 = rng.gen_range(0..4);
+            let _i2 = rng.gen_range(0..4);
+            let _i3 = rng.gen_range(0..10);
+            let _i4 = rng.gen_range(0..10);
+            let _i5 = rng.gen_range(0..10);
+        });
+    });
 
-    // c.bench_function("ThreadLocal_Random_Generator_5", |b| {
-    //     b.iter(|| {
-    //         let _i1 = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..4),rng.gen_range(0..4),rng.gen_range(0..10), rng.gen_range(0..10), rng.gen_range(0..10)]);
-    //     });
-    // });
+    c.bench_function("ThreadLocal_Random_Generator_5", |b| {
+        b.iter(|| {
+            let _i1 = CURRENT_RNG.with_borrow_mut(|rng| {
+                [
+                    rng.gen_range(0..4),
+                    rng.gen_range(0..4),
+                    rng.gen_range(0..10),
+                    rng.gen_range(0..10),
+                    rng.gen_range(0..10),
+                ]
+            });
+        });
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -66,71 +66,16 @@ pub use view::*;
 
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
-use std::{
-    cmp::Ordering,
-    hash::{Hash, Hasher},
-};
+use std::hash::{Hash, Hasher};
 
-use opentelemetry::{Array, Key, KeyValue, Value};
-use ordered_float::OrderedFloat;
-
-#[derive(Clone, Debug)]
-struct HashKeyValue(KeyValue);
-
-impl Hash for HashKeyValue {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.key.hash(state);
-        match &self.0.value {
-            Value::F64(f) => OrderedFloat(*f).hash(state),
-            Value::Array(a) => match a {
-                Array::Bool(b) => b.hash(state),
-                Array::I64(i) => i.hash(state),
-                Array::F64(f) => f.iter().for_each(|f| OrderedFloat(*f).hash(state)),
-                Array::String(s) => s.hash(state),
-            },
-            Value::Bool(b) => b.hash(state),
-            Value::I64(i) => i.hash(state),
-            Value::String(s) => s.hash(state),
-        };
-    }
-}
-
-impl PartialOrd for HashKeyValue {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for HashKeyValue {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.key.cmp(&other.0.key)
-    }
-}
-
-impl PartialEq for HashKeyValue {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.key == other.0.key
-            && match (&self.0.value, &other.0.value) {
-                (Value::F64(f), Value::F64(of)) => OrderedFloat(*f).eq(&OrderedFloat(*of)),
-                (Value::Array(Array::F64(f)), Value::Array(Array::F64(of))) => {
-                    f.len() == of.len()
-                        && f.iter()
-                            .zip(of.iter())
-                            .all(|(f, of)| OrderedFloat(*f).eq(&OrderedFloat(*of)))
-                }
-                (non_float, other_non_float) => non_float.eq(other_non_float),
-            }
-    }
-}
-
-impl Eq for HashKeyValue {}
+use opentelemetry::{Key, KeyValue, Value};
 
 /// A unique set of attributes that can be used as instrument identifiers.
 ///
 /// This must implement [Hash], [PartialEq], and [Eq] so it may be used as
 /// HashMap keys and other de-duplication methods.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub struct AttributeSet(Vec<HashKeyValue>, u64);
+pub struct AttributeSet(Vec<KeyValue>, u64);
 
 impl From<&[KeyValue]> for AttributeSet {
     fn from(values: &[KeyValue]) -> Self {
@@ -140,7 +85,7 @@ impl From<&[KeyValue]> for AttributeSet {
             .rev()
             .filter_map(|kv| {
                 if seen_keys.insert(kv.key.clone()) {
-                    Some(HashKeyValue(kv.clone()))
+                    Some(kv.clone())
                 } else {
                     None
                 }
@@ -151,7 +96,7 @@ impl From<&[KeyValue]> for AttributeSet {
     }
 }
 
-fn calculate_hash(values: &[HashKeyValue]) -> u64 {
+fn calculate_hash(values: &[KeyValue]) -> u64 {
     let mut hasher = DefaultHasher::new();
     values.iter().fold(&mut hasher, |mut hasher, item| {
         item.hash(&mut hasher);
@@ -161,7 +106,7 @@ fn calculate_hash(values: &[HashKeyValue]) -> u64 {
 }
 
 impl AttributeSet {
-    fn new(mut values: Vec<HashKeyValue>) -> Self {
+    fn new(mut values: Vec<KeyValue>) -> Self {
         values.sort_unstable();
         let hash = calculate_hash(&values);
         AttributeSet(values, hash)
@@ -177,7 +122,7 @@ impl AttributeSet {
     where
         F: Fn(&KeyValue) -> bool,
     {
-        self.0.retain(|kv| f(&kv.0));
+        self.0.retain(|kv| f(kv));
 
         // Recalculate the hash as elements are changed.
         self.1 = calculate_hash(&self.0);
@@ -185,7 +130,7 @@ impl AttributeSet {
 
     /// Iterate over key value pairs in the set
     pub fn iter(&self) -> impl Iterator<Item = (&Key, &Value)> {
-        self.0.iter().map(|kv| (&kv.0.key, &kv.0.value))
+        self.0.iter().map(|kv| (&kv.key, &kv.value))
     }
 }
 
@@ -209,52 +154,9 @@ mod tests {
         KeyValue,
     };
     use std::borrow::Cow;
-    use std::hash::DefaultHasher;
-    use std::hash::{Hash, Hasher};
 
     // Run all tests in this mod
     // cargo test metrics::tests --features=metrics,testing
-
-    #[test]
-    fn equality_kv_float() {
-        let kv1 = HashKeyValue(KeyValue::new("key", 1.0));
-        let kv2 = HashKeyValue(KeyValue::new("key", 1.0));
-        assert_eq!(kv1, kv2);
-
-        let kv1 = HashKeyValue(KeyValue::new("key", 1.0));
-        let kv2 = HashKeyValue(KeyValue::new("key", 1.01));
-        assert_ne!(kv1, kv2);
-
-        let kv1 = HashKeyValue(KeyValue::new("key", std::f64::NAN));
-        let kv2 = HashKeyValue(KeyValue::new("key", std::f64::NAN));
-        assert_eq!(kv1, kv2);
-
-        let kv1 = HashKeyValue(KeyValue::new("key", std::f64::INFINITY));
-        let kv2 = HashKeyValue(KeyValue::new("key", std::f64::INFINITY));
-        assert_eq!(kv1, kv2);
-    }
-
-    #[test]
-    fn hash_kv_float() {
-        let kv1 = HashKeyValue(KeyValue::new("key", 1.0));
-        let kv2 = HashKeyValue(KeyValue::new("key", 1.0));
-        assert_eq!(hash_helper(&kv1), hash_helper(&kv2));
-
-        let kv1 = HashKeyValue(KeyValue::new("key", std::f64::NAN));
-        let kv2 = HashKeyValue(KeyValue::new("key", std::f64::NAN));
-        assert_eq!(hash_helper(&kv1), hash_helper(&kv2));
-
-        let kv1 = HashKeyValue(KeyValue::new("key", std::f64::INFINITY));
-        let kv2 = HashKeyValue(KeyValue::new("key", std::f64::INFINITY));
-        assert_eq!(hash_helper(&kv1), hash_helper(&kv2));
-    }
-
-    fn hash_helper<T: Hash>(item: &T) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        item.hash(&mut hasher);
-        hasher.finish()
-    }
-
     // Note for all tests from this point onwards in this mod:
     // "multi_thread" tokio flavor must be used else flush won't
     // be able to make progress!

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Add "metrics", "logs" to default features. With this, default feature list is
   "trace", "metrics" and "logs".
+- When "metrics" feature is enabled, `KeyValue` implements `PartialEq`, `Eq`,
+  `PartialOrder`, `Order`, `Hash`. This is meant to be used for metrics
+  aggregation purposes only.
 
 ## v0.23.0
 

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -42,6 +42,7 @@ otel_unstable = []
 [dev-dependencies]
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["logs_level_enabled"]} # for documentation tests
 criterion = { version = "0.3" }
+rand = { workspace = true }
 
 [[bench]]
 name = "metrics"

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -336,8 +336,8 @@ mod tests {
     use rand::Rng;
 
     use crate::KeyValue;
+    use std::collections::hash_map::DefaultHasher;
     use std::f64;
-    use std::hash::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
     #[test]

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -1,6 +1,8 @@
 //! # OpenTelemetry Metrics API
 
 use std::any::Any;
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 use std::result;
 use std::sync::PoisonError;
 use std::{borrow::Cow, sync::Arc};
@@ -10,7 +12,7 @@ mod instruments;
 mod meter;
 pub mod noop;
 
-use crate::ExportError;
+use crate::{Array, ExportError, KeyValue, Value};
 pub use instruments::{
     counter::{Counter, ObservableCounter, SyncCounter},
     gauge::{Gauge, ObservableGauge, SyncGauge},
@@ -80,6 +82,55 @@ impl AsRef<str> for Unit {
         self.0.as_ref()
     }
 }
+
+struct F64Hashable(f64);
+
+impl PartialEq for F64Hashable {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.to_bits() == other.0.to_bits()
+    }
+}
+
+impl Eq for F64Hashable {}
+
+impl Hash for F64Hashable {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.to_bits().hash(state);
+    }
+}
+
+impl Hash for KeyValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.key.hash(state);
+        match &self.value {
+            Value::F64(f) => F64Hashable(*f).hash(state),
+            Value::Array(a) => match a {
+                Array::Bool(b) => b.hash(state),
+                Array::I64(i) => i.hash(state),
+                Array::F64(f) => f.iter().for_each(|f| F64Hashable(*f).hash(state)),
+                Array::String(s) => s.hash(state),
+            },
+            Value::Bool(b) => b.hash(state),
+            Value::I64(i) => i.hash(state),
+            Value::String(s) => s.hash(state),
+        };
+    }
+}
+
+impl PartialOrd for KeyValue {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Ordering is based on the key only.
+impl Ord for KeyValue {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key.cmp(&other.key)
+    }
+}
+
+impl Eq for KeyValue {}
 
 /// SDK implemented trait for creating instruments
 pub trait InstrumentProvider {
@@ -279,3 +330,105 @@ pub trait InstrumentProvider {
 }
 
 type MultiInstrumentCallback = dyn Fn(&dyn Observer) + Send + Sync;
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+
+    use crate::KeyValue;
+    use std::f64;
+    use std::hash::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    #[test]
+    fn kv_float_equality() {
+        let kv1 = KeyValue::new("key", 1.0);
+        let kv2 = KeyValue::new("key", 1.0);
+        assert_eq!(kv1, kv2);
+
+        let kv1 = KeyValue::new("key", 1.0);
+        let kv2 = KeyValue::new("key", 1.01);
+        assert_ne!(kv1, kv2);
+
+        let kv1 = KeyValue::new("key", f64::NAN);
+        let kv2 = KeyValue::new("key", f64::NAN);
+        assert_ne!(kv1, kv2, "NAN is not equal to itself");
+
+        for float_val in [
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::MAX,
+            f64::MIN,
+            f64::MIN_POSITIVE,
+        ]
+        .iter()
+        {
+            let kv1 = KeyValue::new("key", *float_val);
+            let kv2 = KeyValue::new("key", *float_val);
+            assert_eq!(kv1, kv2);
+        }
+
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..100 {
+            let random_value = rng.gen::<f64>();
+            let kv1 = KeyValue::new("key", random_value);
+            let kv2 = KeyValue::new("key", random_value);
+            assert_eq!(kv1, kv2);
+        }
+    }
+
+    #[test]
+    fn kv_float_hash() {
+        for float_val in [
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::MAX,
+            f64::MIN,
+            f64::MIN_POSITIVE,
+        ]
+        .iter()
+        {
+            let kv1 = KeyValue::new("key", *float_val);
+            let kv2 = KeyValue::new("key", *float_val);
+            assert_eq!(hash_helper(&kv1), hash_helper(&kv2));
+        }
+
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..100 {
+            let random_value = rng.gen::<f64>();
+            let kv1 = KeyValue::new("key", random_value);
+            let kv2 = KeyValue::new("key", random_value);
+            assert_eq!(hash_helper(&kv1), hash_helper(&kv2));
+        }
+    }
+
+    #[test]
+    fn kv_float_order() {
+        // TODO: Extend this test to all value types, not just F64
+        let float_vals = [
+            0.0,
+            1.0,
+            -1.0,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::NAN,
+            f64::MIN,
+            f64::MAX,
+        ];
+
+        for v in float_vals {
+            let kv1 = KeyValue::new("a", v);
+            let kv2 = KeyValue::new("b", v);
+            assert!(kv1 < kv2, "Order is solely based on key!");
+        }
+    }
+
+    fn hash_helper<T: Hash>(item: &T) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        item.hash(&mut hasher);
+        hasher.finish()
+    }
+}

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -45,7 +45,8 @@ fn main() {
 
 fn test_counter() {
     let len = ATTRIBUTE_VALUES.len();
-    let rands = CURRENT_RNG.with_borrow_mut(|rng| {
+    let rands = CURRENT_RNG.with(|rng| {
+        let mut rng = rng.borrow_mut();
         [
             rng.gen_range(0..len),
             rng.gen_range(0..len),

--- a/stress/src/metrics.rs
+++ b/stress/src/metrics.rs
@@ -45,7 +45,13 @@ fn main() {
 
 fn test_counter() {
     let len = ATTRIBUTE_VALUES.len();
-    let rands = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..len), rng.gen_range(0..len), rng.gen_range(0..len)]);
+    let rands = CURRENT_RNG.with_borrow_mut(|rng| {
+        [
+            rng.gen_range(0..len),
+            rng.gen_range(0..len),
+            rng.gen_range(0..len),
+        ]
+    });
     let index_first_attribute = rands[0];
     let index_second_attribute = rands[1];
     let index_third_attribute = rands[2];

--- a/stress/src/random.rs
+++ b/stress/src/random.rs
@@ -25,5 +25,11 @@ fn main() {
 }
 
 fn test_random_generation() {
-    let _i1 = CURRENT_RNG.with_borrow_mut(|rng| [rng.gen_range(0..10), rng.gen_range(0..10), rng.gen_range(0..10)]);
+    let _i1 = CURRENT_RNG.with_borrow_mut(|rng| {
+        [
+            rng.gen_range(0..10),
+            rng.gen_range(0..10),
+            rng.gen_range(0..10),
+        ]
+    });
 }

--- a/stress/src/random.rs
+++ b/stress/src/random.rs
@@ -25,7 +25,8 @@ fn main() {
 }
 
 fn test_random_generation() {
-    let _i1 = CURRENT_RNG.with_borrow_mut(|rng| {
+    let _i1 = CURRENT_RNG.with(|rng| {
+        let mut rng = rng.borrow_mut();
         [
             rng.gen_range(0..10),
             rng.gen_range(0..10),


### PR DESCRIPTION
Replaces https://github.com/open-telemetry/opentelemetry-rust/pull/1780

Removes ordered-float dependency, and make own implementation for f64 hashing.