### PR TITLE
BatchSpanProcessor to trigger first export after the interval instead of right away

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `opentelemetry_sdk::logs::record::LogRecord` and `opentelemetry_sdk::logs::record::TraceContext` derive from `PartialEq` to facilitate Unit Testing.
 - Fixed an issue causing a panic during shutdown when using the `TokioCurrentThread` tracing batch processor.
+  [#1964](https://github.com/open-telemetry/opentelemetry-rust/pull/1964)
+- Fix BatchSpanProcessor to trigger first export at the first interval
+  instead of doing it right away.
+  [#1970](https://github.com/open-telemetry/opentelemetry-rust/pull/1970)
 
 ## v0.24.1
 

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -457,6 +457,7 @@ impl<R: RuntimeChannel> BatchSpanProcessor<R> {
             // runtime.spawn()
             let ticker = inner_runtime
                 .interval(config.scheduled_delay)
+                .skip(1) // The ticker is fired immediately, so we should skip the first one to align with the interval.
                 .map(|_| BatchMessage::Flush(None));
             let timeout_runtime = inner_runtime.clone();
 


### PR DESCRIPTION
Part of #1968 
Similar to https://github.com/open-telemetry/opentelemetry-rust/pull/1766/files, this makes similar change to BatchSpanProcessor. 

Before the PR:
Exports were triggered at T, T+60, T+120 and so on, where T is the time BSP was built.

With this change:
Exports are triggered at T+60, T+120 and so on, where T is the time BSP  was built.
