### PR TITLE
chore: update proto definition to v1.3.2

### DIFF
--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNext
+-  Update protobuf definitions to v1.3.2 [#1945](https://github.com/open-telemetry/opentelemetry-rust/pull/1945)
 
 ## v0.7.0
 


### PR DESCRIPTION
## Changes

Just a routine update, even though it doesn't bring any change for all the 3 signals. Only change is in `profiles` proto file which doesn't affect us.

https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.3.2

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
