### PR TITLE
feature: expose `SimpleSpanProcessor::new`

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Update `async-std` dependency version to 1.13
 - *Breaking* - Remove support for `MetricProducer` which allowed metrics from
   external sources to be sent through OpenTelemetry.
-  [#2105](https://github.com/open-telemetry/opentelemetry-rust/pull/2105)  
+  [#2105](https://github.com/open-telemetry/opentelemetry-rust/pull/2105)
+- Feature: `SimpleSpanProcessor::new` is now public [#2119](https://github.com/open-telemetry/opentelemetry-rust/pull/2119)
 
 ## v0.25.0
 

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -109,7 +109,8 @@ pub struct SimpleSpanProcessor {
 }
 
 impl SimpleSpanProcessor {
-    pub(crate) fn new(exporter: Box<dyn SpanExporter>) -> Self {
+    /// Create a new [SimpleSpanProcessor] using the provided exporter.
+    pub fn new(exporter: Box<dyn SpanExporter>) -> Self {
         Self {
             exporter: Mutex::new(exporter),
         }


### PR DESCRIPTION
Fixes #2060

## Changes

This commit update the visibility of the method `SimpleSpanProcessor::new` from `pub(crate)` to `pub`. This enables consumers to create `SimpleSpanProcessor` values for use with `trace::provider::Builder::with_span_processor`.

In particular, this fixes a consistency issue: the `BatchSpanProcessor` struct may already be built thanks to its `pub` builder. With this change, both processors in this repo may be built manually.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable) (not applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
