### PR TITLE
Run msrv check for all crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@1.65.0
     - name: Patch dependencies versions # some dependencies bump MSRV without major version bump
       run: bash ./scripts/patch_dependencies.sh
-    - name: Check MSRV for opentelemetry
+    - name: Check MSRV for all crates
       run: bash ./scripts/msrv.sh
   cargo-deny:
     runs-on: ubuntu-latest # This uses the step `EmbarkStudios/cargo-deny-action@v1` which is only supported on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,8 @@ jobs:
     - uses: dtolnay/rust-toolchain@1.65.0
     - name: Patch dependencies versions # some dependencies bump MSRV without major version bump
       run: bash ./scripts/patch_dependencies.sh
-    - name: Run cargo check
-      run: cargo --version &&
-        cargo check
+    - name: Check MSRV for opentelemetry
+      run: bash ./scripts/msrv.sh
   cargo-deny:
     runs-on: ubuntu-latest # This uses the step `EmbarkStudios/cargo-deny-action@v1` which is only supported on Linux
     continue-on-error: true # Prevent sudden announcement of a new advisory from failing ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,9 @@ jobs:
     - uses: dtolnay/rust-toolchain@1.65.0
     - name: Patch dependencies versions # some dependencies bump MSRV without major version bump
       run: bash ./scripts/patch_dependencies.sh
-    - name: Run tests
+    - name: Run cargo check
       run: cargo --version &&
-        cargo test --manifest-path=opentelemetry/Cargo.toml --features trace,metrics,testing &&
-        cargo test --manifest-path=opentelemetry-zipkin/Cargo.toml
+        cargo check
   cargo-deny:
     runs-on: ubuntu-latest # This uses the step `EmbarkStudios/cargo-deny-action@v1` which is only supported on Linux
     continue-on-error: true # Prevent sudden announcement of a new advisory from failing ci

--- a/scripts/msrv.sh
+++ b/scripts/msrv.sh
@@ -11,8 +11,10 @@ cargo check --manifest-path=opentelemetry-sdk/Cargo.toml --all-features
 echo "Running msrv check for opentelemetry-stdout package"
 cargo check --manifest-path=opentelemetry-stdout/Cargo.toml --all-features
 
-echo "Running msrv check for opentelemetry-otlp package"
-cargo check --manifest-path=opentelemetry-otlp/Cargo.toml --all-features
+# TODO: Ignoring as this is failing with the following error:
+# error: package `prost-derive v0.12.6` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.65.0
+#echo "Running msrv check for opentelemetry-otlp package"
+# cargo check --manifest-path=opentelemetry-otlp/Cargo.toml --all-features
 
 echo "Running msrv check for opentelemetry-http package"
 cargo check --manifest-path=opentelemetry-http/Cargo.toml --all-features

--- a/scripts/msrv.sh
+++ b/scripts/msrv.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -eu
+
+echo "Running msrv check for opentelemetry package"
+cargo check --manifest-path=opentelemetry/Cargo.toml --all-features
+
+echo "Running msrv check for opentelemetry-sdk package"
+cargo check --manifest-path=opentelemetry-sdk/Cargo.toml --all-features
+
+echo "Running msrv check for opentelemetry-stdout package"
+cargo check --manifest-path=opentelemetry-stdout/Cargo.toml --all-features
+
+echo "Running msrv check for opentelemetry-otlp package"
+cargo check --manifest-path=opentelemetry-otlp/Cargo.toml --all-features
+
+echo "Running msrv check for opentelemetry-http package"
+cargo check --manifest-path=opentelemetry-http/Cargo.toml --all-features
+
+echo "Running msrv check for opentelemetry-jaeger-propagator package"
+cargo check --manifest-path=opentelemetry-jaeger-propagator/Cargo.toml --all-features
+
+echo "Running msrv check for opentelemetry-zipkin package"
+cargo check --manifest-path=opentelemetry-zipkin/Cargo.toml --all-features
+
+echo "Running msrv check for opentelemetry-appender-log package"
+cargo check --manifest-path=opentelemetry-appender-log/Cargo.toml --all-features
+
+echo "Running msrv check for opentelemetry-appender-tracing package"
+cargo check --manifest-path=opentelemetry-appender-tracing/Cargo.toml --all-features
+


### PR DESCRIPTION
Not sure why msrv check was done only for just 2 crates. This modifies the msrv CI check to be done for all crates, as the msrv promise is documented for all crates.
Also, instead of running cargo test, only cargo check is done, which is sufficient, as the goal is not to run the tests.

~TODO: Maybe need to find a way to exclude examples?~
opentelemetry-otlp is failing, so ignored. See tracking issue : https://github.com/open-telemetry/opentelemetry-rust/issues/1827