### PR TITLE
Update code samples to use `KeyValue::new()`

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -3,7 +3,7 @@ use opentelemetry::{
     global,
     metrics::MetricsError,
     trace::{TraceContextExt, TraceError, Tracer, TracerProvider as _},
-    Key, KeyValue,
+    KeyValue,
 };
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::Protocol;
@@ -146,7 +146,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let span = cx.span();
         span.add_event(
             "Nice operation!".to_string(),
-            vec![Key::new("bogons").i64(100)],
+            vec![KeyValue::new("bogons", 100)],
         );
         span.set_attribute(KeyValue::new("another.key", "yes"));
 

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -5,7 +5,7 @@ use opentelemetry::metrics::MetricsError;
 use opentelemetry::trace::{TraceError, TracerProvider};
 use opentelemetry::{
     trace::{TraceContextExt, Tracer},
-    Key, KeyValue,
+    KeyValue,
 };
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{ExportConfig, WithExportConfig};
@@ -136,7 +136,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let span = cx.span();
         span.add_event(
             "Nice operation!".to_string(),
-            vec![Key::new("bogons").i64(100)],
+            vec![KeyValue::new("bogons", 100)],
         );
         span.set_attribute(KeyValue::new("another.key", "yes"));
 

--- a/opentelemetry-otlp/tests/integration_test/tests/traces.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/traces.rs
@@ -41,7 +41,7 @@ pub async fn traces() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let span = cx.span();
         span.add_event(
             "Nice operation!".to_string(),
-            vec![Key::new("bogons").i64(100)],
+            vec![KeyValue::new("bogons", 100)],
         );
         span.set_attribute(KeyValue::new(ANOTHER_KEY, "yes"));
 

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use futures_util::future::BoxFuture;
 use opentelemetry::{
     trace::{Span, Tracer, TracerProvider},
-    Key,
+    KeyValue,
 };
 use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
@@ -16,42 +16,42 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     trace_benchmark_group(c, "start-end-span-4-attrs", |tracer| {
         let mut span = tracer.start("foo");
-        span.set_attribute(Key::new("key1").bool(false));
-        span.set_attribute(Key::new("key2").string("hello"));
-        span.set_attribute(Key::new("key4").f64(123.456));
+        span.set_attribute(KeyValue::new("key1", false));
+        span.set_attribute(KeyValue::new("key2", "hello"));
+        span.set_attribute(KeyValue::new("key4", 123.456));
         span.end();
     });
 
     trace_benchmark_group(c, "start-end-span-8-attrs", |tracer| {
         let mut span = tracer.start("foo");
-        span.set_attribute(Key::new("key1").bool(false));
-        span.set_attribute(Key::new("key2").string("hello"));
-        span.set_attribute(Key::new("key4").f64(123.456));
-        span.set_attribute(Key::new("key11").bool(false));
-        span.set_attribute(Key::new("key12").string("hello"));
-        span.set_attribute(Key::new("key14").f64(123.456));
+        span.set_attribute(KeyValue::new("key1", false));
+        span.set_attribute(KeyValue::new("key2", "hello"));
+        span.set_attribute(KeyValue::new("key4", 123.456));
+        span.set_attribute(KeyValue::new("key11", false));
+        span.set_attribute(KeyValue::new("key12", "hello"));
+        span.set_attribute(KeyValue::new("key14", 123.456));
         span.end();
     });
 
     trace_benchmark_group(c, "start-end-span-all-attr-types", |tracer| {
         let mut span = tracer.start("foo");
-        span.set_attribute(Key::new("key1").bool(false));
-        span.set_attribute(Key::new("key2").string("hello"));
-        span.set_attribute(Key::new("key3").i64(123));
-        span.set_attribute(Key::new("key5").f64(123.456));
+        span.set_attribute(KeyValue::new("key1", false));
+        span.set_attribute(KeyValue::new("key2", "hello"));
+        span.set_attribute(KeyValue::new("key3", 123));
+        span.set_attribute(KeyValue::new("key5", 123.456));
         span.end();
     });
 
     trace_benchmark_group(c, "start-end-span-all-attr-types-2x", |tracer| {
         let mut span = tracer.start("foo");
-        span.set_attribute(Key::new("key1").bool(false));
-        span.set_attribute(Key::new("key2").string("hello"));
-        span.set_attribute(Key::new("key3").i64(123));
-        span.set_attribute(Key::new("key5").f64(123.456));
-        span.set_attribute(Key::new("key11").bool(false));
-        span.set_attribute(Key::new("key12").string("hello"));
-        span.set_attribute(Key::new("key13").i64(123));
-        span.set_attribute(Key::new("key15").f64(123.456));
+        span.set_attribute(KeyValue::new("key1", false));
+        span.set_attribute(KeyValue::new("key2", "hello"));
+        span.set_attribute(KeyValue::new("key3", 123));
+        span.set_attribute(KeyValue::new("key5", 123.456));
+        span.set_attribute(KeyValue::new("key11", false));
+        span.set_attribute(KeyValue::new("key12", "hello"));
+        span.set_attribute(KeyValue::new("key13", 123));
+        span.set_attribute(KeyValue::new("key15", 123.456));
         span.end();
     });
 }

--- a/opentelemetry-sdk/src/propagation/baggage.rs
+++ b/opentelemetry-sdk/src/propagation/baggage.rs
@@ -25,7 +25,7 @@ static BAGGAGE_FIELDS: Lazy<[String; 1]> = Lazy::new(|| [BAGGAGE_HEADER.to_owned
 /// # Examples
 ///
 /// ```
-/// use opentelemetry::{baggage::BaggageExt, Key, propagation::TextMapPropagator};
+/// use opentelemetry::{baggage::BaggageExt, KeyValue, propagation::TextMapPropagator};
 /// use opentelemetry_sdk::propagation::BaggagePropagator;
 /// use std::collections::HashMap;
 ///
@@ -43,7 +43,7 @@ static BAGGAGE_FIELDS: Lazy<[String; 1]> = Lazy::new(|| [BAGGAGE_HEADER.to_owned
 /// }
 ///
 /// // Add new baggage
-/// let cx_with_additions = cx.with_baggage(vec![Key::new("server_id").i64(42)]);
+/// let cx_with_additions = cx.with_baggage(vec![KeyValue::new("server_id", 42)]);
 ///
 /// // Inject baggage into http request
 /// propagator.inject_context(&cx_with_additions, &mut headers);

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -32,46 +32,6 @@ impl Key {
         Key(OtelString::Static(value))
     }
 
-    /// Create a `KeyValue` pair for `bool` values.
-    pub fn bool<T: Into<bool>>(self, value: T) -> KeyValue {
-        KeyValue {
-            key: self,
-            value: Value::Bool(value.into()),
-        }
-    }
-
-    /// Create a `KeyValue` pair for `i64` values.
-    pub fn i64(self, value: i64) -> KeyValue {
-        KeyValue {
-            key: self,
-            value: Value::I64(value),
-        }
-    }
-
-    /// Create a `KeyValue` pair for `f64` values.
-    pub fn f64(self, value: f64) -> KeyValue {
-        KeyValue {
-            key: self,
-            value: Value::F64(value),
-        }
-    }
-
-    /// Create a `KeyValue` pair for string-like values.
-    pub fn string(self, value: impl Into<StringValue>) -> KeyValue {
-        KeyValue {
-            key: self,
-            value: Value::String(value.into()),
-        }
-    }
-
-    /// Create a `KeyValue` pair for arrays.
-    pub fn array<T: Into<Array>>(self, value: T) -> KeyValue {
-        KeyValue {
-            key: self,
-            value: Value::Array(value.into()),
-        }
-    }
-
     /// Returns a reference to the underlying key name
     pub fn as_str(&self) -> &str {
         self.0.as_str()


### PR DESCRIPTION
Related to #2090 

## Changes
- Update code samples to use `KeyValue::new()` instead of creating a Key first and then value
- This is also to show that we don't need the additional public APIs mentioned in #2090

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
