### PR TITLE
fix msrv

### DIFF
--- a/scripts/patch_dependencies.sh
+++ b/scripts/patch_dependencies.sh
@@ -8,3 +8,4 @@ function patch_version() {
 
 patch_version cc 1.0.105
 patch_version url 2.5.0
+patch_version hyper-rustls 0.27.2 # 0.27.3 needs rustc v1.70.0


### PR DESCRIPTION
Error:
```
error: package `hyper-rustls v0.27.3` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.65.0
Either upgrade to rustc 1.70 or newer, or use
cargo update -p hyper-rustls@0.27.3 --precise ver
where `ver` is the latest version of `hyper-rustls` supporting rustc 1.65.0
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
