### PR TITLE
Fix CI and bump the msrv of OTLP to 1.71.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        rust: [1.65.0, 1.70.0]
+        rust: [1.65.0, 1.71.1]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNext
+- Bump MSRV to 1.71.1 [2140](https://github.com/open-telemetry/opentelemetry-rust/pull/2140)
 
 ## v0.25.0
 

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.71.1"
 autotests = false
 
 [[test]]

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -30,7 +30,7 @@ can easily instrument your applications or systems, no matter their language,
 infrastructure, or runtime environment. Crucially, the storage and visualization
 of telemetry is intentionally left to other tools.
 
-*Compiler support: [requires `rustc` 1.70+][msrv]*
+*Compiler support: [requires `rustc` 1.71.1+][msrv]*
 
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
@@ -43,7 +43,7 @@ See [docs](https://docs.rs/opentelemetry-otlp).
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.70. The current OpenTelemetry version is not guaranteed to build
+version is 1.71.1. The current OpenTelemetry version is not guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## vNext
 
 - Fix JSON serialization of `metrics::Exemplar` and `trace::span::Link` [#2069](https://github.com/open-telemetry/opentelemetry-rust/pull/2069)
-- Bump MSRV to 1.71.1 [2140](https://github.com/open-telemetry/opentelemetry-rust/pull/2140)
 
 ## v0.25.0
 - Update `opentelemetry` dependency version to 0.25

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Fix JSON serialization of `metrics::Exemplar` and `trace::span::Link` [#2069](https://github.com/open-telemetry/opentelemetry-rust/pull/2069)
+- Bump MSRV to 1.71.1 [2140](https://github.com/open-telemetry/opentelemetry-rust/pull/2140)
 
 ## v0.25.0
 - Update `opentelemetry` dependency version to 0.25

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.71.1"
+rust-version = "1.70"
 autotests = false
 
 [lib]

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.71.1"
 autotests = false
 
 [lib]

--- a/opentelemetry-proto/README.md
+++ b/opentelemetry-proto/README.md
@@ -7,4 +7,4 @@ This crate contains generated files from [opentelemetry-proto](https://github.co
 repository and transformation between types from generated files and types defined in [opentelemetry](https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry).
 
 
-*Compiler support: [requires `rustc` 1.70+]
+*Compiler support: [requires `rustc` 1.71.1+]

--- a/opentelemetry-proto/README.md
+++ b/opentelemetry-proto/README.md
@@ -7,4 +7,4 @@ This crate contains generated files from [opentelemetry-proto](https://github.co
 repository and transformation between types from generated files and types defined in [opentelemetry](https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry).
 
 
-*Compiler support: [requires `rustc` 1.71.1+]
+*Compiler support: [requires `rustc` 1.70+]

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
@@ -227,31 +227,31 @@ impl SeverityNumber {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            SeverityNumber::Unspecified => "SEVERITY_NUMBER_UNSPECIFIED",
-            SeverityNumber::Trace => "SEVERITY_NUMBER_TRACE",
-            SeverityNumber::Trace2 => "SEVERITY_NUMBER_TRACE2",
-            SeverityNumber::Trace3 => "SEVERITY_NUMBER_TRACE3",
-            SeverityNumber::Trace4 => "SEVERITY_NUMBER_TRACE4",
-            SeverityNumber::Debug => "SEVERITY_NUMBER_DEBUG",
-            SeverityNumber::Debug2 => "SEVERITY_NUMBER_DEBUG2",
-            SeverityNumber::Debug3 => "SEVERITY_NUMBER_DEBUG3",
-            SeverityNumber::Debug4 => "SEVERITY_NUMBER_DEBUG4",
-            SeverityNumber::Info => "SEVERITY_NUMBER_INFO",
-            SeverityNumber::Info2 => "SEVERITY_NUMBER_INFO2",
-            SeverityNumber::Info3 => "SEVERITY_NUMBER_INFO3",
-            SeverityNumber::Info4 => "SEVERITY_NUMBER_INFO4",
-            SeverityNumber::Warn => "SEVERITY_NUMBER_WARN",
-            SeverityNumber::Warn2 => "SEVERITY_NUMBER_WARN2",
-            SeverityNumber::Warn3 => "SEVERITY_NUMBER_WARN3",
-            SeverityNumber::Warn4 => "SEVERITY_NUMBER_WARN4",
-            SeverityNumber::Error => "SEVERITY_NUMBER_ERROR",
-            SeverityNumber::Error2 => "SEVERITY_NUMBER_ERROR2",
-            SeverityNumber::Error3 => "SEVERITY_NUMBER_ERROR3",
-            SeverityNumber::Error4 => "SEVERITY_NUMBER_ERROR4",
-            SeverityNumber::Fatal => "SEVERITY_NUMBER_FATAL",
-            SeverityNumber::Fatal2 => "SEVERITY_NUMBER_FATAL2",
-            SeverityNumber::Fatal3 => "SEVERITY_NUMBER_FATAL3",
-            SeverityNumber::Fatal4 => "SEVERITY_NUMBER_FATAL4",
+            Self::Unspecified => "SEVERITY_NUMBER_UNSPECIFIED",
+            Self::Trace => "SEVERITY_NUMBER_TRACE",
+            Self::Trace2 => "SEVERITY_NUMBER_TRACE2",
+            Self::Trace3 => "SEVERITY_NUMBER_TRACE3",
+            Self::Trace4 => "SEVERITY_NUMBER_TRACE4",
+            Self::Debug => "SEVERITY_NUMBER_DEBUG",
+            Self::Debug2 => "SEVERITY_NUMBER_DEBUG2",
+            Self::Debug3 => "SEVERITY_NUMBER_DEBUG3",
+            Self::Debug4 => "SEVERITY_NUMBER_DEBUG4",
+            Self::Info => "SEVERITY_NUMBER_INFO",
+            Self::Info2 => "SEVERITY_NUMBER_INFO2",
+            Self::Info3 => "SEVERITY_NUMBER_INFO3",
+            Self::Info4 => "SEVERITY_NUMBER_INFO4",
+            Self::Warn => "SEVERITY_NUMBER_WARN",
+            Self::Warn2 => "SEVERITY_NUMBER_WARN2",
+            Self::Warn3 => "SEVERITY_NUMBER_WARN3",
+            Self::Warn4 => "SEVERITY_NUMBER_WARN4",
+            Self::Error => "SEVERITY_NUMBER_ERROR",
+            Self::Error2 => "SEVERITY_NUMBER_ERROR2",
+            Self::Error3 => "SEVERITY_NUMBER_ERROR3",
+            Self::Error4 => "SEVERITY_NUMBER_ERROR4",
+            Self::Fatal => "SEVERITY_NUMBER_FATAL",
+            Self::Fatal2 => "SEVERITY_NUMBER_FATAL2",
+            Self::Fatal3 => "SEVERITY_NUMBER_FATAL3",
+            Self::Fatal4 => "SEVERITY_NUMBER_FATAL4",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -313,8 +313,8 @@ impl LogRecordFlags {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            LogRecordFlags::DoNotUse => "LOG_RECORD_FLAGS_DO_NOT_USE",
-            LogRecordFlags::TraceFlagsMask => "LOG_RECORD_FLAGS_TRACE_FLAGS_MASK",
+            Self::DoNotUse => "LOG_RECORD_FLAGS_DO_NOT_USE",
+            Self::TraceFlagsMask => "LOG_RECORD_FLAGS_TRACE_FLAGS_MASK",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.metrics.v1.rs
@@ -808,9 +808,9 @@ impl AggregationTemporality {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            AggregationTemporality::Unspecified => "AGGREGATION_TEMPORALITY_UNSPECIFIED",
-            AggregationTemporality::Delta => "AGGREGATION_TEMPORALITY_DELTA",
-            AggregationTemporality::Cumulative => "AGGREGATION_TEMPORALITY_CUMULATIVE",
+            Self::Unspecified => "AGGREGATION_TEMPORALITY_UNSPECIFIED",
+            Self::Delta => "AGGREGATION_TEMPORALITY_DELTA",
+            Self::Cumulative => "AGGREGATION_TEMPORALITY_CUMULATIVE",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -851,10 +851,8 @@ impl DataPointFlags {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            DataPointFlags::DoNotUse => "DATA_POINT_FLAGS_DO_NOT_USE",
-            DataPointFlags::NoRecordedValueMask => {
-                "DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK"
-            }
+            Self::DoNotUse => "DATA_POINT_FLAGS_DO_NOT_USE",
+            Self::NoRecordedValueMask => "DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.trace.v1.rs
@@ -378,12 +378,12 @@ pub mod span {
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
-                SpanKind::Unspecified => "SPAN_KIND_UNSPECIFIED",
-                SpanKind::Internal => "SPAN_KIND_INTERNAL",
-                SpanKind::Server => "SPAN_KIND_SERVER",
-                SpanKind::Client => "SPAN_KIND_CLIENT",
-                SpanKind::Producer => "SPAN_KIND_PRODUCER",
-                SpanKind::Consumer => "SPAN_KIND_CONSUMER",
+                Self::Unspecified => "SPAN_KIND_UNSPECIFIED",
+                Self::Internal => "SPAN_KIND_INTERNAL",
+                Self::Server => "SPAN_KIND_SERVER",
+                Self::Client => "SPAN_KIND_CLIENT",
+                Self::Producer => "SPAN_KIND_PRODUCER",
+                Self::Consumer => "SPAN_KIND_CONSUMER",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -450,9 +450,9 @@ pub mod status {
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
         pub fn as_str_name(&self) -> &'static str {
             match self {
-                StatusCode::Unset => "STATUS_CODE_UNSET",
-                StatusCode::Ok => "STATUS_CODE_OK",
-                StatusCode::Error => "STATUS_CODE_ERROR",
+                Self::Unset => "STATUS_CODE_UNSET",
+                Self::Ok => "STATUS_CODE_OK",
+                Self::Error => "STATUS_CODE_ERROR",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -504,10 +504,10 @@ impl SpanFlags {
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            SpanFlags::DoNotUse => "SPAN_FLAGS_DO_NOT_USE",
-            SpanFlags::TraceFlagsMask => "SPAN_FLAGS_TRACE_FLAGS_MASK",
-            SpanFlags::ContextHasIsRemoteMask => "SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK",
-            SpanFlags::ContextIsRemoteMask => "SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK",
+            Self::DoNotUse => "SPAN_FLAGS_DO_NOT_USE",
+            Self::TraceFlagsMask => "SPAN_FLAGS_TRACE_FLAGS_MASK",
+            Self::ContextHasIsRemoteMask => "SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK",
+            Self::ContextIsRemoteMask => "SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.

--- a/scripts/msrv_config.json
+++ b/scripts/msrv_config.json
@@ -9,11 +9,9 @@
       "opentelemetry-appender-log/Cargo.toml",
       "opentelemetry-appender-tracing/Cargo.toml"
     ],
-    "1.70.0": [
-      "opentelemetry-proto/Cargo.toml"
-    ],
     "1.71.1": [
-      "opentelemetry-otlp/Cargo.toml"
+      "opentelemetry-otlp/Cargo.toml",
+      "opentelemetry-proto/Cargo.toml"
     ]
 }
   

--- a/scripts/msrv_config.json
+++ b/scripts/msrv_config.json
@@ -1,17 +1,16 @@
 {
-    "1.65.0": [
-      "opentelemetry/Cargo.toml",
-      "opentelemetry-sdk/Cargo.toml",
-      "opentelemetry-stdout/Cargo.toml",
-      "opentelemetry-http/Cargo.toml",
-      "opentelemetry-jaeger-propagator/Cargo.toml",
-      "opentelemetry-zipkin/Cargo.toml",
-      "opentelemetry-appender-log/Cargo.toml",
-      "opentelemetry-appender-tracing/Cargo.toml"
-    ],
-    "1.71.1": [
-      "opentelemetry-otlp/Cargo.toml",
-      "opentelemetry-proto/Cargo.toml"
-    ]
+  "1.65.0": [
+    "opentelemetry/Cargo.toml",
+    "opentelemetry-sdk/Cargo.toml",
+    "opentelemetry-stdout/Cargo.toml",
+    "opentelemetry-http/Cargo.toml",
+    "opentelemetry-jaeger-propagator/Cargo.toml",
+    "opentelemetry-zipkin/Cargo.toml",
+    "opentelemetry-appender-log/Cargo.toml",
+    "opentelemetry-appender-tracing/Cargo.toml"
+  ],
+  "1.71.1": [
+    "opentelemetry-otlp/Cargo.toml",
+    "opentelemetry-proto/Cargo.toml"
+  ]
 }
-  

--- a/scripts/msrv_config.json
+++ b/scripts/msrv_config.json
@@ -9,9 +9,11 @@
       "opentelemetry-appender-log/Cargo.toml",
       "opentelemetry-appender-tracing/Cargo.toml"
     ],
-    "1.70.0": [
-      "opentelemetry-otlp/Cargo.toml",
+    "1.71.0": [
       "opentelemetry-proto/Cargo.toml"
+    ],
+    "1.71.1": [
+      "opentelemetry-otlp/Cargo.toml"
     ]
   }
   

--- a/scripts/msrv_config.json
+++ b/scripts/msrv_config.json
@@ -9,11 +9,11 @@
       "opentelemetry-appender-log/Cargo.toml",
       "opentelemetry-appender-tracing/Cargo.toml"
     ],
-    "1.71.0": [
+    "1.70.0": [
       "opentelemetry-proto/Cargo.toml"
     ],
     "1.71.1": [
       "opentelemetry-otlp/Cargo.toml"
     ]
-  }
+}
   


### PR DESCRIPTION
## Changes
- CI checks are failing
  - [test workflow](https://github.com/open-telemetry/opentelemetry-rust/actions/runs/10975946115/job/30476167559) Needs to conform to the new code analysis rules of using `Self` instead of the type name
  - [msrv workflow](https://github.com/open-telemetry/opentelemetry-rust/actions/runs/10975946115/job/30476167398) OTLP exporter and proto project have to use a newer version of rustc

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
