### PR TITLE
Update attributes benchmarks

### DIFF
--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -7,7 +7,7 @@ RAM: 64.0 GB
 | CreateOTelKey_Owned            |     12.6 ns |
 | CreateOTelKey_Arc              |    23.35 ns |
 | CreateOTelKeyValue             |     3.24 ns |
-| CreateTupleKeyValue            |      671 ps |  
+| CreateTupleKeyValue            |      671 ps |
 | CreateOtelKeyValueVector       |     18.4 ns |
 | CreateTupleKeyValueVector      |     2.73 ns |
 */

--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -1,10 +1,3 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use opentelemetry::{Key, KeyValue};
-use std::sync::Arc;
-
-// Run this benchmark with:
-// cargo bench --bench attributes
-
 /* OS: Ubuntu 22.04.4 LTS (5.15.153.1-microsoft-standard-WSL2)
 Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
 RAM: 64.0 GB
@@ -18,6 +11,13 @@ RAM: 64.0 GB
 | CreateOtelKeyValueVector       |     18.4 ns |
 | CreateTupleKeyValueVector      |     2.73 ns |
 */
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use opentelemetry::{Key, KeyValue};
+use std::sync::Arc;
+
+// Run this benchmark with:
+// cargo bench --bench attributes
 
 fn criterion_benchmark(c: &mut Criterion) {
     attributes_creation(c);

--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -5,6 +5,20 @@ use std::sync::Arc;
 // Run this benchmark with:
 // cargo bench --bench attributes
 
+/* OS: Ubuntu 22.04.4 LTS (5.15.153.1-microsoft-standard-WSL2)
+Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
+RAM: 64.0 GB
+| Test                           | Average time|
+|--------------------------------|-------------|
+| CreateOTelKey_Static           |      1.2 ns |
+| CreateOTelKey_Owned            |     12.6 ns |
+| CreateOTelKey_Arc              |    23.35 ns |
+| CreateOTelKeyValue             |     3.24 ns |
+| CreateTupleKeyValue            |      671 ps |  
+| CreateOtelKeyValueVector       |     18.4 ns |
+| CreateTupleKeyValueVector      |     2.73 ns |
+*/
+
 fn criterion_benchmark(c: &mut Criterion) {
     attributes_creation(c);
 }
@@ -43,7 +57,7 @@ fn attributes_creation(c: &mut Criterion) {
     #[allow(clippy::useless_vec)]
     c.bench_function("CreateOtelKeyValueVector", |b| {
         b.iter(|| {
-            let _v1 = black_box(vec![
+            let _v1 = black_box([
                 KeyValue::new("attribute1", "value1"),
                 KeyValue::new("attribute2", "value2"),
                 KeyValue::new("attribute3", "value3"),
@@ -55,7 +69,7 @@ fn attributes_creation(c: &mut Criterion) {
     #[allow(clippy::useless_vec)]
     c.bench_function("CreateTupleKeyValueVector", |b| {
         b.iter(|| {
-            let _v1 = black_box(vec![
+            let _v1 = black_box([
                 ("attribute1", "value1"),
                 ("attribute2", "value2"),
                 ("attribute3", "value3"),

--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -8,8 +8,8 @@ RAM: 64.0 GB
 | CreateOTelKey_Arc              |    23.35 ns |
 | CreateOTelKeyValue             |     3.24 ns |
 | CreateTupleKeyValue            |      671 ps |
-| CreateOtelKeyValueVector       |     18.4 ns |
-| CreateTupleKeyValueVector      |     2.73 ns |
+| CreateOtelKeyValueArray        |     18.4 ns |
+| CreateTupleKeyValueArray       |     2.73 ns |
 */
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
@@ -55,7 +55,7 @@ fn attributes_creation(c: &mut Criterion) {
     });
 
     #[allow(clippy::useless_vec)]
-    c.bench_function("CreateOtelKeyValueVector", |b| {
+    c.bench_function("CreateOtelKeyValueArray", |b| {
         b.iter(|| {
             let _v1 = black_box([
                 KeyValue::new("attribute1", "value1"),
@@ -67,7 +67,7 @@ fn attributes_creation(c: &mut Criterion) {
     });
 
     #[allow(clippy::useless_vec)]
-    c.bench_function("CreateTupleKeyValueVector", |b| {
+    c.bench_function("CreateTupleKeyValueArray", |b| {
         b.iter(|| {
             let _v1 = black_box([
                 ("attribute1", "value1"),


### PR DESCRIPTION
## Changes
- Update attributes benchmarks to use an array instead of a `vec`. Creation of a vector overshadows the time difference between creation of `KeyValue` struct vs tuple
- Added benchmark results

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
