### PR TITLE
Fix metrics sorted/deduped bug AND extract common functionality for better code usage/consistency.

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/expected/serialized_traces.json
+++ b/opentelemetry-otlp/tests/integration_test/expected/serialized_traces.json
@@ -112,6 +112,12 @@
                       "value": {
                         "intValue": "100"
                       }
+                    },
+                    {
+                      "key": "number/int",
+                      "value": {
+                        "intValue": "100"
+                      }
                     }
                   ],
                   "droppedAttributesCount": 0

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -20,6 +20,7 @@ futures-util = { workspace = true, features = ["std", "sink", "async-await-macro
 once_cell = { workspace = true }
 percent-encoding = { version = "2.0", optional = true }
 rand = { workspace = true, features = ["std", "std_rng","small_rng"], optional = true }
+rustc-hash = "2.0"
 glob = { version = "0.3.1", optional =true}
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 serde_json = { workspace = true, optional = true }

--- a/opentelemetry-sdk/src/metrics/attribute_set.rs
+++ b/opentelemetry-sdk/src/metrics/attribute_set.rs
@@ -1,0 +1,63 @@
+use std::hash::{Hash, Hasher};
+
+use opentelemetry::{Key, KeyValue, Value};
+use rustc_hash::FxHasher;
+
+/// A unique set of attributes that can be used as instrument identifiers.
+///
+/// This must implement [Hash], [PartialEq], and [Eq] so it may be used as
+/// HashMap keys and other de-duplication methods.
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub(crate) struct AttributeSet(Vec<KeyValue>, u64);
+
+impl From<&[KeyValue]> for AttributeSet {
+    fn from(values: &[KeyValue]) -> Self {
+        let mut vec = Vec::from_iter(values.into_iter().cloned());
+        vec.sort_by(|a, b| a.key.cmp(&b.key));
+
+        // we cannot use vec.dedup_by because it will remove last duplicate not first
+        if vec.len() > 1 {
+            let mut i = vec.len() - 1;
+            while i != 0 {
+                let is_same = unsafe { vec.get_unchecked(i - 1).key == vec.get_unchecked(i).key };
+                if is_same {
+                    vec.remove(i - 1);
+                }
+                i -= 1;
+            }
+        }
+
+        let hash = calculate_hash(&vec);
+        AttributeSet(vec, hash)
+    }
+}
+
+fn calculate_hash(values: &[KeyValue]) -> u64 {
+    let mut hasher = FxHasher::default();
+    values.iter().fold(&mut hasher, |mut hasher, item| {
+        item.hash(&mut hasher);
+        hasher
+    });
+    hasher.finish()
+}
+
+impl AttributeSet {
+    /// Iterate over key value pairs in the set
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&Key, &Value)> {
+        self.0.iter().map(|kv| (&kv.key, &kv.value))
+    }
+
+    pub(crate) fn into_inner(self) -> Vec<KeyValue> {
+        self.0
+    }
+
+    pub(crate) fn as_ref(&self) -> &Vec<KeyValue> {
+        &self.0
+    }
+}
+
+impl Hash for AttributeSet {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.1)
+    }
+}

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -1,13 +1,12 @@
-use std::{
-    collections::HashSet,
-    sync::{atomic::Ordering, Arc, Mutex},
-    time::SystemTime,
-};
+use std::{sync::Mutex, time::SystemTime};
 
 use crate::metrics::data::DataPoint;
 use opentelemetry::KeyValue;
 
-use super::{Assign, AtomicTracker, Number, ValueMap};
+use super::{
+    collect_data_points_readonly, collect_data_points_reset, Assign, AtomicTracker, Number,
+    ValueMap,
+};
 
 /// Summarizes a set of measurements as the last one made.
 pub(crate) struct LastValue<T: Number<T>> {
@@ -33,50 +32,27 @@ impl<T: Number<T>> LastValue<T> {
         let prev_start = self.start.lock().map(|start| *start).unwrap_or(t);
         dest.clear();
 
-        // Max number of data points need to account for the special casing
-        // of the no attribute value + overflow attribute.
-        let n = self.value_map.count.load(Ordering::SeqCst) + 2;
-        if n > dest.capacity() {
-            dest.reserve_exact(n - dest.capacity());
-        }
-
-        if self
-            .value_map
-            .has_no_attribute_value
-            .swap(false, Ordering::AcqRel)
-        {
-            dest.push(DataPoint {
-                attributes: vec![],
-                start_time: Some(prev_start),
-                time: Some(t),
-                value: self.value_map.no_attribute_tracker.get_and_reset_value(),
-                exemplars: vec![],
-            });
-        }
-
-        let mut trackers = match self.value_map.trackers.write() {
-            Ok(v) => v,
-            _ => return,
+        let Ok(mut trackers) = self.value_map.trackers.write() else {
+            return;
         };
 
-        let mut seen = HashSet::new();
-        for (attrs, tracker) in trackers.drain() {
-            if seen.insert(Arc::as_ptr(&tracker)) {
-                dest.push(DataPoint {
-                    attributes: attrs.clone(),
-                    start_time: Some(prev_start),
-                    time: Some(t),
-                    value: tracker.get_value(),
-                    exemplars: vec![],
-                });
-            }
-        }
+        collect_data_points_reset(
+            &self.value_map.no_attribs_tracker,
+            &mut trackers,
+            dest,
+            |attributes, tracker| DataPoint {
+                attributes,
+                start_time: Some(prev_start),
+                time: Some(t),
+                value: tracker.get_and_reset_value(),
+                exemplars: vec![],
+            },
+        );
 
         // The delta collection cycle resets.
         if let Ok(mut start) = self.start.lock() {
             *start = t;
         }
-        self.value_map.count.store(0, Ordering::SeqCst);
     }
 
     pub(crate) fn compute_aggregation_cumulative(&self, dest: &mut Vec<DataPoint<T>>) {
@@ -85,43 +61,21 @@ impl<T: Number<T>> LastValue<T> {
 
         dest.clear();
 
-        // Max number of data points need to account for the special casing
-        // of the no attribute value + overflow attribute.
-        let n = self.value_map.count.load(Ordering::SeqCst) + 2;
-        if n > dest.capacity() {
-            dest.reserve_exact(n - dest.capacity());
-        }
-
-        if self
-            .value_map
-            .has_no_attribute_value
-            .load(Ordering::Acquire)
-        {
-            dest.push(DataPoint {
-                attributes: vec![],
-                start_time: Some(prev_start),
-                time: Some(t),
-                value: self.value_map.no_attribute_tracker.get_value(),
-                exemplars: vec![],
-            });
-        }
-
-        let trackers = match self.value_map.trackers.write() {
-            Ok(v) => v,
-            _ => return,
+        let Ok(trackers) = self.value_map.trackers.read() else {
+            return;
         };
 
-        let mut seen = HashSet::new();
-        for (attrs, tracker) in trackers.iter() {
-            if seen.insert(Arc::as_ptr(tracker)) {
-                dest.push(DataPoint {
-                    attributes: attrs.clone(),
-                    start_time: Some(prev_start),
-                    time: Some(t),
-                    value: tracker.get_value(),
-                    exemplars: vec![],
-                });
-            }
-        }
+        collect_data_points_readonly(
+            &self.value_map.no_attribs_tracker,
+            &trackers,
+            dest,
+            |attributes, tracker| DataPoint {
+                attributes,
+                start_time: Some(prev_start),
+                time: Some(t),
+                value: tracker.get_value(),
+                exemplars: vec![],
+            },
+        );
     }
 }

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -40,6 +40,7 @@
 //! [Resource]: crate::Resource
 
 pub(crate) mod aggregation;
+pub(crate) mod attribute_set;
 pub mod data;
 pub mod exporter;
 pub(crate) mod instrument;
@@ -53,6 +54,7 @@ pub mod reader;
 pub(crate) mod view;
 
 pub use aggregation::*;
+pub(crate) use attribute_set::*;
 pub use instrument::*;
 pub use manual_reader::*;
 pub use meter::*;
@@ -60,71 +62,6 @@ pub use meter_provider::*;
 pub use periodic_reader::*;
 pub use pipeline::Pipeline;
 pub use view::*;
-
-use std::collections::hash_map::DefaultHasher;
-use std::collections::HashSet;
-use std::hash::{Hash, Hasher};
-
-use opentelemetry::{Key, KeyValue, Value};
-
-/// A unique set of attributes that can be used as instrument identifiers.
-///
-/// This must implement [Hash], [PartialEq], and [Eq] so it may be used as
-/// HashMap keys and other de-duplication methods.
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub(crate) struct AttributeSet(Vec<KeyValue>, u64);
-
-impl From<&[KeyValue]> for AttributeSet {
-    fn from(values: &[KeyValue]) -> Self {
-        let mut seen_keys = HashSet::with_capacity(values.len());
-        let vec = values
-            .iter()
-            .rev()
-            .filter_map(|kv| {
-                if seen_keys.insert(kv.key.clone()) {
-                    Some(kv.clone())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-
-        AttributeSet::new(vec)
-    }
-}
-
-fn calculate_hash(values: &[KeyValue]) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    values.iter().fold(&mut hasher, |mut hasher, item| {
-        item.hash(&mut hasher);
-        hasher
-    });
-    hasher.finish()
-}
-
-impl AttributeSet {
-    fn new(mut values: Vec<KeyValue>) -> Self {
-        values.sort_unstable();
-        let hash = calculate_hash(&values);
-        AttributeSet(values, hash)
-    }
-
-    /// Iterate over key value pairs in the set
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&Key, &Value)> {
-        self.0.iter().map(|kv| (&kv.key, &kv.value))
-    }
-
-    /// Returns the underlying Vec of KeyValue pairs
-    pub(crate) fn into_vec(self) -> Vec<KeyValue> {
-        self.0
-    }
-}
-
-impl Hash for AttributeSet {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write_u64(self.1)
-    }
-}
 
 #[cfg(all(test, feature = "testing"))]
 mod tests {


### PR DESCRIPTION
Fixes #
https://github.com/open-telemetry/opentelemetry-rust/pull/2085#issuecomment-2339729168

Basically the issue was, that introduced in #1989.
It made success path super fast, by avoiding any copying/sorting/deduplicating of attributes, which is very cool, 
BUT...
in order to achieve that in attribute set tracker it was inserted two records: `original_list` AND `sorted_deduped_list`.
Later, during aggregation, there was introduced deduplication mechanism, so that only one attribute set would be selected for specific tracker.
However, since rust uses randomness in hashing, the order in which these two attribute sets (original and deduped) is returned is random.
So the end result is that everytime application is restarted, `MetricReader` will get `original_list`  OR `sorted_dedup_list` at random.

## Changes

### Bug fix

* by introducing separate list for `sorted_deduped` attributes. 
This should also improve performance for collection stage as it only needs to go through this list of already `sorted_deduped` attributes.
* added `attributes_should_be_sorted_and_deduplicated` test, to make sure this wouldn't happen again.

### Other improvements

* extracted common functionality used across all (except one) aggregators into few functions and classes/struts. 
  * this reduces code duplication by 4x, and makes implementations more consistent.
  * all logic related to updating aggregates for specific attribute sets is more isolated an in one place.
* several improvements related to `AttributeSet`
  * use faster hashing function `rustc-hash`.
  * improved sorting/deduping implementation.
  * `sorted_deduped` list uses AttributeSet as key, for faster hashing/lookup.
  * moved `AttributeSet` to it's own file, in order to better protect internal implementation to guarantee sorting&deduping.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
