### PR TITLE
Provide default implementation for event_enabled trait in LogProcessor

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -23,6 +23,8 @@
 - Fixed a bug related to cumulative aggregation of `Gauge` measurements.
   [#1975](https://github.com/open-telemetry/opentelemetry-rust/issues/1975).
   [#2021](https://github.com/open-telemetry/opentelemetry-rust/pull/2021)
+- Provide default implementation for `event_enabled` trait in LogProcessor that
+  returns `true` always.
 
 ## v0.24.1
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -23,8 +23,8 @@
 - Fixed a bug related to cumulative aggregation of `Gauge` measurements.
   [#1975](https://github.com/open-telemetry/opentelemetry-rust/issues/1975).
   [#2021](https://github.com/open-telemetry/opentelemetry-rust/pull/2021)
-- Provide default implementation for `event_enabled` trait in LogProcessor that
-  returns `true` always.
+- Provide default implementation for `event_enabled` method in `LogProcessor`
+  trait that returns `true` always.
 
 ## v0.24.1
 

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -45,16 +45,6 @@ impl LogProcessor for NoopProcessor {
     fn shutdown(&self) -> LogResult<()> {
         Ok(())
     }
-
-    #[cfg(feature = "logs_level_enabled")]
-    fn event_enabled(
-        &self,
-        _level: opentelemetry::logs::Severity,
-        _target: &str,
-        _name: &str,
-    ) -> bool {
-        true
-    }
 }
 
 fn log_benchmark_group<F: Fn(&Logger)>(c: &mut Criterion, name: &str, f: F) {

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -21,6 +21,7 @@ pub trait LogExporter: Send + Sync + Debug {
     #[cfg(feature = "logs_level_enabled")]
     /// Chek if logs are enabled.
     fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
+        // By default, all logs are enabled
         true
     }
     /// Set the resource for the exporter.

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -359,11 +359,6 @@ mod tests {
                 .expect("lock poisoned");
             Ok(())
         }
-
-        #[cfg(feature = "logs_level_enabled")]
-        fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-            true
-        }
     }
     #[test]
     fn test_logger_provider_default_resource() {
@@ -583,11 +578,6 @@ mod tests {
         fn shutdown(&self) -> LogResult<()> {
             *self.shutdown_called.lock().unwrap() = true;
             Ok(())
-        }
-
-        #[cfg(feature = "logs_level_enabled")]
-        fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-            true
         }
     }
 }

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -522,8 +522,6 @@ mod tests {
     };
     use async_trait::async_trait;
     use opentelemetry::logs::AnyValue;
-    #[cfg(feature = "logs_level_enabled")]
-    use opentelemetry::logs::Severity;
     use opentelemetry::logs::{Logger, LoggerProvider as _};
     use opentelemetry::Key;
     use opentelemetry::{logs::LogResult, KeyValue};

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -64,7 +64,10 @@ pub trait LogProcessor: Send + Sync + Debug {
     fn shutdown(&self) -> LogResult<()>;
     #[cfg(feature = "logs_level_enabled")]
     /// Check if logging is enabled
-    fn event_enabled(&self, level: Severity, target: &str, name: &str) -> bool;
+    fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
+        // By default, all logs are enabled
+        true
+    }
 
     /// Set the resource for the log processor.
     fn set_resource(&self, _resource: &Resource) {}
@@ -130,11 +133,6 @@ impl LogProcessor for SimpleLogProcessor {
             exporter.set_resource(resource);
         }
     }
-
-    #[cfg(feature = "logs_level_enabled")]
-    fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        true
-    }
 }
 
 /// A [`LogProcessor`] that asynchronously buffers log records and reports
@@ -160,11 +158,6 @@ impl<R: RuntimeChannel> LogProcessor for BatchLogProcessor<R> {
         if let Err(err) = result {
             global::handle_error(LogError::Other(err.into()));
         }
-    }
-
-    #[cfg(feature = "logs_level_enabled")]
-    fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-        true
     }
 
     fn force_flush(&self) -> LogResult<()> {
@@ -830,11 +823,6 @@ mod tests {
             self.logs.lock().unwrap().push(data.clone()); //clone as the LogProcessor is storing the data.
         }
 
-        #[cfg(feature = "logs_level_enabled")]
-        fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-            true
-        }
-
         fn force_flush(&self) -> LogResult<()> {
             Ok(())
         }
@@ -862,11 +850,6 @@ mod tests {
                     == AnyValue::String("Updated by FirstProcessor".into())
             );
             self.logs.lock().unwrap().push(data.clone());
-        }
-
-        #[cfg(feature = "logs_level_enabled")]
-        fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
-            true
         }
 
         fn force_flush(&self) -> LogResult<()> {

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -29,15 +29,6 @@ impl LogProcessor for NoOpLogProcessor {
     fn shutdown(&self) -> opentelemetry::logs::LogResult<()> {
         Ok(())
     }
-
-    fn event_enabled(
-        &self,
-        _level: opentelemetry::logs::Severity,
-        _target: &str,
-        _name: &str,
-    ) -> bool {
-        true
-    }
 }
 
 fn main() {


### PR DESCRIPTION
Provide default implementation for `event_enabled` trait in LogProcessor, so only those implementations that care about this feature need to implement and override the method. Less thing for LogProcessor author to worry about. 

I am also thinking we should do default implementation for flush, shutdown as well, and only those processor that need to care about them should override it. For example, If one were writing a `EnrichProcessor`, it has no interest in flush or shutdown. If this direction is accepted, I can send similar change for Flush, Shutdown as well.