### PR TITLE
[Metrics API] Mark structs non-exhaustive

### DIFF
--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -10,6 +10,7 @@ pub trait SyncCounter<T> {
 
 /// An instrument that records increasing values.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct Counter<T>(Arc<dyn SyncCounter<T> + Send + Sync>);
 
 impl<T> fmt::Debug for Counter<T>
@@ -35,6 +36,7 @@ impl<T> Counter<T> {
 
 /// An async instrument that records increasing values.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct ObservableCounter<T>(Arc<dyn AsyncInstrument<T>>);
 
 impl<T> ObservableCounter<T> {

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -10,6 +10,7 @@ pub trait SyncGauge<T> {
 
 /// An instrument that records independent values
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct Gauge<T>(Arc<dyn SyncGauge<T> + Send + Sync>);
 
 impl<T> fmt::Debug for Gauge<T>
@@ -35,6 +36,7 @@ impl<T> Gauge<T> {
 
 /// An async instrument that records independent readings.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct ObservableGauge<T>(Arc<dyn AsyncInstrument<T>>);
 
 impl<T> fmt::Debug for ObservableGauge<T>

--- a/opentelemetry/src/metrics/instruments/histogram.rs
+++ b/opentelemetry/src/metrics/instruments/histogram.rs
@@ -10,6 +10,7 @@ pub trait SyncHistogram<T> {
 
 /// An instrument that records a distribution of values.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct Histogram<T>(Arc<dyn SyncHistogram<T> + Send + Sync>);
 
 impl<T> fmt::Debug for Histogram<T>

--- a/opentelemetry/src/metrics/instruments/up_down_counter.rs
+++ b/opentelemetry/src/metrics/instruments/up_down_counter.rs
@@ -12,6 +12,7 @@ pub trait SyncUpDownCounter<T> {
 
 /// An instrument that records increasing or decreasing values.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct UpDownCounter<T>(Arc<dyn SyncUpDownCounter<T> + Send + Sync>);
 
 impl<T> fmt::Debug for UpDownCounter<T>
@@ -40,6 +41,7 @@ impl<T> UpDownCounter<T> {
 
 /// An async instrument that records increasing or decreasing values.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct ObservableUpDownCounter<T>(Arc<dyn AsyncInstrument<T>>);
 
 impl<T> fmt::Debug for ObservableUpDownCounter<T>

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -290,6 +290,7 @@ pub trait MeterProvider {
 /// ```
 ///
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct Meter {
     pub(crate) instrument_provider: Arc<dyn InstrumentProvider + Send + Sync>,
 }


### PR DESCRIPTION
## Changes
- Mark `Meter` and all the instruments structs as `non_exhaustive`

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
