### PR TITLE
CI fix

### DIFF
--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! * The [`Tracer`] struct which performs all tracing operations.
 //! * The [`Span`] struct with is a mutable object storing information about the
-//! current operation execution.
+//!   current operation execution.
 //! * The [`TracerProvider`] struct which configures and produces [`Tracer`]s.
 mod config;
 mod events;

--- a/opentelemetry-zipkin/src/propagator/mod.rs
+++ b/opentelemetry-zipkin/src/propagator/mod.rs
@@ -3,13 +3,13 @@
 //! The `B3Propagator` facilitates `SpanContext` propagation using
 //! B3 Headers. This propagator supports both version of B3 headers,
 //!  1. Single Header:
-//!    b3: {trace_id}-{span_id}-{sampling_state}-{parent_span_id}
+//!     b3: {trace_id}-{span_id}-{sampling_state}-{parent_span_id}
 //!  2. Multiple Headers:
-//!    X-B3-TraceId: {trace_id}
-//!    X-B3-ParentSpanId: {parent_span_id}
-//!    X-B3-SpanId: {span_id}
-//!    X-B3-Sampled: {sampling_state}
-//!    X-B3-Flags: {debug_flag}
+//!     X-B3-TraceId: {trace_id}
+//!     X-B3-ParentSpanId: {parent_span_id}
+//!     X-B3-SpanId: {span_id}
+//!     X-B3-Sampled: {sampling_state}
+//!     X-B3-Flags: {debug_flag}
 //!
 //! If `inject_encoding` is set to `B3Encoding::SingleHeader` then `b3` header is used to inject
 //! and extract. Otherwise, separate headers are used to inject and extract.


### PR DESCRIPTION
## Changes
Error: [rustc v1.80.0](https://releases.rs/docs/1.80.0/) is propagated as new stable release today and the clippy is failing for [doc formatting.](https://github.com/open-telemetry/opentelemetry-rust/actions/runs/10119640635/job/27988363185?pr=1969)
Fix: As suggested here - https://rust-lang.github.io/rust-clippy/master/index.html#/doc_lazy_continuation


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
