### PR TITLE
Allow values containing '=' in OTEL_RESOURCE_ATTRIBUTES

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -44,7 +44,7 @@
 - *Breaking* Removed the following deprecated methods:
   - `Logger::provider()` : Previously deprecated in version 0.27.1
   - `Logger::instrumentation_scope()` : Previously deprecated in version 0.27.1.
-     Migration Guidance: 
+     Migration Guidance:
         - These methods were intended for log appenders. Keep the clone of the provider handle, instead of depending on above methods.
 
 - *Breaking* - `PeriodicReader` Updates
@@ -62,7 +62,7 @@
  1. *Default Implementation, requires no async runtime* (**Recommended**) The
     new default implementation does not require a runtime argument. Replace the
     builder method accordingly:
-    - *Before:* 
+    - *Before:*
       ```rust
       let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter, runtime::Tokio).build();
       ```
@@ -75,7 +75,7 @@
     If your application cannot spin up new threads or you prefer using async
     runtimes, enable the
     "experimental_metrics_periodicreader_with_async_runtime" feature flag and
-    adjust code as below.  
+    adjust code as below.
 
     - *Before:*
       ```rust
@@ -85,11 +85,11 @@
     - *After:*
       ```rust
       let reader = opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader::builder(exporter, runtime::Tokio).build();
-      ```      
+      ```
 
     *Requirements:*
     - Enable the feature flag:
-      `experimental_metrics_periodicreader_with_async_runtime`.  
+      `experimental_metrics_periodicreader_with_async_runtime`.
     - Continue enabling one of the async runtime feature flags: `rt-tokio`,
       `rt-tokio-current-thread`, or `rt-async-std`.
 
@@ -104,7 +104,7 @@
     - Getter methods have been introduced to access field values.
     This change impacts custom exporter and processor developers by requiring updates to code that directly accessed LogRecord fields. They must now use the provided getter methods (e.g., `log_record.event_name()` instead of `log_record.event_name`).
 
-- Upgrade the tracing crate used for internal logging to version 0.1.40 or later. This is necessary because the internal logging macros utilize the name field as       
+- Upgrade the tracing crate used for internal logging to version 0.1.40 or later. This is necessary because the internal logging macros utilize the name field as
 metadata, a feature introduced in version 0.1.40. [#2418](https://github.com/open-telemetry/opentelemetry-rust/pull/2418)
 
 - **Breaking** [#2436](https://github.com/open-telemetry/opentelemetry-rust/pull/2436)
@@ -155,7 +155,7 @@ metadata, a feature introduced in version 0.1.40. [#2418](https://github.com/ope
 
     *Requirements:*
     - Enable the feature flag:
-      `experimental_logs_batch_log_processor_with_async_runtime`.  
+      `experimental_logs_batch_log_processor_with_async_runtime`.
     - Continue enabling one of the async runtime feature flags: `rt-tokio`,
       `rt-tokio-current-thread`, or `rt-async-std`.
 
@@ -207,13 +207,15 @@ metadata, a feature introduced in version 0.1.40. [#2418](https://github.com/ope
 
     *Requirements:*
     - Enable the feature flag:
-      `experimental_trace_batch_span_processor_with_async_runtime`.  
+      `experimental_trace_batch_span_processor_with_async_runtime`.
     - Continue enabling one of the async runtime feature flags: `rt-tokio`,
       `rt-tokio-current-thread`, or `rt-async-std`.
 
 - Bug fix: Empty Tracer names are retained as-is instead of replacing with
   "rust.opentelemetry.io/sdk/tracer"
   [#2486](https://github.com/open-telemetry/opentelemetry-rust/pull/2486)
+- Update `EnvResourceDetector` to allow resource attribute values containing
+  equal signs (`"="`). [#2120](https://github.com/open-telemetry/opentelemetry-rust/pull/2120)
 
 ## 0.27.1
 
@@ -242,10 +244,10 @@ Released 2024-Nov-27
   - Bug fix: Empty Logger names are retained as-is instead of replacing with
     "rust.opentelemetry.io/sdk/logger"
     [#2316](https://github.com/open-telemetry/opentelemetry-rust/pull/2316)
-  
+
   - `Logger::provider`: This method is deprecated as of version `0.27.1`. To be removed in `0.28.0`.
   - `Logger::instrumentation_scope`: This method is deprecated as of version `0.27.1`. To be removed in `0.28.0`
-     Migration Guidance: 
+     Migration Guidance:
         - These methods are intended for log appenders. Keep the clone of the provider handle, instead of depending on above methods.
 
 
@@ -271,7 +273,7 @@ Released 2024-Nov-11
   - **Replaced**
     - ([#2217](https://github.com/open-telemetry/opentelemetry-rust/pull/2217)): Removed `{Delta,Cumulative}TemporalitySelector::new()` in favor of directly using `Temporality` enum to simplify the configuration of MetricsExporterBuilder with different temporalities.
   - **Renamed**
-    - ([#2232](https://github.com/open-telemetry/opentelemetry-rust/pull/2232)): The `init` method used to create instruments has been renamed to `build`.  
+    - ([#2232](https://github.com/open-telemetry/opentelemetry-rust/pull/2232)): The `init` method used to create instruments has been renamed to `build`.
       Before:
       ```rust
       let counter = meter.u64_counter("my_counter").init();


### PR DESCRIPTION
Values passed in to `OTEL_RESOURCE_ATTRIBUTES` containing an equal sign `"="` are currently ignored by the Resource constructor, but should be accepted as it is part of the [W3C Baggage octet
range](https://www.w3.org/TR/baggage/#header-content).

Fixes #2110

## Changes

Updates the `EnvResourceDetector` to allow resource attributes values containing an equal sign (`"="`).

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [X] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
