### PR TITLE
Fix shutdown of single threaded trace batch provider

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - `opentelemetry_sdk::logs::record::LogRecord` and `opentelemetry_sdk::logs::record::TraceContext` derive from `PartialEq` to facilitate Unit Testing.
+- Fixed an issue causing a panic during shutdown when using the `TokioCurrentThread` tracing batch processor.
 
 ## v0.24.1
 


### PR DESCRIPTION
Fixes #1963


## Changes

This fixes an issue when shutting down the application and using the single-threaded runtime. I have a reproducer in the issue, but TBH have no clue how to test this due to the nature of the problem

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
