### PR TITLE
PeriodicReader::build make interval registration in same thread/task

### DIFF
--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -470,7 +470,6 @@ fn aggregate_fn<T: Number>(
     agg: &aggregation::Aggregation,
     kind: InstrumentKind,
 ) -> Result<Option<AggregateFns<T>>> {
-    use aggregation::Aggregation;
     fn box_val<T>(
         (m, ca): (impl internal::Measure<T>, impl internal::ComputeAggregation),
     ) -> (
@@ -544,7 +543,6 @@ fn aggregate_fn<T: Number>(
 /// | Gauge                    | ✓    | ✓         |     | ✓         | ✓                     |
 /// | Observable Gauge         | ✓    | ✓         |     | ✓         | ✓                     |
 fn is_aggregator_compatible(kind: &InstrumentKind, agg: &aggregation::Aggregation) -> Result<()> {
-    use aggregation::Aggregation;
     match agg {
         Aggregation::Default => Ok(()),
         Aggregation::ExplicitBucketHistogram { .. }


### PR DESCRIPTION
## Changes

Previous behavior was that in `PeriodicReader::build` interval was registered before spawning a task. Which means that we effectively need already running runtime in order to register an `interval`.

This revision moves `interval` registration within `spawn` function, which allow to register `PeriodicReader` independently of any runtime.

You can see in test `collection_triggered_by_interval`, that this works perfectly fine without any runtime when using `TokioCurrentThread`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
