### PR TITLE
[WIP] Remove Send bounds on wasm32

### DIFF
--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -32,7 +32,8 @@ struct NoopExporter {
     enabled: bool,
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl LogExporter for NoopExporter {
     async fn export(&mut self, _: LogBatch<'_>) -> LogResult<()> {
         LogResult::Ok(())

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -53,7 +53,8 @@ pub type HttpError = Box<dyn std::error::Error + Send + Sync + 'static>;
 ///
 /// Users sometime choose HTTP clients that relay on a certain async runtime. This trait allows
 /// users to bring their choice of HTTP client.
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait HttpClient: Debug + Send + Sync {
     /// Send the specified HTTP request
     ///
@@ -68,7 +69,8 @@ pub trait HttpClient: Debug + Send + Sync {
 mod reqwest {
     use super::{async_trait, Bytes, HttpClient, HttpError, Request, Response};
 
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl HttpClient for reqwest::Client {
         async fn send(&self, request: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
             let request = request.try_into()?;
@@ -83,7 +85,8 @@ mod reqwest {
         }
     }
 
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl HttpClient for reqwest::blocking::Client {
         async fn send(&self, request: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
             let request = request.try_into()?;
@@ -143,7 +146,8 @@ pub mod hyper {
         }
     }
 
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl<C> HttpClient for HyperClient<C>
     where
         C: Connect + Send + Sync + Clone + Debug + 'static,

--- a/opentelemetry-otlp/src/exporter/http/logs.rs
+++ b/opentelemetry-otlp/src/exporter/http/logs.rs
@@ -7,7 +7,8 @@ use opentelemetry_sdk::export::logs::{LogBatch, LogExporter};
 
 use super::OtlpHttpClient;
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl LogExporter for OtlpHttpClient {
     async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()> {
         let client = self

--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -9,7 +9,8 @@ use crate::{metric::MetricsClient, Error};
 
 use super::OtlpHttpClient;
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl MetricsClient for OtlpHttpClient {
     async fn export(&self, metrics: &mut ResourceMetrics) -> Result<()> {
         let client = self

--- a/opentelemetry-otlp/src/exporter/http/trace.rs
+++ b/opentelemetry-otlp/src/exporter/http/trace.rs
@@ -1,14 +1,13 @@
 use std::sync::Arc;
 
-use futures_core::future::BoxFuture;
 use http::{header::CONTENT_TYPE, Method};
-use opentelemetry::trace::TraceError;
+use opentelemetry::{trace::TraceError, MaybeSendBoxFuture};
 use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
 
 use super::OtlpHttpClient;
 
 impl SpanExporter for OtlpHttpClient {
-    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, batch: Vec<SpanData>) -> MaybeSendBoxFuture<'static, ExportResult> {
         let client = match self
             .client
             .lock()

--- a/opentelemetry-otlp/src/exporter/tonic/logs.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/logs.rs
@@ -52,7 +52,8 @@ impl TonicLogsClient {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl LogExporter for TonicLogsClient {
     async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()> {
         let (mut client, metadata, extensions) = match &mut self.inner {

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -49,7 +49,8 @@ impl TonicMetricsClient {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl MetricsClient for TonicMetricsClient {
     async fn export(&self, metrics: &mut ResourceMetrics) -> Result<()> {
         let (mut client, metadata, extensions) =

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -97,7 +97,8 @@ impl LogExporter {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl opentelemetry_sdk::export::logs::LogExporter for LogExporter {
     async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()> {
         self.client.export(batch).await

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -285,7 +285,8 @@ impl TemporalitySelector for DeltaTemporalitySelector {
 }
 
 /// An interface for OTLP metrics clients
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait MetricsClient: fmt::Debug + Send + Sync + 'static {
     async fn export(&self, metrics: &mut ResourceMetrics) -> Result<()>;
     fn shutdown(&self) -> Result<()>;
@@ -316,7 +317,8 @@ impl AggregationSelector for MetricsExporter {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl PushMetricsExporter for MetricsExporter {
     async fn export(&self, metrics: &mut ResourceMetrics) -> Result<()> {
         self.client.export(metrics).await

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -4,8 +4,7 @@
 
 use std::fmt::Debug;
 
-use futures_core::future::BoxFuture;
-use opentelemetry::trace::TraceError;
+use opentelemetry::{trace::TraceError, MaybeSendBoxFuture};
 use opentelemetry_sdk::{
     self as sdk,
     export::trace::{ExportResult, SpanData},
@@ -210,7 +209,7 @@ impl SpanExporter {
 }
 
 impl opentelemetry_sdk::export::trace::SpanExporter for SpanExporter {
-    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, batch: Vec<SpanData>) -> MaybeSendBoxFuture<'static, ExportResult> {
         self.0.export(batch)
     }
 

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
@@ -190,7 +190,8 @@ pub mod logs_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with LogsServiceServer.
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     pub trait LogsService: std::marker::Send + std::marker::Sync + 'static {
         /// For performance reasons, it is recommended to keep this RPC
         /// alive for the entire life of the application.

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
@@ -190,7 +190,8 @@ pub mod metrics_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with MetricsServiceServer.
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     pub trait MetricsService: std::marker::Send + std::marker::Sync + 'static {
         /// For performance reasons, it is recommended to keep this RPC
         /// alive for the entire life of the application.

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
@@ -190,7 +190,8 @@ pub mod trace_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with TraceServiceServer.
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     pub trait TraceService: std::marker::Send + std::marker::Sync + 'static {
         /// For performance reasons, it is recommended to keep this RPC
         /// alive for the entire life of the application.

--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -28,7 +28,8 @@ use std::fmt::Debug;
 
 // Run this benchmark with:
 // cargo bench --bench log_exporter
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait LogExporterWithFuture: Send + Sync + Debug {
     async fn export(&mut self, batch: LogBatch<'_>);
 }
@@ -40,7 +41,8 @@ pub trait LogExporterWithoutFuture: Send + Sync + Debug {
 #[derive(Debug)]
 struct NoOpExporterWithFuture {}
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl LogExporterWithFuture for NoOpExporterWithFuture {
     async fn export(&mut self, _batch: LogBatch<'_>) {}
 }

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -65,7 +65,8 @@ impl LogBatch<'_> {
 }
 
 /// `LogExporter` defines the interface that log exporters should implement.
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait LogExporter: Send + Sync + Debug {
     /// Exports a batch of log records and their associated instrumentation libraries.
     ///

--- a/opentelemetry-sdk/src/export/trace.rs
+++ b/opentelemetry-sdk/src/export/trace.rs
@@ -2,7 +2,7 @@
 use crate::Resource;
 use futures_util::future::BoxFuture;
 use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceError};
-use opentelemetry::KeyValue;
+use opentelemetry::{KeyValue, MaybeSendBoxFuture};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::time::SystemTime;
@@ -30,7 +30,7 @@ pub trait SpanExporter: Send + Sync + Debug {
     ///
     /// Any retry logic that is required by the exporter is the responsibility
     /// of the exporter.
-    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult>;
+    fn export(&mut self, batch: Vec<SpanData>) -> MaybeSendBoxFuture<'static, ExportResult>;
 
     /// Shuts down the exporter. Called when SDK is shut down. This is an
     /// opportunity for exporter to do any cleanup required.

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -545,7 +545,8 @@ mod tests {
         resource: Arc<Mutex<Option<Resource>>>,
     }
 
-    #[async_trait]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl LogExporter for MockLogExporter {
         async fn export(&mut self, _batch: LogBatch<'_>) -> LogResult<()> {
             Ok(())

--- a/opentelemetry-sdk/src/metrics/exporter.rs
+++ b/opentelemetry-sdk/src/metrics/exporter.rs
@@ -11,7 +11,8 @@ use crate::metrics::{
 /// Exporter handles the delivery of metric data to external receivers.
 ///
 /// This is the final component in the metric push pipeline.
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait PushMetricsExporter:
     AggregationSelector + TemporalitySelector + Send + Sync + 'static
 {

--- a/opentelemetry-sdk/src/runtime.rs
+++ b/opentelemetry-sdk/src/runtime.rs
@@ -6,7 +6,7 @@
 //! [Tokio]: https://crates.io/crates/tokio
 //! [async-std]: https://crates.io/crates/async-std
 
-use futures_util::stream::Stream;
+use futures_util::stream::{BoxFuture, Stream};
 use opentelemetry::MaybeSendBoxFuture;
 use std::{fmt::Debug, future::Future, time::Duration};
 use thiserror::Error;

--- a/opentelemetry-sdk/src/runtime.rs
+++ b/opentelemetry-sdk/src/runtime.rs
@@ -6,7 +6,8 @@
 //! [Tokio]: https://crates.io/crates/tokio
 //! [async-std]: https://crates.io/crates/async-std
 
-use futures_util::{future::BoxFuture, stream::Stream};
+use futures_util::stream::Stream;
+use opentelemetry::MaybeSendBoxFuture;
 use std::{fmt::Debug, future::Future, time::Duration};
 use thiserror::Error;
 
@@ -37,7 +38,7 @@ pub trait Runtime: Clone + Send + Sync + 'static {
     /// finish when TracerProvider gets shutdown. At the moment this happens by blocking the
     /// current thread. This means runtime implementations need to make sure they can still execute
     /// the given future even if the main thread is blocked.
-    fn spawn(&self, future: BoxFuture<'static, ()>);
+    fn spawn(&self, future: MaybeSendBoxFuture<'static, ()>);
 
     /// Return a new future, which resolves after the specified [std::time::Duration].
     fn delay(&self, duration: Duration) -> Self::Delay;

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -182,7 +182,8 @@ impl InMemoryLogsExporter {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl LogExporter for InMemoryLogsExporter {
     async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()> {
         let mut logs_guard = self.logs.lock().map_err(LogError::from)?;

--- a/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
@@ -282,7 +282,8 @@ impl TemporalitySelector for InMemoryMetricsExporter {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl PushMetricsExporter for InMemoryMetricsExporter {
     async fn export(&self, metrics: &mut ResourceMetrics) -> Result<()> {
         self.metrics

--- a/opentelemetry-stdout/src/logs/exporter.rs
+++ b/opentelemetry-stdout/src/logs/exporter.rs
@@ -29,7 +29,8 @@ impl fmt::Debug for LogExporter {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl opentelemetry_sdk::export::logs::LogExporter for LogExporter {
     /// Export spans to stdout
     async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()> {

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -51,7 +51,8 @@ impl AggregationSelector for MetricsExporter {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl PushMetricsExporter for MetricsExporter {
     /// Write Metrics to stdout
     async fn export(&self, metrics: &mut data::ResourceMetrics) -> Result<()> {

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -214,7 +214,8 @@ async fn zipkin_export(
     uploader.upload(zipkin_spans).await
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl trace::SpanExporter for Exporter {
     /// Export spans to Zipkin collector.
     fn export(&mut self, batch: Vec<trace::SpanData>) -> BoxFuture<'static, trace::ExportResult> {

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -1,6 +1,9 @@
 use std::borrow::{Borrow, Cow};
+use std::pin::Pin;
 use std::sync::Arc;
 use std::{fmt, hash};
+
+use futures_core::Future;
 
 /// The key part of attribute [KeyValue] pairs.
 ///
@@ -433,6 +436,14 @@ impl KeyValue {
         }
     }
 }
+
+#[cfg(target_arch = "wasm32")]
+/// A pinned, boxed future which is Send + Sync when the platform is not wasm
+pub type MaybeSendBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+/// A pinned, boxed future which is Send + Sync when the platform is not wasm
+pub type MaybeSendBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Marker trait for errors returned by exporters
 pub trait ExportError: std::error::Error + Send + Sync + 'static {

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -205,7 +205,7 @@ pub mod testing;
 
 pub use common::{
     Array, ExportError, InstrumentationLibrary, InstrumentationLibraryBuilder, Key, KeyValue,
-    StringValue, Value,
+    MaybeSendBoxFuture, StringValue, Value,
 };
 
 #[cfg(feature = "metrics")]

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -63,6 +63,11 @@ pub trait MeterProvider {
     ) -> Meter;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+type ArcInstrumentProvider = Arc<dyn InstrumentProvider + Send + Sync>;
+#[cfg(target_arch = "wasm32")]
+type ArcInstrumentProvider = Arc<dyn InstrumentProvider>;
+
 /// Provides the ability to create instruments for recording measurements or
 /// accepting callbacks to report measurements.
 ///
@@ -265,13 +270,13 @@ pub trait MeterProvider {
 ///
 #[derive(Clone)]
 pub struct Meter {
-    pub(crate) instrument_provider: Arc<dyn InstrumentProvider + Send + Sync>,
+    pub(crate) instrument_provider: ArcInstrumentProvider,
 }
 
 impl Meter {
     /// Create a new named meter from an instrumentation provider
     #[doc(hidden)]
-    pub fn new(instrument_provider: Arc<dyn InstrumentProvider + Send + Sync>) -> Self {
+    pub fn new(instrument_provider: ArcInstrumentProvider) -> Self {
         Meter {
             instrument_provider,
         }


### PR DESCRIPTION
Fixes #910

Also related: #1235

## Changes

Attempting to compile to WASM produces a number of errors regarding `Send` bounds, as reported in #1235. This is because `wasm_bindgen::JsValue` [is not `Send`](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/struct.JsValue.html#impl-Send-for-JsValue), since it's intended to run in a single-threaded JS environment.

This issue was successfully addressed in the `rspotify` crate in https://github.com/ramsayleung/rspotify/pull/458, although I think `opentelemetry-rust` requires a somewhat more complex solution.

I've managed to fix _these_ errors (see other WASM errors in #1472 and #2047) by conditionally removing `Send` bounds for `target_arch="wasm32"`.

I've done this in three ways:
- conditionally change `#[async_trait]` to `#[async_trait(?Send)]` based on `target_arch`
- Replace `BoxFuture` with `MaybeSendBoxFuture`, which conditionally removes `Send` bounds on wasm
- Replace `Arc<dyn InstrumentProvider + Send + Sync>` with `type ArcInstrumentProvider = Arc<dyn InstrumentProvider>` on WASM and `type ArcInstrumentProvider = Arc<dyn InstrumentProvider + Send + Sync>` otherwise.

I suspect that this PR is not yet complete. Initially, I only made enough changes to get my application to compile, using the following feature flags:
```toml
opentelemetry = { version = "0.24.0" }
opentelemetry_sdk = { version = "0.24.1", features=["logs"] }
opentelemetry-semantic-conventions = "0.16.0"
opentelemetry-otlp = { version = "0.17.0", default-features = false, features = ["logs", "trace", "http", "http-json", "reqwest-client"] }
opentelemetry-http = { version = "0.13.0", default-features = false }
```

I then continued by replacing all instances of `#[async_trait]` that seemed relevant. But I assume that there are other crates or feature flags that would require similar changes.

I'm also happy to hear your feedback on this approach, and make changes as necessary.

Thanks,
Oliver

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
