### PR TITLE
Remove CoW for `LogRecord::event_name` and `LogRecord::severity_text`

### DIFF
--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -128,7 +128,7 @@ where
         if self.enabled(record.metadata()) {
             let mut log_record = self.logger.create_log_record();
             log_record.set_severity_number(severity_of_level(record.level()));
-            log_record.set_severity_text(record.level().as_str().into());
+            log_record.set_severity_text(record.level().as_str());
             log_record.set_body(AnyValue::from(record.args().to_string()));
             log_record.add_attributes(log_attributes(record.key_values()));
             log_record.set_target(record.metadata().target().to_string());

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -176,7 +176,7 @@ where
         log_record.set_target(meta.target().to_string());
         log_record.set_event_name(meta.name());
         log_record.set_severity_number(severity_of_level(meta.level()));
-        log_record.set_severity_text(meta.level().as_str().into());
+        log_record.set_severity_text(meta.level().as_str());
         let mut visitor = EventVisitor::new(&mut log_record);
         #[cfg(feature = "experimental_metadata_attributes")]
         visitor.visit_experimental_metadata(meta);

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -131,7 +131,7 @@ fn logging_comparable_to_appender(c: &mut Criterion) {
             log_record.set_target("my-target".to_string());
             log_record.set_event_name("CheckoutFailed");
             log_record.set_severity_number(Severity::Warn);
-            log_record.set_severity_text("WARN".into());
+            log_record.set_severity_text("WARN");
             log_record.add_attribute("book_id", "12345");
             log_record.add_attribute("book_title", "Rust Programming Adventures");
             log_record.add_attribute("message", "Unable to process checkout.");
@@ -275,7 +275,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         log_record.set_timestamp(now);
         log_record.set_observed_timestamp(now);
         log_record.set_severity_number(Severity::Warn);
-        log_record.set_severity_text(Severity::Warn.name().into());
+        log_record.set_severity_text(Severity::Warn.name());
         logger.emit(log_record);
     });
 
@@ -285,7 +285,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         log_record.set_timestamp(now);
         log_record.set_observed_timestamp(now);
         log_record.set_severity_number(Severity::Warn);
-        log_record.set_severity_text(Severity::Warn.name().into());
+        log_record.set_severity_text(Severity::Warn.name());
         log_record.add_attribute("name", "my-event-name");
         log_record.add_attribute("event.id", 20);
         log_record.add_attribute("user.name", "otel");
@@ -299,7 +299,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         log_record.set_timestamp(now);
         log_record.set_observed_timestamp(now);
         log_record.set_severity_number(Severity::Warn);
-        log_record.set_severity_text(Severity::Warn.name().into());
+        log_record.set_severity_text(Severity::Warn.name());
         log_record.add_attribute("name", "my-event-name");
         log_record.add_attribute("event.id", 20);
         log_record.add_attribute("user.name", "otel");
@@ -338,7 +338,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         log_record.set_timestamp(now);
         log_record.set_observed_timestamp(now);
         log_record.set_severity_number(Severity::Warn);
-        log_record.set_severity_text(Severity::Warn.name().into());
+        log_record.set_severity_text(Severity::Warn.name());
         log_record.add_attributes(attributes.clone());
         logger.emit(log_record);
     });

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -41,7 +41,7 @@ mod tests {
         let logger = logger_provider.logger("test-logger");
         let mut log_record = logger.create_log_record();
         log_record.set_severity_number(Severity::Error);
-        log_record.set_severity_text("Error".into());
+        log_record.set_severity_text("Error");
 
         // Adding attributes using a vector with explicitly constructed Key and AnyValue objects.
         log_record.add_attributes(vec![

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -26,7 +26,8 @@ pub struct LogRecord {
     pub trace_context: Option<TraceContext>,
 
     /// The original severity string from the source
-    pub severity_text: Option<Cow<'static, str>>,
+    pub severity_text: Option<&'static str>,
+
     /// The corresponding severity value, normalized
     pub severity_number: Option<Severity>,
 
@@ -58,7 +59,7 @@ impl opentelemetry::logs::LogRecord for LogRecord {
         self.observed_timestamp = Some(timestamp);
     }
 
-    fn set_severity_text(&mut self, severity_text: Cow<'static, str>) {
+    fn set_severity_text(&mut self, severity_text: &'static str) {
         self.severity_text = Some(severity_text);
     }
 
@@ -180,9 +181,8 @@ mod tests {
     #[test]
     fn test_set_severity_text() {
         let mut log_record = LogRecord::default();
-        let severity_text: Cow<'static, str> = "ERROR".into(); // Explicitly typed
-        log_record.set_severity_text(severity_text);
-        assert_eq!(log_record.severity_text, Some(Cow::Borrowed("ERROR")));
+        log_record.set_severity_text("ERROR");
+        assert_eq!(log_record.severity_text, Some("ERROR"));
     }
 
     #[test]
@@ -248,7 +248,7 @@ mod tests {
             target: Some(Cow::Borrowed("foo::bar")),
             timestamp: Some(SystemTime::now()),
             observed_timestamp: Some(SystemTime::now()),
-            severity_text: Some(Cow::Borrowed("ERROR")),
+            severity_text: Some("ERROR"),
             severity_number: Some(Severity::Error),
             body: Some(AnyValue::String("Test body".into())),
             attributes: Some(vec![(Key::new("key"), AnyValue::String("value".into()))]),

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -11,7 +11,7 @@ use std::{borrow::Cow, time::SystemTime};
 /// is provided to `LogExporter`s as input.
 pub struct LogRecord {
     /// Event name. Optional as not all the logging API support it.
-    pub event_name: Option<Cow<'static, str>>,
+    pub event_name: Option<&'static str>,
 
     /// Target of the log record
     pub target: Option<Cow<'static, str>>,
@@ -38,11 +38,8 @@ pub struct LogRecord {
 }
 
 impl opentelemetry::logs::LogRecord for LogRecord {
-    fn set_event_name<T>(&mut self, name: T)
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        self.event_name = Some(name.into());
+    fn set_event_name(&mut self, name: &'static str) {
+        self.event_name = Some(name);
     }
 
     // Sets the `target` of a record
@@ -154,7 +151,7 @@ mod tests {
     fn test_set_eventname() {
         let mut log_record = LogRecord::default();
         log_record.set_event_name("test_event");
-        assert_eq!(log_record.event_name, Some(Cow::Borrowed("test_event")));
+        assert_eq!(log_record.event_name, Some("test_event"));
     }
 
     #[test]
@@ -247,7 +244,7 @@ mod tests {
     #[test]
     fn compare_log_record() {
         let log_record = LogRecord {
-            event_name: Some(Cow::Borrowed("test_event")),
+            event_name: Some("test_event"),
             target: Some(Cow::Borrowed("foo::bar")),
             timestamp: Some(SystemTime::now()),
             observed_timestamp: Some(SystemTime::now()),
@@ -267,7 +264,7 @@ mod tests {
         assert_eq!(log_record, log_record_cloned);
 
         let mut log_record_different = log_record.clone();
-        log_record_different.event_name = Some(Cow::Borrowed("different_event"));
+        log_record_different.event_name = Some("different_event");
 
         assert_ne!(log_record, log_record_different);
     }
@@ -275,12 +272,12 @@ mod tests {
     #[test]
     fn compare_log_record_target_borrowed_eq_owned() {
         let log_record_borrowed = LogRecord {
-            event_name: Some(Cow::Borrowed("test_event")),
+            event_name: Some("test_event"),
             ..Default::default()
         };
 
         let log_record_owned = LogRecord {
-            event_name: Some(Cow::Owned("test_event".to_string())),
+            event_name: Some("test_event"),
             ..Default::default()
         };
 

--- a/opentelemetry-stdout/src/logs/transform.rs
+++ b/opentelemetry-stdout/src/logs/transform.rs
@@ -91,7 +91,7 @@ struct LogRecord {
     observed_time: SystemTime,
     severity_number: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
-    severity_text: Option<Cow<'static, str>>,
+    severity_text: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     body: Option<Value>,
     attributes: Vec<KeyValue>,

--- a/opentelemetry-stdout/src/logs/transform.rs
+++ b/opentelemetry-stdout/src/logs/transform.rs
@@ -115,11 +115,11 @@ impl From<opentelemetry_sdk::export::logs::LogData> for LogRecord {
                     .collect::<Vec<KeyValue>>(); // Collect into a Vec<KeyValue>s
 
                 #[cfg(feature = "populate-logs-event-name")]
-                if let Some(event_name) = &value.record.event_name {
+                if let Some(event_name) = value.record.event_name {
                     let mut attributes_with_name = attributes;
                     attributes_with_name.push(KeyValue::from((
                         "name".into(),
-                        opentelemetry::Value::String(event_name.clone().into()),
+                        opentelemetry::Value::String(event_name.into()),
                     )));
                     attributes_with_name
                 } else {

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -41,11 +41,7 @@ pub struct NoopLogRecord;
 impl LogRecord for NoopLogRecord {
     // Implement the LogRecord trait methods with empty bodies.
     #[inline]
-    fn set_event_name<T>(&mut self, _name: T)
-    where
-        T: Into<Cow<'static, str>>,
-    {
-    }
+    fn set_event_name(&mut self, _name: &'static str) {}
     #[inline]
     fn set_timestamp(&mut self, _timestamp: SystemTime) {}
     #[inline]

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -47,7 +47,7 @@ impl LogRecord for NoopLogRecord {
     #[inline]
     fn set_observed_timestamp(&mut self, _timestamp: SystemTime) {}
     #[inline]
-    fn set_severity_text(&mut self, _text: Cow<'static, str>) {}
+    fn set_severity_text(&mut self, _text: &'static str) {}
     #[inline]
     fn set_severity_number(&mut self, _number: Severity) {}
     #[inline]

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -4,11 +4,7 @@ use std::{borrow::Cow, collections::HashMap, time::SystemTime};
 /// SDK implemented trait for managing log records
 pub trait LogRecord {
     /// Sets the `event_name` of a record
-    fn set_event_name<T>(&mut self, _name: T)
-    where
-        T: Into<Cow<'static, str>>,
-    {
-    }
+    fn set_event_name(&mut self, _name: &'static str);
 
     /// Sets the `target` of a record.
     /// Currently, both `opentelemetry-appender-tracing` and `opentelemetry-appender-log` create a single logger

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, collections::HashMap, time::SystemTime};
 /// SDK implemented trait for managing log records
 pub trait LogRecord {
     /// Sets the `event_name` of a record
-    fn set_event_name(&mut self, _name: &'static str);
+    fn set_event_name(&mut self, name: &'static str);
 
     /// Sets the `target` of a record.
     /// Currently, both `opentelemetry-appender-tracing` and `opentelemetry-appender-log` create a single logger
@@ -21,7 +21,7 @@ pub trait LogRecord {
     fn set_observed_timestamp(&mut self, timestamp: SystemTime);
 
     /// Sets severity as text.
-    fn set_severity_text(&mut self, text: Cow<'static, str>);
+    fn set_severity_text(&mut self, text: &'static str);
 
     /// Sets severity as a numeric value.
     fn set_severity_number(&mut self, number: Severity);


### PR DESCRIPTION
Fixes #2011 

## Changes

As discussed in #2011.
Before:

```rust
pub trait LogRecord {
    fn set_event_name<T>(&mut self, _name: T)
    where
        T: Into<Cow<'static, str>>,
    {
    }
    fn set_severity_text(&mut self, text: Cow<'static, str>);
}

pub struct LogRecord {
    pub event_name: Option<Cow<'static, str>>,
    pub severity_text: Option<Cow<'static, str>>,
}

```

After:
```rust
pub trait LogRecord {
    fn set_event_name(&mut self, name: &'static str);
    fn set_severity_text(&mut self, text: &'static str)
}

pub struct LogRecord {
    pub event_name:   Option<&'static str>,
    pub severity_text:  Option<&'static str>,
}
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
