### PR TITLE
Use event.name as attribute key for exporting Log event name

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## vNext
 
 - **Breaking**
-[1994](https://github.com/open-telemetry/opentelemetry-rust/pull/1994) The
-logrecord event-name is added as an attribute only if the feature flag
+The logrecord event-name is added as an attribute only if the feature flag
 `populate-logs-event-name` is enabled. The name of the attribute is changed from
 "name" to "event.name".
+[1994](https://github.com/open-telemetry/opentelemetry-rust/pull/1994),
+[2050](https://github.com/open-telemetry/opentelemetry-rust/pull/2050)
 
 ## v0.17.0
 

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## vNext
 
-- **Breaking** [1994](https://github.com/open-telemetry/opentelemetry-rust/pull/1994) The logrecord event-name is added as attribute with
-key `name` only if the feature flag `populate-logs-event-name` is enabled.
+- **Breaking**
+[1994](https://github.com/open-telemetry/opentelemetry-rust/pull/1994) The
+logrecord event-name is added as an attribute only if the feature flag
+`populate-logs-event-name` is enabled. The name of the attribute is changed from
+"name" to "event.name".
 
 ## v0.17.0
 

--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -103,7 +103,7 @@ pub mod tonic {
                         if let Some(event_name) = &log_record.event_name {
                             let mut attributes_with_name = attributes;
                             attributes_with_name.push(KeyValue {
-                                key: "name".into(),
+                                key: "event.name".into(),
                                 value: Some(AnyValue {
                                     value: Some(Value::StringValue(event_name.to_string())),
                                 }),


### PR DESCRIPTION
This is still being discussed in Event SIG and semantic conventions, but I propose to name it "event.name" before the upcoming release. There is high chance that "event.name" will be the final name, so we can avoid yet another breaking change after the coming release. 
This is still under feature-flag.

(Similar change for stdout exporter is needed, but that'll be done the current refactoring of stdout exporter to avoid conflicts)