### PR TITLE
Use the correct format when deserializing body field from logs

### DIFF
--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
@@ -10,6 +10,14 @@ pub struct AnyValue {
     /// The value is one of the listed fields. It is valid for all values to be unspecified
     /// in which case this AnyValue is considered to be "empty".
     #[prost(oneof = "any_value::Value", tags = "1, 2, 3, 4, 5, 6, 7")]
+    #[cfg_attr(
+        feature = "with-serde",
+        serde(
+            flatten,
+            serialize_with = "crate::proto::serializers::serialize_to_value",
+            deserialize_with = "crate::proto::serializers::deserialize_from_value"
+        )
+    )]
     pub value: ::core::option::Option<any_value::Value>,
 }
 /// Nested message and enum types in `AnyValue`.
@@ -75,13 +83,6 @@ pub struct KeyValue {
     #[prost(string, tag = "1")]
     pub key: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
-    #[cfg_attr(
-        feature = "with-serde",
-        serde(
-            serialize_with = "crate::proto::serializers::serialize_to_value",
-            deserialize_with = "crate::proto::serializers::deserialize_from_value"
-        )
-    )]
     pub value: ::core::option::Option<AnyValue>,
 }
 /// InstrumentationScope is a message representing the instrumentation scope information

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
@@ -122,13 +122,6 @@ pub struct LogRecord {
     /// string message (including multi-line) describing the event in a free form or it can
     /// be a structured data composed of arrays and maps of other values. \[Optional\].
     #[prost(message, optional, tag = "5")]
-    #[cfg_attr(
-        feature = "with-serde",
-        serde(
-            serialize_with = "crate::proto::serializers::serialize_to_value",
-            deserialize_with = "crate::proto::serializers::deserialize_from_value"
-        )
-    )]
     pub body: ::core::option::Option<super::super::common::v1::AnyValue>,
     /// Additional attributes that describe the specific event occurrence. \[Optional\].
     /// Attribute keys MUST be unique (it is not allowed to have more than one

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -111,10 +111,11 @@ fn build_tonic() {
             .field_attribute(path, "#[cfg_attr(feature = \"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_u64_to_string\", deserialize_with = \"crate::proto::serializers::deserialize_string_to_u64\"))]")
     }
 
-    // add custom serializer and deserializer for AnyValue
-    for path in ["common.v1.KeyValue.value", "logs.v1.LogRecord.body"] {
+    // special serializer and deserializer for value
+    // The Value::value field must be hidden
+    for path in ["common.v1.AnyValue.value"] {
         builder = builder
-        .field_attribute(path, "#[cfg_attr(feature =\"with-serde\", serde(serialize_with = \"crate::proto::serializers::serialize_to_value\", deserialize_with = \"crate::proto::serializers::deserialize_from_value\"))]");
+        .field_attribute(path, "#[cfg_attr(feature =\"with-serde\", serde(flatten, serialize_with = \"crate::proto::serializers::serialize_to_value\", deserialize_with = \"crate::proto::serializers::deserialize_from_value\"))]");
     }
 
     // flatten

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -113,10 +113,8 @@ fn build_tonic() {
 
     // special serializer and deserializer for value
     // The Value::value field must be hidden
-    for path in ["common.v1.AnyValue.value"] {
-        builder = builder
-        .field_attribute(path, "#[cfg_attr(feature =\"with-serde\", serde(flatten, serialize_with = \"crate::proto::serializers::serialize_to_value\", deserialize_with = \"crate::proto::serializers::deserialize_from_value\"))]");
-    }
+    builder = builder
+        .field_attribute("common.v1.AnyValue.value", "#[cfg_attr(feature =\"with-serde\", serde(flatten, serialize_with = \"crate::proto::serializers::serialize_to_value\", deserialize_with = \"crate::proto::serializers::deserialize_from_value\"))]");
 
     // flatten
     for path in ["metrics.v1.Metric.data", "metrics.v1.NumberDataPoint.value"] {

--- a/opentelemetry-proto/tests/json_serde.rs
+++ b/opentelemetry-proto/tests/json_serde.rs
@@ -518,14 +518,10 @@ mod json_serde {
   "arrayValue": {
     "values": [
       {
-        "value": {
-          "stringValue": "foo"
-        }
+        "stringValue": "foo"
       },
       {
-        "value": {
-          "stringValue": "bar"
-        }
+        "stringValue": "bar"
       }
     ]
   }
@@ -557,14 +553,10 @@ mod json_serde {
   "arrayValue": {
     "values": [
       {
-        "value": {
-          "stringValue": "foo"
-        }
+        "stringValue": "foo"
       },
       {
-        "value": {
-          "intValue": 1337
-        }
+        "intValue": "1337"
       }
     ]
   }
@@ -1339,14 +1331,10 @@ mod json_serde {
                     "arrayValue": {
                       "values": [
                         {
-                          "value": {
-                            "stringValue": "many"
-                          }
+                          "stringValue": "many"
                         },
                         {
-                          "value": {
-                            "stringValue": "values"
-                          }
+                          "stringValue": "values"
                         }
                       ]
                     }
@@ -1453,14 +1441,10 @@ mod json_serde {
                     "arrayValue": {
                       "values": [
                         {
-                          "value": {
-                            "stringValue": "many"
-                          }
+                          "stringValue": "many"
                         },
                         {
-                          "value": {
-                            "stringValue": "values"
-                          }
+                          "stringValue": "values"
                         }
                       ]
                     }


### PR DESCRIPTION
Fixes #2173 

## Changes

Use the correct format when serializing/deserializing body field from logs. Item inside arrays will not be wrapped inside a 'value' field.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
