### PR TITLE
[WIP] Remove usage of `futures_executor::block_on` in WASM targets

### DIFF
--- a/opentelemetry-appender-log/examples/logs-basic.rs
+++ b/opentelemetry-appender-log/examples/logs-basic.rs
@@ -32,5 +32,5 @@ async fn main() {
     warn!("warn!");
     info!("test log!");
 
-    let _ = logger_provider.shutdown();
+    let _ = logger_provider.shutdown().await;
 }

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -26,6 +26,7 @@ opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["logs", "testin
 tracing-log = "0.2"
 async-trait = { workspace = true }
 criterion = { workspace = true }
+tokio = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { version = "0.13", features = ["flamegraph", "criterion"] }

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 rust-version = "1.65"
 
 [dependencies]
+futures-util = { workspace = true }
 log = { workspace = true, optional = true }
 opentelemetry = { version = "0.24", path = "../opentelemetry", features = ["logs"] }
 tracing = { workspace = true, features = ["std"]}

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -56,16 +56,17 @@ impl NoopProcessor {
     }
 }
 
+#[async_trait::async_trait]
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _: &mut LogRecord, _: &InstrumentationLibrary) {
+    async fn emit(&self, _: &mut LogRecord, _: &InstrumentationLibrary) {
         // no-op
     }
 
-    fn force_flush(&self) -> LogResult<()> {
+    async fn force_flush(&self) -> LogResult<()> {
         Ok(())
     }
 
-    fn shutdown(&self) -> LogResult<()> {
+    async fn shutdown(&self) -> LogResult<()> {
         Ok(())
     }
 

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -13,8 +13,8 @@
     | ot_layer_enabled            | 250 ns      |
 */
 
-use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, Criterion};
+use futures_util::future::BoxFuture;
 use opentelemetry::logs::LogResult;
 use opentelemetry::{InstrumentationLibrary, KeyValue};
 use opentelemetry_appender_tracing::layer as tracing_layer;
@@ -32,10 +32,12 @@ struct NoopExporter {
     enabled: bool,
 }
 
-#[async_trait]
 impl LogExporter for NoopExporter {
-    async fn export(&mut self, _: Vec<(&LogRecord, &InstrumentationLibrary)>) -> LogResult<()> {
-        LogResult::Ok(())
+    fn export(
+        &mut self,
+        _: Vec<(&LogRecord, &InstrumentationLibrary)>,
+    ) -> BoxFuture<'static, LogResult<()>> {
+        Box::pin(std::future::ready(LogResult::Ok(())))
     }
 
     fn event_enabled(&self, _: opentelemetry::logs::Severity, _: &str, _: &str) -> bool {

--- a/opentelemetry-appender-tracing/examples/basic.rs
+++ b/opentelemetry-appender-tracing/examples/basic.rs
@@ -6,7 +6,8 @@ use opentelemetry_sdk::{logs::LoggerProvider, Resource};
 use tracing::error;
 use tracing_subscriber::prelude::*;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let exporter = opentelemetry_stdout::LogExporter::default();
     let provider: LoggerProvider = LoggerProvider::builder()
         .with_resource(Resource::new(vec![KeyValue::new(
@@ -19,5 +20,5 @@ fn main() {
     tracing_subscriber::registry().with(layer).init();
 
     error!(name: "my-event-name", target: "my-system", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io", message = "This is an example message");
-    let _ = provider.shutdown();
+    let _ = provider.shutdown().await;
 }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -230,8 +230,8 @@ mod tests {
     }
 
     // cargo test --features=testing
-    #[test]
-    fn tracing_appender_standalone() {
+    #[tokio::test]
+    async fn tracing_appender_standalone() {
         // Arrange
         let exporter: InMemoryLogsExporter = InMemoryLogsExporter::default();
         let logger_provider = LoggerProvider::builder()
@@ -247,7 +247,7 @@ mod tests {
 
         // Act
         error!(name: "my-event-name", target: "my-system", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");
-        logger_provider.force_flush();
+        logger_provider.force_flush().await;
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter
@@ -311,8 +311,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn tracing_appender_inside_tracing_context() {
+    #[tokio::test]
+    async fn tracing_appender_inside_tracing_context() {
         // Arrange
         let exporter: InMemoryLogsExporter = InMemoryLogsExporter::default();
         let logger_provider = LoggerProvider::builder()
@@ -342,7 +342,7 @@ mod tests {
             (trace_id, span_id)
         });
 
-        logger_provider.force_flush();
+        logger_provider.force_flush().await;
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter
@@ -423,8 +423,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn tracing_appender_standalone_with_tracing_log() {
+    #[tokio::test]
+    async fn tracing_appender_standalone_with_tracing_log() {
         // Arrange
         let exporter: InMemoryLogsExporter = InMemoryLogsExporter::default();
         let logger_provider = LoggerProvider::builder()
@@ -441,7 +441,7 @@ mod tests {
 
         // Act
         log::error!("log from log crate");
-        logger_provider.force_flush();
+        logger_provider.force_flush().await;
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter
@@ -489,8 +489,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn tracing_appender_inside_tracing_context_with_tracing_log() {
+    #[tokio::test]
+    async fn tracing_appender_inside_tracing_context_with_tracing_log() {
         // Arrange
         let exporter: InMemoryLogsExporter = InMemoryLogsExporter::default();
         let logger_provider = LoggerProvider::builder()
@@ -521,7 +521,7 @@ mod tests {
             (trace_id, span_id)
         });
 
-        logger_provider.force_flush();
+        logger_provider.force_flush().await;
 
         // Assert TODO: move to helper methods
         let exported_logs = exporter

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -28,6 +28,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-trait = { workspace = true }
 futures-core = { workspace = true }
+futures-util = { workspace = true }
 opentelemetry = { version = "0.24", default-features = false, path = "../opentelemetry" }
 opentelemetry_sdk = { version = "0.24", default-features = false, path = "../opentelemetry-sdk" }
 opentelemetry-http = { version = "0.13", path = "../opentelemetry-http", optional = true }

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -162,7 +162,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     info!(target: "my-target", "hello from {}. My price is {}", "apple", 1.99);
 
     global::shutdown_tracer_provider();
-    logger_provider.shutdown()?;
+    logger_provider.shutdown().await?;
     meter_provider.shutdown()?;
 
     Ok(())

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -153,7 +153,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     global::shutdown_tracer_provider();
     meter_provider.shutdown()?;
-    logger_provider.shutdown()?;
+    logger_provider.shutdown().await?;
 
     Ok(())
 }

--- a/opentelemetry-otlp/src/exporter/http/logs.rs
+++ b/opentelemetry-otlp/src/exporter/http/logs.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use async_trait::async_trait;
+use futures_core::future::BoxFuture;
 use http::{header::CONTENT_TYPE, Method};
 use opentelemetry::logs::{LogError, LogResult};
 use opentelemetry::InstrumentationLibrary;
@@ -9,44 +9,61 @@ use opentelemetry_sdk::logs::LogRecord;
 
 use super::OtlpHttpClient;
 
-#[async_trait]
 impl LogExporter for OtlpHttpClient {
-    async fn export(&mut self, batch: Vec<(&LogRecord, &InstrumentationLibrary)>) -> LogResult<()> {
-        let client = self
+    fn export(
+        &mut self,
+        batch: Vec<(&LogRecord, &InstrumentationLibrary)>,
+    ) -> BoxFuture<'static, LogResult<()>> {
+        let client = match self
             .client
             .lock()
             .map_err(|e| LogError::Other(e.to_string().into()))
             .and_then(|g| match &*g {
                 Some(client) => Ok(Arc::clone(client)),
                 _ => Err(LogError::Other("exporter is already shut down".into())),
-            })?;
+            }) {
+            Ok(client) => client,
+            Err(err) => return Box::pin(std::future::ready(Err(err))),
+        };
 
-        let (body, content_type) = { self.build_logs_export_body(batch)? };
-        let mut request = http::Request::builder()
+        let (body, content_type) = match self.build_logs_export_body(batch) {
+            Ok(body) => body,
+            Err(err) => return Box::pin(std::future::ready(Err(err))),
+        };
+        let mut request = match http::Request::builder()
             .method(Method::POST)
             .uri(&self.collector_endpoint)
             .header(CONTENT_TYPE, content_type)
             .body(body)
-            .map_err(|e| crate::Error::RequestFailed(Box::new(e)))?;
+        {
+            Ok(req) => req,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(crate::Error::RequestFailed(
+                    Box::new(e),
+                )
+                .into())))
+            }
+        };
 
         for (k, v) in &self.headers {
             request.headers_mut().insert(k.clone(), v.clone());
         }
 
         let request_uri = request.uri().to_string();
-        let response = client.send(request).await?;
+        Box::pin(async move {
+            let response = client.send(request).await?;
 
-        if !response.status().is_success() {
-            let error = format!(
-                "OpenTelemetry logs export failed. Url: {}, Status Code: {}, Response: {:?}",
-                response.status().as_u16(),
-                request_uri,
-                response.body()
-            );
-            return Err(LogError::Other(error.into()));
-        }
-
-        Ok(())
+            if !response.status().is_success() {
+                let error = format!(
+                    "OpenTelemetry logs export failed. Url: {}, Status Code: {}, Response: {:?}",
+                    response.status().as_u16(),
+                    request_uri,
+                    response.body()
+                );
+                return Err(LogError::Other(error.into()));
+            }
+            Ok(())
+        })
     }
 
     fn shutdown(&mut self) {

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -9,7 +9,7 @@ use crate::exporter::tonic::TonicExporterBuilder;
 use crate::exporter::http::HttpExporterBuilder;
 
 use crate::{NoExporterConfig, OtlpPipeline};
-use async_trait::async_trait;
+use futures_core::future::BoxFuture;
 use std::fmt::Debug;
 
 use opentelemetry::logs::{LogError, LogResult};
@@ -97,10 +97,12 @@ impl LogExporter {
     }
 }
 
-#[async_trait]
 impl opentelemetry_sdk::export::logs::LogExporter for LogExporter {
-    async fn export(&mut self, batch: Vec<(&LogRecord, &InstrumentationLibrary)>) -> LogResult<()> {
-        self.client.export(batch).await
+    fn export(
+        &mut self,
+        batch: Vec<(&LogRecord, &InstrumentationLibrary)>,
+    ) -> BoxFuture<'static, LogResult<()>> {
+        Box::pin(self.client.export(batch))
     }
 
     fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -29,6 +29,9 @@ tokio = { workspace = true, features = ["rt", "time"], optional = true }
 tokio-stream = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
+wasm-bindgen-futures = "0.4.42"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -39,6 +39,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }
 temp-env = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { version = "0.13", features = ["flamegraph", "criterion"] }

--- a/opentelemetry-sdk/benches/batch_span_processor.rs
+++ b/opentelemetry-sdk/benches/batch_span_processor.rs
@@ -64,7 +64,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             let spans = get_span_data();
                             handles.push(tokio::spawn(async move {
                                 for span in spans {
-                                    span_processor.on_end(span);
+                                    span_processor.on_end(span).await;
                                     tokio::task::yield_now().await;
                                 }
                             }));
@@ -73,7 +73,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                         let _ =
                             Arc::<BatchSpanProcessor<Tokio>>::get_mut(&mut shared_span_processor)
                                 .unwrap()
-                                .shutdown();
+                                .shutdown()
+                                .await;
                     });
                 })
             },

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -35,14 +35,15 @@ use opentelemetry_sdk::trace::{Sampler, TracerProvider};
 #[derive(Debug)]
 struct NoopProcessor;
 
+#[async_trait::async_trait]
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _data: &mut LogRecord, _library: &InstrumentationLibrary) {}
+    async fn emit(&self, _data: &mut LogRecord, _library: &InstrumentationLibrary) {}
 
-    fn force_flush(&self) -> LogResult<()> {
+    async fn force_flush(&self) -> LogResult<()> {
         Ok(())
     }
 
-    fn shutdown(&self) -> LogResult<()> {
+    async fn shutdown(&self) -> LogResult<()> {
         Ok(())
     }
 }

--- a/opentelemetry-sdk/benches/log_processor.rs
+++ b/opentelemetry-sdk/benches/log_processor.rs
@@ -42,14 +42,15 @@ fn create_log_record(logger: &Logger) -> LogRecord {
 #[derive(Debug)]
 struct NoopProcessor;
 
+#[async_trait::async_trait]
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _data: &mut LogRecord, _library: &InstrumentationLibrary) {}
+    async fn emit(&self, _data: &mut LogRecord, _library: &InstrumentationLibrary) {}
 
-    fn force_flush(&self) -> LogResult<()> {
+    async fn force_flush(&self) -> LogResult<()> {
         Ok(())
     }
 
-    fn shutdown(&self) -> LogResult<()> {
+    async fn shutdown(&self) -> LogResult<()> {
         Ok(())
     }
 }
@@ -57,16 +58,17 @@ impl LogProcessor for NoopProcessor {
 #[derive(Debug)]
 struct CloningProcessor;
 
+#[async_trait::async_trait]
 impl LogProcessor for CloningProcessor {
-    fn emit(&self, data: &mut LogRecord, _library: &InstrumentationLibrary) {
+    async fn emit(&self, data: &mut LogRecord, _library: &InstrumentationLibrary) {
         let _data_cloned = data.clone();
     }
 
-    fn force_flush(&self) -> LogResult<()> {
+    async fn force_flush(&self) -> LogResult<()> {
         Ok(())
     }
 
-    fn shutdown(&self) -> LogResult<()> {
+    async fn shutdown(&self) -> LogResult<()> {
         Ok(())
     }
 }
@@ -100,19 +102,20 @@ impl SendToChannelProcessor {
     }
 }
 
+#[async_trait::async_trait]
 impl LogProcessor for SendToChannelProcessor {
-    fn emit(&self, record: &mut LogRecord, library: &InstrumentationLibrary) {
+    async fn emit(&self, record: &mut LogRecord, library: &InstrumentationLibrary) {
         let res = self.sender.send((record.clone(), library.clone()));
         if res.is_err() {
             println!("Error sending log data to channel {0}", res.err().unwrap());
         }
     }
 
-    fn force_flush(&self) -> LogResult<()> {
+    async fn force_flush(&self) -> LogResult<()> {
         Ok(())
     }
 
-    fn shutdown(&self) -> LogResult<()> {
+    async fn shutdown(&self) -> LogResult<()> {
         Ok(())
     }
 }

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -1,7 +1,7 @@
 //! Log exporters
 use crate::logs::LogRecord;
 use crate::Resource;
-use async_trait::async_trait;
+use futures_util::future::BoxFuture;
 #[cfg(feature = "logs_level_enabled")]
 use opentelemetry::logs::Severity;
 use opentelemetry::{
@@ -11,10 +11,12 @@ use opentelemetry::{
 use std::fmt::Debug;
 
 /// `LogExporter` defines the interface that log exporters should implement.
-#[async_trait]
 pub trait LogExporter: Send + Sync + Debug {
     /// Exports a batch of [`LogRecord`, `InstrumentationLibrary`].
-    async fn export(&mut self, batch: Vec<(&LogRecord, &InstrumentationLibrary)>) -> LogResult<()>;
+    fn export(
+        &mut self,
+        batch: Vec<(&LogRecord, &InstrumentationLibrary)>,
+    ) -> BoxFuture<'static, LogResult<()>>;
     /// Shuts down the exporter.
     fn shutdown(&mut self) {}
     #[cfg(feature = "logs_level_enabled")]

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -530,7 +530,7 @@ mod tests {
         testing::logs::InMemoryLogsExporter,
         Resource,
     };
-    use async_trait::async_trait;
+    use futures_util::future::BoxFuture;
     use opentelemetry::logs::AnyValue;
     use opentelemetry::logs::{Logger, LoggerProvider as _};
     use opentelemetry::InstrumentationLibrary;
@@ -544,13 +544,12 @@ mod tests {
         resource: Arc<Mutex<Option<Resource>>>,
     }
 
-    #[async_trait]
     impl LogExporter for MockLogExporter {
-        async fn export(
+        fn export(
             &mut self,
             _batch: Vec<(&LogRecord, &InstrumentationLibrary)>,
-        ) -> LogResult<()> {
-            Ok(())
+        ) -> BoxFuture<'static, LogResult<()>> {
+            Box::pin(std::future::ready(Ok(())))
         }
 
         fn shutdown(&mut self) {}

--- a/opentelemetry-sdk/src/testing/trace/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/trace/in_memory_exporter.rs
@@ -37,7 +37,7 @@ use std::sync::{Arc, Mutex};
 ///     cx.span().add_event("handling this...", Vec::new());
 ///     cx.span().end();
 ///
-///     let results = provider.force_flush();
+///     let results = provider.force_flush().await;
 ///     for result in results {
 ///         if let Err(e) = result {
 ///             println!("{:?}", e)

--- a/opentelemetry-sdk/src/util.rs
+++ b/opentelemetry-sdk/src/util.rs
@@ -1,4 +1,5 @@
 //! Internal utilities
+use std::future::Future;
 
 /// Helper which wraps `tokio::time::interval` and makes it return a stream
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
@@ -6,4 +7,25 @@ pub fn tokio_interval_stream(
     period: std::time::Duration,
 ) -> tokio_stream::wrappers::IntervalStream {
     tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(period))
+}
+
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(target_arch = "wasm32", target_os = "wasi")
+))]
+pub(crate) fn spawn_future<F>(f: F)
+where
+    F: Future + 'static,
+{
+    futures_executor::block_on(f);
+}
+
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+pub(crate) fn spawn_future<F>(f: F)
+where
+    F: Future + 'static,
+{
+    wasm_bindgen_futures::spawn_local(async move {
+        f.await;
+    })
 }

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     meter_provider.shutdown()?;
 
     #[cfg(feature = "logs")]
-    logger_provider.shutdown()?;
+    logger_provider.shutdown().await?;
 
     Ok(())
 }

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -40,6 +40,7 @@ path = "src/random.rs"
 doc = false
 
 [dependencies]
+async-trait.workspace = true
 ctrlc = "3.2.5"
 lazy_static = "1.4.0"
 num_cpus = "1.15.0"

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -20,19 +20,20 @@ mod throughput;
 #[derive(Debug)]
 pub struct NoOpLogProcessor;
 
+#[async_trait::async_trait]
 impl LogProcessor for NoOpLogProcessor {
-    fn emit(
+    async fn emit(
         &self,
         _record: &mut opentelemetry_sdk::logs::LogRecord,
         _library: &InstrumentationLibrary,
     ) {
     }
 
-    fn force_flush(&self) -> opentelemetry::logs::LogResult<()> {
+    async fn force_flush(&self) -> opentelemetry::logs::LogResult<()> {
         Ok(())
     }
 
-    fn shutdown(&self) -> opentelemetry::logs::LogResult<()> {
+    async fn shutdown(&self) -> opentelemetry::logs::LogResult<()> {
         Ok(())
     }
 }

--- a/stress/src/traces.rs
+++ b/stress/src/traces.rs
@@ -32,20 +32,21 @@ lazy_static! {
 #[derive(Debug)]
 pub struct NoOpSpanProcessor;
 
+#[async_trait::async_trait]
 impl SpanProcessor for NoOpSpanProcessor {
     fn on_start(&self, _span: &mut opentelemetry_sdk::trace::Span, _cx: &Context) {
         // No-op
     }
 
-    fn on_end(&self, _span: SpanData) {
+    async fn on_end(&self, _span: SpanData) {
         // No-op
     }
 
-    fn force_flush(&self) -> TraceResult<()> {
+    async fn force_flush(&self) -> TraceResult<()> {
         Ok(())
     }
 
-    fn shutdown(&self) -> TraceResult<()> {
+    async fn shutdown(&self) -> TraceResult<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
See issue #2047 for discussion about this PR

## Changes

This PR contains 5 changes:
 - first it makes the `LogExporter::export` function return a future that doesn't capture self's lifetime, this is similar to what `SpanExporter` does. This will be important for a follow up commit
 - It adds a runtime agnostic way of spawning futures such that in WASM it uses the JS scheduler to poll futures instead of blocking the main thread
 - Makes the `LogProcessor` async, this is where the first commit is relevant. As it allows me to get around std MutexGuard not being Sync
 - Makes the same change to SpanProcessor, in order to further remove the calls to `block_on`
 - Finally replaces the final two places in the sdk where `block_on` is used explicitly, this however should instead be done by making these two changed methods async, but I was unsure how to proceed with the fallout of that change on the codebase, so settled for this.


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
