### PR TITLE
nit cleanups after upgrde to rustc 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = { version = "1", default-features = false }
 tonic = { version = "0.12", default-features = false }
 tonic-build = "0.12"
 tokio = { version = "1", default-features = false }
-tokio-stream = "0.1.1"
+tokio-stream = "0.1"
 tracing = { version = "0.1", default-features = false }
 tracing-core = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## vNext
 
-- Bump MSRV to 1.70 [#2179](https://github.com/open-telemetry/opentelemetry-rust/pull/2179)
-
 ## v0.26.0
 Released 2024-Sep-30
 

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## vNext
 
-- Bump MSRV to 1.70 [#2179](https://github.com/open-telemetry/opentelemetry-rust/pull/2179)
-
 ## v0.26.0
 Released 2024-Sep-30
 

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -108,7 +108,7 @@ available so be sure to match them appropriately.
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.65. The current OpenTelemetry version is not guaranteed to build on
+version is 1.70. The current OpenTelemetry version is not guaranteed to build on
 Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions before

--- a/scripts/patch_dependencies.sh
+++ b/scripts/patch_dependencies.sh
@@ -1,28 +1,9 @@
 #!/bin/bash
 
-# Function to compare two version numbers
-function version_lt() {
-    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" != "$2" ]
-}
-
-# Get the current Rust compiler version
-rust_version=$(rustc --version | cut -d' ' -f2)
-
-# Target version (Rust 1.71.1)
-target_version="1.71.1"
-
-  function patch_version() {
+function patch_version() {
     local latest_version=$(cargo search --limit 1 $1 | head -1 | cut -d'"' -f2)
     echo "patching $1 from $latest_version to $2"
     cargo update -p $1:$latest_version --precise $2
-  }
+}
 
-  patch_version cc 1.0.105
-  patch_version url 2.5.0
-if version_lt "$rust_version" "$target_version"; then
-  patch_version tonic 0.12.2
-  patch_version hyper-rustls 0.27.2 # 0.27.3 needs rustc v1.70.0
-  patch_version tokio-util 0.7.11 # 0.7.12 needs rustc v1.70.0
-  patch_version tokio-stream 0.1.15 # 0.1.16 needs rustc v1.70.0
-  patch_version tokio 1.38.0 # 1.39 needs msrv bump to rustc 1.70
-fi
+


### PR DESCRIPTION
Remove pinning and msrv-patching, now that we have upgraded to 1.70.0 and higher.
 
## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
