### PR TITLE
Update Log benchmarks

### DIFF
--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -10,7 +10,7 @@
     | noop_layer_disabled         | 12 ns       |
     | noop_layer_enabled          | 25 ns       |
     | ot_layer_disabled           | 19 ns       |
-    | ot_layer_enabled            | 203 ns      |
+    | ot_layer_enabled            | 196 ns      |
 */
 
 use async_trait::async_trait;

--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -6,8 +6,8 @@
     RAM: 64.0 GB
     | Test                           | Average time|
     |--------------------------------|-------------|
-    | LogExporterWithFuture          | 280 ns      |
-    | LogExporterWithoutFuture       | 255 ns      |
+    | LogExporterWithFuture          | 122 ns      |
+    | LogExporterWithoutFuture       | 89 ns      |
 */
 
 use std::sync::Mutex;


### PR DESCRIPTION
## Changes

As tested in Ubuntu 22.04.3,  AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs, 32GB

```
LogExporterWithFuture   time:   [122.05 ns 122.15 ns 122.25 ns]
                        change: [+0.3743% +0.5139% +0.6622%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  2 (2.00%) high mild
  3 (3.00%) high severe

LogExporterWithoutFuture
                        time:   [89.818 ns 89.947 ns 90.117 ns]
                        change: [+0.1721% +0.3737% +0.6130%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```

```
log_no_subscriber       time:   [313.19 ps 313.86 ps 314.84 ps]
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe

ot_layer_enabled        time:   [196.03 ns 196.19 ns 196.37 ns]
                        change: [+0.6202% +0.8194% +1.0726%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  5 (5.00%) high mild
  4 (4.00%) high severe

ot_layer_disabled       time:   [19.514 ns 19.531 ns 19.549 ns]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

noop_layer_enabled      time:   [26.176 ns 26.317 ns 26.481 ns]
Found 18 outliers among 100 measurements (18.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  16 (16.00%) high severe

noop_layer_disabled     time:   [12.567 ns 12.584 ns 12.608 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

```
## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
