### PR TITLE
[opentelemetry-otlp][tonic] Add more information to error message for Unknown status code

### DIFF
--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -381,9 +381,17 @@ impl From<tonic::Status> for Error {
             code: status.code(),
             message: {
                 if !status.message().is_empty() {
-                    ", detailed error message: ".to_string() + status.message()
+                    let mut result = ", detailed error message: ".to_string() + status.message();
+                    if status.code() == tonic::Code::Unknown {
+                        let source = (&status as &dyn std::error::Error)
+                            .source()
+                            .map(|e| format!("{:?}", e));
+                        result.push(' ');
+                        result.push_str(source.unwrap_or_default().as_ref());
+                    }
+                    result
                 } else {
-                    "".to_string()
+                    String::new()
                 }
             },
         }


### PR DESCRIPTION
## Changes

Currently, when the OTLP Exporter receives an `Unknown` code from tonic, the error message isn't helpful. I ran into this issue when I ran the basic-otlp example with the collector container not running on the host machine network. Here is the error message:

```
OpenTelemetry trace error occurred. Exporter otlp encountered the following error(s): the grpc server returns error (Unknown error): , detailed error message: transport error
Error: Other("[ExportErr(Status { code: Unknown, message: \", detailed error message: transport error\" })]")
```

I have updated the conversion logic for `tonic::Status` to `Error` to add information about the source of the error when we receive an `Unkown` error. The error message now captures the connection reset issue:

```
OpenTelemetry trace error occurred. Exporter otlp encountered the following error(s): the grpc server returns error (Unknown error): , detailed error message: transport error tonic::transport::Error(Transport, hyper::Error(Io, Custom { kind: BrokenPipe, error: "stream closed because of a broken pipe" }))
Error: Other("[ExportErr(Status { code: Unknown, message: \", detailed error message: transport error tonic::transport::Error(Transport, hyper::Error(Io, Kind(ConnectionReset)))\" })]")
```

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
