### PR TITLE
Revert "`opentelemetry-appender-log`: Add code attributes to logs"

### DIFF
--- a/opentelemetry-appender-log/CHANGELOG.md
+++ b/opentelemetry-appender-log/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## vNext
 
 - Bump MSRV to 1.70 [#2179](https://github.com/open-telemetry/opentelemetry-rust/pull/2179)
-- [2193](https://github.com/open-telemetry/opentelemetry-rust/pull/2193) `opentelemetry-appender-log`: Output experimental code attributes 
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -11,26 +11,17 @@ rust-version = "1.70"
 edition = "2021"
 
 [dependencies]
-opentelemetry = { version = "0.26", path = "../opentelemetry", features = [
-  "logs",
-] }
-log = { workspace = true, features = ["kv", "std"] }
+opentelemetry = { version = "0.26", path = "../opentelemetry", features = ["logs"]}
+log = { workspace = true, features = ["kv", "std"]}
 serde = { workspace = true, optional = true, features = ["std"] }
-opentelemetry-semantic-conventions = { path = "../opentelemetry-semantic-conventions", optional = true, features = [
-  "semconv_experimental",
-] }
 
 [features]
 logs_level_enabled = ["opentelemetry/logs_level_enabled"]
 with-serde = ["log/kv_serde", "serde"]
-experimental_metadata_attributes = ["dep:opentelemetry-semantic-conventions"]
 
 [dev-dependencies]
-opentelemetry_sdk = { path = "../opentelemetry-sdk", features = [
-  "testing",
-  "logs_level_enabled",
-] }
-opentelemetry-stdout = { path = "../opentelemetry-stdout", features = ["logs"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", features = [ "testing", "logs_level_enabled" ] }
+opentelemetry-stdout = { path = "../opentelemetry-stdout", features = ["logs"]}
 log = { workspace = true, features = ["kv_serde"] }
 tokio = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -99,8 +99,6 @@ use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
     Key,
 };
-#[cfg(feature = "experimental_metadata_attributes")]
-use opentelemetry_semantic_conventions::trace::{CODE_FILEPATH, CODE_LINENO, CODE_NAMESPACE};
 use std::borrow::Cow;
 
 pub struct OpenTelemetryLogBridge<P, L>
@@ -132,28 +130,6 @@ where
             log_record.set_severity_number(severity_of_level(record.level()));
             log_record.set_severity_text(record.level().as_str());
             log_record.set_body(AnyValue::from(record.args().to_string()));
-
-            #[cfg(feature = "experimental_metadata_attributes")]
-            {
-                if let Some(filepath) = record.file() {
-                    log_record.add_attribute(
-                        Key::new(CODE_FILEPATH),
-                        AnyValue::from(filepath.to_string()),
-                    );
-                }
-
-                if let Some(line_no) = record.line() {
-                    log_record.add_attribute(Key::new(CODE_LINENO), AnyValue::from(line_no));
-                }
-
-                if let Some(module) = record.module_path() {
-                    log_record.add_attribute(
-                        Key::new(CODE_NAMESPACE),
-                        AnyValue::from(module.to_string()),
-                    );
-                }
-            }
-
             log_record.add_attributes(log_attributes(record.key_values()));
             log_record.set_target(record.metadata().target().to_string());
 
@@ -1149,54 +1125,6 @@ mod tests {
                 get("tuple_variant_value").unwrap()
             );
         }
-    }
-
-    #[cfg(feature = "experimental_metadata_attributes")]
-    #[test]
-    fn logbridge_code_attributes() {
-        use opentelemetry_semantic_conventions::trace::{
-            CODE_FILEPATH, CODE_LINENO, CODE_NAMESPACE,
-        };
-
-        let exporter = InMemoryLogsExporter::default();
-
-        let logger_provider = LoggerProvider::builder()
-            .with_simple_exporter(exporter.clone())
-            .build();
-
-        let otel_log_appender = OpenTelemetryLogBridge::new(&logger_provider);
-
-        otel_log_appender.log(
-            &log::RecordBuilder::new()
-                .level(log::Level::Warn)
-                .args(format_args!("WARN"))
-                .file(Some("src/main.rs"))
-                .module_path(Some("service"))
-                .line(Some(101))
-                .build(),
-        );
-
-        let logs = exporter.get_emitted_logs().unwrap();
-
-        let get = |needle: &str| -> Option<AnyValue> {
-            logs[0].record.attributes_iter().find_map(|(k, v)| {
-                if k.as_str() == needle {
-                    Some(v.clone())
-                } else {
-                    None
-                }
-            })
-        };
-
-        assert_eq!(
-            Some(AnyValue::String(StringValue::from("src/main.rs"))),
-            get(CODE_FILEPATH)
-        );
-        assert_eq!(
-            Some(AnyValue::String(StringValue::from("service"))),
-            get(CODE_NAMESPACE)
-        );
-        assert_eq!(Some(AnyValue::Int(101)), get(CODE_LINENO));
     }
 
     #[test]


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-rust#2193 to fix CI.
It is not clear how this was allowed to be merged?