### PR TITLE
sdk: expose hidden Tracer::should_sample() method

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## v0.24.1
+
+- Add hidden method to support tracing-opentelemetry
+
 ## v0.24.0
 
 - Add "metrics", "logs" to default features. With this, default feature list is

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -34,13 +34,13 @@
     - Added `non_exhaustive` annotation to [`trace::Config`]. Marked [`config`] as deprecated since it's only a wrapper for `Config::default`
     - Removed [`Tracer::tracer_provder`] and [`Tracer::instrument_libraries`] as it's not part of the spec.
 
-- **Breaking** [#1830](https://github.com/open-telemetry/opentelemetry-rust/pull/1830/files) [Traces SDK] Improves 
+- **Breaking** [#1830](https://github.com/open-telemetry/opentelemetry-rust/pull/1830/files) [Traces SDK] Improves
   performance by sending Resource information to processors (and exporters) once, instead of sending with every log. If you are an author
   of Processor, Exporter, the following are *BREAKING* changes.
     - Implement `set_resource` method in your custom SpanProcessor, which invokes exporter's `set_resource`.
     - Implement `set_resource` method in your custom SpanExporter. This method should save the resource object
       in original or serialized format, to be merged with every span event during export.
-    - `SpanData` doesn't have the resource attributes. The `SpanExporter::export()` method needs to merge it 
+    - `SpanData` doesn't have the resource attributes. The `SpanExporter::export()` method needs to merge it
       with the earlier preserved resource before export.
 
 - **Breaking** [1836](https://github.com/open-telemetry/opentelemetry-rust/pull/1836) `SpanProcessor::shutdown` now takes an immutable reference to self. Any reference can call shutdown on the processor. After the first call to `shutdown` the processor will not process any new spans.
@@ -95,17 +95,17 @@ The `LogRecord::target` field contains the actual target/component emitting the 
 - **Breaking** [#1624](https://github.com/open-telemetry/opentelemetry-rust/pull/1624) Remove `OsResourceDetector` and
   `ProcessResourceDetector` resource detectors, use the
   [`opentelemetry-resource-detector`](https://crates.io/crates/opentelemetry-resource-detectors) instead.
-- [#1636](https://github.com/open-telemetry/opentelemetry-rust/pull/1636) [Logs SDK] Improves performance by sending 
+- [#1636](https://github.com/open-telemetry/opentelemetry-rust/pull/1636) [Logs SDK] Improves performance by sending
   Resource information to processors (and exporters) once, instead of sending with every log. If you are an author
   of Processor, Exporter, the following are *BREAKING* changes.
     - Implement `set_resource` method in your custom LogProcessor, which invokes exporter's `set_resource`.
     - Implement `set_resource` method in your custom LogExporter. This method should save the resource object
       in original or serialized format, to be merged with every log event during export.
-    - `LogData` doesn't have the resource attributes. The `LogExporter::export()` method needs to merge it 
+    - `LogData` doesn't have the resource attributes. The `LogExporter::export()` method needs to merge it
       with the earlier preserved resource before export.
 - Baggage propagation error will be reported to global error handler [#1640](https://github.com/open-telemetry/opentelemetry-rust/pull/1640)
 - Improves `shutdown` behavior of `LoggerProvider` and `LogProcessor` [#1643](https://github.com/open-telemetry/opentelemetry-rust/pull/1643).
-  - `shutdown` can be called by any clone of the `LoggerProvider` without the need of waiting on all `Logger` drops. Thus, `try_shutdown` has been removed. 
+  - `shutdown` can be called by any clone of the `LoggerProvider` without the need of waiting on all `Logger` drops. Thus, `try_shutdown` has been removed.
   - `shutdown` methods in `LoggerProvider` and `LogProcessor` now takes a immutable reference
   - After `shutdown`, `LoggerProvider` will return noop `Logger`
   - After `shutdown`, `LogProcessor` will not process any new logs

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry_sdk"
-version = "0.24.0"
+version = "0.24.1"
 description = "The SDK for the OpenTelemetry metrics collection and distributed tracing framework"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -11,7 +11,7 @@ use crate::{
     trace::{
         provider::TracerProvider,
         span::{Span, SpanData},
-        IdGenerator, SpanEvents, SpanLimits, SpanLinks,
+        IdGenerator, ShouldSample, SpanEvents, SpanLimits, SpanLinks,
     },
     InstrumentationLibrary,
 };
@@ -165,6 +165,14 @@ impl Tracer {
     #[doc(hidden)]
     pub fn id_generator(&self) -> &dyn IdGenerator {
         &*self.provider.config().id_generator
+    }
+
+    /// The [`ShouldSample`] associated with this tracer.
+    ///
+    // Note: this is necessary for tracing-opentelemetry's `PreSampledTracer`.
+    #[doc(hidden)]
+    pub fn should_sample(&self) -> &dyn ShouldSample {
+        &*self.provider.config().sampler
     }
 }
 


### PR DESCRIPTION
## Changes

Unfortunately while working on #1934 I missed that tracing-opentelemetry needs one additional API method. Add that here. I will put up a draft tracing-opentelemetry PR after this to make sure this is complete.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
