### PR TITLE
Nit update to stress test

### DIFF
--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -4,6 +4,9 @@
     Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
     RAM: 64.0 GB
     ~31 M/sec
+
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    ~38 M /sec
 */
 
 use opentelemetry_appender_tracing::layer;
@@ -50,5 +53,10 @@ fn main() {
 }
 
 fn test_log() {
-    error!(target: "my-system", event_id = 20, event_name = "my-event_name", user_name = "otel", user_email = "otel@opentelemetry.io");
+    error!(
+        name = "CheckoutFailed",
+        book_id = "12345",
+        book_title = "Rust Programming Adventures",
+        message = "Unable to process checkout."
+    );
 }

--- a/stress/src/metrics_histogram.rs
+++ b/stress/src/metrics_histogram.rs
@@ -4,6 +4,9 @@
     Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
     RAM: 64.0 GB
     ~1.8 M/sec
+
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    ~2.2 M /sec
 */
 
 use lazy_static::lazy_static;

--- a/stress/src/traces.rs
+++ b/stress/src/traces.rs
@@ -4,6 +4,9 @@
     Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
     RAM: 64.0 GB
     ~6.5 M/sec
+
+    Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
+    ~10.6 M /sec
 */
 
 use lazy_static::lazy_static;


### PR DESCRIPTION
Stress test for logs to use same code as that used in criterion based benchmarks for the same.
Also put numbers from the AMD test machine for easy comparisons.
