### PR TITLE
Fix serde

### DIFF
--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
@@ -11,6 +11,7 @@ pub struct AnyValue {
     /// The value is one of the listed fields. It is valid for all values to be unspecified
     /// in which case this AnyValue is considered to be "empty".
     #[prost(oneof = "any_value::Value", tags = "1, 2, 3, 4, 5, 6, 7")]
+    #[cfg_attr(feature = "with-serde", serde(flatten))]
     pub value: ::core::option::Option<any_value::Value>,
 }
 /// Nested message and enum types in `AnyValue`.
@@ -80,13 +81,6 @@ pub struct KeyValue {
     #[prost(string, tag = "1")]
     pub key: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
-    #[cfg_attr(
-        feature = "with-serde",
-        serde(
-            serialize_with = "crate::proto::serializers::serialize_to_value",
-            deserialize_with = "crate::proto::serializers::deserialize_from_value"
-        )
-    )]
     pub value: ::core::option::Option<AnyValue>,
 }
 /// InstrumentationScope is a message representing the instrumentation scope information

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
@@ -181,6 +181,7 @@ pub struct Metric {
     /// reported value type for the data points, as well as the relatationship to
     /// the time interval over which they are reported.
     #[prost(oneof = "metric::Data", tags = "5, 7, 9, 10, 11")]
+    #[cfg_attr(feature = "with-serde", serde(flatten))]
     pub data: ::core::option::Option<metric::Data>,
 }
 /// Nested message and enum types in `Metric`.
@@ -325,6 +326,7 @@ pub struct NumberDataPoint {
     /// The value itself.  A point is considered invalid when one of the recognized
     /// value fields is not present inside this oneof.
     #[prost(oneof = "number_data_point::Value", tags = "4, 6")]
+    #[cfg_attr(feature = "with-serde", serde(flatten))]
     pub value: ::core::option::Option<number_data_point::Value>,
 }
 /// Nested message and enum types in `NumberDataPoint`.
@@ -674,6 +676,7 @@ pub struct Exemplar {
     /// considered invalid when one of the recognized value fields is not present
     /// inside this oneof.
     #[prost(oneof = "exemplar::Value", tags = "3, 6")]
+    #[cfg_attr(feature = "with-serde", serde(flatten))]
     pub value: ::core::option::Option<exemplar::Value>,
 }
 /// Nested message and enum types in `Exemplar`.

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -94,9 +94,20 @@ fn build_tonic() {
     }
 
     // add custom serializer and deserializer for AnyValue
-    for path in ["common.v1.KeyValue.value", "logs.v1.LogRecord.body"] {
+    for path in ["logs.v1.LogRecord.body"] {
         builder = builder
         .field_attribute(path, "#[cfg_attr(feature =\"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_to_value\", deserialize_with = \"crate::proto::serializers::deserialize_from_value\"))]");
+    }
+
+    // flatten
+    for path in [
+        "common.v1.AnyValue.value",
+        "metrics.v1.Metric.data",
+        "metrics.v1.NumberDataPoint.value",
+        "metrics.v1.Exemplar.value",
+    ] {
+        builder =
+            builder.field_attribute(path, "#[cfg_attr(feature =\"with-serde\", serde(flatten))]");
     }
 
     builder

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -94,10 +94,8 @@ fn build_tonic() {
     }
 
     // add custom serializer and deserializer for AnyValue
-    for path in ["logs.v1.LogRecord.body"] {
-        builder = builder
-        .field_attribute(path, "#[cfg_attr(feature =\"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_to_value\", deserialize_with = \"crate::proto::serializers::deserialize_from_value\"))]");
-    }
+    builder = builder
+        .field_attribute("logs.v1.LogRecord.body", "#[cfg_attr(feature =\"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_to_value\", deserialize_with = \"crate::proto::serializers::deserialize_from_value\"))]");
 
     // flatten
     for path in [


### PR DESCRIPTION
Make compatible with Collector serde shape

## Changes

This PR:
- Flattens some `data` and `value` fields in order to be consistent with the JSON schema implemented on the OTEL Collector
  - See [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/internal/data/protogen/metrics/v1/metrics.pb.go#L469) for the struct defs and JSON tags
  - Also see [here](https://github.com/open-telemetry/opentelemetry-proto/blob/v1.3.1/examples/metrics.json) for an example resource metric in JSON
- Make the `common::v1::KeyValue::value` field serde into an `Option<AnyValue>` rather than the direct serialized value in order to be consistent with the JSON schema implemented on the OTEL Collector
  - See [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/internal/data/protogen/common/v1/common.pb.go#L288) for the struct defs and JSON tags
  - Also see [here](https://github.com/open-telemetry/opentelemetry-proto/blob/v1.3.1/examples/trace.json#L40-L42) for an example resource span in JSON
  - Similar comment made on an earlier PR: https://github.com/open-telemetry/opentelemetry-rust/pull/1462/files#r1623330058

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
