### PR TITLE
Rename metrics benchmarks

### DIFF
--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -61,15 +61,15 @@ name = "span_builder"
 harness = false
 
 [[bench]]
-name = "metric_counter"
+name = "metrics_counter"
 harness = false
 
 [[bench]]
-name = "metric_gauge"
+name = "metrics_gauge"
 harness = false
 
 [[bench]]
-name = "metric_histogram"
+name = "metrics_histogram"
 harness = false
 
 [[bench]]

--- a/opentelemetry-sdk/benches/metrics_counter.rs
+++ b/opentelemetry-sdk/benches/metrics_counter.rs
@@ -36,7 +36,7 @@ static ATTRIBUTE_VALUES: [&str; 10] = [
 ];
 
 // Run this benchmark with:
-// cargo bench --bench metric_counter
+// cargo bench --bench metrics_counter
 fn create_counter(name: &'static str) -> Counter<u64> {
     let meter_provider: SdkMeterProvider = SdkMeterProvider::builder()
         .with_reader(ManualReader::builder().build())

--- a/opentelemetry-sdk/benches/metrics_histogram.rs
+++ b/opentelemetry-sdk/benches/metrics_histogram.rs
@@ -6,15 +6,17 @@
     RAM: 64.0 GB
     | Test                           | Average time|
     |--------------------------------|-------------|
-    | Gauge_Add                      | 178.37 ns   |
+    | Histogram_Record               | 193.04 ns   |
+
 */
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::{
-    metrics::{Gauge, MeterProvider as _},
+    metrics::{Histogram, MeterProvider as _},
     KeyValue,
 };
 use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
+use pprof::criterion::{Output, PProfProfiler};
 use rand::{
     rngs::{self},
     Rng, SeedableRng,
@@ -32,23 +34,23 @@ static ATTRIBUTE_VALUES: [&str; 10] = [
 ];
 
 // Run this benchmark with:
-// cargo bench --bench metric_gauge
-fn create_gauge() -> Gauge<u64> {
+// cargo bench --bench metrics_histogram
+fn create_histogram(name: &'static str) -> Histogram<u64> {
     let meter_provider: SdkMeterProvider = SdkMeterProvider::builder()
         .with_reader(ManualReader::builder().build())
         .build();
     let meter = meter_provider.meter("benchmarks");
 
-    meter.u64_gauge("gauge_bench").init()
+    meter.u64_histogram(name).init()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    gauge_record(c);
+    histogram_record(c);
 }
 
-fn gauge_record(c: &mut Criterion) {
-    let gauge = create_gauge();
-    c.bench_function("Gauge_Add", |b| {
+fn histogram_record(c: &mut Criterion) {
+    let histogram = create_histogram("Histogram_Record");
+    c.bench_function("Histogram_Record", |b| {
         b.iter(|| {
             // 4*4*10*10 = 1600 time series.
             let rands = CURRENT_RNG.with(|rng| {
@@ -64,7 +66,7 @@ fn gauge_record(c: &mut Criterion) {
             let index_second_attribute = rands[1];
             let index_third_attribute = rands[2];
             let index_fourth_attribute = rands[3];
-            gauge.record(
+            histogram.record(
                 1,
                 &[
                     KeyValue::new("attribute1", ATTRIBUTE_VALUES[index_first_attribute]),
@@ -77,6 +79,16 @@ fn gauge_record(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
-
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = criterion_benchmark
+}
 criterion_main!(benches);


### PR DESCRIPTION
## Changes
- Use the plural form of the word: "metrics" in the benchmark methods
- This is now consistent with Stress Tests for metrics

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
