### PR TITLE
Fix overflow for counter metric

### DIFF
--- a/opentelemetry-sdk/benches/metric_counter.rs
+++ b/opentelemetry-sdk/benches/metric_counter.rs
@@ -19,7 +19,7 @@ use opentelemetry::{
 };
 use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
 use rand::{
-    rngs::{self, SmallRng},
+    rngs::{self},
     Rng, SeedableRng,
 };
 use std::cell::RefCell;

--- a/opentelemetry-sdk/benches/metric_counter.rs
+++ b/opentelemetry-sdk/benches/metric_counter.rs
@@ -107,14 +107,35 @@ fn counter_add(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("Random_Generator_5", |b| {
+    // Cause overflow.
+    for v in 0..2001 {
+        counter.add(100, &[KeyValue::new("A", v.to_string())]);
+    }
+    c.bench_function("Counter_Overflow", |b| {
         b.iter(|| {
-            let mut rng = SmallRng::from_entropy();
-            let _i1 = rng.gen_range(0..4);
-            let _i2 = rng.gen_range(0..4);
-            let _i3 = rng.gen_range(0..10);
-            let _i4 = rng.gen_range(0..10);
-            let _i5 = rng.gen_range(0..10);
+            // 4*4*10*10 = 1600 time series.
+            let rands = CURRENT_RNG.with(|rng| {
+                let mut rng = rng.borrow_mut();
+                [
+                    rng.gen_range(0..4),
+                    rng.gen_range(0..4),
+                    rng.gen_range(0..10),
+                    rng.gen_range(0..10),
+                ]
+            });
+            let index_first_attribute = rands[0];
+            let index_second_attribute = rands[1];
+            let index_third_attribute = rands[2];
+            let index_forth_attribute = rands[3];
+            counter.add(
+                1,
+                &[
+                    KeyValue::new("attribute1", attribute_values[index_first_attribute]),
+                    KeyValue::new("attribute2", attribute_values[index_second_attribute]),
+                    KeyValue::new("attribute3", attribute_values[index_third_attribute]),
+                    KeyValue::new("attribute4", attribute_values[index_forth_attribute]),
+                ],
+            );
         });
     });
 

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -24,7 +24,7 @@ pub(crate) static STREAM_OVERFLOW_ATTRIBUTE_SET: Lazy<AttributeSet> = Lazy::new(
 
 /// Checks whether aggregator has hit cardinality limit for metric streams
 pub(crate) fn is_under_cardinality_limit(size: usize) -> bool {
-    size < STREAM_CARDINALITY_LIMIT as usize - 1
+    size < STREAM_CARDINALITY_LIMIT as usize
 }
 
 /// Receives measurements to be aggregated.

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -55,14 +55,12 @@ impl<T: Number<T>> ValueMap<T> {
                 Entry::Vacant(vacant_entry) => {
                     if is_under_cardinality_limit(size) {
                         vacant_entry.insert(measurement);
+                    } else if let Some(val) = values.get_mut(&STREAM_OVERFLOW_ATTRIBUTE_SET) {
+                        *val += measurement;
+                        return;
                     } else {
-                        if let Some(val) = values.get_mut(&STREAM_OVERFLOW_ATTRIBUTE_SET) {
-                            *val += measurement;
-                            return;
-                        } else {
-                            values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone(), measurement);
-                            global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow. Further overflows to same metric until next collect will not be logged.".into()));
-                        }
+                        values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone(), measurement);
+                        global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow. Further overflows to same metric until next collect will not be logged.".into()));
                     }
                 }
             }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -60,7 +60,7 @@ impl<T: Number<T>> ValueMap<T> {
                         return;
                     } else {
                         values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone(), measurement);
-                        global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow. Further overflows to same metric until next collect will not be logged.".into()));
+                        global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow. Subsequent overflows to same metric until next collect will not be logged.".into()));
                     }
                 }
             }

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -9,6 +9,11 @@ name = "metrics"
 path = "src/metrics.rs"
 doc = false
 
+[[bin]] # Bin to run the metrics overflow stress tests
+name = "metrics_overflow"
+path = "src/metrics_overflow.rs"
+doc = false
+
 [[bin]] # Bin to run the logs stress tests
 name = "logs"
 path = "src/logs.rs"

--- a/stress/src/metrics_overflow.rs
+++ b/stress/src/metrics_overflow.rs
@@ -1,0 +1,43 @@
+/*
+    Stress test results:
+    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    RAM: 64.0 GB
+    4.5M /sec
+*/
+
+use lazy_static::lazy_static;
+use opentelemetry::{
+    metrics::{Counter, MeterProvider as _},
+    KeyValue,
+};
+use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+use std::borrow::Cow;
+
+mod throughput;
+
+lazy_static! {
+    static ref PROVIDER: SdkMeterProvider = SdkMeterProvider::builder()
+        .with_reader(ManualReader::builder().build())
+        .build();
+    static ref ATTRIBUTE_VALUES: [&'static str; 10] = [
+        "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
+        "value10"
+    ];
+    static ref COUNTER: Counter<u64> = PROVIDER
+        .meter(<&str as Into<Cow<'static, str>>>::into("test"))
+        .u64_counter("hello")
+        .init();
+}
+
+fn main() {
+    for v in 0..2001 {
+        COUNTER.add(100, &[KeyValue::new("A", v.to_string())]);
+    }
+    throughput::test_throughput(test_counter);
+}
+
+fn test_counter() {
+    COUNTER.add(1, &[KeyValue::new("A", "2001")]);
+}


### PR DESCRIPTION
Overflow handling for Counter fixed to:
1. Allow 2000 unique entries, *excluding* the overflow and 0 attributes case. i.e we will store 2002 entries, specially treating the 0 attribute and overflow to optimize performance (later)
2. Fix the error handling to be triggered once per collection interval at max.
3. Avoid unnecessary cloning of overflow atttribute.
4. Added tests and perf tests to have targeted testing for overflow scenario.

Note: Did not touch Histogram,Gauge, as there are no tests today for them, and their overflow logic looks incorrectly implemented. Will comeback to them after Counter is fully resolved.