### PR TITLE
Metric refactor - 2x perf and allocation free

### DIFF
--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -72,74 +72,20 @@ impl TemporalitySelector for DeltaTemporalitySelector {
     }
 }
 
-// * Summary *
+/*
+    The benchmark results:
+    criterion = "0.5.1"
+    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    RAM: 64.0 GB
+    | Test                           | Average time|
+    |--------------------------------|-------------|
+    | Counter_Add_Sorted             | 560 ns      |
+    | Counter_Add_Unsorted           | 565 ns      |
+    | Counter_Overflow               | 568 ns      |
+    | ThreadLocal_Random_Generator_5 |  37 ns      |
+*/
 
-// rustc 1.68.0 (2c8cc3432 2023-03-06)
-// cargo 1.68.0 (115f34552 2023-02-26), OS=Windows 11 Enterprise
-// Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz   2.59 GHz
-// 12 logical and 6 physical cores
-
-// Counter/AddNoAttrs      time:   [65.406 ns 65.535 ns 65.675 ns]
-// Counter/AddNoAttrsDelta time:   [65.553 ns 65.761 ns 65.981 ns]
-// Counter/AddOneAttr      time:   [341.55 ns 344.40 ns 347.58 ns]
-// Counter/AddOneAttrDelta time:   [340.11 ns 342.42 ns 344.89 ns]
-// Counter/AddThreeAttr    time:   [619.01 ns 624.16 ns 630.16 ns]
-// Counter/AddThreeAttrDelta
-//                         time:   [606.71 ns 611.45 ns 616.66 ns]
-// Counter/AddFiveAttr     time:   [3.7551 µs 3.7813 µs 3.8094 µs]
-// Counter/AddFiveAttrDelta
-//                         time:   [3.7550 µs 3.7870 µs 3.8266 µs]
-// Counter/AddTenAttr      time:   [4.7684 µs 4.7909 µs 4.8146 µs]
-// Counter/AddTenAttrDelta time:   [4.7682 µs 4.8152 µs 4.8722 µs]
-// Counter/AddInvalidAttr  time:   [469.31 ns 472.97 ns 476.92 ns]
-// Counter/AddSingleUseAttrs
-//                         time:   [749.15 ns 805.09 ns 868.03 ns]
-// Counter/AddSingleUseInvalid
-//                         time:   [693.75 ns 702.65 ns 713.20 ns]
-// Counter/AddSingleUseFiltered
-//                         time:   [677.00 ns 681.63 ns 686.88 ns]
-// Counter/CollectOneAttr  time:   [659.29 ns 681.20 ns 708.04 ns]
-// Counter/CollectTenAttrs time:   [3.5048 µs 3.5384 µs 3.5777 µs]
-// Histogram/Record0Attrs10bounds
-//                         time:   [75.790 ns 77.235 ns 78.825 ns]
-// Histogram/Record3Attrs10bounds
-//                         time:   [580.88 ns 603.84 ns 628.71 ns]
-// Histogram/Record5Attrs10bounds
-//                         time:   [3.8539 µs 3.8988 µs 3.9519 µs]
-// Histogram/Record7Attrs10bounds
-//                         time:   [699.46 ns 720.17 ns 742.24 ns]
-// Histogram/Record10Attrs10bounds
-//                         time:   [844.95 ns 861.92 ns 880.23 ns]
-// Histogram/Record0Attrs49bounds
-//                         time:   [75.198 ns 77.081 ns 79.449 ns]
-// Histogram/Record3Attrs49bounds
-//                         time:   [533.82 ns 540.44 ns 547.30 ns]
-// Histogram/Record5Attrs49bounds
-//                         time:   [583.01 ns 588.27 ns 593.98 ns]
-// Histogram/Record7Attrs49bounds
-//                         time:   [645.67 ns 652.03 ns 658.35 ns]
-// Histogram/Record10Attrs49bounds
-//                         time:   [747.24 ns 755.42 ns 764.37 ns]
-// Histogram/Record0Attrs50bounds
-//                         time:   [72.023 ns 72.218 ns 72.426 ns]
-// Histogram/Record3Attrs50bounds
-//                         time:   [530.21 ns 534.23 ns 538.63 ns]
-// Histogram/Record5Attrs50bounds
-//                         time:   [3.2934 µs 3.3069 µs 3.3228 µs]
-// Histogram/Record7Attrs50bounds
-//                         time:   [633.88 ns 638.87 ns 644.52 ns]
-// Histogram/Record10Attrs50bounds
-//                         time:   [759.69 ns 768.42 ns 778.12 ns]
-// Histogram/Record0Attrs1000bounds
-//                         time:   [75.495 ns 75.942 ns 76.529 ns]
-// Histogram/Record3Attrs1000bounds
-//                         time:   [542.06 ns 548.37 ns 555.31 ns]
-// Histogram/Record5Attrs1000bounds
-//                         time:   [3.2935 µs 3.3058 µs 3.3215 µs]
-// Histogram/Record7Attrs1000bounds
-//                         time:   [643.75 ns 649.05 ns 655.14 ns]
-// Histogram/Record10Attrs1000bounds
-//                         time:   [726.87 ns 736.52 ns 747.09 ns]
 fn bench_counter(view: Option<Box<dyn View>>, temporality: &str) -> (SharedReader, Counter<u64>) {
     let rdr = if temporality == "cumulative" {
         SharedReader(Arc::new(ManualReader::builder().build()))

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -72,20 +72,74 @@ impl TemporalitySelector for DeltaTemporalitySelector {
     }
 }
 
-/*
-    The benchmark results:
-    criterion = "0.5.1"
-    OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
-    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
-    RAM: 64.0 GB
-    | Test                           | Average time|
-    |--------------------------------|-------------|
-    | Counter_Add_Sorted             | 560 ns      |
-    | Counter_Add_Unsorted           | 565 ns      |
-    | Counter_Overflow               | 568 ns      |
-    | ThreadLocal_Random_Generator_5 |  37 ns      |
-*/
+// * Summary *
 
+// rustc 1.68.0 (2c8cc3432 2023-03-06)
+// cargo 1.68.0 (115f34552 2023-02-26), OS=Windows 11 Enterprise
+// Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz   2.59 GHz
+// 12 logical and 6 physical cores
+
+// Counter/AddNoAttrs      time:   [65.406 ns 65.535 ns 65.675 ns]
+// Counter/AddNoAttrsDelta time:   [65.553 ns 65.761 ns 65.981 ns]
+// Counter/AddOneAttr      time:   [341.55 ns 344.40 ns 347.58 ns]
+// Counter/AddOneAttrDelta time:   [340.11 ns 342.42 ns 344.89 ns]
+// Counter/AddThreeAttr    time:   [619.01 ns 624.16 ns 630.16 ns]
+// Counter/AddThreeAttrDelta
+//                         time:   [606.71 ns 611.45 ns 616.66 ns]
+// Counter/AddFiveAttr     time:   [3.7551 µs 3.7813 µs 3.8094 µs]
+// Counter/AddFiveAttrDelta
+//                         time:   [3.7550 µs 3.7870 µs 3.8266 µs]
+// Counter/AddTenAttr      time:   [4.7684 µs 4.7909 µs 4.8146 µs]
+// Counter/AddTenAttrDelta time:   [4.7682 µs 4.8152 µs 4.8722 µs]
+// Counter/AddInvalidAttr  time:   [469.31 ns 472.97 ns 476.92 ns]
+// Counter/AddSingleUseAttrs
+//                         time:   [749.15 ns 805.09 ns 868.03 ns]
+// Counter/AddSingleUseInvalid
+//                         time:   [693.75 ns 702.65 ns 713.20 ns]
+// Counter/AddSingleUseFiltered
+//                         time:   [677.00 ns 681.63 ns 686.88 ns]
+// Counter/CollectOneAttr  time:   [659.29 ns 681.20 ns 708.04 ns]
+// Counter/CollectTenAttrs time:   [3.5048 µs 3.5384 µs 3.5777 µs]
+// Histogram/Record0Attrs10bounds
+//                         time:   [75.790 ns 77.235 ns 78.825 ns]
+// Histogram/Record3Attrs10bounds
+//                         time:   [580.88 ns 603.84 ns 628.71 ns]
+// Histogram/Record5Attrs10bounds
+//                         time:   [3.8539 µs 3.8988 µs 3.9519 µs]
+// Histogram/Record7Attrs10bounds
+//                         time:   [699.46 ns 720.17 ns 742.24 ns]
+// Histogram/Record10Attrs10bounds
+//                         time:   [844.95 ns 861.92 ns 880.23 ns]
+// Histogram/Record0Attrs49bounds
+//                         time:   [75.198 ns 77.081 ns 79.449 ns]
+// Histogram/Record3Attrs49bounds
+//                         time:   [533.82 ns 540.44 ns 547.30 ns]
+// Histogram/Record5Attrs49bounds
+//                         time:   [583.01 ns 588.27 ns 593.98 ns]
+// Histogram/Record7Attrs49bounds
+//                         time:   [645.67 ns 652.03 ns 658.35 ns]
+// Histogram/Record10Attrs49bounds
+//                         time:   [747.24 ns 755.42 ns 764.37 ns]
+// Histogram/Record0Attrs50bounds
+//                         time:   [72.023 ns 72.218 ns 72.426 ns]
+// Histogram/Record3Attrs50bounds
+//                         time:   [530.21 ns 534.23 ns 538.63 ns]
+// Histogram/Record5Attrs50bounds
+//                         time:   [3.2934 µs 3.3069 µs 3.3228 µs]
+// Histogram/Record7Attrs50bounds
+//                         time:   [633.88 ns 638.87 ns 644.52 ns]
+// Histogram/Record10Attrs50bounds
+//                         time:   [759.69 ns 768.42 ns 778.12 ns]
+// Histogram/Record0Attrs1000bounds
+//                         time:   [75.495 ns 75.942 ns 76.529 ns]
+// Histogram/Record3Attrs1000bounds
+//                         time:   [542.06 ns 548.37 ns 555.31 ns]
+// Histogram/Record5Attrs1000bounds
+//                         time:   [3.2935 µs 3.3058 µs 3.3215 µs]
+// Histogram/Record7Attrs1000bounds
+//                         time:   [643.75 ns 649.05 ns 655.14 ns]
+// Histogram/Record10Attrs1000bounds
+//                         time:   [726.87 ns 736.52 ns 747.09 ns]
 fn bench_counter(view: Option<Box<dyn View>>, temporality: &str) -> (SharedReader, Counter<u64>) {
     let rdr = if temporality == "cumulative" {
         SharedReader(Arc::new(ManualReader::builder().build()))

--- a/opentelemetry-sdk/benches/metric_counter.rs
+++ b/opentelemetry-sdk/benches/metric_counter.rs
@@ -6,9 +6,9 @@
     RAM: 64.0 GB
     | Test                           | Average time|
     |--------------------------------|-------------|
-    | Counter_Add_Sorted             | 560 ns      |
-    | Counter_Add_Unsorted           | 565 ns      |
-    | Counter_Overflow               | 568 ns      |
+    | Counter_Add_Sorted             | 193 ns      |
+    | Counter_Add_Unsorted           | 209 ns      |
+    | Counter_Overflow               | 898 ns      |
     | ThreadLocal_Random_Generator_5 |  37 ns      |
 */
 

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -74,7 +74,7 @@ impl<T: Number<T>> ValueMap<T> {
                         } else if let Some(value_to_update) = values.get(sorted_attrs.as_slice()) {
                             value_to_update.add(measurement);
                             return;
-                        } else if is_under_cardinality_limit(self.count.load(Ordering::Acquire)) {
+                        } else if is_under_cardinality_limit(self.count.load(Ordering::SeqCst)) {
                             let new_value = T::new_atomic_tracker();
                             new_value.add(measurement);
                             let new_value = Arc::new(new_value);
@@ -85,7 +85,7 @@ impl<T: Number<T>> ValueMap<T> {
                             // Insert sorted order
                             values.insert(sorted_attrs, new_value);
 
-                            self.count.fetch_add(1, Ordering::Release);
+                            self.count.fetch_add(1, Ordering::SeqCst);
                         } else if let Some(overflow_value) =
                             values.get_mut(STREAM_OVERFLOW_ATTRIBUTES.as_slice())
                         {

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -56,7 +56,7 @@ impl<T: Number<T>> ValueMap<T> {
                 value_to_update.add(measurement);
                 return;
             } else {
-                // Then try sorted order.                
+                // Then try sorted order.
                 let sorted_attrs = AttributeSet::from(attrs).into_vec();
                 if let Some(value_to_update) = values.get(sorted_attrs.as_slice()) {
                     value_to_update.add(measurement);
@@ -81,15 +81,14 @@ impl<T: Number<T>> ValueMap<T> {
 
                             // Insert original order
                             values.insert(attrs.to_vec(), new_value.clone());
-                            
+
                             // Insert sorted order
                             values.insert(sorted_attrs, new_value);
 
                             self.count.fetch_add(1, Ordering::Release);
-                            
                         } else if let Some(overflow_value) =
                             values.get_mut(STREAM_OVERFLOW_ATTRIBUTES.as_slice())
-                        {                            
+                        {
                             overflow_value.add(measurement);
                             return;
                         } else {
@@ -150,7 +149,7 @@ impl<T: Number<T>> Sum<T> {
         s_data.temporality = Temporality::Delta;
         s_data.is_monotonic = self.monotonic;
         s_data.data_points.clear();
-        
+
         // Max number of data points need to account for the special casing
         // of the no attribute value + overflow attribute.
         let n = self.value_map.count.load(Ordering::Relaxed) + 2;
@@ -160,7 +159,7 @@ impl<T: Number<T>> Sum<T> {
                 .reserve_exact(n - s_data.data_points.capacity());
         }
 
-        let prev_start = self.start.lock().map(|start| *start).unwrap_or(t);        
+        let prev_start = self.start.lock().map(|start| *start).unwrap_or(t);
         if self
             .value_map
             .has_no_value_attribute_value

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -218,7 +218,7 @@ impl<T: Number<T>> Sum<T> {
         let s_data = s_data.unwrap_or_else(|| new_agg.as_mut().expect("present if s_data is none"));
         s_data.temporality = Temporality::Cumulative;
         s_data.is_monotonic = self.monotonic;
-        s_data.data_points.clear();        
+        s_data.data_points.clear();
 
         // Max number of data points need to account for the special casing
         // of the no attribute value + overflow attribute.
@@ -313,7 +313,7 @@ impl<T: Number<T>> PrecomputedSum<T> {
         let s_data = s_data.unwrap_or_else(|| new_agg.as_mut().expect("present if s_data is none"));
         s_data.data_points.clear();
         s_data.temporality = Temporality::Delta;
-        s_data.is_monotonic = self.monotonic;        
+        s_data.is_monotonic = self.monotonic;
 
         // Max number of data points need to account for the special casing
         // of the no attribute value + overflow attribute.
@@ -398,7 +398,7 @@ impl<T: Number<T>> PrecomputedSum<T> {
         let s_data = s_data.unwrap_or_else(|| new_agg.as_mut().expect("present if s_data is none"));
         s_data.data_points.clear();
         s_data.temporality = Temporality::Cumulative;
-        s_data.is_monotonic = self.monotonic;        
+        s_data.is_monotonic = self.monotonic;
 
         // Max number of data points need to account for the special casing
         // of the no attribute value + overflow attribute.

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -83,7 +83,7 @@ impl<T: Number<T>> ValueMap<T> {
 
                             self.count.fetch_add(1, Ordering::SeqCst);
                         } else if let Some(overflow_value) =
-                            values.get_mut(STREAM_OVERFLOW_ATTRIBUTES.as_slice())
+                            values.get(STREAM_OVERFLOW_ATTRIBUTES.as_slice())
                         {
                             overflow_value.add(measurement);
                         } else {
@@ -191,7 +191,7 @@ impl<T: Number<T>> Sum<T> {
         if let Ok(mut start) = self.start.lock() {
             *start = t;
         }
-        self.value_map.count.store(0, Ordering::Release);
+        self.value_map.count.store(0, Ordering::SeqCst);
 
         (
             s_data.data_points.len(),
@@ -367,7 +367,7 @@ impl<T: Number<T>> PrecomputedSum<T> {
         if let Ok(mut start) = self.start.lock() {
             *start = t;
         }
-        self.value_map.count.store(0, Ordering::Release);
+        self.value_map.count.store(0, Ordering::SeqCst);
 
         *reported = new_reported;
         drop(reported); // drop before values guard is dropped

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -945,13 +945,13 @@ mod tests {
         ];
         let mut rng = rngs::SmallRng::from_entropy();
 
-        for _ in 0..1000000 {
+        for _ in 0..100000 {
             let mut rands: [usize; 4] = [0; 4];
+            // 4X4X10X10 = 1600 time-series.
             rands[0] = rng.gen_range(0..4);
             rands[1] = rng.gen_range(0..4);
             rands[2] = rng.gen_range(0..10);
-            rands[3] = rng.gen_range(0..10);
-
+            rands[3] = rng.gen_range(0..10);            
             let index_first_attribute = rands[0];
             let index_second_attribute = rands[1];
             let index_third_attribute = rands[2];
@@ -971,14 +971,14 @@ mod tests {
 
         let sum = test_context.get_aggregation::<data::Sum<u64>>("my_counter", None);
 
-        // Expecting 1 time-series.
+        // Expecting 1600 time-series.
         assert_eq!(sum.data_points.len(), 1600);
 
-        // find and validate key1=value2 datapoint
-        let data_point1 =
+        // validate that overflow data point is not present.
+        let overflow_point =
             find_datapoint_with_key_value(&sum.data_points, "otel.metric.overflow", "true");
 
-        assert!(data_point1.is_none());
+        assert!(overflow_point.is_none());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -926,6 +926,62 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn counter_aggregation_attribute_ordering() {
+        // Run this test with stdout enabled to see output.
+        // cargo test counter_aggregation_attribute_ordering --features=testing -- --nocapture
+
+        // Arrange
+        let mut test_context = TestContext::new(Temporality::Delta);
+        let counter = test_context.u64_counter("test", "my_counter", None);
+
+        // Act
+        // Add the same set of attributes in different order. (they are expected
+        // to be treated as same attributes)
+        // start with unsorted order
+
+        let attribute_values = [
+        "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
+        "value10",
+        ];
+        let mut rng = rngs::SmallRng::from_entropy();
+
+        for _ in 0..1000000 {
+            let mut rands:[usize; 4] = [0; 4];
+            rands[0] = rng.gen_range(0..4);
+            rands[1] = rng.gen_range(0..4);
+            rands[2] = rng.gen_range(0..10);
+            rands[3] = rng.gen_range(0..10);
+                
+            
+            let index_first_attribute = rands[0];
+            let index_second_attribute = rands[1];
+            let index_third_attribute = rands[2];
+            let index_fourth_attribute = rands[3];
+            counter.add(
+                1,
+                &[
+                    KeyValue::new("attribute1", attribute_values[index_first_attribute]),
+                    KeyValue::new("attribute2", attribute_values[index_second_attribute]),
+                    KeyValue::new("attribute3", attribute_values[index_third_attribute]),
+                    KeyValue::new("attribute4", attribute_values[index_fourth_attribute]),
+                ],
+            );
+        }
+                
+        test_context.flush_metrics();
+
+        let sum = test_context.get_aggregation::<data::Sum<u64>>("my_counter", None);
+
+        // Expecting 1 time-series.
+        assert_eq!(sum.data_points.len(), 1600);
+
+        // find and validate key1=value2 datapoint
+        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "otel.metric.overflow", "true");
+            
+        assert!(data_point1.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn no_attr_cumulative_counter() {
         let mut test_context = TestContext::new(Temporality::Cumulative);
         let counter = test_context.u64_counter("test", "my_counter", None);

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -940,19 +940,18 @@ mod tests {
         // start with unsorted order
 
         let attribute_values = [
-        "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
-        "value10",
+            "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8",
+            "value9", "value10",
         ];
         let mut rng = rngs::SmallRng::from_entropy();
 
         for _ in 0..1000000 {
-            let mut rands:[usize; 4] = [0; 4];
+            let mut rands: [usize; 4] = [0; 4];
             rands[0] = rng.gen_range(0..4);
             rands[1] = rng.gen_range(0..4);
             rands[2] = rng.gen_range(0..10);
             rands[3] = rng.gen_range(0..10);
-                
-            
+
             let index_first_attribute = rands[0];
             let index_second_attribute = rands[1];
             let index_third_attribute = rands[2];
@@ -967,7 +966,7 @@ mod tests {
                 ],
             );
         }
-                
+
         test_context.flush_metrics();
 
         let sum = test_context.get_aggregation::<data::Sum<u64>>("my_counter", None);
@@ -976,8 +975,9 @@ mod tests {
         assert_eq!(sum.data_points.len(), 1600);
 
         // find and validate key1=value2 datapoint
-        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "otel.metric.overflow", "true");
-            
+        let data_point1 =
+            find_datapoint_with_key_value(&sum.data_points, "otel.metric.overflow", "true");
+
         assert!(data_point1.is_none());
     }
 

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -951,7 +951,7 @@ mod tests {
             rands[0] = rng.gen_range(0..4);
             rands[1] = rng.gen_range(0..4);
             rands[2] = rng.gen_range(0..10);
-            rands[3] = rng.gen_range(0..10);            
+            rands[3] = rng.gen_range(0..10);
             let index_first_attribute = rands[0];
             let index_second_attribute = rands[1];
             let index_third_attribute = rands[2];

--- a/stress/src/metrics_counter.rs
+++ b/stress/src/metrics_counter.rs
@@ -4,6 +4,9 @@
     Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
     RAM: 64.0 GB
     ~9.5 M /sec
+
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    ~20 M /sec
 */
 
 use lazy_static::lazy_static;


### PR DESCRIPTION
Part 2 of https://github.com/open-telemetry/opentelemetry-rust/issues/1740, addressing 1,2,3. Also closes #1954 for SUM.

Refactoring SUM aggregation logic to operate entirely on user provided slice of KeyValues. In hot-path, we avoid **allocating, copying, sorting, de-duplicating.**, leading to **2X or more gains** (with 4 attributes. More attributes = much more gains), as long as user do not keep changing the order of attributes.

This is mostly based on the prototypes did outside this repo in https://github.com/cijothomas/metrics-mini/tree/main/metrics
Once the approach is settled, we can replicate to all aggregations. (This PR is only fixing SUM)

Benchmarks:
```
Counter_Add_Sorted      time:   [192.64 ns 193.03 ns 193.48 ns]
                        change: [-66.328% -66.034% -65.769%] (p = 0.00 < 0.05)
                        Performance has improved.
Counter_Add_Unsorted    time:   [209.09 ns 209.41 ns 209.74 ns]
                        change: [-63.198% -62.905% -62.670%] (p = 0.00 < 0.05)
                        Performance has improved.
Counter_Overflow        time:   [895.61 ns 898.58 ns 902.11 ns]
                        change: [+54.000% +58.218% +61.362%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

Stress Test also shows small gains (17M/sec to 20M/sec). https://github.com/open-telemetry/opentelemetry-rust/pull/1833 fixed the major contention, so this PR has limited impact on stress test, but the raw speed is significantly improved.

**Stress Test with memory stats:**

Main:
Throughput: 17,842,800 iterations/sec
Memory usage: 5.06 MB
CPU usage: 98.61875%
Virtual memory usage: 2249.73 MB

PR:
Throughput: 18,869,600 iterations/sec
Memory usage: 4.23 MB
CPU usage: 99.2016%
Virtual memory usage: 2249.55 MB

Visible memory reduction as well from ~5 MB to ~4.2 MB

*note*: Overflow perf regressed, and that is acceptable. The main goal with overflow feature is to protect SDK from consuming unlimited memory, so it is acceptable that this path is slower. This is rare case, and indicates user needs to adjust cardinality.