### PR TITLE
Add criterion to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ debug = 1
 async-std = "1.10"
 async-trait = "0.1"
 bytes = "1"
+criterion = "0.5"
 futures-core = "0.3"
 futures-executor = "0.3"
 futures-util = { version = "0.3", default-features = false }

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -24,8 +24,8 @@ log = { workspace = true }
 opentelemetry-stdout = { path = "../opentelemetry-stdout", features = ["logs"] }
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["logs", "testing"]  }
 tracing-log = "0.2"
-async-trait = "0.1"
-criterion = "0.5.1"
+async-trait = { workspace = true }
+criterion = { workspace = true }
 
 [features]
 experimental_metadata_attributes = ["dep:tracing-log"]

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -60,4 +60,4 @@ hex = { version = "0.4.3", optional = true }
 tonic-build = { workspace = true }
 prost-build = { workspace = true }
 tempfile = "3.3.0"
-serde_json = "1.0"
+serde_json = { workspace = true }

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { workspace = true, features = ["html_reports"] }
 temp-env = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -41,7 +41,7 @@ otel_unstable = []
 
 [dev-dependencies]
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["logs_level_enabled"]} # for documentation tests
-criterion = { version = "0.3" }
+criterion = { workspace = true }
 rand = { workspace = true }
 
 [[bench]]


### PR DESCRIPTION
## Changes
- `criterion` is used by multiple projects
- Add `criterion` to workspace dependencies
- Use the package version specified in workspace dependencies for `criterion` and a few other packages
