### PR TITLE
Add Feature Flag to Disable Array Preallocation for Log Record Attributes in Limited Stack Environments

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -38,6 +38,12 @@
     ```
     This change simplifies the processing required by exporters. Exporters no longer need to determine if the LogData is borrowed or owned, as they now work directly with references. As a result, exporters must explicitly create a copy of LogRecord and/or InstrumentationLibrary when needed, as the new interface only provides references to these structures.
 
+- [#2055](https://github.com/open-telemetry/opentelemetry-rust/pull/2055)
+  New Feature Flag: `disable_stack_log_attributes`
+  * Default Behavior: By default, the `LogRecord::attributes` field uses a combination of stack and heap allocation for storing attributes. This approach is efficient for handling a limited number of attributes with minimal heap allocation.
+
+  * Behavior with `disable_stack_log_attributes` Enabled: When the `disable_stack_log_attributes` feature flag is enabled, the LogRecord::attributes field only uses vector-based heap allocation, bypassing stack allocation entirely. This setting is beneficial for applications that run in constrained environment with limited stack, and thus avoiding potential stack overflow.
+
 ## v0.24.1
 
 - Add hidden method to support tracing-opentelemetry

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -51,6 +51,7 @@ testing = ["opentelemetry/testing", "trace", "metrics", "logs", "rt-async-std", 
 rt-tokio = ["tokio", "tokio-stream"]
 rt-tokio-current-thread = ["tokio", "tokio-stream"]
 rt-async-std = ["async-std"]
+no-preallocate-attributes-array = []
 
 [[bench]]
 name = "context"

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -51,7 +51,7 @@ testing = ["opentelemetry/testing", "trace", "metrics", "logs", "rt-async-std", 
 rt-tokio = ["tokio", "tokio-stream"]
 rt-tokio-current-thread = ["tokio", "tokio-stream"]
 rt-async-std = ["async-std"]
-no-preallocate-attributes-array = []
+disable_stack_log_attributes = []
 
 [[bench]]
 name = "context"

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -8,15 +8,27 @@ use std::{borrow::Cow, time::SystemTime};
 
 // According to a Go-specific study mentioned on https://go.dev/blog/slog,
 // up to 5 attributes is the most common case.
+#[cfg(not(feature = "no-preallocate-attributes-array"))]
 const PREALLOCATED_ATTRIBUTE_CAPACITY: usize = 5;
+#[cfg(feature = "no-preallocate-attributes-array")]
+const PREALLOCATED_ATTRIBUTE_CAPACITY: usize = 0;
+#[cfg(feature = "no-preallocate-attributes-array")]
+const OVERFLOW_ATTRIBUTE_CAPACITY: usize = 5;
 
 /// Represents a collection of log record attributes with a predefined capacity.
 ///
 /// This type uses `GrowableArray` to store key-value pairs of log attributes, where each attribute is an `Option<(Key, AnyValue)>`.
 /// The initial attributes are allocated in a fixed-size array of capacity `PREALLOCATED_ATTRIBUTE_CAPACITY`.
 /// If more attributes are added beyond this capacity, additional storage is handled by dynamically growing a vector.
+#[cfg(not(feature = "no-preallocate-attributes-array"))]
 pub(crate) type LogRecordAttributes =
     GrowableArray<Option<(Key, AnyValue)>, PREALLOCATED_ATTRIBUTE_CAPACITY>;
+#[cfg(feature = "no-preallocate-attributes-array")]
+pub(crate) type LogRecordAttributes = GrowableArray<
+    Option<(Key, AnyValue)>,
+    PREALLOCATED_ATTRIBUTE_CAPACITY,
+    OVERFLOW_ATTRIBUTE_CAPACITY,
+>;
 
 #[derive(Debug, Default, Clone, PartialEq)]
 #[non_exhaustive]

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -23,6 +23,8 @@ const OVERFLOW_ATTRIBUTE_CAPACITY: usize = 5;
 #[cfg(not(feature = "no-preallocate-attributes-array"))]
 pub(crate) type LogRecordAttributes =
     GrowableArray<Option<(Key, AnyValue)>, PREALLOCATED_ATTRIBUTE_CAPACITY>;
+/// When the `no-preallocate-attributes-array` feature flag is enabled, we don't use array allocation.
+/// Instead, the vector part of `GrowableArray` is used, and OVERFLOW_ATTRIBUTE_CAPACITY allocation occurs when the first entry is added.
 #[cfg(feature = "no-preallocate-attributes-array")]
 pub(crate) type LogRecordAttributes = GrowableArray<
     Option<(Key, AnyValue)>,

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -8,11 +8,11 @@ use std::{borrow::Cow, time::SystemTime};
 
 // According to a Go-specific study mentioned on https://go.dev/blog/slog,
 // up to 5 attributes is the most common case.
-#[cfg(not(feature = "no-preallocate-attributes-array"))]
+#[cfg(not(feature = "disable_stack_log_attributes"))]
 const PREALLOCATED_ATTRIBUTE_CAPACITY: usize = 5;
-#[cfg(feature = "no-preallocate-attributes-array")]
+#[cfg(feature = "disable_stack_log_attributes")]
 const PREALLOCATED_ATTRIBUTE_CAPACITY: usize = 0;
-#[cfg(feature = "no-preallocate-attributes-array")]
+#[cfg(feature = "disable_stack_log_attributes")]
 const OVERFLOW_ATTRIBUTE_CAPACITY: usize = 5;
 
 /// Represents a collection of log record attributes with a predefined capacity.
@@ -20,12 +20,12 @@ const OVERFLOW_ATTRIBUTE_CAPACITY: usize = 5;
 /// This type uses `GrowableArray` to store key-value pairs of log attributes, where each attribute is an `Option<(Key, AnyValue)>`.
 /// The initial attributes are allocated in a fixed-size array of capacity `PREALLOCATED_ATTRIBUTE_CAPACITY`.
 /// If more attributes are added beyond this capacity, additional storage is handled by dynamically growing a vector.
-#[cfg(not(feature = "no-preallocate-attributes-array"))]
+#[cfg(not(feature = "disable_stack_log_attributes"))]
 pub(crate) type LogRecordAttributes =
     GrowableArray<Option<(Key, AnyValue)>, PREALLOCATED_ATTRIBUTE_CAPACITY>;
-/// When the `no-preallocate-attributes-array` feature flag is enabled, we don't use array allocation.
+/// When the `disable_stack_log_attributes` feature flag is enabled, we don't use array allocation.
 /// Instead, the vector part of `GrowableArray` is used, and OVERFLOW_ATTRIBUTE_CAPACITY allocation occurs when the first entry is added.
-#[cfg(feature = "no-preallocate-attributes-array")]
+#[cfg(feature = "disable_stack_log_attributes")]
 pub(crate) type LogRecordAttributes = GrowableArray<
     Option<(Key, AnyValue)>,
     PREALLOCATED_ATTRIBUTE_CAPACITY,


### PR DESCRIPTION
Fixes #1920 

## Changes
This PR introduces a feature flag, `no-preallocate-attributes-array`, that disables the default behavior of preallocating a fixed-size array for storing log record attributes. Instead of using a preallocated array, this feature flag enables the use of the vector part of `GrowableArray`, which allocates memory dynamically when the first entry is added.

Rationale: Kernel mode and other environments with limited stack space require careful management of stack allocations. By using a dynamically growing vector instead of preallocating a fixed-size array, we can reduce the stack footprint.

Note - We could have directly used the `Vector` instead of `GrowableArray` for this scenario, however didn't find any visible difference in stress tests with either approach, so kept `GrowableArray` to be consistent.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
