### PR TITLE
Nits: Collect config fix in examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
         os: [windows-latest, ubuntu-latest]
         rust: [1.65.0, 1.71.1]
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/opentelemetry-otlp/examples/basic-otlp/otel-collector-config.yaml
+++ b/opentelemetry-otlp/examples/basic-otlp/otel-collector-config.yaml
@@ -8,7 +8,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 
 exporters:
   debug:

--- a/opentelemetry-otlp/tests/integration_test/otel-collector-config.yaml
+++ b/opentelemetry-otlp/tests/integration_test/otel-collector-config.yaml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 
 exporters:
   file:


### PR DESCRIPTION
Config fix
CI check to keep running all msrv targets, even if one fails.