### PR TITLE
Use arrays instead of vec for creating resource in examples

### DIFF
--- a/examples/logs-basic/src/main.rs
+++ b/examples/logs-basic/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
         //    Ok(serde_json::to_writer_pretty(writer, &data).unwrap()))
         .build();
     let logger_provider = LoggerProvider::builder()
-        .with_resource(Resource::new(vec![KeyValue::new(
+        .with_resource(Resource::new([KeyValue::new(
             SERVICE_NAME,
             "logs-basic-example",
         )]))

--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -52,7 +52,7 @@ fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
     let provider = SdkMeterProvider::builder()
         .with_reader(reader)
-        .with_resource(Resource::new(vec![KeyValue::new(
+        .with_resource(Resource::new([KeyValue::new(
             "service.name",
             "metrics-advanced-example",
         )]))

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -13,7 +13,7 @@ fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
     let provider = SdkMeterProvider::builder()
         .with_reader(reader)
-        .with_resource(Resource::new(vec![KeyValue::new(
+        .with_resource(Resource::new([KeyValue::new(
             "service.name",
             "metrics-basic-example",
         )]))


### PR DESCRIPTION
## Changes
- No need to allocate a vec just to create resource
