### PR TITLE
Update KeyValue to avoid copying non-static string slices

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -3,7 +3,7 @@ use opentelemetry::{
     global,
     metrics::MetricsError,
     trace::{TraceContextExt, TraceError, Tracer, TracerProvider as _},
-    Key, KeyValue,
+    KeyValue,
 };
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::Protocol;
@@ -146,7 +146,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let span = cx.span();
         span.add_event(
             "Nice operation!".to_string(),
-            vec![Key::new("bogons").i64(100)],
+            vec![KeyValue::new("bogons", 100)],
         );
         span.set_attribute(KeyValue::new("another.key", "yes"));
 

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -5,7 +5,7 @@ use opentelemetry::metrics::MetricsError;
 use opentelemetry::trace::{TraceError, TracerProvider};
 use opentelemetry::{
     trace::{TraceContextExt, Tracer},
-    Key, KeyValue,
+    KeyValue,
 };
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{ExportConfig, WithExportConfig};
@@ -136,7 +136,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let span = cx.span();
         span.add_event(
             "Nice operation!".to_string(),
-            vec![Key::new("bogons").i64(100)],
+            vec![KeyValue::new("bogons", 100)],
         );
         span.set_attribute(KeyValue::new("another.key", "yes"));
 

--- a/opentelemetry-otlp/tests/integration_test/tests/traces.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/traces.rs
@@ -41,7 +41,7 @@ pub async fn traces() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let span = cx.span();
         span.add_event(
             "Nice operation!".to_string(),
-            vec![Key::new("bogons").i64(100)],
+            vec![KeyValue::new("bogons", 100)],
         );
         span.set_attribute(KeyValue::new(ANOTHER_KEY, "yes"));
 

--- a/opentelemetry-proto/src/transform/common.rs
+++ b/opentelemetry-proto/src/transform/common.rs
@@ -112,8 +112,8 @@ pub mod tonic {
     #[derive(Default, Debug)]
     pub struct Attributes(pub ::std::vec::Vec<crate::proto::tonic::common::v1::KeyValue>);
 
-    impl From<Vec<opentelemetry::KeyValue>> for Attributes {
-        fn from(kvs: Vec<opentelemetry::KeyValue>) -> Self {
+    impl From<Vec<opentelemetry::KeyValue<'static>>> for Attributes {
+        fn from(kvs: Vec<opentelemetry::KeyValue<'static>>) -> Self {
             Attributes(
                 kvs.into_iter()
                     .map(|api_kv| KeyValue {
@@ -139,19 +139,19 @@ pub mod tonic {
         }
     }
 
-    impl From<Value> for AnyValue {
+    impl From<Value<'static>> for AnyValue {
         fn from(value: Value) -> Self {
             AnyValue {
                 value: match value {
-                    Value::Bool(val) => Some(any_value::Value::BoolValue(val)),
-                    Value::I64(val) => Some(any_value::Value::IntValue(val)),
-                    Value::F64(val) => Some(any_value::Value::DoubleValue(val)),
+                    Value::Bool(val) => Some(any_value::Value::BoolValue(*val)),
+                    Value::I64(val) => Some(any_value::Value::IntValue(*val)),
+                    Value::F64(val) => Some(any_value::Value::DoubleValue(*val)),
                     Value::String(val) => Some(any_value::Value::StringValue(val.to_string())),
                     Value::Array(array) => Some(any_value::Value::ArrayValue(match array {
-                        Array::Bool(vals) => array_into_proto(vals),
-                        Array::I64(vals) => array_into_proto(vals),
-                        Array::F64(vals) => array_into_proto(vals),
-                        Array::String(vals) => array_into_proto(vals),
+                        Array::Bool(vals) => array_into_proto(vals.to_vec()),
+                        Array::I64(vals) => array_into_proto(vals.to_vec()),
+                        Array::F64(vals) => array_into_proto(vals.to_vec()),
+                        Array::String(vals) => array_into_proto(vals.to_vec()),
                     })),
                 },
             }
@@ -160,7 +160,7 @@ pub mod tonic {
 
     fn array_into_proto<T>(vals: Vec<T>) -> ArrayValue
     where
-        Value: From<T>,
+        Value<'static>: From<T>,
     {
         let values = vals
             .into_iter()

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -73,8 +73,8 @@ pub mod tonic {
         }
     }
 
-    impl From<(&Key, &Value)> for KeyValue {
-        fn from(kv: (&Key, &Value)) -> Self {
+    impl From<(&Key, &Value<'static>)> for KeyValue {
+        fn from(kv: (&Key, &Value<'static>)) -> Self {
             KeyValue {
                 key: kv.0.to_string(),
                 value: Some(kv.1.clone().into()),
@@ -82,8 +82,8 @@ pub mod tonic {
         }
     }
 
-    impl From<&opentelemetry::KeyValue> for KeyValue {
-        fn from(kv: &opentelemetry::KeyValue) -> Self {
+    impl From<&opentelemetry::KeyValue<'static>> for KeyValue {
+        fn from(kv: &opentelemetry::KeyValue<'static>) -> Self {
             KeyValue {
                 key: kv.key.to_string(),
                 value: Some(kv.value.clone().into()),

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use futures_util::future::BoxFuture;
 use opentelemetry::{
     trace::{Span, Tracer, TracerProvider},
-    Key,
+    KeyValue,
 };
 use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
@@ -16,42 +16,42 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     trace_benchmark_group(c, "start-end-span-4-attrs", |tracer| {
         let mut span = tracer.start("foo");
-        span.set_attribute(Key::new("key1").bool(false));
-        span.set_attribute(Key::new("key2").string("hello"));
-        span.set_attribute(Key::new("key4").f64(123.456));
+        span.set_attribute(KeyValue::new("key1", false));
+        span.set_attribute(KeyValue::new("key2", "hello"));
+        span.set_attribute(KeyValue::new("key4", 123.456));
         span.end();
     });
 
     trace_benchmark_group(c, "start-end-span-8-attrs", |tracer| {
         let mut span = tracer.start("foo");
-        span.set_attribute(Key::new("key1").bool(false));
-        span.set_attribute(Key::new("key2").string("hello"));
-        span.set_attribute(Key::new("key4").f64(123.456));
-        span.set_attribute(Key::new("key11").bool(false));
-        span.set_attribute(Key::new("key12").string("hello"));
-        span.set_attribute(Key::new("key14").f64(123.456));
+        span.set_attribute(KeyValue::new("key1", false));
+        span.set_attribute(KeyValue::new("key2", "hello"));
+        span.set_attribute(KeyValue::new("key4", 123.456));
+        span.set_attribute(KeyValue::new("key11", false));
+        span.set_attribute(KeyValue::new("key12", "hello"));
+        span.set_attribute(KeyValue::new("key14", 123.456));
         span.end();
     });
 
     trace_benchmark_group(c, "start-end-span-all-attr-types", |tracer| {
         let mut span = tracer.start("foo");
-        span.set_attribute(Key::new("key1").bool(false));
-        span.set_attribute(Key::new("key2").string("hello"));
-        span.set_attribute(Key::new("key3").i64(123));
-        span.set_attribute(Key::new("key5").f64(123.456));
+        span.set_attribute(KeyValue::new("key1", false));
+        span.set_attribute(KeyValue::new("key2", "hello"));
+        span.set_attribute(KeyValue::new("key3", 123));
+        span.set_attribute(KeyValue::new("key5", 123.456));
         span.end();
     });
 
     trace_benchmark_group(c, "start-end-span-all-attr-types-2x", |tracer| {
         let mut span = tracer.start("foo");
-        span.set_attribute(Key::new("key1").bool(false));
-        span.set_attribute(Key::new("key2").string("hello"));
-        span.set_attribute(Key::new("key3").i64(123));
-        span.set_attribute(Key::new("key5").f64(123.456));
-        span.set_attribute(Key::new("key11").bool(false));
-        span.set_attribute(Key::new("key12").string("hello"));
-        span.set_attribute(Key::new("key13").i64(123));
-        span.set_attribute(Key::new("key15").f64(123.456));
+        span.set_attribute(KeyValue::new("key1", false));
+        span.set_attribute(KeyValue::new("key2", "hello"));
+        span.set_attribute(KeyValue::new("key3", 123));
+        span.set_attribute(KeyValue::new("key5", 123.456));
+        span.set_attribute(KeyValue::new("key11", false));
+        span.set_attribute(KeyValue::new("key12", "hello"));
+        span.set_attribute(KeyValue::new("key13", 123));
+        span.set_attribute(KeyValue::new("key15", 123.456));
         span.end();
     });
 }

--- a/opentelemetry-sdk/src/export/trace.rs
+++ b/opentelemetry-sdk/src/export/trace.rs
@@ -85,7 +85,7 @@ pub struct SpanData {
     /// Span end time
     pub end_time: SystemTime,
     /// Span attributes
-    pub attributes: Vec<KeyValue>,
+    pub attributes: Vec<KeyValue<'static>>,
     /// The number of attributes that were above the configured limit, and thus
     /// dropped.
     pub dropped_attributes_count: u32,

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -46,7 +46,7 @@ impl opentelemetry::logs::LoggerProvider for LoggerProvider {
         name: impl Into<Cow<'static, str>>,
         version: Option<Cow<'static, str>>,
         schema_url: Option<Cow<'static, str>>,
-        attributes: Option<Vec<opentelemetry::KeyValue>>,
+        attributes: Option<Vec<opentelemetry::KeyValue<'static>>>,
     ) -> Logger {
         let name = name.into();
 

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -97,7 +97,7 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Sum<T> {
 pub struct DataPoint<T> {
     /// Attributes is the set of key value pairs that uniquely identify the
     /// time series.
-    pub attributes: Vec<KeyValue>,
+    pub attributes: Vec<KeyValue<'static>>,
     /// The time when the time series was started.
     pub start_time: Option<SystemTime>,
     /// The time when the time series was recorded.
@@ -143,7 +143,7 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Histogram<T> {
 #[derive(Debug)]
 pub struct HistogramDataPoint<T> {
     /// The set of key value pairs that uniquely identify the time series.
-    pub attributes: Vec<KeyValue>,
+    pub attributes: Vec<KeyValue<'static>>,
     /// The time when the time series was started.
     pub start_time: SystemTime,
     /// The time when the time series was recorded.
@@ -210,7 +210,7 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for ExponentialHistogram
 #[derive(Debug)]
 pub struct ExponentialHistogramDataPoint<T> {
     /// The set of key value pairs that uniquely identify the time series.
-    pub attributes: Vec<KeyValue>,
+    pub attributes: Vec<KeyValue<'static>>,
     /// When the time series was started.
     pub start_time: SystemTime,
     /// The time when the time series was recorded.
@@ -273,7 +273,7 @@ pub struct ExponentialBucket {
 pub struct Exemplar<T> {
     /// The attributes recorded with the measurement but filtered out of the
     /// time series' aggregated data.
-    pub filtered_attributes: Vec<KeyValue>,
+    pub filtered_attributes: Vec<KeyValue<'static>>,
     /// The time when the measurement was recorded.
     pub time: SystemTime,
     /// The measured value.

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -253,7 +253,7 @@ pub(crate) struct ResolvedMeasures<T> {
 }
 
 impl<T: Copy + 'static> SyncCounter<T> for ResolvedMeasures<T> {
-    fn add(&self, val: T, attrs: &[KeyValue]) {
+    fn add(&self, val: T, attrs: &[KeyValue<'_>]) {
         for measure in &self.measures {
             measure.call(val, attrs)
         }
@@ -261,7 +261,7 @@ impl<T: Copy + 'static> SyncCounter<T> for ResolvedMeasures<T> {
 }
 
 impl<T: Copy + 'static> SyncUpDownCounter<T> for ResolvedMeasures<T> {
-    fn add(&self, val: T, attrs: &[KeyValue]) {
+    fn add(&self, val: T, attrs: &[KeyValue<'_>]) {
         for measure in &self.measures {
             measure.call(val, attrs)
         }
@@ -269,7 +269,7 @@ impl<T: Copy + 'static> SyncUpDownCounter<T> for ResolvedMeasures<T> {
 }
 
 impl<T: Copy + 'static> SyncGauge<T> for ResolvedMeasures<T> {
-    fn record(&self, val: T, attrs: &[KeyValue]) {
+    fn record(&self, val: T, attrs: &[KeyValue<'_>]) {
         for measure in &self.measures {
             measure.call(val, attrs)
         }
@@ -277,7 +277,7 @@ impl<T: Copy + 'static> SyncGauge<T> for ResolvedMeasures<T> {
 }
 
 impl<T: Copy + 'static> SyncHistogram<T> for ResolvedMeasures<T> {
-    fn record(&self, val: T, attrs: &[KeyValue]) {
+    fn record(&self, val: T, attrs: &[KeyValue<'_>]) {
         for measure in &self.measures {
             measure.call(val, attrs)
         }
@@ -296,7 +296,7 @@ impl<T> Observable<T> {
 }
 
 impl<T: Copy + Send + Sync + 'static> AsyncInstrument<T> for Observable<T> {
-    fn observe(&self, measurement: T, attrs: &[KeyValue]) {
+    fn observe(&self, measurement: T, attrs: &[KeyValue<'_>]) {
         for measure in &self.measures {
             measure.call(measurement, attrs)
         }

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -340,7 +340,7 @@ impl<T: Number<T>> ExpoHistogram<T> {
         }
     }
 
-    pub(crate) fn measure(&self, value: T, attrs: &[KeyValue]) {
+    pub(crate) fn measure(&self, value: T, attrs: &[KeyValue<'_>]) {
         let f_value = value.into_float();
         // Ignore NaN and infinity.
         if f_value.is_infinite() || f_value.is_nan() {

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -120,7 +120,7 @@ impl<T: Number<T>> Histogram<T> {
         histogram
     }
 
-    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
+    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue<'_>]) {
         let f = measurement.into_float();
 
         // This search will return an index in the range `[0, bounds.len()]`, where

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -23,7 +23,7 @@ impl<T: Number<T>> LastValue<T> {
         }
     }
 
-    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
+    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue<'_>]) {
         // The argument index is not applicable to LastValue.
         self.value_map.measure(measurement, attrs, 0);
     }

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -14,7 +14,7 @@ pub(crate) struct PrecomputedSum<T: Number<T>> {
     value_map: ValueMap<T, T, Assign>,
     monotonic: bool,
     start: Mutex<SystemTime>,
-    reported: Mutex<HashMap<Vec<KeyValue>, T>>,
+    reported: Mutex<HashMap<Vec<KeyValue<'static>>, T>>,
 }
 
 impl<T: Number<T>> PrecomputedSum<T> {
@@ -27,7 +27,7 @@ impl<T: Number<T>> PrecomputedSum<T> {
         }
     }
 
-    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
+    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue<'_>]) {
         // The argument index is not applicable to PrecomputedSum.
         self.value_map.measure(measurement, attrs, 0);
     }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -31,7 +31,7 @@ impl<T: Number<T>> Sum<T> {
         }
     }
 
-    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
+    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue<'_>]) {
         // The argument index is not applicable to Sum.
         self.value_map.measure(measurement, attrs, 0);
     }

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -142,7 +142,7 @@ impl MeterProvider for SdkMeterProvider {
         name: impl Into<Cow<'static, str>>,
         version: Option<impl Into<Cow<'static, str>>>,
         schema_url: Option<impl Into<Cow<'static, str>>>,
-        attributes: Option<Vec<KeyValue>>,
+        attributes: Option<Vec<KeyValue<'static>>>,
     ) -> Meter {
         if self.inner.is_shutdown.load(Ordering::Relaxed) {
             return Meter::new(Arc::new(NoopMeterCore::new()));

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -367,10 +367,9 @@ where
         let mut cache = self.aggregators.lock()?;
 
         let cached = cache.entry(id).or_insert_with(|| {
-            let filter = stream
-                .allowed_attribute_keys
-                .clone()
-                .map(|allowed| Arc::new(move |kv: &KeyValue| allowed.contains(&kv.key)) as Arc<_>);
+            let filter = stream.allowed_attribute_keys.clone().map(|allowed| {
+                Arc::new(move |kv: &KeyValue<'_>| allowed.contains(&kv.key)) as Arc<_>
+            });
 
             let b = AggregateBuilder::new(Some(self.pipeline.reader.temporality(kind)), filter);
             let (m, ca) = match aggregate_fn(b, &agg, kind) {

--- a/opentelemetry-sdk/src/propagation/baggage.rs
+++ b/opentelemetry-sdk/src/propagation/baggage.rs
@@ -25,7 +25,7 @@ static BAGGAGE_FIELDS: Lazy<[String; 1]> = Lazy::new(|| [BAGGAGE_HEADER.to_owned
 /// # Examples
 ///
 /// ```
-/// use opentelemetry::{baggage::BaggageExt, Key, propagation::TextMapPropagator};
+/// use opentelemetry::{baggage::BaggageExt, Key, KeyValue, propagation::TextMapPropagator};
 /// use opentelemetry_sdk::propagation::BaggagePropagator;
 /// use std::collections::HashMap;
 ///
@@ -43,7 +43,7 @@ static BAGGAGE_FIELDS: Lazy<[String; 1]> = Lazy::new(|| [BAGGAGE_HEADER.to_owned
 /// }
 ///
 /// // Add new baggage
-/// let cx_with_additions = cx.with_baggage(vec![Key::new("server_id").i64(42)]);
+/// let cx_with_additions = cx.with_baggage(vec![KeyValue::new("server_id", 42)]);
 ///
 /// // Inject baggage into http request
 /// propagator.inject_context(&cx_with_additions, &mut headers);
@@ -159,7 +159,7 @@ mod tests {
     use std::collections::HashMap;
 
     #[rustfmt::skip]
-    fn valid_extract_data() -> Vec<(&'static str, HashMap<Key, Value>)> {
+    fn valid_extract_data() -> Vec<(&'static str, HashMap<Key, Value<'static>>)> {
         vec![
             // "valid w3cHeader"
             ("key1=val1,key2=val2", vec![(Key::new("key1"), Value::from("val1")), (Key::new("key2"), Value::from("val2"))].into_iter().collect()),
@@ -176,7 +176,7 @@ mod tests {
 
     #[rustfmt::skip]
     #[allow(clippy::type_complexity)]
-    fn valid_extract_data_with_metadata() -> Vec<(&'static str, HashMap<Key, (Value, BaggageMetadata)>)> {
+    fn valid_extract_data_with_metadata() -> Vec<(&'static str, HashMap<Key, (Value<'static>, BaggageMetadata)>)> {
         vec![
             // "valid w3cHeader with properties"
             ("key1=val1,key2=val2;prop=1", vec![(Key::new("key1"), (Value::from("val1"), BaggageMetadata::default())), (Key::new("key2"), (Value::from("val2"), BaggageMetadata::from("prop=1")))].into_iter().collect()),
@@ -192,7 +192,7 @@ mod tests {
     }
 
     #[rustfmt::skip]
-    fn valid_inject_data() -> Vec<(Vec<KeyValue>, Vec<&'static str>)> {
+    fn valid_inject_data() -> Vec<(Vec<KeyValue<'static>>, Vec<&'static str>)> {
         vec![
             // "two simple values"
             (vec![KeyValue::new("key1", "val1"), KeyValue::new("key2", "val2")], vec!["key1=val1", "key2=val2"]),
@@ -202,8 +202,8 @@ mod tests {
             (
                 vec![
                     KeyValue::new("key1", true),
-                    KeyValue::new("key2", Value::I64(123)),
-                    KeyValue::new("key3", Value::F64(123.567)),
+                    KeyValue::new("key2", 123),
+                    KeyValue::new("key3", 123.567),
                 ],
                 vec![
                     "key1=true",
@@ -214,9 +214,9 @@ mod tests {
             // "values of array types"
             (
                 vec![
-                    KeyValue::new("key1", Value::Array(vec![true, false].into())),
-                    KeyValue::new("key2", Value::Array(vec![123, 456].into())),
-                    KeyValue::new("key3", Value::Array(vec![StringValue::from("val1"), StringValue::from("val2")].into())),
+                    KeyValue::new("key1", Value::Array(vec![true, false].as_slice().into())),
+                    KeyValue::new("key2", Value::Array(vec![123, 456].as_slice().into())),
+                    KeyValue::new("key3", Value::Array(vec![StringValue::from("val1"), StringValue::from("val2")].as_slice().into())),
                 ],
                 vec![
                     "key1=[true%2Cfalse]",

--- a/opentelemetry-sdk/src/resource/mod.rs
+++ b/opentelemetry-sdk/src/resource/mod.rs
@@ -41,7 +41,7 @@ use std::time::Duration;
 /// This structure is designed to be shared among `Resource` instances via `Arc`.
 #[derive(Debug, Clone, PartialEq)]
 struct ResourceInner {
-    attrs: HashMap<Key, Value>,
+    attrs: HashMap<Key, Value<'static>>,
     schema_url: Option<Cow<'static, str>>,
 }
 
@@ -81,7 +81,7 @@ impl Resource {
     ///
     /// Values are de-duplicated by key, and the first key-value pair with a non-empty string value
     /// will be retained
-    pub fn new<T: IntoIterator<Item = KeyValue>>(kvs: T) -> Self {
+    pub fn new<T: IntoIterator<Item = KeyValue<'static>>>(kvs: T) -> Self {
         let mut attrs = HashMap::new();
         for kv in kvs {
             attrs.insert(kv.key, kv.value);
@@ -105,7 +105,7 @@ impl Resource {
     /// [schema url]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/schemas/overview.md#schema-url
     pub fn from_schema_url<KV, S>(kvs: KV, schema_url: S) -> Self
     where
-        KV: IntoIterator<Item = KeyValue>,
+        KV: IntoIterator<Item = KeyValue<'static>>,
         S: Into<Cow<'static, str>>,
     {
         let schema_url_str = schema_url.into();
@@ -215,17 +215,17 @@ impl Resource {
     }
 
     /// Retrieve the value from resource associate with given key.
-    pub fn get(&self, key: Key) -> Option<Value> {
+    pub fn get(&self, key: Key) -> Option<Value<'static>> {
         self.inner.attrs.get(&key).cloned()
     }
 }
 
 /// An iterator over the entries of a `Resource`.
 #[derive(Debug)]
-pub struct Iter<'a>(hash_map::Iter<'a, Key, Value>);
+pub struct Iter<'a>(hash_map::Iter<'a, Key, Value<'static>>);
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = (&'a Key, &'a Value);
+    type Item = (&'a Key, &'a Value<'static>);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
@@ -233,7 +233,7 @@ impl<'a> Iterator for Iter<'a> {
 }
 
 impl<'a> IntoIterator for &'a Resource {
-    type Item = (&'a Key, &'a Value);
+    type Item = (&'a Key, &'a Value<'static>);
     type IntoIter = Iter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -271,7 +271,7 @@ mod tests {
             _trace_id: TraceId,
             _name: &str,
             _span_kind: &SpanKind,
-            _attributes: &[KeyValue],
+            _attributes: &[KeyValue<'static>],
             _links: &[Link],
         ) -> SamplingResult {
             let trace_state = parent_context

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -189,7 +189,7 @@ impl opentelemetry::trace::TracerProvider for TracerProvider {
         name: impl Into<Cow<'static, str>>,
         version: Option<impl Into<Cow<'static, str>>>,
         schema_url: Option<impl Into<Cow<'static, str>>>,
-        attributes: Option<Vec<opentelemetry::KeyValue>>,
+        attributes: Option<Vec<opentelemetry::KeyValue<'static>>>,
     ) -> Self::Tracer {
         // Use default value if name is invalid empty string
         let name = name.into();

--- a/opentelemetry-sdk/src/trace/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler.rs
@@ -77,7 +77,7 @@ pub trait ShouldSample: CloneShouldSample + Send + Sync + std::fmt::Debug {
         trace_id: TraceId,
         name: &str,
         span_kind: &SpanKind,
-        attributes: &[KeyValue],
+        attributes: &[KeyValue<'static>],
         links: &[Link],
     ) -> SamplingResult;
 }
@@ -169,7 +169,7 @@ impl ShouldSample for Sampler {
         trace_id: TraceId,
         name: &str,
         span_kind: &SpanKind,
-        attributes: &[KeyValue],
+        attributes: &[KeyValue<'static>],
         links: &[Link],
     ) -> SamplingResult {
         let decision = match self {

--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
@@ -251,7 +251,7 @@ impl ShouldSample for JaegerRemoteSampler {
         trace_id: TraceId,
         name: &str,
         span_kind: &SpanKind,
-        attributes: &[KeyValue],
+        attributes: &[KeyValue<'static>],
         links: &[Link],
     ) -> SamplingResult {
         self.inner

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -36,7 +36,7 @@ pub(crate) struct SpanData {
     /// Span end time
     pub(crate) end_time: SystemTime,
     /// Span attributes
-    pub(crate) attributes: Vec<KeyValue>,
+    pub(crate) attributes: Vec<KeyValue<'static>>,
     /// The number of attributes that were above the configured limit, and thus
     /// dropped.
     pub(crate) dropped_attributes_count: u32,
@@ -93,7 +93,7 @@ impl opentelemetry::trace::Span for Span {
         &mut self,
         name: T,
         timestamp: SystemTime,
-        mut attributes: Vec<KeyValue>,
+        mut attributes: Vec<KeyValue<'static>>,
     ) where
         T: Into<Cow<'static, str>>,
     {
@@ -134,7 +134,7 @@ impl opentelemetry::trace::Span for Span {
     /// Note that the OpenTelemetry project documents certain ["standard
     /// attributes"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
     /// that have prescribed semantic meanings.
-    fn set_attribute(&mut self, attribute: KeyValue) {
+    fn set_attribute(&mut self, attribute: KeyValue<'static>) {
         let span_attribute_limit = self.span_limits.max_attributes_per_span as usize;
         self.with_data(|data| {
             if data.attributes.len() < span_attribute_limit {
@@ -170,7 +170,7 @@ impl opentelemetry::trace::Span for Span {
 
     /// Add `Link` to this `Span`
     ///
-    fn add_link(&mut self, span_context: SpanContext, attributes: Vec<KeyValue>) {
+    fn add_link(&mut self, span_context: SpanContext, attributes: Vec<KeyValue<'static>>) {
         let span_links_limit = self.span_limits.max_links_per_span as usize;
         let link_attributes_limit = self.span_limits.max_attributes_per_link as usize;
         self.with_data(|data| {
@@ -391,7 +391,7 @@ mod tests {
         let attributes = KeyValue::new("k", "v");
         span.set_attribute(attributes.clone());
         span.with_data(|data| {
-            let matching_attribute: Vec<&KeyValue> = data
+            let matching_attribute: Vec<&KeyValue<'static>> = data
                 .attributes
                 .iter()
                 .filter(|kv| kv.key.as_str() == attributes.key.as_str())

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -67,7 +67,7 @@ impl Tracer {
         psc: &SpanContext,
         sc: SpanContext,
         mut builder: SpanBuilder,
-        attrs: Vec<KeyValue>,
+        attrs: Vec<KeyValue<'static>>,
         span_limits: SpanLimits,
     ) -> Span {
         let mut attribute_options = builder.attributes.take().unwrap_or_default();
@@ -315,7 +315,7 @@ mod tests {
             _trace_id: TraceId,
             _name: &str,
             _span_kind: &SpanKind,
-            _attributes: &[KeyValue],
+            _attributes: &[KeyValue<'static>],
             _links: &[Link],
         ) -> SamplingResult {
             let trace_state = parent_context

--- a/opentelemetry-stdout/src/common.rs
+++ b/opentelemetry-stdout/src/common.rs
@@ -124,25 +124,25 @@ impl Hash for Value {
     }
 }
 
-impl From<opentelemetry::Value> for Value {
+impl From<opentelemetry::Value<'_>> for Value {
     fn from(value: opentelemetry::Value) -> Self {
         match value {
-            opentelemetry::Value::Bool(b) => Value::Bool(b),
-            opentelemetry::Value::I64(i) => Value::Int(i),
-            opentelemetry::Value::F64(f) => Value::Double(f),
+            opentelemetry::Value::Bool(b) => Value::Bool(*b),
+            opentelemetry::Value::I64(i) => Value::Int(*i),
+            opentelemetry::Value::F64(f) => Value::Double(*f),
             opentelemetry::Value::String(s) => Value::String(s.into()),
             opentelemetry::Value::Array(a) => match a {
                 opentelemetry::Array::Bool(b) => {
-                    Value::Array(b.into_iter().map(Value::Bool).collect())
+                    Value::Array(b.iter().map(|b| Value::Bool(*b)).collect())
                 }
                 opentelemetry::Array::I64(i) => {
-                    Value::Array(i.into_iter().map(Value::Int).collect())
+                    Value::Array(i.iter().map(|i| Value::Int(*i)).collect())
                 }
                 opentelemetry::Array::F64(f) => {
-                    Value::Array(f.into_iter().map(Value::Double).collect())
+                    Value::Array(f.iter().map(|f| Value::Double(*f)).collect())
                 }
                 opentelemetry::Array::String(s) => {
-                    Value::Array(s.into_iter().map(|s| Value::String(s.into())).collect())
+                    Value::Array(s.iter().map(|s| Value::String(s.clone().into())).collect())
                 }
             },
         }
@@ -190,7 +190,7 @@ impl From<(opentelemetry::Key, opentelemetry::logs::AnyValue)> for KeyValue {
     }
 }
 
-impl From<opentelemetry::KeyValue> for KeyValue {
+impl From<opentelemetry::KeyValue<'_>> for KeyValue {
     fn from(value: opentelemetry::KeyValue) -> Self {
         KeyValue {
             key: value.key.into(),
@@ -199,7 +199,7 @@ impl From<opentelemetry::KeyValue> for KeyValue {
     }
 }
 
-impl From<&opentelemetry::KeyValue> for KeyValue {
+impl From<&opentelemetry::KeyValue<'_>> for KeyValue {
     fn from(value: &opentelemetry::KeyValue) -> Self {
         KeyValue {
             key: value.key.clone().into(),
@@ -208,7 +208,7 @@ impl From<&opentelemetry::KeyValue> for KeyValue {
     }
 }
 
-impl From<(opentelemetry::Key, opentelemetry::Value)> for KeyValue {
+impl From<(opentelemetry::Key, opentelemetry::Value<'_>)> for KeyValue {
     fn from((key, value): (opentelemetry::Key, opentelemetry::Value)) -> Self {
         KeyValue {
             key: key.into(),

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -102,7 +102,7 @@ impl ZipkinPipelineBuilder {
                         .iter()
                         .filter(|(k, _v)| k.as_str() != semcov::resource::SERVICE_NAME)
                         .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
-                        .collect::<Vec<KeyValue>>(),
+                        .collect::<Vec<KeyValue<'static>>>(),
                 ));
                 cfg
             } else {

--- a/opentelemetry-zipkin/src/exporter/model/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/model/mod.rs
@@ -104,7 +104,7 @@ pub(crate) fn into_zipkin_span(local_endpoint: Endpoint, span_data: SpanData) ->
 
 fn map_from_kvs<T>(kvs: T) -> HashMap<String, String>
 where
-    T: IntoIterator<Item = KeyValue>,
+    T: IntoIterator<Item = KeyValue<'static>>,
 {
     let mut map: HashMap<String, String> = HashMap::new();
     for kv in kvs {

--- a/opentelemetry/benches/anyvalue.rs
+++ b/opentelemetry/benches/anyvalue.rs
@@ -28,7 +28,7 @@ fn attributes_creation(c: &mut Criterion) {
 
     c.bench_function("CreateOTelValueInt", |b| {
         b.iter(|| {
-            let _v = black_box(Value::I64(123));
+            let _v = black_box(Into::<Value>::into(123));
         });
     });
 

--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -10,7 +10,7 @@ RAM: 64.0 GB
 | CreateTupleKeyValue                              |      671 ps |
 | CreateOtelKeyValueArray                          |     18.4 ns |
 | CreateOtelKeyValueArrayWithMixedValueTypes       |     18.1 ns |
-| CreateOtelKeyValueArrayWithNonStaticValues       |     90.1 ns |
+| CreateOtelKeyValueArrayWithNonStaticValues       |     61.2 ns |
 | CreateTupleKeyValueArray                         |     2.73 ns |
 */
 

--- a/opentelemetry/src/global/metrics.rs
+++ b/opentelemetry/src/global/metrics.rs
@@ -24,7 +24,7 @@ pub trait ObjectSafeMeterProvider {
         name: Cow<'static, str>,
         version: Option<Cow<'static, str>>,
         schema_url: Option<Cow<'static, str>>,
-        attributes: Option<Vec<KeyValue>>,
+        attributes: Option<Vec<KeyValue<'static>>>,
     ) -> Meter;
 }
 
@@ -38,7 +38,7 @@ where
         name: Cow<'static, str>,
         version: Option<Cow<'static, str>>,
         schema_url: Option<Cow<'static, str>>,
-        attributes: Option<Vec<KeyValue>>,
+        attributes: Option<Vec<KeyValue<'static>>>,
     ) -> Meter {
         self.versioned_meter(name, version, schema_url, attributes)
     }
@@ -63,7 +63,7 @@ impl MeterProvider for GlobalMeterProvider {
         name: impl Into<Cow<'static, str>>,
         version: Option<impl Into<Cow<'static, str>>>,
         schema_url: Option<impl Into<Cow<'static, str>>>,
-        attributes: Option<Vec<KeyValue>>,
+        attributes: Option<Vec<KeyValue<'static>>>,
     ) -> Meter {
         self.provider.versioned_meter_cow(
             name.into(),
@@ -141,7 +141,7 @@ pub fn meter_with_version(
     name: impl Into<Cow<'static, str>>,
     version: Option<impl Into<Cow<'static, str>>>,
     schema_url: Option<impl Into<Cow<'static, str>>>,
-    attributes: Option<Vec<KeyValue>>,
+    attributes: Option<Vec<KeyValue<'static>>>,
 ) -> Meter {
     meter_provider().versioned_meter(
         name.into(),

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -23,7 +23,7 @@ pub trait ObjectSafeSpan {
         &mut self,
         name: Cow<'static, str>,
         timestamp: SystemTime,
-        attributes: Vec<KeyValue>,
+        attributes: Vec<KeyValue<'static>>,
     );
 
     /// Returns the `SpanContext` for the given `Span`. The returned value may be used even after
@@ -61,7 +61,7 @@ pub trait ObjectSafeSpan {
     /// Note that the OpenTelemetry project documents certain ["standard
     /// attributes"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
     /// that have prescribed semantic meanings.
-    fn set_attribute(&mut self, attribute: KeyValue);
+    fn set_attribute(&mut self, attribute: KeyValue<'static>);
 
     /// Sets the status of the `Span`. `message` MUST be ignored when the status is `OK` or
     /// `Unset`.
@@ -88,7 +88,7 @@ pub trait ObjectSafeSpan {
 
     /// Adds a link to this span
     ///
-    fn add_link(&mut self, span_context: SpanContext, attributes: Vec<KeyValue>);
+    fn add_link(&mut self, span_context: SpanContext, attributes: Vec<KeyValue<'static>>);
 
     /// Finishes the `Span`.
     ///
@@ -117,7 +117,7 @@ impl<T: trace::Span> ObjectSafeSpan for T {
         &mut self,
         name: Cow<'static, str>,
         timestamp: SystemTime,
-        attributes: Vec<KeyValue>,
+        attributes: Vec<KeyValue<'static>>,
     ) {
         self.add_event_with_timestamp(name, timestamp, attributes)
     }
@@ -130,7 +130,7 @@ impl<T: trace::Span> ObjectSafeSpan for T {
         self.is_recording()
     }
 
-    fn set_attribute(&mut self, attribute: KeyValue) {
+    fn set_attribute(&mut self, attribute: KeyValue<'static>) {
         self.set_attribute(attribute)
     }
 
@@ -142,7 +142,7 @@ impl<T: trace::Span> ObjectSafeSpan for T {
         self.update_name(new_name)
     }
 
-    fn add_link(&mut self, span_context: SpanContext, attributes: Vec<KeyValue>) {
+    fn add_link(&mut self, span_context: SpanContext, attributes: Vec<KeyValue<'static>>) {
         self.add_link(span_context, attributes)
     }
 
@@ -182,7 +182,7 @@ impl trace::Span for BoxedSpan {
         &mut self,
         name: T,
         timestamp: SystemTime,
-        attributes: Vec<KeyValue>,
+        attributes: Vec<KeyValue<'static>>,
     ) where
         T: Into<Cow<'static, str>>,
     {
@@ -206,7 +206,7 @@ impl trace::Span for BoxedSpan {
     /// Note that the OpenTelemetry project documents certain ["standard
     /// attributes"](https://github.com/open-telemetry/opentelemetry-specification/tree/v0.5.0/specification/trace/semantic_conventions/README.md)
     /// that have prescribed semantic meanings.
-    fn set_attribute(&mut self, attribute: KeyValue) {
+    fn set_attribute(&mut self, attribute: KeyValue<'static>) {
         self.0.set_attribute(attribute)
     }
 
@@ -226,7 +226,7 @@ impl trace::Span for BoxedSpan {
 
     /// Adds a link to this span
     ///
-    fn add_link(&mut self, span_context: trace::SpanContext, attributes: Vec<KeyValue>) {
+    fn add_link(&mut self, span_context: trace::SpanContext, attributes: Vec<KeyValue<'static>>) {
         self.0.add_link(span_context, attributes)
     }
 

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -44,7 +44,7 @@ pub trait LoggerProvider {
         name: impl Into<Cow<'static, str>>,
         version: Option<Cow<'static, str>>,
         schema_url: Option<Cow<'static, str>>,
-        attributes: Option<Vec<KeyValue>>,
+        attributes: Option<Vec<KeyValue<'static>>>,
     ) -> Self::Logger {
         let mut builder = self.logger_builder(name);
         if let Some(v) = version {
@@ -144,7 +144,7 @@ impl<'a, T: LoggerProvider + ?Sized> LoggerBuilder<'a, T> {
 
     pub fn with_attributes<I>(mut self, attributes: I) -> Self
     where
-        I: IntoIterator<Item = KeyValue>,
+        I: IntoIterator<Item = KeyValue<'static>>,
     {
         self.library_builder = self.library_builder.with_attributes(attributes);
         self

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -28,7 +28,7 @@ impl LoggerProvider for NoopLoggerProvider {
         _name: impl Into<Cow<'static, str>>,
         _version: Option<Cow<'static, str>>,
         _schema_url: Option<Cow<'static, str>>,
-        _attributes: Option<Vec<KeyValue>>,
+        _attributes: Option<Vec<KeyValue<'static>>>,
     ) -> Self::Logger {
         NoopLogger(())
     }

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -1,4 +1,4 @@
-use crate::{Array, Key, StringValue, Value};
+use crate::{Key, StringValue};
 use std::{borrow::Cow, collections::HashMap, time::SystemTime};
 
 /// SDK implemented trait for managing log records
@@ -105,23 +105,6 @@ impl<K: Into<Key>, V: Into<AnyValue>> FromIterator<(K, V)> for AnyValue {
         AnyValue::Map(Box::new(HashMap::from_iter(
             iter.into_iter().map(|(k, v)| (k.into(), v.into())),
         )))
-    }
-}
-
-impl From<Value> for AnyValue {
-    fn from(value: Value) -> Self {
-        match value {
-            Value::Bool(b) => b.into(),
-            Value::I64(i) => i.into(),
-            Value::F64(f) => f.into(),
-            Value::String(s) => s.into(),
-            Value::Array(a) => match a {
-                Array::Bool(b) => AnyValue::from_iter(b),
-                Array::F64(f) => AnyValue::from_iter(f),
-                Array::I64(i) => AnyValue::from_iter(i),
-                Array::String(s) => AnyValue::from_iter(s),
-            },
-        }
     }
 }
 

--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 /// An SDK implemented instrument that records increasing values.
 pub trait SyncCounter<T> {
     /// Records an increment to the counter.
-    fn add(&self, value: T, attributes: &[KeyValue]);
+    fn add(&self, value: T, attributes: &[KeyValue<'_>]);
 }
 
 /// An instrument that records increasing values.
@@ -32,7 +32,7 @@ impl<T> Counter<T> {
     }
 
     /// Records an increment to the counter.
-    pub fn add(&self, value: T, attributes: &[KeyValue]) {
+    pub fn add(&self, value: T, attributes: &[KeyValue<'_>]) {
         self.0.add(value, attributes)
     }
 }
@@ -83,7 +83,7 @@ impl<T> ObservableCounter<T> {
     /// It is only valid to call this within a callback. If called outside of the
     /// registered callback it should have no effect on the instrument, and an
     /// error will be reported via the error handler.
-    pub fn observe(&self, value: T, attributes: &[KeyValue]) {
+    pub fn observe(&self, value: T, attributes: &[KeyValue<'_>]) {
         self.0.observe(value, attributes)
     }
 
@@ -94,7 +94,7 @@ impl<T> ObservableCounter<T> {
 }
 
 impl<T> AsyncInstrument<T> for ObservableCounter<T> {
-    fn observe(&self, measurement: T, attributes: &[KeyValue]) {
+    fn observe(&self, measurement: T, attributes: &[KeyValue<'_>]) {
         self.0.observe(measurement, attributes)
     }
 

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 /// An SDK implemented instrument that records independent values
 pub trait SyncGauge<T> {
     /// Records an independent value.
-    fn record(&self, value: T, attributes: &[KeyValue]);
+    fn record(&self, value: T, attributes: &[KeyValue<'_>]);
 }
 
 /// An instrument that records independent values
@@ -32,7 +32,7 @@ impl<T> Gauge<T> {
     }
 
     /// Records an independent value.
-    pub fn record(&self, value: T, attributes: &[KeyValue]) {
+    pub fn record(&self, value: T, attributes: &[KeyValue<'_>]) {
         self.0.record(value, attributes)
     }
 }
@@ -89,7 +89,7 @@ impl<T> ObservableGauge<T> {
     /// It is only valid to call this within a callback. If called outside of the
     /// registered callback it should have no effect on the instrument, and an
     /// error will be reported via the error handler.
-    pub fn observe(&self, measurement: T, attributes: &[KeyValue]) {
+    pub fn observe(&self, measurement: T, attributes: &[KeyValue<'_>]) {
         self.0.observe(measurement, attributes)
     }
 
@@ -100,7 +100,7 @@ impl<T> ObservableGauge<T> {
 }
 
 impl<M> AsyncInstrument<M> for ObservableGauge<M> {
-    fn observe(&self, measurement: M, attributes: &[KeyValue]) {
+    fn observe(&self, measurement: M, attributes: &[KeyValue<'_>]) {
         self.observe(measurement, attributes)
     }
 

--- a/opentelemetry/src/metrics/instruments/histogram.rs
+++ b/opentelemetry/src/metrics/instruments/histogram.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 /// An SDK implemented instrument that records a distribution of values.
 pub trait SyncHistogram<T> {
     /// Adds an additional value to the distribution.
-    fn record(&self, value: T, attributes: &[KeyValue]);
+    fn record(&self, value: T, attributes: &[KeyValue<'_>]);
 }
 
 /// An instrument that records a distribution of values.
@@ -31,7 +31,7 @@ impl<T> Histogram<T> {
     }
 
     /// Adds an additional value to the distribution.
-    pub fn record(&self, value: T, attributes: &[KeyValue]) {
+    pub fn record(&self, value: T, attributes: &[KeyValue<'_>]) {
         self.0.record(value, attributes)
     }
 }

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -18,7 +18,7 @@ pub trait AsyncInstrument<T>: Send + Sync {
     /// Observes the state of the instrument.
     ///
     /// It is only valid to call this within a callback.
-    fn observe(&self, measurement: T, attributes: &[KeyValue]);
+    fn observe(&self, measurement: T, attributes: &[KeyValue<'_>]);
 
     /// Used for SDKs to downcast instruments in callbacks.
     fn as_any(&self) -> Arc<dyn Any>;

--- a/opentelemetry/src/metrics/instruments/up_down_counter.rs
+++ b/opentelemetry/src/metrics/instruments/up_down_counter.rs
@@ -11,7 +11,7 @@ use super::{AsyncInstrument, AsyncInstrumentBuilder};
 /// An SDK implemented instrument that records increasing or decreasing values.
 pub trait SyncUpDownCounter<T> {
     /// Records an increment or decrement to the counter.
-    fn add(&self, value: T, attributes: &[KeyValue]);
+    fn add(&self, value: T, attributes: &[KeyValue<'_>]);
 }
 
 /// An instrument that records increasing or decreasing values.
@@ -37,7 +37,7 @@ impl<T> UpDownCounter<T> {
     }
 
     /// Records an increment or decrement to the counter.
-    pub fn add(&self, value: T, attributes: &[KeyValue]) {
+    pub fn add(&self, value: T, attributes: &[KeyValue<'_>]) {
         self.0.add(value, attributes)
     }
 }
@@ -93,7 +93,7 @@ impl<T> ObservableUpDownCounter<T> {
     /// It is only valid to call this within a callback. If called outside of the
     /// registered callback it should have no effect on the instrument, and an
     /// error will be reported via the error handler.
-    pub fn observe(&self, value: T, attributes: &[KeyValue]) {
+    pub fn observe(&self, value: T, attributes: &[KeyValue<'_>]) {
         self.0.observe(value, attributes)
     }
 
@@ -104,7 +104,7 @@ impl<T> ObservableUpDownCounter<T> {
 }
 
 impl<T> AsyncInstrument<T> for ObservableUpDownCounter<T> {
-    fn observe(&self, measurement: T, attributes: &[KeyValue]) {
+    fn observe(&self, measurement: T, attributes: &[KeyValue<'_>]) {
         self.0.observe(measurement, attributes)
     }
 

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -59,7 +59,7 @@ pub trait MeterProvider {
         name: impl Into<Cow<'static, str>>,
         version: Option<impl Into<Cow<'static, str>>>,
         schema_url: Option<impl Into<Cow<'static, str>>>,
-        attributes: Option<Vec<KeyValue>>,
+        attributes: Option<Vec<KeyValue<'static>>>,
     ) -> Meter;
 }
 

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -72,11 +72,11 @@ impl Hash for F64Hashable {
     }
 }
 
-impl Hash for KeyValue {
+impl Hash for KeyValue<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.key.hash(state);
         match &self.value {
-            Value::F64(f) => F64Hashable(*f).hash(state),
+            Value::F64(f) => F64Hashable(**f).hash(state),
             Value::Array(a) => match a {
                 Array::Bool(b) => b.hash(state),
                 Array::I64(i) => i.hash(state),
@@ -90,20 +90,20 @@ impl Hash for KeyValue {
     }
 }
 
-impl PartialOrd for KeyValue {
+impl PartialOrd for KeyValue<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 /// Ordering is based on the key only.
-impl Ord for KeyValue {
+impl Ord for KeyValue<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.key.cmp(&other.key)
     }
 }
 
-impl Eq for KeyValue {}
+impl Eq for KeyValue<'_> {}
 
 /// SDK implemented trait for creating instruments
 pub trait InstrumentProvider {

--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -31,7 +31,7 @@ impl MeterProvider for NoopMeterProvider {
         _name: impl Into<Cow<'static, str>>,
         _version: Option<impl Into<Cow<'static, str>>>,
         _schema_url: Option<impl Into<Cow<'static, str>>>,
-        _attributes: Option<Vec<KeyValue>>,
+        _attributes: Option<Vec<KeyValue<'static>>>,
     ) -> Meter {
         Meter::new(Arc::new(NoopMeterCore::new()))
     }
@@ -66,25 +66,25 @@ impl NoopSyncInstrument {
 }
 
 impl<T> SyncCounter<T> for NoopSyncInstrument {
-    fn add(&self, _value: T, _attributes: &[KeyValue]) {
+    fn add(&self, _value: T, _attributes: &[KeyValue<'_>]) {
         // Ignored
     }
 }
 
 impl<T> SyncUpDownCounter<T> for NoopSyncInstrument {
-    fn add(&self, _value: T, _attributes: &[KeyValue]) {
+    fn add(&self, _value: T, _attributes: &[KeyValue<'_>]) {
         // Ignored
     }
 }
 
 impl<T> SyncHistogram<T> for NoopSyncInstrument {
-    fn record(&self, _value: T, _attributes: &[KeyValue]) {
+    fn record(&self, _value: T, _attributes: &[KeyValue<'_>]) {
         // Ignored
     }
 }
 
 impl<T> SyncGauge<T> for NoopSyncInstrument {
-    fn record(&self, _value: T, _attributes: &[KeyValue]) {
+    fn record(&self, _value: T, _attributes: &[KeyValue<'_>]) {
         // Ignored
     }
 }
@@ -103,7 +103,7 @@ impl NoopAsyncInstrument {
 }
 
 impl<T> AsyncInstrument<T> for NoopAsyncInstrument {
-    fn observe(&self, _value: T, _attributes: &[KeyValue]) {
+    fn observe(&self, _value: T, _attributes: &[KeyValue<'_>]) {
         // Ignored
     }
 

--- a/opentelemetry/src/testing/trace.rs
+++ b/opentelemetry/src/testing/trace.rs
@@ -12,7 +12,7 @@ impl Span for TestSpan {
         &mut self,
         _name: T,
         _timestamp: std::time::SystemTime,
-        _attributes: Vec<KeyValue>,
+        _attributes: Vec<KeyValue<'static>>,
     ) where
         T: Into<Cow<'static, str>>,
     {
@@ -23,7 +23,7 @@ impl Span for TestSpan {
     fn is_recording(&self) -> bool {
         false
     }
-    fn set_attribute(&mut self, _attribute: KeyValue) {}
+    fn set_attribute(&mut self, _attribute: KeyValue<'static>) {}
     fn set_status(&mut self, _status: Status) {}
     fn update_name<T>(&mut self, _new_name: T)
     where
@@ -31,7 +31,7 @@ impl Span for TestSpan {
     {
     }
 
-    fn add_link(&mut self, _span_context: SpanContext, _attributes: Vec<KeyValue>) {}
+    fn add_link(&mut self, _span_context: SpanContext, _attributes: Vec<KeyValue<'static>>) {}
     fn end_with_timestamp(&mut self, _timestamp: std::time::SystemTime) {}
 }
 

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -70,7 +70,7 @@ impl SpanRef<'_> {
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
-    pub fn add_event<T>(&self, name: T, attributes: Vec<KeyValue>)
+    pub fn add_event<T>(&self, name: T, attributes: Vec<KeyValue<'static>>)
     where
         T: Into<Cow<'static, str>>,
     {
@@ -99,7 +99,7 @@ impl SpanRef<'_> {
         &self,
         name: T,
         timestamp: std::time::SystemTime,
-        attributes: Vec<crate::KeyValue>,
+        attributes: Vec<crate::KeyValue<'static>>,
     ) where
         T: Into<Cow<'static, str>>,
     {
@@ -142,7 +142,7 @@ impl SpanRef<'_> {
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
-    pub fn set_attribute(&self, attribute: crate::KeyValue) {
+    pub fn set_attribute(&self, attribute: crate::KeyValue<'static>) {
         self.with_inner_mut(move |inner| inner.set_attribute(attribute))
     }
 
@@ -157,7 +157,7 @@ impl SpanRef<'_> {
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
-    pub fn set_attributes(&self, attributes: impl IntoIterator<Item = KeyValue>) {
+    pub fn set_attributes(&self, attributes: impl IntoIterator<Item = KeyValue<'static>>) {
         self.with_inner_mut(move |inner| inner.set_attributes(attributes))
     }
 

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -248,7 +248,7 @@ pub struct Event {
     pub timestamp: time::SystemTime,
 
     /// Attributes that describe this event.
-    pub attributes: Vec<KeyValue>,
+    pub attributes: Vec<KeyValue<'static>>,
 
     /// The number of attributes that were above the configured limit, and thus
     /// dropped.
@@ -260,7 +260,7 @@ impl Event {
     pub fn new<T: Into<Cow<'static, str>>>(
         name: T,
         timestamp: time::SystemTime,
-        attributes: Vec<KeyValue>,
+        attributes: Vec<KeyValue<'static>>,
         dropped_attributes_count: u32,
     ) -> Self {
         Event {
@@ -292,7 +292,7 @@ pub struct Link {
     pub span_context: SpanContext,
 
     /// Attributes that describe this link.
-    pub attributes: Vec<KeyValue>,
+    pub attributes: Vec<KeyValue<'static>>,
 
     /// The number of attributes that were above the configured limit, and thus
     /// dropped.
@@ -303,7 +303,7 @@ impl Link {
     /// Create new `Link`
     pub fn new(
         span_context: SpanContext,
-        attributes: Vec<KeyValue>,
+        attributes: Vec<KeyValue<'static>>,
         dropped_attributes_count: u32,
     ) -> Self {
         Link {

--- a/opentelemetry/src/trace/noop.rs
+++ b/opentelemetry/src/trace/noop.rs
@@ -47,7 +47,7 @@ impl NoopSpan {
 
 impl trace::Span for NoopSpan {
     /// Ignores all events
-    fn add_event<T>(&mut self, _name: T, _attributes: Vec<KeyValue>)
+    fn add_event<T>(&mut self, _name: T, _attributes: Vec<KeyValue<'static>>)
     where
         T: Into<Cow<'static, str>>,
     {
@@ -59,7 +59,7 @@ impl trace::Span for NoopSpan {
         &mut self,
         _name: T,
         _timestamp: SystemTime,
-        _attributes: Vec<KeyValue>,
+        _attributes: Vec<KeyValue<'static>>,
     ) where
         T: Into<Cow<'static, str>>,
     {
@@ -77,7 +77,7 @@ impl trace::Span for NoopSpan {
     }
 
     /// Ignores all attributes
-    fn set_attribute(&mut self, _attribute: KeyValue) {
+    fn set_attribute(&mut self, _attribute: KeyValue<'static>) {
         // Ignored
     }
 
@@ -94,7 +94,7 @@ impl trace::Span for NoopSpan {
         // Ignored
     }
 
-    fn add_link(&mut self, _span_context: trace::SpanContext, _attributes: Vec<KeyValue>) {
+    fn add_link(&mut self, _span_context: trace::SpanContext, _attributes: Vec<KeyValue<'static>>) {
         // Ignored
     }
 

--- a/opentelemetry/src/trace/span.rs
+++ b/opentelemetry/src/trace/span.rs
@@ -56,7 +56,7 @@ pub trait Span {
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
-    fn add_event<T>(&mut self, name: T, attributes: Vec<KeyValue>)
+    fn add_event<T>(&mut self, name: T, attributes: Vec<KeyValue<'static>>)
     where
         T: Into<Cow<'static, str>>,
     {
@@ -88,7 +88,7 @@ pub trait Span {
         &mut self,
         name: T,
         timestamp: SystemTime,
-        attributes: Vec<KeyValue>,
+        attributes: Vec<KeyValue<'static>>,
     ) where
         T: Into<Cow<'static, str>>;
 
@@ -119,7 +119,7 @@ pub trait Span {
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
-    fn set_attribute(&mut self, attribute: KeyValue);
+    fn set_attribute(&mut self, attribute: KeyValue<'static>);
 
     /// Set multiple attributes of this span.
     ///
@@ -133,7 +133,7 @@ pub trait Span {
     ///
     /// [standard attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/README.md
     /// [opentelemetry_semantic_conventions]: https://docs.rs/opentelemetry-semantic-conventions
-    fn set_attributes(&mut self, attributes: impl IntoIterator<Item = KeyValue>) {
+    fn set_attributes(&mut self, attributes: impl IntoIterator<Item = KeyValue<'static>>) {
         if self.is_recording() {
             for attr in attributes.into_iter() {
                 self.set_attribute(attr);
@@ -168,7 +168,7 @@ pub trait Span {
     ///   can include any contextual information relevant to the link between the spans.
     ///
     /// [`Link`]: crate::trace::Link
-    fn add_link(&mut self, span_context: SpanContext, attributes: Vec<KeyValue>);
+    fn add_link(&mut self, span_context: SpanContext, attributes: Vec<KeyValue<'static>>);
 
     /// Signals that the operation described by this span has now ended.
     fn end(&mut self) {

--- a/opentelemetry/src/trace/tracer.rs
+++ b/opentelemetry/src/trace/tracer.rs
@@ -262,7 +262,7 @@ pub struct SpanBuilder {
     /// More attributes can be added afterwards.
     /// Providing duplicate keys will result in multiple attributes
     /// with the same key, as there is no de-duplication performed.
-    pub attributes: Option<Vec<KeyValue>>,
+    pub attributes: Option<Vec<KeyValue<'static>>>,
 
     /// Span events
     pub events: Option<Vec<Event>>,
@@ -332,7 +332,7 @@ impl SpanBuilder {
     /// with the same key, as there is no de-duplication performed.    
     pub fn with_attributes<I>(self, attributes: I) -> Self
     where
-        I: IntoIterator<Item = KeyValue>,
+        I: IntoIterator<Item = KeyValue<'static>>,
     {
         SpanBuilder {
             attributes: Some(attributes.into_iter().collect()),
@@ -388,7 +388,7 @@ pub struct SamplingResult {
     pub decision: SamplingDecision,
 
     /// Extra attributes to be added to the span by the sampler
-    pub attributes: Vec<KeyValue>,
+    pub attributes: Vec<KeyValue<'static>>,
 
     /// Trace state from parent context, may be modified by samplers.
     pub trace_state: TraceState,

--- a/opentelemetry/src/trace/tracer_provider.rs
+++ b/opentelemetry/src/trace/tracer_provider.rs
@@ -71,7 +71,7 @@ pub trait TracerProvider {
         name: impl Into<Cow<'static, str>>,
         version: Option<impl Into<Cow<'static, str>>>,
         schema_url: Option<impl Into<Cow<'static, str>>>,
-        attributes: Option<Vec<KeyValue>>,
+        attributes: Option<Vec<KeyValue<'static>>>,
     ) -> Self::Tracer {
         let mut builder = self.tracer_builder(name);
         if let Some(v) = version {
@@ -160,7 +160,7 @@ impl<'a, T: TracerProvider + ?Sized> TracerBuilder<'a, T> {
 
     pub fn with_attributes<I>(mut self, attributes: I) -> Self
     where
-        I: IntoIterator<Item = KeyValue>,
+        I: IntoIterator<Item = KeyValue<'static>>,
     {
         self.library_builder = self.library_builder.with_attributes(attributes);
         self


### PR DESCRIPTION
Related to #1642

## Changes
- Update `Value` struct to avoid copying non-static string slices

### Benchmarks
- There is around a **32% improvement in perf** for the scenario where the attribute values are not static string slices
- No regression with other existing scenarios 

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
