### PR TITLE
Remove "logs_level_enabled" from cargo toml for appender crates

### DIFF
--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -18,7 +18,6 @@ serde = { workspace = true, optional = true, features = ["std"] }
 [features]
 logs_level_enabled = ["opentelemetry/logs_level_enabled"]
 with-serde = ["log/kv_serde", "serde"]
-default = ["logs_level_enabled"]
 
 [dev-dependencies]
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = [ "testing", "logs_level_enabled" ] }

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -30,7 +30,6 @@ criterion = { workspace = true }
 [features]
 experimental_metadata_attributes = ["dep:tracing-log"]
 logs_level_enabled = ["opentelemetry/logs_level_enabled"]
-default = ["logs_level_enabled"]
 
 
 [[bench]]


### PR DESCRIPTION
Towards #1880

## Changes
- Remove "logs_level_enabled" as the default feature from the appender crates
- Users who want to use this would now have to explicitly opt-in for it

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
