### PR TITLE
ValueMap interface change

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -343,6 +343,7 @@ impl<T: Number> ExpoHistogram<T> {
     pub(crate) fn measure(&self, value: T, attrs: &[KeyValue]) {
         let f_value = value.into_float();
         // Ignore NaN and infinity.
+        // Only makes sense if T is f64, maybe this could be no-op for other cases?
         if f_value.is_infinite() || f_value.is_nan() {
             return;
         }

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -7,25 +7,51 @@ use std::{
 use crate::metrics::data::DataPoint;
 use opentelemetry::KeyValue;
 
-use super::{Assign, AtomicTracker, Number, ValueMap};
+use super::{Aggregator, AtomicTracker, AtomicallyUpdate, Number, ValueMap};
+
+/// this is reused by PrecomputedSum
+pub(crate) struct Assign<T>
+where
+    T: AtomicallyUpdate<T>,
+{
+    pub(crate) value: T::AtomicTracker,
+}
+
+impl<T> Aggregator<T> for Assign<T>
+where
+    T: Number,
+{
+    type InitConfig = ();
+    type PreComputedValue = T;
+
+    fn create(_init: &()) -> Self {
+        Self {
+            value: T::new_atomic_tracker(T::default()),
+        }
+    }
+
+    fn update(&self, value: T) {
+        self.value.store(value)
+    }
+}
 
 /// Summarizes a set of measurements as the last one made.
 pub(crate) struct LastValue<T: Number> {
-    value_map: ValueMap<T, T, Assign>,
+    value_map: ValueMap<T, Assign<T>>,
     start: Mutex<SystemTime>,
 }
 
 impl<T: Number> LastValue<T> {
     pub(crate) fn new() -> Self {
         LastValue {
-            value_map: ValueMap::new(),
+            value_map: ValueMap::new(()),
             start: Mutex::new(SystemTime::now()),
         }
     }
 
     pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
         // The argument index is not applicable to LastValue.
-        self.value_map.measure(measurement, attrs, 0);
+        self.value_map.measure(measurement, attrs);
     }
 
     pub(crate) fn compute_aggregation_delta(&self, dest: &mut Vec<DataPoint<T>>) {
@@ -49,7 +75,11 @@ impl<T: Number> LastValue<T> {
                 attributes: vec![],
                 start_time: Some(prev_start),
                 time: Some(t),
-                value: self.value_map.no_attribute_tracker.get_and_reset_value(),
+                value: self
+                    .value_map
+                    .no_attribute_tracker
+                    .value
+                    .get_and_reset_value(),
                 exemplars: vec![],
             });
         }
@@ -66,7 +96,7 @@ impl<T: Number> LastValue<T> {
                     attributes: attrs.clone(),
                     start_time: Some(prev_start),
                     time: Some(t),
-                    value: tracker.get_value(),
+                    value: tracker.value.get_value(),
                     exemplars: vec![],
                 });
             }
@@ -101,7 +131,7 @@ impl<T: Number> LastValue<T> {
                 attributes: vec![],
                 start_time: Some(prev_start),
                 time: Some(t),
-                value: self.value_map.no_attribute_tracker.get_value(),
+                value: self.value_map.no_attribute_tracker.value.get_value(),
                 exemplars: vec![],
             });
         }
@@ -118,7 +148,7 @@ impl<T: Number> LastValue<T> {
                     attributes: attrs.clone(),
                     start_time: Some(prev_start),
                     time: Some(t),
-                    value: tracker.get_value(),
+                    value: tracker.value.get_value(),
                     exemplars: vec![],
                 });
             }

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -7,7 +7,6 @@ mod sum;
 
 use core::fmt;
 use std::collections::HashMap;
-use std::marker::PhantomData;
 use std::ops::{Add, AddAssign, Sub};
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
@@ -24,79 +23,65 @@ use crate::metrics::AttributeSet;
 pub(crate) static STREAM_OVERFLOW_ATTRIBUTES: Lazy<Vec<KeyValue>> =
     Lazy::new(|| vec![KeyValue::new("otel.metric.overflow", "true")]);
 
-/// Abstracts the update operation for a measurement.
-pub(crate) trait Operation {
-    fn update_tracker<T: Default, AT: AtomicTracker<T>>(tracker: &AT, value: T, index: usize);
-}
+pub(crate) trait Aggregator<T>
+where
+    T: Number,
+{
+    /// A static configuration that is needed in order to initialize aggregator.
+    /// E.g. bucket_size at creation time .
+    type InitConfig;
 
-struct Increment;
+    /// Some aggregators can do some computations before updating aggregator.
+    /// This helps to reduce contention for aggregators because it makes
+    /// [`Aggregator::update`] as short as possible.
+    type PreComputedValue;
 
-impl Operation for Increment {
-    fn update_tracker<T: Default, AT: AtomicTracker<T>>(tracker: &AT, value: T, _: usize) {
-        tracker.add(value);
-    }
-}
+    /// Called everytime a new attribute-set is stored.
+    fn create(init: &Self::InitConfig) -> Self;
 
-struct Assign;
-
-impl Operation for Assign {
-    fn update_tracker<T: Default, AT: AtomicTracker<T>>(tracker: &AT, value: T, _: usize) {
-        tracker.store(value);
-    }
+    /// Called for each measurement.
+    fn update(&self, value: Self::PreComputedValue);
 }
 
 /// The storage for sums.
 ///
 /// This structure is parametrized by an `Operation` that indicates how
 /// updates to the underlying value trackers should be performed.
-pub(crate) struct ValueMap<AU: AtomicallyUpdate<T>, T: Number, O> {
+pub(crate) struct ValueMap<T, A>
+where
+    T: Number,
+    A: Aggregator<T>,
+{
     /// Trackers store the values associated with different attribute sets.
-    trackers: RwLock<HashMap<Vec<KeyValue>, Arc<AU::AtomicTracker>>>,
+    trackers: RwLock<HashMap<Vec<KeyValue>, Arc<A>>>,
     /// Number of different attribute set stored in the `trackers` map.
     count: AtomicUsize,
     /// Indicates whether a value with no attributes has been stored.
     has_no_attribute_value: AtomicBool,
     /// Tracker for values with no attributes attached.
-    no_attribute_tracker: AU::AtomicTracker,
-    /// Buckets Count is only used by Histogram.
-    buckets_count: Option<usize>,
-    phantom: PhantomData<O>,
+    no_attribute_tracker: A,
+    /// Configuration for an Aggregator
+    config: A::InitConfig,
 }
 
-impl<AU: AtomicallyUpdate<T>, T: Number, O> Default for ValueMap<AU, T, O> {
-    fn default() -> Self {
-        ValueMap::new()
-    }
-}
-
-impl<AU: AtomicallyUpdate<T>, T: Number, O> ValueMap<AU, T, O> {
-    fn new() -> Self {
+impl<T, A> ValueMap<T, A>
+where
+    T: Number,
+    A: Aggregator<T>,
+{
+    fn new(config: A::InitConfig) -> Self {
         ValueMap {
             trackers: RwLock::new(HashMap::new()),
             has_no_attribute_value: AtomicBool::new(false),
-            no_attribute_tracker: AU::new_atomic_tracker(None),
+            no_attribute_tracker: A::create(&config),
             count: AtomicUsize::new(0),
-            buckets_count: None,
-            phantom: PhantomData,
+            config,
         }
     }
 
-    fn new_with_buckets_count(buckets_count: usize) -> Self {
-        ValueMap {
-            trackers: RwLock::new(HashMap::new()),
-            has_no_attribute_value: AtomicBool::new(false),
-            no_attribute_tracker: AU::new_atomic_tracker(Some(buckets_count)),
-            count: AtomicUsize::new(0),
-            buckets_count: Some(buckets_count),
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<AU: AtomicallyUpdate<T>, T: Number, O: Operation> ValueMap<AU, T, O> {
-    fn measure(&self, measurement: T, attributes: &[KeyValue], index: usize) {
+    fn measure(&self, value: A::PreComputedValue, attributes: &[KeyValue]) {
         if attributes.is_empty() {
-            O::update_tracker(&self.no_attribute_tracker, measurement, index);
+            self.no_attribute_tracker.update(value);
             self.has_no_attribute_value.store(true, Ordering::Release);
             return;
         }
@@ -107,14 +92,14 @@ impl<AU: AtomicallyUpdate<T>, T: Number, O: Operation> ValueMap<AU, T, O> {
 
         // Try to retrieve and update the tracker with the attributes in the provided order first
         if let Some(tracker) = trackers.get(attributes) {
-            O::update_tracker(&**tracker, measurement, index);
+            tracker.update(value);
             return;
         }
 
         // Try to retrieve and update the tracker with the attributes sorted.
         let sorted_attrs = AttributeSet::from(attributes).into_vec();
         if let Some(tracker) = trackers.get(sorted_attrs.as_slice()) {
-            O::update_tracker(&**tracker, measurement, index);
+            tracker.update(value);
             return;
         }
 
@@ -128,12 +113,12 @@ impl<AU: AtomicallyUpdate<T>, T: Number, O: Operation> ValueMap<AU, T, O> {
         // Recheck both the provided and sorted orders after acquiring the write lock
         // in case another thread has pushed an update in the meantime.
         if let Some(tracker) = trackers.get(attributes) {
-            O::update_tracker(&**tracker, measurement, index);
+            tracker.update(value);
         } else if let Some(tracker) = trackers.get(sorted_attrs.as_slice()) {
-            O::update_tracker(&**tracker, measurement, index);
+            tracker.update(value);
         } else if is_under_cardinality_limit(self.count.load(Ordering::SeqCst)) {
-            let new_tracker = Arc::new(AU::new_atomic_tracker(self.buckets_count));
-            O::update_tracker(&*new_tracker, measurement, index);
+            let new_tracker = Arc::new(A::create(&self.config));
+            new_tracker.update(value);
 
             // Insert tracker with the attributes in the provided and sorted orders
             trackers.insert(attributes.to_vec(), new_tracker.clone());
@@ -141,10 +126,10 @@ impl<AU: AtomicallyUpdate<T>, T: Number, O: Operation> ValueMap<AU, T, O> {
 
             self.count.fetch_add(1, Ordering::SeqCst);
         } else if let Some(overflow_value) = trackers.get(STREAM_OVERFLOW_ATTRIBUTES.as_slice()) {
-            O::update_tracker(&**overflow_value, measurement, index);
+            overflow_value.update(value);
         } else {
-            let new_tracker = AU::new_atomic_tracker(self.buckets_count);
-            O::update_tracker(&new_tracker, measurement, index);
+            let new_tracker = A::create(&self.config);
+            new_tracker.update(value);
             trackers.insert(STREAM_OVERFLOW_ATTRIBUTES.clone(), Arc::new(new_tracker));
             global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow. Subsequent overflows to same metric until next collect will not be logged.".into()));
             otel_warn!( name: "ValueMap.measure",
@@ -156,22 +141,17 @@ impl<AU: AtomicallyUpdate<T>, T: Number, O: Operation> ValueMap<AU, T, O> {
 
 /// Marks a type that can have a value added and retrieved atomically. Required since
 /// different types have different backing atomic mechanisms
-pub(crate) trait AtomicTracker<T: Default>: Sync + Send + 'static {
-    fn store(&self, _value: T) {}
-    fn add(&self, _value: T) {}
-    fn get_value(&self) -> T {
-        T::default()
-    }
-    fn get_and_reset_value(&self) -> T {
-        T::default()
-    }
-    fn update_histogram(&self, _index: usize, _value: T) {}
+pub(crate) trait AtomicTracker<T>: Sync + Send + 'static {
+    fn store(&self, _value: T);
+    fn add(&self, _value: T);
+    fn get_value(&self) -> T;
+    fn get_and_reset_value(&self) -> T;
 }
 
 /// Marks a type that can have an atomic tracker generated for it
-pub(crate) trait AtomicallyUpdate<T: Default> {
+pub(crate) trait AtomicallyUpdate<T> {
     type AtomicTracker: AtomicTracker<T>;
-    fn new_atomic_tracker(buckets_count: Option<usize>) -> Self::AtomicTracker;
+    fn new_atomic_tracker(init: T) -> Self::AtomicTracker;
 }
 
 pub(crate) trait Number:
@@ -258,8 +238,8 @@ impl AtomicTracker<u64> for AtomicU64 {
 impl AtomicallyUpdate<u64> for u64 {
     type AtomicTracker = AtomicU64;
 
-    fn new_atomic_tracker(_: Option<usize>) -> Self::AtomicTracker {
-        AtomicU64::new(0)
+    fn new_atomic_tracker(init: u64) -> Self::AtomicTracker {
+        AtomicU64::new(init)
     }
 }
 
@@ -284,8 +264,8 @@ impl AtomicTracker<i64> for AtomicI64 {
 impl AtomicallyUpdate<i64> for i64 {
     type AtomicTracker = AtomicI64;
 
-    fn new_atomic_tracker(_: Option<usize>) -> Self::AtomicTracker {
-        AtomicI64::new(0)
+    fn new_atomic_tracker(init: i64) -> Self::AtomicTracker {
+        AtomicI64::new(init)
     }
 }
 
@@ -294,10 +274,10 @@ pub(crate) struct F64AtomicTracker {
 }
 
 impl F64AtomicTracker {
-    fn new() -> Self {
-        let zero_as_u64 = 0.0_f64.to_bits();
+    fn new(init: f64) -> Self {
+        let value_as_u64 = init.to_bits();
         F64AtomicTracker {
-            inner: AtomicU64::new(zero_as_u64),
+            inner: AtomicU64::new(value_as_u64),
         }
     }
 }
@@ -346,8 +326,8 @@ impl AtomicTracker<f64> for F64AtomicTracker {
 impl AtomicallyUpdate<f64> for f64 {
     type AtomicTracker = F64AtomicTracker;
 
-    fn new_atomic_tracker(_: Option<usize>) -> Self::AtomicTracker {
-        F64AtomicTracker::new()
+    fn new_atomic_tracker(init: f64) -> Self::AtomicTracker {
+        F64AtomicTracker::new(init)
     }
 }
 
@@ -357,7 +337,7 @@ mod tests {
 
     #[test]
     fn can_store_u64_atomic_value() {
-        let atomic = u64::new_atomic_tracker(None);
+        let atomic = u64::new_atomic_tracker(0);
         let atomic_tracker = &atomic as &dyn AtomicTracker<u64>;
 
         let value = atomic.get_value();
@@ -370,7 +350,7 @@ mod tests {
 
     #[test]
     fn can_add_and_get_u64_atomic_value() {
-        let atomic = u64::new_atomic_tracker(None);
+        let atomic = u64::new_atomic_tracker(0);
         atomic.add(15);
         atomic.add(10);
 
@@ -380,7 +360,7 @@ mod tests {
 
     #[test]
     fn can_reset_u64_atomic_value() {
-        let atomic = u64::new_atomic_tracker(None);
+        let atomic = u64::new_atomic_tracker(0);
         atomic.add(15);
 
         let value = atomic.get_and_reset_value();
@@ -392,7 +372,7 @@ mod tests {
 
     #[test]
     fn can_store_i64_atomic_value() {
-        let atomic = i64::new_atomic_tracker(None);
+        let atomic = i64::new_atomic_tracker(0);
         let atomic_tracker = &atomic as &dyn AtomicTracker<i64>;
 
         let value = atomic.get_value();
@@ -409,7 +389,7 @@ mod tests {
 
     #[test]
     fn can_add_and_get_i64_atomic_value() {
-        let atomic = i64::new_atomic_tracker(None);
+        let atomic = i64::new_atomic_tracker(0);
         atomic.add(15);
         atomic.add(-10);
 
@@ -419,7 +399,7 @@ mod tests {
 
     #[test]
     fn can_reset_i64_atomic_value() {
-        let atomic = i64::new_atomic_tracker(None);
+        let atomic = i64::new_atomic_tracker(0);
         atomic.add(15);
 
         let value = atomic.get_and_reset_value();
@@ -431,7 +411,7 @@ mod tests {
 
     #[test]
     fn can_store_f64_atomic_value() {
-        let atomic = f64::new_atomic_tracker(None);
+        let atomic = f64::new_atomic_tracker(0.0);
         let atomic_tracker = &atomic as &dyn AtomicTracker<f64>;
 
         let value = atomic.get_value();
@@ -448,7 +428,7 @@ mod tests {
 
     #[test]
     fn can_add_and_get_f64_atomic_value() {
-        let atomic = f64::new_atomic_tracker(None);
+        let atomic = f64::new_atomic_tracker(0.0);
         atomic.add(15.3);
         atomic.add(10.4);
 
@@ -459,7 +439,7 @@ mod tests {
 
     #[test]
     fn can_reset_f64_atomic_value() {
-        let atomic = f64::new_atomic_tracker(None);
+        let atomic = f64::new_atomic_tracker(0.0);
         atomic.add(15.5);
 
         let value = atomic.get_and_reset_value();


### PR DESCRIPTION
## Changes

Absolute minimum changes to `ValueMap` in order to provide interface that can be applied for all kinds of metrics.
I've tried to make this revision as small as possible, (leaving out optimization opportunities and bugs that noticed along the way), so it would be easier to review.
The benefit of this new interface is that it can be applied efficiently to all histograms. I have a proof in #2114 (which uses same interface) that it can be elegantly applied to `ExpoHistogram` as well.

Few more points/notes that might be helpful for reviewer:
* `Histogram` might be a bit harder to review, because it required most changes, but essentially there's configuration extracted into new `BucketsConfig` type, and `Aggregator` is implemented for `Mutex<Buckets<T>>`, the rest is basically compiler-driven-development.
* `LastValue`, `Sum`, `PrecomputedSum` should be trivial to review, I just had to implement `Aggregator` interface for `Increment` and `Assign` functionality, which is pretty trivial.
* Changes to `AtomicTracker` and `AtomicallyUpdate` had to be made as well, either to get rid of "unused code" warning, or required for `Increment` and `Assign`. Generally these interfaces got simplified as well, as they no longer contain histogram-only related stuff.

I really want to unify common/important code so all metrics could benefit from it.
And I really hope this revision is small enough to review efficiently :) Happy reviewing :)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
