### PR TITLE
Update builder for Counter, UpDownCounter, and Gauge

### DIFF
--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -5,7 +5,7 @@ use opentelemetry::{
     global,
     metrics::{
         noop::NoopAsyncInstrument, Callback, Counter, Gauge, Histogram, HistogramBuilder,
-        InstrumentProvider, MetricsError, ObservableCounter, ObservableGauge,
+        InstrumentBuilder, InstrumentProvider, MetricsError, ObservableCounter, ObservableGauge,
         ObservableUpDownCounter, Result, UpDownCounter,
     },
 };
@@ -76,28 +76,28 @@ impl SdkMeter {
 
 #[doc(hidden)]
 impl InstrumentProvider for SdkMeter {
-    fn u64_counter(
-        &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-    ) -> Result<Counter<u64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+    fn u64_counter(&self, builder: InstrumentBuilder<'_, Counter<u64>>) -> Result<Counter<u64>> {
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.u64_resolver);
-        p.lookup(InstrumentKind::Counter, name, description, unit)
-            .map(|i| Counter::new(Arc::new(i)))
+        p.lookup(
+            InstrumentKind::Counter,
+            builder.name,
+            builder.description,
+            builder.unit,
+        )
+        .map(|i| Counter::new(Arc::new(i)))
     }
 
-    fn f64_counter(
-        &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-    ) -> Result<Counter<f64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+    fn f64_counter(&self, builder: InstrumentBuilder<'_, Counter<f64>>) -> Result<Counter<f64>> {
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.f64_resolver);
-        p.lookup(InstrumentKind::Counter, name, description, unit)
-            .map(|i| Counter::new(Arc::new(i)))
+        p.lookup(
+            InstrumentKind::Counter,
+            builder.name,
+            builder.description,
+            builder.unit,
+        )
+        .map(|i| Counter::new(Arc::new(i)))
     }
 
     fn u64_observable_counter(
@@ -161,26 +161,32 @@ impl InstrumentProvider for SdkMeter {
 
     fn i64_up_down_counter(
         &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
+        builder: InstrumentBuilder<'_, UpDownCounter<i64>>,
     ) -> Result<UpDownCounter<i64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.i64_resolver);
-        p.lookup(InstrumentKind::UpDownCounter, name, description, unit)
-            .map(|i| UpDownCounter::new(Arc::new(i)))
+        p.lookup(
+            InstrumentKind::UpDownCounter,
+            builder.name,
+            builder.description,
+            builder.unit,
+        )
+        .map(|i| UpDownCounter::new(Arc::new(i)))
     }
 
     fn f64_up_down_counter(
         &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
+        builder: InstrumentBuilder<'_, UpDownCounter<f64>>,
     ) -> Result<UpDownCounter<f64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.f64_resolver);
-        p.lookup(InstrumentKind::UpDownCounter, name, description, unit)
-            .map(|i| UpDownCounter::new(Arc::new(i)))
+        p.lookup(
+            InstrumentKind::UpDownCounter,
+            builder.name,
+            builder.description,
+            builder.unit,
+        )
+        .map(|i| UpDownCounter::new(Arc::new(i)))
     }
 
     fn i64_observable_up_down_counter(
@@ -247,40 +253,40 @@ impl InstrumentProvider for SdkMeter {
         Ok(ObservableUpDownCounter::new(observable))
     }
 
-    fn u64_gauge(
-        &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-    ) -> Result<Gauge<u64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+    fn u64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<u64>>) -> Result<Gauge<u64>> {
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.u64_resolver);
-        p.lookup(InstrumentKind::Gauge, name, description, unit)
-            .map(|i| Gauge::new(Arc::new(i)))
+        p.lookup(
+            InstrumentKind::Gauge,
+            builder.name,
+            builder.description,
+            builder.unit,
+        )
+        .map(|i| Gauge::new(Arc::new(i)))
     }
 
-    fn f64_gauge(
-        &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-    ) -> Result<Gauge<f64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+    fn f64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<f64>>) -> Result<Gauge<f64>> {
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.f64_resolver);
-        p.lookup(InstrumentKind::Gauge, name, description, unit)
-            .map(|i| Gauge::new(Arc::new(i)))
+        p.lookup(
+            InstrumentKind::Gauge,
+            builder.name,
+            builder.description,
+            builder.unit,
+        )
+        .map(|i| Gauge::new(Arc::new(i)))
     }
 
-    fn i64_gauge(
-        &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-    ) -> Result<Gauge<i64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+    fn i64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<i64>>) -> Result<Gauge<i64>> {
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.i64_resolver);
-        p.lookup(InstrumentKind::Gauge, name, description, unit)
-            .map(|i| Gauge::new(Arc::new(i)))
+        p.lookup(
+            InstrumentKind::Gauge,
+            builder.name,
+            builder.description,
+            builder.unit,
+        )
+        .map(|i| Gauge::new(Arc::new(i)))
     }
 
     fn u64_observable_gauge(
@@ -582,8 +588,13 @@ mod tests {
                 }
             };
 
-            assert(meter.u64_counter(name.into(), None, None).map(|_| ()));
-            assert(meter.f64_counter(name.into(), None, None).map(|_| ()));
+            // Get handle to InstrumentBuilder for testing
+            let global_meter = global::meter("test");
+            let counter_builder_u64 = global_meter.u64_counter(name);
+            let counter_builder_f64 = global_meter.f64_counter(name);
+
+            assert(meter.u64_counter(counter_builder_u64).map(|_| ()));
+            assert(meter.f64_counter(counter_builder_f64).map(|_| ()));
             assert(
                 meter
                     .u64_observable_counter(name.into(), None, None, Vec::new())
@@ -594,14 +605,19 @@ mod tests {
                     .f64_observable_counter(name.into(), None, None, Vec::new())
                     .map(|_| ()),
             );
+
+            // Get handle to InstrumentBuilder for testing
+            let up_down_counter_builder_i64 = global_meter.i64_up_down_counter(name);
+            let up_down_counter_builder_f64 = global_meter.f64_up_down_counter(name);
+
             assert(
                 meter
-                    .i64_up_down_counter(name.into(), None, None)
+                    .i64_up_down_counter(up_down_counter_builder_i64)
                     .map(|_| ()),
             );
             assert(
                 meter
-                    .f64_up_down_counter(name.into(), None, None)
+                    .f64_up_down_counter(up_down_counter_builder_f64)
                     .map(|_| ()),
             );
             assert(
@@ -614,9 +630,15 @@ mod tests {
                     .f64_observable_up_down_counter(name.into(), None, None, Vec::new())
                     .map(|_| ()),
             );
-            assert(meter.u64_gauge(name.into(), None, None).map(|_| ()));
-            assert(meter.f64_gauge(name.into(), None, None).map(|_| ()));
-            assert(meter.i64_gauge(name.into(), None, None).map(|_| ()));
+
+            // Get handle to InstrumentBuilder for testing
+            let gauge_builder_u64 = global_meter.u64_gauge(name);
+            let gauge_builder_f64 = global_meter.f64_gauge(name);
+            let gauge_builder_i64 = global_meter.i64_gauge(name);
+
+            assert(meter.u64_gauge(gauge_builder_u64).map(|_| ()));
+            assert(meter.f64_gauge(gauge_builder_f64).map(|_| ()));
+            assert(meter.i64_gauge(gauge_builder_i64).map(|_| ()));
             assert(
                 meter
                     .u64_observable_gauge(name.into(), None, None, Vec::new())
@@ -634,7 +656,6 @@ mod tests {
             );
 
             // Get handle to HistogramBuilder for testing
-            let global_meter = global::meter("test");
             let histogram_builder_f64 = global_meter.f64_histogram(name);
             let histogram_builder_u64 = global_meter.u64_histogram(name);
 
@@ -667,16 +688,18 @@ mod tests {
                 }
             };
             let unit = Some(unit.into());
-            assert(
-                meter
-                    .u64_counter("test".into(), None, unit.clone())
-                    .map(|_| ()),
-            );
-            assert(
-                meter
-                    .f64_counter("test".into(), None, unit.clone())
-                    .map(|_| ()),
-            );
+
+            // Get handle to InstrumentBuilder for testing
+            let global_meter = global::meter("test");
+            let counter_builder_u64 = global_meter
+                .u64_counter("test")
+                .with_unit(unit.clone().unwrap());
+            let counter_builder_f64 = global_meter
+                .f64_counter("test")
+                .with_unit(unit.clone().unwrap());
+
+            assert(meter.u64_counter(counter_builder_u64).map(|_| ()));
+            assert(meter.f64_counter(counter_builder_f64).map(|_| ()));
             assert(
                 meter
                     .u64_observable_counter("test".into(), None, unit.clone(), Vec::new())
@@ -687,14 +710,24 @@ mod tests {
                     .f64_observable_counter("test".into(), None, unit.clone(), Vec::new())
                     .map(|_| ()),
             );
+
+            // Get handle to InstrumentBuilder for testing
+            let up_down_counter_builder_i64 = global_meter
+                .i64_up_down_counter("test")
+                .with_unit(unit.clone().unwrap());
+            let up_down_counter_builder_f64 = global_meter
+                .f64_up_down_counter("test")
+                .with_unit(unit.clone().unwrap());
+
             assert(
                 meter
-                    .i64_up_down_counter("test".into(), None, unit.clone())
+                    .i64_up_down_counter(up_down_counter_builder_i64)
                     .map(|_| ()),
             );
+
             assert(
                 meter
-                    .f64_up_down_counter("test".into(), None, unit.clone())
+                    .f64_up_down_counter(up_down_counter_builder_f64)
                     .map(|_| ()),
             );
             assert(
@@ -724,7 +757,6 @@ mod tests {
             );
 
             // Get handle to HistogramBuilder for testing
-            let global_meter = global::meter("test");
             let histogram_builder_f64 = global_meter
                 .f64_histogram("test")
                 .with_unit(unit.clone().unwrap());

--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -1,10 +1,12 @@
 use crate::{
-    metrics::{AsyncInstrument, AsyncInstrumentBuilder, InstrumentBuilder, MetricsError},
+    metrics::{AsyncInstrument, AsyncInstrumentBuilder, MetricsError},
     KeyValue,
 };
 use core::fmt;
 use std::any::Any;
 use std::sync::Arc;
+
+use super::InstrumentBuilder;
 
 /// An SDK implemented instrument that records increasing values.
 pub trait SyncCounter<T> {
@@ -41,9 +43,7 @@ impl TryFrom<InstrumentBuilder<'_, Counter<u64>>> for Counter<u64> {
     type Error = MetricsError;
 
     fn try_from(builder: InstrumentBuilder<'_, Counter<u64>>) -> Result<Self, Self::Error> {
-        builder
-            .instrument_provider
-            .u64_counter(builder.name, builder.description, builder.unit)
+        builder.instrument_provider.u64_counter(builder)
     }
 }
 
@@ -51,9 +51,7 @@ impl TryFrom<InstrumentBuilder<'_, Counter<f64>>> for Counter<f64> {
     type Error = MetricsError;
 
     fn try_from(builder: InstrumentBuilder<'_, Counter<f64>>) -> Result<Self, Self::Error> {
-        builder
-            .instrument_provider
-            .f64_counter(builder.name, builder.description, builder.unit)
+        builder.instrument_provider.f64_counter(builder)
     }
 }
 

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -41,9 +41,7 @@ impl TryFrom<InstrumentBuilder<'_, Gauge<u64>>> for Gauge<u64> {
     type Error = MetricsError;
 
     fn try_from(builder: InstrumentBuilder<'_, Gauge<u64>>) -> Result<Self, Self::Error> {
-        builder
-            .instrument_provider
-            .u64_gauge(builder.name, builder.description, builder.unit)
+        builder.instrument_provider.u64_gauge(builder)
     }
 }
 
@@ -51,9 +49,7 @@ impl TryFrom<InstrumentBuilder<'_, Gauge<f64>>> for Gauge<f64> {
     type Error = MetricsError;
 
     fn try_from(builder: InstrumentBuilder<'_, Gauge<f64>>) -> Result<Self, Self::Error> {
-        builder
-            .instrument_provider
-            .f64_gauge(builder.name, builder.description, builder.unit)
+        builder.instrument_provider.f64_gauge(builder)
     }
 }
 
@@ -61,9 +57,7 @@ impl TryFrom<InstrumentBuilder<'_, Gauge<i64>>> for Gauge<i64> {
     type Error = MetricsError;
 
     fn try_from(builder: InstrumentBuilder<'_, Gauge<i64>>) -> Result<Self, Self::Error> {
-        builder
-            .instrument_provider
-            .i64_gauge(builder.name, builder.description, builder.unit)
+        builder.instrument_provider.i64_gauge(builder)
     }
 }
 

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -25,7 +25,7 @@ pub trait AsyncInstrument<T>: Send + Sync {
 }
 
 /// Configuration for building a Histogram.
-#[non_exhaustive]
+#[non_exhaustive] // We expect to add more configuration fields in the future
 pub struct HistogramBuilder<'a, T> {
     /// Instrument provider is used to create the instrument.
     pub instrument_provider: &'a dyn InstrumentProvider,
@@ -113,11 +113,20 @@ impl<'a> HistogramBuilder<'a, u64> {
 }
 
 /// Configuration for building a sync instrument.
+#[non_exhaustive] // We expect to add more configuration fields in the future
 pub struct InstrumentBuilder<'a, T> {
-    instrument_provider: &'a dyn InstrumentProvider,
-    name: Cow<'static, str>,
-    description: Option<Cow<'static, str>>,
-    unit: Option<Cow<'static, str>>,
+    /// Instrument provider is used to create the instrument.
+    pub instrument_provider: &'a dyn InstrumentProvider,
+
+    /// Name of the instrument.
+    pub name: Cow<'static, str>,
+
+    /// Description of the instrument.
+    pub description: Option<Cow<'static, str>>,
+
+    /// Unit of the instrument.
+    pub unit: Option<Cow<'static, str>>,
+
     _marker: marker::PhantomData<T>,
 }
 
@@ -171,6 +180,46 @@ where
         T::try_from(self).unwrap()
     }
 }
+
+/*
+impl<'a> InstrumentBuilder<'a, f64> {
+    /// Validate the instrument configuration and creates a new instrument.
+    pub fn try_init(self) -> Result<Counter<f64>> {
+        self.instrument_provider.f64_counter(self)
+    }
+
+    /// Creates a new instrument.
+    ///
+    /// Validate the instrument configuration and crates a new instrument.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the instrument cannot be created. Use
+    /// [`try_init`](InstrumentBuilder::try_init) if you want to handle errors.
+    pub fn init(self) -> Counter<f64> {
+        self.try_init().unwrap()
+    }
+}
+
+impl<'a> InstrumentBuilder<'a, u64> {
+    /// Validate the instrument configuration and creates a new instrument.
+    pub fn try_init(self) -> Result<Counter<u64>> {
+        self.instrument_provider.u64_counter(self)
+    }
+
+    /// Creates a new instrument.
+    ///
+    /// Validate the instrument configuration and crates a new instrument.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the instrument cannot be created. Use
+    /// [`try_init`](InstrumentBuilder::try_init) if you want to handle errors.
+    pub fn init(self) -> Counter<u64> {
+        self.try_init().unwrap()
+    }
+}
+*/
 
 impl<T> fmt::Debug for InstrumentBuilder<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -181,46 +181,6 @@ where
     }
 }
 
-/*
-impl<'a> InstrumentBuilder<'a, f64> {
-    /// Validate the instrument configuration and creates a new instrument.
-    pub fn try_init(self) -> Result<Counter<f64>> {
-        self.instrument_provider.f64_counter(self)
-    }
-
-    /// Creates a new instrument.
-    ///
-    /// Validate the instrument configuration and crates a new instrument.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the instrument cannot be created. Use
-    /// [`try_init`](InstrumentBuilder::try_init) if you want to handle errors.
-    pub fn init(self) -> Counter<f64> {
-        self.try_init().unwrap()
-    }
-}
-
-impl<'a> InstrumentBuilder<'a, u64> {
-    /// Validate the instrument configuration and creates a new instrument.
-    pub fn try_init(self) -> Result<Counter<u64>> {
-        self.instrument_provider.u64_counter(self)
-    }
-
-    /// Creates a new instrument.
-    ///
-    /// Validate the instrument configuration and crates a new instrument.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the instrument cannot be created. Use
-    /// [`try_init`](InstrumentBuilder::try_init) if you want to handle errors.
-    pub fn init(self) -> Counter<u64> {
-        self.try_init().unwrap()
-    }
-}
-*/
-
 impl<T> fmt::Debug for InstrumentBuilder<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("InstrumentBuilder")

--- a/opentelemetry/src/metrics/instruments/up_down_counter.rs
+++ b/opentelemetry/src/metrics/instruments/up_down_counter.rs
@@ -46,11 +46,7 @@ impl TryFrom<InstrumentBuilder<'_, UpDownCounter<i64>>> for UpDownCounter<i64> {
     type Error = MetricsError;
 
     fn try_from(builder: InstrumentBuilder<'_, UpDownCounter<i64>>) -> Result<Self, Self::Error> {
-        builder.instrument_provider.i64_up_down_counter(
-            builder.name,
-            builder.description,
-            builder.unit,
-        )
+        builder.instrument_provider.i64_up_down_counter(builder)
     }
 }
 
@@ -58,11 +54,7 @@ impl TryFrom<InstrumentBuilder<'_, UpDownCounter<f64>>> for UpDownCounter<f64> {
     type Error = MetricsError;
 
     fn try_from(builder: InstrumentBuilder<'_, UpDownCounter<f64>>) -> Result<Self, Self::Error> {
-        builder.instrument_provider.f64_up_down_counter(
-            builder.name,
-            builder.description,
-            builder.unit,
-        )
+        builder.instrument_provider.f64_up_down_counter(builder)
     }
 }
 

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -3,12 +3,12 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use crate::metrics::{
-    AsyncInstrumentBuilder, Counter, Gauge, InstrumentBuilder, InstrumentProvider,
-    ObservableCounter, ObservableGauge, ObservableUpDownCounter, UpDownCounter,
+    AsyncInstrumentBuilder, Gauge, InstrumentBuilder, InstrumentProvider, ObservableCounter,
+    ObservableGauge, ObservableUpDownCounter, UpDownCounter,
 };
 use crate::KeyValue;
 
-use super::HistogramBuilder;
+use super::{Counter, HistogramBuilder};
 
 /// Provides access to named [Meter] instances, for instrumenting an application
 /// or crate.

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -108,22 +108,12 @@ impl Eq for KeyValue {}
 /// SDK implemented trait for creating instruments
 pub trait InstrumentProvider {
     /// creates an instrument for recording increasing values.
-    fn u64_counter(
-        &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-    ) -> Result<Counter<u64>> {
+    fn u64_counter(&self, _builder: InstrumentBuilder<'_, Counter<u64>>) -> Result<Counter<u64>> {
         Ok(Counter::new(Arc::new(noop::NoopSyncInstrument::new())))
     }
 
     /// creates an instrument for recording increasing values.
-    fn f64_counter(
-        &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-    ) -> Result<Counter<f64>> {
+    fn f64_counter(&self, _builder: InstrumentBuilder<'_, Counter<f64>>) -> Result<Counter<f64>> {
         Ok(Counter::new(Arc::new(noop::NoopSyncInstrument::new())))
     }
 
@@ -156,9 +146,7 @@ pub trait InstrumentProvider {
     /// creates an instrument for recording changes of a value.
     fn i64_up_down_counter(
         &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
+        _builder: InstrumentBuilder<'_, UpDownCounter<i64>>,
     ) -> Result<UpDownCounter<i64>> {
         Ok(UpDownCounter::new(
             Arc::new(noop::NoopSyncInstrument::new()),
@@ -168,9 +156,7 @@ pub trait InstrumentProvider {
     /// creates an instrument for recording changes of a value.
     fn f64_up_down_counter(
         &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
+        _builder: InstrumentBuilder<'_, UpDownCounter<f64>>,
     ) -> Result<UpDownCounter<f64>> {
         Ok(UpDownCounter::new(
             Arc::new(noop::NoopSyncInstrument::new()),
@@ -204,32 +190,17 @@ pub trait InstrumentProvider {
     }
 
     /// creates an instrument for recording independent values.
-    fn u64_gauge(
-        &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-    ) -> Result<Gauge<u64>> {
+    fn u64_gauge(&self, _builder: InstrumentBuilder<'_, Gauge<u64>>) -> Result<Gauge<u64>> {
         Ok(Gauge::new(Arc::new(noop::NoopSyncInstrument::new())))
     }
 
     /// creates an instrument for recording independent values.
-    fn f64_gauge(
-        &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-    ) -> Result<Gauge<f64>> {
+    fn f64_gauge(&self, _builder: InstrumentBuilder<'_, Gauge<f64>>) -> Result<Gauge<f64>> {
         Ok(Gauge::new(Arc::new(noop::NoopSyncInstrument::new())))
     }
 
     /// creates an instrument for recording independent values.
-    fn i64_gauge(
-        &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-    ) -> Result<Gauge<i64>> {
+    fn i64_gauge(&self, _builder: InstrumentBuilder<'_, Gauge<i64>>) -> Result<Gauge<i64>> {
         Ok(Gauge::new(Arc::new(noop::NoopSyncInstrument::new())))
     }
 


### PR DESCRIPTION
Follow-up to #2130 

## Changes
- `InstrumentBuilder` struct has been marked `non_exhaustive` to allow for adding more configuration in the future.
-  Update `InstrumentProvider` trait methods for creating counters, up_down_counters, and gauges to only take the builder as the input. This reduces the number of public API changes when adding newer configuration.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
