### PR TITLE
Log SDK optimization - Improve perf 15%-30%

### DIFF
--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -55,7 +55,7 @@ impl NoopProcessor {
 }
 
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _: &mut LogData) {
+    fn emit(&self, _: &mut LogRecord, _: &InstrumentationLibrary) {
         // no-op
     }
 

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -19,7 +19,7 @@ use opentelemetry::logs::LogResult;
 use opentelemetry::{InstrumentationLibrary, KeyValue};
 use opentelemetry_appender_tracing::layer as tracing_layer;
 use opentelemetry_sdk::export::logs::LogExporter;
-use opentelemetry_sdk::logs::{LogData, LogProcessor, LogRecord, LoggerProvider};
+use opentelemetry_sdk::logs::{LogProcessor, LogRecord, LoggerProvider};
 use opentelemetry_sdk::Resource;
 use pprof::criterion::{Output, PProfProfiler};
 use tracing::error;

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -25,9 +25,9 @@ use opentelemetry::logs::{
 };
 use opentelemetry::trace::Tracer;
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry::Key;
-use opentelemetry_sdk::logs::LogData;
+use opentelemetry::{InstrumentationLibrary, Key};
 use opentelemetry_sdk::logs::LogProcessor;
+use opentelemetry_sdk::logs::LogRecord;
 use opentelemetry_sdk::logs::{Logger, LoggerProvider};
 use opentelemetry_sdk::trace;
 use opentelemetry_sdk::trace::{Sampler, TracerProvider};
@@ -36,7 +36,7 @@ use opentelemetry_sdk::trace::{Sampler, TracerProvider};
 struct NoopProcessor;
 
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _data: &mut LogData) {}
+    fn emit(&self, _data: &mut LogRecord, _library: &InstrumentationLibrary) {}
 
     fn force_flush(&self) -> LogResult<()> {
         Ok(())

--- a/opentelemetry-sdk/benches/log_processor.rs
+++ b/opentelemetry-sdk/benches/log_processor.rs
@@ -20,10 +20,7 @@ use std::{
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::logs::{LogRecord as _, LogResult, Logger as _, LoggerProvider as _, Severity};
 use opentelemetry::InstrumentationLibrary;
-use opentelemetry_sdk::{
-    logs::LogData,
-    logs::{LogProcessor, LogRecord, Logger, LoggerProvider},
-};
+use opentelemetry_sdk::logs::{LogProcessor, LogRecord, Logger, LoggerProvider};
 
 // Run this benchmark with:
 // cargo bench --bench log_processor

--- a/opentelemetry-sdk/benches/log_processor.rs
+++ b/opentelemetry-sdk/benches/log_processor.rs
@@ -19,6 +19,7 @@ use std::{
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::logs::{LogRecord as _, LogResult, Logger as _, LoggerProvider as _, Severity};
+use opentelemetry::InstrumentationLibrary;
 use opentelemetry_sdk::{
     logs::LogData,
     logs::{LogProcessor, LogRecord, Logger, LoggerProvider},
@@ -45,7 +46,7 @@ fn create_log_record(logger: &Logger) -> LogRecord {
 struct NoopProcessor;
 
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _data: &mut LogData) {}
+    fn emit(&self, _data: &mut LogRecord, _library: &InstrumentationLibrary) {}
 
     fn force_flush(&self) -> LogResult<()> {
         Ok(())
@@ -60,7 +61,7 @@ impl LogProcessor for NoopProcessor {
 struct CloningProcessor;
 
 impl LogProcessor for CloningProcessor {
-    fn emit(&self, data: &mut LogData) {
+    fn emit(&self, data: &mut LogRecord, _library: &InstrumentationLibrary) {
         let _data_cloned = data.clone();
     }
 
@@ -75,8 +76,8 @@ impl LogProcessor for CloningProcessor {
 
 #[derive(Debug)]
 struct SendToChannelProcessor {
-    sender: std::sync::mpsc::Sender<LogData>,
-    receiver: Arc<Mutex<std::sync::mpsc::Receiver<LogData>>>,
+    sender: std::sync::mpsc::Sender<(LogRecord, InstrumentationLibrary)>,
+    receiver: Arc<Mutex<std::sync::mpsc::Receiver<(LogRecord, InstrumentationLibrary)>>>,
 }
 
 impl SendToChannelProcessor {
@@ -103,9 +104,8 @@ impl SendToChannelProcessor {
 }
 
 impl LogProcessor for SendToChannelProcessor {
-    fn emit(&self, data: &mut LogData) {
-        let data_cloned = data.clone();
-        let res = self.sender.send(data_cloned);
+    fn emit(&self, record: &mut LogRecord, library: &InstrumentationLibrary) {
+        let res = self.sender.send((record.clone(), library.clone()));
         if res.is_err() {
             println!("Error sending log data to channel {0}", res.err().unwrap());
         }

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -106,7 +106,7 @@ impl LogProcessor for SimpleLogProcessor {
             .lock()
             .map_err(|_| LogError::Other("simple logprocessor mutex poison".into()))
             .and_then(|mut exporter| {
-                futures_executor::block_on(exporter.export(vec![(record, &instrumentation)]))
+                futures_executor::block_on(exporter.export(vec![(record, instrumentation)]))
             });
         if let Err(err) = result {
             global::handle_error(err);

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -9,6 +9,7 @@
     ~38 M /sec
 */
 
+use opentelemetry::InstrumentationLibrary;
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::logs::{LogProcessor, LoggerProvider};
 use tracing::error;
@@ -20,7 +21,12 @@ mod throughput;
 pub struct NoOpLogProcessor;
 
 impl LogProcessor for NoOpLogProcessor {
-    fn emit(&self, _data: &mut opentelemetry_sdk::logs::LogData) {}
+    fn emit(
+        &self,
+        _record: &mut opentelemetry_sdk::logs::LogRecord,
+        _library: &InstrumentationLibrary,
+    ) {
+    }
 
     fn force_flush(&self) -> opentelemetry::logs::LogResult<()> {
         Ok(())


### PR DESCRIPTION

## Changes

Optimize Log SDK by avoiding unnecessary copy operation and redirections 

- `LogData` structure is removed.
- `Logger::emit()` method is modified for unnecessary copy/assignment operation.
- `LogProcessor::emit` method is modified to directly take reference of `LogRecord` and `InstrumentationLibrary` instead of `LogData`. This simplifies the API, and more importantly ones less level of redirection while accessing these components.

Existing:
```rust
fn emit(&self, _: &mut LogData)
```

Updated:
```rust
fn emit(&self, record: &mut LogRecord, library: &InstrumentationLibrary);
```

**Benchmarks and stress:** (courtesy chatgpt to generate table from the results):

| **Benchmark**                                | **Main Branch (ns)**                         | **PR Branch (ns)**                            | **Change**                      | **Performance**           |
|----------------------------------------------|----------------------------------------------|----------------------------------------------|---------------------------------|---------------------------|
| `ot_layer_enabled`                           | 264.70 - 268.47                              | 216.33 - 216.69                              | -17.979% to -18.548%            | Improved                   |
| `Logging_Comparable_To_Appender`             | 134.11 - 134.30                              | 96.087 - 96.240                              | -28.174% to -28.378%            | Improved                   |
| `log_noop_processor`                         | 141.65 - 141.81                              | 102.56 - 102.70                              | -27.468% to -27.635%            | Improved                   |
| `log_cloning_processor`                      | 238.92 - 239.35                              | 178.97 - 179.24                              | -25.048% to -25.337%            | Improved                   |
| `log_clone_and_send_to_channel_processor`    | 620.69 - 628.54                              | 582.68 - 584.69                              | -6.0463% to -6.9739%            | Improved                   |
| `LogExporterWithFuture`                      | 284.68 - 285.04                              | 129.92 - 130.31                              | -54.197% to -54.449%            | Improved                   |
| `LogExporterWithoutFuture`                   | 250.91 - 251.26                              | 98.156 - 98.299                              | -60.799% to -60.891%            | Improved                   |

| **Stress (Throughput)**                      | **Main Branch (iterations/sec)**             | **PR Branch (iterations/sec)**               | **Change**                      | **Performance**           |
|----------------------------------------------|----------------------------------------------|----------------------------------------------|---------------------------------|---------------------------|
| Average                                      | 38,812,133                                   | 44,491,457                                   | +14.7%                          | Improved                   |
 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
