### PR TITLE
msrv patch for tokio-stream

### DIFF
--- a/scripts/patch_dependencies.sh
+++ b/scripts/patch_dependencies.sh
@@ -10,3 +10,5 @@ patch_version cc 1.0.105
 patch_version url 2.5.0
 patch_version hyper-rustls 0.27.2 # 0.27.3 needs rustc v1.70.0
 patch_version tokio-util 0.7.11 # 0.7.12 needs rustc v1.70.0
+patch_version tokio-stream 0.1.15 # 0.1.15 needs rustc v1.70.0
+


### PR DESCRIPTION
## Changes

Patching till we decide to bump msrv for opentelemetry-sdk, opentelemetry-http to v1.70

Error: https://github.com/open-telemetry/opentelemetry-rust/actions/runs/10751933526/job/29819701086?pr=2083

```
  Downloaded linux-raw-sys v0.4.14
error: package `tokio-stream v0.1.16` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.65.0
Either upgrade to rustc 1.70 or newer, or use
cargo update -p tokio-stream@0.1.16 --precise ver
where `ver` is the latest version of `tokio-stream` supporting rustc 1.65.0
Error: Process completed with exit code 101.
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
