### PR TITLE
[Metrics-API] Mark no-op structs as pub(crate)

### DIFF
--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -4,7 +4,6 @@ use std::{borrow::Cow, sync::Arc};
 use opentelemetry::{
     global,
     metrics::{
-        noop::{NoopAsyncInstrument, NoopSyncInstrument},
         AsyncInstrumentBuilder, Counter, Gauge, Histogram, HistogramBuilder, InstrumentBuilder,
         InstrumentProvider, MetricsError, ObservableCounter, ObservableGauge,
         ObservableUpDownCounter, Result, UpDownCounter,
@@ -17,6 +16,8 @@ use crate::metrics::{
     internal::{self, Number},
     pipeline::{Pipelines, Resolver},
 };
+
+use super::noop::{NoopAsyncInstrument, NoopSyncInstrument};
 
 // maximum length of instrument name
 const INSTRUMENT_NAME_MAX_LENGTH: usize = 255;

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -9,13 +9,15 @@ use std::{
 
 use opentelemetry::{
     global,
-    metrics::{noop::NoopMeter, Meter, MeterProvider, MetricsError, Result},
+    metrics::{Meter, MeterProvider, MetricsError, Result},
     KeyValue,
 };
 
 use crate::{instrumentation::Scope, Resource};
 
-use super::{meter::SdkMeter, pipeline::Pipelines, reader::MetricReader, view::View};
+use super::{
+    meter::SdkMeter, noop::NoopMeter, pipeline::Pipelines, reader::MetricReader, view::View,
+};
 
 /// Handles the creation and coordination of [Meter]s.
 ///

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -47,6 +47,7 @@ pub(crate) mod internal;
 pub(crate) mod manual_reader;
 pub(crate) mod meter;
 mod meter_provider;
+pub(crate) mod noop;
 pub(crate) mod periodic_reader;
 pub(crate) mod pipeline;
 pub mod reader;

--- a/opentelemetry-sdk/src/metrics/noop.rs
+++ b/opentelemetry-sdk/src/metrics/noop.rs
@@ -1,41 +1,10 @@
-//! # No-op OpenTelemetry Metrics Implementation
-//!
-//! This implementation is returned as the global Meter if no `MeterProvider`
-//! has been set. It is expected to have minimal resource utilization and
-//! runtime impact.
-use crate::{
+use opentelemetry::{
     metrics::{
-        AsyncInstrument, InstrumentProvider, Meter, MeterProvider, SyncCounter, SyncGauge,
-        SyncHistogram, SyncUpDownCounter,
+        AsyncInstrument, InstrumentProvider, SyncCounter, SyncGauge, SyncHistogram,
+        SyncUpDownCounter,
     },
     KeyValue,
 };
-use std::sync::Arc;
-
-/// A no-op instance of a `MetricProvider`
-#[derive(Debug, Default)]
-pub(crate) struct NoopMeterProvider {
-    _private: (),
-}
-
-impl NoopMeterProvider {
-    /// Create a new no-op meter provider.
-    pub(crate) fn new() -> Self {
-        NoopMeterProvider { _private: () }
-    }
-}
-
-impl MeterProvider for NoopMeterProvider {
-    fn versioned_meter(
-        &self,
-        _name: &'static str,
-        _version: Option<&'static str>,
-        _schema_url: Option<&'static str>,
-        _attributes: Option<Vec<KeyValue>>,
-    ) -> Meter {
-        Meter::new(Arc::new(NoopMeter::new()))
-    }
-}
 
 /// A no-op instance of a `Meter`
 #[derive(Debug, Default)]

--- a/opentelemetry/src/global/metrics.rs
+++ b/opentelemetry/src/global/metrics.rs
@@ -7,7 +7,7 @@ type GlobalMeterProvider = Arc<dyn MeterProvider + Send + Sync>;
 
 /// The global `MeterProvider` singleton.
 static GLOBAL_METER_PROVIDER: Lazy<RwLock<GlobalMeterProvider>> =
-    Lazy::new(|| RwLock::new(Arc::new(metrics::noop::NoopMeterProvider::new())));
+    Lazy::new(|| RwLock::new(Arc::new(crate::metrics::noop::NoopMeterProvider::new())));
 
 /// Sets the given [`MeterProvider`] instance as the current global meter
 /// provider.

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 mod instruments;
 mod meter;
-pub mod noop;
+pub(crate) mod noop;
 
 use crate::{Array, ExportError, KeyValue, Value};
 pub use instruments::{


### PR DESCRIPTION
## Changes
- This PR reduces the number of public APIs exposed by removing SDK's dependency on using API's no-op versions of Meter and instruments
- The intended behavior is retained by SDK keeping its own version of these no-op structs

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
