### PR TITLE
Chore/metrics advanced

### DIFF
--- a/examples/metrics-advanced/Cargo.toml
+++ b/examples/metrics-advanced/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 opentelemetry = { path = "../../opentelemetry", features = ["metrics"] }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["metrics", "rt-tokio"] }
-opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["metrics"]}
+opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["metrics"] }
 tokio = { workspace = true, features = ["full"] }
 serde_json = { workspace = true }

--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -1,6 +1,7 @@
 use opentelemetry::global;
 use opentelemetry::Key;
 use opentelemetry::KeyValue;
+use opentelemetry_sdk::metrics::reader::DeltaTemporalitySelector;
 use opentelemetry_sdk::metrics::{
     Aggregation, Instrument, PeriodicReader, SdkMeterProvider, Stream,
 };
@@ -44,7 +45,11 @@ fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
         }
     };
 
-    let exporter = opentelemetry_stdout::MetricsExporterBuilder::default().build();
+    // Build exporter using Delta Temporality.
+    let exporter = opentelemetry_stdout::MetricsExporterBuilder::default()
+        .with_temporality_selector(DeltaTemporalitySelector::new())
+        .build();
+
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
     let provider = SdkMeterProvider::builder()
         .with_reader(reader)

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -14,7 +14,7 @@ use opentelemetry_sdk::{
     metrics::{
         data::{ResourceMetrics, Temporality},
         exporter::PushMetricsExporter,
-        reader::{DefaultTemporalitySelector, TemporalitySelector},
+        reader::{DefaultTemporalitySelector, DeltaTemporalitySelector, TemporalitySelector},
         InstrumentKind, PeriodicReader, SdkMeterProvider,
     },
     runtime::Runtime,
@@ -169,7 +169,7 @@ where
     ///
     /// [exporter-docs]: https://github.com/open-telemetry/opentelemetry-specification/blob/a1c13d59bb7d0fb086df2b3e1eaec9df9efef6cc/specification/metrics/sdk_exporters/otlp.md#additional-configuration
     pub fn with_delta_temporality(self) -> Self {
-        self.with_temporality_selector(DeltaTemporalitySelector)
+        self.with_temporality_selector(DeltaTemporalitySelector::new())
     }
 }
 
@@ -234,35 +234,6 @@ impl<RT, EB: Debug> Debug for OtlpMetricPipeline<RT, EB> {
             .field("period", &self.period)
             .field("timeout", &self.timeout)
             .finish()
-    }
-}
-
-/// A temporality selector that returns [`Delta`][Temporality::Delta] for all
-/// instruments except `UpDownCounter` and `ObservableUpDownCounter`.
-///
-/// This temporality selector is equivalent to OTLP Metrics Exporter's
-/// `Delta` temporality preference (see [its documentation][exporter-docs]).
-///
-/// [exporter-docs]: https://github.com/open-telemetry/opentelemetry-specification/blob/a1c13d59bb7d0fb086df2b3e1eaec9df9efef6cc/specification/metrics/sdk_exporters/otlp.md#additional-configuration
-#[derive(Debug)]
-struct DeltaTemporalitySelector;
-
-impl TemporalitySelector for DeltaTemporalitySelector {
-    #[rustfmt::skip]
-    fn temporality(&self, kind: InstrumentKind) -> Temporality {
-        match kind {
-            InstrumentKind::Counter
-            | InstrumentKind::Histogram
-            | InstrumentKind::ObservableCounter
-            | InstrumentKind::Gauge
-            | InstrumentKind::ObservableGauge => {
-                Temporality::Delta
-            }
-            InstrumentKind::UpDownCounter
-            | InstrumentKind::ObservableUpDownCounter => {
-                Temporality::Cumulative
-            }
-        }
     }
 }
 

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -10,7 +10,7 @@ use opentelemetry_sdk::{
     metrics::{
         data::{ResourceMetrics, Temporality},
         new_view,
-        reader::{MetricReader, TemporalitySelector},
+        reader::{DeltaTemporalitySelector, MetricReader, TemporalitySelector},
         Aggregation, Instrument, InstrumentKind, ManualReader, Pipeline, SdkMeterProvider, Stream,
         View,
     },
@@ -41,28 +41,6 @@ impl MetricReader for SharedReader {
 
     fn shutdown(&self) -> Result<()> {
         self.0.shutdown()
-    }
-}
-
-/// Configure delta temporality for all [InstrumentKind]
-///
-/// [Temporality::Delta] will be used for all instrument kinds if this
-/// [TemporalitySelector] is used.
-#[derive(Clone, Default, Debug)]
-pub struct DeltaTemporalitySelector {
-    pub(crate) _private: (),
-}
-
-impl DeltaTemporalitySelector {
-    /// Create a new default temporality selector.
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-impl TemporalitySelector for DeltaTemporalitySelector {
-    fn temporality(&self, _kind: InstrumentKind) -> Temporality {
-        Temporality::Delta
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -86,3 +86,41 @@ impl TemporalitySelector for DefaultTemporalitySelector {
         Temporality::Cumulative
     }
 }
+
+/// A temporality selector that returns [`Delta`][Temporality::Delta] for all
+/// instruments except `UpDownCounter` and `ObservableUpDownCounter`.
+///
+/// This temporality selector is equivalent to OTLP Metrics Exporter's
+/// `Delta` temporality preference (see [its documentation][exporter-docs]).
+///
+/// [exporter-docs]: https://github.com/open-telemetry/opentelemetry-specification/blob/a1c13d59bb7d0fb086df2b3e1eaec9df9efef6cc/specification/metrics/sdk_exporters/otlp.md#additional-configuration
+#[derive(Clone, Default, Debug)]
+pub struct DeltaTemporalitySelector {
+    pub(crate) _private: (),
+}
+
+impl DeltaTemporalitySelector {
+    /// Create a new default temporality selector.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl TemporalitySelector for DeltaTemporalitySelector {
+    #[rustfmt::skip]
+    fn temporality(&self, kind: InstrumentKind) -> Temporality {
+        match kind {
+            InstrumentKind::Counter
+            | InstrumentKind::Histogram
+            | InstrumentKind::ObservableCounter
+            | InstrumentKind::Gauge
+            | InstrumentKind::ObservableGauge => {
+                Temporality::Delta
+            }
+            InstrumentKind::UpDownCounter
+            | InstrumentKind::ObservableUpDownCounter => {
+                Temporality::Cumulative
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue That prompted these changes: https://github.com/open-telemetry/opentelemetry-rust/issues/1060

References:
- mention of wanting alternate Temporality example: https://github.com/open-telemetry/opentelemetry-rust/issues/1060#issuecomment-1834421336
- mention of duplication in benches: https://github.com/open-telemetry/opentelemetry-rust/pull/1057#discussion_r1205798111

## Changes
`DeltaTemporalitySelector`:
- Moving the `DeltaTemporalitySelector` to same file as `DefaultTemporalitySelector`.
- make the visibility of the struct `pub` so its usable for pipeline setup.

Example:
- Update the advanced metrics example to use `DeltaTemporalitySelector`.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
