### PR TITLE
Fix Stress Test

### DIFF
--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -1,9 +1,9 @@
 /*
     Stress test results:
-    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
-    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    OS: Ubuntu 22.04.4 LTS (5.15.153.1-microsoft-standard-WSL2)
+    Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
     RAM: 64.0 GB
-    69 M/sec
+    ~31 M/sec
 */
 
 use opentelemetry_appender_tracing::layer;

--- a/stress/src/metrics_counter.rs
+++ b/stress/src/metrics_counter.rs
@@ -1,9 +1,9 @@
 /*
     Stress test results:
-    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
-    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    OS: Ubuntu 22.04.4 LTS (5.15.153.1-microsoft-standard-WSL2)
+    Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
     RAM: 64.0 GB
-    35 M /sec
+    ~9.5 M /sec
 */
 
 use lazy_static::lazy_static;

--- a/stress/src/metrics_histogram.rs
+++ b/stress/src/metrics_histogram.rs
@@ -1,9 +1,9 @@
 /*
     Stress test results:
-    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
-    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    OS: Ubuntu 22.04.4 LTS (5.15.153.1-microsoft-standard-WSL2)
+    Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
     RAM: 64.0 GB
-    4.6M /sec
+    ~1.8 M/sec
 */
 
 use lazy_static::lazy_static;

--- a/stress/src/metrics_overflow.rs
+++ b/stress/src/metrics_overflow.rs
@@ -1,9 +1,9 @@
 /*
     Stress test results:
-    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
-    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    OS: Ubuntu 22.04.4 LTS (5.15.153.1-microsoft-standard-WSL2)
+    Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
     RAM: 64.0 GB
-    4.5M /sec
+    ~1.9 M/sec
 */
 
 use lazy_static::lazy_static;

--- a/stress/src/random.rs
+++ b/stress/src/random.rs
@@ -1,9 +1,9 @@
 /*
     Stress test results:
-    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
-    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    OS: Ubuntu 22.04.4 LTS (5.15.153.1-microsoft-standard-WSL2)
+    Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
     RAM: 64.0 GB
-    1.25 B/sec
+    ~540 M/sec
 */
 
 use rand::{

--- a/stress/src/throughput.rs
+++ b/stress/src/throughput.rs
@@ -70,7 +70,6 @@ where
 
     let handle_main_thread = thread::spawn(move || {
         let mut last_collect_time = Instant::now();
-        let mut current_time: Instant;
         let mut total_count_old: u64 = 0;
 
         #[cfg(feature = "stats")]
@@ -79,7 +78,7 @@ where
         let mut system = System::new_all();
 
         loop {
-            current_time = Instant::now();
+            let current_time = Instant::now();
             let elapsed = current_time.duration_since(last_collect_time).as_secs();
             if elapsed >= SLIDING_WINDOW_SIZE {
                 let total_count_u64: u64 = worker_stats_shared_monitor

--- a/stress/src/traces.rs
+++ b/stress/src/traces.rs
@@ -1,9 +1,9 @@
 /*
     Stress test results:
-    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
-    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    OS: Ubuntu 22.04.4 LTS (5.15.153.1-microsoft-standard-WSL2)
+    Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
     RAM: 64.0 GB
-    9 M/sec
+    ~6.5 M/sec
 */
 
 use lazy_static::lazy_static;


### PR DESCRIPTION
## Changes
- Fixed the Stress to not double count throughput

Here's a comparison of the stress test results:

| Test    | main branch              | Current PR               |
|---------|--------------------------|--------------------------|
|[Logs](https://github.com/open-telemetry/opentelemetry-rust/blob/5922205d07e10db56cbb4731eebbcbea14500b51/stress/src/logs.rs#L52-L54)     |62,050,400 iterations/sec |31,245,400 iterations/sec |
|[Metrics](https://github.com/open-telemetry/opentelemetry-rust/blob/5922205d07e10db56cbb4731eebbcbea14500b51/stress/src/metrics_counter.rs#L43-L66)|19,652,600 iterations/sec |9,550,400 iterations/sec  |
|[Traces](https://github.com/open-telemetry/opentelemetry-rust/blob/5922205d07e10db56cbb4731eebbcbea14500b51/stress/src/traces.rs#L54-L64)     |13,256,000 iterations/sec |6,496,600 iterations/sec  |
