### PR TITLE
[Metrics-API] Update asynchronous instruments to only allow one callback

### DIFF
--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -125,7 +125,7 @@ impl SdkMeter {
 
         let observable = Arc::new(Observable::new(ms));
 
-        for callback in builder.callbacks {
+        if let Some(callback) = builder.callback {
             let cb_inst = Arc::clone(&observable);
             self.pipes
                 .register_callback(move || callback(cb_inst.as_ref()));
@@ -166,7 +166,7 @@ impl SdkMeter {
 
         let observable = Arc::new(Observable::new(ms));
 
-        for callback in builder.callbacks {
+        if let Some(callback) = builder.callback {
             let cb_inst = Arc::clone(&observable);
             self.pipes
                 .register_callback(move || callback(cb_inst.as_ref()));
@@ -203,7 +203,7 @@ impl SdkMeter {
 
         let observable = Arc::new(Observable::new(ms));
 
-        for callback in builder.callbacks {
+        if let Some(callback) = builder.callback {
             let cb_inst = Arc::clone(&observable);
             self.pipes
                 .register_callback(move || callback(cb_inst.as_ref()));

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -258,7 +258,7 @@ where
     pub unit: Option<Cow<'static, str>>,
 
     /// Callbacks to be called for this instrument.
-    pub callbacks: Vec<Callback<M>>,
+    pub callback: Option<Callback<M>>,
 
     _inst: marker::PhantomData<I>,
 }
@@ -275,7 +275,7 @@ where
             description: None,
             unit: None,
             _inst: marker::PhantomData,
-            callbacks: Vec::new(),
+            callback: None,
         }
     }
 
@@ -302,7 +302,7 @@ where
     where
         F: Fn(&dyn AsyncInstrument<M>) + Send + Sync + 'static,
     {
-        self.callbacks.push(Box::new(callback));
+        self.callback = Some(Box::new(callback));
         self
     }
 }
@@ -354,7 +354,7 @@ where
             .field("description", &self.description)
             .field("unit", &self.unit)
             .field("kind", &std::any::type_name::<I>())
-            .field("callbacks_len", &self.callbacks.len())
+            .field("has callback", &self.callback.is_some())
             .finish()
     }
 }


### PR DESCRIPTION
## Changes
- This PR updates the `AynshronousInstrumentBuilder` and related code to only allow for one callback
- If a user provides multiple callbacks for an instrument by calling `with_callback` multiple times, we select the last provided `with_callback` for the instrument

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
