### PR TITLE
Add memory and cpu stats to Stress test

### DIFF
--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -41,4 +41,7 @@ tracing = { workspace = true, features = ["std"]}
 tracing-core = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["registry", "std"] }
 num-format = "0.4.4"
-sysinfo = "0.30.12"
+sysinfo = { version = "0.30.12", optional = true }
+
+[features]
+stats = ["sysinfo"]

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -41,3 +41,4 @@ tracing = { workspace = true, features = ["std"]}
 tracing-core = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["registry", "std"] }
 num-format = "0.4.4"
+sysinfo = "0.30.12"

--- a/stress/README.md
+++ b/stress/README.md
@@ -36,3 +36,11 @@ Throughput: 3,905,200 iterations/sec
 Throughput: 4,106,600 iterations/sec
 Throughput: 5,075,400 iterations/sec
 ```
+
+## Feature flags
+
+"stats" - Prints memory and CPU usage. Has slight impact on throughput.
+
+```sh
+cargo run --release --bin metrics --feature=stats
+```

--- a/stress/src/throughput.rs
+++ b/stress/src/throughput.rs
@@ -1,4 +1,5 @@
 use num_format::{Locale, ToFormattedString};
+use sysinfo::{Pid, System};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread;
@@ -27,7 +28,7 @@ where
     })
     .expect("Error setting Ctrl-C handler");
     let num_threads = num_cpus::get();
-    println!("Number of threads: {}", num_threads);
+    println!("Number of threads: {}\n", num_threads);
     let mut handles = Vec::with_capacity(num_threads);
     let func_arc = Arc::new(func);
     let mut worker_stats_vec: Vec<WorkerStats> = Vec::new();
@@ -42,6 +43,10 @@ where
         let mut start_time = Instant::now();
         let mut end_time = start_time;
         let mut total_count_old: u64 = 0;
+        
+        let pid = Pid::from(std::process::id() as usize);
+        let mut system = System::new_all();
+
         loop {
             let elapsed = end_time.duration_since(start_time).as_secs();
             if elapsed >= SLIDING_WINDOW_SIZE {
@@ -56,6 +61,16 @@ where
                     "Throughput: {} iterations/sec",
                     throughput.to_formatted_string(&Locale::en)
                 );
+                system.refresh_all();
+                if let Some(process) = system.process(pid) {
+                    println!("Memory usage: {:.2} MB", process.memory() as f64/(1024.0 * 1024.0));
+                    println!("CPU usage: {}%", process.cpu_usage()/num_threads as f32);
+                    println!("Virtual memory usage: {:.2} MB", process.virtual_memory() as f64/(1024.0 * 1024.0));
+                } else {
+                    println!("Process not found");
+                }
+
+                println!("\n");
                 start_time = Instant::now();
             }
 


### PR DESCRIPTION
Opt-in via "stats" feature flag.
Example output:

```txt
Number of threads: 8

Throughput: 9,390,400 iterations/sec
Memory usage: 2.41 MB
CPU usage: 87.44615%
Virtual memory usage: 1127.27 MB
```