### PR TITLE
update trait `Number<T>` to `Number`

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -71,7 +71,7 @@ pub(crate) struct AggregateBuilder<T> {
 
 type Filter = Arc<dyn Fn(&KeyValue) -> bool + Send + Sync>;
 
-impl<T: Number<T>> AggregateBuilder<T> {
+impl<T: Number> AggregateBuilder<T> {
     pub(crate) fn new(temporality: Option<Temporality>, filter: Option<Filter>) -> Self {
         AggregateBuilder {
             temporality,

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -32,7 +32,7 @@ struct ExpoHistogramDataPoint<T> {
     zero_count: u64,
 }
 
-impl<T: Number<T>> ExpoHistogramDataPoint<T> {
+impl<T: Number> ExpoHistogramDataPoint<T> {
     fn new(max_size: i32, max_scale: i8, record_min_max: bool, record_sum: bool) -> Self {
         ExpoHistogramDataPoint {
             count: 0,
@@ -50,7 +50,7 @@ impl<T: Number<T>> ExpoHistogramDataPoint<T> {
     }
 }
 
-impl<T: Number<T>> ExpoHistogramDataPoint<T> {
+impl<T: Number> ExpoHistogramDataPoint<T> {
     /// Adds a new measurement to the histogram.
     ///
     /// It will rescale the buckets if needed.
@@ -322,7 +322,7 @@ pub(crate) struct ExpoHistogram<T> {
     start: Mutex<SystemTime>,
 }
 
-impl<T: Number<T>> ExpoHistogram<T> {
+impl<T: Number> ExpoHistogram<T> {
     /// Create a new exponential histogram.
     pub(crate) fn new(
         max_size: u32,
@@ -535,7 +535,7 @@ mod tests {
         run_data_point_record::<i64>();
     }
 
-    fn run_data_point_record<T: Number<T> + Neg<Output = T> + From<u32>>() {
+    fn run_data_point_record<T: Number + Neg<Output = T> + From<u32>>() {
         struct TestCase<T> {
             max_size: i32,
             values: Vec<T>,
@@ -695,7 +695,7 @@ mod tests {
         }
     }
 
-    fn run_min_max_sum<T: Number<T> + From<u32>>() {
+    fn run_min_max_sum<T: Number + From<u32>>() {
         let alice = &[KeyValue::new("user", "alice")][..];
         struct Expected<T> {
             min: T,
@@ -703,7 +703,7 @@ mod tests {
             sum: T,
             count: usize,
         }
-        impl<T: Number<T>> Expected<T> {
+        impl<T: Number> Expected<T> {
             fn new(min: T, max: T, sum: T, count: usize) -> Self {
                 Expected {
                     min,
@@ -1229,7 +1229,7 @@ mod tests {
         (Box::new(m), Box::new(ca))
     }
 
-    fn hist_aggregation<T: Number<T> + From<u32>>() {
+    fn hist_aggregation<T: Number + From<u32>>() {
         let max_size = 4;
         let max_scale = 20;
         let record_min_max = true;
@@ -1449,7 +1449,7 @@ mod tests {
         }
     }
 
-    fn assert_aggregation_eq<T: Number<T> + PartialEq>(
+    fn assert_aggregation_eq<T: Number + PartialEq>(
         a: Box<dyn Aggregation>,
         b: Box<dyn Aggregation>,
         ignore_timestamp: bool,
@@ -1558,7 +1558,7 @@ mod tests {
         }
     }
 
-    fn assert_data_points_eq<T: Number<T>>(
+    fn assert_data_points_eq<T: Number>(
         a: &data::DataPoint<T>,
         b: &data::DataPoint<T>,
         ignore_timestamp: bool,
@@ -1582,7 +1582,7 @@ mod tests {
         }
     }
 
-    fn assert_hist_data_points_eq<T: Number<T>>(
+    fn assert_hist_data_points_eq<T: Number>(
         a: &data::HistogramDataPoint<T>,
         b: &data::HistogramDataPoint<T>,
         ignore_timestamp: bool,
@@ -1615,7 +1615,7 @@ mod tests {
         }
     }
 
-    fn assert_exponential_hist_data_points_eq<T: Number<T>>(
+    fn assert_exponential_hist_data_points_eq<T: Number>(
         a: &data::ExponentialHistogramDataPoint<T>,
         b: &data::ExponentialHistogramDataPoint<T>,
         ignore_timestamp: bool,

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -22,7 +22,7 @@ struct HistogramTracker<T> {
     buckets: Mutex<Buckets<T>>,
 }
 
-impl<T: Number<T>> AtomicTracker<T> for HistogramTracker<T> {
+impl<T: Number> AtomicTracker<T> for HistogramTracker<T> {
     fn update_histogram(&self, index: usize, value: T) {
         let mut buckets = match self.buckets.lock() {
             Ok(guard) => guard,
@@ -34,7 +34,7 @@ impl<T: Number<T>> AtomicTracker<T> for HistogramTracker<T> {
     }
 }
 
-impl<T: Number<T>> AtomicallyUpdate<T> for HistogramTracker<T> {
+impl<T: Number> AtomicallyUpdate<T> for HistogramTracker<T> {
     type AtomicTracker = HistogramTracker<T>;
 
     fn new_atomic_tracker(buckets_count: Option<usize>) -> Self::AtomicTracker {
@@ -54,7 +54,7 @@ struct Buckets<T> {
     max: T,
 }
 
-impl<T: Number<T>> Buckets<T> {
+impl<T: Number> Buckets<T> {
     /// returns buckets with `n` bins.
     fn new(n: usize) -> Buckets<T> {
         Buckets {
@@ -93,7 +93,7 @@ impl<T: Number<T>> Buckets<T> {
 
 /// Summarizes a set of measurements as a histogram with explicitly defined
 /// buckets.
-pub(crate) struct Histogram<T: Number<T>> {
+pub(crate) struct Histogram<T: Number> {
     value_map: ValueMap<HistogramTracker<T>, T, HistogramUpdate>,
     bounds: Vec<f64>,
     record_min_max: bool,
@@ -101,7 +101,7 @@ pub(crate) struct Histogram<T: Number<T>> {
     start: Mutex<SystemTime>,
 }
 
-impl<T: Number<T>> Histogram<T> {
+impl<T: Number> Histogram<T> {
     pub(crate) fn new(boundaries: Vec<f64>, record_min_max: bool, record_sum: bool) -> Self {
         let buckets_count = boundaries.len() + 1;
         let mut histogram = Histogram {

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -10,12 +10,12 @@ use opentelemetry::KeyValue;
 use super::{Assign, AtomicTracker, Number, ValueMap};
 
 /// Summarizes a set of measurements as the last one made.
-pub(crate) struct LastValue<T: Number<T>> {
+pub(crate) struct LastValue<T: Number> {
     value_map: ValueMap<T, T, Assign>,
     start: Mutex<SystemTime>,
 }
 
-impl<T: Number<T>> LastValue<T> {
+impl<T: Number> LastValue<T> {
     pub(crate) fn new() -> Self {
         LastValue {
             value_map: ValueMap::new(),

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -49,7 +49,7 @@ impl Operation for Assign {
 ///
 /// This structure is parametrized by an `Operation` that indicates how
 /// updates to the underlying value trackers should be performed.
-pub(crate) struct ValueMap<AU: AtomicallyUpdate<T>, T: Number<T>, O> {
+pub(crate) struct ValueMap<AU: AtomicallyUpdate<T>, T: Number, O> {
     /// Trackers store the values associated with different attribute sets.
     trackers: RwLock<HashMap<Vec<KeyValue>, Arc<AU::AtomicTracker>>>,
     /// Number of different attribute set stored in the `trackers` map.
@@ -63,13 +63,13 @@ pub(crate) struct ValueMap<AU: AtomicallyUpdate<T>, T: Number<T>, O> {
     phantom: PhantomData<O>,
 }
 
-impl<AU: AtomicallyUpdate<T>, T: Number<T>, O> Default for ValueMap<AU, T, O> {
+impl<AU: AtomicallyUpdate<T>, T: Number, O> Default for ValueMap<AU, T, O> {
     fn default() -> Self {
         ValueMap::new()
     }
 }
 
-impl<AU: AtomicallyUpdate<T>, T: Number<T>, O> ValueMap<AU, T, O> {
+impl<AU: AtomicallyUpdate<T>, T: Number, O> ValueMap<AU, T, O> {
     fn new() -> Self {
         ValueMap {
             trackers: RwLock::new(HashMap::new()),
@@ -93,7 +93,7 @@ impl<AU: AtomicallyUpdate<T>, T: Number<T>, O> ValueMap<AU, T, O> {
     }
 }
 
-impl<AU: AtomicallyUpdate<T>, T: Number<T>, O: Operation> ValueMap<AU, T, O> {
+impl<AU: AtomicallyUpdate<T>, T: Number, O: Operation> ValueMap<AU, T, O> {
     fn measure(&self, measurement: T, attributes: &[KeyValue], index: usize) {
         if attributes.is_empty() {
             O::update_tracker(&self.no_attribute_tracker, measurement, index);
@@ -171,10 +171,10 @@ pub(crate) trait AtomicallyUpdate<T: Default> {
     fn new_atomic_tracker(buckets_count: Option<usize>) -> Self::AtomicTracker;
 }
 
-pub(crate) trait Number<T: Default>:
-    Add<Output = T>
+pub(crate) trait Number:
+    Add<Output = Self>
     + AddAssign
-    + Sub<Output = T>
+    + Sub<Output = Self>
     + PartialOrd
     + fmt::Debug
     + Clone
@@ -184,7 +184,7 @@ pub(crate) trait Number<T: Default>:
     + Send
     + Sync
     + 'static
-    + AtomicallyUpdate<T>
+    + AtomicallyUpdate<Self>
 {
     fn min() -> Self;
     fn max() -> Self;
@@ -192,7 +192,7 @@ pub(crate) trait Number<T: Default>:
     fn into_float(self) -> f64;
 }
 
-impl Number<i64> for i64 {
+impl Number for i64 {
     fn min() -> Self {
         i64::MIN
     }
@@ -206,7 +206,7 @@ impl Number<i64> for i64 {
         self as f64
     }
 }
-impl Number<u64> for u64 {
+impl Number for u64 {
     fn min() -> Self {
         u64::MIN
     }
@@ -220,7 +220,7 @@ impl Number<u64> for u64 {
         self as f64
     }
 }
-impl Number<f64> for f64 {
+impl Number for f64 {
     fn min() -> Self {
         f64::MIN
     }

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -10,14 +10,14 @@ use std::{
 };
 
 /// Summarizes a set of pre-computed sums as their arithmetic sum.
-pub(crate) struct PrecomputedSum<T: Number<T>> {
+pub(crate) struct PrecomputedSum<T: Number> {
     value_map: ValueMap<T, T, Assign>,
     monotonic: bool,
     start: Mutex<SystemTime>,
     reported: Mutex<HashMap<Vec<KeyValue>, T>>,
 }
 
-impl<T: Number<T>> PrecomputedSum<T> {
+impl<T: Number> PrecomputedSum<T> {
     pub(crate) fn new(monotonic: bool) -> Self {
         PrecomputedSum {
             value_map: ValueMap::new(),

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -11,13 +11,13 @@ use super::{AtomicTracker, Number};
 use super::{Increment, ValueMap};
 
 /// Summarizes a set of measurements made as their arithmetic sum.
-pub(crate) struct Sum<T: Number<T>> {
+pub(crate) struct Sum<T: Number> {
     value_map: ValueMap<T, T, Increment>,
     monotonic: bool,
     start: Mutex<SystemTime>,
 }
 
-impl<T: Number<T>> Sum<T> {
+impl<T: Number> Sum<T> {
     /// Returns an aggregator that summarizes a set of measurements as their
     /// arithmetic sum.
     ///

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -481,7 +481,7 @@ struct InstrumentResolver<'a, T> {
 
 impl<'a, T> InstrumentResolver<'a, T>
 where
-    T: Number<T>,
+    T: Number,
 {
     fn new(meter: &'a SdkMeter, resolve: &'a Resolver<T>) -> Self {
         InstrumentResolver { meter, resolve }

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -211,7 +211,7 @@ struct Inserter<T> {
 
 impl<T> Inserter<T>
 where
-    T: Number<T>,
+    T: Number,
 {
     fn new(p: Arc<Pipeline>, vc: Arc<Mutex<HashMap<Cow<'static, str>, InstrumentId>>>) -> Self {
         Inserter {
@@ -465,7 +465,7 @@ type AggregateFns<T> = (
 /// Returns new aggregate functions for the given params.
 ///
 /// If the aggregation is unknown or temporality is invalid, an error is returned.
-fn aggregate_fn<T: Number<T>>(
+fn aggregate_fn<T: Number>(
     b: AggregateBuilder<T>,
     agg: &aggregation::Aggregation,
     kind: InstrumentKind,
@@ -668,7 +668,7 @@ pub(crate) struct Resolver<T> {
 
 impl<T> Resolver<T>
 where
-    T: Number<T>,
+    T: Number,
 {
     pub(crate) fn new(
         pipelines: Arc<Pipelines>,


### PR DESCRIPTION
## Changes

Simply updated `trait Number<T>` by removing unnecessary generic type from it.

There is exactly these changes (you can repeat it in 1 min)
* search for regex `Number(<[a-zA-Z0-9]*>)` replace with `Number`
* in `trait Number` replace `T` with `Self`.

What is the value? It's easier to understand to newcomers such as myself :)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
