### PR TITLE
Simplify tracing-grpc example

### DIFF
--- a/examples/tracing-grpc/src/client.rs
+++ b/examples/tracing-grpc/src/client.rs
@@ -75,10 +75,8 @@ async fn greet() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static
             status_code.to_string()
         }
     };
-    cx.span().add_event(
-        "Got response!",
-        vec![KeyValue::new("status", status)],
-    );
+    cx.span()
+        .add_event("Got response!", vec![KeyValue::new("status", status)]);
 
     Ok(())
 }

--- a/examples/tracing-grpc/src/client.rs
+++ b/examples/tracing-grpc/src/client.rs
@@ -50,9 +50,9 @@ pub mod hello_world {
 async fn greet() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let tracer = global::tracer("example/client");
     let span = tracer
-        .span_builder(String::from("Greeter/client"))
+        .span_builder("Greeter/client")
         .with_kind(SpanKind::Client)
-        .with_attributes(vec![KeyValue::new("component", "grpc")])
+        .with_attributes([KeyValue::new("component", "grpc")])
         .start(&tracer);
     let cx = Context::current_with_span(span);
     let mut client = GreeterClient::connect("http://[::1]:50051").await?;

--- a/examples/tracing-grpc/src/client.rs
+++ b/examples/tracing-grpc/src/client.rs
@@ -76,7 +76,7 @@ async fn greet() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static
         }
     };
     cx.span().add_event(
-        "Got response!".to_string(),
+        "Got response!",
         vec![KeyValue::new("status", status)],
     );
 

--- a/examples/tracing-http-propagator/src/client.rs
+++ b/examples/tracing-http-propagator/src/client.rs
@@ -41,7 +41,7 @@ async fn send_request(
         .await?;
 
     cx.span().add_event(
-        "Got response!".to_string(),
+        "Got response!",
         vec![KeyValue::new("status", res.status().to_string())],
     );
 


### PR DESCRIPTION
## Changes
- Users can simply pass a `&str` instead of a `String`
- Users don't have to create a `Vec` and pass an array
