### PR TITLE
Update Histogram min max computation

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -24,6 +24,8 @@ impl<T: Number<T>> Buckets<T> {
     fn new(n: usize) -> Buckets<T> {
         Buckets {
             counts: vec![0; n],
+            min: T::max(),
+            max: T::min(),
             ..Default::default()
         }
     }
@@ -37,7 +39,8 @@ impl<T: Number<T>> Buckets<T> {
         self.count += 1;
         if value < self.min {
             self.min = value;
-        } else if value > self.max {
+        }
+        if value > self.max {
             self.max = value
         }
     }
@@ -98,9 +101,7 @@ impl<T: Number<T>> Histogram<T> {
             // Then,
             //
             //   buckets = (-∞, 0], (0, 5.0], (5.0, 10.0], (10.0, +∞)
-            let mut b = Buckets::new(self.bounds.len() + 1);
-            // Ensure min and max are recorded values (not zero), for new buckets.
-            (b.min, b.max) = (measurement, measurement);
+            let b = Buckets::new(self.bounds.len() + 1);
 
             if is_under_cardinality_limit(size) {
                 values.entry(attrs).or_insert(b)

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -4,7 +4,7 @@ mod histogram;
 mod last_value;
 mod sum;
 
-use core::fmt;
+use core::{f64, fmt};
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Sub};
@@ -202,11 +202,11 @@ impl Number<u64> for u64 {
 }
 impl Number<f64> for f64 {
     fn min() -> Self {
-        f64::MIN
+        f64::NEG_INFINITY
     }
 
     fn max() -> Self {
-        f64::MAX
+        f64::INFINITY
     }
 
     fn into_float(self) -> f64 {


### PR DESCRIPTION
## Changes

- I'm working on incorporating `ValueMap` to Histogram updates. It would be much easier to pursue that if we can keep the initialization of `Buckets` struct independent of the measurement value that triggered its creation. This PR does that by updating the way we compute min and max for Histograms.

  Note: This is now similar to how we compute min and max for Exponential Histograms.

- I have also updated `Number<f64>::min()` and ``Number<f64>::max()` implementation to return negative and positive infinity instead of `f64::MIN` and `f64::MAX`

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
