### PR TITLE
[opentelemetry-otlp] fix example when running with OTEL Collector 0.104+

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/otel-collector-config.yaml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/otel-collector-config.yaml
@@ -8,7 +8,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 
 exporters:
   debug:


### PR DESCRIPTION
as mentioned in https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.104.0 the collector now binds to localhost by default, so the config needs to be explicit to allow access from outside of the Docker container

fixes #1958
