### PR TITLE
[Metrics-API] Update asynchronous instruments to not allow calling `observe` outside of a callback

### DIFF
--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -17,7 +17,7 @@ use crate::metrics::{
     pipeline::{Pipelines, Resolver},
 };
 
-use super::noop::{NoopAsyncInstrument, NoopSyncInstrument};
+use super::noop::NoopSyncInstrument;
 
 // maximum length of instrument name
 const INSTRUMENT_NAME_MAX_LENGTH: usize = 255;
@@ -108,7 +108,7 @@ impl SdkMeter {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
             global::handle_error(err);
-            return Ok(ObservableCounter::new(Arc::new(NoopAsyncInstrument::new())));
+            return Ok(ObservableCounter::new());
         }
 
         let ms = resolver.measures(
@@ -120,7 +120,7 @@ impl SdkMeter {
         )?;
 
         if ms.is_empty() {
-            return Ok(ObservableCounter::new(Arc::new(NoopAsyncInstrument::new())));
+            return Ok(ObservableCounter::new());
         }
 
         let observable = Arc::new(Observable::new(ms));
@@ -131,7 +131,7 @@ impl SdkMeter {
                 .register_callback(move || callback(cb_inst.as_ref()));
         }
 
-        Ok(ObservableCounter::new(observable))
+        Ok(ObservableCounter::new())
     }
 
     fn create_observable_updown_counter<T>(
@@ -145,9 +145,7 @@ impl SdkMeter {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
             global::handle_error(err);
-            return Ok(ObservableUpDownCounter::new(Arc::new(
-                NoopAsyncInstrument::new(),
-            )));
+            return Ok(ObservableUpDownCounter::new());
         }
 
         let ms = resolver.measures(
@@ -159,9 +157,7 @@ impl SdkMeter {
         )?;
 
         if ms.is_empty() {
-            return Ok(ObservableUpDownCounter::new(Arc::new(
-                NoopAsyncInstrument::new(),
-            )));
+            return Ok(ObservableUpDownCounter::new());
         }
 
         let observable = Arc::new(Observable::new(ms));
@@ -172,7 +168,7 @@ impl SdkMeter {
                 .register_callback(move || callback(cb_inst.as_ref()));
         }
 
-        Ok(ObservableUpDownCounter::new(observable))
+        Ok(ObservableUpDownCounter::new())
     }
 
     fn create_observable_gauge<T>(
@@ -186,7 +182,7 @@ impl SdkMeter {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
             global::handle_error(err);
-            return Ok(ObservableGauge::new(Arc::new(NoopAsyncInstrument::new())));
+            return Ok(ObservableGauge::new());
         }
 
         let ms = resolver.measures(
@@ -198,7 +194,7 @@ impl SdkMeter {
         )?;
 
         if ms.is_empty() {
-            return Ok(ObservableGauge::new(Arc::new(NoopAsyncInstrument::new())));
+            return Ok(ObservableGauge::new());
         }
 
         let observable = Arc::new(Observable::new(ms));
@@ -209,7 +205,7 @@ impl SdkMeter {
                 .register_callback(move || callback(cb_inst.as_ref()));
         }
 
-        Ok(ObservableGauge::new(observable))
+        Ok(ObservableGauge::new())
     }
 
     fn create_updown_counter<T>(

--- a/opentelemetry-sdk/src/metrics/noop.rs
+++ b/opentelemetry-sdk/src/metrics/noop.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{
-    metrics::{AsyncInstrument, InstrumentProvider, SyncInstrument},
+    metrics::{InstrumentProvider, SyncInstrument},
     KeyValue,
 };
 
@@ -33,25 +33,6 @@ impl NoopSyncInstrument {
 
 impl<T> SyncInstrument<T> for NoopSyncInstrument {
     fn measure(&self, _value: T, _attributes: &[KeyValue]) {
-        // Ignored
-    }
-}
-
-/// A no-op async instrument.
-#[derive(Debug, Default)]
-pub(crate) struct NoopAsyncInstrument {
-    _private: (),
-}
-
-impl NoopAsyncInstrument {
-    /// Create a new no-op async instrument
-    pub(crate) fn new() -> Self {
-        NoopAsyncInstrument { _private: () }
-    }
-}
-
-impl<T> AsyncInstrument<T> for NoopAsyncInstrument {
-    fn observe(&self, _value: T, _attributes: &[KeyValue]) {
         // Ignored
     }
 }

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 - Bump MSRV to 1.70 [#2179](https://github.com/open-telemetry/opentelemetry-rust/pull/2179)
 - Add `LogRecord::set_trace_context`; an optional method conditional on the `trace` feature for setting trace context on a log record.
-- Removed unnecessary public methods named `as_any` from `AsyncInstrument` trait and the implementing instruments: `ObservableCounter`, `ObservableGauge`, and `ObservableUpDownCounter` [#2187](https://github.com/open-telemetry/opentelemetry-rust/issues/2187)
-- Introduced `SyncInstrument` trait to replace the individual synchronous instrument traits (`SyncCounter`, `SyncGauge`, `SyncHistogram`, `SyncUpDownCounter`) which are meant for SDK implementation. [#2207](https://github.com/open-telemetry/opentelemetry-rust/issues/2207)
+- Removed unnecessary public methods named `as_any` from `AsyncInstrument` trait and the implementing instruments: `ObservableCounter`, `ObservableGauge`, and `ObservableUpDownCounter` [#2187](https://github.com/open-telemetry/opentelemetry-rust/pull/2187)
+- Introduced `SyncInstrument` trait to replace the individual synchronous instrument traits (`SyncCounter`, `SyncGauge`, `SyncHistogram`, `SyncUpDownCounter`) which are meant for SDK implementation. [#2207](https://github.com/open-telemetry/opentelemetry-rust/pull/2207)
+- Ensured that `observe` method on asynchronous instruments can only be called inside a callback. This was done by removing the implementation of `AsyncInstrument` trait for each of the asynchronous instruments. [#2210](https://github.com/open-telemetry/opentelemetry-rust/pull/2210)
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -1,4 +1,4 @@
-use crate::{metrics::AsyncInstrument, KeyValue};
+use crate::KeyValue;
 use core::fmt;
 use std::sync::Arc;
 
@@ -37,12 +37,17 @@ impl<T> Counter<T> {
 /// An async instrument that records increasing values.
 #[derive(Clone)]
 #[non_exhaustive]
-pub struct ObservableCounter<T>(Arc<dyn AsyncInstrument<T>>);
+pub struct ObservableCounter<T> {
+    _marker: std::marker::PhantomData<T>,
+}
 
 impl<T> ObservableCounter<T> {
     /// Create a new observable counter.
-    pub fn new(inner: Arc<dyn AsyncInstrument<T>>) -> Self {
-        ObservableCounter(inner)
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        ObservableCounter {
+            _marker: std::marker::PhantomData,
+        }
     }
 }
 
@@ -52,11 +57,5 @@ impl<T> fmt::Debug for ObservableCounter<T> {
             "ObservableCounter<{}>",
             std::any::type_name::<T>()
         ))
-    }
-}
-
-impl<T> AsyncInstrument<T> for ObservableCounter<T> {
-    fn observe(&self, measurement: T, attributes: &[KeyValue]) {
-        self.0.observe(measurement, attributes)
     }
 }

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -1,4 +1,4 @@
-use crate::{metrics::AsyncInstrument, KeyValue};
+use crate::KeyValue;
 use core::fmt;
 use std::sync::Arc;
 
@@ -37,7 +37,9 @@ impl<T> Gauge<T> {
 /// An async instrument that records independent readings.
 #[derive(Clone)]
 #[non_exhaustive]
-pub struct ObservableGauge<T>(Arc<dyn AsyncInstrument<T>>);
+pub struct ObservableGauge<T> {
+    _marker: std::marker::PhantomData<T>,
+}
 
 impl<T> fmt::Debug for ObservableGauge<T>
 where
@@ -51,15 +53,12 @@ where
     }
 }
 
-impl<M> AsyncInstrument<M> for ObservableGauge<M> {
-    fn observe(&self, measurement: M, attributes: &[KeyValue]) {
-        self.0.observe(measurement, attributes)
-    }
-}
-
 impl<T> ObservableGauge<T> {
     /// Create a new gauge
-    pub fn new(inner: Arc<dyn AsyncInstrument<T>>) -> Self {
-        ObservableGauge(inner)
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        ObservableGauge {
+            _marker: std::marker::PhantomData,
+        }
     }
 }

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -235,10 +235,7 @@ pub type Callback<T> = Box<dyn Fn(&dyn AsyncInstrument<T>) + Send + Sync>;
 
 /// Configuration for building an async instrument.
 #[non_exhaustive] // We expect to add more configuration fields in the future
-pub struct AsyncInstrumentBuilder<'a, I, M>
-where
-    I: AsyncInstrument<M>,
-{
+pub struct AsyncInstrumentBuilder<'a, I, M> {
     /// Instrument provider is used to create the instrument.
     pub instrument_provider: &'a dyn InstrumentProvider,
 
@@ -257,10 +254,7 @@ where
     _inst: marker::PhantomData<I>,
 }
 
-impl<'a, I, M> AsyncInstrumentBuilder<'a, I, M>
-where
-    I: AsyncInstrument<M>,
-{
+impl<'a, I, M> AsyncInstrumentBuilder<'a, I, M> {
     /// Create a new instrument builder
     pub(crate) fn new(meter: &'a Meter, name: Cow<'static, str>) -> Self {
         AsyncInstrumentBuilder {

--- a/opentelemetry/src/metrics/instruments/up_down_counter.rs
+++ b/opentelemetry/src/metrics/instruments/up_down_counter.rs
@@ -2,8 +2,6 @@ use crate::KeyValue;
 use core::fmt;
 use std::sync::Arc;
 
-use super::AsyncInstrument;
-
 /// An SDK implemented instrument that records increasing or decreasing values.
 pub trait SyncUpDownCounter<T> {
     /// Records an increment or decrement to the counter.
@@ -42,7 +40,9 @@ impl<T> UpDownCounter<T> {
 /// An async instrument that records increasing or decreasing values.
 #[derive(Clone)]
 #[non_exhaustive]
-pub struct ObservableUpDownCounter<T>(Arc<dyn AsyncInstrument<T>>);
+pub struct ObservableUpDownCounter<T> {
+    _marker: std::marker::PhantomData<T>,
+}
 
 impl<T> fmt::Debug for ObservableUpDownCounter<T>
 where
@@ -58,13 +58,10 @@ where
 
 impl<T> ObservableUpDownCounter<T> {
     /// Create a new observable up down counter.
-    pub fn new(inner: Arc<dyn AsyncInstrument<T>>) -> Self {
-        ObservableUpDownCounter(inner)
-    }
-}
-
-impl<T> AsyncInstrument<T> for ObservableUpDownCounter<T> {
-    fn observe(&self, measurement: T, attributes: &[KeyValue]) {
-        self.0.observe(measurement, attributes)
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        ObservableUpDownCounter {
+            _marker: std::marker::PhantomData,
+        }
     }
 }

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -122,9 +122,7 @@ pub trait InstrumentProvider {
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableCounter<u64>, u64>,
     ) -> Result<ObservableCounter<u64>> {
-        Ok(ObservableCounter::new(Arc::new(
-            noop::NoopAsyncInstrument::new(),
-        )))
+        Ok(ObservableCounter::new())
     }
 
     /// creates an instrument for recording increasing values via callback.
@@ -132,9 +130,7 @@ pub trait InstrumentProvider {
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableCounter<f64>, f64>,
     ) -> Result<ObservableCounter<f64>> {
-        Ok(ObservableCounter::new(Arc::new(
-            noop::NoopAsyncInstrument::new(),
-        )))
+        Ok(ObservableCounter::new())
     }
 
     /// creates an instrument for recording changes of a value.
@@ -162,9 +158,7 @@ pub trait InstrumentProvider {
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<i64>, i64>,
     ) -> Result<ObservableUpDownCounter<i64>> {
-        Ok(ObservableUpDownCounter::new(Arc::new(
-            noop::NoopAsyncInstrument::new(),
-        )))
+        Ok(ObservableUpDownCounter::new())
     }
 
     /// creates an instrument for recording changes of a value via callback.
@@ -172,9 +166,7 @@ pub trait InstrumentProvider {
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<f64>, f64>,
     ) -> Result<ObservableUpDownCounter<f64>> {
-        Ok(ObservableUpDownCounter::new(Arc::new(
-            noop::NoopAsyncInstrument::new(),
-        )))
+        Ok(ObservableUpDownCounter::new())
     }
 
     /// creates an instrument for recording independent values.
@@ -197,9 +189,7 @@ pub trait InstrumentProvider {
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableGauge<u64>, u64>,
     ) -> Result<ObservableGauge<u64>> {
-        Ok(ObservableGauge::new(Arc::new(
-            noop::NoopAsyncInstrument::new(),
-        )))
+        Ok(ObservableGauge::new())
     }
 
     /// creates an instrument for recording the current value via callback.
@@ -207,9 +197,7 @@ pub trait InstrumentProvider {
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableGauge<i64>, i64>,
     ) -> Result<ObservableGauge<i64>> {
-        Ok(ObservableGauge::new(Arc::new(
-            noop::NoopAsyncInstrument::new(),
-        )))
+        Ok(ObservableGauge::new())
     }
 
     /// creates an instrument for recording the current value via callback.
@@ -217,9 +205,7 @@ pub trait InstrumentProvider {
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableGauge<f64>, f64>,
     ) -> Result<ObservableGauge<f64>> {
-        Ok(ObservableGauge::new(Arc::new(
-            noop::NoopAsyncInstrument::new(),
-        )))
+        Ok(ObservableGauge::new())
     }
 
     /// creates an instrument for recording a distribution of values.

--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -4,7 +4,7 @@
 //! has been set. It is expected to have minimal resource utilization and
 //! runtime impact.
 use crate::{
-    metrics::{AsyncInstrument, InstrumentProvider, Meter, MeterProvider},
+    metrics::{InstrumentProvider, Meter, MeterProvider},
     KeyValue,
 };
 use std::sync::Arc;
@@ -66,25 +66,6 @@ impl NoopSyncInstrument {
 
 impl<T> SyncInstrument<T> for NoopSyncInstrument {
     fn measure(&self, _value: T, _attributes: &[KeyValue]) {
-        // Ignored
-    }
-}
-
-/// A no-op async instrument.
-#[derive(Debug, Default)]
-pub(crate) struct NoopAsyncInstrument {
-    _private: (),
-}
-
-impl NoopAsyncInstrument {
-    /// Create a new no-op async instrument
-    pub(crate) fn new() -> Self {
-        NoopAsyncInstrument { _private: () }
-    }
-}
-
-impl<T> AsyncInstrument<T> for NoopAsyncInstrument {
-    fn observe(&self, _value: T, _attributes: &[KeyValue]) {
         // Ignored
     }
 }


### PR DESCRIPTION
All the asynchronous instruments implement the trait `AsyncInstrument` which allows users to call `observe` method outside of the callback
```rust
let observable_counter = meter
        .u64_observable_counter("my_observable_counter")
        .with_callback(|observer| {
            observer.observe(
                100,
                &[
                    KeyValue::new("mykey1", "myvalue1"),
                    KeyValue::new("mykey2", "myvalue2"),
                ],
            )
        })
        .init();

observable_counter.observe(500, &[]); // This should not be allowed
```

## Changes
- This PR removes the implementation of `AsyncInstrument` for each of the asynchronous instruments to not allow calling `observe` outside of a callback (as a side benefit, we also reduce the public API surface)
- That also means that we can completely remove `AsyncInstrument` from each of asynchronous instruments as it was only used for implementation of itself

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
