### PR TITLE
[Metrics API] Mark NoopMeterProvider as pub(crate)

### DIFF
--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -14,13 +14,13 @@ use std::sync::Arc;
 
 /// A no-op instance of a `MetricProvider`
 #[derive(Debug, Default)]
-pub struct NoopMeterProvider {
+pub(crate) struct NoopMeterProvider {
     _private: (),
 }
 
 impl NoopMeterProvider {
     /// Create a new no-op meter provider.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         NoopMeterProvider { _private: () }
     }
 }


### PR DESCRIPTION
## Changes
- `NoopMeterProvider` is only used in the API project

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
