### PR TITLE
Update builder for ObservableCounter, ObservableUpDownCounter, and ObservableGauge

### DIFF
--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -4,9 +4,9 @@ use std::{borrow::Cow, sync::Arc};
 use opentelemetry::{
     global,
     metrics::{
-        noop::NoopAsyncInstrument, Callback, Counter, Gauge, Histogram, HistogramBuilder,
-        InstrumentBuilder, InstrumentProvider, MetricsError, ObservableCounter, ObservableGauge,
-        ObservableUpDownCounter, Result, UpDownCounter,
+        noop::NoopAsyncInstrument, AsyncInstrumentBuilder, Counter, Gauge, Histogram,
+        HistogramBuilder, InstrumentBuilder, InstrumentProvider, MetricsError, ObservableCounter,
+        ObservableGauge, ObservableUpDownCounter, Result, UpDownCounter,
     },
 };
 
@@ -102,18 +102,15 @@ impl InstrumentProvider for SdkMeter {
 
     fn u64_observable_counter(
         &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-        callbacks: Vec<Callback<u64>>,
+        builder: AsyncInstrumentBuilder<'_, ObservableCounter<u64>, u64>,
     ) -> Result<ObservableCounter<u64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.u64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableCounter,
-            name.clone(),
-            description.clone(),
-            unit.clone(),
+            builder.name,
+            builder.description,
+            builder.unit,
         )?;
         if ms.is_empty() {
             return Ok(ObservableCounter::new(Arc::new(NoopAsyncInstrument::new())));
@@ -121,7 +118,7 @@ impl InstrumentProvider for SdkMeter {
 
         let observable = Arc::new(Observable::new(ms));
 
-        for callback in callbacks {
+        for callback in builder.callbacks {
             let cb_inst = Arc::clone(&observable);
             self.pipes
                 .register_callback(move || callback(cb_inst.as_ref()));
@@ -132,25 +129,22 @@ impl InstrumentProvider for SdkMeter {
 
     fn f64_observable_counter(
         &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-        callbacks: Vec<Callback<f64>>,
+        builder: AsyncInstrumentBuilder<'_, ObservableCounter<f64>, f64>,
     ) -> Result<ObservableCounter<f64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.f64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableCounter,
-            name.clone(),
-            description.clone(),
-            unit.clone(),
+            builder.name,
+            builder.description,
+            builder.unit,
         )?;
         if ms.is_empty() {
             return Ok(ObservableCounter::new(Arc::new(NoopAsyncInstrument::new())));
         }
         let observable = Arc::new(Observable::new(ms));
 
-        for callback in callbacks {
+        for callback in builder.callbacks {
             let cb_inst = Arc::clone(&observable);
             self.pipes
                 .register_callback(move || callback(cb_inst.as_ref()));
@@ -191,18 +185,15 @@ impl InstrumentProvider for SdkMeter {
 
     fn i64_observable_up_down_counter(
         &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-        callbacks: Vec<Callback<i64>>,
+        builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<i64>, i64>,
     ) -> Result<ObservableUpDownCounter<i64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.i64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableUpDownCounter,
-            name.clone(),
-            description.clone(),
-            unit.clone(),
+            builder.name,
+            builder.description,
+            builder.unit,
         )?;
         if ms.is_empty() {
             return Ok(ObservableUpDownCounter::new(Arc::new(
@@ -212,7 +203,7 @@ impl InstrumentProvider for SdkMeter {
 
         let observable = Arc::new(Observable::new(ms));
 
-        for callback in callbacks {
+        for callback in builder.callbacks {
             let cb_inst = Arc::clone(&observable);
             self.pipes
                 .register_callback(move || callback(cb_inst.as_ref()));
@@ -223,18 +214,15 @@ impl InstrumentProvider for SdkMeter {
 
     fn f64_observable_up_down_counter(
         &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-        callbacks: Vec<Callback<f64>>,
+        builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<f64>, f64>,
     ) -> Result<ObservableUpDownCounter<f64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.f64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableUpDownCounter,
-            name.clone(),
-            description.clone(),
-            unit.clone(),
+            builder.name,
+            builder.description,
+            builder.unit,
         )?;
         if ms.is_empty() {
             return Ok(ObservableUpDownCounter::new(Arc::new(
@@ -244,7 +232,7 @@ impl InstrumentProvider for SdkMeter {
 
         let observable = Arc::new(Observable::new(ms));
 
-        for callback in callbacks {
+        for callback in builder.callbacks {
             let cb_inst = Arc::clone(&observable);
             self.pipes
                 .register_callback(move || callback(cb_inst.as_ref()));
@@ -291,18 +279,15 @@ impl InstrumentProvider for SdkMeter {
 
     fn u64_observable_gauge(
         &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-        callbacks: Vec<Callback<u64>>,
+        builder: AsyncInstrumentBuilder<'_, ObservableGauge<u64>, u64>,
     ) -> Result<ObservableGauge<u64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.u64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableGauge,
-            name.clone(),
-            description.clone(),
-            unit.clone(),
+            builder.name,
+            builder.description,
+            builder.unit,
         )?;
         if ms.is_empty() {
             return Ok(ObservableGauge::new(Arc::new(NoopAsyncInstrument::new())));
@@ -310,7 +295,7 @@ impl InstrumentProvider for SdkMeter {
 
         let observable = Arc::new(Observable::new(ms));
 
-        for callback in callbacks {
+        for callback in builder.callbacks {
             let cb_inst = Arc::clone(&observable);
             self.pipes
                 .register_callback(move || callback(cb_inst.as_ref()));
@@ -321,18 +306,15 @@ impl InstrumentProvider for SdkMeter {
 
     fn i64_observable_gauge(
         &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-        callbacks: Vec<Callback<i64>>,
+        builder: AsyncInstrumentBuilder<'_, ObservableGauge<i64>, i64>,
     ) -> Result<ObservableGauge<i64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.i64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableGauge,
-            name.clone(),
-            description.clone(),
-            unit.clone(),
+            builder.name,
+            builder.description,
+            builder.unit,
         )?;
         if ms.is_empty() {
             return Ok(ObservableGauge::new(Arc::new(NoopAsyncInstrument::new())));
@@ -340,7 +322,7 @@ impl InstrumentProvider for SdkMeter {
 
         let observable = Arc::new(Observable::new(ms));
 
-        for callback in callbacks {
+        for callback in builder.callbacks {
             let cb_inst = Arc::clone(&observable);
             self.pipes
                 .register_callback(move || callback(cb_inst.as_ref()));
@@ -351,18 +333,15 @@ impl InstrumentProvider for SdkMeter {
 
     fn f64_observable_gauge(
         &self,
-        name: Cow<'static, str>,
-        description: Option<Cow<'static, str>>,
-        unit: Option<Cow<'static, str>>,
-        callbacks: Vec<Callback<f64>>,
+        builder: AsyncInstrumentBuilder<'_, ObservableGauge<f64>, f64>,
     ) -> Result<ObservableGauge<f64>> {
-        validate_instrument_config(name.as_ref(), &unit, self.validation_policy)?;
+        validate_instrument_config(builder.name.as_ref(), &builder.unit, self.validation_policy)?;
         let p = InstrumentResolver::new(self, &self.f64_resolver);
         let ms = p.measures(
             InstrumentKind::ObservableGauge,
-            name.clone(),
-            description.clone(),
-            unit.clone(),
+            builder.name,
+            builder.description,
+            builder.unit,
         )?;
         if ms.is_empty() {
             return Ok(ObservableGauge::new(Arc::new(NoopAsyncInstrument::new())));
@@ -370,7 +349,7 @@ impl InstrumentProvider for SdkMeter {
 
         let observable = Arc::new(Observable::new(ms));
 
-        for callback in callbacks {
+        for callback in builder.callbacks {
             let cb_inst = Arc::clone(&observable);
             self.pipes
                 .register_callback(move || callback(cb_inst.as_ref()));
@@ -528,7 +507,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{borrow::Cow, sync::Arc};
 
     use opentelemetry::{
         global,
@@ -593,16 +572,20 @@ mod tests {
             let counter_builder_u64 = global_meter.u64_counter(name);
             let counter_builder_f64 = global_meter.f64_counter(name);
 
+            // Get handle to AsyncInstrumentBuilder for testing
+            let observable_counter_u64 = global_meter.u64_observable_counter(name);
+            let observable_counter_f64 = global_meter.f64_observable_counter(name);
+
             assert(meter.u64_counter(counter_builder_u64).map(|_| ()));
             assert(meter.f64_counter(counter_builder_f64).map(|_| ()));
             assert(
                 meter
-                    .u64_observable_counter(name.into(), None, None, Vec::new())
+                    .u64_observable_counter(observable_counter_u64)
                     .map(|_| ()),
             );
             assert(
                 meter
-                    .f64_observable_counter(name.into(), None, None, Vec::new())
+                    .f64_observable_counter(observable_counter_f64)
                     .map(|_| ()),
             );
 
@@ -620,14 +603,19 @@ mod tests {
                     .f64_up_down_counter(up_down_counter_builder_f64)
                     .map(|_| ()),
             );
+
+            // Get handle to AsyncInstrumentBuilder for testing
+            let observable_up_down_counter_i64 = global_meter.i64_observable_up_down_counter(name);
+            let observable_up_down_counter_f64 = global_meter.f64_observable_up_down_counter(name);
+
             assert(
                 meter
-                    .i64_observable_up_down_counter(name.into(), None, None, Vec::new())
+                    .i64_observable_up_down_counter(observable_up_down_counter_i64)
                     .map(|_| ()),
             );
             assert(
                 meter
-                    .f64_observable_up_down_counter(name.into(), None, None, Vec::new())
+                    .f64_observable_up_down_counter(observable_up_down_counter_f64)
                     .map(|_| ()),
             );
 
@@ -639,21 +627,15 @@ mod tests {
             assert(meter.u64_gauge(gauge_builder_u64).map(|_| ()));
             assert(meter.f64_gauge(gauge_builder_f64).map(|_| ()));
             assert(meter.i64_gauge(gauge_builder_i64).map(|_| ()));
-            assert(
-                meter
-                    .u64_observable_gauge(name.into(), None, None, Vec::new())
-                    .map(|_| ()),
-            );
-            assert(
-                meter
-                    .i64_observable_gauge(name.into(), None, None, Vec::new())
-                    .map(|_| ()),
-            );
-            assert(
-                meter
-                    .f64_observable_gauge(name.into(), None, None, Vec::new())
-                    .map(|_| ()),
-            );
+
+            // Get handle to AsyncInstrumentBuilder for testing
+            let observable_gauge_u64 = global_meter.u64_observable_gauge(name);
+            let observable_gauge_i64 = global_meter.i64_observable_gauge(name);
+            let observable_gauge_f64 = global_meter.f64_observable_gauge(name);
+
+            assert(meter.u64_observable_gauge(observable_gauge_u64).map(|_| ()));
+            assert(meter.i64_observable_gauge(observable_gauge_i64).map(|_| ()));
+            assert(meter.f64_observable_gauge(observable_gauge_f64).map(|_| ()));
 
             // Get handle to HistogramBuilder for testing
             let histogram_builder_f64 = global_meter.f64_histogram(name);
@@ -687,7 +669,7 @@ mod tests {
                     ));
                 }
             };
-            let unit = Some(unit.into());
+            let unit: Option<Cow<'static, str>> = Some(unit.into());
 
             // Get handle to InstrumentBuilder for testing
             let global_meter = global::meter("test");
@@ -700,14 +682,23 @@ mod tests {
 
             assert(meter.u64_counter(counter_builder_u64).map(|_| ()));
             assert(meter.f64_counter(counter_builder_f64).map(|_| ()));
+
+            // Get handle to AsyncInstrumentBuilder for testing
+            let observable_counter_u64 = global_meter
+                .u64_observable_counter("test")
+                .with_unit(unit.clone().unwrap());
+            let observable_counter_f64 = global_meter
+                .f64_observable_counter("test")
+                .with_unit(unit.clone().unwrap());
+
             assert(
                 meter
-                    .u64_observable_counter("test".into(), None, unit.clone(), Vec::new())
+                    .u64_observable_counter(observable_counter_u64)
                     .map(|_| ()),
             );
             assert(
                 meter
-                    .f64_observable_counter("test".into(), None, unit.clone(), Vec::new())
+                    .f64_observable_counter(observable_counter_f64)
                     .map(|_| ()),
             );
 
@@ -730,31 +721,40 @@ mod tests {
                     .f64_up_down_counter(up_down_counter_builder_f64)
                     .map(|_| ()),
             );
+
+            // Get handle to AsyncInstrumentBuilder for testing
+            let observable_up_down_counter_i64 = global_meter
+                .i64_observable_up_down_counter("test")
+                .with_unit(unit.clone().unwrap());
+            let observable_up_down_counter_f64 = global_meter
+                .f64_observable_up_down_counter("test")
+                .with_unit(unit.clone().unwrap());
+
             assert(
                 meter
-                    .i64_observable_up_down_counter("test".into(), None, unit.clone(), Vec::new())
+                    .i64_observable_up_down_counter(observable_up_down_counter_i64)
                     .map(|_| ()),
             );
             assert(
                 meter
-                    .f64_observable_up_down_counter("test".into(), None, unit.clone(), Vec::new())
+                    .f64_observable_up_down_counter(observable_up_down_counter_f64)
                     .map(|_| ()),
             );
-            assert(
-                meter
-                    .u64_observable_gauge("test".into(), None, unit.clone(), Vec::new())
-                    .map(|_| ()),
-            );
-            assert(
-                meter
-                    .i64_observable_gauge("test".into(), None, unit.clone(), Vec::new())
-                    .map(|_| ()),
-            );
-            assert(
-                meter
-                    .f64_observable_gauge("test".into(), None, unit.clone(), Vec::new())
-                    .map(|_| ()),
-            );
+
+            // Get handle to AsyncInstrumentBuilder for testing
+            let observable_gauge_u64 = global_meter
+                .u64_observable_gauge("test")
+                .with_unit(unit.clone().unwrap());
+            let observable_gauge_i64 = global_meter
+                .i64_observable_gauge("test")
+                .with_unit(unit.clone().unwrap());
+            let observable_gauge_f64 = global_meter
+                .f64_observable_gauge("test")
+                .with_unit(unit.clone().unwrap());
+
+            assert(meter.u64_observable_gauge(observable_gauge_u64).map(|_| ()));
+            assert(meter.i64_observable_gauge(observable_gauge_i64).map(|_| ()));
+            assert(meter.f64_observable_gauge(observable_gauge_f64).map(|_| ()));
 
             // Get handle to HistogramBuilder for testing
             let histogram_builder_f64 = global_meter

--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -107,12 +107,7 @@ impl TryFrom<AsyncInstrumentBuilder<'_, ObservableCounter<u64>, u64>> for Observ
     fn try_from(
         builder: AsyncInstrumentBuilder<'_, ObservableCounter<u64>, u64>,
     ) -> Result<Self, Self::Error> {
-        builder.meter.instrument_provider.u64_observable_counter(
-            builder.name,
-            builder.description,
-            builder.unit,
-            builder.callbacks,
-        )
+        builder.instrument_provider.u64_observable_counter(builder)
     }
 }
 
@@ -122,11 +117,6 @@ impl TryFrom<AsyncInstrumentBuilder<'_, ObservableCounter<f64>, f64>> for Observ
     fn try_from(
         builder: AsyncInstrumentBuilder<'_, ObservableCounter<f64>, f64>,
     ) -> Result<Self, Self::Error> {
-        builder.meter.instrument_provider.f64_observable_counter(
-            builder.name,
-            builder.description,
-            builder.unit,
-            builder.callbacks,
-        )
+        builder.instrument_provider.f64_observable_counter(builder)
     }
 }

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -116,12 +116,7 @@ impl TryFrom<AsyncInstrumentBuilder<'_, ObservableGauge<u64>, u64>> for Observab
     fn try_from(
         builder: AsyncInstrumentBuilder<'_, ObservableGauge<u64>, u64>,
     ) -> Result<Self, Self::Error> {
-        builder.meter.instrument_provider.u64_observable_gauge(
-            builder.name,
-            builder.description,
-            builder.unit,
-            builder.callbacks,
-        )
+        builder.instrument_provider.u64_observable_gauge(builder)
     }
 }
 
@@ -131,12 +126,7 @@ impl TryFrom<AsyncInstrumentBuilder<'_, ObservableGauge<f64>, f64>> for Observab
     fn try_from(
         builder: AsyncInstrumentBuilder<'_, ObservableGauge<f64>, f64>,
     ) -> Result<Self, Self::Error> {
-        builder.meter.instrument_provider.f64_observable_gauge(
-            builder.name,
-            builder.description,
-            builder.unit,
-            builder.callbacks,
-        )
+        builder.instrument_provider.f64_observable_gauge(builder)
     }
 }
 
@@ -146,11 +136,6 @@ impl TryFrom<AsyncInstrumentBuilder<'_, ObservableGauge<i64>, i64>> for Observab
     fn try_from(
         builder: AsyncInstrumentBuilder<'_, ObservableGauge<i64>, i64>,
     ) -> Result<Self, Self::Error> {
-        builder.meter.instrument_provider.i64_observable_gauge(
-            builder.name,
-            builder.description,
-            builder.unit,
-            builder.callbacks,
-        )
+        builder.instrument_provider.i64_observable_gauge(builder)
     }
 }

--- a/opentelemetry/src/metrics/instruments/up_down_counter.rs
+++ b/opentelemetry/src/metrics/instruments/up_down_counter.rs
@@ -114,14 +114,8 @@ impl TryFrom<AsyncInstrumentBuilder<'_, ObservableUpDownCounter<i64>, i64>>
         builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<i64>, i64>,
     ) -> Result<Self, Self::Error> {
         builder
-            .meter
             .instrument_provider
-            .i64_observable_up_down_counter(
-                builder.name,
-                builder.description,
-                builder.unit,
-                builder.callbacks,
-            )
+            .i64_observable_up_down_counter(builder)
     }
 }
 
@@ -134,13 +128,7 @@ impl TryFrom<AsyncInstrumentBuilder<'_, ObservableUpDownCounter<f64>, f64>>
         builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<f64>, f64>,
     ) -> Result<Self, Self::Error> {
         builder
-            .meter
             .instrument_provider
-            .f64_observable_up_down_counter(
-                builder.name,
-                builder.description,
-                builder.unit,
-                builder.callbacks,
-            )
+            .f64_observable_up_down_counter(builder)
     }
 }

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -3,8 +3,8 @@
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use std::result;
+use std::sync::Arc;
 use std::sync::PoisonError;
-use std::{borrow::Cow, sync::Arc};
 use thiserror::Error;
 
 mod instruments;
@@ -120,10 +120,7 @@ pub trait InstrumentProvider {
     /// creates an instrument for recording increasing values via callback.
     fn u64_observable_counter(
         &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-        _callback: Vec<Callback<u64>>,
+        _builder: AsyncInstrumentBuilder<'_, ObservableCounter<u64>, u64>,
     ) -> Result<ObservableCounter<u64>> {
         Ok(ObservableCounter::new(Arc::new(
             noop::NoopAsyncInstrument::new(),
@@ -133,10 +130,7 @@ pub trait InstrumentProvider {
     /// creates an instrument for recording increasing values via callback.
     fn f64_observable_counter(
         &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-        _callback: Vec<Callback<f64>>,
+        _builder: AsyncInstrumentBuilder<'_, ObservableCounter<f64>, f64>,
     ) -> Result<ObservableCounter<f64>> {
         Ok(ObservableCounter::new(Arc::new(
             noop::NoopAsyncInstrument::new(),
@@ -166,10 +160,7 @@ pub trait InstrumentProvider {
     /// creates an instrument for recording changes of a value.
     fn i64_observable_up_down_counter(
         &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-        _callback: Vec<Callback<i64>>,
+        _builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<i64>, i64>,
     ) -> Result<ObservableUpDownCounter<i64>> {
         Ok(ObservableUpDownCounter::new(Arc::new(
             noop::NoopAsyncInstrument::new(),
@@ -179,10 +170,7 @@ pub trait InstrumentProvider {
     /// creates an instrument for recording changes of a value via callback.
     fn f64_observable_up_down_counter(
         &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-        _callback: Vec<Callback<f64>>,
+        _builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<f64>, f64>,
     ) -> Result<ObservableUpDownCounter<f64>> {
         Ok(ObservableUpDownCounter::new(Arc::new(
             noop::NoopAsyncInstrument::new(),
@@ -207,10 +195,7 @@ pub trait InstrumentProvider {
     /// creates an instrument for recording the current value via callback.
     fn u64_observable_gauge(
         &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-        _callback: Vec<Callback<u64>>,
+        _builder: AsyncInstrumentBuilder<'_, ObservableGauge<u64>, u64>,
     ) -> Result<ObservableGauge<u64>> {
         Ok(ObservableGauge::new(Arc::new(
             noop::NoopAsyncInstrument::new(),
@@ -220,10 +205,7 @@ pub trait InstrumentProvider {
     /// creates an instrument for recording the current value via callback.
     fn i64_observable_gauge(
         &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-        _callback: Vec<Callback<i64>>,
+        _builder: AsyncInstrumentBuilder<'_, ObservableGauge<i64>, i64>,
     ) -> Result<ObservableGauge<i64>> {
         Ok(ObservableGauge::new(Arc::new(
             noop::NoopAsyncInstrument::new(),
@@ -233,10 +215,7 @@ pub trait InstrumentProvider {
     /// creates an instrument for recording the current value via callback.
     fn f64_observable_gauge(
         &self,
-        _name: Cow<'static, str>,
-        _description: Option<Cow<'static, str>>,
-        _unit: Option<Cow<'static, str>>,
-        _callback: Vec<Callback<f64>>,
+        _builder: AsyncInstrumentBuilder<'_, ObservableGauge<f64>, f64>,
     ) -> Result<ObservableGauge<f64>> {
         Ok(ObservableGauge::new(Arc::new(
             noop::NoopAsyncInstrument::new(),


### PR DESCRIPTION
Follow-up to #2130, #2131

## Changes
- `AsyncInstrumentBuilder` struct has been marked `non_exhaustive` to allow for adding more configuration in the future.
- `AsyncInstrumentBuilder` struct would now have the field `instrument_provider` instead of `Meter`. This is consistent with `InstrumentBuilder` and `HistogramBuilder`
-  Update `InstrumentProvider` trait methods for creating observable counters, observable up_down_counters, and observable gauges to only take the builder as the input. This reduces the number of public API changes when adding newer configuration.

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
