### PR TITLE
Use as many threads as logical cores for achieving full utilization

### DIFF
--- a/stress/README.md
+++ b/stress/README.md
@@ -42,5 +42,5 @@ Throughput: 5,075,400 iterations/sec
 "stats" - Prints memory and CPU usage. Has slight impact on throughput.
 
 ```sh
-cargo run --release --bin metrics --feature=stats
+cargo run --release --bin metrics --features=stats
 ```

--- a/stress/src/throughput.rs
+++ b/stress/src/throughput.rs
@@ -126,7 +126,7 @@ where
 
     handles.push(handle_main_thread);
 
-    for thread_index in 0..num_threads - 1 {
+    for thread_index in 0..num_threads {
         let worker_stats_shared = Arc::clone(&worker_stats_shared);
         let func_arc_clone = Arc::clone(&func_arc);
         let handle = thread::spawn(move || loop {


### PR DESCRIPTION
Not sure why we were doing 1 thread less! With this the cpu shows 99% consistently, as opposed to ~90% before.

PR:

Number of threads: 16
Throughput: 51,652,400 iterations/sec
Memory usage: 3.85 MB
**CPU usage: 99.551765%**
Virtual memory usage: 2249.09 MB

main:

Number of threads: 16
Throughput: 51,308,600 iterations/sec
Memory usage: 4.16 MB
**CPU usage: 92.986916%**
Virtual memory usage: 2183.07 MB