### PR TITLE
Add benchmarks for measuring cost of Logger, Provider creation

### DIFF
--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -2,6 +2,17 @@
 //! So to run test named "full-log-with-attributes/with-context" you would run `$ cargo bench --bench log -- --exact full-log-with-attributes/with-context`
 //! To run all tests for logs you would run `$ cargo bench --bench log`
 //!
+/*
+The benchmark results:
+criterion = "0.5.1"
+OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
+Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+RAM: 64.0 GB
+| Test                           | Average time|
+|--------------------------------|-------------|
+| Logger_Creation                |  30 ns      |
+| LoggerProvider_Creation        | 909 ns      |
+*/
 
 use std::collections::HashMap;
 use std::time::SystemTime;
@@ -80,7 +91,32 @@ fn log_benchmark_group<F: Fn(&Logger)>(c: &mut Criterion, name: &str, f: F) {
     group.finish();
 }
 
+fn log_provider_creation(c: &mut Criterion) {
+    c.bench_function("LoggerProvider_Creation", |b| {
+        b.iter(|| {
+            let _provider = LoggerProvider::builder()
+            .with_log_processor(NoopProcessor {})
+            .build();
+        });
+    });
+}
+
+fn logger_creation(c: &mut Criterion) {
+    // Provider is created once, outside of the benchmark
+    let provider = LoggerProvider::builder()
+            .with_log_processor(NoopProcessor {})
+            .build();
+
+    c.bench_function("Logger_Creation", |b| {
+        b.iter(|| {
+            let _logger = provider.logger("benchmark");
+        });
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
+    logger_creation(c);
+    log_provider_creation(c);
     log_benchmark_group(c, "simple-log", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -95,8 +95,8 @@ fn log_provider_creation(c: &mut Criterion) {
     c.bench_function("LoggerProvider_Creation", |b| {
         b.iter(|| {
             let _provider = LoggerProvider::builder()
-            .with_log_processor(NoopProcessor {})
-            .build();
+                .with_log_processor(NoopProcessor {})
+                .build();
         });
     });
 }
@@ -104,8 +104,8 @@ fn log_provider_creation(c: &mut Criterion) {
 fn logger_creation(c: &mut Criterion) {
     // Provider is created once, outside of the benchmark
     let provider = LoggerProvider::builder()
-            .with_log_processor(NoopProcessor {})
-            .build();
+        .with_log_processor(NoopProcessor {})
+        .build();
 
     c.bench_function("Logger_Creation", |b| {
         b.iter(|| {


### PR DESCRIPTION
Related to #1995 
This adds a dedicated benchmark to show the cost of creating provider, and logger. These are expected to be one-time operation and end users are expected to re-use them.