### PR TITLE
Fix external-types check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-07
+          toolchain: nightly-2024-05-01
           components: rustfmt
       - name: external-type-check
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-07-25
+          toolchain: nightly-2024-02-07
           components: rustfmt
       - name: external-type-check
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-07
+          toolchain: nightly-2024-07-25
           components: rustfmt
       - name: external-type-check
         run: |


### PR DESCRIPTION
`external-types` check is failing: https://github.com/open-telemetry/opentelemetry-rust/actions/runs/9275023674/job/25518752628?pr=1831#step:4:159

## Changes
- Update the nightly version to fix the error (Check this: https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.1.12)