### PR TITLE
Implement clone for ExponentialBucket and ExponentialHistogramDataPoint

### DIFF
--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -255,6 +255,26 @@ pub struct ExponentialHistogramDataPoint<T> {
     pub exemplars: Vec<Exemplar<T>>,
 }
 
+impl<T: Copy> Clone for ExponentialHistogramDataPoint<T> {
+    fn clone(&self) -> Self {
+        Self {
+            attributes: self.attributes.clone(),
+            start_time: self.start_time,
+            time: self.time,
+            count: self.count,
+            min: self.min,
+            max: self.max,
+            sum: self.sum,
+            scale: self.scale,
+            zero_count: self.zero_count,
+            positive_bucket: self.positive_bucket.clone(),
+            negative_bucket: self.negative_bucket.clone(),
+            zero_threshold: self.zero_threshold,
+            exemplars: self.exemplars.clone(),
+        }
+    }
+}
+
 /// A set of bucket counts, encoded in a contiguous array of counts.
 #[derive(Debug, PartialEq)]
 pub struct ExponentialBucket {
@@ -266,6 +286,15 @@ pub struct ExponentialBucket {
     /// `counts[i]` is the count of values greater than base^(offset+i) and less than
     /// or equal to base^(offset+i+1).
     pub counts: Vec<u64>,
+}
+
+impl Clone for ExponentialBucket {
+    fn clone(&self) -> Self {
+        Self {
+            offset: self.offset,
+            counts: self.counts.clone(),
+        }
+    }
 }
 
 /// A measurement sampled from a time series providing a typical example.

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -332,7 +332,7 @@ impl<T: Copy> Clone for Exemplar<T> {
 #[cfg(test)]
 mod tests {
 
-    use super::{DataPoint, ExponentialHistogramDataPoint, HistogramDataPoint};
+    use super::{DataPoint, Exemplar, ExponentialHistogramDataPoint, HistogramDataPoint};
 
     use opentelemetry::KeyValue;
 
@@ -343,7 +343,13 @@ mod tests {
             start_time: Some(std::time::SystemTime::now()),
             time: Some(std::time::SystemTime::now()),
             value: 0u32,
-            exemplars: vec![],
+            exemplars: vec![Exemplar {
+                filtered_attributes: vec![],
+                time: std::time::SystemTime::now(),
+                value: 0u32,
+                span_id: [0; 8],
+                trace_id: [0; 16],
+            }],
         };
         assert_eq!(data_type.clone(), data_type);
 
@@ -357,7 +363,13 @@ mod tests {
             min: None,
             max: None,
             sum: 0u32,
-            exemplars: vec![],
+            exemplars: vec![Exemplar {
+                filtered_attributes: vec![],
+                time: std::time::SystemTime::now(),
+                value: 0u32,
+                span_id: [0; 8],
+                trace_id: [0; 16],
+            }],
         };
         assert_eq!(histogram_data_point.clone(), histogram_data_point);
 
@@ -380,7 +392,13 @@ mod tests {
                 counts: vec![],
             },
             zero_threshold: 0.0,
-            exemplars: vec![],
+            exemplars: vec![Exemplar {
+                filtered_attributes: vec![],
+                time: std::time::SystemTime::now(),
+                value: 0u32,
+                span_id: [0; 8],
+                trace_id: [0; 16],
+            }],
         };
         assert_eq!(
             exponential_histogram_data_point.clone(),

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -93,7 +93,7 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Sum<T> {
 }
 
 /// DataPoint is a single data point in a time series.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct DataPoint<T> {
     /// Attributes is the set of key value pairs that uniquely identify the
     /// time series.
@@ -140,7 +140,7 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Histogram<T> {
 }
 
 /// A single histogram data point in a time series.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct HistogramDataPoint<T> {
     /// The set of key value pairs that uniquely identify the time series.
     pub attributes: Vec<KeyValue>,
@@ -207,7 +207,7 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for ExponentialHistogram
 }
 
 /// A single exponential histogram data point in a time series.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct ExponentialHistogramDataPoint<T> {
     /// The set of key value pairs that uniquely identify the time series.
     pub attributes: Vec<KeyValue>,
@@ -298,7 +298,7 @@ impl Clone for ExponentialBucket {
 }
 
 /// A measurement sampled from a time series providing a typical example.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Exemplar<T> {
     /// The attributes recorded with the measurement but filtered out of the
     /// time series' aggregated data.
@@ -326,5 +326,65 @@ impl<T: Copy> Clone for Exemplar<T> {
             span_id: self.span_id,
             trace_id: self.trace_id,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{DataPoint, ExponentialHistogramDataPoint, HistogramDataPoint};
+
+    use opentelemetry::KeyValue;
+
+    #[test]
+    fn validate_cloning_data_points() {
+        let data_type = DataPoint {
+            attributes: vec![KeyValue::new("key", "value")],
+            start_time: Some(std::time::SystemTime::now()),
+            time: Some(std::time::SystemTime::now()),
+            value: 0u32,
+            exemplars: vec![],
+        };
+        assert_eq!(data_type.clone(), data_type);
+
+        let histogram_data_point = HistogramDataPoint {
+            attributes: vec![KeyValue::new("key", "value")],
+            start_time: std::time::SystemTime::now(),
+            time: std::time::SystemTime::now(),
+            count: 0,
+            bounds: vec![],
+            bucket_counts: vec![],
+            min: None,
+            max: None,
+            sum: 0u32,
+            exemplars: vec![],
+        };
+        assert_eq!(histogram_data_point.clone(), histogram_data_point);
+
+        let exponential_histogram_data_point = ExponentialHistogramDataPoint {
+            attributes: vec![KeyValue::new("key", "value")],
+            start_time: std::time::SystemTime::now(),
+            time: std::time::SystemTime::now(),
+            count: 0,
+            min: None,
+            max: None,
+            sum: 0u32,
+            scale: 0,
+            zero_count: 0,
+            positive_bucket: super::ExponentialBucket {
+                offset: 0,
+                counts: vec![],
+            },
+            negative_bucket: super::ExponentialBucket {
+                offset: 0,
+                counts: vec![],
+            },
+            zero_threshold: 0.0,
+            exemplars: vec![],
+        };
+        assert_eq!(
+            exponential_histogram_data_point.clone(),
+            exponential_histogram_data_point
+        );
     }
 }


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes
* Implements `clone` for `ExponentialBucket` and `ExponentialHistogramDataPoint<T: Copy>`
* Derives `PartialEq` for `DataPoint`, `HistogramDataPoint`, `ExponentialHistogramDataPoint`, and `Exemplar`

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
