### PR TITLE
Fix aggregation for Gauge

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -20,6 +20,9 @@
   ObservableCounter,UpDownCounter including
   [#1517](https://github.com/open-telemetry/opentelemetry-rust/issues/1517).
   [#2004](https://github.com/open-telemetry/opentelemetry-rust/pull/2004)
+- Fixed a bug related to cumulative aggregation of `Gauge` measurements.
+  [#1975](https://github.com/open-telemetry/opentelemetry-rust/issues/1975).
+  [#2021](https://github.com/open-telemetry/opentelemetry-rust/pull/2021)
 
 ## v0.24.1
 

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -106,11 +106,7 @@ impl<T: Number<T>> AggregateBuilder<T> {
     }
 
     /// Builds a last-value aggregate function input and output.
-    ///
-    /// [Builder::temporality] is ignored and delta is always used.
     pub(crate) fn last_value(&self) -> (impl Measure<T>, impl ComputeAggregation) {
-        // Delta temporality is the only temporality that makes semantic sense for
-        // a last-value aggregate.
         let lv_filter = Arc::new(LastValue::new());
         let lv_agg = Arc::clone(&lv_filter);
         let t = self.temporality;


### PR DESCRIPTION
Fixes #1975 

## Changes
- Added dedicated collect handling logic for Delta and Cumulative temporality for Gauge
- Added a test to ensure that asynchronous instruments with Cumulative temporality keep reporting the last recorded measurement if there was no new measurement made from the last collect

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
