### PR TITLE
Hide LogRecord attributes Implementation Details from exporters

### DIFF
--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -938,10 +938,9 @@ mod tests {
         );
 
         let logs = exporter.get_emitted_logs().unwrap();
-        let attributes = &logs[0].record.attributes.as_ref().unwrap();
 
-        let get = |needle: &str| {
-            attributes.iter().find_map(|(k, v)| {
+        let get = |needle: &str| -> Option<AnyValue> {
+            logs[0].record.attributes_iter().find_map(|(k, v)| {
                 if k.as_str() == needle {
                     Some(v.clone())
                 } else {

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -244,7 +244,6 @@ mod tests {
             .first()
             .expect("Atleast one log is expected to be present.");
 
-        // Validate common fields
         assert_eq!(log.instrumentation.name, "opentelemetry-appender-tracing");
         assert_eq!(log.record.severity_number, Some(Severity::Error));
 
@@ -252,29 +251,38 @@ mod tests {
         assert!(log.record.trace_context.is_none());
 
         // Validate attributes
-        let attributes: Vec<(Key, AnyValue)> = log
-            .record
-            .attributes
-            .clone()
-            .expect("Attributes are expected");
         #[cfg(not(feature = "experimental_metadata_attributes"))]
-        assert_eq!(attributes.len(), 3);
+        assert_eq!(log.record.attributes_len(), 3);
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(attributes.len(), 8);
-        assert!(attributes.contains(&(Key::new("event_id"), 20.into())));
-        assert!(attributes.contains(&(Key::new("user_name"), "otel".into())));
-        assert!(attributes.contains(&(Key::new("user_email"), "otel@opentelemetry.io".into())));
+        assert_eq!(log.record.attributes_len(), 8);
+        assert!(log
+            .record
+            .attributes_contains(&Key::new("event_id"), &AnyValue::Int(20)));
+        assert!(log
+            .record
+            .attributes_contains(&Key::new("user_name"), &AnyValue::String("otel".into())));
+        assert!(log.record.attributes_contains(
+            &Key::new("user_email"),
+            &AnyValue::String("otel@opentelemetry.io".into())
+        ));
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(attributes.contains(&(Key::new("code.filename"), "layer.rs".into())));
-            assert!(attributes.contains(&(
-                Key::new("code.namespace"),
-                "opentelemetry_appender_tracing::layer::tests".into()
-            )));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.filename"),
+                &AnyValue::String("layer.rs".into())
+            ));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.namespace"),
+                &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
+            ));
             // The other 3 experimental_metadata_attributes are too unstable to check their value.
             // Ex.: The path will be different on a Windows and Linux machine.
             // Ex.: The line can change easily if someone makes changes in this source file.
-            let attributes_key: Vec<Key> = attributes.iter().map(|(key, _)| key.clone()).collect();
+            let attributes_key: Vec<Key> = log
+                .record
+                .attributes_iter()
+                .map(|(key, _)| key.clone())
+                .collect();
             assert!(attributes_key.contains(&Key::new("code.filepath")));
             assert!(attributes_key.contains(&Key::new("code.lineno")));
             assert!(attributes_key.contains(&Key::new("log.target")));
@@ -348,29 +356,38 @@ mod tests {
         );
 
         // validate attributes.
-        let attributes: Vec<(Key, AnyValue)> = log
-            .record
-            .attributes
-            .clone()
-            .expect("Attributes are expected");
         #[cfg(not(feature = "experimental_metadata_attributes"))]
-        assert_eq!(attributes.len(), 3);
+        assert_eq!(log.record.attributes_len(), 3);
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(attributes.len(), 8);
-        assert!(attributes.contains(&(Key::new("event_id"), 20.into())));
-        assert!(attributes.contains(&(Key::new("user_name"), "otel".into())));
-        assert!(attributes.contains(&(Key::new("user_email"), "otel@opentelemetry.io".into())));
+        assert_eq!(log.record.attributes_len(), 8);
+        assert!(log
+            .record
+            .attributes_contains(&Key::new("event_id"), &AnyValue::Int(20.into())));
+        assert!(log
+            .record
+            .attributes_contains(&Key::new("user_name"), &AnyValue::String("otel".into())));
+        assert!(log.record.attributes_contains(
+            &Key::new("user_email"),
+            &AnyValue::String("otel@opentelemetry.io".into())
+        ));
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(attributes.contains(&(Key::new("code.filename"), "layer.rs".into())));
-            assert!(attributes.contains(&(
-                Key::new("code.namespace"),
-                "opentelemetry_appender_tracing::layer::tests".into()
-            )));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.filename"),
+                &AnyValue::String("layer.rs".into())
+            ));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.namespace"),
+                &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
+            ));
             // The other 3 experimental_metadata_attributes are too unstable to check their value.
             // Ex.: The path will be different on a Windows and Linux machine.
             // Ex.: The line can change easily if someone makes changes in this source file.
-            let attributes_key: Vec<Key> = attributes.iter().map(|(key, _)| key.clone()).collect();
+            let attributes_key: Vec<Key> = log
+                .record
+                .attributes_iter()
+                .map(|(key, _)| key.clone())
+                .collect();
             assert!(attributes_key.contains(&Key::new("code.filepath")));
             assert!(attributes_key.contains(&Key::new("code.lineno")));
             assert!(attributes_key.contains(&Key::new("log.target")));
@@ -413,29 +430,28 @@ mod tests {
         // Validate trace context is none.
         assert!(log.record.trace_context.is_none());
 
-        // Validate attributes
-        #[cfg(feature = "experimental_metadata_attributes")]
-        let attributes: Vec<(Key, AnyValue)> = log
-            .record
-            .attributes
-            .clone()
-            .expect("Attributes are expected");
-
         // Attributes can be polluted when we don't use this feature.
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(attributes.len(), 5);
+        assert_eq!(log.record.attributes_len(), 5);
 
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(attributes.contains(&(Key::new("code.filename"), "layer.rs".into())));
-            assert!(attributes.contains(&(
-                Key::new("code.namespace"),
-                "opentelemetry_appender_tracing::layer::tests".into()
-            )));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.filename"),
+                &AnyValue::String("layer.rs".into())
+            ));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.namespace"),
+                &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
+            ));
             // The other 3 experimental_metadata_attributes are too unstable to check their value.
             // Ex.: The path will be different on a Windows and Linux machine.
             // Ex.: The line can change easily if someone makes changes in this source file.
-            let attributes_key: Vec<Key> = attributes.iter().map(|(key, _)| key.clone()).collect();
+            let attributes_key: Vec<Key> = log
+                .record
+                .attributes_iter()
+                .map(|(key, _)| key.clone())
+                .collect();
             assert!(attributes_key.contains(&Key::new("code.filepath")));
             assert!(attributes_key.contains(&Key::new("code.lineno")));
             assert!(attributes_key.contains(&Key::new("log.target")));
@@ -509,29 +525,28 @@ mod tests {
             TraceFlags::SAMPLED
         );
 
-        // validate attributes.
-        #[cfg(feature = "experimental_metadata_attributes")]
-        let attributes: Vec<(Key, AnyValue)> = log
-            .record
-            .attributes
-            .clone()
-            .expect("Attributes are expected");
-
         // Attributes can be polluted when we don't use this feature.
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(attributes.len(), 5);
+        assert_eq!(log.record.attributes_len(), 5);
 
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(attributes.contains(&(Key::new("code.filename"), "layer.rs".into())));
-            assert!(attributes.contains(&(
-                Key::new("code.namespace"),
-                "opentelemetry_appender_tracing::layer::tests".into()
-            )));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.filename"),
+                &AnyValue::String("layer.rs".into())
+            ));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.namespace"),
+                &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
+            ));
             // The other 3 experimental_metadata_attributes are too unstable to check their value.
             // Ex.: The path will be different on a Windows and Linux machine.
             // Ex.: The line can change easily if someone makes changes in this source file.
-            let attributes_key: Vec<Key> = attributes.iter().map(|(key, _)| key.clone()).collect();
+            let attributes_key: Vec<Key> = log
+                .record
+                .attributes_iter()
+                .map(|(key, _)| key.clone())
+                .collect();
             assert!(attributes_key.contains(&Key::new("code.filepath")));
             assert!(attributes_key.contains(&Key::new("code.lineno")));
             assert!(attributes_key.contains(&Key::new("log.target")));


### PR DESCRIPTION
## Changes

Hide the implementation details of LogRecord attributes by:

- Making the attributes private to the opentelemetry-sdk crate.
- Creating wrapper methods `attributes_iter()`, `attributes_contains()`, and `attributes_len()` to expose the functionality of these attributes to the exporter.
These changes will enable modifications to the internal implementation of these attributes without requiring any changes in the exporter code.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
