### PR TITLE
[Metrics API] Remove unnecessary auto trait implementations

### DIFF
--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -227,7 +227,7 @@ pub enum Value {
 }
 
 /// Wrapper for string-like values
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct StringValue(OtelString);
 
 impl fmt::Debug for StringValue {


### PR DESCRIPTION
## Changes
- Remove unnecessary `PartialOrd` and `Ord` implementations for `StringValue`

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
