### PR TITLE
Small cleanup in Logs SDK.

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -41,7 +41,9 @@
     - `SpanData` doesn't have the resource attributes. The `SpanExporter::export()` method needs to merge it 
       with the earlier preserved resource before export.
 
-- **Breaking** [1836](https://github.com/open-telemetry/opentelemetry-rust/pull/1836) `SpanProcessor::shutdown` now takes an immutable reference to self. Any reference can call shutdown on the processor. After the first call to `shutdown` the processor will not process any new spans. 
+- **Breaking** [1836](https://github.com/open-telemetry/opentelemetry-rust/pull/1836) `SpanProcessor::shutdown` now takes an immutable reference to self. Any reference can call shutdown on the processor. After the first call to `shutdown` the processor will not process any new spans.
+
+- **Breaking** [1850] (https://github.com/open-telemetry/opentelemetry-rust/pull/1850) `LoggerProvider::log_processors()` and `LoggerProvider::resource()` are not public methods anymore. They are only used within the `opentelemetry-sdk` crate.
 
 ## v0.23.0
 

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -90,14 +90,12 @@ impl LoggerProvider {
         Builder::default()
     }
 
-    /// Resource associated with this provider.
-    pub fn resource(&self) -> &Resource {
-        &self.inner.resource
+    pub(crate) fn log_processors(&self) -> &[Box<dyn LogProcessor>] {
+        &self.inner.processors
     }
 
-    /// Log processors associated with this provider.
-    pub fn log_processors(&self) -> &[Box<dyn LogProcessor>] {
-        &self.inner.processors
+    pub(crate) fn resource(&self) -> &Resource {
+        &self.inner.resource
     }
 
     /// Force flush all remaining logs in log processors and return results.
@@ -196,17 +194,20 @@ impl Builder {
     /// Create a new provider from this configuration.
     pub fn build(self) -> LoggerProvider {
         let resource = self.resource.unwrap_or_default();
-        // invoke set_resource on all the processors
-        for processor in &self.processors {
-            processor.set_resource(&resource);
-        }
-        LoggerProvider {
+
+        let logger_provider = LoggerProvider {
             inner: Arc::new(LoggerProviderInner {
                 processors: self.processors,
                 resource,
             }),
             is_shutdown: Arc::new(AtomicBool::new(false)),
+        };
+
+        // invoke set_resource on all the processors
+        for processor in logger_provider.log_processors() {
+            processor.set_resource(logger_provider.resource());
         }
+        logger_provider
     }
 }
 


### PR DESCRIPTION
## Changes

- Set `LoggerProvider::log_processors()` visibility to crate scope.
- Set `LoggerProvider::resource()` visibility to crate scope.
- Modify Builder::build() to first create the `LoggerProvider`, and then propagate the resource to the processor, to address below warning after above scope changes:

```rust
warning: method `resource` is never used
   --> opentelemetry-sdk/src/logs/log_emitter.rs:94:19
    |
87  | impl LoggerProvider {
    | ------------------- method in this implementation
...
94  |     pub(crate) fn resource(&self) -> &Resource {
    |                   ^^^^^^^^
    |
note: the lint level is defined here
   --> opentelemetry-sdk/src/lib.rs:110:5
    |
110 |     unused
    |     ^^^^^^
    = note: `#[warn(dead_code)]` implied by `#[warn(unused)]`
```
- 
## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
