### PR TITLE
CI failure: msrv patch tokio-util

### DIFF
--- a/scripts/patch_dependencies.sh
+++ b/scripts/patch_dependencies.sh
@@ -9,3 +9,4 @@ function patch_version() {
 patch_version cc 1.0.105
 patch_version url 2.5.0
 patch_version hyper-rustls 0.27.2 # 0.27.3 needs rustc v1.70.0
+patch_version tokio-util 0.7.11 # 0.7.12 needs rustc v1.70.0


### PR DESCRIPTION
Error - https://github.com/open-telemetry/opentelemetry-rust/actions/runs/10714378235/job/29707978476?pr=2073

```
error: package `tokio-util v0.7.12` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.65.0
Either upgrade to rustc 1.70 or newer, or use
cargo update -p tokio-util@0.7.12 --precise ver
where `ver` is the latest version of `tokio-util` supporting rustc 1.65.0
Error: Process completed with exit code 101.
```
The error is coming from opentelemetry-http which has msrv of 1.65.0. The tokio-util is optional dependency there (through tokio), so as of now, sticking to the last supported version of tokio-util should be fine. 

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
