### PR TITLE
Adding `PartialEq` for `LogRecord` and `SpanContext` to help unit testing

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- `LogRecord` and `SpanContext` derive from `PartialEq` to facilitate Unit Testing.
+
 ## v0.24.1
 
 - Add hidden method to support tracing-opentelemetry

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- `LogRecord` and `SpanContext` derive from `PartialEq` to facilitate Unit Testing.
+- `opentelemetry_sdk::logs::record::LogRecord` and `opentelemetry_sdk::logs::record::TraceContext` derive from `PartialEq` to facilitate Unit Testing.
 
 ## v0.24.1
 

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -124,7 +124,6 @@ impl From<&SpanContext> for TraceContext {
 mod tests {
     use super::*;
     use opentelemetry::logs::{AnyValue, LogRecord as _, Severity};
-    use opentelemetry::trace::TraceState;
     use std::borrow::Cow;
     use std::time::SystemTime;
 
@@ -202,27 +201,23 @@ mod tests {
 
     #[test]
     fn compare_trace_context() {
-        let span_context = SpanContext::new(
-            TraceId::from_u128(1),
-            SpanId::from_u64(1),
-            TraceFlags::default(),
-            false,
-            TraceState::default(),
-        );
+        let trace_context = TraceContext {
+            trace_id: TraceId::from_u128(1),
+            span_id: SpanId::from_u64(1),
+            trace_flags: Some(TraceFlags::default()),
+        };
 
-        let span_context_cloned = span_context.clone();
+        let trace_context_cloned = trace_context.clone();
 
-        assert_eq!(span_context, span_context_cloned);
+        assert_eq!(trace_context, trace_context_cloned);
 
-        let span_context_different = SpanContext::new(
-            TraceId::from_u128(2),
-            SpanId::from_u64(2),
-            TraceFlags::default(),
-            false,
-            TraceState::default(),
-        );
+        let trace_context_different = TraceContext {
+            trace_id: TraceId::from_u128(2),
+            span_id: SpanId::from_u64(2),
+            trace_flags: Some(TraceFlags::default()),
+        };
 
-        assert_ne!(span_context, span_context_different);
+        assert_ne!(trace_context, trace_context_different);
     }
 
     #[test]

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -247,4 +247,19 @@ mod tests {
 
         assert_ne!(log_record, log_record_different);
     }
+
+    #[test]
+    fn compare_log_record_target_borrowed_eq_owned() {
+        let log_record_borrowed = LogRecord {
+            event_name: Some(Cow::Borrowed("test_event")),
+            ..Default::default()
+        };
+
+        let log_record_owned = LogRecord {
+            event_name: Some(Cow::Owned("test_event".to_string())),
+            ..Default::default()
+        };
+
+        assert_eq!(log_record_borrowed, log_record_owned);
+    }
 }


### PR DESCRIPTION
Fixes (NA)
Design discussion issue (if applicable) (NA)

## Changes

Added `PartialEq` derive for `LogRecord` and `SpanContext`. This way, they are comparable among their types, which is important for correct unit testing.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [X] Unit tests added/updated (if applicable)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
