### PR TITLE
Hide LogRecord attributes Implementation Details from exporters

### DIFF
--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -938,10 +938,9 @@ mod tests {
         );
 
         let logs = exporter.get_emitted_logs().unwrap();
-        let attributes = &logs[0].record.attributes.as_ref().unwrap();
 
-        let get = |needle: &str| {
-            attributes.iter().find_map(|(k, v)| {
+        let get = |needle: &str| -> Option<AnyValue> {
+            logs[0].record.attributes_iter().find_map(|(k, v)| {
                 if k.as_str() == needle {
                     Some(v.clone())
                 } else {

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -252,29 +252,38 @@ mod tests {
         assert!(log.record.trace_context.is_none());
 
         // Validate attributes
-        let attributes: Vec<(Key, AnyValue)> = log
-            .record
-            .attributes
-            .clone()
-            .expect("Attributes are expected");
         #[cfg(not(feature = "experimental_metadata_attributes"))]
-        assert_eq!(attributes.len(), 3);
+        assert_eq!(log.record.attributes_len(), 3);
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(attributes.len(), 8);
-        assert!(attributes.contains(&(Key::new("event_id"), 20.into())));
-        assert!(attributes.contains(&(Key::new("user_name"), "otel".into())));
-        assert!(attributes.contains(&(Key::new("user_email"), "otel@opentelemetry.io".into())));
+        assert_eq!(log.record.attributes_len(), 8);
+        assert!(log
+            .record
+            .attributes_contains(&Key::new("event_id"), &AnyValue::Int(20)));
+        assert!(log
+            .record
+            .attributes_contains(&Key::new("user_name"), &AnyValue::String("otel".into())));
+        assert!(log.record.attributes_contains(
+            &Key::new("user_email"),
+            &AnyValue::String("otel@opentelemetry.io".into())
+        ));
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(attributes.contains(&(Key::new("code.filename"), "layer.rs".into())));
-            assert!(attributes.contains(&(
-                Key::new("code.namespace"),
-                "opentelemetry_appender_tracing::layer::tests".into()
-            )));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.filename"),
+                &AnyValue::String("layer.rs".into())
+            ));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.namespace"),
+                &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
+            ));
             // The other 3 experimental_metadata_attributes are too unstable to check their value.
             // Ex.: The path will be different on a Windows and Linux machine.
             // Ex.: The line can change easily if someone makes changes in this source file.
-            let attributes_key: Vec<Key> = attributes.iter().map(|(key, _)| key.clone()).collect();
+            let attributes_key: Vec<Key> = log
+                .record
+                .attributes_iter()
+                .map(|(key, _)| key.clone())
+                .collect();
             assert!(attributes_key.contains(&Key::new("code.filepath")));
             assert!(attributes_key.contains(&Key::new("code.lineno")));
             assert!(attributes_key.contains(&Key::new("log.target")));
@@ -348,29 +357,38 @@ mod tests {
         );
 
         // validate attributes.
-        let attributes: Vec<(Key, AnyValue)> = log
-            .record
-            .attributes
-            .clone()
-            .expect("Attributes are expected");
         #[cfg(not(feature = "experimental_metadata_attributes"))]
-        assert_eq!(attributes.len(), 3);
+        assert_eq!(log.record.attributes_len(), 3);
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(attributes.len(), 8);
-        assert!(attributes.contains(&(Key::new("event_id"), 20.into())));
-        assert!(attributes.contains(&(Key::new("user_name"), "otel".into())));
-        assert!(attributes.contains(&(Key::new("user_email"), "otel@opentelemetry.io".into())));
+        assert_eq!(log.record.attributes_len(), 8);
+        assert!(log
+            .record
+            .attributes_contains(&Key::new("event_id"), &AnyValue::Int(20.into())));
+        assert!(log
+            .record
+            .attributes_contains(&Key::new("user_name"), &AnyValue::String("otel".into())));
+        assert!(log.record.attributes_contains(
+            &Key::new("user_email"),
+            &AnyValue::String("otel@opentelemetry.io".into())
+        ));
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(attributes.contains(&(Key::new("code.filename"), "layer.rs".into())));
-            assert!(attributes.contains(&(
-                Key::new("code.namespace"),
-                "opentelemetry_appender_tracing::layer::tests".into()
-            )));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.filename"),
+                &AnyValue::String("layer.rs".into())
+            ));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.namespace"),
+                &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
+            ));
             // The other 3 experimental_metadata_attributes are too unstable to check their value.
             // Ex.: The path will be different on a Windows and Linux machine.
             // Ex.: The line can change easily if someone makes changes in this source file.
-            let attributes_key: Vec<Key> = attributes.iter().map(|(key, _)| key.clone()).collect();
+            let attributes_key: Vec<Key> = log
+                .record
+                .attributes_iter()
+                .map(|(key, _)| key.clone())
+                .collect();
             assert!(attributes_key.contains(&Key::new("code.filepath")));
             assert!(attributes_key.contains(&Key::new("code.lineno")));
             assert!(attributes_key.contains(&Key::new("log.target")));
@@ -413,29 +431,28 @@ mod tests {
         // Validate trace context is none.
         assert!(log.record.trace_context.is_none());
 
-        // Validate attributes
-        #[cfg(feature = "experimental_metadata_attributes")]
-        let attributes: Vec<(Key, AnyValue)> = log
-            .record
-            .attributes
-            .clone()
-            .expect("Attributes are expected");
-
         // Attributes can be polluted when we don't use this feature.
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(attributes.len(), 5);
+        assert_eq!(log.record.attributes_len(), 5);
 
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(attributes.contains(&(Key::new("code.filename"), "layer.rs".into())));
-            assert!(attributes.contains(&(
-                Key::new("code.namespace"),
-                "opentelemetry_appender_tracing::layer::tests".into()
-            )));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.filename"),
+                &AnyValue::String("layer.rs".into())
+            ));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.namespace"),
+                &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
+            ));
             // The other 3 experimental_metadata_attributes are too unstable to check their value.
             // Ex.: The path will be different on a Windows and Linux machine.
             // Ex.: The line can change easily if someone makes changes in this source file.
-            let attributes_key: Vec<Key> = attributes.iter().map(|(key, _)| key.clone()).collect();
+            let attributes_key: Vec<Key> = log
+                .record
+                .attributes_iter()
+                .map(|(key, _)| key.clone())
+                .collect();
             assert!(attributes_key.contains(&Key::new("code.filepath")));
             assert!(attributes_key.contains(&Key::new("code.lineno")));
             assert!(attributes_key.contains(&Key::new("log.target")));
@@ -509,29 +526,28 @@ mod tests {
             TraceFlags::SAMPLED
         );
 
-        // validate attributes.
-        #[cfg(feature = "experimental_metadata_attributes")]
-        let attributes: Vec<(Key, AnyValue)> = log
-            .record
-            .attributes
-            .clone()
-            .expect("Attributes are expected");
-
         // Attributes can be polluted when we don't use this feature.
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(attributes.len(), 5);
+        assert_eq!(log.record.attributes_len(), 5);
 
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(attributes.contains(&(Key::new("code.filename"), "layer.rs".into())));
-            assert!(attributes.contains(&(
-                Key::new("code.namespace"),
-                "opentelemetry_appender_tracing::layer::tests".into()
-            )));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.filename"),
+                &AnyValue::String("layer.rs".into())
+            ));
+            assert!(log.record.attributes_contains(
+                &Key::new("code.namespace"),
+                &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
+            ));
             // The other 3 experimental_metadata_attributes are too unstable to check their value.
             // Ex.: The path will be different on a Windows and Linux machine.
             // Ex.: The line can change easily if someone makes changes in this source file.
-            let attributes_key: Vec<Key> = attributes.iter().map(|(key, _)| key.clone()).collect();
+            let attributes_key: Vec<Key> = log
+                .record
+                .attributes_iter()
+                .map(|(key, _)| key.clone())
+                .collect();
             assert!(attributes_key.contains(&Key::new("code.filepath")));
             assert!(attributes_key.contains(&Key::new("code.lineno")));
             assert!(attributes_key.contains(&Key::new("log.target")));

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -259,9 +259,9 @@ mod tests {
 
         // Validate attributes
         #[cfg(not(feature = "experimental_metadata_attributes"))]
-        assert_eq!(log.record.attributes_len(), 3);
+        assert_eq!(log.record.attributes_iter().count(), 3);
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(log.record.attributes_len(), 8);
+        assert_eq!(log.record.attributes_iter().count(), 8);
         assert!(attributes_contains(
             &log.record,
             &Key::new("event_id"),
@@ -371,9 +371,9 @@ mod tests {
 
         // validate attributes.
         #[cfg(not(feature = "experimental_metadata_attributes"))]
-        assert_eq!(log.record.attributes_len(), 3);
+        assert_eq!(log.record.attributes_iter().count(), 3);
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(log.record.attributes_len(), 8);
+        assert_eq!(log.record.attributes_iter().count(), 8);
         assert!(attributes_contains(
             &log.record,
             &Key::new("event_id"),
@@ -453,7 +453,7 @@ mod tests {
 
         // Attributes can be polluted when we don't use this feature.
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(log.record.attributes_len(), 5);
+        assert_eq!(log.record.attributes_iter().count(), 5);
 
         #[cfg(feature = "experimental_metadata_attributes")]
         {
@@ -550,7 +550,7 @@ mod tests {
 
         // Attributes can be polluted when we don't use this feature.
         #[cfg(feature = "experimental_metadata_attributes")]
-        assert_eq!(log.record.attributes_len(), 5);
+        assert_eq!(log.record.attributes_iter().count(), 5);
 
         #[cfg(feature = "experimental_metadata_attributes")]
         {

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -208,12 +208,18 @@ mod tests {
     use opentelemetry::trace::TracerProvider as _;
     use opentelemetry::trace::{TraceContextExt, TraceFlags, Tracer};
     use opentelemetry::{logs::AnyValue, Key};
-    use opentelemetry_sdk::logs::LoggerProvider;
+    use opentelemetry_sdk::logs::{LogRecord, LoggerProvider};
     use opentelemetry_sdk::testing::logs::InMemoryLogsExporter;
     use opentelemetry_sdk::trace;
     use opentelemetry_sdk::trace::{Sampler, TracerProvider};
     use tracing::error;
     use tracing_subscriber::layer::SubscriberExt;
+
+    pub fn attributes_contains(log_record: &LogRecord, key: &Key, value: &AnyValue) -> bool {
+        log_record
+            .attributes_iter()
+            .any(|(k, v)| k == key && v == value)
+    }
 
     // cargo test --features=testing
     #[test]
@@ -256,23 +262,30 @@ mod tests {
         assert_eq!(log.record.attributes_len(), 3);
         #[cfg(feature = "experimental_metadata_attributes")]
         assert_eq!(log.record.attributes_len(), 8);
-        assert!(log
-            .record
-            .attributes_contains(&Key::new("event_id"), &AnyValue::Int(20)));
-        assert!(log
-            .record
-            .attributes_contains(&Key::new("user_name"), &AnyValue::String("otel".into())));
-        assert!(log.record.attributes_contains(
+        assert!(attributes_contains(
+            &log.record,
+            &Key::new("event_id"),
+            &AnyValue::Int(20)
+        ));
+        assert!(attributes_contains(
+            &log.record,
+            &Key::new("user_name"),
+            &AnyValue::String("otel".into())
+        ));
+        assert!(attributes_contains(
+            &log.record,
             &Key::new("user_email"),
             &AnyValue::String("otel@opentelemetry.io".into())
         ));
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(log.record.attributes_contains(
+            assert!(attributes_contains(
+                &log.record,
                 &Key::new("code.filename"),
                 &AnyValue::String("layer.rs".into())
             ));
-            assert!(log.record.attributes_contains(
+            assert!(attributes_contains(
+                &log.record,
                 &Key::new("code.namespace"),
                 &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
             ));
@@ -361,23 +374,30 @@ mod tests {
         assert_eq!(log.record.attributes_len(), 3);
         #[cfg(feature = "experimental_metadata_attributes")]
         assert_eq!(log.record.attributes_len(), 8);
-        assert!(log
-            .record
-            .attributes_contains(&Key::new("event_id"), &AnyValue::Int(20.into())));
-        assert!(log
-            .record
-            .attributes_contains(&Key::new("user_name"), &AnyValue::String("otel".into())));
-        assert!(log.record.attributes_contains(
+        assert!(attributes_contains(
+            &log.record,
+            &Key::new("event_id"),
+            &AnyValue::Int(20.into())
+        ));
+        assert!(attributes_contains(
+            &log.record,
+            &Key::new("user_name"),
+            &AnyValue::String("otel".into())
+        ));
+        assert!(attributes_contains(
+            &log.record,
             &Key::new("user_email"),
             &AnyValue::String("otel@opentelemetry.io".into())
         ));
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(log.record.attributes_contains(
+            assert!(attributes_contains(
+                &log.record,
                 &Key::new("code.filename"),
                 &AnyValue::String("layer.rs".into())
             ));
-            assert!(log.record.attributes_contains(
+            assert!(attributes_contains(
+                &log.record,
                 &Key::new("code.namespace"),
                 &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
             ));
@@ -437,11 +457,13 @@ mod tests {
 
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(log.record.attributes_contains(
+            assert!(attributes_contains(
+                &log.record,
                 &Key::new("code.filename"),
                 &AnyValue::String("layer.rs".into())
             ));
-            assert!(log.record.attributes_contains(
+            assert!(attributes_contains(
+                &log.record,
                 &Key::new("code.namespace"),
                 &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
             ));
@@ -532,11 +554,13 @@ mod tests {
 
         #[cfg(feature = "experimental_metadata_attributes")]
         {
-            assert!(log.record.attributes_contains(
+            assert!(attributes_contains(
+                &log.record,
                 &Key::new("code.filename"),
                 &AnyValue::String("layer.rs".into())
             ));
-            assert!(log.record.attributes_contains(
+            assert!(attributes_contains(
+                &log.record,
                 &Key::new("code.namespace"),
                 &AnyValue::String("opentelemetry_appender_tracing::layer::tests".into())
             ));

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -13,9 +13,9 @@
   [#1973](https://github.com/open-telemetry/opentelemetry-rust/pull/1973)
   - **Breaking** [#1985](https://github.com/open-telemetry/opentelemetry-rust/pull/1985)
   Hide LogRecord attributes Implementation Details from processors and exporters.
-  The custom exporter's can't directly access the `LogData::LogRecord::attributes`, as
+  The custom exporters and processors can't directly access the `LogData::LogRecord::attributes`, as
   these are private to opentelemetry-sdk. Instead, they would now use LogRecord::attributes_iter()
-  and LogRecord::attributes_len() methods to access them.
+  method to access them.
 
 
 ## v0.24.1

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -11,6 +11,11 @@
   first interval instead of doing it right away.
   [#1970](https://github.com/open-telemetry/opentelemetry-rust/pull/1970)
   [#1973](https://github.com/open-telemetry/opentelemetry-rust/pull/1973)
+  - **Breaking** [#1985](https://github.com/open-telemetry/opentelemetry-rust/pull/1985)
+  Hide LogRecord attributes Implementation Details from exporters.
+  The custom exporter's can't directly access the `LogData::LogRecord::attributes`, as
+  these are private to opentelemetry-sdk. Instead, they would now use LogRecord::attributes_iter()
+  and LogRecord::attributes_len() methods to access them.
 
 
 ## v0.24.1

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -110,8 +110,9 @@ impl LogRecord {
         self.attributes.as_ref().map_or(0, |attrs| attrs.len())
     }
 
+    #[allow(dead_code)]
     /// Returns true if the `LogRecord` contains the specified attribute.
-    pub fn attributes_contains(&self, key: &Key, value: &AnyValue) -> bool {
+    pub(crate) fn attributes_contains(&self, key: &Key, value: &AnyValue) -> bool {
         self.attributes.as_ref().map_or(false, |attrs| {
             attrs.iter().any(|(k, v)| k == key && v == value)
         })

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -105,8 +105,9 @@ impl LogRecord {
             .map_or_else(|| [].iter(), |attrs| attrs.iter())
     }
 
+    #[allow(dead_code)]
     /// Returns the number of attributes in the `LogRecord`.
-    pub fn attributes_len(&self) -> usize {
+    pub(crate) fn attributes_len(&self) -> usize {
         self.attributes.as_ref().map_or(0, |attrs| attrs.len())
     }
 


### PR DESCRIPTION
## Changes

Hide the implementation details of LogRecord attributes by:

- Making the LogRecord attributes private to the opentelemetry-sdk crate.
- Creating wrapper methods attributes_iter(), attributes_contains(), and attributes_len() to expose the functionality of these attributes to the exporter.

These changes will enable modifications to the internal implementation of these attributes without requiring any changes in the exporter code.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
