### PR TITLE
Prepare for 0.25 release

### DIFF
--- a/opentelemetry-appender-log/CHANGELOG.md
+++ b/opentelemetry-appender-log/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+## v0.25.0
+
+- Update `opentelemetry` dependency version to 0.25
+- Starting with this version, this crate will align with `opentelemetry` crate
+  on major,minor versions.
+
 ## v0.5.0
 
 - [1869](https://github.com/open-telemetry/opentelemetry-rust/pull/1869) Utilize the `LogRecord::set_target()` method to pass the log target to the SDK.

--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-appender-log"
-version = "0.5.0"
+version = "0.25.0"
 description = "An OpenTelemetry appender for the log crate"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-log"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-log"
@@ -11,7 +11,7 @@ rust-version = "1.65"
 edition = "2021"
 
 [dependencies]
-opentelemetry = { version = "0.24", path = "../opentelemetry", features = ["logs"]}
+opentelemetry = { version = "0.25", path = "../opentelemetry", features = ["logs"]}
 log = { workspace = true, features = ["kv", "std"]}
 serde = { workspace = true, optional = true, features = ["std"] }
 

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+## v0.25.0
+
+- Update `opentelemetry` dependency version to 0.25
+- Starting with this version, this crate will align with `opentelemetry` crate
+  on major,minor versions.
 - Reduce heap allocation by using `&'static str` for `SeverityText`.
 
 ## v0.5.0

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-appender-tracing"
-version = "0.5.0"
+version = "0.25.0"
 edition = "2021"
 description = "An OpenTelemetry log appender for the tracing crate"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-tracing"
@@ -12,7 +12,7 @@ rust-version = "1.65"
 
 [dependencies]
 log = { workspace = true, optional = true }
-opentelemetry = { version = "0.24", path = "../opentelemetry", features = ["logs"] }
+opentelemetry = { version = "0.25", path = "../opentelemetry", features = ["logs"] }
 tracing = { workspace = true, features = ["std"]}
 tracing-core = { workspace = true }
 tracing-log = { version = "0.2", optional = true }

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+## v0.25.0
+
+- Update `opentelemetry` dependency version to 0.25
+- Starting with this version, this crate will align with `opentelemetry` crate
+  on major,minor versions.
+  
 ## v0.13.0
 
 - **Breaking** Correct the misspelling of "webkpi" to "webpki" in features [#1842](https://github.com/open-telemetry/opentelemetry-rust/pull/1842)

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-http"
-version = "0.13.0"
+version = "0.25.0"
 description = "Helper implementations for sending HTTP requests. Uses include propagating and extracting context over http, exporting telemetry, requesting sampling strategies."
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"
@@ -21,6 +21,6 @@ http = { workspace = true }
 http-body-util = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }
 hyper-util = { workspace = true, features = ["client-legacy", "http2"], optional = true }
-opentelemetry = { version = "0.24", path = "../opentelemetry", features = ["trace"] }
+opentelemetry = { version = "0.25", path = "../opentelemetry", features = ["trace"] }
 reqwest = { workspace = true, features = ["blocking"], optional = true }
 tokio = { workspace = true, features = ["time"], optional = true }

--- a/opentelemetry-jaeger-propagator/CHANGELOG.md
+++ b/opentelemetry-jaeger-propagator/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+## v0.25.0
+
+- Update `opentelemetry` dependency version to 0.25
+- Starting with this version, this crate will align with `opentelemetry` crate
+  on major,minor versions.
+  
 ## v0.3.0
 - Update `opentelemetry` dependency version to 0.24
 

--- a/opentelemetry-jaeger-propagator/Cargo.toml
+++ b/opentelemetry-jaeger-propagator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-jaeger-propagator"
-version = "0.3.0"
+version = "0.25.0"
 description = "Jaeger propagator for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger-propagator"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger-propagator"
@@ -20,7 +20,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-opentelemetry = { version = "0.24", default-features = false, features = [
+opentelemetry = { version = "0.25", default-features = false, features = [
     "trace",
 ], path = "../opentelemetry" }
 

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## vNext
 
+## v0.25.0
+
+- Update `opentelemetry` dependency version to 0.25
+- Update `opentelemetry_sdk` dependency version to 0.25
+- Update `opentelemetry-http` dependency version to 0.25
+- Update `opentelemetry-proto` dependency version to 0.25
+- Starting with this version, this crate will align with `opentelemetry` crate
+  on major,minor versions.
 - **Breaking**
 The logrecord event-name is added as an attribute only if the feature flag
 `populate-logs-event-name` is enabled. The name of the attribute is changed from

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-otlp"
-version = "0.17.0"
+version = "0.25.0"
 description = "Exporter for the OpenTelemetry Collector"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp"
@@ -28,10 +28,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-trait = { workspace = true }
 futures-core = { workspace = true }
-opentelemetry = { version = "0.24", default-features = false, path = "../opentelemetry" }
-opentelemetry_sdk = { version = "0.24", default-features = false, path = "../opentelemetry-sdk" }
-opentelemetry-http = { version = "0.13", path = "../opentelemetry-http", optional = true }
-opentelemetry-proto = { version = "0.7", path = "../opentelemetry-proto", default-features = false }
+opentelemetry = { version = "0.25", default-features = false, path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.25", default-features = false, path = "../opentelemetry-sdk" }
+opentelemetry-http = { version = "0.25", path = "../opentelemetry-http", optional = true }
+opentelemetry-proto = { version = "0.25", path = "../opentelemetry-proto", default-features = false }
 
 prost = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
 ## vNext
--  Update protobuf definitions to v1.3.2 [#1945](https://github.com/open-telemetry/opentelemetry-rust/pull/1945)
+
+## v0.25.0
+- Update `opentelemetry` dependency version to 0.25
+- Update `opentelemetry_sdk` dependency version to 0.25
+- Starting with this version, this crate will align with `opentelemetry` crate
+  on major,minor versions.
+- Update protobuf definitions to v1.3.2 [#1945](https://github.com/open-telemetry/opentelemetry-rust/pull/1945)
 
 ## v0.7.0
 

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -58,7 +58,7 @@ serde = { workspace = true, optional = true, features = ["serde_derive"] }
 hex = { version = "0.4.3", optional = true }
 
 [dev-dependencies]
-opentelemetry = { version = "0.24", features = ["testing"], path = "../opentelemetry" }
+opentelemetry = { features = ["testing"], path = "../opentelemetry" }
 tonic-build = { workspace = true }
 prost-build = { workspace = true }
 tempfile = "3.3.0"

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-proto"
-version = "0.7.0"
+version = "0.25.0"
 description = "Protobuf generated files and transformations."
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto"
@@ -51,8 +51,8 @@ populate-logs-event-name = []
 [dependencies]
 tonic = { workspace = true, optional = true, features = ["codegen", "prost"] }
 prost = { workspace = true, optional = true }
-opentelemetry = { version = "0.24", default-features = false, path = "../opentelemetry" }
-opentelemetry_sdk = { version = "0.24", default-features = false, path = "../opentelemetry-sdk" }
+opentelemetry = { version = "0.25", default-features = false, path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.25", default-features = false, path = "../opentelemetry-sdk" }
 schemars = { version = "0.8", optional = true }
 serde = { workspace = true, optional = true, features = ["serde_derive"] }
 hex = { version = "0.4.3", optional = true }

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## v0.25.0
 
+- Update `opentelemetry` dependency version to 0.25
+- Starting with this version, this crate will align with `opentelemetry` crate
+  on major,minor versions.
 - Perf improvements for all metric instruments (except `ExponentialHistogram`) that led to **faster metric updates** and **higher throughput** [#1740](https://github.com/open-telemetry/opentelemetry-rust/pull/1740):
   - **Zero allocations when recording measurements**: Once a measurement for a given attribute combination is reported, the SDK would not allocate additional memory for subsquent measurements reported for the same combination.
   - **Minimized thread contention**: Threads reporting measurements for the same instrument no longer contest for the same `Mutex`. The internal aggregation data structure now uses a combination of `RwLock` and atomics. Consequently, threads reporting measurements now only have to acquire a read lock.

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.25.0
+
 - Perf improvements for all metric instruments (except `ExponentialHistogram`) that led to **faster metric updates** and **higher throughput** [#1740](https://github.com/open-telemetry/opentelemetry-rust/pull/1740):
   - **Zero allocations when recording measurements**: Once a measurement for a given attribute combination is reported, the SDK would not allocate additional memory for subsquent measurements reported for the same combination.
   - **Minimized thread contention**: Threads reporting measurements for the same instrument no longer contest for the same `Mutex`. The internal aggregation data structure now uses a combination of `RwLock` and atomics. Consequently, threads reporting measurements now only have to acquire a read lock.

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-opentelemetry = { version = "0.24", path = "../opentelemetry/" }
-opentelemetry-http = { version = "0.13", path = "../opentelemetry-http", optional = true }
+opentelemetry = { version = "0.25", path = "../opentelemetry/" }
+opentelemetry-http = { version = "0.25", path = "../opentelemetry-http", optional = true }
 async-std = { workspace = true, features = ["unstable"], optional = true }
 async-trait = { workspace = true, optional = true }
 futures-channel = "0.3"

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry_sdk"
-version = "0.24.1"
+version = "0.25.0"
 description = "The SDK for the OpenTelemetry metrics collection and distributed tracing framework"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"

--- a/opentelemetry-semantic-conventions/CHANGELOG.md
+++ b/opentelemetry-semantic-conventions/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## vNext
 
+## v0.25.0
 ### Changed
 
+- Starting with this version, this crate will align with `opentelemetry` crate
+  on major,minor versions.
 - Update to [v1.27.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.27.0) of the semantic conventions.
   [#2000](https://github.com/open-telemetry/opentelemetry-rust/pull/2000)
 

--- a/opentelemetry-semantic-conventions/Cargo.toml
+++ b/opentelemetry-semantic-conventions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-semantic-conventions"
-version = "0.16.0"
+version = "0.25.0"
 description = "Semantic conventions for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-semantic-conventions"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-semantic-conventions"

--- a/opentelemetry-stdout/CHANGELOG.md
+++ b/opentelemetry-stdout/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+## v0.25.0
+
+- Update `opentelemetry` dependency version to 0.25
+- Update `opentelemetry_sdk` dependency version to 0.25
+- Starting with this version, this crate will align with `opentelemetry` crate
+  on major,minor versions.
 - **Breaking** [1994](https://github.com/open-telemetry/opentelemetry-rust/pull/1994) The logrecord event-name is added as attribute with
 key `name` only if the feature flag `populate-logs-event-name` is enabled.
 - **Breaking** [2040](https://github.com/open-telemetry/opentelemetry-rust/pull/2040) Simplified stdout exporter:

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-stdout"
-version = "0.5.0"
+version = "0.25.0"
 description = "An OpenTelemetry exporter for stdout"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-stdout"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-stdout"
@@ -31,8 +31,8 @@ async-trait = { workspace = true, optional = true }
 chrono = { version = "0.4.34", default-features = false, features = ["now"] }
 thiserror = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
-opentelemetry = { version = "0.24", path = "../opentelemetry" }
-opentelemetry_sdk = { version = "0.24", path = "../opentelemetry-sdk" }
+opentelemetry = { version = "0.25", path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.25", path = "../opentelemetry-sdk" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 ordered-float = { workspace = true }

--- a/opentelemetry-zipkin/CHANGELOG.md
+++ b/opentelemetry-zipkin/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## vNext
 
+## v0.25.0
+
+- Update `opentelemetry` dependency version to 0.25
+- Update `opentelemetry_sdk` dependency version to 0.25
+- Update `opentelemetry-http` dependency version to 0.25
+- Update `opentelemetry-semantic-conventions` dependency version to 0.25
+- Starting with this version, this crate will align with `opentelemetry` crate
+  on major,minor versions.
+
 ## v0.22.0
 
 ### Changed

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-zipkin"
-version = "0.22.0"
+version = "0.25.0"
 description = "Zipkin exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-zipkin"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-zipkin"
@@ -28,10 +28,10 @@ reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
 [dependencies]
 async-trait = { workspace = true }
 once_cell = { workspace = true }
-opentelemetry = { version = "0.24", path = "../opentelemetry" }
-opentelemetry_sdk = { version = "0.24", path = "../opentelemetry-sdk", features = ["trace"] }
-opentelemetry-http = { version = "0.13", path = "../opentelemetry-http" }
-opentelemetry-semantic-conventions = { version = "0.16", path = "../opentelemetry-semantic-conventions" }
+opentelemetry = { version = "0.25", path = "../opentelemetry" }
+opentelemetry_sdk = { version = "0.25", path = "../opentelemetry-sdk", features = ["trace"] }
+opentelemetry-http = { version = "0.15", path = "../opentelemetry-http" }
+opentelemetry-semantic-conventions = { version = "0.15", path = "../opentelemetry-semantic-conventions" }
 serde_json = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 typed-builder = "0.18"

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -30,8 +30,8 @@ async-trait = { workspace = true }
 once_cell = { workspace = true }
 opentelemetry = { version = "0.25", path = "../opentelemetry" }
 opentelemetry_sdk = { version = "0.25", path = "../opentelemetry-sdk", features = ["trace"] }
-opentelemetry-http = { version = "0.15", path = "../opentelemetry-http" }
-opentelemetry-semantic-conventions = { version = "0.15", path = "../opentelemetry-semantic-conventions" }
+opentelemetry-http = { version = "0.25", path = "../opentelemetry-http" }
+opentelemetry-semantic-conventions = { version = "0.25", path = "../opentelemetry-semantic-conventions" }
 serde_json = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 typed-builder = "0.18"

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+## v0.25.0
+
 - **BREAKING** [#1993](https://github.com/open-telemetry/opentelemetry-rust/pull/1993) Box complex types in AnyValue enum
 Before:
 ```rust

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry"
-version = "0.24.0"
+version = "0.25.0"
 description = "OpenTelemetry API for Rust"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"


### PR DESCRIPTION
Preparing for the release (Sorry for the delays!).
The version is now unified as discussed in https://github.com/open-telemetry/opentelemetry-rust/issues/2084, so this is "0.25.0" release of OpenTelemetry Core Components.