### PR TITLE
zstd compression for tonic exporter

### DIFF
--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -65,6 +65,7 @@ default = ["grpc-tonic", "trace", "metrics", "logs"]
 # grpc using tonic
 grpc-tonic = ["tonic", "prost", "http", "tokio", "opentelemetry-proto/gen-tonic"]
 gzip-tonic = ["tonic/gzip"]
+zstd-tonic = ["tonic/zstd"]
 tls = ["tonic/tls"]
 tls-roots = ["tls", "tonic/tls-roots"]
 tls-webpki-roots = ["tls", "tonic/tls-webpki-roots"]

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -98,12 +98,15 @@ impl Default for ExportConfig {
 pub enum Compression {
     /// Compresses data using gzip.
     Gzip,
+    /// Compresses data using zstd.
+    Zstd,
 }
 
 impl Display for Compression {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Compression::Gzip => write!(f, "gzip"),
+            Compression::Zstd => write!(f, "zstd"),
         }
     }
 }
@@ -114,6 +117,7 @@ impl FromStr for Compression {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "gzip" => Ok(Compression::Gzip),
+            "zstd" => Ok(Compression::Zstd),
             _ => Err(Error::UnsupportedCompressionAlgorithm(s.to_string())),
         }
     }

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -54,14 +54,14 @@ impl TryFrom<Compression> for tonic::codec::CompressionEncoding {
             #[cfg(not(feature = "gzip-tonic"))]
             Compression::Gzip => Err(crate::Error::FeatureRequiredForCompressionAlgorithm(
                 "gzip-tonic",
-                "gzip",
+                Compression::Gzip,
             )),
             #[cfg(feature = "zstd-tonic")]
             Compression::Zstd => Ok(tonic::codec::CompressionEncoding::Zstd),
             #[cfg(not(feature = "zstd-tonic"))]
             Compression::Zstd => Err(crate::Error::FeatureRequiredForCompressionAlgorithm(
                 "zstd-tonic",
-                "zstd",
+                Compression::Zstd,
             )),
         }
     }

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -377,7 +377,7 @@ pub enum Error {
     /// Feature required to use the specified compression algorithm.
     #[cfg(any(not(feature = "gzip-tonic"), not(feature = "zstd-tonic")))]
     #[error("feature '{0}' is required to use the compression algorithm '{1}'")]
-    FeatureRequiredForCompressionAlgorithm(&'static str, &'static str),
+    FeatureRequiredForCompressionAlgorithm(&'static str, Compression),
 }
 
 #[cfg(feature = "grpc-tonic")]

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -97,6 +97,7 @@
 //! For users uses `tonic` as grpc layer:
 //! * `grpc-tonic`: Use `tonic` as grpc layer. This is enabled by default.
 //! * `gzip-tonic`: Use gzip compression for `tonic` grpc layer.
+//! * `zstd-tonic`: Use zstd compression for `tonic` grpc layer.
 //! * `tls-tonic`: Enable TLS.
 //! * `tls-roots`: Adds system trust roots to rustls-based gRPC clients using the rustls-native-certs crate
 //! * `tls-webkpi-roots`: Embeds Mozilla's trust roots to rustls-based gRPC clients using the webkpi-roots crate
@@ -372,6 +373,11 @@ pub enum Error {
     /// Unsupported compression algorithm.
     #[error("unsupported compression algorithm '{0}'")]
     UnsupportedCompressionAlgorithm(String),
+
+    /// Feature required to use the specified compression algorithm.
+    #[cfg(any(not(feature = "gzip-tonic"), not(feature = "zstd-tonic")))]
+    #[error("feature '{0}' is required to use the compression algorithm '{1}'")]
+    FeatureRequiredForCompressionAlgorithm(&'static str, &'static str),
 }
 
 #[cfg(feature = "grpc-tonic")]


### PR DESCRIPTION
## Changes

Zstd compression can be used with tonic https://docs.rs/tonic/0.12.1/tonic/codec/enum.CompressionEncoding.html#variant.Zstd

It is the recommended compression algorithm for NewRelic https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/

> Additionally, you should enable compression to reduce payload size and limit the likelihood of encountering payload size limits. New Relic supports gzip and zstd compression. zstd compression is higher performance and recommended if your exporter supports it. See [compression comparison](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md#compression-comparison) for more details on benchmark information.

As this requires a feature, I changed the error message for `FeatureRequiredForCompressionAlgorithm` to have a more detailed error

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
