### PR TITLE
Fix typos in webpki feature name

### DIFF
--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.65"
 
 [features]
 reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
-reqwest-rustls-webkpi-roots = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
+reqwest-rustls-webpki-roots = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -67,7 +67,7 @@ grpc-tonic = ["tonic", "prost", "http", "tokio", "opentelemetry-proto/gen-tonic"
 gzip-tonic = ["tonic/gzip"]
 tls = ["tonic/tls"]
 tls-roots = ["tls", "tonic/tls-roots"]
-tls-webkpi-roots = ["tls", "tonic/tls-webpki-roots"]
+tls-webpki-roots = ["tls", "tonic/tls-webpki-roots"]
 
 # http binary
 http-proto = ["prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "http", "trace", "metrics"]
@@ -76,7 +76,7 @@ http-json = ["serde_json", "prost", "opentelemetry-http", "opentelemetry-proto/g
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 reqwest-rustls = ["reqwest", "opentelemetry-http/reqwest-rustls"]
-reqwest-rustls-webkpi-roots = ["reqwest", "opentelemetry-http/reqwest-rustls-webkpi-roots"]
+reqwest-rustls-webpki-roots = ["reqwest", "opentelemetry-http/reqwest-rustls-webpki-roots"]
 
 # test
 integration-testing = ["tonic", "prost", "tokio/full", "trace"]


### PR DESCRIPTION
## Changes

`webpki` is misspelled as `webkpi` in `opentelemetry-otlp` and `opentelemetry-http` features. This PR fixed the typo.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
