### PR TITLE
Remove temporary vector in tracer appender

### DIFF
--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -10,7 +10,7 @@
     | noop_layer_disabled         | 12 ns       |
     | noop_layer_enabled          | 25 ns       |
     | ot_layer_disabled           | 19 ns       |
-    | ot_layer_enabled            | 446 ns      |
+    | ot_layer_enabled            | 371 ns      |
 */
 
 use async_trait::async_trait;

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -59,7 +59,6 @@ impl<'a, LR: LogRecord> EventVisitor<'a, LR> {
                 Key::new("code.namespace"),
                 AnyValue::from(module_path.to_owned()),
             );
-            s
         }
 
         if let Some(filepath) = meta.file() {

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -11,10 +11,8 @@ use tracing_subscriber::Layer;
 const INSTRUMENTATION_LIBRARY_NAME: &str = "opentelemetry-appender-tracing";
 
 /// Visitor to record the fields from the event record.
-#[derive(Default)]
-struct EventVisitor {
-    log_record_attributes: Vec<(Key, AnyValue)>,
-    log_record_body: Option<AnyValue>,
+struct EventVisitor<'a, LR: LogRecord> {
+    log_record: &'a mut LR,
 }
 
 /// Logs from the log crate have duplicated attributes that we removed here.
@@ -37,10 +35,13 @@ fn get_filename(filepath: &str) -> &str {
     filepath
 }
 
-impl EventVisitor {
+impl<'a, LR: LogRecord> EventVisitor<'a, LR> {
+    fn new(log_record: &'a mut LR) -> Self {
+        EventVisitor { log_record }
+    }
     fn visit_metadata(&mut self, meta: &Metadata) {
-        self.log_record_attributes
-            .push(("name".into(), meta.name().into()));
+        self.log_record
+            .add_attribute(Key::new("name"), AnyValue::from(meta.name()));
 
         #[cfg(feature = "experimental_metadata_attributes")]
         self.visit_experimental_metadata(meta);
@@ -48,48 +49,48 @@ impl EventVisitor {
 
     #[cfg(feature = "experimental_metadata_attributes")]
     fn visit_experimental_metadata(&mut self, meta: &Metadata) {
-        self.log_record_attributes
-            .push(("log.target".into(), meta.target().to_owned().into()));
+        self.log_record.add_attribute(
+            Key::new("log.target"),
+            AnyValue::from(meta.target().to_owned()),
+        );
 
         if let Some(module_path) = meta.module_path() {
-            self.log_record_attributes
-                .push(("code.namespace".into(), module_path.to_owned().into()));
+            self.log_record.add_attribute(
+                Key::new("code.namespace"),
+                AnyValue::from(module_path.to_owned()),
+            );
+            s
         }
 
         if let Some(filepath) = meta.file() {
-            self.log_record_attributes
-                .push(("code.filepath".into(), filepath.to_owned().into()));
-            self.log_record_attributes.push((
-                "code.filename".into(),
-                get_filename(filepath).to_owned().into(),
-            ));
+            self.log_record.add_attribute(
+                Key::new("code.filepath"),
+                AnyValue::from(filepath.to_owned()),
+            );
+            self.log_record.add_attribute(
+                Key::new("code.filename"),
+                AnyValue::from(get_filename(filepath).to_owned()),
+            );
         }
 
         if let Some(line) = meta.line() {
-            self.log_record_attributes
-                .push(("code.lineno".into(), line.into()));
+            self.log_record
+                .add_attribute(Key::new("code.lineno"), AnyValue::from(line));
         }
-    }
-
-    fn push_to_otel_log_record<LR: LogRecord>(self, log_record: &mut LR) {
-        if let Some(body) = self.log_record_body {
-            log_record.set_body(body);
-        }
-        log_record.add_attributes(self.log_record_attributes);
     }
 }
 
-impl tracing::field::Visit for EventVisitor {
+impl<'a, LR: LogRecord> tracing::field::Visit for EventVisitor<'a, LR> {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         #[cfg(feature = "experimental_metadata_attributes")]
         if is_duplicated_metadata(field.name()) {
             return;
         }
         if field.name() == "message" {
-            self.log_record_body = Some(format!("{value:?}").into());
+            self.log_record.set_body(format!("{:?}", value).into());
         } else {
-            self.log_record_attributes
-                .push((field.name().into(), format!("{value:?}").into()));
+            self.log_record
+                .add_attribute(Key::new(field.name()), AnyValue::from(format!("{value:?}")));
         }
     }
 
@@ -98,18 +99,18 @@ impl tracing::field::Visit for EventVisitor {
         if is_duplicated_metadata(field.name()) {
             return;
         }
-        self.log_record_attributes
-            .push((field.name().into(), value.to_owned().into()));
+        self.log_record
+            .add_attribute(Key::new(field.name()), AnyValue::from(value.to_owned()));
     }
 
     fn record_bool(&mut self, field: &tracing_core::Field, value: bool) {
-        self.log_record_attributes
-            .push((field.name().into(), value.into()));
+        self.log_record
+            .add_attribute(Key::new(field.name()), AnyValue::from(value));
     }
 
     fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
-        self.log_record_attributes
-            .push((field.name().into(), value.into()));
+        self.log_record
+            .add_attribute(Key::new(field.name()), AnyValue::from(value));
     }
 
     fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
@@ -117,8 +118,8 @@ impl tracing::field::Visit for EventVisitor {
         if is_duplicated_metadata(field.name()) {
             return;
         }
-        self.log_record_attributes
-            .push((field.name().into(), value.into()));
+        self.log_record
+            .add_attribute(Key::new(field.name()), AnyValue::from(value));
     }
 
     // TODO: Remaining field types from AnyValue : Bytes, ListAny, Boolean
@@ -173,11 +174,10 @@ where
         log_record.set_severity_number(severity_of_level(meta.level()));
         log_record.set_severity_text(meta.level().to_string().into());
 
-        let mut visitor = EventVisitor::default();
+        let mut visitor = EventVisitor::new(&mut log_record);
         visitor.visit_metadata(meta);
         // Visit fields.
         event.record(&mut visitor);
-        visitor.push_to_otel_log_record(&mut log_record);
 
         self.logger.emit(log_record);
     }

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -3,7 +3,7 @@
     OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
     Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
     RAM: 64.0 GB
-    39 M/sec
+    53 M/sec
 */
 
 use opentelemetry_appender_tracing::layer;


### PR DESCRIPTION
Fixes #1799 

## Changes
As mentioned in issue, removed the temporary vector to store attributes, and instead directly pass the attribute as they are read to `LogRecord` using `add_attribute`

**Bench (for appender-tracing):**
**PR**: 371 ns
**main**: 446 ns
_**which is 17% improvement**_

**Stress test**
**PR**: 53 M/sec
**main**: 39 M/sec
**_which is 35% improvement_**



## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
