### PR TITLE
[Metrics API] Remove unnecessary auto trait implementations

### DIFF
--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -104,7 +104,7 @@ fn calculate_hash(values: &[KeyValue]) -> u64 {
 
 impl AttributeSet {
     fn new(mut values: Vec<KeyValue>) -> Self {
-        values.sort_unstable();
+        values.sort_unstable_by(|a, b| a.key.cmp(&b.key));
         let hash = calculate_hash(&values);
         AttributeSet(values, hash)
     }

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed unnecessary public methods named `as_any` from `AsyncInstrument` trait and the implementing instruments: `ObservableCounter`, `ObservableGauge`, and `ObservableUpDownCounter` [#2187](https://github.com/open-telemetry/opentelemetry-rust/pull/2187)
 - Introduced `SyncInstrument` trait to replace the individual synchronous instrument traits (`SyncCounter`, `SyncGauge`, `SyncHistogram`, `SyncUpDownCounter`) which are meant for SDK implementation. [#2207](https://github.com/open-telemetry/opentelemetry-rust/pull/2207)
 - Ensured that `observe` method on asynchronous instruments can only be called inside a callback. This was done by removing the implementation of `AsyncInstrument` trait for each of the asynchronous instruments. [#2210](https://github.com/open-telemetry/opentelemetry-rust/pull/2210)
+- Removed `PartialOrd` and `Ord` implementations for `KeyValue`. [#2215](https://github.com/open-telemetry/opentelemetry-rust/pull/2215)
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -1,6 +1,5 @@
 //! # OpenTelemetry Metrics API
 
-use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use std::result;
 use std::sync::Arc;
@@ -88,19 +87,6 @@ impl Hash for KeyValue {
             Value::I64(i) => i.hash(state),
             Value::String(s) => s.hash(state),
         };
-    }
-}
-
-impl PartialOrd for KeyValue {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-/// Ordering is based on the key only.
-impl Ord for KeyValue {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.key.cmp(&other.key)
     }
 }
 
@@ -297,27 +283,6 @@ mod tests {
             let kv1 = KeyValue::new("key", random_value);
             let kv2 = KeyValue::new("key", random_value);
             assert_eq!(hash_helper(&kv1), hash_helper(&kv2));
-        }
-    }
-
-    #[test]
-    fn kv_float_order() {
-        // TODO: Extend this test to all value types, not just F64
-        let float_vals = [
-            0.0,
-            1.0,
-            -1.0,
-            f64::INFINITY,
-            f64::NEG_INFINITY,
-            f64::NAN,
-            f64::MIN,
-            f64::MAX,
-        ];
-
-        for v in float_vals {
-            let kv1 = KeyValue::new("a", v);
-            let kv2 = KeyValue::new("b", v);
-            assert!(kv1 < kv2, "Order is solely based on key!");
         }
     }
 


### PR DESCRIPTION
## Changes
- Remove unnecessary `Ord` and `PartialOrd` implementation for `KeyValue`
- This was only used for sorting a vec of `KeyValue` pairs in the SDK which could be done using `sort_unstable_by` method anyway

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
