### PR TITLE
Unify Histogram and ExpHistogram aggregation

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/attribute_set_aggregation.rs
+++ b/opentelemetry-sdk/src/metrics/internal/attribute_set_aggregation.rs
@@ -1,0 +1,183 @@
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    ops::Deref,
+    sync::{Arc, Mutex, RwLock},
+};
+
+use opentelemetry::{global, metrics::MetricsError, KeyValue};
+
+use crate::metrics::AttributeSet;
+
+use super::{
+    aggregate::is_under_cardinality_limit, Number, STREAM_OVERFLOW_ATTRIBUTES,
+    STREAM_OVERFLOW_ATTRIBUTES_ERR,
+};
+
+/// Aggregator interface
+pub(crate) trait Aggregator<T>: Debug + Clone
+where
+    T: Number,
+{
+    /// A static configuration that is needed by configurators.
+    /// E.g. bucket_size at creation time and buckets list at aggregator update.
+    type Config;
+
+    /// Called everytime a new attribute-set is stored.
+    fn create(init: &Self::Config) -> Self;
+
+    /// Called for each measurement.
+    fn update(&mut self, config: &Self::Config, measurement: T);
+}
+
+/// hashing and sorting is expensive, so we have two lists
+/// sorted list is mainly needed for fast collection phase
+struct WithAttribsAggregators<A> {
+    // put all attribute combinations in this list
+    all: HashMap<Vec<KeyValue>, Arc<Mutex<A>>>,
+    sorted: HashMap<Vec<KeyValue>, Arc<Mutex<A>>>,
+}
+
+/// This class is responsible for two things:
+/// * send measurement information for specific aggregator (per attribute-set)
+/// * collect all attribute-sets + aggregators (either readonly OR reset)
+///
+/// Even though it's simple to understand it's responsibility,
+/// implementation is a lot more complex to make it very performant.
+pub(crate) struct AttributeSetAggregation<T, A>
+where
+    T: Number,
+    A: Aggregator<T>,
+{
+    /// Aggregator for values with no attributes attached.
+    no_attribs: Mutex<Option<A>>,
+    list: RwLock<WithAttribsAggregators<A>>,
+    /// Configuration required to create and update the [`Aggregator`]
+    config: A::Config,
+}
+
+impl<T, A> AttributeSetAggregation<T, A>
+where
+    T: Number,
+    A: Aggregator<T>,
+{
+    /// Initiate aggregators by specifing [`Aggregator`] configuration.
+    pub(crate) fn new(init_data: A::Config) -> Self {
+        Self {
+            no_attribs: Mutex::new(None),
+            list: RwLock::new(WithAttribsAggregators {
+                all: Default::default(),
+                sorted: Default::default(),
+            }),
+            config: init_data,
+        }
+    }
+
+    /// Update specific aggregator depending on provided attributes.
+    pub(crate) fn measure(&self, attrs: &[KeyValue], measurement: T) {
+        if attrs.is_empty() {
+            if let Ok(mut aggr) = self.no_attribs.lock() {
+                aggr.get_or_insert_with(|| A::create(&self.config))
+                    .update(&self.config, measurement);
+            }
+            return;
+        }
+        let Ok(list) = self.list.read() else {
+            return;
+        };
+        if let Some(aggr) = list.all.get(attrs) {
+            if let Ok(mut aggr) = aggr.lock() {
+                aggr.update(&self.config, measurement);
+            }
+            return;
+        }
+        drop(list);
+        let Ok(mut list) = self.list.write() else {
+            return;
+        };
+
+        // Recheck again in case another thread already inserted
+        if let Some(aggr) = list.all.get(attrs) {
+            if let Ok(mut aggr) = aggr.lock() {
+                aggr.update(&self.config, measurement);
+            }
+        } else if is_under_cardinality_limit(list.all.len()) {
+            let mut aggr = A::create(&self.config);
+            aggr.update(&self.config, measurement);
+            let aggr = Arc::new(Mutex::new(aggr));
+            list.all.insert(attrs.into(), aggr.clone());
+            let sorted_attribs = AttributeSet::from(attrs).into_vec();
+            list.sorted.insert(sorted_attribs, aggr);
+        } else if let Some(aggr) = list.sorted.get(STREAM_OVERFLOW_ATTRIBUTES.deref()) {
+            if let Ok(mut aggr) = aggr.lock() {
+                aggr.update(&self.config, measurement);
+            }
+        } else {
+            let mut aggr = A::create(&self.config);
+            aggr.update(&self.config, measurement);
+            list.sorted.insert(
+                STREAM_OVERFLOW_ATTRIBUTES.clone(),
+                Arc::new(Mutex::new(aggr)),
+            );
+            global::handle_error(MetricsError::Other(STREAM_OVERFLOW_ATTRIBUTES_ERR.into()));
+        }
+    }
+
+    /// Iterate through all attribute sets and populate `DataPoints`in readonly mode.
+    pub(crate) fn collect_readonly<Res, MapFn>(&self, dest: &mut Vec<Res>, mut map_fn: MapFn)
+    where
+        MapFn: FnMut(Vec<KeyValue>, A) -> Res,
+    {
+        let Ok(list) = self.list.read() else {
+            return;
+        };
+        prepare_data(dest, list.sorted.len());
+        if let Ok(aggr) = self.no_attribs.lock() {
+            if let Some(aggr) = aggr.deref() {
+                dest.push(map_fn(Default::default(), aggr.clone()));
+            }
+        };
+        dest.extend(
+            list.sorted
+                .iter()
+                .filter_map(|(k, v)| v.lock().ok().map(|v| map_fn(k.clone(), v.clone()))),
+        )
+    }
+
+    /// Iterate through all attribute sets and populate `DataPoints`, while also consuming (reseting) aggregators
+    pub(crate) fn collect_and_reset<Res, MapFn>(&self, dest: &mut Vec<Res>, mut map_fn: MapFn)
+    where
+        MapFn: FnMut(Vec<KeyValue>, A) -> Res,
+    {
+        let Ok(mut list) = self.list.write() else {
+            return;
+        };
+        prepare_data(dest, list.sorted.len());
+        if let Ok(mut aggr) = self.no_attribs.lock() {
+            if let Some(aggr) = aggr.take() {
+                dest.push(map_fn(Default::default(), aggr));
+            }
+        };
+        list.all.clear();
+        dest.extend(list.sorted.drain().filter_map(|(k, v)| {
+            Arc::try_unwrap(v)
+                .expect("this is last instance, so we cannot fail to get it")
+                .into_inner()
+                .ok()
+                .map(|v| map_fn(k, v))
+        }));
+    }
+
+    pub(crate) fn config(&self) -> &A::Config {
+        &self.config
+    }
+}
+
+/// Clear and allocate exactly required amount of space for all attribute-sets
+fn prepare_data<T>(data: &mut Vec<T>, list_len: usize) {
+    data.clear();
+    let total_len = list_len + 1; // to account for no_attributes case
+    if total_len > data.capacity() {
+        data.reserve_exact(total_len - data.capacity());
+    }
+}

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -1,51 +1,19 @@
-use std::collections::HashSet;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
 use std::{sync::Mutex, time::SystemTime};
 
 use crate::metrics::data::HistogramDataPoint;
 use crate::metrics::data::{self, Aggregation, Temporality};
 use opentelemetry::KeyValue;
 
+use super::attribute_set_aggregation::{Aggregator, AttributeSetAggregation};
 use super::Number;
-use super::{AtomicTracker, AtomicallyUpdate, Operation, ValueMap};
 
-struct HistogramUpdate;
-
-impl Operation for HistogramUpdate {
-    fn update_tracker<T: Default, AT: AtomicTracker<T>>(tracker: &AT, value: T, index: usize) {
-        tracker.update_histogram(index, value);
-    }
+struct BucketsConfig {
+    bounds: Vec<f64>,
+    record_min_max: bool,
+    record_sum: bool,
 }
 
-struct HistogramTracker<T> {
-    buckets: Mutex<Buckets<T>>,
-}
-
-impl<T: Number> AtomicTracker<T> for HistogramTracker<T> {
-    fn update_histogram(&self, index: usize, value: T) {
-        let mut buckets = match self.buckets.lock() {
-            Ok(guard) => guard,
-            Err(_) => return,
-        };
-
-        buckets.bin(index, value);
-        buckets.sum(value);
-    }
-}
-
-impl<T: Number> AtomicallyUpdate<T> for HistogramTracker<T> {
-    type AtomicTracker = HistogramTracker<T>;
-
-    fn new_atomic_tracker(buckets_count: Option<usize>) -> Self::AtomicTracker {
-        let count = buckets_count.unwrap();
-        HistogramTracker {
-            buckets: Mutex::new(Buckets::<T>::new(count)),
-        }
-    }
-}
-
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 struct Buckets<T> {
     counts: Vec<u64>,
     count: u64,
@@ -54,82 +22,72 @@ struct Buckets<T> {
     max: T,
 }
 
-impl<T: Number> Buckets<T> {
-    /// returns buckets with `n` bins.
-    fn new(n: usize) -> Buckets<T> {
+impl<T> Aggregator<T> for Buckets<T>
+where
+    T: Number,
+{
+    type Config = BucketsConfig;
+
+    fn create(config: &BucketsConfig) -> Self {
+        let size = config.bounds.len() + 1;
         Buckets {
-            counts: vec![0; n],
+            counts: vec![0; size],
             min: T::max(),
             max: T::min(),
             ..Default::default()
         }
     }
 
-    fn sum(&mut self, value: T) {
-        self.total += value;
-    }
-
-    fn bin(&mut self, idx: usize, value: T) {
+    fn update(&mut self, config: &BucketsConfig, measurement: T) {
+        let f_value = measurement.into_float();
+        // Ignore NaN and infinity.
+        if f_value.is_infinite() || f_value.is_nan() {
+            return;
+        }
+        // This search will return an index in the range `[0, bounds.len()]`, where
+        // it will return `bounds.len()` if value is greater than the last element
+        // of `bounds`. This aligns with the buckets in that the length of buckets
+        // is `bounds.len()+1`, with the last bucket representing:
+        // `(bounds[bounds.len()-1], +∞)`.
+        let idx = config.bounds.partition_point(|&x| x < f_value);
         self.counts[idx] += 1;
         self.count += 1;
-        if value < self.min {
-            self.min = value;
+        if config.record_min_max {
+            if measurement < self.min {
+                self.min = measurement;
+            }
+            if measurement > self.max {
+                self.max = measurement
+            }
         }
-        if value > self.max {
-            self.max = value
-        }
-    }
-
-    fn reset(&mut self) {
-        for item in &mut self.counts {
-            *item = 0;
-        }
-        self.count = Default::default();
-        self.total = Default::default();
-        self.min = T::max();
-        self.max = T::min();
+        // it's very cheap to update it, even if it is not configured to record_sum
+        self.total += measurement;
     }
 }
 
 /// Summarizes a set of measurements as a histogram with explicitly defined
 /// buckets.
 pub(crate) struct Histogram<T: Number> {
-    value_map: ValueMap<HistogramTracker<T>, T, HistogramUpdate>,
-    bounds: Vec<f64>,
-    record_min_max: bool,
-    record_sum: bool,
+    aggregators: AttributeSetAggregation<T, Buckets<T>>,
     start: Mutex<SystemTime>,
 }
 
 impl<T: Number> Histogram<T> {
-    pub(crate) fn new(boundaries: Vec<f64>, record_min_max: bool, record_sum: bool) -> Self {
-        let buckets_count = boundaries.len() + 1;
-        let mut histogram = Histogram {
-            value_map: ValueMap::new_with_buckets_count(buckets_count),
-            bounds: boundaries,
-            record_min_max,
-            record_sum,
+    pub(crate) fn new(mut bounds: Vec<f64>, record_min_max: bool, record_sum: bool) -> Self {
+        bounds.retain(|v| !v.is_nan());
+        bounds.sort_by(|a, b| a.partial_cmp(b).expect("NaNs filtered out"));
+        Self {
+            aggregators: AttributeSetAggregation::new(BucketsConfig {
+                record_min_max,
+                record_sum,
+                bounds,
+            }),
             start: Mutex::new(SystemTime::now()),
-        };
-
-        histogram.bounds.retain(|v| !v.is_nan());
-        histogram
-            .bounds
-            .sort_by(|a, b| a.partial_cmp(b).expect("NaNs filtered out"));
-
-        histogram
+        }
     }
 
     pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
-        let f = measurement.into_float();
-
-        // This search will return an index in the range `[0, bounds.len()]`, where
-        // it will return `bounds.len()` if value is greater than the last element
-        // of `bounds`. This aligns with the buckets in that the length of buckets
-        // is `bounds.len()+1`, with the last bucket representing:
-        // `(bounds[bounds.len()-1], +∞)`.
-        let index = self.bounds.partition_point(|&x| x < f);
-        self.value_map.measure(measurement, attrs, index);
+        self.aggregators.measure(attrs, measurement)
     }
 
     pub(crate) fn delta(
@@ -153,92 +111,17 @@ impl<T: Number> Histogram<T> {
         };
         let h = h.unwrap_or_else(|| new_agg.as_mut().expect("present if h is none"));
         h.temporality = Temporality::Delta;
-        h.data_points.clear();
 
-        // Max number of data points need to account for the special casing
-        // of the no attribute value + overflow attribute.
-        let n = self.value_map.count.load(Ordering::SeqCst) + 2;
-        if n > h.data_points.capacity() {
-            h.data_points.reserve_exact(n - h.data_points.capacity());
-        }
-
-        if self
-            .value_map
-            .has_no_attribute_value
-            .swap(false, Ordering::AcqRel)
-        {
-            if let Ok(ref mut b) = self.value_map.no_attribute_tracker.buckets.lock() {
-                h.data_points.push(HistogramDataPoint {
-                    attributes: vec![],
-                    start_time: start,
-                    time: t,
-                    count: b.count,
-                    bounds: self.bounds.clone(),
-                    bucket_counts: b.counts.clone(),
-                    sum: if self.record_sum {
-                        b.total
-                    } else {
-                        T::default()
-                    },
-                    min: if self.record_min_max {
-                        Some(b.min)
-                    } else {
-                        None
-                    },
-                    max: if self.record_min_max {
-                        Some(b.max)
-                    } else {
-                        None
-                    },
-                    exemplars: vec![],
-                });
-
-                b.reset();
-            }
-        }
-
-        let mut trackers = match self.value_map.trackers.write() {
-            Ok(v) => v,
-            Err(_) => return (0, None),
-        };
-
-        let mut seen = HashSet::new();
-        for (attrs, tracker) in trackers.drain() {
-            if seen.insert(Arc::as_ptr(&tracker)) {
-                if let Ok(b) = tracker.buckets.lock() {
-                    h.data_points.push(HistogramDataPoint {
-                        attributes: attrs.clone(),
-                        start_time: start,
-                        time: t,
-                        count: b.count,
-                        bounds: self.bounds.clone(),
-                        bucket_counts: b.counts.clone(),
-                        sum: if self.record_sum {
-                            b.total
-                        } else {
-                            T::default()
-                        },
-                        min: if self.record_min_max {
-                            Some(b.min)
-                        } else {
-                            None
-                        },
-                        max: if self.record_min_max {
-                            Some(b.max)
-                        } else {
-                            None
-                        },
-                        exemplars: vec![],
-                    });
-                }
-            }
-        }
+        let config = self.aggregators.config();
+        self.aggregators
+            .collect_and_reset(&mut h.data_points, |attributes, buckets| {
+                to_data_point(start, t, config, attributes, buckets)
+            });
 
         // The delta collection cycle resets.
         if let Ok(mut start) = self.start.lock() {
             *start = t;
         }
-        self.value_map.count.store(0, Ordering::SeqCst);
 
         (h.data_points.len(), new_agg.map(|a| Box::new(a) as Box<_>))
     }
@@ -264,89 +147,49 @@ impl<T: Number> Histogram<T> {
         };
         let h = h.unwrap_or_else(|| new_agg.as_mut().expect("present if h is none"));
         h.temporality = Temporality::Cumulative;
-        h.data_points.clear();
 
-        // Max number of data points need to account for the special casing
-        // of the no attribute value + overflow attribute.
-        let n = self.value_map.count.load(Ordering::SeqCst) + 2;
-        if n > h.data_points.capacity() {
-            h.data_points.reserve_exact(n - h.data_points.capacity());
-        }
-
-        if self
-            .value_map
-            .has_no_attribute_value
-            .load(Ordering::Acquire)
-        {
-            if let Ok(b) = &self.value_map.no_attribute_tracker.buckets.lock() {
-                h.data_points.push(HistogramDataPoint {
-                    attributes: vec![],
-                    start_time: start,
-                    time: t,
-                    count: b.count,
-                    bounds: self.bounds.clone(),
-                    bucket_counts: b.counts.clone(),
-                    sum: if self.record_sum {
-                        b.total
-                    } else {
-                        T::default()
-                    },
-                    min: if self.record_min_max {
-                        Some(b.min)
-                    } else {
-                        None
-                    },
-                    max: if self.record_min_max {
-                        Some(b.max)
-                    } else {
-                        None
-                    },
-                    exemplars: vec![],
-                });
-            }
-        }
-
-        let trackers = match self.value_map.trackers.write() {
-            Ok(v) => v,
-            Err(_) => return (0, None),
-        };
-
-        // TODO: This will use an unbounded amount of memory if there
-        // are unbounded number of attribute sets being aggregated. Attribute
-        // sets that become "stale" need to be forgotten so this will not
-        // overload the system.
-        let mut seen = HashSet::new();
-        for (attrs, tracker) in trackers.iter() {
-            if seen.insert(Arc::as_ptr(tracker)) {
-                if let Ok(b) = tracker.buckets.lock() {
-                    h.data_points.push(HistogramDataPoint {
-                        attributes: attrs.clone(),
-                        start_time: start,
-                        time: t,
-                        count: b.count,
-                        bounds: self.bounds.clone(),
-                        bucket_counts: b.counts.clone(),
-                        sum: if self.record_sum {
-                            b.total
-                        } else {
-                            T::default()
-                        },
-                        min: if self.record_min_max {
-                            Some(b.min)
-                        } else {
-                            None
-                        },
-                        max: if self.record_min_max {
-                            Some(b.max)
-                        } else {
-                            None
-                        },
-                        exemplars: vec![],
-                    });
-                }
-            }
-        }
+        let config = self.aggregators.config();
+        self.aggregators
+            .collect_readonly(&mut h.data_points, |attributes, buckets| {
+                to_data_point(start, t, config, attributes, buckets)
+            });
 
         (h.data_points.len(), new_agg.map(|a| Box::new(a) as Box<_>))
+    }
+}
+
+fn to_data_point<T>(
+    start_time: SystemTime,
+    time: SystemTime,
+    config: &BucketsConfig,
+    attributes: Vec<KeyValue>,
+    buckets: Buckets<T>,
+) -> HistogramDataPoint<T>
+where
+    T: Default,
+{
+    HistogramDataPoint {
+        attributes,
+        start_time,
+        time,
+        count: buckets.count,
+        bounds: config.bounds.clone(),
+        bucket_counts: buckets.counts,
+        sum: if config.record_sum {
+            buckets.total
+        } else {
+            T::default()
+        },
+        min: if config.record_min_max {
+            Some(buckets.min)
+        } else {
+            None
+        },
+        max: if config.record_min_max {
+            Some(buckets.max)
+        } else {
+            None
+        },
+        exemplars: vec![],
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -13,6 +13,7 @@ use super::{Increment, ValueMap};
 /// Summarizes a set of measurements made as their arithmetic sum.
 pub(crate) struct Sum<T: Number> {
     value_map: ValueMap<T, T, Increment>,
+    // value_map2: ValueMap2<T, IncrementAggr<T>>,
     monotonic: bool,
     start: Mutex<SystemTime>,
 }
@@ -26,6 +27,7 @@ impl<T: Number> Sum<T> {
     pub(crate) fn new(monotonic: bool) -> Self {
         Sum {
             value_map: ValueMap::new(),
+            // value_map2: ValueMap2::new(T::default()),
             monotonic,
             start: Mutex::new(SystemTime::now()),
         }
@@ -34,6 +36,7 @@ impl<T: Number> Sum<T> {
     pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
         // The argument index is not applicable to Sum.
         self.value_map.measure(measurement, attrs, 0);
+        // self.value_map2.measure(measurement, attrs);
     }
 
     pub(crate) fn delta(
@@ -67,6 +70,16 @@ impl<T: Number> Sum<T> {
         }
 
         let prev_start = self.start.lock().map(|start| *start).unwrap_or(t);
+
+        // self.value_map2
+        //     .read_measurements(&mut s_data.data_points, |attributes, tracker| DataPoint {
+        //         attributes,
+        //         start_time: Some(prev_start),
+        //         time: Some(t),
+        //         value: tracker.value.get(),
+        //         exemplars: vec![],
+        //     });
+
         if self
             .value_map
             .has_no_attribute_value

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -64,7 +64,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 
-use opentelemetry::{Key, KeyValue, Value};
+use opentelemetry::KeyValue;
 
 /// A unique set of attributes that can be used as instrument identifiers.
 ///
@@ -106,11 +106,6 @@ impl AttributeSet {
         values.sort_unstable();
         let hash = calculate_hash(&values);
         AttributeSet(values, hash)
-    }
-
-    /// Iterate over key value pairs in the set
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&Key, &Value)> {
-        self.0.iter().map(|kv| (&kv.key, &kv.value))
     }
 
     /// Returns the underlying Vec of KeyValue pairs


### PR DESCRIPTION
Fixes #
Introducing common abstraction solved several issues with `ExpoHistogram`:
* added `is_under_cardinality_limit`
* improved performance GREATLY +100%.

Also fixed broken benchmark for histogram collection.

## Changes

Provided abstractions to unify `Histogram` and `ExpoHistogram` behaviour.
There's two new types:
* `trait Aggregator` - provides aggregation specific implementation
* `struct AttributeSetAggregation` - has two tasks:
  * select and update specific aggregator very efficiently. (very similar to current `ValueMap` implementation.)
  * provide functions to collect (and reset) all measurements for DataPoints.
  
 Generally performance for Histogram is not changes much, only collection phase was improved 10-30% percent (the more data you have the bigger the improvement)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
