### PR TITLE
[Metrics API] Remove as_any methods

### DIFF
--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, borrow::Cow, collections::HashSet, hash::Hash, sync::Arc};
+use std::{borrow::Cow, collections::HashSet, sync::Arc};
 
 use opentelemetry::{
     metrics::{AsyncInstrument, SyncCounter, SyncGauge, SyncHistogram, SyncUpDownCounter},
@@ -300,9 +300,5 @@ impl<T: Copy + Send + Sync + 'static> AsyncInstrument<T> for Observable<T> {
         for measure in &self.measures {
             measure.call(measurement, attrs)
         }
-    }
-
-    fn as_any(&self) -> Arc<dyn Any> {
-        Arc::new(self.clone())
     }
 }

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump MSRV to 1.70 [#2179](https://github.com/open-telemetry/opentelemetry-rust/pull/2179)
 - Add `LogRecord::set_trace_context`; an optional method conditional on the `trace` feature for setting trace context on a log record.
+- Remove unnecessary public methods named `as_any` from `AsyncInstrument` trait and the implementing instruments: `ObservableCounter`, `ObservableGauge`, and `ObservableUpDownCounter` [#2187](https://github.com/open-telemetry/opentelemetry-rust/issues/2187)
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -1,6 +1,5 @@
 use crate::{metrics::AsyncInstrument, KeyValue};
 use core::fmt;
-use std::any::Any;
 use std::sync::Arc;
 
 /// An SDK implemented instrument that records increasing values.
@@ -63,19 +62,10 @@ impl<T> ObservableCounter<T> {
     pub fn observe(&self, value: T, attributes: &[KeyValue]) {
         self.0.observe(value, attributes)
     }
-
-    /// Used for SDKs to downcast instruments in callbacks.
-    pub fn as_any(&self) -> Arc<dyn Any> {
-        self.0.as_any()
-    }
 }
 
 impl<T> AsyncInstrument<T> for ObservableCounter<T> {
     fn observe(&self, measurement: T, attributes: &[KeyValue]) {
         self.0.observe(measurement, attributes)
-    }
-
-    fn as_any(&self) -> Arc<dyn Any> {
-        self.0.as_any()
     }
 }

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -1,6 +1,5 @@
 use crate::{metrics::AsyncInstrument, KeyValue};
 use core::fmt;
-use std::any::Any;
 use std::sync::Arc;
 
 /// An SDK implemented instrument that records independent values
@@ -59,20 +58,11 @@ impl<T> ObservableGauge<T> {
     pub fn observe(&self, measurement: T, attributes: &[KeyValue]) {
         self.0.observe(measurement, attributes)
     }
-
-    /// Used by SDKs to downcast instruments in callbacks.
-    pub fn as_any(&self) -> Arc<dyn Any> {
-        self.0.as_any()
-    }
 }
 
 impl<M> AsyncInstrument<M> for ObservableGauge<M> {
     fn observe(&self, measurement: M, attributes: &[KeyValue]) {
         self.observe(measurement, attributes)
-    }
-
-    fn as_any(&self) -> Arc<dyn Any> {
-        self.0.as_any()
     }
 }
 

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -3,10 +3,8 @@ use gauge::{Gauge, ObservableGauge};
 use crate::metrics::{Meter, Result};
 use crate::KeyValue;
 use core::fmt;
-use std::any::Any;
 use std::borrow::Cow;
 use std::marker;
-use std::sync::Arc;
 
 use super::{
     Counter, Histogram, InstrumentProvider, ObservableCounter, ObservableUpDownCounter,
@@ -24,9 +22,6 @@ pub trait AsyncInstrument<T>: Send + Sync {
     ///
     /// It is only valid to call this within a callback.
     fn observe(&self, measurement: T, attributes: &[KeyValue]);
-
-    /// Used for SDKs to downcast instruments in callbacks.
-    fn as_any(&self) -> Arc<dyn Any>;
 }
 
 /// Configuration for building a Histogram.

--- a/opentelemetry/src/metrics/instruments/up_down_counter.rs
+++ b/opentelemetry/src/metrics/instruments/up_down_counter.rs
@@ -1,6 +1,5 @@
 use crate::KeyValue;
 use core::fmt;
-use std::any::Any;
 use std::sync::Arc;
 
 use super::AsyncInstrument;
@@ -69,19 +68,10 @@ impl<T> ObservableUpDownCounter<T> {
     pub fn observe(&self, value: T, attributes: &[KeyValue]) {
         self.0.observe(value, attributes)
     }
-
-    /// Used for SDKs to downcast instruments in callbacks.
-    pub fn as_any(&self) -> Arc<dyn Any> {
-        self.0.as_any()
-    }
 }
 
 impl<T> AsyncInstrument<T> for ObservableUpDownCounter<T> {
     fn observe(&self, measurement: T, attributes: &[KeyValue]) {
         self.0.observe(measurement, attributes)
-    }
-
-    fn as_any(&self) -> Arc<dyn std::any::Any> {
-        self.0.as_any()
     }
 }

--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     KeyValue,
 };
-use std::{any::Any, sync::Arc};
+use std::sync::Arc;
 
 /// A no-op instance of a `MetricProvider`
 #[derive(Debug, Default)]
@@ -105,9 +105,5 @@ impl NoopAsyncInstrument {
 impl<T> AsyncInstrument<T> for NoopAsyncInstrument {
     fn observe(&self, _value: T, _attributes: &[KeyValue]) {
         // Ignored
-    }
-
-    fn as_any(&self) -> Arc<dyn Any> {
-        Arc::new(())
     }
 }


### PR DESCRIPTION
## Changes
- Remove unnecessary public methods named `as_any` from `AsyncInstrument` trait and the implementing instruments: `ObservableCounter`, `ObservableGauge`, and `ObservableUpDownCounter`

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes

