### PR TITLE
[WIP] Cleanup Global Error handler

### DIFF
--- a/opentelemetry-jaeger-propagator/Cargo.toml
+++ b/opentelemetry-jaeger-propagator/Cargo.toml
@@ -23,9 +23,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 opentelemetry = { version = "0.26", default-features = false, features = [
     "trace",
 ], path = "../opentelemetry" }
+tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
 opentelemetry = { features = ["testing"], path = "../opentelemetry" }
 
 [features]
-default = []
+default = ["internal-logs"]
+internal-logs = ["tracing"]

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -29,12 +29,13 @@ path = "tests/json_serde.rs"
 
 
 [features]
-default = ["full"]
+default = ["full", "internal-logs"]
+internal-logs = ["tracing"]
 full = ["gen-tonic", "trace", "logs", "metrics", "zpages", "with-serde"]
 
 # crates used to generate rs files
 gen-tonic = ["gen-tonic-messages", "tonic/transport"]
-gen-tonic-messages = ["tonic", "prost"]
+gen-tonic-messages = ["tonic", "prost", "internal-logs"]
 
 # telemetry pillars and functions
 trace = ["opentelemetry/trace", "opentelemetry_sdk/trace"]
@@ -51,11 +52,12 @@ populate-logs-event-name = []
 [dependencies]
 tonic = { workspace = true, optional = true, features = ["codegen", "prost"] }
 prost = { workspace = true, optional = true }
-opentelemetry = { version = "0.26", default-features = false, path = "../opentelemetry" }
-opentelemetry_sdk = { version = "0.26", default-features = false, path = "../opentelemetry-sdk" }
+opentelemetry = { version = "0.26", default-features = false, path = "../opentelemetry", features = ["internal-logs"] }
+opentelemetry_sdk = { version = "0.26", default-features = false, path = "../opentelemetry-sdk", features = ["internal-logs"] }
 schemars = { version = "0.8", optional = true }
 serde = { workspace = true, optional = true, features = ["serde_derive"] }
 hex = { version = "0.4.3", optional = true }
+tracing = {workspace = true, optional = true}
 
 [dev-dependencies]
 opentelemetry = { features = ["testing"], path = "../opentelemetry" }

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -1,12 +1,11 @@
 use super::{BatchLogProcessor, LogProcessor, LogRecord, SimpleLogProcessor, TraceContext};
 use crate::{export::logs::LogExporter, runtime::RuntimeChannel, Resource};
-use opentelemetry::otel_warn;
 use opentelemetry::{
-    global,
     logs::{LogError, LogResult},
     trace::TraceContextExt,
     Context, InstrumentationLibrary,
 };
+use opentelemetry::{otel_error, otel_warn};
 
 #[cfg(feature = "logs_level_enabled")]
 use opentelemetry::logs::Severity;
@@ -146,7 +145,7 @@ impl Drop for LoggerProviderInner {
     fn drop(&mut self) {
         for processor in &mut self.processors {
             if let Err(err) = processor.shutdown() {
-                global::handle_error(err);
+                otel_error!(name: "LoggerProviderInner.Drop",  otel_name = "LoggerProviderInner.Drop", error = format!("{:?}", err));
             }
         }
     }

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, f64::consts::LOG2_E, sync::Mutex, time::SystemTime};
 
 use once_cell::sync::Lazy;
-use opentelemetry::{metrics::MetricsError, KeyValue};
+use opentelemetry::{metrics::MetricsError, otel_error, KeyValue};
 
 use crate::{
     metrics::data::{self, Aggregation, Temporality},
@@ -100,9 +100,7 @@ impl<T: Number> ExpoHistogramDataPoint<T> {
             if (self.scale - scale_delta as i8) < EXPO_MIN_SCALE {
                 // With a scale of -10 there is only two buckets for the whole range of f64 values.
                 // This can only happen if there is a max size of 1.
-                opentelemetry::global::handle_error(MetricsError::Other(
-                    "exponential histogram scale underflow".into(),
-                ));
+                otel_error!(name: "ExpoHistogramDataPoint::record", otel_name = "ExpoHistogramDataPoint::record", error = format!("{:?}", MetricsError::Other("exponential histogram scale underflow".into())));
                 return;
             }
             // Downscale

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use aggregate::{AggregateBuilder, ComputeAggregation, Measure};
 pub(crate) use exponential_histogram::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
 use once_cell::sync::Lazy;
 use opentelemetry::metrics::MetricsError;
-use opentelemetry::{global, otel_warn, KeyValue};
+use opentelemetry::{otel_warn, KeyValue};
 
 use crate::metrics::AttributeSet;
 
@@ -146,9 +146,8 @@ impl<AU: AtomicallyUpdate<T>, T: Number, O: Operation> ValueMap<AU, T, O> {
             let new_tracker = AU::new_atomic_tracker(self.buckets_count);
             O::update_tracker(&new_tracker, measurement, index);
             trackers.insert(STREAM_OVERFLOW_ATTRIBUTES.clone(), Arc::new(new_tracker));
-            global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow. Subsequent overflows to same metric until next collect will not be logged.".into()));
             otel_warn!( name: "ValueMap.measure",
-                message = "Maximum data points for metric stream exceeded. Entry added to overflow. Subsequent overflows to same metric until next collect will not be logged."
+                message = format!("{:?}", MetricsError::Other("Maximum data points for metric stream exceeded. Entry added to overflow. Subsequent overflows to same metric until next collect will not be logged.".into()))
             );
         }
     }

--- a/opentelemetry-sdk/src/metrics/manual_reader.rs
+++ b/opentelemetry-sdk/src/metrics/manual_reader.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use opentelemetry::{
-    global,
     metrics::{MetricsError, Result},
+    otel_error,
 };
 
 use super::{
@@ -84,9 +84,10 @@ impl MetricReader for ManualReader {
             if inner.sdk_producer.is_none() {
                 inner.sdk_producer = Some(pipeline);
             } else {
-                global::handle_error(MetricsError::Config(
-                    "duplicate reader registration, did not register manual reader".into(),
-                ))
+                otel_error!(name: "ManualReader.register_pipeline", 
+                otel_name= "ManualReader.register_pipeline", 
+                error = format!("{:?}", MetricsError::Config(
+                    "duplicate reader registration, did not register manual reader".into())));
             }
         });
     }

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -2,13 +2,13 @@ use core::fmt;
 use std::{borrow::Cow, sync::Arc};
 
 use opentelemetry::{
-    global,
     metrics::{
         noop::{NoopAsyncInstrument, NoopSyncInstrument},
         AsyncInstrumentBuilder, Counter, Gauge, Histogram, HistogramBuilder, InstrumentBuilder,
         InstrumentProvider, MetricsError, ObservableCounter, ObservableGauge,
         ObservableUpDownCounter, Result, UpDownCounter,
     },
+    otel_error,
 };
 
 use crate::instrumentation::Scope;
@@ -74,7 +74,7 @@ impl SdkMeter {
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
-            global::handle_error(err);
+            otel_error!(name: "SdkMeter.create_counter", otel_name= "SdkMeter.create_counter", error = format!("{:?}", err));
             return Ok(Counter::new(Arc::new(NoopSyncInstrument::new())));
         }
 
@@ -90,7 +90,7 @@ impl SdkMeter {
         {
             Ok(counter) => Ok(counter),
             Err(err) => {
-                global::handle_error(err);
+                otel_error!(name: "SdkMetercreate_counter", otel_name= "SdkMeter.create_counter", error = format!("{:?}", err));
                 Ok(Counter::new(Arc::new(NoopSyncInstrument::new())))
             }
         }
@@ -106,7 +106,7 @@ impl SdkMeter {
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
-            global::handle_error(err);
+            otel_error!(name: "SdkMeter.create_observable_counter", otel_name= "SdkMeter.create_observable_counter", error = format!("{:?}", err));
             return Ok(ObservableCounter::new(Arc::new(NoopAsyncInstrument::new())));
         }
 
@@ -143,7 +143,7 @@ impl SdkMeter {
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
-            global::handle_error(err);
+            otel_error!(name: "SdkMeter.create_observable_updown_counter", otel_name= "SdkMeter.create_observable_updown_counter", error = format!("{:?}", err));
             return Ok(ObservableUpDownCounter::new(Arc::new(
                 NoopAsyncInstrument::new(),
             )));
@@ -184,7 +184,7 @@ impl SdkMeter {
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
-            global::handle_error(err);
+            otel_error!(name: "SdkMeter.create_observable_gauge", otel_name= "SdkMeter.create_observable_gauge", error = format!("{:?}", err));
             return Ok(ObservableGauge::new(Arc::new(NoopAsyncInstrument::new())));
         }
 
@@ -221,7 +221,7 @@ impl SdkMeter {
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
-            global::handle_error(err);
+            otel_error!(name: "SdkMeter.create_updown_counter", otel_name= "SdkMeter.create_updown_counter", error = format!("{:?}", err));
             return Ok(UpDownCounter::new(Arc::new(NoopSyncInstrument::new())));
         }
 
@@ -237,7 +237,7 @@ impl SdkMeter {
         {
             Ok(updown_counter) => Ok(updown_counter),
             Err(err) => {
-                global::handle_error(err);
+                otel_error!(name: "SdkMeter.create_updown_counter", otel_name= "SdkMeter.create_updown_counter", error = format!("{:?}", err));
                 Ok(UpDownCounter::new(Arc::new(NoopSyncInstrument::new())))
             }
         }
@@ -253,7 +253,7 @@ impl SdkMeter {
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
-            global::handle_error(err);
+            otel_error!(name: "SdkMeter.create_gauge", otel_name= "SdkMeter.create_gauge", error = format!("{:?}", err));
             return Ok(Gauge::new(Arc::new(NoopSyncInstrument::new())));
         }
 
@@ -269,7 +269,7 @@ impl SdkMeter {
         {
             Ok(gauge) => Ok(gauge),
             Err(err) => {
-                global::handle_error(err);
+                otel_error!(name: "SdkMeter.create_gauge", otel_name= "SdkMeter.create_gauge", error = format!("{:?}", err));
                 Ok(Gauge::new(Arc::new(NoopSyncInstrument::new())))
             }
         }
@@ -285,7 +285,7 @@ impl SdkMeter {
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
-            global::handle_error(err);
+            otel_error!(name: "SdkMeter.create_histogram", otel_name= "SdkMeter.create_histogram", error = format!("{:?}", err));
             return Ok(Histogram::new(Arc::new(NoopSyncInstrument::new())));
         }
 
@@ -301,7 +301,7 @@ impl SdkMeter {
         {
             Ok(histogram) => Ok(histogram),
             Err(err) => {
-                global::handle_error(err);
+                otel_error!(name: "SdkMeter.create_histogram", otel_name= "SdkMeter.create_histogram", error = format!("{:?}", err));
                 Ok(Histogram::new(Arc::new(NoopSyncInstrument::new())))
             }
         }

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -8,9 +8,8 @@ use std::{
 };
 
 use opentelemetry::{
-    global,
     metrics::{noop::NoopMeter, Meter, MeterProvider, MetricsError, Result},
-    KeyValue,
+    otel_error, KeyValue,
 };
 
 use crate::{instrumentation::Scope, Resource};
@@ -137,7 +136,7 @@ impl Drop for SdkMeterProviderInner {
         // shutdown(), then we don't need to call shutdown again.
         if !self.is_shutdown.load(Ordering::Relaxed) {
             if let Err(err) = self.shutdown() {
-                global::handle_error(err);
+                otel_error!(name: "SdkMeterProviderInner.drop", otel_name= "SdkMeterProviderInner.drop", error = format!("{:?}", err));
             }
         }
     }

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -6,9 +6,8 @@ use std::{
 };
 
 use opentelemetry::{
-    global,
     metrics::{MetricsError, Result},
-    KeyValue,
+    otel_error, KeyValue,
 };
 
 use crate::{
@@ -414,15 +413,15 @@ where
                 if existing == id {
                     return;
                 }
-
-                global::handle_error(MetricsError::Other(format!(
-                    "duplicate metric stream definitions, names: ({} and {}), descriptions: ({} and {}), kinds: ({:?} and {:?}), units: ({:?} and {:?}), and numbers: ({} and {})",
-                    existing.name, id.name,
-                    existing.description, id.description,
-                    existing.kind, id.kind,
-                    existing.unit, id.unit,
-                    existing.number, id.number,
-               )))
+                otel_error!(name: "inserter.log_conflict", otel_name = "inserter.log_conflict",
+                    error = format!("{:?}", MetricsError::Other("duplicate metric stream definitions.".into())),
+                    instrument_name = format!("{:?}", existing.name),
+                    instrument_description = format!("{:?}", existing.description),
+                    instrument_kind = format!("{:?}",existing.kind),
+                    instrument_unit = format!("{:?}",existing.unit),
+                    instrument_number = format!("{:?}", existing.number),
+                    new_instrument_name = format!("{:?}", id.name),
+                );
             }
         }
     }

--- a/opentelemetry-sdk/src/metrics/view.rs
+++ b/opentelemetry-sdk/src/metrics/view.rs
@@ -1,8 +1,8 @@
 use super::instrument::{Instrument, Stream};
 use glob::Pattern;
 use opentelemetry::{
-    global,
     metrics::{MetricsError, Result},
+    otel_error,
 };
 
 fn empty_view(_inst: &Instrument) -> Option<Stream> {
@@ -102,9 +102,7 @@ impl View for Box<dyn View> {
 /// ```
 pub fn new_view(criteria: Instrument, mask: Stream) -> Result<Box<dyn View>> {
     if criteria.is_empty() {
-        global::handle_error(MetricsError::Config(format!(
-            "no criteria provided, dropping view. mask: {mask:?}"
-        )));
+        otel_error!(name: "new_view", otel_name= "new_view", error = format!("no criteria provided, dropping view. mask: {mask:?}"));
         return Ok(Box::new(empty_view));
     }
     let contains_wildcard = criteria.name.contains(['*', '?']);
@@ -112,9 +110,12 @@ pub fn new_view(criteria: Instrument, mask: Stream) -> Result<Box<dyn View>> {
 
     let match_fn: Box<dyn Fn(&Instrument) -> bool + Send + Sync> = if contains_wildcard {
         if mask.name != "" {
-            global::handle_error(MetricsError::Config(format!(
-				"name replacement for multiple instruments, dropping view, criteria: {criteria:?}, mask: {mask:?}"
-			)));
+            otel_error!(name: "new_view",
+            otel_name= "new_view",
+            error = format!("{:?}", MetricsError::Config("name replacement for wildcard instrument, dropping view, criteria".into())),
+            criteria = format!("{:?}", criteria),
+            mask = format!("{:?}", criteria),
+            );
             return Ok(Box::new(empty_view));
         }
 
@@ -138,10 +139,13 @@ pub fn new_view(criteria: Instrument, mask: Stream) -> Result<Box<dyn View>> {
         match ma.validate() {
             Ok(_) => agg = Some(ma.clone()),
             Err(err) => {
-                global::handle_error(MetricsError::Other(format!(
-                    "{}, proceeding as if view did not exist. criteria: {:?}, mask: {:?}",
-                    err, err_msg_criteria, mask
-                )));
+                otel_error!(
+                    name: "new_view", 
+                    otel_name= "new_view", 
+                    error = format!("{:?} Error : {:?}", MetricsError::Other("Proceeding as if view did not exist. Error:".into()), err),
+                    criteria = format!("{:?}", err_msg_criteria),
+                    mask = format!("{:?}", mask));
+
                 return Ok(Box::new(empty_view));
             }
         }

--- a/opentelemetry-sdk/src/propagation/baggage.rs
+++ b/opentelemetry-sdk/src/propagation/baggage.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 use opentelemetry::propagation::PropagationError;
 use opentelemetry::{
     baggage::{BaggageExt, KeyValueMetadata},
-    global,
+    otel_error,
     propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
     Context,
 };
@@ -120,24 +120,30 @@ impl TextMapPropagator for BaggagePropagator {
                                 decoded_props.as_str(),
                             ))
                         } else {
-                            global::handle_error(PropagationError::extract(
+                            otel_error!(name: "BaggagePropagator.extract_with_context",
+                            otel_name = "BaggagePropagator.extract_with_context",
+                            error = format!("{:?}", PropagationError::extract(
                                 "invalid UTF8 string in key values",
                                 "BaggagePropagator",
-                            ));
+                            )));
                             None
                         }
                     } else {
-                        global::handle_error(PropagationError::extract(
+                        otel_error!(name: "BaggagePropagator.extract_with_context",
+                        otel_name = "BaggagePropagator.extract_with_context",
+                        error = format!("{:?}", PropagationError::extract(
                             "invalid baggage key-value format",
                             "BaggagePropagator",
-                        ));
+                        )));
                         None
                     }
                 } else {
-                    global::handle_error(PropagationError::extract(
+                    otel_error!(name: "BaggagePropagator.extract_with_context",
+                    otel_name = "BaggagePropagator.extract_with_context",
+                    error = format!("{:?}", PropagationError::extract(
                         "invalid baggage format",
                         "BaggagePropagator",
-                    ));
+                    )));
                     None
                 }
             });

--- a/opentelemetry-sdk/src/trace/config.rs
+++ b/opentelemetry-sdk/src/trace/config.rs
@@ -4,7 +4,7 @@
 //! can be set for the default OpenTelemetry limits and Sampler.
 use crate::trace::{span_limit::SpanLimits, IdGenerator, RandomIdGenerator, Sampler, ShouldSample};
 use crate::Resource;
-use opentelemetry::global::{handle_error, Error};
+use opentelemetry::otel_error;
 use std::borrow::Cow;
 use std::env;
 use std::str::FromStr;
@@ -129,10 +129,9 @@ impl Default for Config {
                     if let Some(r) = ratio {
                         Box::new(Sampler::TraceIdRatioBased(r))
                     } else {
-                        handle_error(
-                            Error::Other(String::from(
-                                "Missing or invalid OTEL_TRACES_SAMPLER_ARG value. Falling back to default: 1.0"))
-                        );
+                        otel_error!(name: "Config::default", 
+                            otel_name= "Config::default",
+                            error = "Missing or invalid OTEL_TRACES_SAMPLER_ARG value. Falling back to default: 1.0");
                         Box::new(Sampler::TraceIdRatioBased(1.0))
                     }
                 }
@@ -149,37 +148,38 @@ impl Default for Config {
                             r,
                         ))))
                     } else {
-                        handle_error(
-                            Error::Other(String::from(
-                            "Missing or invalid OTEL_TRACES_SAMPLER_ARG value. Falling back to default: 1.0"
-                        )));
+                        otel_error!(name: "Config::default", 
+                            otel_name= "Config::default",
+                            error = "Missing or invalid OTEL_TRACES_SAMPLER_ARG value. Falling back to default: 1.0");
                         Box::new(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
                             1.0,
                         ))))
                     }
                 }
                 "parentbased_jaeger_remote" => {
-                    handle_error(
-                        Error::Other(String::from(
-                        "Unimplemented parentbased_jaeger_remote sampler. Falling back to default: parentbased_always_on"
-                    )));
+                    otel_error!(name: "Config::default", 
+                        otel_name= "Config::default",
+                        error = "Unimplemented parentbased_jaeger_remote sampler. Falling back to default: parentbased_always_on");
                     Box::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)))
                 }
                 "jaeger_remote" => {
-                    handle_error(
-                        Error::Other(String::from("Unimplemented jaeger_remote sampler. Falling back to default: parentbased_always_on")));
+                    otel_error!(name: "Config::default", 
+                        otel_name= "Config::default",
+                        error = "Unimplemented jaeger_remote sampler. Falling back to default: parentbased_always_on");
                     Box::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)))
                 }
                 "xray" => {
-                    handle_error(
-                        Error::Other(String::from("Unimplemented xray sampler. Falling back to default: parentbased_always_on")));
+                    otel_error!(name: "Config::default", 
+                        otel_name= "Config::default",
+                        error = "Unimplemented xray sampler. Falling back to default: parentbased_always_on");
                     Box::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)))
                 }
                 s => {
-                    handle_error(
-                        Error::Other(format!("Unrecognised OTEL_TRACES_SAMPLER value: {}. Falling back to default: parentbased_always_on",
-                        s
-                    )));
+                    otel_error!(name: "Config::default",
+                        otel_name= "Config::default",
+                        error = "Unrecognised OTEL_TRACES_SAMPLER. Falling back to default: parentbased_always_on",
+                        sampler = format!("{:?}", s)
+                    );
                     Box::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)))
                 }
             }

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -16,7 +16,7 @@ use crate::{export::trace::SpanExporter, trace::SpanProcessor};
 use crate::{InstrumentationLibrary, Resource};
 use once_cell::sync::{Lazy, OnceCell};
 use opentelemetry::trace::TraceError;
-use opentelemetry::{global, trace::TraceResult};
+use opentelemetry::{otel_error, trace::TraceResult};
 use std::borrow::Cow;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -51,7 +51,7 @@ impl Drop for TracerProviderInner {
     fn drop(&mut self) {
         for processor in &mut self.processors {
             if let Err(err) = processor.shutdown() {
-                global::handle_error(err);
+                otel_error!(name: "TracerProviderInner.drop", otel_name = "TracerProviderInner.drop", error = format!("{:?}", err));
             }
         }
     }

--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/rate_limit.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/rate_limit.rs
@@ -1,3 +1,4 @@
+use opentelemetry::otel_error;
 use opentelemetry::trace::TraceError;
 use std::time::SystemTime;
 
@@ -54,9 +55,7 @@ impl LeakyBucket {
                     }
                 }
                 Err(_) => {
-                    opentelemetry::global::handle_error(TraceError::Other(
-                        "jaeger remote sampler gets rewinded timestamp".into(),
-                    ));
+                    otel_error!(name: "LeakyBucket.check_availability", otel_name = "LeakyBucket.check_availability", error = format!("{:?}", TraceError::Other("jaeger remote sampler gets rewinded timestamp".into())));
                     true
                 }
             }

--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
@@ -5,7 +5,7 @@ use crate::trace::{Sampler, ShouldSample};
 use futures_util::{stream, StreamExt as _};
 use http::Uri;
 use opentelemetry::trace::{Link, SamplingResult, SpanKind, TraceError, TraceId};
-use opentelemetry::{global, Context, KeyValue};
+use opentelemetry::{otel_error, Context, KeyValue};
 use opentelemetry_http::HttpClient;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -203,7 +203,9 @@ impl JaegerRemoteSampler {
                     // send request
                     match Self::request_new_strategy(&client, endpoint.clone()).await {
                         Ok(remote_strategy_resp) => strategy.update(remote_strategy_resp),
-                        Err(err_msg) => global::handle_error(TraceError::Other(err_msg.into())),
+                        Err(err_msg) => {
+                            otel_error!(name: "JaegerRemoteSampler.update", otel_name = "JaegerRemoteSampler.update", error = format!("{:?}", TraceError::Other(err_msg.into())));
+                        }
                     };
                 } else {
                     // shutdown

--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampling_strategy.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampling_strategy.rs
@@ -6,7 +6,7 @@ use crate::trace::sampler::sample_based_on_probability;
 use opentelemetry::trace::{
     SamplingDecision, SamplingResult, TraceContextExt, TraceError, TraceId, TraceState,
 };
-use opentelemetry::{global, Context};
+use opentelemetry::{otel_error, Context};
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::sync::Mutex;
@@ -107,9 +107,7 @@ impl Inner {
                 }
             })
             .unwrap_or_else(|_err| {
-                global::handle_error(TraceError::Other(
-                    "jaeger remote sampler mutex poisoned".into(),
-                ))
+                otel_error!(name: "JaegerRemoteSampler.update", otel_name = "JaegerRemoteSampler.update", error = format!("{:?}", TraceError::Other("jaeger remote sampler mutex poisoned".into())));
             });
     }
 

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -26,18 +26,20 @@ futures-sink = "0.3"
 once_cell = { workspace = true }
 pin-project-lite = { workspace = true, optional = true }
 thiserror = { workspace = true }
+tracing = { workspace =  true, optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
 js-sys = "0.3.63"
 
 [features]
-default = ["trace", "metrics", "logs"]
+default = ["trace", "metrics", "logs", "internal-logs"]
 trace = ["pin-project-lite"]
 metrics = []
 testing = ["trace", "metrics"]
 logs = []
 logs_level_enabled = ["logs"]
 otel_unstable = []
+internal-logs = ["tracing"]
 
 [dev-dependencies]
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["logs_level_enabled"]} # for documentation tests

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -1,5 +1,4 @@
 use std::sync::PoisonError;
-use std::sync::RwLock;
 
 #[cfg(feature = "logs")]
 use crate::logs::LogError;
@@ -8,14 +7,11 @@ use crate::metrics::MetricsError;
 use crate::propagation::PropagationError;
 #[cfg(feature = "trace")]
 use crate::trace::TraceError;
-use once_cell::sync::Lazy;
-
-static GLOBAL_ERROR_HANDLER: Lazy<RwLock<Option<ErrorHandler>>> = Lazy::new(|| RwLock::new(None));
 
 /// Wrapper for error from both tracing and metrics part of open telemetry.
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
-pub enum Error {
+enum Error {
     #[cfg(feature = "trace")]
     #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
     #[error(transparent)]
@@ -46,41 +42,4 @@ impl<T> From<PoisonError<T>> for Error {
     fn from(err: PoisonError<T>) -> Self {
         Error::Other(err.to_string())
     }
-}
-
-struct ErrorHandler(Box<dyn Fn(Error) + Send + Sync>);
-
-/// Handle error using the globally configured error handler.
-///
-/// Writes to stderr if unset.
-pub fn handle_error<T: Into<Error>>(err: T) {
-    match GLOBAL_ERROR_HANDLER.read() {
-        Ok(handler) if handler.is_some() => (handler.as_ref().unwrap().0)(err.into()),
-        _ => match err.into() {
-            #[cfg(feature = "metrics")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-            Error::Metric(err) => eprintln!("OpenTelemetry metrics error occurred. {}", err),
-            #[cfg(feature = "trace")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
-            Error::Trace(err) => eprintln!("OpenTelemetry trace error occurred. {}", err),
-            #[cfg(feature = "logs")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "logs")))]
-            Error::Log(err) => eprintln!("OpenTelemetry log error occurred. {}", err),
-            Error::Propagation(err) => {
-                eprintln!("OpenTelemetry propagation error occurred. {}", err)
-            }
-            Error::Other(err_msg) => eprintln!("OpenTelemetry error occurred. {}", err_msg),
-        },
-    }
-}
-
-/// Set global error handler.
-pub fn set_error_handler<F>(f: F) -> std::result::Result<(), Error>
-where
-    F: Fn(Error) + Send + Sync + 'static,
-{
-    GLOBAL_ERROR_HANDLER
-        .write()
-        .map(|mut handler| *handler = Some(ErrorHandler(Box::new(f))))
-        .map_err(Into::into)
 }

--- a/opentelemetry/src/global/internal_logging.rs
+++ b/opentelemetry/src/global/internal_logging.rs
@@ -50,11 +50,23 @@ macro_rules! otel_warn {
         {
             tracing::warn!(name: $name, target: env!("CARGO_PKG_NAME"), "");
         }
+        #[cfg(not(feature = "internal-logs"))]
+        {
+            eprintln!("[WARN] {}: {}", env!("CARGO_PKG_NAME"), $name);
+        }
     };
     (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             tracing::warn!(name: $name, target: env!("CARGO_PKG_NAME"), $($key = $value),+, "");
+        }
+        #[cfg(not(feature = "internal-logs"))]
+        {
+            eprintln!("[ERROR] {}: {} ({})",
+                env!("CARGO_PKG_NAME"),
+                $name,
+                stringify!($($key = $value),+)
+            );
         }
     };
 }
@@ -104,11 +116,23 @@ macro_rules! otel_error {
         {
             tracing::error!(name: $name, target: env!("CARGO_PKG_NAME"), "");
         }
+        #[cfg(not(feature = "internal-logs"))]
+        {
+            eprintln!("[ERROR] {}: {}", env!("CARGO_PKG_NAME"), $name);
+        }
     };
     (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             tracing::error!(name: $name, target: env!("CARGO_PKG_NAME"), $($key = $value),+, "");
+        }
+        #[cfg(not(feature = "internal-logs"))]
+        {
+            eprintln!("[ERROR] {}: {} ({})",
+                env!("CARGO_PKG_NAME"),
+                $name,
+                stringify!($($key = $value),+)
+            );
         }
     };
 }

--- a/opentelemetry/src/global/mod.rs
+++ b/opentelemetry/src/global/mod.rs
@@ -134,7 +134,6 @@ mod propagation;
 #[cfg(feature = "trace")]
 mod trace;
 
-pub use error_handler::{handle_error, set_error_handler, Error};
 #[cfg(feature = "metrics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 pub use metrics::*;

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -1,6 +1,6 @@
 //! Context extensions for tracing
 use crate::{
-    global,
+    global, otel_error,
     trace::{Span, SpanContext, Status},
     Context, ContextGuard, KeyValue,
 };
@@ -55,7 +55,9 @@ impl SpanRef<'_> {
         if let Some(ref inner) = self.0.inner {
             match inner.lock() {
                 Ok(mut locked) => f(&mut locked),
-                Err(err) => global::handle_error(err),
+                Err(_err) => {
+                    otel_error!(name: "SpanRef.with_inner_mut", otel_name = "SpanRef.with_inner_mut", error = format!("{:?}", _err));
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #2175

## Changes

In Progress. TODO:
 - Move TraceError and LogError from API to SDK. API should be only returning no-op constructs, and not the error objects. MetricsError is still being used in its API, so need to be handled separately.
 - Better handling for `<signal>Error`, `CoW` and few other types inside otel macros. As of now, the called needs to use `format!` to invoke their Debug impl, which is cumbersome. 

For future improvement:
- Allow applications/users to plugin their log handler.

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
