### PR TITLE
Lock free updates for floating point metrics - Throughput increased by up to 50%

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Sub};
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use aggregate::is_under_cardinality_limit;
 pub(crate) use aggregate::{AggregateBuilder, ComputeAggregation, Measure};
@@ -267,39 +267,56 @@ impl AtomicallyUpdate<i64> for i64 {
 }
 
 pub(crate) struct F64AtomicTracker {
-    inner: Mutex<f64>, // Floating points don't have true atomics, so we need to use mutex for them
+    inner: AtomicU64, // Floating points don't have true atomics, so we need to use the their binary representation to perform atomic operations
 }
 
 impl F64AtomicTracker {
     fn new() -> Self {
+        let zero_as_u64 = 0.0_f64.to_bits();
         F64AtomicTracker {
-            inner: Mutex::new(0.0),
+            inner: AtomicU64::new(zero_as_u64),
         }
     }
 }
 
 impl AtomicTracker<f64> for F64AtomicTracker {
     fn store(&self, value: f64) {
-        let mut guard = self.inner.lock().expect("F64 mutex was poisoned");
-        *guard = value;
+        let value_as_u64 = value.to_bits();
+        self.inner.store(value_as_u64, Ordering::Relaxed);
     }
 
     fn add(&self, value: f64) {
-        let mut guard = self.inner.lock().expect("F64 mutex was poisoned");
-        *guard += value;
+        let mut current_value_as_u64 = self.inner.load(Ordering::Relaxed);
+
+        loop {
+            let current_value = f64::from_bits(current_value_as_u64);
+            let new_value = current_value + value;
+            let new_value_as_u64 = new_value.to_bits();
+            match self.inner.compare_exchange(
+                current_value_as_u64,
+                new_value_as_u64,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                // Succeeded in updating the value
+                Ok(_) => return,
+
+                // Some other thread changed the value before this thread could update it.
+                // Read the latest value again and try to swap it with the recomputed `new_value_as_u64`.
+                Err(v) => current_value_as_u64 = v,
+            }
+        }
     }
 
     fn get_value(&self) -> f64 {
-        let guard = self.inner.lock().expect("F64 mutex was poisoned");
-        *guard
+        let value_as_u64 = self.inner.load(Ordering::Relaxed);
+        f64::from_bits(value_as_u64)
     }
 
     fn get_and_reset_value(&self) -> f64 {
-        let mut guard = self.inner.lock().expect("F64 mutex was poisoned");
-        let value = *guard;
-        *guard = 0.0;
-
-        value
+        let zero_as_u64 = 0.0_f64.to_bits();
+        let value = self.inner.swap(zero_as_u64, Ordering::Relaxed);
+        f64::from_bits(value)
     }
 }
 


### PR DESCRIPTION
`AtomicTracker` implementation for `f64` is using a `Mutex` for all the operations. This could lead to high contention when multiple threads concurrently update the same tracker as each of them would try to acquire a lock before making the update. Rust std library doesn't have support for atomic f64 but we can effectively do these operations in a thread-safe manner using atomic u64. This is coming from the one of the team members of the Rust language: https://github.com/rust-lang/rust/issues/72353#issuecomment-1069628753

The idea is to use the memory representation (`f64::to_bits()`) of an `f64` value which is in turn a `u64` number. Rust already provides support for AtomicU64 which we can use to back our "Atomic floating point" number.

<details>
<summary>Machine information</summary>
OS: Ubuntu 22.04.3 LTS (5.15.146.1-microsoft-standard-WSL2)
Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
RAM: 64.0 GB
</details>

### Benchmarks

There is a 5% increase in benchmark performance. This should be coming from avoiding the cost to acquire and release a lock in the hot path.

| Counter_Add_With_Three_Random_Attributes  | Average time|
|----------------------------------------------------|---------------|
| main branch                                                       | 191.48 ns     |
| **PR**                                                          | **181.95 ns**     |


### Stress Test (with high contention)

This is the scenario where all the threads concurrently update the same tracker meaning they emit measurement for the same set of attributes. This is where we see the highest perf benefit! **An improvement of nearly 50%.**

| 16 threads updating the same tracker              | Throughput|
|----------------------------------------------------|---------------|
| main branch                                                       |   6.2 M/sec   |
| **PR**                                                                 |  9.4 M/sec   |


### Stress Test (with low contention)

This is the scenario where threads concurrently update random trackers meaning they emit measurement for a random set of attributes. In the stress test, there were 16 threads and 1000 unique combinations of attributes. This means that probability of two or more threads trying to update the same tracker is quite low. There is only a minor improvement here as expected. This is also arguably within the deviation range of the stress test results.


| 16 threads updating random trackers               | Throughput|
|----------------------------------------------------|---------------|
| main branch                                                       |   11.2 M/sec |
| **PR**                                                                 |  11.5 M/sec   |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
