### PR TITLE
note breaking change in opentlemetry-otlp v0.17.0 CHANGELOG

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -21,7 +21,7 @@ The logrecord event-name is added as an attribute only if the feature flag
 
 - Add "metrics", "logs" to default features. With this, default feature list is
   "trace", "metrics" and "logs".
-- `OtlpMetricPipeline.build()` no longer invoke the
+- **Breaking** `OtlpMetricPipeline.build()` no longer invoke the
   `global::set_meter_provider`. User who setup the pipeline must do it
   themselves using `global::set_meter_provider(meter_provider.clone());`.
 - Add `with_resource` on `OtlpLogPipeline`, replacing the `with_config` method.


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

notes that the change in 0.17.0 to not register the global meter provider with `OtlpMetricPipeline.build()` is a breaking change, as it will cause an application to silently not export metrics.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
