### PR TITLE
Update http example with json protocol

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -20,7 +20,7 @@ now use `.with_resource(RESOURCE::default())` to configure Resource when using
   previous release.
 - **Breaking** [1869](https://github.com/open-telemetry/opentelemetry-rust/pull/1869) The OTLP logs exporter now overrides the [InstrumentationScope::name](https://github.com/open-telemetry/opentelemetry-proto/blob/b3060d2104df364136d75a35779e6bd48bac449a/opentelemetry/proto/common/v1/common.proto#L73) field with the `target` from `LogRecord`, if target is populated.
 - Groups batch of `LogRecord` and `Span` by their resource and instrumentation scope before exporting, for better efficiency [#1873](https://github.com/open-telemetry/opentelemetry-rust/pull/1873).
-
+- Updated basic-otlp-http example to make use of `protocol` setting when building the exporter
 
 ## v0.16.0
 

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -20,7 +20,6 @@ now use `.with_resource(RESOURCE::default())` to configure Resource when using
   previous release.
 - **Breaking** [1869](https://github.com/open-telemetry/opentelemetry-rust/pull/1869) The OTLP logs exporter now overrides the [InstrumentationScope::name](https://github.com/open-telemetry/opentelemetry-proto/blob/b3060d2104df364136d75a35779e6bd48bac449a/opentelemetry/proto/common/v1/common.proto#L73) field with the `target` from `LogRecord`, if target is populated.
 - Groups batch of `LogRecord` and `Span` by their resource and instrumentation scope before exporting, for better efficiency [#1873](https://github.com/open-telemetry/opentelemetry-rust/pull/1873).
-- Updated basic-otlp-http example to make use of `protocol` setting when building the exporter
 
 ## v0.16.0
 

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -21,6 +21,7 @@ now use `.with_resource(RESOURCE::default())` to configure Resource when using
 - **Breaking** [1869](https://github.com/open-telemetry/opentelemetry-rust/pull/1869) The OTLP logs exporter now overrides the [InstrumentationScope::name](https://github.com/open-telemetry/opentelemetry-proto/blob/b3060d2104df364136d75a35779e6bd48bac449a/opentelemetry/proto/common/v1/common.proto#L73) field with the `target` from `LogRecord`, if target is populated.
 - Groups batch of `LogRecord` and `Span` by their resource and instrumentation scope before exporting, for better efficiency [#1873](https://github.com/open-telemetry/opentelemetry-rust/pull/1873).
 
+
 ## v0.16.0
 
 ### Fixed

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -71,7 +71,6 @@ tls-webpki-roots = ["tls", "tonic/tls-webpki-roots"]
 
 # http binary
 http-proto = ["prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "http", "trace", "metrics"]
-# http json This does not work today due to known issue. See https://github.com/open-telemetry/opentelemetry-rust/issues/1763.
 http-json = ["serde_json", "prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "opentelemetry-proto/with-serde", "http", "trace", "metrics"]
 reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]

--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -16,7 +16,7 @@ once_cell = { workspace = true }
 opentelemetry = { path = "../../../opentelemetry" }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "metrics", "logs"] }
 opentelemetry-http = { path = "../../../opentelemetry-http", optional = true }
-opentelemetry-otlp = { path = "../..", features = ["http-proto", "reqwest-client", "logs"] }
+opentelemetry-otlp = { path = "../..", features = ["http-proto", "http-json", "reqwest-client", "logs"] }
 opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}
 opentelemetry-semantic-conventions = { path = "../../../opentelemetry-semantic-conventions" }
 

--- a/opentelemetry-otlp/examples/basic-otlp-http/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp-http/README.md
@@ -1,9 +1,9 @@
 # Basic OTLP exporter Example
 
 This example shows how to setup OpenTelemetry OTLP exporter for logs, metrics
-and traces to exports them to the [OpenTelemetry
+and traces to export them to the [OpenTelemetry
 Collector](https://github.com/open-telemetry/opentelemetry-collector) via OTLP
-over HTTP/protobuf. The Collector then sends the data to the appropriate
+over selected protocol such as HTTP/protobuf or HTTP/json. The Collector then sends the data to the appropriate
 backend, in this case, the logging Exporter, which displays data to console.
 
 ## Usage

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -41,7 +41,7 @@ fn init_logs() -> Result<sdklogs::LoggerProvider, opentelemetry::logs::LogError>
         .with_resource(RESOURCE.clone())
         .with_exporter(
             http_exporter()
-                .with_protocol(Protocol::HttpBinary)
+                .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
                 .with_endpoint("http://localhost:4318/v1/logs"),
         )
         .install_batch(opentelemetry_sdk::runtime::Tokio)
@@ -52,7 +52,7 @@ fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
         .tracing()
         .with_exporter(
             http_exporter()
-                .with_protocol(Protocol::HttpBinary)
+                .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
                 .with_endpoint("http://localhost:4318/v1/traces"),
         )
         .with_trace_config(Config::default().with_resource(RESOURCE.clone()))
@@ -64,7 +64,7 @@ fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, Metric
         .metrics(opentelemetry_sdk::runtime::Tokio)
         .with_exporter(
             http_exporter()
-                .with_protocol(Protocol::HttpBinary)
+                .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
                 .with_endpoint("http://localhost:4318/v1/metrics"),
         )
         .with_resource(RESOURCE.clone())


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

- Update http example to enable `http-json` feature 
- Update code to specify `protocol` when building http exporter

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
