### PR TITLE
Update collector config to use debug exporter

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/otel-collector-config.yaml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/otel-collector-config.yaml
@@ -11,17 +11,17 @@ receivers:
       http:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]

--- a/opentelemetry-otlp/examples/basic-otlp/otel-collector-config.yaml
+++ b/opentelemetry-otlp/examples/basic-otlp/otel-collector-config.yaml
@@ -11,17 +11,17 @@ receivers:
       http:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]

--- a/opentelemetry-otlp/tests/integration_test/otel-collector-config.yaml
+++ b/opentelemetry-otlp/tests/integration_test/otel-collector-config.yaml
@@ -5,8 +5,6 @@ receivers:
       http:
 
 exporters:
-  logging:
-    loglevel: debug
   file:
     path: /testresults/result.json
 


### PR DESCRIPTION
## Changes
- `loggingexporter` has been marked deprecated in favor of `debug` exporter in the collector repo. Check [this](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CHANGELOG.md#-deprecations--2).
- Update the collector config in the examples to use `debug` exporter instead of `loggingexporter`
- Remove `loggingexporter` from integration tests config as it was not being used
