### PR TITLE
Use arrays instead of vec in the documentation

### DIFF
--- a/opentelemetry-semantic-conventions/src/trace.rs
+++ b/opentelemetry-semantic-conventions/src/trace.rs
@@ -21,7 +21,7 @@
 //! let tracer = global::tracer("my-component");
 //! let _span = tracer
 //!     .span_builder("span-name")
-//!     .with_attributes(vec![
+//!     .with_attributes([
 //!         KeyValue::new(semconv::trace::CLIENT_ADDRESS, "example.org"),
 //!         KeyValue::new(semconv::trace::CLIENT_PORT, 80i64),
 //!     ])

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -585,7 +585,7 @@ impl InstrumentationLibraryBuilder {
     /// use opentelemetry::KeyValue;
     ///
     /// let library = opentelemetry::InstrumentationLibrary::builder("my-crate")
-    ///     .with_attributes(vec![KeyValue::new("k", "v")])
+    ///     .with_attributes([KeyValue::new("k", "v")])
     ///     .build();
     /// ```
     pub fn with_attributes<I>(mut self, attributes: I) -> Self

--- a/opentelemetry/src/trace/tracer_provider.rs
+++ b/opentelemetry/src/trace/tracer_provider.rs
@@ -32,7 +32,7 @@ pub trait TracerProvider {
     /// let tracer = provider.tracer_builder("my_library").
     ///     with_version(env!("CARGO_PKG_VERSION")).
     ///     with_schema_url("https://opentelemetry.io/schema/1.0.0").
-    ///     with_attributes(vec![KeyValue::new("key", "value")]).
+    ///     with_attributes([KeyValue::new("key", "value")]).
     ///     build();
     /// ```
     fn tracer(&self, name: impl Into<Cow<'static, str>>) -> Self::Tracer {


### PR DESCRIPTION
## Changes
- Update code documentation to use array instead of vec to promote good practices and avoid unnecessary allocations

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
