### PR TITLE
Minor cleanups in Metrics module

### DIFF
--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -9,7 +9,7 @@ use std::{
 
 use opentelemetry::{
     global,
-    metrics::{noop::NoopMeterCore, Meter, MeterProvider, MetricsError, Result},
+    metrics::{noop::NoopMeter, Meter, MeterProvider, MetricsError, Result},
     KeyValue,
 };
 
@@ -21,8 +21,11 @@ use super::{meter::SdkMeter, pipeline::Pipelines, reader::MetricReader, view::Vi
 ///
 /// All `Meter`s created by a `MeterProvider` will be associated with the same
 /// [Resource], have the same [View]s applied to them, and have their produced
-/// metric telemetry passed to the configured [MetricReader]s.
-///
+/// metric telemetry passed to the configured [MetricReader]s. This is a
+/// clonable handle to the MeterProvider implementation itself, and cloning it
+/// will create a new reference, not a new instance of a MeterProvider. Dropping
+/// the last reference to it will trigger shutdown of the provider. Shutdown can
+/// also be triggered manually by calling the `shutdown` method.
 /// [Meter]: opentelemetry::metrics::Meter
 #[derive(Clone, Debug)]
 pub struct SdkMeterProvider {
@@ -144,7 +147,7 @@ impl MeterProvider for SdkMeterProvider {
         attributes: Option<Vec<KeyValue>>,
     ) -> Meter {
         if self.inner.is_shutdown.load(Ordering::Relaxed) {
-            return Meter::new(Arc::new(NoopMeterCore::new()));
+            return Meter::new(Arc::new(NoopMeter::new()));
         }
 
         let mut builder = Scope::builder(name);
@@ -170,7 +173,7 @@ impl MeterProvider for SdkMeterProvider {
                 .clone();
             Meter::new(meter)
         } else {
-            Meter::new(Arc::new(NoopMeterCore::new()))
+            Meter::new(Arc::new(NoopMeter::new()))
         }
     }
 }

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -9,6 +9,8 @@
 
   - **Modified**: `MeterProvider.meter()` and `MeterProvider.versioned_meter()` argument types have been updated to `&'static str` instead of `impl Into<Cow<'static, str>>>` [#2112](https://github.com/open-telemetry/opentelemetry-rust/pull/2112). These APIs were modified to enforce the Meter `name`, `version`, and `schema_url` to be `&'static str`.
 
+  - **Renamed**: `NoopMeterCore` to `NoopMeter`
+
 - Added `with_boundaries` API to allow users to provide custom bounds for Histogram instruments. [#2135](https://github.com/open-telemetry/opentelemetry-rust/pull/2135)
 
 ## v0.25.0

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -11,7 +11,7 @@ categories = [
     "api-bindings",
     "asynchronous",
 ]
-keywords = ["opentelemetry", "logging", "tracing", "metrics", "async"]
+keywords = ["opentelemetry", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.65"

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -199,7 +199,7 @@ pub trait MeterProvider {
 ///     KeyValue::new("mykey2", "myvalue2"),
 /// ],
 /// );
-/// 
+///
 /// // u64 Gauge
 /// let gauge = meter.u64_gauge("my_gauge").init();
 /// gauge.record(
@@ -209,7 +209,7 @@ pub trait MeterProvider {
 ///     KeyValue::new("mykey2", "myvalue2"),
 /// ],
 /// );
-/// 
+///
 /// // f64 Gauge
 /// let gauge = meter.f64_gauge("my_gauge").init();
 /// gauge.record(

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -71,10 +71,10 @@ pub trait MeterProvider {
 ///   your application's processing logic. For example, you might use a Counter
 ///   to record the number of HTTP requests received.
 ///
-/// - **Asynchronous Instruments** (e.g., Gauge): These allow you to register a
-///   callback function that is invoked during export. For instance, you could
-///   use an asynchronous gauge to monitor temperature from a sensor every time
-///   metrics are exported.
+/// - **Asynchronous Instruments** (e.g., ObservableGauge): These allow you to
+///   register a callback function that is invoked during export. For instance,
+///   you could use an asynchronous gauge to monitor temperature from a sensor
+///   every time metrics are exported.
 ///
 /// # Example Usage
 ///
@@ -105,7 +105,6 @@ pub trait MeterProvider {
 ///     ],
 /// );
 ///
-/// // Asynchronous Instruments
 ///
 /// // u64 Observable Counter
 /// let _observable_u64_counter = meter
@@ -190,6 +189,36 @@ pub trait MeterProvider {
 ///         )
 ///     })
 ///     .init();
+///
+/// // i64 Gauge
+/// let gauge = meter.i64_gauge("my_gauge").init();
+/// gauge.record(
+/// 1,
+/// &[
+///     KeyValue::new("mykey1", "myvalue1"),
+///     KeyValue::new("mykey2", "myvalue2"),
+/// ],
+/// );
+/// 
+/// // u64 Gauge
+/// let gauge = meter.u64_gauge("my_gauge").init();
+/// gauge.record(
+/// -101,
+/// &[
+///     KeyValue::new("mykey1", "myvalue1"),
+///     KeyValue::new("mykey2", "myvalue2"),
+/// ],
+/// );
+/// 
+/// // f64 Gauge
+/// let gauge = meter.f64_gauge("my_gauge").init();
+/// gauge.record(
+/// 12.5,
+/// &[
+///     KeyValue::new("mykey1", "myvalue1"),
+///     KeyValue::new("mykey2", "myvalue2"),
+/// ],
+/// );
 ///
 /// // u64 Observable Gauge
 /// let _observable_u64_gauge = meter

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -193,7 +193,7 @@ pub trait MeterProvider {
 /// // i64 Gauge
 /// let gauge = meter.i64_gauge("my_gauge").init();
 /// gauge.record(
-/// 1,
+/// -10,
 /// &[
 ///     KeyValue::new("mykey1", "myvalue1"),
 ///     KeyValue::new("mykey2", "myvalue2"),
@@ -203,7 +203,7 @@ pub trait MeterProvider {
 /// // u64 Gauge
 /// let gauge = meter.u64_gauge("my_gauge").init();
 /// gauge.record(
-/// -101,
+/// 101,
 /// &[
 ///     KeyValue::new("mykey1", "myvalue1"),
 ///     KeyValue::new("mykey2", "myvalue2"),

--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -33,24 +33,24 @@ impl MeterProvider for NoopMeterProvider {
         _schema_url: Option<&'static str>,
         _attributes: Option<Vec<KeyValue>>,
     ) -> Meter {
-        Meter::new(Arc::new(NoopMeterCore::new()))
+        Meter::new(Arc::new(NoopMeter::new()))
     }
 }
 
 /// A no-op instance of a `Meter`
 #[derive(Debug, Default)]
-pub struct NoopMeterCore {
+pub struct NoopMeter {
     _private: (),
 }
 
-impl NoopMeterCore {
+impl NoopMeter {
     /// Create a new no-op meter core.
     pub fn new() -> Self {
-        NoopMeterCore { _private: () }
+        NoopMeter { _private: () }
     }
 }
 
-impl InstrumentProvider for NoopMeterCore {}
+impl InstrumentProvider for NoopMeter {}
 
 /// A no-op sync instrument
 #[derive(Debug, Default)]


### PR DESCRIPTION
Renamed `NoopMeterCore` to just `NoopMeter`, and few other minor fixes, in preparation of moving metrics to beta.