### PR TITLE
sdk: expose Tracer::id_generator()

### DIFF
--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -11,7 +11,7 @@ use crate::{
     trace::{
         provider::TracerProvider,
         span::{Span, SpanData},
-        SpanLimits, SpanLinks,
+        IdGenerator, SpanEvents, SpanLimits, SpanLinks,
     },
     InstrumentationLibrary,
 };
@@ -21,8 +21,6 @@ use opentelemetry::{
 };
 use std::fmt;
 use std::sync::Arc;
-
-use super::SpanEvents;
 
 /// `Tracer` implementation to create and manage spans
 #[derive(Clone)]
@@ -159,6 +157,14 @@ impl Tracer {
             self.clone(),
             span_limits,
         )
+    }
+
+    /// The [`IdGenerator`] associated with this tracer.
+    ///
+    // Note: this is necessary for tracing-opentelemetry's `PreSampledTracer`.
+    #[doc(hidden)]
+    pub fn id_generator(&self) -> &dyn IdGenerator {
+        &*self.provider.config().id_generator
     }
 }
 


### PR DESCRIPTION
## Changes

https://github.com/open-telemetry/opentelemetry-rust/pull/1755 privatized `Tracer::provider()` which tracing-opentelemetry needs to build its [`PreSampledTracer`](https://github.com/tokio-rs/tracing-opentelemetry/blob/v0.1.x/src/tracer.rs#L67). Pending a long-term solution for #1571, add a more restricted `#[doc(hidden)]` `Tracer::id_generator()` method that only exposes the internal `provider`'s `config().id_generator`.

This is blocking the 0.24 release.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)