### PR TITLE
[CI fix] Fix community contributing hyperlink

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,12 @@ you're more than welcome to participate!
 
 Even though, anybody can contribute, there are benefits of being a member of our
 community. See to the [community membership
-document](https://github.com/open-telemetry/community/blob/main/community-membership.md)
+document](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md)
 on how to become a
-[**Member**](https://github.com/open-telemetry/community/blob/main/community-membership.md#member),
-[**Approver**](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver)
+[**Member**](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#member),
+[**Approver**](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver)
 and
-[**Maintainer**](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
+[**Maintainer**](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 
 ## Pull Requests
 
@@ -99,9 +99,9 @@ the repo to catch any issues locally.
 A PR is considered to be **ready to merge** when:
 
 - It has received approval from
-  [Approvers](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).
+  [Approvers](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
   /
-  [Maintainers](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
+  [Maintainers](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 - Major feedbacks are resolved.
 
 Any Maintainer can merge the PR once it is **ready to merge**. Note, that some

--- a/scripts/markdown-link-check-with-retry.sh
+++ b/scripts/markdown-link-check-with-retry.sh
@@ -3,20 +3,10 @@
 # this script helps to reduce sporadic link check failures by retrying at a file-by-file level
 
 retry_count=3
-ignore_dirs=("opentelemetry-proto/src/proto/opentelemetry-proto")
 
 for file in "$@"; do
-  skip=false
-  # Check if file path contains any ignore dir
-  for ignore_dir in "${ignore_dirs[@]}"; do
-    if [[ "$file" == *"$ignore_dir"* ]]; then
-      skip=true
-      break
-    fi
-  done
-  if [ "$skip" = false ]; then
-    for i in $(seq 1 $retry_count); do
-      if markdown-link-check --config "$(dirname "$0")/markdown-link-check-config.json" \
+  for i in $(seq 1 $retry_count); do
+    if markdown-link-check --config "$(dirname "$0")/markdown-link-check-config.json" \
                            "$file"; then
       break
     elif [[ $i -eq $retry_count ]]; then
@@ -24,5 +14,4 @@ for file in "$@"; do
     fi
     sleep 5
   done
-  fi
 done

--- a/scripts/markdown-link-check-with-retry.sh
+++ b/scripts/markdown-link-check-with-retry.sh
@@ -3,10 +3,20 @@
 # this script helps to reduce sporadic link check failures by retrying at a file-by-file level
 
 retry_count=3
+ignore_dirs=("opentelemetry-proto/src/proto/opentelemetry-proto")
 
 for file in "$@"; do
-  for i in $(seq 1 $retry_count); do
-    if markdown-link-check --config "$(dirname "$0")/markdown-link-check-config.json" \
+  skip=false
+  # Check if file path contains any ignore dir
+  for ignore_dir in "${ignore_dirs[@]}"; do
+    if [[ "$file" == *"$ignore_dir"* ]]; then
+      skip=true
+      break
+    fi
+  done
+  if [ "$skip" = false ]; then
+    for i in $(seq 1 $retry_count); do
+      if markdown-link-check --config "$(dirname "$0")/markdown-link-check-config.json" \
                            "$file"; then
       break
     elif [[ $i -eq $retry_count ]]; then
@@ -14,4 +24,5 @@ for file in "$@"; do
     fi
     sleep 5
   done
+  fi
 done


### PR DESCRIPTION
## Changes

Some of the links have been recently moved in the community repo - https://github.com/open-telemetry/community/pull/2051
Fixing these links in our repo for the CI.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
