### PR TITLE
Remove `isahc` support

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -37,7 +37,6 @@
         "Dirkjan",
         "EPYC",
         "hasher",
-        "isahc",
         "Isobel",
         "jaegertracing",
         "Kühle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ futures-executor = "0.3"
 futures-util = { version = "0.3", default-features = false }
 hyper = { version = "0.14", default-features = false }
 http = { version = "0.2", default-features = false }
-isahc = { version = "1.4", default-features = false }
 log = "0.4.21"
 once_cell = "1.13"
 ordered-float = "4.0"

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -18,7 +18,6 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 hyper = { workspace = true, features = ["http2", "client", "tcp"], optional = true }
-isahc = { workspace = true, optional = true }
 opentelemetry = { version = "0.23", path = "../opentelemetry", features = ["trace"] }
 reqwest = { workspace = true, features = ["blocking"], optional = true }
 tokio = { workspace = true, features = ["time"], optional = true }


### PR DESCRIPTION
Removes `isahc` as part of the http v1 upgrade (see <https://github.com/open-telemetry/opentelemetry-rust/pull/1674#discussion_r1668348354>)

## Changes

**Breaking** change: Remove the `isahc` client from `opentelemetry-http`. Progress on that client has been pretty much non-existent lately and is therefore stuck on http v0.2.

In preparation for the upgrade, we need to remove that client first since supporting it, while possible, would add a maintainance burden in form of the compatibility layer.

Also the author has mentioned that they are attempting to pick up development again, meaning as soon as it reaches support for v1, it can be added again (it's not a lot of code tbh)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
