### PR TITLE
LogAppender - 5% perf gain and reduce heap alloc for SeverityText

### DIFF
--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Reduce heap allocation by using `&'static str` for `SeverityText`.
+
 ## v0.5.0
 
 - [1869](https://github.com/open-telemetry/opentelemetry-rust/pull/1869) Utilize the `LogRecord::set_target()` method to pass the tracing target to the SDK.

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -10,7 +10,7 @@
     | noop_layer_disabled         | 12 ns       |
     | noop_layer_enabled          | 25 ns       |
     | ot_layer_disabled           | 19 ns       |
-    | ot_layer_enabled            | 305 ns      |
+    | ot_layer_enabled            | 280 ns      |
 */
 
 use async_trait::async_trait;

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -168,7 +168,7 @@ where
         log_record.set_target(meta.target().to_string());
         log_record.set_event_name(meta.name());
         log_record.set_severity_number(severity_of_level(meta.level()));
-        log_record.set_severity_text(meta.level().to_string().into());
+        log_record.set_severity_text(severity_text_of_level(meta.level()).into());
         let mut visitor = EventVisitor::new(&mut log_record);
         #[cfg(feature = "experimental_metadata_attributes")]
         visitor.visit_experimental_metadata(meta);
@@ -198,6 +198,16 @@ const fn severity_of_level(level: &Level) -> Severity {
         Level::INFO => Severity::Info,
         Level::WARN => Severity::Warn,
         Level::ERROR => Severity::Error,
+    }
+}
+
+const fn severity_text_of_level(level: &Level) -> &'static str {
+    match *level {
+        Level::TRACE => "TRACE",
+        Level::DEBUG => "DEBUG",
+        Level::INFO => "INFO",
+        Level::WARN => "WARN",
+        Level::ERROR => "ERROR",
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-rust/issues/1953
Gains are between 5-10% in my machine.