### PR TITLE
fix msrv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,4 @@ tokio-stream = "0.1.1"
 tracing = { version = "0.1", default-features = false }
 tracing-core = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
-url = { version = "2.2", default-features = false }
+url = { version = "=2.5.0", default-features = false } #pinning the version supporting rustc 1.65


### PR DESCRIPTION
Fixes #1874 
Design discussion issue (if applicable) #

## Changes

The `opentelemetry-http` has an indirect dependency on the `url` crate via `reqwest`. Pinning the `url` crate to a version that supports Rust 1.65.0.


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
