### PR TITLE
feat: add `shutdown` in `TracerProvider`

### DIFF
--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -77,7 +77,7 @@ impl opentelemetry::logs::LoggerProvider for LoggerProvider {
 
     fn library_logger(&self, library: Arc<InstrumentationLibrary>) -> Self::Logger {
         // If the provider is shutdown, new logger will refer a no-op logger provider.
-        if self.is_shutdown.load(std::sync::atomic::Ordering::Relaxed) {
+        if self.is_shutdown.load(Ordering::Relaxed) {
             return Logger::new(library, NOOP_LOGGER_PROVIDER.clone());
         }
         Logger::new(library, self.clone())

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -158,7 +158,7 @@ impl TracerProvider {
             .is_ok()
         {
             // propagate the shutdown signal to processors
-            // it's up to the processor to properly block new logs after shutdown
+            // it's up to the processor to properly block new spans after shutdown
             let mut errs = vec![];
             for processor in &self.inner.processors {
                 if let Err(err) = processor.shutdown() {

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 const DEFAULT_COMPONENT_NAME: &str = "rust.opentelemetry.io/sdk/tracer";
 static PROVIDER_RESOURCE: OnceCell<Resource> = OnceCell::new();
 
-// a no nop logger provider used as placeholder when the provider is shutdown
+// a no nop tracer provider used as placeholder when the provider is shutdown
 static NOOP_TRACER_PROVIDER: Lazy<TracerProvider> = Lazy::new(|| TracerProvider {
     inner: Arc::new(TracerProviderInner {
         processors: Vec::new(),

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -324,7 +324,7 @@ mod tests {
 
     impl SharedAssertInfo {
         fn started_span_count(&self, count: u32) -> bool {
-            return self.0.started_span.load(Ordering::SeqCst) == count;
+            self.0.started_span.load(Ordering::SeqCst) == count
         }
     }
 
@@ -370,7 +370,7 @@ mod tests {
 
         fn shutdown(&self) -> TraceResult<()> {
             if self.assert_info.0.is_shutdown.load(Ordering::SeqCst) {
-                return Ok(());
+                Ok(())
             } else {
                 let _ = self.assert_info.0.is_shutdown.compare_exchange(
                     false,

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -204,11 +204,11 @@ impl Span {
             None => return,
         };
 
+        let provider = self.tracer.provider();
         // skip if provider has been shut down
-        let provider = match self.tracer.provider() {
-            Some(provider) => provider,
-            None => return,
-        };
+        if provider.is_shutdown() {
+            return;
+        }
 
         // ensure end time is set via explicit end or implicitly on drop
         if let Some(timestamp) = timestamp {
@@ -719,7 +719,7 @@ mod tests {
         let exported_data = span.exported_data();
         assert!(exported_data.is_some());
 
-        drop(provider);
+        provider.shutdown().expect("shutdown panicked");
         let dropped_span = tracer.start("span_with_dropped_provider");
         // return none if the provider has already been dropped
         assert!(dropped_span.exported_data().is_none());

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -924,23 +924,6 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_batch_span_processor_multiple_shutdown() {
-        let processor = BatchSpanProcessor::new(
-            Box::new(NoopSpanExporter::new()),
-            BatchConfig::default(),
-            Tokio,
-        );
-
-        let shutdown = |processor: &BatchSpanProcessor<Tokio>| {
-            let result = processor.shutdown();
-            assert!(result.is_ok());
-        };
-
-        shutdown(&processor);
-        shutdown(&processor);
-    }
-
     struct BlockingExporter<D> {
         delay_for: Duration,
         delay_fn: D,

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -693,10 +693,8 @@ mod tests {
     };
     use crate::export::trace::{ExportResult, SpanData, SpanExporter};
     use crate::runtime;
-    use crate::runtime::Tokio;
     use crate::testing::trace::{
         new_test_export_span_data, new_tokio_test_exporter, InMemorySpanExporterBuilder,
-        NoopSpanExporter,
     };
     use crate::trace::span_processor::{
         OTEL_BSP_EXPORT_TIMEOUT_DEFAULT, OTEL_BSP_MAX_CONCURRENT_EXPORTS,


### PR DESCRIPTION
Towards #1801

## Changes

- Add `shutdown` in `TracerProvider`.
- `Tracer` now takes a `TracerProvider` instead of `Weak<TracerProviderInner>`, removing the upgrading cost
- A span will NOT started when `TracerProvider` has already shutdown
- A span will NOT be exportered when `TracerProvider` has already shutdown
- Minor fix for LoggerProvider

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
