### PR TITLE
MetricRefactor - Part1 - Move AttributeSet inside aggregations

### DIFF
--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -10,7 +10,6 @@ use opentelemetry::{
 
 use crate::{
     instrumentation::Scope,
-    metrics::AttributeSet,
     metrics::{aggregation::Aggregation, internal::Measure},
 };
 
@@ -261,7 +260,7 @@ pub(crate) struct ResolvedMeasures<T> {
 impl<T: Copy + 'static> SyncCounter<T> for ResolvedMeasures<T> {
     fn add(&self, val: T, attrs: &[KeyValue]) {
         for measure in &self.measures {
-            measure.call(val, AttributeSet::from(attrs))
+            measure.call(val, attrs)
         }
     }
 }
@@ -269,7 +268,7 @@ impl<T: Copy + 'static> SyncCounter<T> for ResolvedMeasures<T> {
 impl<T: Copy + 'static> SyncUpDownCounter<T> for ResolvedMeasures<T> {
     fn add(&self, val: T, attrs: &[KeyValue]) {
         for measure in &self.measures {
-            measure.call(val, AttributeSet::from(attrs))
+            measure.call(val, attrs)
         }
     }
 }
@@ -277,7 +276,7 @@ impl<T: Copy + 'static> SyncUpDownCounter<T> for ResolvedMeasures<T> {
 impl<T: Copy + 'static> SyncGauge<T> for ResolvedMeasures<T> {
     fn record(&self, val: T, attrs: &[KeyValue]) {
         for measure in &self.measures {
-            measure.call(val, AttributeSet::from(attrs))
+            measure.call(val, attrs)
         }
     }
 }
@@ -285,7 +284,7 @@ impl<T: Copy + 'static> SyncGauge<T> for ResolvedMeasures<T> {
 impl<T: Copy + 'static> SyncHistogram<T> for ResolvedMeasures<T> {
     fn record(&self, val: T, attrs: &[KeyValue]) {
         for measure in &self.measures {
-            measure.call(val, AttributeSet::from(attrs))
+            measure.call(val, attrs)
         }
     }
 }
@@ -379,7 +378,7 @@ impl<T> Observable<T> {
 impl<T: Copy + Send + Sync + 'static> AsyncInstrument<T> for Observable<T> {
     fn observe(&self, measurement: T, attrs: &[KeyValue]) {
         for measure in &self.measures {
-            measure.call(measurement, AttributeSet::from(attrs))
+            measure.call(measurement, attrs)
         }
     }
 

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -3,7 +3,10 @@ use std::{marker, sync::Arc};
 use once_cell::sync::Lazy;
 use opentelemetry::KeyValue;
 
-use crate::metrics::data::{Aggregation, Gauge, Temporality};
+use crate::metrics::{
+    data::{Aggregation, Gauge, Temporality},
+    AttributeSet,
+};
 
 use super::{
     exponential_histogram::ExpoHistogram,
@@ -14,8 +17,10 @@ use super::{
 };
 
 const STREAM_CARDINALITY_LIMIT: u32 = 2000;
-pub(crate) static STREAM_OVERFLOW_ATTRIBUTE_SET: Lazy<Vec<KeyValue>> =
-    Lazy::new(|| vec![KeyValue::new("otel.metric.overflow", "true")]);
+pub(crate) static STREAM_OVERFLOW_ATTRIBUTE_SET: Lazy<AttributeSet> = Lazy::new(|| {
+    let key_values: [KeyValue; 1] = [KeyValue::new("otel.metric.overflow", "true")];
+    AttributeSet::from(&key_values[..])
+});
 
 /// Checks whether aggregator has hit cardinality limit for metric streams
 pub(crate) fn is_under_cardinality_limit(size: usize) -> bool {

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -96,7 +96,8 @@ impl<T: Number<T>> AggregateBuilder<T> {
         let filter = self.filter.clone();
         move |n, attrs: &[KeyValue]| {
             if let Some(filter) = &filter {
-                let filtered_attrs: Vec<KeyValue> = attrs.iter().filter(|kv| filter(kv)).cloned().collect();
+                let filtered_attrs: Vec<KeyValue> =
+                    attrs.iter().filter(|kv| filter(kv)).cloned().collect();
                 f.call(n, &filtered_attrs);
             } else {
                 f.call(n, attrs);

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -138,7 +138,7 @@ impl<T: Number<T>> AggregateBuilder<T> {
         let t = self.temporality;
 
         (
-            move |n, a: &[KeyValue]| s.measure(n, a),
+            self.filter(move |n, a: &[KeyValue]| s.measure(n, a)),
             move |dest: Option<&mut dyn Aggregation>| match t {
                 Some(Temporality::Delta) => agg_sum.delta(dest),
                 _ => agg_sum.cumulative(dest),
@@ -173,7 +173,7 @@ impl<T: Number<T>> AggregateBuilder<T> {
         let t = self.temporality;
 
         (
-            move |n, a: &[KeyValue]| h.measure(n, a),
+            self.filter(move |n, a: &[KeyValue]| h.measure(n, a)),
             move |dest: Option<&mut dyn Aggregation>| match t {
                 Some(Temporality::Delta) => agg_h.delta(dest),
                 _ => agg_h.cumulative(dest),
@@ -199,7 +199,7 @@ impl<T: Number<T>> AggregateBuilder<T> {
         let t = self.temporality;
 
         (
-            move |n, a: &[KeyValue]| h.measure(n, a),
+            self.filter(move |n, a: &[KeyValue]| h.measure(n, a)),
             move |dest: Option<&mut dyn Aggregation>| match t {
                 Some(Temporality::Delta) => agg_h.delta(dest),
                 _ => agg_h.cumulative(dest),

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -98,6 +98,7 @@ impl<T: Number<T>> AggregateBuilder<T> {
             let filtered_attrs: Vec<KeyValue> = if let Some(filter) = &filter {
                 attrs.iter().filter(|kv| filter(kv)).cloned().collect()
             } else {
+                // TODO: This is unwanted allocation. We should avoid it.
                 attrs.to_vec()
             };
             f.call(n, &filtered_attrs);

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -95,13 +95,12 @@ impl<T: Number<T>> AggregateBuilder<T> {
     fn filter(&self, f: impl Measure<T>) -> impl Measure<T> {
         let filter = self.filter.clone();
         move |n, attrs: &[KeyValue]| {
-            let filtered_attrs: Vec<KeyValue> = if let Some(filter) = &filter {
-                attrs.iter().filter(|kv| filter(kv)).cloned().collect()
+            if let Some(filter) = &filter {
+                let filtered_attrs: Vec<KeyValue> = attrs.iter().filter(|kv| filter(kv)).cloned().collect();
+                f.call(n, &filtered_attrs);
             } else {
-                // TODO: This is unwanted allocation. We should avoid it.
-                attrs.to_vec()
+                f.call(n, attrs);
             };
-            f.call(n, &filtered_attrs);
         }
     }
 

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -340,13 +340,14 @@ impl<T: Number<T>> ExpoHistogram<T> {
         }
     }
 
-    pub(crate) fn measure(&self, value: T, attrs: AttributeSet) {
+    pub(crate) fn measure(&self, value: T, attrs: &[KeyValue]) {
         let f_value = value.into_float();
         // Ignore NaN and infinity.
         if f_value.is_infinite() || f_value.is_nan() {
             return;
         }
 
+        let attrs : AttributeSet = attrs.into();
         if let Ok(mut values) = self.values.lock() {
             let v = values.entry(attrs).or_insert_with(|| {
                 ExpoHistogramDataPoint::new(
@@ -633,7 +634,7 @@ mod tests {
     }
 
     fn run_min_max_sum_f64() {
-        let alice = AttributeSet::from(&[KeyValue::new("user", "alice")][..]);
+        let alice = &[KeyValue::new("user", "alice")][..];
         struct Expected {
             min: f64,
             max: f64,
@@ -681,9 +682,10 @@ mod tests {
         for test in test_cases {
             let h = ExpoHistogram::new(4, 20, true, true);
             for v in test.values {
-                h.measure(v, alice.clone());
+                h.measure(v, alice);
             }
             let values = h.values.lock().unwrap();
+            let alice : AttributeSet = alice.into();
             let dp = values.get(&alice).unwrap();
 
             assert_eq!(test.expected.max, dp.max);
@@ -694,7 +696,7 @@ mod tests {
     }
 
     fn run_min_max_sum<T: Number<T> + From<u32>>() {
-        let alice = AttributeSet::from(&[KeyValue::new("user", "alice")][..]);
+        let alice = &[KeyValue::new("user", "alice")][..];
         struct Expected<T> {
             min: T,
             max: T,
@@ -732,9 +734,10 @@ mod tests {
         for test in test_cases {
             let h = ExpoHistogram::new(4, 20, true, true);
             for v in test.values {
-                h.measure(v, alice.clone());
+                h.measure(v, alice);
             }
             let values = h.values.lock().unwrap();
+            let alice:AttributeSet = alice.into();
             let dp = values.get(&alice).unwrap();
 
             assert_eq!(test.expected.max, dp.max);
@@ -1436,7 +1439,7 @@ mod tests {
             let mut count = 0;
             for n in test.input {
                 for v in n {
-                    in_fn.call(v, AttributeSet::default())
+                    in_fn.call(v, &[])
                 }
                 count = out_fn.call(Some(got.as_mut())).0
             }

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -347,7 +347,7 @@ impl<T: Number<T>> ExpoHistogram<T> {
             return;
         }
 
-        let attrs : AttributeSet = attrs.into();
+        let attrs: AttributeSet = attrs.into();
         if let Ok(mut values) = self.values.lock() {
             let v = values.entry(attrs).or_insert_with(|| {
                 ExpoHistogramDataPoint::new(
@@ -685,7 +685,7 @@ mod tests {
                 h.measure(v, alice);
             }
             let values = h.values.lock().unwrap();
-            let alice : AttributeSet = alice.into();
+            let alice: AttributeSet = alice.into();
             let dp = values.get(&alice).unwrap();
 
             assert_eq!(test.expected.max, dp.max);
@@ -737,7 +737,7 @@ mod tests {
                 h.measure(v, alice);
             }
             let values = h.values.lock().unwrap();
-            let alice:AttributeSet = alice.into();
+            let alice: AttributeSet = alice.into();
             let dp = values.get(&alice).unwrap();
 
             assert_eq!(test.expected.max, dp.max);

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -99,7 +99,7 @@ impl<T: Number<T>> HistValues<T> {
             } else {
                 global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.".into()));
                 values
-                    .entry(STREAM_OVERFLOW_ATTRIBUTE_SET.clone().as_slice().into())
+                    .entry(STREAM_OVERFLOW_ATTRIBUTE_SET.clone())
                     .or_insert(b)
             }
         };

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -129,7 +129,7 @@ impl<T: Number<T>> Histogram<T> {
     }
 
     pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
-        let attrs : AttributeSet = attrs.into();
+        let attrs: AttributeSet = attrs.into();
         self.hist_values.measure(measurement, attrs)
     }
 

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -99,7 +99,7 @@ impl<T: Number<T>> HistValues<T> {
             } else {
                 global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.".into()));
                 values
-                    .entry(STREAM_OVERFLOW_ATTRIBUTE_SET.clone())
+                    .entry(STREAM_OVERFLOW_ATTRIBUTE_SET.clone().as_slice().into())
                     .or_insert(b)
             }
         };
@@ -128,7 +128,8 @@ impl<T: Number<T>> Histogram<T> {
         }
     }
 
-    pub(crate) fn measure(&self, measurement: T, attrs: AttributeSet) {
+    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
+        let attrs : AttributeSet = attrs.into();
         self.hist_values.measure(measurement, attrs)
     }
 

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -29,11 +29,13 @@ impl<T: Number<T>> LastValue<T> {
         Self::default()
     }
 
-    pub(crate) fn measure(&self, measurement: T, attrs: AttributeSet) {
+    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
         let d: DataPointValue<T> = DataPointValue {
             timestamp: SystemTime::now(),
             value: measurement,
         };
+
+        let attrs : AttributeSet = attrs.into();
         if let Ok(mut values) = self.values.lock() {
             let size = values.len();
             match values.entry(attrs) {
@@ -44,7 +46,7 @@ impl<T: Number<T>> LastValue<T> {
                     if is_under_cardinality_limit(size) {
                         vacant_entry.insert(d);
                     } else {
-                        values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone(), d);
+                        values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone().as_slice().into(), d);
                         global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.".into()));
                     }
                 }

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -35,7 +35,7 @@ impl<T: Number<T>> LastValue<T> {
             value: measurement,
         };
 
-        let attrs : AttributeSet = attrs.into();
+        let attrs: AttributeSet = attrs.into();
         if let Ok(mut values) = self.values.lock() {
             let size = values.len();
             match values.entry(attrs) {

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -46,7 +46,7 @@ impl<T: Number<T>> LastValue<T> {
                     if is_under_cardinality_limit(size) {
                         vacant_entry.insert(d);
                     } else {
-                        values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone().as_slice().into(), d);
+                        values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone(), d);
                         global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow.".into()));
                     }
                 }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -40,7 +40,8 @@ impl<T: Number<T>> ValueMap<T> {
 }
 
 impl<T: Number<T>> ValueMap<T> {
-    fn measure(&self, measurement: T, attrs: AttributeSet) {
+    fn measure(&self, measurement: T, attrs: &[KeyValue]) {
+        let attrs : AttributeSet = attrs.into();
         if attrs.is_empty() {
             self.no_attribute_value.add(measurement);
             self.has_no_value_attribute_value
@@ -62,14 +63,14 @@ impl<T: Number<T>> ValueMap<T> {
                         new_value.add(measurement);
                         values.insert(attrs, new_value);
                     } else if let Some(overflow_value) =
-                        values.get_mut(&STREAM_OVERFLOW_ATTRIBUTE_SET)
+                        values.get_mut(&STREAM_OVERFLOW_ATTRIBUTE_SET.clone().as_slice().into())
                     {
                         overflow_value.add(measurement);
                         return;
                     } else {
                         let new_value = T::new_atomic_tracker();
                         new_value.add(measurement);
-                        values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone(), new_value);
+                        values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone().as_slice().into(), new_value);
                         global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow. Subsequent overflows to same metric until next collect will not be logged.".into()));
                     }
                 }
@@ -99,7 +100,7 @@ impl<T: Number<T>> Sum<T> {
         }
     }
 
-    pub(crate) fn measure(&self, measurement: T, attrs: AttributeSet) {
+    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
         self.value_map.measure(measurement, attrs)
     }
 
@@ -266,7 +267,7 @@ impl<T: Number<T>> PrecomputedSum<T> {
         }
     }
 
-    pub(crate) fn measure(&self, measurement: T, attrs: AttributeSet) {
+    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
         self.value_map.measure(measurement, attrs)
     }
 

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -41,7 +41,7 @@ impl<T: Number<T>> ValueMap<T> {
 
 impl<T: Number<T>> ValueMap<T> {
     fn measure(&self, measurement: T, attrs: &[KeyValue]) {
-        let attrs : AttributeSet = attrs.into();
+        let attrs: AttributeSet = attrs.into();
         if attrs.is_empty() {
             self.no_attribute_value.add(measurement);
             self.has_no_value_attribute_value
@@ -70,7 +70,10 @@ impl<T: Number<T>> ValueMap<T> {
                     } else {
                         let new_value = T::new_atomic_tracker();
                         new_value.add(measurement);
-                        values.insert(STREAM_OVERFLOW_ATTRIBUTE_SET.clone().as_slice().into(), new_value);
+                        values.insert(
+                            STREAM_OVERFLOW_ATTRIBUTE_SET.clone().as_slice().into(),
+                            new_value,
+                        );
                         global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow. Subsequent overflows to same metric until next collect will not be logged.".into()));
                     }
                 }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -267,7 +267,8 @@ impl<T: Number<T>> PrecomputedSum<T> {
         }
     }
 
-    pub(crate) fn measure(&self, measurement: T, attrs: AttributeSet) {
+    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
+        let attrs: AttributeSet = attrs.into();
         self.value_map.measure(measurement, attrs)
     }
 

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -129,6 +129,16 @@ impl AttributeSet {
     pub fn iter(&self) -> impl Iterator<Item = (&Key, &Value)> {
         self.0.iter().map(|kv| (&kv.key, &kv.value))
     }
+
+    /// Returns a slice of the key value pairs in the set
+    pub fn as_slice(&self) -> &[KeyValue] {
+        &self.0
+    }
+
+    /// Returns the underlying Vec of KeyValue pairs
+    pub fn into_vec(self) -> Vec<KeyValue> {
+        self.0
+    }
 }
 
 impl Hash for AttributeSet {


### PR DESCRIPTION
Part 1 of metric sdk refactor to achieve perf gains and [no-heap-allocation](https://github.com/open-telemetry/opentelemetry-rust/issues/1954). The heap allocation and perf cost is due to the usage of `AttributeSet` which clones and stores the incoming slice of KV pairs, after sorting + de-duplicating, which can be eliminated.

This PR modifies traits to only need `&[KeyValue]` (which is what API accepts from user) instead of `AttributeSet`. There is no perf gain in this PR, as the `AttributeSet` is still constructed inside each aggregations. This is done to keep the scope of PR very small, and easy to review.
In the next PR, Sum aggregation will be targeted to achieve the perf gains and no-heap alloc, later extending to other instruments.