### PR TITLE
Remove redundant Arc's in MeterProviderInner

### DIFF
--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -32,11 +32,11 @@ pub struct SdkMeterProvider {
     inner: Arc<SdkMeterProviderInner>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct SdkMeterProviderInner {
     pipes: Arc<Pipelines>,
-    meters: Arc<Mutex<HashMap<Scope, Arc<SdkMeter>>>>,
-    is_shutdown: Arc<AtomicBool>,
+    meters: Mutex<HashMap<Scope, Arc<SdkMeter>>>,
+    is_shutdown: AtomicBool,
 }
 
 impl Default for SdkMeterProvider {
@@ -236,7 +236,7 @@ impl MeterProviderBuilder {
                     self.views,
                 )),
                 meters: Default::default(),
-                is_shutdown: Arc::new(AtomicBool::new(false)),
+                is_shutdown: AtomicBool::new(false),
             }),
         }
     }


### PR DESCRIPTION
## Changes

Remove the redundant Arc around `SdkMeterProviderInner::meters` and `is_shutdown`, as `SdkMeterProviderInner` is already wrapped in an Arc within `SdkMeterProvide`r, making the extra indirection unnecessary. This simplifies access and avoids double reference counting.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
