### PR TITLE
AggregationSelector is not needed anymore

### DIFF
--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -78,7 +78,7 @@ impl Default for HttpConfig {
 /// ```
 /// # #[cfg(feature="metrics")]
 /// use opentelemetry_sdk::metrics::reader::{
-///     DefaultAggregationSelector, DefaultTemporalitySelector,
+///     DefaultTemporalitySelector,
 /// };
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -91,7 +91,6 @@ impl Default for HttpConfig {
 /// let metrics_exporter = opentelemetry_otlp::new_exporter()
 ///     .http()
 ///     .build_metrics_exporter(
-///         Box::new(DefaultAggregationSelector::new()),
 ///         Box::new(DefaultTemporalitySelector::new()),
 ///     )?;
 ///
@@ -252,7 +251,6 @@ impl HttpExporterBuilder {
     #[cfg(feature = "metrics")]
     pub fn build_metrics_exporter(
         mut self,
-        aggregation_selector: Box<dyn opentelemetry_sdk::metrics::reader::AggregationSelector>,
         temporality_selector: Box<dyn opentelemetry_sdk::metrics::reader::TemporalitySelector>,
     ) -> opentelemetry::metrics::Result<crate::MetricsExporter> {
         use crate::{
@@ -267,11 +265,7 @@ impl HttpExporterBuilder {
             OTEL_EXPORTER_OTLP_METRICS_HEADERS,
         )?;
 
-        Ok(crate::MetricsExporter::new(
-            client,
-            temporality_selector,
-            aggregation_selector,
-        ))
+        Ok(crate::MetricsExporter::new(client, temporality_selector))
     }
 }
 

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -97,7 +97,7 @@ fn resolve_compression(
 /// ```no_run
 /// # #[cfg(feature="metrics")]
 /// use opentelemetry_sdk::metrics::reader::{
-///     DefaultAggregationSelector, DefaultTemporalitySelector,
+///     DefaultTemporalitySelector,
 /// };
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -110,7 +110,6 @@ fn resolve_compression(
 /// let metrics_exporter = opentelemetry_otlp::new_exporter()
 ///     .tonic()
 ///     .build_metrics_exporter(
-///         Box::new(DefaultAggregationSelector::new()),
 ///         Box::new(DefaultTemporalitySelector::new()),
 ///     )?;
 ///
@@ -332,7 +331,6 @@ impl TonicExporterBuilder {
     #[cfg(feature = "metrics")]
     pub fn build_metrics_exporter(
         self,
-        aggregation_selector: Box<dyn opentelemetry_sdk::metrics::reader::AggregationSelector>,
         temporality_selector: Box<dyn opentelemetry_sdk::metrics::reader::TemporalitySelector>,
     ) -> opentelemetry::metrics::Result<crate::MetricsExporter> {
         use crate::MetricsExporter;
@@ -347,11 +345,7 @@ impl TonicExporterBuilder {
 
         let client = TonicMetricsClient::new(channel, interceptor, compression);
 
-        Ok(MetricsExporter::new(
-            client,
-            temporality_selector,
-            aggregation_selector,
-        ))
+        Ok(MetricsExporter::new(client, temporality_selector))
     }
 
     /// Build a new tonic span exporter

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -126,7 +126,7 @@
 //! use opentelemetry::{global, KeyValue, trace::Tracer};
 //! use opentelemetry_sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
 //! # #[cfg(feature = "metrics")]
-//! use opentelemetry_sdk::metrics::reader::{DefaultAggregationSelector, DefaultTemporalitySelector};
+//! use opentelemetry_sdk::metrics::reader::DefaultTemporalitySelector;
 //! use opentelemetry_otlp::{Protocol, WithExportConfig, ExportConfig};
 //! use std::time::Duration;
 //! # #[cfg(feature = "grpc-tonic")]
@@ -184,7 +184,6 @@
 //!         .with_resource(Resource::new(vec![KeyValue::new("service.name", "example")]))
 //!         .with_period(Duration::from_secs(3))
 //!         .with_timeout(Duration::from_secs(10))
-//!         .with_aggregation_selector(DefaultAggregationSelector::new())
 //!         .with_temporality_selector(DefaultTemporalitySelector::new())
 //!         .build();
 //!     # }

--- a/opentelemetry-otlp/tests/integration_test/expected/serialized_traces.json
+++ b/opentelemetry-otlp/tests/integration_test/expected/serialized_traces.json
@@ -112,6 +112,12 @@
                       "value": {
                         "intValue": "100"
                       }
+                    },
+                    {
+                      "key": "number/int",
+                      "value": {
+                        "intValue": "100"
+                      }
                     }
                   ],
                   "droppedAttributesCount": 0

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -10,7 +10,7 @@ use opentelemetry_sdk::{
     metrics::{
         data::{ResourceMetrics, Temporality},
         new_view,
-        reader::{AggregationSelector, MetricReader, TemporalitySelector},
+        reader::{MetricReader, TemporalitySelector},
         Aggregation, Instrument, InstrumentKind, ManualReader, Pipeline, SdkMeterProvider, Stream,
         View,
     },
@@ -23,12 +23,6 @@ struct SharedReader(Arc<dyn MetricReader>);
 impl TemporalitySelector for SharedReader {
     fn temporality(&self, kind: InstrumentKind) -> Temporality {
         self.0.temporality(kind)
-    }
-}
-
-impl AggregationSelector for SharedReader {
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        self.0.aggregation(kind)
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/aggregation.rs
+++ b/opentelemetry-sdk/src/metrics/aggregation.rs
@@ -17,10 +17,10 @@ pub enum Aggregation {
     /// instrument kind that differs from the default. This aggregation ensures the
     /// default is used.
     ///
-    /// See the [DefaultAggregationSelector] for information about the default
+    /// See the [the spec] for information about the default
     /// instrument kind selection mapping.
     ///
-    /// [DefaultAggregationSelector]: crate::metrics::reader::DefaultAggregationSelector
+    /// [the spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.19.0/specification/metrics/sdk.md#default-aggregation
     Default,
 
     /// An aggregation that summarizes a set of measurements as their arithmetic

--- a/opentelemetry-sdk/src/metrics/exporter.rs
+++ b/opentelemetry-sdk/src/metrics/exporter.rs
@@ -3,18 +3,13 @@ use async_trait::async_trait;
 
 use opentelemetry::metrics::Result;
 
-use crate::metrics::{
-    data::ResourceMetrics,
-    reader::{AggregationSelector, TemporalitySelector},
-};
+use crate::metrics::{data::ResourceMetrics, reader::TemporalitySelector};
 
 /// Exporter handles the delivery of metric data to external receivers.
 ///
 /// This is the final component in the metric push pipeline.
 #[async_trait]
-pub trait PushMetricsExporter:
-    AggregationSelector + TemporalitySelector + Send + Sync + 'static
-{
+pub trait PushMetricsExporter: TemporalitySelector + Send + Sync + 'static {
     /// Export serializes and transmits metric data to a receiver.
     ///
     /// All retry logic must be contained in this function. The SDK does not

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -26,10 +26,9 @@ use crate::{
 };
 
 use super::{
-    aggregation::Aggregation,
     data::{ResourceMetrics, Temporality},
     instrument::InstrumentKind,
-    reader::{AggregationSelector, MetricReader, TemporalitySelector},
+    reader::{MetricReader, TemporalitySelector},
     Pipeline,
 };
 
@@ -297,12 +296,6 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
                 break;
             }
         }
-    }
-}
-
-impl AggregationSelector for PeriodicReader {
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        self.exporter.aggregation(kind)
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -20,11 +20,13 @@ use crate::{
         internal,
         internal::AggregateBuilder,
         internal::Number,
-        reader::{AggregationSelector, DefaultAggregationSelector, MetricReader, SdkProducer},
+        reader::{MetricReader, SdkProducer},
         view::View,
     },
     Resource,
 };
+
+use super::Aggregation;
 
 /// Connects all of the instruments created by a meter provider to a [MetricReader].
 ///
@@ -340,11 +342,11 @@ where
         let mut agg = stream
             .aggregation
             .take()
-            .unwrap_or_else(|| self.pipeline.reader.aggregation(kind));
+            .unwrap_or_else(|| default_aggregation_selector(kind));
 
         // Apply default if stream or reader aggregation returns default
         if matches!(agg, aggregation::Aggregation::Default) {
-            agg = DefaultAggregationSelector::new().aggregation(kind);
+            agg = default_aggregation_selector(kind);
         }
 
         if let Err(err) = is_aggregator_compatible(&kind, &agg) {
@@ -430,6 +432,37 @@ where
     }
 }
 
+/// The default aggregation and parameters for an instrument of [InstrumentKind].
+///
+/// This aggregation selector uses the following selection mapping per [the spec]:
+///
+/// * Counter ⇨ Sum
+/// * Observable Counter ⇨ Sum
+/// * UpDownCounter ⇨ Sum
+/// * Observable UpDownCounter ⇨ Sum
+/// * Gauge ⇨ LastValue
+/// * Observable Gauge ⇨ LastValue
+/// * Histogram ⇨ ExplicitBucketHistogram
+///
+/// [the spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.19.0/specification/metrics/sdk.md#default-aggregation
+fn default_aggregation_selector(kind: InstrumentKind) -> Aggregation {
+    match kind {
+        InstrumentKind::Counter
+        | InstrumentKind::UpDownCounter
+        | InstrumentKind::ObservableCounter
+        | InstrumentKind::ObservableUpDownCounter => Aggregation::Sum,
+        InstrumentKind::Gauge => Aggregation::LastValue,
+        InstrumentKind::ObservableGauge => Aggregation::LastValue,
+        InstrumentKind::Histogram => Aggregation::ExplicitBucketHistogram {
+            boundaries: vec![
+                0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0,
+                5000.0, 7500.0, 10000.0,
+            ],
+            record_min_max: true,
+        },
+    }
+}
+
 type AggregateFns<T> = (
     Arc<dyn internal::Measure<T>>,
     Box<dyn internal::ComputeAggregation>,
@@ -454,11 +487,7 @@ fn aggregate_fn<T: Number<T>>(
     }
 
     match agg {
-        Aggregation::Default => aggregate_fn(
-            b,
-            &DefaultAggregationSelector::new().aggregation(kind),
-            kind,
-        ),
+        Aggregation::Default => aggregate_fn(b, &default_aggregation_selector(kind), kind),
         Aggregation::Drop => Ok(None),
         Aggregation::LastValue => Ok(Some(box_val(b.last_value()))),
         Aggregation::Sum => {

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -4,7 +4,6 @@ use std::{fmt, sync::Weak};
 use opentelemetry::metrics::Result;
 
 use super::{
-    aggregation::Aggregation,
     data::{ResourceMetrics, ScopeMetrics, Temporality},
     instrument::InstrumentKind,
     pipeline::Pipeline,
@@ -24,9 +23,7 @@ use super::{
 ///
 /// Pull-based exporters will typically implement `MetricReader` themselves,
 /// since they read on demand.
-pub trait MetricReader:
-    AggregationSelector + TemporalitySelector + fmt::Debug + Send + Sync + 'static
-{
+pub trait MetricReader: TemporalitySelector + fmt::Debug + Send + Sync + 'static {
     /// Registers a [MetricReader] with a [Pipeline].
     ///
     /// The pipeline argument allows the `MetricReader` to signal the sdk to collect
@@ -93,67 +90,5 @@ impl DefaultTemporalitySelector {
 impl TemporalitySelector for DefaultTemporalitySelector {
     fn temporality(&self, _kind: InstrumentKind) -> Temporality {
         Temporality::Cumulative
-    }
-}
-
-/// An interface for selecting the aggregation and the parameters for an
-/// [InstrumentKind].
-pub trait AggregationSelector: Send + Sync {
-    /// Selects the aggregation and the parameters to use for that aggregation based on
-    /// the [InstrumentKind].
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation;
-}
-
-impl<T> AggregationSelector for T
-where
-    T: Fn(InstrumentKind) -> Aggregation + Send + Sync,
-{
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        self(kind)
-    }
-}
-
-/// The default aggregation and parameters for an instrument of [InstrumentKind].
-///
-/// This [AggregationSelector] uses the following selection mapping per [the spec]:
-///
-/// * Counter ⇨ Sum
-/// * Observable Counter ⇨ Sum
-/// * UpDownCounter ⇨ Sum
-/// * Observable UpDownCounter ⇨ Sum
-/// * Gauge ⇨ LastValue
-/// * Observable Gauge ⇨ LastValue
-/// * Histogram ⇨ ExplicitBucketHistogram
-///
-/// [the spec]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.19.0/specification/metrics/sdk.md#default-aggregation
-#[derive(Clone, Default, Debug)]
-pub struct DefaultAggregationSelector {
-    pub(crate) _private: (),
-}
-
-impl DefaultAggregationSelector {
-    /// Create a new default aggregation selector.
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl AggregationSelector for DefaultAggregationSelector {
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        match kind {
-            InstrumentKind::Counter
-            | InstrumentKind::UpDownCounter
-            | InstrumentKind::ObservableCounter
-            | InstrumentKind::ObservableUpDownCounter => Aggregation::Sum,
-            InstrumentKind::Gauge => Aggregation::LastValue,
-            InstrumentKind::ObservableGauge => Aggregation::LastValue,
-            InstrumentKind::Histogram => Aggregation::ExplicitBucketHistogram {
-                boundaries: vec![
-                    0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0,
-                    5000.0, 7500.0, 10000.0,
-                ],
-                record_min_max: true,
-            },
-        }
     }
 }

--- a/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
@@ -1,10 +1,7 @@
 use crate::metrics::data::{Histogram, Metric, ResourceMetrics, ScopeMetrics, Temporality};
 use crate::metrics::exporter::PushMetricsExporter;
-use crate::metrics::reader::{
-    AggregationSelector, DefaultAggregationSelector, DefaultTemporalitySelector,
-    TemporalitySelector,
-};
-use crate::metrics::{data, Aggregation, InstrumentKind};
+use crate::metrics::reader::{DefaultTemporalitySelector, TemporalitySelector};
+use crate::metrics::{data, InstrumentKind};
 use async_trait::async_trait;
 use opentelemetry::metrics::MetricsError;
 use opentelemetry::metrics::Result;
@@ -61,7 +58,6 @@ use std::sync::{Arc, Mutex};
 /// ```
 pub struct InMemoryMetricsExporter {
     metrics: Arc<Mutex<VecDeque<ResourceMetrics>>>,
-    aggregation_selector: Arc<dyn AggregationSelector + Send + Sync>,
     temporality_selector: Arc<dyn TemporalitySelector + Send + Sync>,
 }
 
@@ -69,7 +65,6 @@ impl Clone for InMemoryMetricsExporter {
     fn clone(&self) -> Self {
         InMemoryMetricsExporter {
             metrics: self.metrics.clone(),
-            aggregation_selector: self.aggregation_selector.clone(),
             temporality_selector: self.temporality_selector.clone(),
         }
     }
@@ -96,7 +91,6 @@ impl Default for InMemoryMetricsExporter {
 /// let exporter = InMemoryMetricsExporterBuilder::new().build();
 /// ```
 pub struct InMemoryMetricsExporterBuilder {
-    aggregation_selector: Option<Arc<dyn AggregationSelector + Send + Sync>>,
     temporality_selector: Option<Arc<dyn TemporalitySelector + Send + Sync>>,
 }
 
@@ -116,18 +110,8 @@ impl InMemoryMetricsExporterBuilder {
     /// Creates a new instance of the `InMemoryMetricsExporterBuilder`.
     pub fn new() -> Self {
         Self {
-            aggregation_selector: None,
             temporality_selector: None,
         }
-    }
-
-    /// Sets the aggregation selector for the exporter.
-    pub fn with_aggregation_selector<T>(mut self, aggregation_selector: T) -> Self
-    where
-        T: AggregationSelector + Send + Sync + 'static,
-    {
-        self.aggregation_selector = Some(Arc::new(aggregation_selector));
-        self
     }
 
     /// Sets the temporality selector for the exporter.
@@ -144,9 +128,6 @@ impl InMemoryMetricsExporterBuilder {
     pub fn build(self) -> InMemoryMetricsExporter {
         InMemoryMetricsExporter {
             metrics: Arc::new(Mutex::new(VecDeque::new())),
-            aggregation_selector: self
-                .aggregation_selector
-                .unwrap_or_else(|| Arc::new(DefaultAggregationSelector::default())),
             temporality_selector: self
                 .temporality_selector
                 .unwrap_or_else(|| Arc::new(DefaultTemporalitySelector::default())),
@@ -267,12 +248,6 @@ impl InMemoryMetricsExporter {
             // unknown data type
             None
         }
-    }
-}
-
-impl AggregationSelector for InMemoryMetricsExporter {
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        self.aggregation_selector.aggregation(kind)
     }
 }
 

--- a/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
+++ b/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
@@ -1,11 +1,10 @@
 use std::sync::{Arc, Mutex, Weak};
 
 use crate::metrics::{
-    aggregation::Aggregation,
     data::{ResourceMetrics, Temporality},
     instrument::InstrumentKind,
     pipeline::Pipeline,
-    reader::{AggregationSelector, MetricReader, TemporalitySelector},
+    reader::{MetricReader, TemporalitySelector},
 };
 use opentelemetry::metrics::Result;
 
@@ -52,12 +51,6 @@ impl MetricReader for TestMetricReader {
             *is_shutdown = true;
         }
         result
-    }
-}
-
-impl AggregationSelector for TestMetricReader {
-    fn aggregation(&self, _kind: InstrumentKind) -> Aggregation {
-        Aggregation::Drop
     }
 }
 


### PR DESCRIPTION
Hello,

I'm not sure if this is a right way to approach this, but basically I think that `AggregationSelector` trait, and many `with_aggregation_selector` configuration methods on various public SDK types is not needed anymore, because newly introduced [Views](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view) feature fully replaces this trait and removing `AggregationSelector` only makes things simpler/more understandable.

I created this PR as a proof to show that we can simply remove it without loosing any current functionality.

The only issue is this sentence in SDK:
> If the MeterProvider has no View registered, take the Instrument and apply the default Aggregation on the basis of instrument kind according to the [MetricReader](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#metricreader) instance’s aggregation property.

If I'm not missing anything, I think it could be changed to:
> If the MeterProvider has no View registered, take the Instrument and apply the [default aggregation](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#default-aggregation).

What do you think, do you agree, or I'm missing something important here?

## Changes

* Remove `AggregationSelector` trait
* Remove `with_aggregation_selector` configuration function from many public types.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
