### PR TITLE
Improve internal opentelemetry logging - directly using tracing mcros

### DIFF
--- a/examples/self-diagnostics/Cargo.toml
+++ b/examples/self-diagnostics/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 opentelemetry = { path = "../../opentelemetry" }
-opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio"]}
+opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio", "experimental-internal-logs"]}
 opentelemetry-stdout = { path = "../../opentelemetry-stdout"}
 opentelemetry-appender-tracing = { path = "../../opentelemetry-appender-tracing"}
 tokio = { workspace = true, features = ["full"] }

--- a/examples/self-diagnostics/Cargo.toml
+++ b/examples/self-diagnostics/Cargo.toml
@@ -14,6 +14,6 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true, features = ["std"]}
 tracing-core = { workspace = true }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter","registry", "std"]}
-opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["http-proto", "reqwest-client", "logs"] }
+opentelemetry-otlp = { path = "../../opentelemetry-otlp", features = ["http-proto", "reqwest-client", "logs", "experimental-internal-logs"] }
 once_cell ={ version = "1.19.0"}
 ctrlc = "3.4"

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -32,6 +32,7 @@ opentelemetry = { version = "0.25", default-features = false, path = "../opentel
 opentelemetry_sdk = { version = "0.25", default-features = false, path = "../opentelemetry-sdk" }
 opentelemetry-http = { version = "0.25", path = "../opentelemetry-http", optional = true }
 opentelemetry-proto = { version = "0.25", path = "../opentelemetry-proto", default-features = false }
+tracing = {workspace = true, optional = true}
 
 prost = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }
@@ -57,6 +58,7 @@ trace = ["opentelemetry/trace", "opentelemetry_sdk/trace", "opentelemetry-proto/
 metrics = ["opentelemetry/metrics", "opentelemetry_sdk/metrics", "opentelemetry-proto/metrics"]
 logs = ["opentelemetry/logs", "opentelemetry_sdk/logs", "opentelemetry-proto/logs"]
 populate-logs-event-name = ["opentelemetry-proto/populate-logs-event-name"]
+experimental-internal-logs = ["tracing"]
 
 # add ons
 serialize = ["serde", "serde_json"]

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -298,7 +298,11 @@ impl PushMetricsExporter for MetricsExporter {
         tracing::debug!(
             name = "export_metrics",
             target = "opentelemetry-otlp",
-            metrics_count = metrics.metrics_count(),
+            metrics_count = metrics
+                .scope_metrics
+                .iter()
+                .map(|scope| scope.metrics.len())
+                .sum::<usize>(),
             status = "started"
         );
         let result = self.client.export(metrics).await;

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -28,6 +28,7 @@ url = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt", "time"], optional = true }
 tokio-stream = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
+tracing = {workspace = true, optional = true}
 
 [package.metadata.docs.rs]
 all-features = true
@@ -51,6 +52,7 @@ testing = ["opentelemetry/testing", "trace", "metrics", "logs", "rt-async-std", 
 rt-tokio = ["tokio", "tokio-stream"]
 rt-tokio-current-thread = ["tokio", "tokio-stream"]
 rt-async-std = ["async-std"]
+experimental-internal-logs = ["tracing"]
 
 [[bench]]
 name = "context"

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -104,7 +104,7 @@ impl LogProcessor for SimpleLogProcessor {
         #[cfg(all(feature = "experimental-internal-logs"))]
         tracing::debug!(
             name: "simple_log_processor_emit",
-            target: "opentelemetry-sdk",
+            target: "opentelemetry",
             event_name = record.event_name
         );
 
@@ -227,6 +227,7 @@ impl<R: RuntimeChannel> BatchLogProcessor<R> {
                         #[cfg(feature = "experimental-internal-logs")]
                         tracing::debug!(
                             name: "batch_log_processor_record_count",
+                            target: "opentelemetry",
                             current_batch_size = logs.len()
                         );
 

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -101,6 +101,13 @@ impl LogProcessor for SimpleLogProcessor {
             return;
         }
 
+        #[cfg(all(feature = "experimental-internal-logs"))]
+        tracing::debug!(
+            name: "simple_log_processor_emit",
+            target: "opentelemetry-sdk",
+            event_name = record.event_name
+        );
+
         let result = self
             .exporter
             .lock()
@@ -217,6 +224,11 @@ impl<R: RuntimeChannel> BatchLogProcessor<R> {
                     // Log has finished, add to buffer of pending logs.
                     BatchMessage::ExportLog(log) => {
                         logs.push(log);
+                        #[cfg(feature = "experimental-internal-logs")]
+                        tracing::debug!(
+                            name: "batch_log_processor_record_count",
+                            current_batch_size = logs.len()
+                        );
 
                         if logs.len() == config.max_export_batch_size {
                             let result = export_with_timeout(

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -104,7 +104,7 @@ impl LogProcessor for SimpleLogProcessor {
         #[cfg(all(feature = "experimental-internal-logs"))]
         tracing::debug!(
             name: "simple_log_processor_emit",
-            target: "opentelemetry",
+            target: "opentelemetry-sdk",
             event_name = record.event_name
         );
 
@@ -227,7 +227,7 @@ impl<R: RuntimeChannel> BatchLogProcessor<R> {
                         #[cfg(feature = "experimental-internal-logs")]
                         tracing::debug!(
                             name: "batch_log_processor_record_count",
-                            target: "opentelemetry",
+                            target: "opentelemetry-sdk",
                             current_batch_size = logs.len()
                         );
 

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -101,7 +101,7 @@ impl LogProcessor for SimpleLogProcessor {
             return;
         }
 
-        #[cfg(all(feature = "experimental-internal-logs"))]
+        #[cfg(feature = "experimental-internal-logs")]
         tracing::debug!(
             name: "simple_log_processor_emit",
             target: "opentelemetry-sdk",

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -19,16 +19,6 @@ pub struct ResourceMetrics {
     pub scope_metrics: Vec<ScopeMetrics>,
 }
 
-impl ResourceMetrics {
-    /// Returns the total number of metrics across all `ScopeMetrics`.
-    pub fn metrics_count(&self) -> usize {
-        self.scope_metrics
-            .iter()
-            .map(|scope| scope.metrics.len())
-            .sum()
-    }
-}
-
 /// A collection of metrics produced by a meter.
 #[derive(Default, Debug)]
 pub struct ScopeMetrics {

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -19,6 +19,16 @@ pub struct ResourceMetrics {
     pub scope_metrics: Vec<ScopeMetrics>,
 }
 
+impl ResourceMetrics {
+    /// Returns the total number of metrics across all `ScopeMetrics`.
+    pub fn metrics_count(&self) -> usize {
+        self.scope_metrics
+            .iter()
+            .map(|scope| scope.metrics.len())
+            .sum()
+    }
+}
+
 /// A collection of metrics produced by a meter.
 #[derive(Default, Debug)]
 pub struct ScopeMetrics {

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -255,6 +255,7 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
                 res // return the status of export.
             }
             Either::Right(_) => {
+                #[cfg(feature = "experimental-internal-logs")]
                 tracing::error!(
                     name = "collect_and_export",
                     target = "opentelemetry-sdk",
@@ -268,12 +269,14 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
     async fn process_message(&mut self, message: Message) -> bool {
         match message {
             Message::Export => {
+                #[cfg(feature = "experimental-internal-logs")]
                 tracing::debug!(name: "process_message", target: "opentelemetry-sdk", message_type = "export");
                 if let Err(err) = self.collect_and_export().await {
                     global::handle_error(err)
                 }
             }
             Message::Flush(ch) => {
+                #[cfg(feature = "experimental-internal-logs")]
                 tracing::debug!(name: "process_message", target: "opentelemetry-sdk", message_type = "flush");
                 let res = self.collect_and_export().await;
                 if ch.send(res).is_err() {
@@ -281,6 +284,7 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
                 }
             }
             Message::Shutdown(ch) => {
+                #[cfg(feature = "experimental-internal-logs")]
                 tracing::debug!(name: "process_message", target: "opentelemetry-sdk", message_type = "shutdown");
                 let res = self.collect_and_export().await;
                 let _ = self.reader.exporter.shutdown();

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -235,7 +235,7 @@ struct PeriodicReaderWorker<RT: Runtime> {
 impl<RT: Runtime> PeriodicReaderWorker<RT> {
     async fn collect_and_export(&mut self) -> Result<()> {
         #[cfg(feature = "experimental-internal-logs")]
-        tracing::debug!(name: "collect_and_export", target: "opentelemetry-sdk", status = "started");
+        tracing::debug!(name: "metrics_collect_and_export", target: "opentelemetry-sdk", status = "started");
         self.reader.collect(&mut self.rm)?;
 
         let export = self.reader.exporter.export(&mut self.rm);

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -234,6 +234,8 @@ struct PeriodicReaderWorker<RT: Runtime> {
 
 impl<RT: Runtime> PeriodicReaderWorker<RT> {
     async fn collect_and_export(&mut self) -> Result<()> {
+        #[cfg(feature = "experimental-internal-logs")]
+        tracing::debug!(name: "collect_and_export", target: "opentelemetry", message ="Periodic export triggered.");
         self.reader.collect(&mut self.rm)?;
 
         let export = self.reader.exporter.export(&mut self.rm);

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -238,14 +238,6 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
         tracing::debug!(name: "metrics_collect_and_export", target: "opentelemetry-sdk", status = "started");
         self.reader.collect(&mut self.rm)?;
 
-        #[cfg(feature = "experimental-internal-logs")]
-        let metrics_count = self
-            .rm
-            .scope_metrics
-            .iter()
-            .map(|scope| scope.metrics.len())
-            .sum::<usize>();
-
         let export = self.reader.exporter.export(&mut self.rm);
         let timeout = self.runtime.delay(self.timeout);
         pin_mut!(export);
@@ -258,7 +250,6 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
                     name: "collect_and_export",
                     target: "opentelemetry-sdk",
                     status = "completed",
-                    count = metrics_count,
                     result = ?res
                 );
                 res // return the status of export.


### PR DESCRIPTION
## Changes

#2128 needs more discussion before it can be finalized. 
For now, this PR adds a more simplistic approach to directly use the tracing macro in the code for internal logging.


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
