### PR TITLE
For Delta Temporarlity, avoid exporting when no new measurements are made

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -11,6 +11,9 @@
   external sources to be sent through OpenTelemetry.
   [#2105](https://github.com/open-telemetry/opentelemetry-rust/pull/2105)
 - Feature: `SimpleSpanProcessor::new` is now public [#2119](https://github.com/open-telemetry/opentelemetry-rust/pull/2119)
+- For Delta Temporality, exporters are not invoked unless there were new
+  measurements since the last collect/export.
+  [#2153](https://github.com/open-telemetry/opentelemetry-rust/pull/2153)
 
 ## v0.25.0
 

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -973,7 +973,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[ignore = "Known bug: https://github.com/open-telemetry/opentelemetry-rust/issues/1598"]
     async fn delta_memory_efficiency_test() {
         // Run this test with stdout enabled to see output.
         // cargo test delta_memory_efficiency_test --features=testing -- --nocapture

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -235,6 +235,10 @@ struct PeriodicReaderWorker<RT: Runtime> {
 impl<RT: Runtime> PeriodicReaderWorker<RT> {
     async fn collect_and_export(&mut self) -> Result<()> {
         self.reader.collect(&mut self.rm)?;
+        if self.rm.scope_metrics.len() == 0 {
+            // No metrics to export.
+            return Ok(());
+        }
 
         let export = self.reader.exporter.export(&mut self.rm);
         let timeout = self.runtime.delay(self.timeout);

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -235,7 +235,7 @@ struct PeriodicReaderWorker<RT: Runtime> {
 impl<RT: Runtime> PeriodicReaderWorker<RT> {
     async fn collect_and_export(&mut self) -> Result<()> {
         self.reader.collect(&mut self.rm)?;
-        if self.rm.scope_metrics.len() == 0 {
+        if self.rm.scope_metrics.is_empty() {
             // No metrics to export.
             return Ok(());
         }


### PR DESCRIPTION
Fixes #1598 by doing a simple fix.
This area still require more refactoring (https://github.com/open-telemetry/opentelemetry-rust/issues/2145), but this does the job for now, and avoids sending "empty" metrics to exporters.