### PR TITLE
[TEST] Add test about batch processor with current_thread async runtime

### DIFF
--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -813,6 +813,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    #[ignore = "Enable when this is fixed in the batch processor"]
     async fn test_batch_log_processor_shutdown_with_async_runtime() {
         let exporter = InMemoryLogsExporterBuilder::default()
             .keep_records_on_shutdown()

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -827,8 +827,6 @@ mod tests {
         // deadloack happens in shutdown with tokio current_thread runtime
         //
         processor.shutdown().unwrap();
-
-        assert!(true);
     }
 
     #[derive(Debug)]

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -813,7 +813,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    #[ignore = "Enable when this is fixed in the batch processor"]
+    #[ignore = "See issue https://github.com/open-telemetry/opentelemetry-rust/issues/1968"]
     async fn test_batch_log_processor_shutdown_with_async_runtime() {
         let exporter = InMemoryLogsExporterBuilder::default()
             .keep_records_on_shutdown()

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -812,7 +812,6 @@ mod tests {
         assert_eq!(1, exporter.get_emitted_logs().unwrap().len())
     }
 
-
     #[tokio::test(flavor = "current_thread")]
     async fn test_batch_log_processor_shutdown_with_async_runtime() {
         let exporter = InMemoryLogsExporterBuilder::default()

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -814,7 +814,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     #[ignore = "See issue https://github.com/open-telemetry/opentelemetry-rust/issues/1968"]
-    async fn test_batch_log_processor_shutdown_with_async_runtime() {
+    async fn test_batch_log_processor_shutdown_with_async_runtime_current_flavor_multi_thread() {
         let exporter = InMemoryLogsExporterBuilder::default()
             .keep_records_on_shutdown()
             .build();
@@ -827,6 +827,48 @@ mod tests {
         //
         // deadloack happens in shutdown with tokio current_thread runtime
         //
+        processor.shutdown().unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_batch_log_processor_shutdown_with_async_runtime_current_flavor_current_thread() {
+        let exporter = InMemoryLogsExporterBuilder::default()
+            .keep_records_on_shutdown()
+            .build();
+        let processor = BatchLogProcessor::new(
+            Box::new(exporter.clone()),
+            BatchConfig::default(),
+            runtime::TokioCurrentThread,
+        );
+
+        processor.shutdown().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_batch_log_processor_shutdown_with_async_runtime_multi_flavor_multi_thread() {
+        let exporter = InMemoryLogsExporterBuilder::default()
+            .keep_records_on_shutdown()
+            .build();
+        let processor = BatchLogProcessor::new(
+            Box::new(exporter.clone()),
+            BatchConfig::default(),
+            runtime::Tokio,
+        );
+
+        processor.shutdown().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_batch_log_processor_shutdown_with_async_runtime_multi_flavor_current_thread() {
+        let exporter = InMemoryLogsExporterBuilder::default()
+            .keep_records_on_shutdown()
+            .build();
+        let processor = BatchLogProcessor::new(
+            Box::new(exporter.clone()),
+            BatchConfig::default(),
+            runtime::TokioCurrentThread,
+        );
+
         processor.shutdown().unwrap();
     }
 

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -812,6 +812,26 @@ mod tests {
         assert_eq!(1, exporter.get_emitted_logs().unwrap().len())
     }
 
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_batch_log_processor_shutdown_with_async_runtime() {
+        let exporter = InMemoryLogsExporterBuilder::default()
+            .keep_records_on_shutdown()
+            .build();
+        let processor = BatchLogProcessor::new(
+            Box::new(exporter.clone()),
+            BatchConfig::default(),
+            runtime::Tokio,
+        );
+
+        //
+        // deadloack happens in shutdown with tokio current_thread runtime
+        //
+        processor.shutdown().unwrap();
+
+        assert!(true);
+    }
+
     #[derive(Debug)]
     struct FirstProcessor {
         pub(crate) logs: Arc<Mutex<Vec<(LogRecord, InstrumentationLibrary)>>>,


### PR DESCRIPTION
## Changes

Add test to reproduce the deadlock during shutdown of batch processor when configured with single thread async runtime. Related to issue https://github.com/open-telemetry/opentelemetry-rust/issues/2066.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
