### PR TITLE
Remove range requirement, patch in shell script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ temp-env = "0.3.6"
 thiserror = { version = "1", default-features = false }
 tonic = { version = "0.12", default-features = false }
 tonic-build = "0.12"
-tokio = { version = "~1.38.0", default-features = false } #1.39 needs msrv bump to rustc 1.70
+tokio = { version = "1", default-features = false }
 tokio-stream = "0.1.1"
 tracing = { version = "0.1", default-features = false }
 tracing-core = { version = "0.1", default-features = false }

--- a/scripts/patch_dependencies.sh
+++ b/scripts/patch_dependencies.sh
@@ -11,4 +11,4 @@ patch_version url 2.5.0
 patch_version hyper-rustls 0.27.2 # 0.27.3 needs rustc v1.70.0
 patch_version tokio-util 0.7.11 # 0.7.12 needs rustc v1.70.0
 patch_version tokio-stream 0.1.15 # 0.1.16 needs rustc v1.70.0
-
+patch_version tokio 1.38.0 # 1.39 needs msrv bump to rustc 1.70


### PR DESCRIPTION
Fixes #2094

## Changes

Remove the range requirement from the tokio dependency, enabling usage of more recent versions of tokio.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
