### PR TITLE
[Metrics API] Remove unnecessary public observe methods

### DIFF
--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -53,17 +53,6 @@ impl<T> fmt::Debug for ObservableCounter<T> {
     }
 }
 
-impl<T> ObservableCounter<T> {
-    /// Records an increment to the counter.
-    ///
-    /// It is only valid to call this within a callback. If called outside of the
-    /// registered callback it should have no effect on the instrument, and an
-    /// error will be reported via the error handler.
-    pub fn observe(&self, value: T, attributes: &[KeyValue]) {
-        self.0.observe(value, attributes)
-    }
-}
-
 impl<T> AsyncInstrument<T> for ObservableCounter<T> {
     fn observe(&self, measurement: T, attributes: &[KeyValue]) {
         self.0.observe(measurement, attributes)

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -49,20 +49,9 @@ where
     }
 }
 
-impl<T> ObservableGauge<T> {
-    /// Records the state of the instrument.
-    ///
-    /// It is only valid to call this within a callback. If called outside of the
-    /// registered callback it should have no effect on the instrument, and an
-    /// error will be reported via the error handler.
-    pub fn observe(&self, measurement: T, attributes: &[KeyValue]) {
-        self.0.observe(measurement, attributes)
-    }
-}
-
 impl<M> AsyncInstrument<M> for ObservableGauge<M> {
     fn observe(&self, measurement: M, attributes: &[KeyValue]) {
-        self.observe(measurement, attributes)
+        self.0.observe(measurement, attributes)
     }
 }
 

--- a/opentelemetry/src/metrics/instruments/up_down_counter.rs
+++ b/opentelemetry/src/metrics/instruments/up_down_counter.rs
@@ -59,15 +59,6 @@ impl<T> ObservableUpDownCounter<T> {
     pub fn new(inner: Arc<dyn AsyncInstrument<T>>) -> Self {
         ObservableUpDownCounter(inner)
     }
-
-    /// Records the increment or decrement to the counter.
-    ///
-    /// It is only valid to call this within a callback. If called outside of the
-    /// registered callback it should have no effect on the instrument, and an
-    /// error will be reported via the error handler.
-    pub fn observe(&self, value: T, attributes: &[KeyValue]) {
-        self.0.observe(value, attributes)
-    }
 }
 
 impl<T> AsyncInstrument<T> for ObservableUpDownCounter<T> {


### PR DESCRIPTION
## Changes
- Remove unnecessary public `observe` methods from the ObservableInstruments
- Users only have to use `observe` method of the `AsyncInstrument` trait

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
