### PR TITLE
Add a benchmark to sdk logs that is comparable to tracing appender

### DIFF
--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -12,6 +12,7 @@ RAM: 64.0 GB
 |--------------------------------|-------------|
 | Logger_Creation                |  30 ns      |
 | LoggerProvider_Creation        | 909 ns      |
+| Logging_Comparable_To_Appender | 135 ns      |
 */
 
 use std::collections::HashMap;
@@ -114,9 +115,36 @@ fn logger_creation(c: &mut Criterion) {
     });
 }
 
+fn logging_comparable_to_appender(c: &mut Criterion) {
+    let provider = LoggerProvider::builder()
+        .with_log_processor(NoopProcessor {})
+        .build();
+    let logger = provider.logger("benchmark");
+
+    // This mimics the logic from opentelemetry-tracing-appender closely, but
+    // without the overhead of the tracing layer itself.
+    c.bench_function("Logging_Comparable_To_Appender", |b| {
+        b.iter(|| {
+            let mut log_record = logger.create_log_record();
+            let now = SystemTime::now();
+            log_record.set_observed_timestamp(now);
+            log_record.set_target("my-target".to_string());
+            log_record.set_event_name("CheckoutFailed");
+            log_record.set_severity_number(Severity::Warn);
+            log_record.set_severity_text("WARN".into());
+            log_record.add_attribute("book_id", "12345");
+            log_record.add_attribute("book_title", "Rust Programming Adventures");
+            log_record.add_attribute("message", "Unable to process checkout.");
+
+            logger.emit(log_record);
+        });
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     logger_creation(c);
     log_provider_creation(c);
+    logging_comparable_to_appender(c);
     log_benchmark_group(c, "simple-log", |logger| {
         let mut log_record = logger.create_log_record();
         log_record.set_body("simple log".into());


### PR DESCRIPTION
To make it easy to compare gains from improvements, adding one to the SDK benchmarks that closely mimics what does on when tracing-appender is used as the end user logging api.
It is expected that tracing has its own overhead, so directly using bridge will be faster.