### PR TITLE
Unify builders across signals

### DIFF
--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -97,11 +97,10 @@
 use log::{Level, Metadata, Record};
 use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    InstrumentationLibrary, Key,
+    InstrumentationScope, Key,
 };
 #[cfg(feature = "experimental_metadata_attributes")]
 use opentelemetry_semantic_conventions::attribute::{CODE_FILEPATH, CODE_LINENO, CODE_NAMESPACE};
-use std::sync::Arc;
 
 pub struct OpenTelemetryLogBridge<P, L>
 where
@@ -170,13 +169,12 @@ where
     L: Logger + Send + Sync,
 {
     pub fn new(provider: &P) -> Self {
-        let library = Arc::new(
-            InstrumentationLibrary::builder("opentelemetry-log-appender")
-                .with_version(env!("CARGO_PKG_VERSION"))
-                .build(),
-        );
+        let scope = InstrumentationScope::builder("opentelemetry-log-appender")
+            .with_version(env!("CARGO_PKG_VERSION"))
+            .build();
+
         OpenTelemetryLogBridge {
-            logger: provider.library_logger(library),
+            logger: provider.logger_with_scope(scope),
             _phantom: Default::default(),
         }
     }

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -16,7 +16,7 @@
 use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::logs::LogResult;
-use opentelemetry::{InstrumentationLibrary, KeyValue};
+use opentelemetry::{InstrumentationScope, KeyValue};
 use opentelemetry_appender_tracing::layer as tracing_layer;
 use opentelemetry_sdk::export::logs::{LogBatch, LogExporter};
 use opentelemetry_sdk::logs::{LogProcessor, LogRecord, LoggerProvider};
@@ -55,7 +55,7 @@ impl NoopProcessor {
 }
 
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _: &mut LogRecord, _: &InstrumentationLibrary) {
+    fn emit(&self, _: &mut LogRecord, _: &InstrumentationScope) {
         // no-op
     }
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,8 +1,8 @@
 use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    InstrumentationLibrary, Key,
+    InstrumentationScope, Key,
 };
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::Cow;
 use tracing_core::Level;
 #[cfg(feature = "experimental_metadata_attributes")]
 use tracing_core::Metadata;
@@ -136,14 +136,12 @@ where
     L: Logger + Send + Sync,
 {
     pub fn new(provider: &P) -> Self {
-        let library = Arc::new(
-            InstrumentationLibrary::builder(INSTRUMENTATION_LIBRARY_NAME)
-                .with_version(Cow::Borrowed(env!("CARGO_PKG_VERSION")))
-                .build(),
-        );
+        let scope = InstrumentationScope::builder(INSTRUMENTATION_LIBRARY_NAME)
+            .with_version(Cow::Borrowed(env!("CARGO_PKG_VERSION")))
+            .build();
 
         OpenTelemetryTracingBridge {
-            logger: provider.library_logger(library),
+            logger: provider.logger_with_scope(scope),
             _phantom: Default::default(),
         }
     }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,8 +1,8 @@
 use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    Key,
+    InstrumentationLibrary, Key,
 };
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 use tracing_core::Level;
 #[cfg(feature = "experimental_metadata_attributes")]
 use tracing_core::Metadata;
@@ -136,11 +136,14 @@ where
     L: Logger + Send + Sync,
 {
     pub fn new(provider: &P) -> Self {
-        OpenTelemetryTracingBridge {
-            logger: provider
-                .logger_builder(INSTRUMENTATION_LIBRARY_NAME)
+        let library = Arc::new(
+            InstrumentationLibrary::builder(INSTRUMENTATION_LIBRARY_NAME)
                 .with_version(Cow::Borrowed(env!("CARGO_PKG_VERSION")))
                 .build(),
+        );
+
+        OpenTelemetryTracingBridge {
+            logger: provider.library_logger(library),
             _phantom: Default::default(),
         }
     }

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -3,7 +3,7 @@ use opentelemetry::{
     global,
     metrics::MetricsError,
     trace::{TraceContextExt, TraceError, Tracer},
-    InstrumentationLibrary, KeyValue,
+    InstrumentationScope, KeyValue,
 };
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::WithExportConfig;
@@ -18,7 +18,7 @@ use opentelemetry_sdk::{
     logs::{self as sdklogs},
     Resource,
 };
-use std::{error::Error, sync::Arc};
+use std::error::Error;
 use tracing::info;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
@@ -128,14 +128,13 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .init();
 
     let common_scope_attributes = vec![KeyValue::new("scope-key", "scope-value")];
-    let library = Arc::new(
-        InstrumentationLibrary::builder("basic")
-            .with_version("1.0")
-            .with_attributes(common_scope_attributes)
-            .build(),
-    );
-    let tracer = global::library_tracer(library.clone());
-    let meter = global::library_meter(library);
+    let scope = InstrumentationScope::builder("basic")
+        .with_version("1.0")
+        .with_attributes(common_scope_attributes)
+        .build();
+
+    let tracer = global::tracer_with_scope(scope.clone());
+    let meter = global::meter_with_scope(scope);
 
     let counter = meter
         .u64_counter("test_counter")

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -1,12 +1,9 @@
 use once_cell::sync::Lazy;
-use opentelemetry::global;
 use opentelemetry::logs::LogError;
 use opentelemetry::metrics::MetricsError;
-use opentelemetry::trace::{TraceError, TracerProvider};
-use opentelemetry::{
-    trace::{TraceContextExt, Tracer},
-    KeyValue,
-};
+use opentelemetry::trace::{TraceContextExt, TraceError, Tracer, TracerProvider};
+use opentelemetry::KeyValue;
+use opentelemetry::{global, InstrumentationLibrary};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{LogExporter, MetricsExporter, SpanExporter, WithExportConfig};
 use opentelemetry_sdk::logs::LoggerProvider;
@@ -14,6 +11,7 @@ use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::trace::Config;
 use opentelemetry_sdk::{runtime, trace as sdktrace, Resource};
 use std::error::Error;
+use std::sync::Arc;
 use tracing::info;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
@@ -108,16 +106,14 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .init();
 
     let common_scope_attributes = vec![KeyValue::new("scope-key", "scope-value")];
-    let tracer = global::tracer_provider()
-        .tracer_builder("basic")
-        .with_attributes(common_scope_attributes.clone())
-        .build();
-    let meter = global::meter_with_version(
-        "basic",
-        Some("v1.0"),
-        Some("schema_url"),
-        Some(common_scope_attributes.clone()),
+    let library = Arc::new(
+        InstrumentationLibrary::builder("basic")
+            .with_version("1.0")
+            .with_attributes(common_scope_attributes)
+            .build(),
     );
+    let tracer = global::tracer_provider().library_tracer(library.clone());
+    let meter = global::library_meter(library);
 
     let counter = meter
         .u64_counter("test_counter")

--- a/opentelemetry-otlp/tests/integration_test/expected/serialized_traces.json
+++ b/opentelemetry-otlp/tests/integration_test/expected/serialized_traces.json
@@ -26,7 +26,7 @@
               "spanId": "cd7cf7bf939930b7",
               "traceState": "",
               "parentSpanId": "d58cf2d702a061e0",
-              "flags": 0,
+              "flags": 1,
               "name": "Sub operation...",
               "kind": 1,
               "startTimeUnixNano": "1703985537070566698",
@@ -55,40 +55,13 @@
                 "message": "",
                 "code": 0
               }
-            }
-          ],
-          "schemaUrl": ""
-        }
-      ],
-      "schemaUrl": ""
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "service.name",
-            "value": {
-              "stringValue": "basic-otlp-tracing-example"
-            }
-          }
-        ],
-        "droppedAttributesCount": 0
-      },
-      "scopeSpans": [
-        {
-          "scope": {
-            "name": "ex.com/basic",
-            "version": "",
-            "attributes": [],
-            "droppedAttributesCount": 0
-          },
-          "spans": [
+            },
             {
               "traceId": "9b458af7378cba65253d7042d34fc72e",
               "spanId": "d58cf2d702a061e0",
               "traceState": "",
               "parentSpanId": "",
-              "flags": 0,
+              "flags": 1,
               "name": "operation",
               "kind": 1,
               "startTimeUnixNano": "1703985537070558635",
@@ -109,12 +82,6 @@
                   "attributes": [
                     {
                       "key": "bogons",
-                      "value": {
-                        "intValue": "100"
-                      }
-                    },
-                    {
-                      "key": "number/int",
                       "value": {
                         "intValue": "100"
                       }

--- a/opentelemetry-proto/src/transform/common.rs
+++ b/opentelemetry-proto/src/transform/common.rs
@@ -42,18 +42,8 @@ pub mod tonic {
     #[cfg(any(feature = "trace", feature = "logs"))]
     use opentelemetry_sdk::Resource;
 
-    impl
-        From<(
-            opentelemetry_sdk::InstrumentationScope,
-            Option<Cow<'static, str>>,
-        )> for InstrumentationScope
-    {
-        fn from(
-            data: (
-                opentelemetry_sdk::InstrumentationScope,
-                Option<Cow<'static, str>>,
-            ),
-        ) -> Self {
+    impl From<(opentelemetry_sdk::Scope, Option<Cow<'static, str>>)> for InstrumentationScope {
+        fn from(data: (opentelemetry_sdk::Scope, Option<Cow<'static, str>>)) -> Self {
             let (library, target) = data;
             if let Some(t) = target {
                 InstrumentationScope {
@@ -73,18 +63,8 @@ pub mod tonic {
         }
     }
 
-    impl
-        From<(
-            &opentelemetry_sdk::InstrumentationScope,
-            Option<Cow<'static, str>>,
-        )> for InstrumentationScope
-    {
-        fn from(
-            data: (
-                &opentelemetry_sdk::InstrumentationScope,
-                Option<Cow<'static, str>>,
-            ),
-        ) -> Self {
+    impl From<(&opentelemetry_sdk::Scope, Option<Cow<'static, str>>)> for InstrumentationScope {
+        fn from(data: (&opentelemetry_sdk::Scope, Option<Cow<'static, str>>)) -> Self {
             let (library, target) = data;
             if let Some(t) = target {
                 InstrumentationScope {

--- a/opentelemetry-proto/src/transform/common.rs
+++ b/opentelemetry-proto/src/transform/common.rs
@@ -44,13 +44,13 @@ pub mod tonic {
 
     impl
         From<(
-            opentelemetry_sdk::InstrumentationLibrary,
+            opentelemetry_sdk::InstrumentationScope,
             Option<Cow<'static, str>>,
         )> for InstrumentationScope
     {
         fn from(
             data: (
-                opentelemetry_sdk::InstrumentationLibrary,
+                opentelemetry_sdk::InstrumentationScope,
                 Option<Cow<'static, str>>,
             ),
         ) -> Self {
@@ -75,13 +75,13 @@ pub mod tonic {
 
     impl
         From<(
-            &opentelemetry_sdk::InstrumentationLibrary,
+            &opentelemetry_sdk::InstrumentationScope,
             Option<Cow<'static, str>>,
         )> for InstrumentationScope
     {
         fn from(
             data: (
-                &opentelemetry_sdk::InstrumentationLibrary,
+                &opentelemetry_sdk::InstrumentationScope,
                 Option<Cow<'static, str>>,
             ),
         ) -> Self {

--- a/opentelemetry-proto/src/transform/common.rs
+++ b/opentelemetry-proto/src/transform/common.rs
@@ -42,8 +42,18 @@ pub mod tonic {
     #[cfg(any(feature = "trace", feature = "logs"))]
     use opentelemetry_sdk::Resource;
 
-    impl From<(opentelemetry_sdk::Scope, Option<Cow<'static, str>>)> for InstrumentationScope {
-        fn from(data: (opentelemetry_sdk::Scope, Option<Cow<'static, str>>)) -> Self {
+    impl
+        From<(
+            opentelemetry::InstrumentationScope,
+            Option<Cow<'static, str>>,
+        )> for InstrumentationScope
+    {
+        fn from(
+            data: (
+                opentelemetry::InstrumentationScope,
+                Option<Cow<'static, str>>,
+            ),
+        ) -> Self {
             let (library, target) = data;
             if let Some(t) = target {
                 InstrumentationScope {
@@ -63,8 +73,18 @@ pub mod tonic {
         }
     }
 
-    impl From<(&opentelemetry_sdk::Scope, Option<Cow<'static, str>>)> for InstrumentationScope {
-        fn from(data: (&opentelemetry_sdk::Scope, Option<Cow<'static, str>>)) -> Self {
+    impl
+        From<(
+            &opentelemetry::InstrumentationScope,
+            Option<Cow<'static, str>>,
+        )> for InstrumentationScope
+    {
+        fn from(
+            data: (
+                &opentelemetry::InstrumentationScope,
+                Option<Cow<'static, str>>,
+            ),
+        ) -> Self {
             let (library, target) = data;
             if let Some(t) = target {
                 InstrumentationScope {

--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -143,7 +143,7 @@ pub mod tonic {
         From<(
             (
                 &opentelemetry_sdk::logs::LogRecord,
-                &opentelemetry::InstrumentationLibrary,
+                &opentelemetry::InstrumentationScope,
             ),
             &ResourceAttributesWithSchema,
         )> for ResourceLogs
@@ -152,7 +152,7 @@ pub mod tonic {
             data: (
                 (
                     &opentelemetry_sdk::logs::LogRecord,
-                    &opentelemetry::InstrumentationLibrary,
+                    &opentelemetry::InstrumentationScope,
                 ),
                 &ResourceAttributesWithSchema,
             ),
@@ -189,7 +189,7 @@ pub mod tonic {
                 Cow<'static, str>,
                 Vec<(
                     &opentelemetry_sdk::logs::LogRecord,
-                    &opentelemetry::InstrumentationLibrary,
+                    &opentelemetry::InstrumentationScope,
                 )>,
             >,
              (log_record, instrumentation)| {
@@ -235,19 +235,19 @@ pub mod tonic {
 mod tests {
     use crate::transform::common::tonic::ResourceAttributesWithSchema;
     use opentelemetry::logs::LogRecord as _;
-    use opentelemetry::InstrumentationLibrary;
+    use opentelemetry::InstrumentationScope;
     use opentelemetry_sdk::{export::logs::LogBatch, logs::LogRecord, Resource};
     use std::time::SystemTime;
 
     fn create_test_log_data(
         instrumentation_name: &str,
         _message: &str,
-    ) -> (LogRecord, InstrumentationLibrary) {
+    ) -> (LogRecord, InstrumentationScope) {
         let mut logrecord = LogRecord::default();
         logrecord.set_timestamp(SystemTime::now());
         logrecord.set_observed_timestamp(SystemTime::now());
         let instrumentation =
-            InstrumentationLibrary::builder(instrumentation_name.to_string()).build();
+            InstrumentationScope::builder(instrumentation_name.to_string()).build();
         (logrecord, instrumentation)
     }
 

--- a/opentelemetry-proto/src/transform/trace.rs
+++ b/opentelemetry-proto/src/transform/trace.rs
@@ -158,8 +158,7 @@ pub mod tonic {
         // Group spans by their instrumentation library
         let scope_map = spans.iter().fold(
             HashMap::new(),
-            |mut scope_map: HashMap<&opentelemetry_sdk::InstrumentationScope, Vec<&SpanData>>,
-             span| {
+            |mut scope_map: HashMap<&opentelemetry_sdk::Scope, Vec<&SpanData>>, span| {
                 let instrumentation = &span.instrumentation_scope;
                 scope_map.entry(instrumentation).or_default().push(span);
                 scope_map
@@ -202,7 +201,7 @@ mod tests {
     use opentelemetry_sdk::export::trace::SpanData;
     use opentelemetry_sdk::resource::Resource;
     use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
-    use opentelemetry_sdk::InstrumentationScope;
+    use opentelemetry_sdk::Scope;
     use std::borrow::Cow;
     use std::time::{Duration, SystemTime};
 
@@ -227,7 +226,7 @@ mod tests {
             events: SpanEvents::default(),
             links: SpanLinks::default(),
             status: Status::Unset,
-            instrumentation_scope: InstrumentationScope::builder(instrumentation_name).build(),
+            instrumentation_scope: Scope::builder(instrumentation_name).build(),
         }
     }
 

--- a/opentelemetry-proto/src/transform/trace.rs
+++ b/opentelemetry-proto/src/transform/trace.rs
@@ -158,7 +158,7 @@ pub mod tonic {
         // Group spans by their instrumentation library
         let scope_map = spans.iter().fold(
             HashMap::new(),
-            |mut scope_map: HashMap<&opentelemetry_sdk::Scope, Vec<&SpanData>>, span| {
+            |mut scope_map: HashMap<&opentelemetry::InstrumentationScope, Vec<&SpanData>>, span| {
                 let instrumentation = &span.instrumentation_scope;
                 scope_map.entry(instrumentation).or_default().push(span);
                 scope_map
@@ -197,11 +197,11 @@ mod tests {
     use opentelemetry::trace::{
         SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
     };
+    use opentelemetry::InstrumentationScope;
     use opentelemetry::KeyValue;
     use opentelemetry_sdk::export::trace::SpanData;
     use opentelemetry_sdk::resource::Resource;
     use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
-    use opentelemetry_sdk::Scope;
     use std::borrow::Cow;
     use std::time::{Duration, SystemTime};
 
@@ -226,7 +226,7 @@ mod tests {
             events: SpanEvents::default(),
             links: SpanLinks::default(),
             status: Status::Unset,
-            instrumentation_scope: Scope::builder(instrumentation_name).build(),
+            instrumentation_scope: InstrumentationScope::builder(instrumentation_name).build(),
         }
     }
 

--- a/opentelemetry-proto/src/transform/trace.rs
+++ b/opentelemetry-proto/src/transform/trace.rs
@@ -155,7 +155,7 @@ pub mod tonic {
         spans: Vec<SpanData>,
         resource: &ResourceAttributesWithSchema,
     ) -> Vec<ResourceSpans> {
-        // Group spans by their instrumentation library
+        // Group spans by their instrumentation scope
         let scope_map = spans.iter().fold(
             HashMap::new(),
             |mut scope_map: HashMap<&opentelemetry::InstrumentationScope, Vec<&SpanData>>, span| {

--- a/opentelemetry-proto/src/transform/trace.rs
+++ b/opentelemetry-proto/src/transform/trace.rs
@@ -101,12 +101,12 @@ pub mod tonic {
                 schema_url: resource.schema_url.clone().unwrap_or_default(),
                 scope_spans: vec![ScopeSpans {
                     schema_url: source_span
-                        .instrumentation_lib
+                        .instrumentation_scope
                         .schema_url
                         .as_ref()
                         .map(ToString::to_string)
                         .unwrap_or_default(),
-                    scope: Some((source_span.instrumentation_lib, None).into()),
+                    scope: Some((source_span.instrumentation_scope, None).into()),
                     spans: vec![Span {
                         trace_id: source_span.span_context.trace_id().to_bytes().to_vec(),
                         span_id: source_span.span_context.span_id().to_bytes().to_vec(),
@@ -158,9 +158,9 @@ pub mod tonic {
         // Group spans by their instrumentation library
         let scope_map = spans.iter().fold(
             HashMap::new(),
-            |mut scope_map: HashMap<&opentelemetry_sdk::InstrumentationLibrary, Vec<&SpanData>>,
+            |mut scope_map: HashMap<&opentelemetry_sdk::InstrumentationScope, Vec<&SpanData>>,
              span| {
-                let instrumentation = &span.instrumentation_lib;
+                let instrumentation = &span.instrumentation_scope;
                 scope_map.entry(instrumentation).or_default().push(span);
                 scope_map
             },
@@ -202,7 +202,7 @@ mod tests {
     use opentelemetry_sdk::export::trace::SpanData;
     use opentelemetry_sdk::resource::Resource;
     use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
-    use opentelemetry_sdk::InstrumentationLibrary;
+    use opentelemetry_sdk::InstrumentationScope;
     use std::borrow::Cow;
     use std::time::{Duration, SystemTime};
 
@@ -227,7 +227,7 @@ mod tests {
             events: SpanEvents::default(),
             links: SpanLinks::default(),
             status: Status::Unset,
-            instrumentation_lib: InstrumentationLibrary::builder(instrumentation_name).build(),
+            instrumentation_scope: InstrumentationScope::builder(instrumentation_name).build(),
         }
     }
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -19,6 +19,12 @@ Now:
 ```rust
 let counter = meter.u64_counter("my_counter").build();
 ```
+- **BREAKING**: [#2220](https://github.com/open-telemetry/opentelemetry-rust/pull/2220)
+  - Removed `InstrumentationLibrary` re-export and its `Scope` alias, use `opentelemetry::InstrumentationLibrary` instead.
+  - Unified builders across signals
+    - Removed deprecated `LoggerProvider::versioned_logger`, `TracerProvider::versioned_tracer`
+    - Removed `MeterProvider::versioned_meter`
+    - Replaced these methods with `LoggerProvider::logger_with_scope`, `TracerProvider::logger_with_scope`, `MeterProvider::meter_with_scope`
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry-sdk/benches/batch_span_processor.rs
+++ b/opentelemetry-sdk/benches/batch_span_processor.rs
@@ -32,7 +32,7 @@ fn get_span_data() -> Vec<SpanData> {
             events: SpanEvents::default(),
             links: SpanLinks::default(),
             status: Status::Unset,
-            instrumentation_lib: Default::default(),
+            instrumentation_scope: Default::default(),
         })
         .collect::<Vec<SpanData>>()
 }

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -25,16 +25,17 @@ use opentelemetry::logs::{
 };
 use opentelemetry::trace::Tracer;
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry::{InstrumentationScope, Key};
+use opentelemetry::Key;
 use opentelemetry_sdk::logs::{LogProcessor, LogRecord, Logger, LoggerProvider};
 use opentelemetry_sdk::trace;
 use opentelemetry_sdk::trace::{Sampler, TracerProvider};
+use opentelemetry_sdk::Scope;
 
 #[derive(Debug)]
 struct NoopProcessor;
 
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _data: &mut LogRecord, _scope: &InstrumentationScope) {}
+    fn emit(&self, _data: &mut LogRecord, _scope: &Scope) {}
 
     fn force_flush(&self) -> LogResult<()> {
         Ok(())

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -25,17 +25,16 @@ use opentelemetry::logs::{
 };
 use opentelemetry::trace::Tracer;
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry::Key;
+use opentelemetry::{InstrumentationScope, Key};
 use opentelemetry_sdk::logs::{LogProcessor, LogRecord, Logger, LoggerProvider};
 use opentelemetry_sdk::trace;
 use opentelemetry_sdk::trace::{Sampler, TracerProvider};
-use opentelemetry_sdk::Scope;
 
 #[derive(Debug)]
 struct NoopProcessor;
 
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _data: &mut LogRecord, _scope: &Scope) {}
+    fn emit(&self, _data: &mut LogRecord, _scope: &InstrumentationScope) {}
 
     fn force_flush(&self) -> LogResult<()> {
         Ok(())

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -25,7 +25,7 @@ use opentelemetry::logs::{
 };
 use opentelemetry::trace::Tracer;
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry::{InstrumentationLibrary, Key};
+use opentelemetry::{InstrumentationScope, Key};
 use opentelemetry_sdk::logs::{LogProcessor, LogRecord, Logger, LoggerProvider};
 use opentelemetry_sdk::trace;
 use opentelemetry_sdk::trace::{Sampler, TracerProvider};
@@ -34,7 +34,7 @@ use opentelemetry_sdk::trace::{Sampler, TracerProvider};
 struct NoopProcessor;
 
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _data: &mut LogRecord, _library: &InstrumentationLibrary) {}
+    fn emit(&self, _data: &mut LogRecord, _scope: &InstrumentationScope) {}
 
     fn force_flush(&self) -> LogResult<()> {
         Ok(())

--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -18,11 +18,11 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use opentelemetry::logs::{LogRecord as _, LogResult, Logger as _, LoggerProvider as _, Severity};
 
+use opentelemetry::InstrumentationScope;
 use opentelemetry_sdk::export::logs::LogBatch;
 use opentelemetry_sdk::logs::LogProcessor;
 use opentelemetry_sdk::logs::LogRecord;
 use opentelemetry_sdk::logs::LoggerProvider;
-use opentelemetry_sdk::Scope;
 use pprof::criterion::{Output, PProfProfiler};
 use std::fmt::Debug;
 
@@ -65,7 +65,7 @@ impl ExportingProcessorWithFuture {
 }
 
 impl LogProcessor for ExportingProcessorWithFuture {
-    fn emit(&self, record: &mut LogRecord, scope: &Scope) {
+    fn emit(&self, record: &mut LogRecord, scope: &InstrumentationScope) {
         let mut exporter = self.exporter.lock().expect("lock error");
         let logs = [(record as &LogRecord, scope)];
         futures_executor::block_on(exporter.export(LogBatch::new(&logs)));
@@ -94,7 +94,7 @@ impl ExportingProcessorWithoutFuture {
 }
 
 impl LogProcessor for ExportingProcessorWithoutFuture {
-    fn emit(&self, record: &mut LogRecord, scope: &Scope) {
+    fn emit(&self, record: &mut LogRecord, scope: &InstrumentationScope) {
         let logs = [(record as &LogRecord, scope)];
         self.exporter
             .lock()

--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -18,11 +18,11 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use opentelemetry::logs::{LogRecord as _, LogResult, Logger as _, LoggerProvider as _, Severity};
 
-use opentelemetry::InstrumentationScope;
 use opentelemetry_sdk::export::logs::LogBatch;
 use opentelemetry_sdk::logs::LogProcessor;
 use opentelemetry_sdk::logs::LogRecord;
 use opentelemetry_sdk::logs::LoggerProvider;
+use opentelemetry_sdk::Scope;
 use pprof::criterion::{Output, PProfProfiler};
 use std::fmt::Debug;
 
@@ -65,7 +65,7 @@ impl ExportingProcessorWithFuture {
 }
 
 impl LogProcessor for ExportingProcessorWithFuture {
-    fn emit(&self, record: &mut LogRecord, scope: &InstrumentationScope) {
+    fn emit(&self, record: &mut LogRecord, scope: &Scope) {
         let mut exporter = self.exporter.lock().expect("lock error");
         let logs = [(record as &LogRecord, scope)];
         futures_executor::block_on(exporter.export(LogBatch::new(&logs)));
@@ -94,7 +94,7 @@ impl ExportingProcessorWithoutFuture {
 }
 
 impl LogProcessor for ExportingProcessorWithoutFuture {
-    fn emit(&self, record: &mut LogRecord, scope: &InstrumentationScope) {
+    fn emit(&self, record: &mut LogRecord, scope: &Scope) {
         let logs = [(record as &LogRecord, scope)];
         self.exporter
             .lock()

--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -18,7 +18,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use opentelemetry::logs::{LogRecord as _, LogResult, Logger as _, LoggerProvider as _, Severity};
 
-use opentelemetry::InstrumentationLibrary;
+use opentelemetry::InstrumentationScope;
 use opentelemetry_sdk::export::logs::LogBatch;
 use opentelemetry_sdk::logs::LogProcessor;
 use opentelemetry_sdk::logs::LogRecord;
@@ -65,9 +65,9 @@ impl ExportingProcessorWithFuture {
 }
 
 impl LogProcessor for ExportingProcessorWithFuture {
-    fn emit(&self, record: &mut LogRecord, library: &InstrumentationLibrary) {
+    fn emit(&self, record: &mut LogRecord, scope: &InstrumentationScope) {
         let mut exporter = self.exporter.lock().expect("lock error");
-        let logs = [(record as &LogRecord, library)];
+        let logs = [(record as &LogRecord, scope)];
         futures_executor::block_on(exporter.export(LogBatch::new(&logs)));
     }
 
@@ -94,8 +94,8 @@ impl ExportingProcessorWithoutFuture {
 }
 
 impl LogProcessor for ExportingProcessorWithoutFuture {
-    fn emit(&self, record: &mut LogRecord, library: &InstrumentationLibrary) {
-        let logs = [(record as &LogRecord, library)];
+    fn emit(&self, record: &mut LogRecord, scope: &InstrumentationScope) {
+        let logs = [(record as &LogRecord, scope)];
         self.exporter
             .lock()
             .expect("lock error")

--- a/opentelemetry-sdk/benches/log_processor.rs
+++ b/opentelemetry-sdk/benches/log_processor.rs
@@ -19,7 +19,7 @@ use std::{
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::logs::{LogRecord as _, LogResult, Logger as _, LoggerProvider as _, Severity};
-use opentelemetry::InstrumentationLibrary;
+use opentelemetry::InstrumentationScope;
 use opentelemetry_sdk::logs::{LogProcessor, LogRecord, Logger, LoggerProvider};
 
 // Run this benchmark with:
@@ -43,7 +43,7 @@ fn create_log_record(logger: &Logger) -> LogRecord {
 struct NoopProcessor;
 
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _data: &mut LogRecord, _library: &InstrumentationLibrary) {}
+    fn emit(&self, _data: &mut LogRecord, _scope: &InstrumentationScope) {}
 
     fn force_flush(&self) -> LogResult<()> {
         Ok(())
@@ -58,7 +58,7 @@ impl LogProcessor for NoopProcessor {
 struct CloningProcessor;
 
 impl LogProcessor for CloningProcessor {
-    fn emit(&self, data: &mut LogRecord, _library: &InstrumentationLibrary) {
+    fn emit(&self, data: &mut LogRecord, _scope: &InstrumentationScope) {
         let _data_cloned = data.clone();
     }
 
@@ -73,8 +73,8 @@ impl LogProcessor for CloningProcessor {
 
 #[derive(Debug)]
 struct SendToChannelProcessor {
-    sender: std::sync::mpsc::Sender<(LogRecord, InstrumentationLibrary)>,
-    receiver: Arc<Mutex<std::sync::mpsc::Receiver<(LogRecord, InstrumentationLibrary)>>>,
+    sender: std::sync::mpsc::Sender<(LogRecord, InstrumentationScope)>,
+    receiver: Arc<Mutex<std::sync::mpsc::Receiver<(LogRecord, InstrumentationScope)>>>,
 }
 
 impl SendToChannelProcessor {
@@ -101,8 +101,8 @@ impl SendToChannelProcessor {
 }
 
 impl LogProcessor for SendToChannelProcessor {
-    fn emit(&self, record: &mut LogRecord, library: &InstrumentationLibrary) {
-        let res = self.sender.send((record.clone(), library.clone()));
+    fn emit(&self, record: &mut LogRecord, scope: &InstrumentationScope) {
+        let res = self.sender.send((record.clone(), scope.clone()));
         if res.is_err() {
             println!("Error sending log data to channel {0}", res.err().unwrap());
         }

--- a/opentelemetry-sdk/benches/log_processor.rs
+++ b/opentelemetry-sdk/benches/log_processor.rs
@@ -18,9 +18,11 @@ use std::{
 };
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use opentelemetry::logs::{LogRecord as _, LogResult, Logger as _, LoggerProvider as _, Severity};
+use opentelemetry::{
+    logs::{LogRecord as _, LogResult, Logger as _, LoggerProvider as _, Severity},
+    InstrumentationScope,
+};
 use opentelemetry_sdk::logs::{LogProcessor, LogRecord, Logger, LoggerProvider};
-use opentelemetry_sdk::Scope;
 
 // Run this benchmark with:
 // cargo bench --bench log_processor
@@ -43,7 +45,7 @@ fn create_log_record(logger: &Logger) -> LogRecord {
 struct NoopProcessor;
 
 impl LogProcessor for NoopProcessor {
-    fn emit(&self, _data: &mut LogRecord, _scope: &Scope) {}
+    fn emit(&self, _data: &mut LogRecord, _scope: &InstrumentationScope) {}
 
     fn force_flush(&self) -> LogResult<()> {
         Ok(())
@@ -58,7 +60,7 @@ impl LogProcessor for NoopProcessor {
 struct CloningProcessor;
 
 impl LogProcessor for CloningProcessor {
-    fn emit(&self, data: &mut LogRecord, _scope: &Scope) {
+    fn emit(&self, data: &mut LogRecord, _scope: &InstrumentationScope) {
         let _data_cloned = data.clone();
     }
 
@@ -73,8 +75,8 @@ impl LogProcessor for CloningProcessor {
 
 #[derive(Debug)]
 struct SendToChannelProcessor {
-    sender: std::sync::mpsc::Sender<(LogRecord, Scope)>,
-    receiver: Arc<Mutex<std::sync::mpsc::Receiver<(LogRecord, Scope)>>>,
+    sender: std::sync::mpsc::Sender<(LogRecord, InstrumentationScope)>,
+    receiver: Arc<Mutex<std::sync::mpsc::Receiver<(LogRecord, InstrumentationScope)>>>,
 }
 
 impl SendToChannelProcessor {
@@ -101,7 +103,7 @@ impl SendToChannelProcessor {
 }
 
 impl LogProcessor for SendToChannelProcessor {
-    fn emit(&self, record: &mut LogRecord, scope: &Scope) {
+    fn emit(&self, record: &mut LogRecord, scope: &InstrumentationScope) {
         let res = self.sender.send((record.clone(), scope.clone()));
         if res.is_err() {
             println!("Error sending log data to channel {0}", res.err().unwrap());

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -11,11 +11,11 @@ use std::fmt::Debug;
 /// A batch of log records to be exported by a `LogExporter`.
 ///
 /// The `LogBatch` struct holds a collection of log records along with their associated
-/// instrumentation libraries. This structure is used to group log records together for efficient
+/// instrumentation scopes. This structure is used to group log records together for efficient
 /// export operations.
 ///
 /// # Type Parameters
-/// - `'a`: The lifetime of the references to the log records and instrumentation libraries.
+/// - `'a`: The lifetime of the references to the log records and instrumentation scopes.
 ///
 #[derive(Debug)]
 pub struct LogBatch<'a> {
@@ -31,11 +31,11 @@ impl<'a> LogBatch<'a> {
     ///
     /// * `data` - A slice of tuples, where each tuple consists of a reference to a `LogRecord`
     ///   and a reference to an `InstrumentationScope`. These tuples represent the log records
-    ///   and their associated instrumentation libraries to be exported.
+    ///   and their associated instrumentation scopes to be exported.
     ///
     /// # Returns
     ///
-    /// A `LogBatch` instance containing the provided log records and instrumentation libraries.
+    /// A `LogBatch` instance containing the provided log records and instrumentation scopes.
     ///
     /// Note - this is not a public function, and should not be used directly. This would be
     /// made private in the future.
@@ -46,7 +46,7 @@ impl<'a> LogBatch<'a> {
 }
 
 impl LogBatch<'_> {
-    /// Returns an iterator over the log records and instrumentation libraries in the batch.
+    /// Returns an iterator over the log records and instrumentation scopes in the batch.
     ///
     /// Each item yielded by the iterator is a tuple containing references to a `LogRecord`
     /// and an `InstrumentationScope`.
@@ -65,16 +65,16 @@ impl LogBatch<'_> {
 /// `LogExporter` defines the interface that log exporters should implement.
 #[async_trait]
 pub trait LogExporter: Send + Sync + Debug {
-    /// Exports a batch of log records and their associated instrumentation libraries.
+    /// Exports a batch of log records and their associated instrumentation scopes.
     ///
     /// The `export` method is responsible for sending a batch of log records to an external
     /// destination. It takes a `LogBatch` as an argument, which contains references to the
-    /// log records and their corresponding instrumentation libraries. The method returns
+    /// log records and their corresponding instrumentation scopes. The method returns
     /// a `LogResult` indicating the success or failure of the export operation.
     ///
     /// # Arguments
     ///
-    /// * `batch` - A `LogBatch` containing the log records and instrumentation libraries
+    /// * `batch` - A `LogBatch` containing the log records and instrumentation scopes
     ///   to be exported.
     ///
     /// # Returns

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -1,11 +1,11 @@
 //! Log exporters
 use crate::logs::LogRecord;
 use crate::Resource;
-use crate::Scope;
 use async_trait::async_trait;
 #[cfg(feature = "logs_level_enabled")]
 use opentelemetry::logs::Severity;
 use opentelemetry::logs::{LogError, LogResult};
+use opentelemetry::InstrumentationScope;
 use std::fmt::Debug;
 
 /// A batch of log records to be exported by a `LogExporter`.
@@ -20,8 +20,8 @@ use std::fmt::Debug;
 #[derive(Debug)]
 pub struct LogBatch<'a> {
     /// The data field contains a slice of tuples, where each tuple consists of a reference to
-    /// a `LogRecord` and a reference to an `Scope`.
-    data: &'a [(&'a LogRecord, &'a Scope)],
+    /// a `LogRecord` and a reference to an `InstrumentationScope`.
+    data: &'a [(&'a LogRecord, &'a InstrumentationScope)],
 }
 
 impl<'a> LogBatch<'a> {
@@ -30,7 +30,7 @@ impl<'a> LogBatch<'a> {
     /// # Arguments
     ///
     /// * `data` - A slice of tuples, where each tuple consists of a reference to a `LogRecord`
-    ///   and a reference to an `Scope`. These tuples represent the log records
+    ///   and a reference to an `InstrumentationScope`. These tuples represent the log records
     ///   and their associated instrumentation libraries to be exported.
     ///
     /// # Returns
@@ -40,7 +40,7 @@ impl<'a> LogBatch<'a> {
     /// Note - this is not a public function, and should not be used directly. This would be
     /// made private in the future.
 
-    pub fn new(data: &'a [(&'a LogRecord, &'a Scope)]) -> LogBatch<'a> {
+    pub fn new(data: &'a [(&'a LogRecord, &'a InstrumentationScope)]) -> LogBatch<'a> {
         LogBatch { data }
     }
 }
@@ -49,13 +49,13 @@ impl LogBatch<'_> {
     /// Returns an iterator over the log records and instrumentation libraries in the batch.
     ///
     /// Each item yielded by the iterator is a tuple containing references to a `LogRecord`
-    /// and an `Scope`.
+    /// and an `InstrumentationScope`.
     ///
     /// # Returns
     ///
-    /// An iterator that yields references to the `LogRecord` and `Scope` in the batch.
+    /// An iterator that yields references to the `LogRecord` and `InstrumentationScope` in the batch.
     ///
-    pub fn iter(&self) -> impl Iterator<Item = (&LogRecord, &Scope)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&LogRecord, &InstrumentationScope)> {
         self.data
             .iter()
             .map(|(record, library)| (*record, *library))

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use opentelemetry::logs::Severity;
 use opentelemetry::{
     logs::{LogError, LogResult},
-    InstrumentationLibrary,
+    InstrumentationScope,
 };
 use std::fmt::Debug;
 
@@ -22,8 +22,8 @@ use std::fmt::Debug;
 #[derive(Debug)]
 pub struct LogBatch<'a> {
     /// The data field contains a slice of tuples, where each tuple consists of a reference to
-    /// a `LogRecord` and a reference to an `InstrumentationLibrary`.
-    data: &'a [(&'a LogRecord, &'a InstrumentationLibrary)],
+    /// a `LogRecord` and a reference to an `InstrumentationScope`.
+    data: &'a [(&'a LogRecord, &'a InstrumentationScope)],
 }
 
 impl<'a> LogBatch<'a> {
@@ -32,7 +32,7 @@ impl<'a> LogBatch<'a> {
     /// # Arguments
     ///
     /// * `data` - A slice of tuples, where each tuple consists of a reference to a `LogRecord`
-    ///   and a reference to an `InstrumentationLibrary`. These tuples represent the log records
+    ///   and a reference to an `InstrumentationScope`. These tuples represent the log records
     ///   and their associated instrumentation libraries to be exported.
     ///
     /// # Returns
@@ -42,7 +42,7 @@ impl<'a> LogBatch<'a> {
     /// Note - this is not a public function, and should not be used directly. This would be
     /// made private in the future.
 
-    pub fn new(data: &'a [(&'a LogRecord, &'a InstrumentationLibrary)]) -> LogBatch<'a> {
+    pub fn new(data: &'a [(&'a LogRecord, &'a InstrumentationScope)]) -> LogBatch<'a> {
         LogBatch { data }
     }
 }
@@ -51,13 +51,13 @@ impl LogBatch<'_> {
     /// Returns an iterator over the log records and instrumentation libraries in the batch.
     ///
     /// Each item yielded by the iterator is a tuple containing references to a `LogRecord`
-    /// and an `InstrumentationLibrary`.
+    /// and an `InstrumentationScope`.
     ///
     /// # Returns
     ///
-    /// An iterator that yields references to the `LogRecord` and `InstrumentationLibrary` in the batch.
+    /// An iterator that yields references to the `LogRecord` and `InstrumentationScope` in the batch.
     ///
-    pub fn iter(&self) -> impl Iterator<Item = (&LogRecord, &InstrumentationLibrary)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&LogRecord, &InstrumentationScope)> {
         self.data
             .iter()
             .map(|(record, library)| (*record, *library))

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -1,13 +1,11 @@
 //! Log exporters
 use crate::logs::LogRecord;
 use crate::Resource;
+use crate::Scope;
 use async_trait::async_trait;
 #[cfg(feature = "logs_level_enabled")]
 use opentelemetry::logs::Severity;
-use opentelemetry::{
-    logs::{LogError, LogResult},
-    InstrumentationScope,
-};
+use opentelemetry::logs::{LogError, LogResult};
 use std::fmt::Debug;
 
 /// A batch of log records to be exported by a `LogExporter`.
@@ -22,8 +20,8 @@ use std::fmt::Debug;
 #[derive(Debug)]
 pub struct LogBatch<'a> {
     /// The data field contains a slice of tuples, where each tuple consists of a reference to
-    /// a `LogRecord` and a reference to an `InstrumentationScope`.
-    data: &'a [(&'a LogRecord, &'a InstrumentationScope)],
+    /// a `LogRecord` and a reference to an `Scope`.
+    data: &'a [(&'a LogRecord, &'a Scope)],
 }
 
 impl<'a> LogBatch<'a> {
@@ -32,7 +30,7 @@ impl<'a> LogBatch<'a> {
     /// # Arguments
     ///
     /// * `data` - A slice of tuples, where each tuple consists of a reference to a `LogRecord`
-    ///   and a reference to an `InstrumentationScope`. These tuples represent the log records
+    ///   and a reference to an `Scope`. These tuples represent the log records
     ///   and their associated instrumentation libraries to be exported.
     ///
     /// # Returns
@@ -42,7 +40,7 @@ impl<'a> LogBatch<'a> {
     /// Note - this is not a public function, and should not be used directly. This would be
     /// made private in the future.
 
-    pub fn new(data: &'a [(&'a LogRecord, &'a InstrumentationScope)]) -> LogBatch<'a> {
+    pub fn new(data: &'a [(&'a LogRecord, &'a Scope)]) -> LogBatch<'a> {
         LogBatch { data }
     }
 }
@@ -51,13 +49,13 @@ impl LogBatch<'_> {
     /// Returns an iterator over the log records and instrumentation libraries in the batch.
     ///
     /// Each item yielded by the iterator is a tuple containing references to a `LogRecord`
-    /// and an `InstrumentationScope`.
+    /// and an `Scope`.
     ///
     /// # Returns
     ///
-    /// An iterator that yields references to the `LogRecord` and `InstrumentationScope` in the batch.
+    /// An iterator that yields references to the `LogRecord` and `Scope` in the batch.
     ///
-    pub fn iter(&self) -> impl Iterator<Item = (&LogRecord, &InstrumentationScope)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&LogRecord, &Scope)> {
         self.data
             .iter()
             .map(|(record, library)| (*record, *library))

--- a/opentelemetry-sdk/src/export/trace.rs
+++ b/opentelemetry-sdk/src/export/trace.rs
@@ -96,5 +96,5 @@ pub struct SpanData {
     /// Span status
     pub status: Status,
     /// Instrumentation library that produced this span
-    pub instrumentation_scope: crate::InstrumentationScope,
+    pub instrumentation_scope: crate::Scope,
 }

--- a/opentelemetry-sdk/src/export/trace.rs
+++ b/opentelemetry-sdk/src/export/trace.rs
@@ -2,7 +2,7 @@
 use crate::Resource;
 use futures_util::future::BoxFuture;
 use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceError};
-use opentelemetry::KeyValue;
+use opentelemetry::{InstrumentationScope, KeyValue};
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::time::SystemTime;
@@ -95,6 +95,6 @@ pub struct SpanData {
     pub links: crate::trace::SpanLinks,
     /// Span status
     pub status: Status,
-    /// Instrumentation library that produced this span
-    pub instrumentation_scope: crate::Scope,
+    /// Instrumentation scope that produced this span
+    pub instrumentation_scope: InstrumentationScope,
 }

--- a/opentelemetry-sdk/src/export/trace.rs
+++ b/opentelemetry-sdk/src/export/trace.rs
@@ -96,5 +96,5 @@ pub struct SpanData {
     /// Span status
     pub status: Status,
     /// Instrumentation library that produced this span
-    pub instrumentation_lib: crate::InstrumentationLibrary,
+    pub instrumentation_scope: crate::InstrumentationScope,
 }

--- a/opentelemetry-sdk/src/instrumentation.rs
+++ b/opentelemetry-sdk/src/instrumentation.rs
@@ -1,5 +1,0 @@
-pub use opentelemetry::InstrumentationScope;
-
-/// A logical unit of the application code with which the emitted telemetry can
-/// be associated.
-pub type Scope = InstrumentationScope;

--- a/opentelemetry-sdk/src/instrumentation.rs
+++ b/opentelemetry-sdk/src/instrumentation.rs
@@ -1,5 +1,5 @@
-pub use opentelemetry::InstrumentationLibrary;
+pub use opentelemetry::InstrumentationScope;
 
 /// A logical unit of the application code with which the emitted telemetry can
 /// be associated.
-pub type Scope = InstrumentationLibrary;
+pub type Scope = InstrumentationScope;

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -122,7 +122,7 @@
 
 pub mod export;
 pub(crate) mod growable_array;
-mod instrumentation;
+
 #[cfg(feature = "logs")]
 #[cfg_attr(docsrs, doc(cfg(feature = "logs")))]
 pub mod logs;
@@ -146,6 +146,7 @@ pub mod trace;
 #[doc(hidden)]
 pub mod util;
 
-pub use instrumentation::{InstrumentationScope, Scope};
+#[doc(inline)]
+pub use opentelemetry::InstrumentationScope as Scope;
 #[doc(inline)]
 pub use resource::Resource;

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -146,6 +146,6 @@ pub mod trace;
 #[doc(hidden)]
 pub mod util;
 
-pub use instrumentation::{InstrumentationLibrary, Scope};
+pub use instrumentation::{InstrumentationScope, Scope};
 #[doc(inline)]
 pub use resource::Resource;

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -147,6 +147,4 @@ pub mod trace;
 pub mod util;
 
 #[doc(inline)]
-pub use opentelemetry::InstrumentationScope as Scope;
-#[doc(inline)]
 pub use resource::Resource;

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -10,11 +10,11 @@ use opentelemetry::{
 #[cfg(feature = "logs_level_enabled")]
 use opentelemetry::logs::Severity;
 
-use std::{
-    borrow::Cow,
-    sync::{atomic::Ordering, Arc},
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
 };
-use std::{sync::atomic::AtomicBool, time::SystemTime};
+use std::time::SystemTime;
 
 use once_cell::sync::Lazy;
 
@@ -45,41 +45,8 @@ pub struct LoggerProvider {
     inner: Arc<LoggerProviderInner>,
 }
 
-/// Default logger name if empty string is provided.
-const DEFAULT_COMPONENT_NAME: &str = "rust.opentelemetry.io/sdk/logger";
-
 impl opentelemetry::logs::LoggerProvider for LoggerProvider {
     type Logger = Logger;
-
-    /// Create a new versioned `Logger` instance.
-    fn versioned_logger(
-        &self,
-        name: impl Into<Cow<'static, str>>,
-        version: Option<Cow<'static, str>>,
-        schema_url: Option<Cow<'static, str>>,
-        attributes: Option<Vec<opentelemetry::KeyValue>>,
-    ) -> Logger {
-        let name = name.into();
-        let component_name = if name.is_empty() {
-            Cow::Borrowed(DEFAULT_COMPONENT_NAME)
-        } else {
-            name
-        };
-
-        let mut builder = self.logger_builder(component_name);
-
-        if let Some(v) = version {
-            builder = builder.with_version(v);
-        }
-        if let Some(s) = schema_url {
-            builder = builder.with_schema_url(s);
-        }
-        if let Some(a) = attributes {
-            builder = builder.with_attributes(a);
-        }
-
-        builder.build()
-    }
 
     fn library_logger(&self, library: Arc<InstrumentationLibrary>) -> Self::Logger {
         // If the provider is shutdown, new logger will refer a no-op logger provider.

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -248,7 +248,7 @@ impl Logger {
         &self.provider
     }
 
-    /// Instrumentation library information of this logger.
+    /// Instrumentation scope of this logger.
     pub fn instrumentation_scope(&self) -> &InstrumentationScope {
         &self.scope
     }

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -1,10 +1,10 @@
 use super::{BatchLogProcessor, LogProcessor, LogRecord, SimpleLogProcessor, TraceContext};
-use crate::{export::logs::LogExporter, runtime::RuntimeChannel, Resource};
+use crate::{export::logs::LogExporter, runtime::RuntimeChannel, Resource, Scope};
 use opentelemetry::{
     logs::{LogError, LogResult},
     otel_debug,
     trace::TraceContextExt,
-    Context, InstrumentationScope,
+    Context,
 };
 
 #[cfg(feature = "logs_level_enabled")]
@@ -48,7 +48,7 @@ pub struct LoggerProvider {
 impl opentelemetry::logs::LoggerProvider for LoggerProvider {
     type Logger = Logger;
 
-    fn logger_with_scope(&self, scope: InstrumentationScope) -> Self::Logger {
+    fn logger_with_scope(&self, scope: Scope) -> Self::Logger {
         // If the provider is shutdown, new logger will refer a no-op logger provider.
         if self.inner.is_shutdown.load(Ordering::Relaxed) {
             return Logger::new(scope, NOOP_LOGGER_PROVIDER.clone());
@@ -217,12 +217,12 @@ impl Builder {
 ///
 /// [`LogRecord`]: opentelemetry::logs::LogRecord
 pub struct Logger {
-    scope: InstrumentationScope,
+    scope: Scope,
     provider: LoggerProvider,
 }
 
 impl Logger {
-    pub(crate) fn new(scope: InstrumentationScope, provider: LoggerProvider) -> Self {
+    pub(crate) fn new(scope: Scope, provider: LoggerProvider) -> Self {
         Logger { scope, provider }
     }
 
@@ -232,7 +232,7 @@ impl Logger {
     }
 
     /// Instrumentation library information of this logger.
-    pub fn instrumentation_scope(&self) -> &InstrumentationScope {
+    pub fn instrumentation_scope(&self) -> &Scope {
         &self.scope
     }
 }
@@ -327,7 +327,7 @@ mod tests {
     }
 
     impl LogProcessor for ShutdownTestLogProcessor {
-        fn emit(&self, _data: &mut LogRecord, _scope: &InstrumentationScope) {
+        fn emit(&self, _data: &mut LogRecord, _scope: &Scope) {
             self.is_shutdown
                 .lock()
                 .map(|is_shutdown| {
@@ -706,7 +706,7 @@ mod tests {
     }
 
     impl LogProcessor for LazyLogProcessor {
-        fn emit(&self, _data: &mut LogRecord, _scope: &InstrumentationScope) {
+        fn emit(&self, _data: &mut LogRecord, _scope: &Scope) {
             // nothing to do.
         }
 
@@ -737,7 +737,7 @@ mod tests {
     }
 
     impl LogProcessor for CountingShutdownProcessor {
-        fn emit(&self, _data: &mut LogRecord, _scope: &InstrumentationScope) {
+        fn emit(&self, _data: &mut LogRecord, _scope: &Scope) {
             // nothing to do
         }
 

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -56,7 +56,7 @@ pub trait LogProcessor: Send + Sync + Debug {
     ///
     /// # Parameters
     /// - `record`: A mutable reference to `LogData` representing the log record.
-    /// - `instrumentation`: The instrumentation library associated with the log record.
+    /// - `instrumentation`: The instrumentation scope associated with the log record.
     fn emit(&self, data: &mut LogRecord, instrumentation: &InstrumentationScope);
     /// Force the logs lying in the cache to be exported.
     fn force_flush(&self) -> LogResult<()>;

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -2,7 +2,7 @@ use crate::{
     export::logs::{ExportResult, LogBatch, LogExporter},
     logs::LogRecord,
     runtime::{RuntimeChannel, TrySend},
-    Resource, Scope,
+    Resource,
 };
 use futures_channel::oneshot;
 use futures_util::{
@@ -13,7 +13,7 @@ use futures_util::{
 use opentelemetry::logs::Severity;
 use opentelemetry::{
     logs::{LogError, LogResult},
-    otel_debug, otel_error, otel_warn,
+    otel_debug, otel_error, otel_warn, InstrumentationScope,
 };
 
 use std::sync::atomic::AtomicBool;
@@ -57,7 +57,7 @@ pub trait LogProcessor: Send + Sync + Debug {
     /// # Parameters
     /// - `record`: A mutable reference to `LogData` representing the log record.
     /// - `instrumentation`: The instrumentation library associated with the log record.
-    fn emit(&self, data: &mut LogRecord, instrumentation: &Scope);
+    fn emit(&self, data: &mut LogRecord, instrumentation: &InstrumentationScope);
     /// Force the logs lying in the cache to be exported.
     fn force_flush(&self) -> LogResult<()>;
     /// Shuts down the processor.
@@ -95,7 +95,7 @@ impl SimpleLogProcessor {
 }
 
 impl LogProcessor for SimpleLogProcessor {
-    fn emit(&self, record: &mut LogRecord, instrumentation: &Scope) {
+    fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationScope) {
         // noop after shutdown
         if self.is_shutdown.load(std::sync::atomic::Ordering::Relaxed) {
             // this is a warning, as the user is trying to log after the processor has been shutdown
@@ -168,7 +168,7 @@ impl<R: RuntimeChannel> Debug for BatchLogProcessor<R> {
 }
 
 impl<R: RuntimeChannel> LogProcessor for BatchLogProcessor<R> {
-    fn emit(&self, record: &mut LogRecord, instrumentation: &Scope) {
+    fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationScope) {
         let result = self.message_sender.try_send(BatchMessage::ExportLog((
             record.clone(),
             instrumentation.clone(),
@@ -320,7 +320,7 @@ async fn export_with_timeout<R, E>(
     time_out: Duration,
     exporter: &mut E,
     runtime: &R,
-    batch: Vec<(LogRecord, Scope)>,
+    batch: Vec<(LogRecord, InstrumentationScope)>,
 ) -> ExportResult
 where
     R: RuntimeChannel,
@@ -331,7 +331,7 @@ where
     }
 
     // TBD - Can we avoid this conversion as it involves heap allocation with new vector?
-    let log_vec: Vec<(&LogRecord, &Scope)> = batch
+    let log_vec: Vec<(&LogRecord, &InstrumentationScope)> = batch
         .iter()
         .map(|log_data| (&log_data.0, &log_data.1))
         .collect();
@@ -515,7 +515,7 @@ where
 #[derive(Debug)]
 enum BatchMessage {
     /// Export logs, usually called when the log is emitted.
-    ExportLog((LogRecord, Scope)),
+    ExportLog((LogRecord, InstrumentationScope)),
     /// Flush the current buffer to the backend, it can be triggered by
     /// pre configured interval or a call to `force_push` function.
     Flush(Option<oneshot::Sender<ExportResult>>),
@@ -544,14 +544,14 @@ mod tests {
         },
         runtime,
         testing::logs::InMemoryLogsExporter,
-        Resource, Scope,
+        Resource,
     };
     use async_trait::async_trait;
     use opentelemetry::logs::AnyValue;
     use opentelemetry::logs::LogRecord as _;
     use opentelemetry::logs::{Logger, LoggerProvider as _};
-    use opentelemetry::Key;
     use opentelemetry::{logs::LogResult, KeyValue};
+    use opentelemetry::{InstrumentationScope, Key};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
@@ -793,8 +793,8 @@ mod tests {
             runtime::Tokio,
         );
 
-        let mut record: LogRecord = Default::default();
-        let instrumentation: Scope = Default::default();
+        let mut record = LogRecord::default();
+        let instrumentation = InstrumentationScope::default();
 
         processor.emit(&mut record, &instrumentation);
         processor.force_flush().unwrap();
@@ -812,7 +812,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: Scope = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -882,11 +882,11 @@ mod tests {
 
     #[derive(Debug)]
     struct FirstProcessor {
-        pub(crate) logs: Arc<Mutex<Vec<(LogRecord, Scope)>>>,
+        pub(crate) logs: Arc<Mutex<Vec<(LogRecord, InstrumentationScope)>>>,
     }
 
     impl LogProcessor for FirstProcessor {
-        fn emit(&self, record: &mut LogRecord, instrumentation: &Scope) {
+        fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationScope) {
             // add attribute
             record.add_attribute(
                 Key::from_static_str("processed_by"),
@@ -912,11 +912,11 @@ mod tests {
 
     #[derive(Debug)]
     struct SecondProcessor {
-        pub(crate) logs: Arc<Mutex<Vec<(LogRecord, Scope)>>>,
+        pub(crate) logs: Arc<Mutex<Vec<(LogRecord, InstrumentationScope)>>>,
     }
 
     impl LogProcessor for SecondProcessor {
-        fn emit(&self, record: &mut LogRecord, instrumentation: &Scope) {
+        fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationScope) {
             assert!(record.attributes_contains(
                 &Key::from_static_str("processed_by"),
                 &AnyValue::String("FirstProcessor".into())
@@ -993,7 +993,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: Scope = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -1006,7 +1006,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: Scope = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -1023,7 +1023,7 @@ mod tests {
             let processor_clone = Arc::clone(&processor);
             let handle = tokio::spawn(async move {
                 let mut record: LogRecord = Default::default();
-                let instrumentation: Scope = Default::default();
+                let instrumentation: InstrumentationScope = Default::default();
                 processor_clone.emit(&mut record, &instrumentation);
             });
             handles.push(handle);
@@ -1042,7 +1042,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: Scope = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -1089,7 +1089,7 @@ mod tests {
             let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
             let mut record: LogRecord = Default::default();
-            let instrumentation: Scope = Default::default();
+            let instrumentation: InstrumentationScope = Default::default();
 
             // This will panic because an tokio async operation within exporter without a runtime.
             processor.emit(&mut record, &instrumentation);
@@ -1145,7 +1145,7 @@ mod tests {
             let processor_clone = Arc::clone(&processor);
             let handle = tokio::spawn(async move {
                 let mut record: LogRecord = Default::default();
-                let instrumentation: Scope = Default::default();
+                let instrumentation: InstrumentationScope = Default::default();
                 processor_clone.emit(&mut record, &instrumentation);
             });
             handles.push(handle);
@@ -1169,7 +1169,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: Scope = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -1188,7 +1188,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: Scope = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -1208,7 +1208,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: Scope = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -13,7 +13,7 @@ use futures_util::{
 use opentelemetry::logs::Severity;
 use opentelemetry::{
     logs::{LogError, LogResult},
-    otel_debug, otel_error, otel_warn, InstrumentationLibrary,
+    otel_debug, otel_error, otel_warn, InstrumentationScope,
 };
 
 use std::sync::atomic::AtomicBool;
@@ -57,7 +57,7 @@ pub trait LogProcessor: Send + Sync + Debug {
     /// # Parameters
     /// - `record`: A mutable reference to `LogData` representing the log record.
     /// - `instrumentation`: The instrumentation library associated with the log record.
-    fn emit(&self, data: &mut LogRecord, instrumentation: &InstrumentationLibrary);
+    fn emit(&self, data: &mut LogRecord, instrumentation: &InstrumentationScope);
     /// Force the logs lying in the cache to be exported.
     fn force_flush(&self) -> LogResult<()>;
     /// Shuts down the processor.
@@ -95,7 +95,7 @@ impl SimpleLogProcessor {
 }
 
 impl LogProcessor for SimpleLogProcessor {
-    fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationLibrary) {
+    fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationScope) {
         // noop after shutdown
         if self.is_shutdown.load(std::sync::atomic::Ordering::Relaxed) {
             // this is a warning, as the user is trying to log after the processor has been shutdown
@@ -168,7 +168,7 @@ impl<R: RuntimeChannel> Debug for BatchLogProcessor<R> {
 }
 
 impl<R: RuntimeChannel> LogProcessor for BatchLogProcessor<R> {
-    fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationLibrary) {
+    fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationScope) {
         let result = self.message_sender.try_send(BatchMessage::ExportLog((
             record.clone(),
             instrumentation.clone(),
@@ -320,7 +320,7 @@ async fn export_with_timeout<R, E>(
     time_out: Duration,
     exporter: &mut E,
     runtime: &R,
-    batch: Vec<(LogRecord, InstrumentationLibrary)>,
+    batch: Vec<(LogRecord, InstrumentationScope)>,
 ) -> ExportResult
 where
     R: RuntimeChannel,
@@ -331,7 +331,7 @@ where
     }
 
     // TBD - Can we avoid this conversion as it involves heap allocation with new vector?
-    let log_vec: Vec<(&LogRecord, &InstrumentationLibrary)> = batch
+    let log_vec: Vec<(&LogRecord, &InstrumentationScope)> = batch
         .iter()
         .map(|log_data| (&log_data.0, &log_data.1))
         .collect();
@@ -515,7 +515,7 @@ where
 #[derive(Debug)]
 enum BatchMessage {
     /// Export logs, usually called when the log is emitted.
-    ExportLog((LogRecord, InstrumentationLibrary)),
+    ExportLog((LogRecord, InstrumentationScope)),
     /// Flush the current buffer to the backend, it can be triggered by
     /// pre configured interval or a call to `force_push` function.
     Flush(Option<oneshot::Sender<ExportResult>>),
@@ -550,7 +550,7 @@ mod tests {
     use opentelemetry::logs::AnyValue;
     use opentelemetry::logs::LogRecord as _;
     use opentelemetry::logs::{Logger, LoggerProvider as _};
-    use opentelemetry::InstrumentationLibrary;
+    use opentelemetry::InstrumentationScope;
     use opentelemetry::Key;
     use opentelemetry::{logs::LogResult, KeyValue};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -795,7 +795,7 @@ mod tests {
         );
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: InstrumentationLibrary = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
         processor.force_flush().unwrap();
@@ -813,7 +813,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: InstrumentationLibrary = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -883,11 +883,11 @@ mod tests {
 
     #[derive(Debug)]
     struct FirstProcessor {
-        pub(crate) logs: Arc<Mutex<Vec<(LogRecord, InstrumentationLibrary)>>>,
+        pub(crate) logs: Arc<Mutex<Vec<(LogRecord, InstrumentationScope)>>>,
     }
 
     impl LogProcessor for FirstProcessor {
-        fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationLibrary) {
+        fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationScope) {
             // add attribute
             record.add_attribute(
                 Key::from_static_str("processed_by"),
@@ -913,11 +913,11 @@ mod tests {
 
     #[derive(Debug)]
     struct SecondProcessor {
-        pub(crate) logs: Arc<Mutex<Vec<(LogRecord, InstrumentationLibrary)>>>,
+        pub(crate) logs: Arc<Mutex<Vec<(LogRecord, InstrumentationScope)>>>,
     }
 
     impl LogProcessor for SecondProcessor {
-        fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationLibrary) {
+        fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationScope) {
             assert!(record.attributes_contains(
                 &Key::from_static_str("processed_by"),
                 &AnyValue::String("FirstProcessor".into())
@@ -994,7 +994,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: InstrumentationLibrary = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -1007,7 +1007,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: InstrumentationLibrary = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -1024,7 +1024,7 @@ mod tests {
             let processor_clone = Arc::clone(&processor);
             let handle = tokio::spawn(async move {
                 let mut record: LogRecord = Default::default();
-                let instrumentation: InstrumentationLibrary = Default::default();
+                let instrumentation: InstrumentationScope = Default::default();
                 processor_clone.emit(&mut record, &instrumentation);
             });
             handles.push(handle);
@@ -1043,7 +1043,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: InstrumentationLibrary = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -1090,7 +1090,7 @@ mod tests {
             let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
             let mut record: LogRecord = Default::default();
-            let instrumentation: InstrumentationLibrary = Default::default();
+            let instrumentation: InstrumentationScope = Default::default();
 
             // This will panic because an tokio async operation within exporter without a runtime.
             processor.emit(&mut record, &instrumentation);
@@ -1146,7 +1146,7 @@ mod tests {
             let processor_clone = Arc::clone(&processor);
             let handle = tokio::spawn(async move {
                 let mut record: LogRecord = Default::default();
-                let instrumentation: InstrumentationLibrary = Default::default();
+                let instrumentation: InstrumentationScope = Default::default();
                 processor_clone.emit(&mut record, &instrumentation);
             });
             handles.push(handle);
@@ -1170,7 +1170,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: InstrumentationLibrary = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -1189,7 +1189,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: InstrumentationLibrary = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 
@@ -1209,7 +1209,7 @@ mod tests {
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
-        let instrumentation: InstrumentationLibrary = Default::default();
+        let instrumentation: InstrumentationScope = Default::default();
 
         processor.emit(&mut record, &instrumentation);
 

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -3,12 +3,12 @@ mod log_emitter;
 mod log_processor;
 pub(crate) mod record;
 
-use crate::Scope;
 pub use log_emitter::{Builder, Logger, LoggerProvider};
 pub use log_processor::{
     BatchConfig, BatchConfigBuilder, BatchLogProcessor, BatchLogProcessorBuilder, LogProcessor,
     SimpleLogProcessor,
 };
+use opentelemetry::InstrumentationScope;
 pub use record::{LogRecord, TraceContext};
 
 /// `LogData` represents a single log event without resource context.
@@ -17,7 +17,7 @@ pub struct LogData {
     /// Log record
     pub record: LogRecord,
     /// Instrumentation details for the emitter who produced this `LogEvent`.
-    pub instrumentation: Scope,
+    pub instrumentation: InstrumentationScope,
 }
 
 #[cfg(all(test, feature = "testing"))]
@@ -104,7 +104,7 @@ mod tests {
     #[test]
     fn logger_attributes() {
         let provider = LoggerProvider::builder().build();
-        let scope = Scope::builder("test_logger")
+        let scope = InstrumentationScope::builder("test_logger")
             .with_schema_url("https://opentelemetry.io/schema/1.0.0")
             .with_attributes(vec![(KeyValue::new("test_k", "test_v"))])
             .build();

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -30,6 +30,7 @@ mod tests {
     use opentelemetry::{logs::AnyValue, Key, KeyValue};
     use std::borrow::Borrow;
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     #[test]
     fn logging_sdk_test() {
@@ -104,36 +105,16 @@ mod tests {
     #[test]
     fn logger_attributes() {
         let provider = LoggerProvider::builder().build();
-        let logger = provider
-            .logger_builder("test_logger")
-            .with_schema_url("https://opentelemetry.io/schema/1.0.0")
-            .with_attributes(vec![(KeyValue::new("test_k", "test_v"))])
-            .build();
+        let library = Arc::new(
+            InstrumentationLibrary::builder("test_logger")
+                .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+                .with_attributes(vec![(KeyValue::new("test_k", "test_v"))])
+                .build(),
+        );
+        let logger = provider.library_logger(library);
         let instrumentation_library = logger.instrumentation_library();
         let attributes = &instrumentation_library.attributes;
         assert_eq!(instrumentation_library.name, "test_logger");
-        assert_eq!(
-            instrumentation_library.schema_url,
-            Some("https://opentelemetry.io/schema/1.0.0".into())
-        );
-        assert_eq!(attributes.len(), 1);
-        assert_eq!(attributes[0].key, "test_k".into());
-        assert_eq!(attributes[0].value, "test_v".into());
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn versioned_logger_options() {
-        let provider = LoggerProvider::builder().build();
-        let logger = provider.versioned_logger(
-            "test_logger",
-            Some("v1.2.3".into()),
-            Some("https://opentelemetry.io/schema/1.0.0".into()),
-            Some(vec![(KeyValue::new("test_k", "test_v"))]),
-        );
-        let instrumentation_library = logger.instrumentation_library();
-        let attributes = &instrumentation_library.attributes;
-        assert_eq!(instrumentation_library.version, Some("v1.2.3".into()));
         assert_eq!(
             instrumentation_library.schema_url,
             Some("https://opentelemetry.io/schema/1.0.0".into())

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -3,6 +3,7 @@ mod log_emitter;
 mod log_processor;
 pub(crate) mod record;
 
+use crate::Scope;
 pub use log_emitter::{Builder, Logger, LoggerProvider};
 pub use log_processor::{
     BatchConfig, BatchConfigBuilder, BatchLogProcessor, BatchLogProcessorBuilder, LogProcessor,
@@ -10,14 +11,13 @@ pub use log_processor::{
 };
 pub use record::{LogRecord, TraceContext};
 
-use opentelemetry::InstrumentationScope;
 /// `LogData` represents a single log event without resource context.
 #[derive(Clone, Debug)]
 pub struct LogData {
     /// Log record
     pub record: LogRecord,
     /// Instrumentation details for the emitter who produced this `LogEvent`.
-    pub instrumentation: InstrumentationScope,
+    pub instrumentation: Scope,
 }
 
 #[cfg(all(test, feature = "testing"))]
@@ -104,7 +104,7 @@ mod tests {
     #[test]
     fn logger_attributes() {
         let provider = LoggerProvider::builder().build();
-        let scope = InstrumentationScope::builder("test_logger")
+        let scope = Scope::builder("test_logger")
             .with_schema_url("https://opentelemetry.io/schema/1.0.0")
             .with_attributes(vec![(KeyValue::new("test_k", "test_v"))])
             .build();

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -4,7 +4,7 @@ use std::{any, borrow::Cow, fmt, time::SystemTime};
 
 use opentelemetry::KeyValue;
 
-use crate::{instrumentation::Scope, Resource};
+use crate::{Resource, Scope};
 
 pub use self::temporality::Temporality;
 

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -2,9 +2,9 @@
 
 use std::{any, borrow::Cow, fmt, time::SystemTime};
 
-use opentelemetry::KeyValue;
+use opentelemetry::{InstrumentationScope, KeyValue};
 
-use crate::{Resource, Scope};
+use crate::Resource;
 
 pub use self::temporality::Temporality;
 
@@ -15,15 +15,15 @@ mod temporality;
 pub struct ResourceMetrics {
     /// The entity that collected the metrics.
     pub resource: Resource,
-    /// The collection of metrics with unique [Scope]s.
+    /// The collection of metrics with unique [InstrumentationScope]s.
     pub scope_metrics: Vec<ScopeMetrics>,
 }
 
 /// A collection of metrics produced by a meter.
 #[derive(Default, Debug)]
 pub struct ScopeMetrics {
-    /// The [Scope] that the meter was created with.
-    pub scope: Scope,
+    /// The [InstrumentationScope] that the meter was created with.
+    pub scope: InstrumentationScope,
     /// The list of aggregations created by the meter.
     pub metrics: Vec<Metric>,
 }

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -2,13 +2,10 @@ use std::{borrow::Cow, collections::HashSet, sync::Arc};
 
 use opentelemetry::{
     metrics::{AsyncInstrument, SyncInstrument},
-    Key, KeyValue,
+    InstrumentationScope, Key, KeyValue,
 };
 
-use crate::{
-    metrics::{aggregation::Aggregation, internal::Measure},
-    Scope,
-};
+use crate::metrics::{aggregation::Aggregation, internal::Measure};
 
 use super::data::Temporality;
 
@@ -96,7 +93,7 @@ pub struct Instrument {
     /// Unit is the unit of measurement recorded by the instrument.
     pub unit: Cow<'static, str>,
     /// The instrumentation that created the instrument.
-    pub scope: Scope,
+    pub scope: InstrumentationScope,
 }
 
 impl Instrument {
@@ -124,7 +121,7 @@ impl Instrument {
     }
 
     /// Set the instrument scope.
-    pub fn scope(mut self, scope: Scope) -> Self {
+    pub fn scope(mut self, scope: InstrumentationScope) -> Self {
         self.scope = scope;
         self
     }
@@ -135,7 +132,7 @@ impl Instrument {
             && self.description == ""
             && self.kind.is_none()
             && self.unit == ""
-            && self.scope == Scope::default()
+            && self.scope == InstrumentationScope::default()
     }
 
     pub(crate) fn matches(&self, other: &Instrument) -> bool {

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -6,8 +6,8 @@ use opentelemetry::{
 };
 
 use crate::{
-    instrumentation::Scope,
     metrics::{aggregation::Aggregation, internal::Measure},
+    Scope,
 };
 
 use super::data::Temporality;

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -8,6 +8,7 @@ use opentelemetry::{
         InstrumentProvider, MetricsError, ObservableCounter, ObservableGauge,
         ObservableUpDownCounter, Result, UpDownCounter,
     },
+    InstrumentationScope,
 };
 
 use crate::metrics::{
@@ -15,7 +16,6 @@ use crate::metrics::{
     internal::{self, Number},
     pipeline::{Pipelines, Resolver},
 };
-use crate::Scope;
 
 use super::noop::NoopSyncInstrument;
 
@@ -45,7 +45,7 @@ const INSTRUMENT_UNIT_INVALID_CHAR: &str = "characters in instrument unit must b
 ///
 /// [Meter API]: opentelemetry::metrics::Meter
 pub(crate) struct SdkMeter {
-    scope: Scope,
+    scope: InstrumentationScope,
     pipes: Arc<Pipelines>,
     u64_resolver: Resolver<u64>,
     i64_resolver: Resolver<i64>,
@@ -53,7 +53,7 @@ pub(crate) struct SdkMeter {
 }
 
 impl SdkMeter {
-    pub(crate) fn new(scope: Scope, pipes: Arc<Pipelines>) -> Self {
+    pub(crate) fn new(scope: InstrumentationScope, pipes: Arc<Pipelines>) -> Self {
         let view_cache = Default::default();
 
         SdkMeter {

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -10,12 +10,12 @@ use opentelemetry::{
     },
 };
 
-use crate::instrumentation::Scope;
 use crate::metrics::{
     instrument::{Instrument, InstrumentKind, Observable, ResolvedMeasures},
     internal::{self, Number},
     pipeline::{Pipelines, Resolver},
 };
+use crate::Scope;
 
 use super::noop::NoopSyncInstrument;
 

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -145,7 +145,7 @@ impl Drop for SdkMeterProviderInner {
     }
 }
 
-/// Default logger name if empty string is provided.
+/// Default meter name if empty string is provided.
 const DEFAULT_COMPONENT_NAME: &str = "rust.opentelemetry.io/sdk/meter";
 
 impl MeterProvider for SdkMeterProvider {

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -9,8 +9,7 @@ use std::{
 
 use opentelemetry::{
     metrics::{Meter, MeterProvider, MetricsError, Result},
-    otel_debug, otel_error,
-    InstrumentationScope, KeyValue,
+    otel_debug, otel_error, InstrumentationScope, KeyValue,
 };
 
 use crate::Resource;

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -144,7 +144,20 @@ impl Drop for SdkMeterProviderInner {
         }
     }
 }
+
+/// Default logger name if empty string is provided.
+const DEFAULT_COMPONENT_NAME: &str = "rust.opentelemetry.io/sdk/meter";
+
 impl MeterProvider for SdkMeterProvider {
+    fn meter(&self, mut name: &'static str) -> Meter {
+        if name.is_empty() {
+            name = DEFAULT_COMPONENT_NAME
+        };
+
+        let scope = InstrumentationScope::builder(name).build();
+        self.meter_with_scope(scope)
+    }
+
     fn meter_with_scope(&self, scope: InstrumentationScope) -> Meter {
         if self.inner.is_shutdown.load(Ordering::Relaxed) {
             return Meter::new(Arc::new(NoopMeter::new()));

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -9,7 +9,7 @@ use std::{
 
 use opentelemetry::{
     metrics::{Meter, MeterProvider, MetricsError, Result},
-    otel_debug, otel_error, InstrumentationScope, KeyValue,
+    otel_debug, otel_error, InstrumentationScope,
 };
 
 use crate::Resource;

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -10,10 +10,9 @@ use std::{
 use opentelemetry::{
     global,
     metrics::{Meter, MeterProvider, MetricsError, Result},
-    InstrumentationScope,
 };
 
-use crate::{instrumentation::Scope, Resource};
+use crate::{Resource, Scope};
 
 use super::{
     meter::SdkMeter, noop::NoopMeter, pipeline::Pipelines, reader::MetricReader, view::View,
@@ -145,7 +144,7 @@ impl Drop for SdkMeterProviderInner {
     }
 }
 impl MeterProvider for SdkMeterProvider {
-    fn meter_with_scope(&self, scope: InstrumentationScope) -> Meter {
+    fn meter_with_scope(&self, scope: Scope) -> Meter {
         if self.inner.is_shutdown.load(Ordering::Relaxed) {
             return Meter::new(Arc::new(NoopMeter::new()));
         }
@@ -239,9 +238,9 @@ mod tests {
         SERVICE_NAME, TELEMETRY_SDK_LANGUAGE, TELEMETRY_SDK_NAME, TELEMETRY_SDK_VERSION,
     };
     use crate::testing::metrics::metric_reader::TestMetricReader;
-    use crate::Resource;
+    use crate::{Resource, Scope};
+    use opentelemetry::global;
     use opentelemetry::metrics::MeterProvider;
-    use opentelemetry::{global, InstrumentationScope};
     use opentelemetry::{Key, KeyValue, Value};
     use std::env;
 
@@ -435,7 +434,7 @@ mod tests {
         let _meter2 = provider.meter("test");
         assert_eq!(provider.inner.meters.lock().unwrap().len(), 1);
 
-        let scope = InstrumentationScope::builder("test")
+        let scope = Scope::builder("test")
             .with_version("1.0.0")
             .with_schema_url("http://example.com")
             .build();
@@ -446,7 +445,7 @@ mod tests {
         assert_eq!(provider.inner.meters.lock().unwrap().len(), 2);
 
         // these are different meters because meter names are case sensitive
-        let mut library = InstrumentationScope::builder("ABC")
+        let mut library = Scope::builder("ABC")
             .with_version("1.0.0")
             .with_schema_url("http://example.com")
             .build();

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -134,6 +134,7 @@ mod tests {
     use crate::testing::metrics::InMemoryMetricsExporterBuilder;
     use crate::{runtime, testing::metrics::InMemoryMetricsExporter};
     use opentelemetry::metrics::{Counter, Meter, UpDownCounter};
+    use opentelemetry::InstrumentationLibrary;
     use opentelemetry::{metrics::MeterProvider as _, KeyValue};
     use rand::{rngs, Rng, SeedableRng};
     use std::borrow::Cow;
@@ -637,18 +638,24 @@ mod tests {
         // Act
         // Meters are identical except for scope attributes, but scope attributes are not an identifying property.
         // Hence there should be a single metric stream output for this test.
-        let meter1 = meter_provider.versioned_meter(
-            "test.meter",
-            Some("v0.1.0"),
-            Some("schema_url"),
-            Some(vec![KeyValue::new("key", "value1")]),
+        let library = Arc::new(
+            InstrumentationLibrary::builder("test.meter")
+                .with_version("v0.1.0")
+                .with_schema_url("http://example.com")
+                .with_attributes(vec![KeyValue::new("key", "value1")])
+                .build(),
         );
-        let meter2 = meter_provider.versioned_meter(
-            "test.meter",
-            Some("v0.1.0"),
-            Some("schema_url"),
-            Some(vec![KeyValue::new("key", "value2")]),
+        let meter1 = meter_provider.library_meter(library);
+
+        let library = Arc::new(
+            InstrumentationLibrary::builder("test.meter")
+                .with_version("v0.1.0")
+                .with_schema_url("http://example.com")
+                .with_attributes(vec![KeyValue::new("key", "value2")])
+                .build(),
         );
+        let meter2 = meter_provider.library_meter(library);
+
         let counter1 = meter1
             .u64_counter("my_counter")
             .with_unit("my_unit")
@@ -684,7 +691,7 @@ mod tests {
         let scope = &resource_metrics[0].scope_metrics[0].scope;
         assert_eq!(scope.name, "test.meter");
         assert_eq!(scope.version, Some(Cow::Borrowed("v0.1.0")));
-        assert_eq!(scope.schema_url, Some(Cow::Borrowed("schema_url")));
+        assert_eq!(scope.schema_url, Some(Cow::Borrowed("http://example.com")));
 
         // This is validating current behavior, but it is not guaranteed to be the case in the future,
         // as this is a user error and SDK reserves right to change this behavior.

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -132,8 +132,9 @@ mod tests {
     use super::*;
     use crate::metrics::data::{ResourceMetrics, Temporality};
     use crate::testing::metrics::InMemoryMetricsExporterBuilder;
-    use crate::{runtime, testing::metrics::InMemoryMetricsExporter, Scope};
+    use crate::{runtime, testing::metrics::InMemoryMetricsExporter};
     use opentelemetry::metrics::{Counter, Meter, UpDownCounter};
+    use opentelemetry::InstrumentationScope;
     use opentelemetry::{metrics::MeterProvider as _, KeyValue};
     use rand::{rngs, Rng, SeedableRng};
     use std::borrow::Cow;
@@ -637,7 +638,7 @@ mod tests {
         // Act
         // Meters are identical except for scope attributes, but scope attributes are not an identifying property.
         // Hence there should be a single metric stream output for this test.
-        let mut scope = Scope::builder("test.meter")
+        let mut scope = InstrumentationScope::builder("test.meter")
             .with_version("v0.1.0")
             .with_schema_url("http://example.com")
             .with_attributes(vec![KeyValue::new("key", "value1")])

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -134,7 +134,7 @@ mod tests {
     use crate::testing::metrics::InMemoryMetricsExporterBuilder;
     use crate::{runtime, testing::metrics::InMemoryMetricsExporter};
     use opentelemetry::metrics::{Counter, Meter, UpDownCounter};
-    use opentelemetry::InstrumentationLibrary;
+    use opentelemetry::InstrumentationScope;
     use opentelemetry::{metrics::MeterProvider as _, KeyValue};
     use rand::{rngs, Rng, SeedableRng};
     use std::borrow::Cow;
@@ -638,23 +638,16 @@ mod tests {
         // Act
         // Meters are identical except for scope attributes, but scope attributes are not an identifying property.
         // Hence there should be a single metric stream output for this test.
-        let library = Arc::new(
-            InstrumentationLibrary::builder("test.meter")
-                .with_version("v0.1.0")
-                .with_schema_url("http://example.com")
-                .with_attributes(vec![KeyValue::new("key", "value1")])
-                .build(),
-        );
-        let meter1 = meter_provider.library_meter(library);
+        let mut scope = InstrumentationScope::builder("test.meter")
+            .with_version("v0.1.0")
+            .with_schema_url("http://example.com")
+            .with_attributes(vec![KeyValue::new("key", "value1")])
+            .build();
 
-        let library = Arc::new(
-            InstrumentationLibrary::builder("test.meter")
-                .with_version("v0.1.0")
-                .with_schema_url("http://example.com")
-                .with_attributes(vec![KeyValue::new("key", "value2")])
-                .build(),
-        );
-        let meter2 = meter_provider.library_meter(library);
+        let meter1 = meter_provider.meter_with_scope(scope.clone());
+
+        scope.attributes = vec![KeyValue::new("key", "value2")];
+        let meter2 = meter_provider.meter_with_scope(scope);
 
         let counter1 = meter1
             .u64_counter("my_counter")

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -132,9 +132,8 @@ mod tests {
     use super::*;
     use crate::metrics::data::{ResourceMetrics, Temporality};
     use crate::testing::metrics::InMemoryMetricsExporterBuilder;
-    use crate::{runtime, testing::metrics::InMemoryMetricsExporter};
+    use crate::{runtime, testing::metrics::InMemoryMetricsExporter, Scope};
     use opentelemetry::metrics::{Counter, Meter, UpDownCounter};
-    use opentelemetry::InstrumentationScope;
     use opentelemetry::{metrics::MeterProvider as _, KeyValue};
     use rand::{rngs, Rng, SeedableRng};
     use std::borrow::Cow;
@@ -638,7 +637,7 @@ mod tests {
         // Act
         // Meters are identical except for scope attributes, but scope attributes are not an identifying property.
         // Hence there should be a single metric stream output for this test.
-        let mut scope = InstrumentationScope::builder("test.meter")
+        let mut scope = Scope::builder("test.meter")
             .with_version("v0.1.0")
             .with_schema_url("http://example.com")
             .with_attributes(vec![KeyValue::new("key", "value1")])

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -12,7 +12,6 @@ use opentelemetry::{
 };
 
 use crate::{
-    instrumentation::Scope,
     metrics::{
         aggregation,
         data::{Metric, ResourceMetrics, ScopeMetrics},
@@ -23,7 +22,7 @@ use crate::{
         reader::{MetricReader, SdkProducer},
         view::View,
     },
-    Resource,
+    Resource, Scope,
 };
 
 use super::Aggregation;

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -3,7 +3,7 @@ use crate::logs::LogRecord;
 use crate::Resource;
 use async_trait::async_trait;
 use opentelemetry::logs::{LogError, LogResult};
-use opentelemetry::InstrumentationLibrary;
+use opentelemetry::InstrumentationScope;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
@@ -56,17 +56,17 @@ pub struct OwnedLogData {
     /// Log record, which can be borrowed or owned.
     pub record: LogRecord,
     /// Instrumentation details for the emitter who produced this `LogEvent`.
-    pub instrumentation: InstrumentationLibrary,
+    pub instrumentation: InstrumentationScope,
 }
 
 /// `LogDataWithResource` associates a [`LogRecord`] with a [`Resource`] and
-/// [`InstrumentationLibrary`].
+/// [`InstrumentationScope`].
 #[derive(Clone, Debug)]
 pub struct LogDataWithResource {
     /// Log record
     pub record: LogRecord,
     /// Instrumentation details for the emitter who produced this `LogData`.
-    pub instrumentation: InstrumentationLibrary,
+    pub instrumentation: InstrumentationScope,
     /// Resource for the emitter who produced this `LogData`.
     pub resource: Cow<'static, Resource>,
 }

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -1,8 +1,9 @@
 use crate::export::logs::{LogBatch, LogExporter};
 use crate::logs::LogRecord;
-use crate::{Resource, Scope};
+use crate::Resource;
 use async_trait::async_trait;
 use opentelemetry::logs::{LogError, LogResult};
+use opentelemetry::InstrumentationScope;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
@@ -55,17 +56,17 @@ pub struct OwnedLogData {
     /// Log record, which can be borrowed or owned.
     pub record: LogRecord,
     /// Instrumentation details for the emitter who produced this `LogEvent`.
-    pub instrumentation: Scope,
+    pub instrumentation: InstrumentationScope,
 }
 
 /// `LogDataWithResource` associates a [`LogRecord`] with a [`Resource`] and
-/// [`Scope`].
+/// [`InstrumentationScope`].
 #[derive(Clone, Debug)]
 pub struct LogDataWithResource {
     /// Log record
     pub record: LogRecord,
     /// Instrumentation details for the emitter who produced this `LogData`.
-    pub instrumentation: Scope,
+    pub instrumentation: InstrumentationScope,
     /// Resource for the emitter who produced this `LogData`.
     pub resource: Cow<'static, Resource>,
 }

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -1,9 +1,8 @@
 use crate::export::logs::{LogBatch, LogExporter};
 use crate::logs::LogRecord;
-use crate::Resource;
+use crate::{Resource, Scope};
 use async_trait::async_trait;
 use opentelemetry::logs::{LogError, LogResult};
-use opentelemetry::InstrumentationScope;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
@@ -56,17 +55,17 @@ pub struct OwnedLogData {
     /// Log record, which can be borrowed or owned.
     pub record: LogRecord,
     /// Instrumentation details for the emitter who produced this `LogEvent`.
-    pub instrumentation: InstrumentationScope,
+    pub instrumentation: Scope,
 }
 
 /// `LogDataWithResource` associates a [`LogRecord`] with a [`Resource`] and
-/// [`InstrumentationScope`].
+/// [`Scope`].
 #[derive(Clone, Debug)]
 pub struct LogDataWithResource {
     /// Log record
     pub record: LogRecord,
     /// Instrumentation details for the emitter who produced this `LogData`.
-    pub instrumentation: InstrumentationScope,
+    pub instrumentation: Scope,
     /// Resource for the emitter who produced this `LogData`.
     pub resource: Cow<'static, Resource>,
 }

--- a/opentelemetry-sdk/src/testing/trace/span_exporters.rs
+++ b/opentelemetry-sdk/src/testing/trace/span_exporters.rs
@@ -4,7 +4,7 @@ use crate::{
         ExportError,
     },
     trace::{SpanEvents, SpanLinks},
-    InstrumentationLibrary,
+    InstrumentationScope,
 };
 use futures_util::future::BoxFuture;
 pub use opentelemetry::testing::trace::TestSpan;
@@ -32,7 +32,7 @@ pub fn new_test_export_span_data() -> SpanData {
         events: SpanEvents::default(),
         links: SpanLinks::default(),
         status: Status::Unset,
-        instrumentation_lib: InstrumentationLibrary::default(),
+        instrumentation_scope: InstrumentationScope::default(),
     }
 }
 

--- a/opentelemetry-sdk/src/testing/trace/span_exporters.rs
+++ b/opentelemetry-sdk/src/testing/trace/span_exporters.rs
@@ -4,12 +4,12 @@ use crate::{
         ExportError,
     },
     trace::{SpanEvents, SpanLinks},
-    Scope,
 };
 use futures_util::future::BoxFuture;
 pub use opentelemetry::testing::trace::TestSpan;
-use opentelemetry::trace::{
-    SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
+use opentelemetry::{
+    trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState},
+    InstrumentationScope,
 };
 use std::fmt::{Display, Formatter};
 
@@ -32,7 +32,7 @@ pub fn new_test_export_span_data() -> SpanData {
         events: SpanEvents::default(),
         links: SpanLinks::default(),
         status: Status::Unset,
-        instrumentation_scope: Scope::default(),
+        instrumentation_scope: InstrumentationScope::default(),
     }
 }
 

--- a/opentelemetry-sdk/src/testing/trace/span_exporters.rs
+++ b/opentelemetry-sdk/src/testing/trace/span_exporters.rs
@@ -4,7 +4,7 @@ use crate::{
         ExportError,
     },
     trace::{SpanEvents, SpanLinks},
-    InstrumentationScope,
+    Scope,
 };
 use futures_util::future::BoxFuture;
 pub use opentelemetry::testing::trace::TestSpan;
@@ -32,7 +32,7 @@ pub fn new_test_export_span_data() -> SpanData {
         events: SpanEvents::default(),
         links: SpanLinks::default(),
         status: Status::Unset,
-        instrumentation_scope: InstrumentationScope::default(),
+        instrumentation_scope: Scope::default(),
     }
 }
 

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -45,12 +45,11 @@ mod tests {
     use crate::{
         testing::trace::InMemorySpanExporterBuilder,
         trace::span_limit::{DEFAULT_MAX_EVENT_PER_SPAN, DEFAULT_MAX_LINKS_PER_SPAN},
-        Scope,
     };
-    use opentelemetry::testing::trace::TestSpan;
     use opentelemetry::trace::{
         SamplingDecision, SamplingResult, SpanKind, Status, TraceContextExt, TraceState,
     };
+    use opentelemetry::{testing::trace::TestSpan, InstrumentationScope};
     use opentelemetry::{
         trace::{
             Event, Link, Span, SpanBuilder, SpanContext, SpanId, TraceFlags, TraceId, Tracer,
@@ -328,7 +327,7 @@ mod tests {
     #[test]
     fn tracer_attributes() {
         let provider = TracerProvider::builder().build();
-        let scope = Scope::builder("basic")
+        let scope = InstrumentationScope::builder("basic")
             .with_attributes(vec![KeyValue::new("test_k", "test_v")])
             .build();
 

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -45,11 +45,12 @@ mod tests {
     use crate::{
         testing::trace::InMemorySpanExporterBuilder,
         trace::span_limit::{DEFAULT_MAX_EVENT_PER_SPAN, DEFAULT_MAX_LINKS_PER_SPAN},
+        Scope,
     };
+    use opentelemetry::testing::trace::TestSpan;
     use opentelemetry::trace::{
         SamplingDecision, SamplingResult, SpanKind, Status, TraceContextExt, TraceState,
     };
-    use opentelemetry::{testing::trace::TestSpan, InstrumentationScope};
     use opentelemetry::{
         trace::{
             Event, Link, Span, SpanBuilder, SpanContext, SpanId, TraceFlags, TraceId, Tracer,
@@ -327,7 +328,7 @@ mod tests {
     #[test]
     fn tracer_attributes() {
         let provider = TracerProvider::builder().build();
-        let scope = InstrumentationScope::builder("basic")
+        let scope = Scope::builder("basic")
             .with_attributes(vec![KeyValue::new("test_k", "test_v")])
             .build();
 

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -40,15 +40,17 @@ mod runtime_tests;
 
 #[cfg(all(test, feature = "testing"))]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::{
         testing::trace::InMemorySpanExporterBuilder,
         trace::span_limit::{DEFAULT_MAX_EVENT_PER_SPAN, DEFAULT_MAX_LINKS_PER_SPAN},
     };
-    use opentelemetry::testing::trace::TestSpan;
     use opentelemetry::trace::{
         SamplingDecision, SamplingResult, SpanKind, Status, TraceContextExt, TraceState,
     };
+    use opentelemetry::{testing::trace::TestSpan, InstrumentationLibrary};
     use opentelemetry::{
         trace::{
             Event, Link, Span, SpanBuilder, SpanContext, SpanId, TraceFlags, TraceId, Tracer,
@@ -326,35 +328,14 @@ mod tests {
     #[test]
     fn tracer_attributes() {
         let provider = TracerProvider::builder().build();
-        let tracer = provider
-            .tracer_builder("test_tracer")
-            .with_attributes(vec![KeyValue::new("test_k", "test_v")])
-            .build();
+        let library = Arc::new(
+            InstrumentationLibrary::builder("basic")
+                .with_attributes(vec![KeyValue::new("test_k", "test_v")])
+                .build(),
+        );
+        let tracer = provider.library_tracer(library);
         let instrumentation_library = tracer.instrumentation_library();
         let attributes = &instrumentation_library.attributes;
-        assert_eq!(attributes.len(), 1);
-        assert_eq!(attributes[0].key, "test_k".into());
-        assert_eq!(attributes[0].value, "test_v".into());
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn versioned_tracer_options() {
-        let provider = TracerProvider::builder().build();
-        let tracer = provider.versioned_tracer(
-            "test_tracer",
-            Some(String::from("v1.2.3")),
-            Some(String::from("https://opentelemetry.io/schema/1.0.0")),
-            Some(vec![(KeyValue::new("test_k", "test_v"))]),
-        );
-        let instrumentation_library = tracer.instrumentation_library();
-        let attributes = &instrumentation_library.attributes;
-        assert_eq!(instrumentation_library.name, "test_tracer");
-        assert_eq!(instrumentation_library.version, Some("v1.2.3".into()));
-        assert_eq!(
-            instrumentation_library.schema_url,
-            Some("https://opentelemetry.io/schema/1.0.0".into())
-        );
         assert_eq!(attributes.len(), 1);
         assert_eq!(attributes[0].key, "test_k".into());
         assert_eq!(attributes[0].value, "test_v".into());

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -75,8 +75,6 @@ use std::borrow::Cow;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-/// Default tracer name if empty string is provided.
-const DEFAULT_COMPONENT_NAME: &str = "rust.opentelemetry.io/sdk/tracer";
 static PROVIDER_RESOURCE: OnceCell<Resource> = OnceCell::new();
 
 // a no nop tracer provider used as placeholder when the provider is shutdown
@@ -251,37 +249,6 @@ impl TracerProvider {
 impl opentelemetry::trace::TracerProvider for TracerProvider {
     /// This implementation of `TracerProvider` produces `Tracer` instances.
     type Tracer = Tracer;
-
-    /// Create a new versioned `Tracer` instance.
-    fn versioned_tracer(
-        &self,
-        name: impl Into<Cow<'static, str>>,
-        version: Option<impl Into<Cow<'static, str>>>,
-        schema_url: Option<impl Into<Cow<'static, str>>>,
-        attributes: Option<Vec<opentelemetry::KeyValue>>,
-    ) -> Self::Tracer {
-        // Use default value if name is invalid empty string
-        let name = name.into();
-        let component_name = if name.is_empty() {
-            Cow::Borrowed(DEFAULT_COMPONENT_NAME)
-        } else {
-            name
-        };
-
-        let mut builder = self.tracer_builder(component_name);
-
-        if let Some(v) = version {
-            builder = builder.with_version(v);
-        }
-        if let Some(s) = schema_url {
-            builder = builder.with_schema_url(s);
-        }
-        if let Some(a) = attributes {
-            builder = builder.with_attributes(a);
-        }
-
-        builder.build()
-    }
 
     fn library_tracer(&self, library: Arc<InstrumentationLibrary>) -> Self::Tracer {
         if self.inner.is_shutdown.load(Ordering::Relaxed) {

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -67,7 +67,7 @@ use crate::trace::{
     BatchSpanProcessor, Config, RandomIdGenerator, Sampler, SimpleSpanProcessor, SpanLimits, Tracer,
 };
 use crate::{export::trace::SpanExporter, trace::SpanProcessor};
-use crate::{InstrumentationScope, Resource};
+use crate::{Resource, Scope};
 use once_cell::sync::{Lazy, OnceCell};
 use opentelemetry::trace::TraceError;
 use opentelemetry::{otel_debug, trace::TraceResult};
@@ -250,7 +250,7 @@ impl opentelemetry::trace::TracerProvider for TracerProvider {
     /// This implementation of `TracerProvider` produces `Tracer` instances.
     type Tracer = Tracer;
 
-    fn tracer_with_scope(&self, scope: InstrumentationScope) -> Self::Tracer {
+    fn tracer_with_scope(&self, scope: Scope) -> Self::Tracer {
         if self.inner.is_shutdown.load(Ordering::Relaxed) {
             return Tracer::new(scope, NOOP_TRACER_PROVIDER.clone());
         }

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -247,9 +247,23 @@ impl TracerProvider {
     }
 }
 
+/// Default tracer name if empty string is provided.
+const DEFAULT_COMPONENT_NAME: &str = "rust.opentelemetry.io/sdk/tracer";
+
 impl opentelemetry::trace::TracerProvider for TracerProvider {
     /// This implementation of `TracerProvider` produces `Tracer` instances.
     type Tracer = Tracer;
+
+    fn tracer(&self, name: impl Into<Cow<'static, str>>) -> Self::Tracer {
+        let mut name = name.into();
+
+        if name.is_empty() {
+            name = Cow::Borrowed(DEFAULT_COMPONENT_NAME)
+        };
+
+        let scope = InstrumentationScope::builder(name).build();
+        self.tracer_with_scope(scope)
+    }
 
     fn tracer_with_scope(&self, scope: InstrumentationScope) -> Self::Tracer {
         if self.inner.is_shutdown.load(Ordering::Relaxed) {

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -66,10 +66,11 @@ use crate::runtime::RuntimeChannel;
 use crate::trace::{
     BatchSpanProcessor, Config, RandomIdGenerator, Sampler, SimpleSpanProcessor, SpanLimits, Tracer,
 };
+use crate::Resource;
 use crate::{export::trace::SpanExporter, trace::SpanProcessor};
-use crate::{Resource, Scope};
 use once_cell::sync::{Lazy, OnceCell};
 use opentelemetry::trace::TraceError;
+use opentelemetry::InstrumentationScope;
 use opentelemetry::{otel_debug, trace::TraceResult};
 use std::borrow::Cow;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -250,7 +251,7 @@ impl opentelemetry::trace::TracerProvider for TracerProvider {
     /// This implementation of `TracerProvider` produces `Tracer` instances.
     type Tracer = Tracer;
 
-    fn tracer_with_scope(&self, scope: Scope) -> Self::Tracer {
+    fn tracer_with_scope(&self, scope: InstrumentationScope) -> Self::Tracer {
         if self.inner.is_shutdown.load(Ordering::Relaxed) {
             return Tracer::new(scope, NOOP_TRACER_PROVIDER.clone());
         }

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -67,7 +67,7 @@ use crate::trace::{
     BatchSpanProcessor, Config, RandomIdGenerator, Sampler, SimpleSpanProcessor, SpanLimits, Tracer,
 };
 use crate::{export::trace::SpanExporter, trace::SpanProcessor};
-use crate::{InstrumentationLibrary, Resource};
+use crate::{InstrumentationScope, Resource};
 use once_cell::sync::{Lazy, OnceCell};
 use opentelemetry::trace::TraceError;
 use opentelemetry::{otel_debug, trace::TraceResult};
@@ -250,11 +250,11 @@ impl opentelemetry::trace::TracerProvider for TracerProvider {
     /// This implementation of `TracerProvider` produces `Tracer` instances.
     type Tracer = Tracer;
 
-    fn library_tracer(&self, library: Arc<InstrumentationLibrary>) -> Self::Tracer {
+    fn tracer_with_scope(&self, scope: InstrumentationScope) -> Self::Tracer {
         if self.inner.is_shutdown.load(Ordering::Relaxed) {
-            return Tracer::new(library, NOOP_TRACER_PROVIDER.clone());
+            return Tracer::new(scope, NOOP_TRACER_PROVIDER.clone());
         }
-        Tracer::new(library, self.clone())
+        Tracer::new(scope, self.clone())
     }
 }
 

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -263,7 +263,7 @@ fn build_export_data(
         events: data.events,
         links: data.links,
         status: data.status,
-        instrumentation_lib: tracer.instrumentation_library().clone(),
+        instrumentation_scope: tracer.instrumentation_scope().clone(),
     }
 }
 

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -741,7 +741,7 @@ mod tests {
             events: SpanEvents::default(),
             links: SpanLinks::default(),
             status: Status::Unset,
-            instrumentation_lib: Default::default(),
+            instrumentation_scope: Default::default(),
         };
         processor.on_end(unsampled);
         assert!(exporter.get_finished_spans().unwrap().is_empty());

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -7,24 +7,21 @@
 //! and exposes methods for creating and activating new `Spans`.
 //!
 //! Docs: <https://github.com/open-telemetry/opentelemetry-specification/blob/v1.3.0/specification/trace/api.md#tracer>
-use crate::{
-    trace::{
-        provider::TracerProvider,
-        span::{Span, SpanData},
-        IdGenerator, ShouldSample, SpanEvents, SpanLimits, SpanLinks,
-    },
-    Scope,
+use crate::trace::{
+    provider::TracerProvider,
+    span::{Span, SpanData},
+    IdGenerator, ShouldSample, SpanEvents, SpanLimits, SpanLinks,
 };
 use opentelemetry::{
     trace::{SamplingDecision, SpanBuilder, SpanContext, SpanKind, TraceContextExt, TraceFlags},
-    Context, KeyValue,
+    Context, InstrumentationScope, KeyValue,
 };
 use std::fmt;
 
 /// `Tracer` implementation to create and manage spans
 #[derive(Clone)]
 pub struct Tracer {
-    scope: Scope,
+    scope: InstrumentationScope,
     provider: TracerProvider,
 }
 
@@ -41,7 +38,7 @@ impl fmt::Debug for Tracer {
 
 impl Tracer {
     /// Create a new tracer (used internally by `TracerProvider`s).
-    pub(crate) fn new(scope: Scope, provider: TracerProvider) -> Self {
+    pub(crate) fn new(scope: InstrumentationScope, provider: TracerProvider) -> Self {
         Tracer { scope, provider }
     }
 
@@ -51,7 +48,7 @@ impl Tracer {
     }
 
     /// Instrumentation library information of this tracer.
-    pub(crate) fn instrumentation_scope(&self) -> &Scope {
+    pub(crate) fn instrumentation_scope(&self) -> &InstrumentationScope {
         &self.scope
     }
 

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -47,7 +47,7 @@ impl Tracer {
         &self.provider
     }
 
-    /// Instrumentation library information of this tracer.
+    /// Instrumentation scope of this tracer.
     pub(crate) fn instrumentation_scope(&self) -> &InstrumentationScope {
         &self.scope
     }

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -13,19 +13,18 @@ use crate::{
         span::{Span, SpanData},
         IdGenerator, ShouldSample, SpanEvents, SpanLimits, SpanLinks,
     },
-    InstrumentationLibrary,
+    InstrumentationScope,
 };
 use opentelemetry::{
     trace::{SamplingDecision, SpanBuilder, SpanContext, SpanKind, TraceContextExt, TraceFlags},
     Context, KeyValue,
 };
 use std::fmt;
-use std::sync::Arc;
 
 /// `Tracer` implementation to create and manage spans
 #[derive(Clone)]
 pub struct Tracer {
-    instrumentation_lib: Arc<InstrumentationLibrary>,
+    scope: InstrumentationScope,
     provider: TracerProvider,
 }
 
@@ -34,22 +33,16 @@ impl fmt::Debug for Tracer {
     /// Omitting `provider` here is necessary to avoid cycles.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Tracer")
-            .field("name", &self.instrumentation_lib.name)
-            .field("version", &self.instrumentation_lib.version)
+            .field("name", &self.scope.name)
+            .field("version", &self.scope.version)
             .finish()
     }
 }
 
 impl Tracer {
     /// Create a new tracer (used internally by `TracerProvider`s).
-    pub(crate) fn new(
-        instrumentation_lib: Arc<InstrumentationLibrary>,
-        provider: TracerProvider,
-    ) -> Self {
-        Tracer {
-            instrumentation_lib,
-            provider,
-        }
+    pub(crate) fn new(scope: InstrumentationScope, provider: TracerProvider) -> Self {
+        Tracer { scope, provider }
     }
 
     /// TracerProvider associated with this tracer.
@@ -58,8 +51,8 @@ impl Tracer {
     }
 
     /// Instrumentation library information of this tracer.
-    pub(crate) fn instrumentation_library(&self) -> &InstrumentationLibrary {
-        &self.instrumentation_lib
+    pub(crate) fn instrumentation_scope(&self) -> &InstrumentationScope {
+        &self.scope
     }
 
     fn build_recording_span(

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -13,7 +13,7 @@ use crate::{
         span::{Span, SpanData},
         IdGenerator, ShouldSample, SpanEvents, SpanLimits, SpanLinks,
     },
-    InstrumentationScope,
+    Scope,
 };
 use opentelemetry::{
     trace::{SamplingDecision, SpanBuilder, SpanContext, SpanKind, TraceContextExt, TraceFlags},
@@ -24,7 +24,7 @@ use std::fmt;
 /// `Tracer` implementation to create and manage spans
 #[derive(Clone)]
 pub struct Tracer {
-    scope: InstrumentationScope,
+    scope: Scope,
     provider: TracerProvider,
 }
 
@@ -41,7 +41,7 @@ impl fmt::Debug for Tracer {
 
 impl Tracer {
     /// Create a new tracer (used internally by `TracerProvider`s).
-    pub(crate) fn new(scope: InstrumentationScope, provider: TracerProvider) -> Self {
+    pub(crate) fn new(scope: Scope, provider: TracerProvider) -> Self {
         Tracer { scope, provider }
     }
 
@@ -51,7 +51,7 @@ impl Tracer {
     }
 
     /// Instrumentation library information of this tracer.
-    pub(crate) fn instrumentation_scope(&self) -> &InstrumentationScope {
+    pub(crate) fn instrumentation_scope(&self) -> &Scope {
         &self.scope
     }
 

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -64,16 +64,20 @@ fn init_logs() -> opentelemetry_sdk::logs::LoggerProvider {
 
 #[cfg(feature = "trace")]
 fn emit_span() {
-    use opentelemetry::trace::{
-        SpanContext, SpanId, TraceFlags, TraceId, TraceState, TracerProvider,
+    use std::sync::Arc;
+
+    use opentelemetry::{
+        trace::{SpanContext, SpanId, TraceFlags, TraceId, TraceState, TracerProvider},
+        InstrumentationLibrary,
     };
 
-    let tracer = global::tracer_provider()
-        .tracer_builder("stdout-example")
-        .with_version("v1")
-        .with_schema_url("schema_url")
-        .with_attributes([KeyValue::new("scope_key", "scope_value")])
-        .build();
+    let library = Arc::new(
+        InstrumentationLibrary::builder("stdout-example")
+            .with_version("v1")
+            .with_attributes([KeyValue::new("scope_key", "scope_value")])
+            .build(),
+    );
+    let tracer = global::tracer_provider().library_tracer(library);
     let mut span = tracer.start("example-span");
     span.set_attribute(KeyValue::new("attribute_key1", "attribute_value1"));
     span.set_attribute(KeyValue::new("attribute_key2", "attribute_value2"));

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -64,20 +64,17 @@ fn init_logs() -> opentelemetry_sdk::logs::LoggerProvider {
 
 #[cfg(feature = "trace")]
 fn emit_span() {
-    use std::sync::Arc;
-
     use opentelemetry::{
-        trace::{SpanContext, SpanId, TraceFlags, TraceId, TraceState, TracerProvider},
-        InstrumentationLibrary,
+        trace::{SpanContext, SpanId, TraceFlags, TraceId, TraceState},
+        InstrumentationScope,
     };
 
-    let library = Arc::new(
-        InstrumentationLibrary::builder("stdout-example")
-            .with_version("v1")
-            .with_attributes([KeyValue::new("scope_key", "scope_value")])
-            .build(),
-    );
-    let tracer = global::tracer_provider().library_tracer(library);
+    let scope = InstrumentationScope::builder("stdout-example")
+        .with_version("v1")
+        .with_attributes([KeyValue::new("scope_key", "scope_value")])
+        .build();
+
+    let tracer = global::tracer_with_scope(scope);
     let mut span = tracer.start("example-span");
     span.set_attribute(KeyValue::new("attribute_key1", "attribute_value1"));
     span.set_attribute(KeyValue::new("attribute_key2", "attribute_value2"));

--- a/opentelemetry-stdout/src/common.rs
+++ b/opentelemetry-stdout/src/common.rs
@@ -238,7 +238,7 @@ impl From<opentelemetry_sdk::Scope> for Scope {
         Scope {
             name: value.name,
             version: value.version,
-            attributes: value.attributes.iter().map(Into::into).collect(),
+            attributes: value.attributes.into_iter().map(Into::into).collect(),
             dropped_attributes_count: 0,
         }
     }

--- a/opentelemetry-stdout/src/common.rs
+++ b/opentelemetry-stdout/src/common.rs
@@ -233,8 +233,8 @@ pub(crate) struct Scope {
     dropped_attributes_count: u64,
 }
 
-impl From<opentelemetry_sdk::Scope> for Scope {
-    fn from(value: opentelemetry_sdk::Scope) -> Self {
+impl From<opentelemetry::InstrumentationScope> for Scope {
+    fn from(value: opentelemetry::InstrumentationScope) -> Self {
         Scope {
             name: value.name,
             version: value.version,

--- a/opentelemetry-stdout/src/common.rs
+++ b/opentelemetry-stdout/src/common.rs
@@ -238,7 +238,7 @@ impl From<opentelemetry_sdk::Scope> for Scope {
         Scope {
             name: value.name,
             version: value.version,
-            attributes: value.attributes.into_iter().map(Into::into).collect(),
+            attributes: value.attributes.iter().map(Into::into).collect(),
             dropped_attributes_count: 0,
         }
     }

--- a/opentelemetry-stdout/src/trace/exporter.rs
+++ b/opentelemetry-stdout/src/trace/exporter.rs
@@ -72,14 +72,14 @@ fn print_spans(batch: Vec<export::trace::SpanData>) {
     for (i, span) in batch.into_iter().enumerate() {
         println!("Span #{}", i);
         println!("\tInstrumentation Scope");
-        println!("\t\tName         : {:?}", &span.instrumentation_lib.name);
-        if let Some(version) = &span.instrumentation_lib.version {
+        println!("\t\tName         : {:?}", &span.instrumentation_scope.name);
+        if let Some(version) = &span.instrumentation_scope.version {
             println!("\t\tVersion  : {:?}", version);
         }
-        if let Some(schema_url) = &span.instrumentation_lib.schema_url {
+        if let Some(schema_url) = &span.instrumentation_scope.schema_url {
             println!("\t\tSchemaUrl: {:?}", schema_url);
         }
-        span.instrumentation_lib
+        span.instrumentation_scope
             .attributes
             .iter()
             .enumerate()

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use futures_core::future::BoxFuture;
 use http::Uri;
 use model::endpoint::Endpoint;
-use opentelemetry::{global, trace::TraceError, KeyValue};
+use opentelemetry::{global, trace::TraceError, InstrumentationLibrary, KeyValue};
 use opentelemetry_http::HttpClient;
 use opentelemetry_sdk::{
     export::{trace, ExportError},
@@ -144,11 +144,13 @@ impl ZipkinPipelineBuilder {
         let mut provider_builder = TracerProvider::builder().with_simple_exporter(exporter);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let tracer =
-            opentelemetry::trace::TracerProvider::tracer_builder(&provider, "opentelemetry-zipkin")
+        let library = Arc::new(
+            InstrumentationLibrary::builder("opentelemetry-zipkin")
                 .with_version(env!("CARGO_PKG_VERSION"))
                 .with_schema_url(semcov::SCHEMA_URL)
-                .build();
+                .build(),
+        );
+        let tracer = opentelemetry::trace::TracerProvider::library_tracer(&provider, library);
         let _ = global::set_tracer_provider(provider);
         Ok(tracer)
     }
@@ -161,11 +163,13 @@ impl ZipkinPipelineBuilder {
         let mut provider_builder = TracerProvider::builder().with_batch_exporter(exporter, runtime);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let tracer =
-            opentelemetry::trace::TracerProvider::tracer_builder(&provider, "opentelemetry-zipkin")
+        let library = Arc::new(
+            InstrumentationLibrary::builder("opentelemetry-zipkin")
                 .with_version(env!("CARGO_PKG_VERSION"))
                 .with_schema_url(semcov::SCHEMA_URL)
-                .build();
+                .build(),
+        );
+        let tracer = opentelemetry::trace::TracerProvider::library_tracer(&provider, library);
         let _ = global::set_tracer_provider(provider);
         Ok(tracer)
     }

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use futures_core::future::BoxFuture;
 use http::Uri;
 use model::endpoint::Endpoint;
-use opentelemetry::{global, trace::TraceError, InstrumentationLibrary, KeyValue};
+use opentelemetry::{global, trace::TraceError, InstrumentationScope, KeyValue};
 use opentelemetry_http::HttpClient;
 use opentelemetry_sdk::{
     export::{trace, ExportError},
@@ -144,13 +144,11 @@ impl ZipkinPipelineBuilder {
         let mut provider_builder = TracerProvider::builder().with_simple_exporter(exporter);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let library = Arc::new(
-            InstrumentationLibrary::builder("opentelemetry-zipkin")
-                .with_version(env!("CARGO_PKG_VERSION"))
-                .with_schema_url(semcov::SCHEMA_URL)
-                .build(),
-        );
-        let tracer = opentelemetry::trace::TracerProvider::library_tracer(&provider, library);
+        let scope = InstrumentationScope::builder("opentelemetry-zipkin")
+            .with_version(env!("CARGO_PKG_VERSION"))
+            .with_schema_url(semcov::SCHEMA_URL)
+            .build();
+        let tracer = opentelemetry::trace::TracerProvider::tracer_with_scope(&provider, scope);
         let _ = global::set_tracer_provider(provider);
         Ok(tracer)
     }
@@ -163,13 +161,11 @@ impl ZipkinPipelineBuilder {
         let mut provider_builder = TracerProvider::builder().with_batch_exporter(exporter, runtime);
         provider_builder = provider_builder.with_config(config);
         let provider = provider_builder.build();
-        let library = Arc::new(
-            InstrumentationLibrary::builder("opentelemetry-zipkin")
-                .with_version(env!("CARGO_PKG_VERSION"))
-                .with_schema_url(semcov::SCHEMA_URL)
-                .build(),
-        );
-        let tracer = opentelemetry::trace::TracerProvider::library_tracer(&provider, library);
+        let scope = InstrumentationScope::builder("opentelemetry-zipkin")
+            .with_version(env!("CARGO_PKG_VERSION"))
+            .with_schema_url(semcov::SCHEMA_URL)
+            .build();
+        let tracer = opentelemetry::trace::TracerProvider::tracer_with_scope(&provider, scope);
         let _ = global::set_tracer_provider(provider);
         Ok(tracer)
     }

--- a/opentelemetry-zipkin/src/exporter/model/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/model/mod.rs
@@ -46,11 +46,11 @@ pub(crate) fn into_zipkin_span(local_endpoint: Endpoint, span_data: SpanData) ->
                 [
                     (
                         INSTRUMENTATION_LIBRARY_NAME,
-                        Some(span_data.instrumentation_lib.name),
+                        Some(span_data.instrumentation_scope.name),
                     ),
                     (
                         INSTRUMENTATION_LIBRARY_VERSION,
-                        span_data.instrumentation_lib.version,
+                        span_data.instrumentation_scope.version,
                     ),
                 ]
                 .into_iter()

--- a/opentelemetry-zipkin/src/exporter/model/span.rs
+++ b/opentelemetry-zipkin/src/exporter/model/span.rs
@@ -165,7 +165,7 @@ mod tests {
                 events: SpanEvents::default(),
                 links: SpanLinks::default(),
                 status,
-                instrumentation_lib: Default::default(),
+                instrumentation_scope: Default::default(),
             };
             let local_endpoint = Endpoint::new("test".into(), None);
             let span = into_zipkin_span(local_endpoint, span_data);

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -23,6 +23,15 @@ Now:
 ```rust
 let counter = meter.u64_counter("my_counter").build();
 ```
+- **Breaking change**: [#2220](https://github.com/open-telemetry/opentelemetry-rust/pull/2220)
+  - Removed deprecated method `InstrumentationLibrary::new`
+  - Renamed `InstrumentationLibrary` to `InstrumentationScope`
+  - Renamed `InstrumentationLibraryBuilder` to `InstrumentationScopeBuilder`
+  - Removed deprecated methods `LoggerProvider::versioned_logger` and `TracerProvider::versioned_tracer`
+  - Removed methods `LoggerProvider::logger_builder`, `TracerProvider::tracer_builder` and `MeterProvider::versioned_meter`
+  - Replaced these methods with `LoggerProvider::logger_with_scope`, `TracerProvider::logger_with_scope`, `MeterProvider::meter_with_scope`
+  - Replaced `global::meter_with_version` with `global::meter_with_scope`
+  - Added `global::tracer_with_scope`
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -407,7 +407,7 @@ pub trait ExportError: std::error::Error + Send + Sync + 'static {
 
 /// Information about a library or crate providing instrumentation.
 ///
-/// An instrumentation library should be named to follow any naming conventions
+/// An instrumentation scope should be named to follow any naming conventions
 /// of the instrumented library (e.g. 'middleware' for a web framework).
 ///
 /// See the [instrumentation libraries] spec for more information.
@@ -415,37 +415,28 @@ pub trait ExportError: std::error::Error + Send + Sync + 'static {
 /// [instrumentation libraries]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/overview.md#instrumentation-libraries
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
-pub struct InstrumentationLibrary {
+pub struct InstrumentationScope {
     /// The library name.
     ///
     /// This should be the name of the crate providing the instrumentation.
     pub name: Cow<'static, str>,
 
     /// The library version.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let library = opentelemetry::InstrumentationLibrary::builder("my-crate").
-    ///     with_version(env!("CARGO_PKG_VERSION")).
-    ///     with_schema_url("https://opentelemetry.io/schemas/1.17.0").
-    ///     build();
-    /// ```
     pub version: Option<Cow<'static, str>>,
 
-    /// [Schema url] used by this library.
+    /// [Schema URL] used by this library.
     ///
-    /// [Schema url]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/schemas/overview.md#schema-url
+    /// [Schema URL]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/schemas/overview.md#schema-url
     pub schema_url: Option<Cow<'static, str>>,
 
     /// Specifies the instrumentation scope attributes to associate with emitted telemetry.
     pub attributes: Vec<KeyValue>,
 }
 
-// Uniqueness for InstrumentationLibrary/InstrumentationScope does not depend on attributes
-impl Eq for InstrumentationLibrary {}
+// Uniqueness for InstrumentationScope does not depend on attributes
+impl Eq for InstrumentationScope {}
 
-impl PartialEq for InstrumentationLibrary {
+impl PartialEq for InstrumentationScope {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
             && self.version == other.version
@@ -453,7 +444,7 @@ impl PartialEq for InstrumentationLibrary {
     }
 }
 
-impl hash::Hash for InstrumentationLibrary {
+impl hash::Hash for InstrumentationScope {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.name.hash(state);
         self.version.hash(state);
@@ -461,28 +452,10 @@ impl hash::Hash for InstrumentationLibrary {
     }
 }
 
-impl InstrumentationLibrary {
-    /// Deprecated, use [`InstrumentationLibrary::builder()`]
-    ///
-    /// Create an new instrumentation library.
-    #[deprecated(since = "0.23.0", note = "Please use builder() instead")]
-    pub fn new(
-        name: impl Into<Cow<'static, str>>,
-        version: Option<impl Into<Cow<'static, str>>>,
-        schema_url: Option<impl Into<Cow<'static, str>>>,
-        attributes: Option<Vec<KeyValue>>,
-    ) -> InstrumentationLibrary {
-        InstrumentationLibrary {
-            name: name.into(),
-            version: version.map(Into::into),
-            schema_url: schema_url.map(Into::into),
-            attributes: attributes.unwrap_or_default(),
-        }
-    }
-
-    /// Create a new builder to create an [InstrumentationLibrary]
-    pub fn builder<T: Into<Cow<'static, str>>>(name: T) -> InstrumentationLibraryBuilder {
-        InstrumentationLibraryBuilder {
+impl InstrumentationScope {
+    /// Create a new builder to create an [InstrumentationScope]
+    pub fn builder<T: Into<Cow<'static, str>>>(name: T) -> InstrumentationScopeBuilder {
+        InstrumentationScopeBuilder {
             name: name.into(),
             version: None,
             schema_url: None,
@@ -491,9 +464,9 @@ impl InstrumentationLibrary {
     }
 }
 
-/// Configuration options for [InstrumentationLibrary].
+/// Configuration options for [InstrumentationScope].
 ///
-/// An instrumentation library is a library or crate providing instrumentation.
+/// An instrumentation scope is a library or crate providing instrumentation.
 /// It should be named to follow any naming conventions of the instrumented
 /// library (e.g. 'middleware' for a web framework).
 ///
@@ -503,7 +476,7 @@ impl InstrumentationLibrary {
 ///
 /// [instrumentation libraries]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/overview.md#instrumentation-libraries
 #[derive(Debug)]
-pub struct InstrumentationLibraryBuilder {
+pub struct InstrumentationScopeBuilder {
     name: Cow<'static, str>,
 
     version: Option<Cow<'static, str>>,
@@ -513,13 +486,13 @@ pub struct InstrumentationLibraryBuilder {
     attributes: Option<Vec<KeyValue>>,
 }
 
-impl InstrumentationLibraryBuilder {
-    /// Configure the version for the instrumentation library
+impl InstrumentationScopeBuilder {
+    /// Configure the version for the instrumentation scope
     ///
     /// # Examples
     ///
     /// ```
-    /// let library = opentelemetry::InstrumentationLibrary::builder("my-crate")
+    /// let scope = opentelemetry::InstrumentationScope::builder("my-crate")
     ///     .with_version("v0.1.0")
     ///     .build();
     /// ```
@@ -528,12 +501,12 @@ impl InstrumentationLibraryBuilder {
         self
     }
 
-    /// Configure the Schema URL for the instrumentation library
+    /// Configure the Schema URL for the instrumentation scope
     ///
     /// # Examples
     ///
     /// ```
-    /// let library = opentelemetry::InstrumentationLibrary::builder("my-crate")
+    /// let scope = opentelemetry::InstrumentationScope::builder("my-crate")
     ///     .with_schema_url("https://opentelemetry.io/schemas/1.17.0")
     ///     .build();
     /// ```
@@ -542,14 +515,14 @@ impl InstrumentationLibraryBuilder {
         self
     }
 
-    /// Configure the attributes for the instrumentation library
+    /// Configure the attributes for the instrumentation scope
     ///
     /// # Examples
     ///
     /// ```
     /// use opentelemetry::KeyValue;
     ///
-    /// let library = opentelemetry::InstrumentationLibrary::builder("my-crate")
+    /// let scope = opentelemetry::InstrumentationScope::builder("my-crate")
     ///     .with_attributes([KeyValue::new("k", "v")])
     ///     .build();
     /// ```
@@ -561,9 +534,9 @@ impl InstrumentationLibraryBuilder {
         self
     }
 
-    /// Create a new [InstrumentationLibrary] from this configuration
-    pub fn build(self) -> InstrumentationLibrary {
-        InstrumentationLibrary {
+    /// Create a new [InstrumentationScope] from this configuration
+    pub fn build(self) -> InstrumentationScope {
+        InstrumentationScope {
             name: self.name,
             version: self.version,
             schema_url: self.schema_url,

--- a/opentelemetry/src/global/metrics.rs
+++ b/opentelemetry/src/global/metrics.rs
@@ -1,5 +1,5 @@
 use crate::metrics::{self, Meter, MeterProvider};
-use crate::KeyValue;
+use crate::InstrumentationLibrary;
 use once_cell::sync::Lazy;
 use std::sync::{Arc, RwLock};
 
@@ -38,32 +38,28 @@ pub fn meter(name: &'static str) -> Meter {
     meter_provider().meter(name)
 }
 
-/// Creates a [`Meter`] with the name, version and schema url.
+/// Creates a [`Meter`] with the given instrumentation library.
 ///
-/// - name SHOULD uniquely identify the instrumentation scope, such as the instrumentation library (e.g. io.opentelemetry.contrib.mongodb), package, module or class name.
-/// - version specifies the version of the instrumentation scope if the scope has a version
-/// - schema url specifies the Schema URL that should be recorded in the emitted telemetry.
-///
-/// This is a convenient way of `global::meter_provider().versioned_meter(...)`
+/// This is a shortcut `global::meter_provider().library_meter(...)`
 ///
 /// # Example
 ///
 /// ```
-/// use opentelemetry::global::meter_with_version;
+/// use std::sync::Arc;
+/// use opentelemetry::global::library_meter;
+/// use opentelemetry::InstrumentationLibrary;
 /// use opentelemetry::KeyValue;
 ///
-/// let meter = meter_with_version(
-///     "io.opentelemetry",
-///     Some("0.17"),
-///     Some("https://opentelemetry.io/schemas/1.2.0"),
-///     Some(vec![KeyValue::new("key", "value")]),
+/// let library = Arc::new(
+///     InstrumentationLibrary::builder("io.opentelemetry")
+///         .with_version("0.17")
+///         .with_schema_url("https://opentelemetry.io/schema/1.2.0")
+///         .with_attributes(vec![(KeyValue::new("key", "value"))])
+///         .build(),
 /// );
+///
+/// let meter = library_meter(library);
 /// ```
-pub fn meter_with_version(
-    name: &'static str,
-    version: Option<&'static str>,
-    schema_url: Option<&'static str>,
-    attributes: Option<Vec<KeyValue>>,
-) -> Meter {
-    meter_provider().versioned_meter(name, version, schema_url, attributes)
+pub fn library_meter(library: Arc<InstrumentationLibrary>) -> Meter {
+    meter_provider().library_meter(library)
 }

--- a/opentelemetry/src/global/metrics.rs
+++ b/opentelemetry/src/global/metrics.rs
@@ -1,5 +1,5 @@
 use crate::metrics::{self, Meter, MeterProvider};
-use crate::InstrumentationLibrary;
+use crate::InstrumentationScope;
 use once_cell::sync::Lazy;
 use std::sync::{Arc, RwLock};
 
@@ -40,26 +40,24 @@ pub fn meter(name: &'static str) -> Meter {
 
 /// Creates a [`Meter`] with the given instrumentation library.
 ///
-/// This is a shortcut `global::meter_provider().library_meter(...)`
+/// This is a shortcut `global::meter_provider().meter_with_scope(...)`
 ///
 /// # Example
 ///
 /// ```
 /// use std::sync::Arc;
-/// use opentelemetry::global::library_meter;
-/// use opentelemetry::InstrumentationLibrary;
+/// use opentelemetry::global::meter_with_scope;
+/// use opentelemetry::InstrumentationScope;
 /// use opentelemetry::KeyValue;
 ///
-/// let library = Arc::new(
-///     InstrumentationLibrary::builder("io.opentelemetry")
-///         .with_version("0.17")
-///         .with_schema_url("https://opentelemetry.io/schema/1.2.0")
-///         .with_attributes(vec![(KeyValue::new("key", "value"))])
-///         .build(),
-/// );
+/// let scope = InstrumentationScope::builder("io.opentelemetry")
+///     .with_version("0.17")
+///     .with_schema_url("https://opentelemetry.io/schema/1.2.0")
+///     .with_attributes(vec![(KeyValue::new("key", "value"))])
+///     .build();
 ///
-/// let meter = library_meter(library);
+/// let meter = meter_with_scope(scope);
 /// ```
-pub fn library_meter(library: Arc<InstrumentationLibrary>) -> Meter {
-    meter_provider().library_meter(library)
+pub fn meter_with_scope(scope: InstrumentationScope) -> Meter {
+    meter_provider().meter_with_scope(scope)
 }

--- a/opentelemetry/src/global/metrics.rs
+++ b/opentelemetry/src/global/metrics.rs
@@ -38,9 +38,9 @@ pub fn meter(name: &'static str) -> Meter {
     meter_provider().meter(name)
 }
 
-/// Creates a [`Meter`] with the given instrumentation library.
+/// Creates a [`Meter`] with the given instrumentation scope.
 ///
-/// This is a shortcut `global::meter_provider().meter_with_scope(...)`
+/// This is a simpler alternative to `global::meter_provider().meter_with_scope(...)`
 ///
 /// # Example
 ///

--- a/opentelemetry/src/global/mod.rs
+++ b/opentelemetry/src/global/mod.rs
@@ -50,16 +50,22 @@
 //! ```
 //! # #[cfg(feature="trace")]
 //! # {
+//! use std::sync::Arc;
 //! use opentelemetry::trace::{Tracer, TracerProvider};
 //! use opentelemetry::global;
+//! use opentelemetry::InstrumentationLibrary;
 //!
 //! pub fn my_traced_library_function() {
 //!     // End users of your library will configure their global tracer provider
 //!     // so you can use the global tracer without any setup
-//!     let tracer = global::tracer_provider().tracer_builder("my-library-name").
-//!         with_version(env!("CARGO_PKG_VERSION")).
-//!         with_schema_url("https://opentelemetry.io/schemas/1.17.0").
-//!         build();
+//!
+//!     let library = Arc::new(InstrumentationLibrary::builder("my_library-name")
+//!         .with_version(env!("CARGO_PKG_VERSION"))
+//!         .with_schema_url("https://opentelemetry.io/schemas/1.17.0")
+//!         .build()
+//!     );
+//!
+//!     let tracer = global::tracer_provider().library_tracer(library);
 //!
 //!     tracer.in_span("doing_library_work", |cx| {
 //!         // Traced library logic here...

--- a/opentelemetry/src/global/mod.rs
+++ b/opentelemetry/src/global/mod.rs
@@ -51,7 +51,7 @@
 //! # #[cfg(feature="trace")]
 //! # {
 //! use std::sync::Arc;
-//! use opentelemetry::trace::{Tracer, TracerProvider};
+//! use opentelemetry::trace::Tracer;
 //! use opentelemetry::global;
 //! use opentelemetry::InstrumentationScope;
 //!
@@ -64,7 +64,7 @@
 //!         .with_schema_url("https://opentelemetry.io/schemas/1.17.0")
 //!         .build();
 //!
-//!     let tracer = global::tracer_provider().tracer_with_scope(scope);
+//!     let tracer = global::tracer_with_scope(scope);
 //!
 //!     tracer.in_span("doing_library_work", |cx| {
 //!         // Traced library logic here...

--- a/opentelemetry/src/global/mod.rs
+++ b/opentelemetry/src/global/mod.rs
@@ -53,19 +53,18 @@
 //! use std::sync::Arc;
 //! use opentelemetry::trace::{Tracer, TracerProvider};
 //! use opentelemetry::global;
-//! use opentelemetry::InstrumentationLibrary;
+//! use opentelemetry::InstrumentationScope;
 //!
 //! pub fn my_traced_library_function() {
 //!     // End users of your library will configure their global tracer provider
 //!     // so you can use the global tracer without any setup
 //!
-//!     let library = Arc::new(InstrumentationLibrary::builder("my_library-name")
+//!     let scope = InstrumentationScope::builder("my_library-name")
 //!         .with_version(env!("CARGO_PKG_VERSION"))
 //!         .with_schema_url("https://opentelemetry.io/schemas/1.17.0")
-//!         .build()
-//!     );
+//!         .build();
 //!
-//!     let tracer = global::tracer_provider().library_tracer(library);
+//!     let tracer = global::tracer_provider().tracer_with_scope(scope);
 //!
 //!     tracer.in_span("doing_library_work", |cx| {
 //!         // Traced library logic here...

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -389,10 +389,10 @@ pub fn tracer(name: impl Into<Cow<'static, str>>) -> BoxedTracer {
     tracer_provider().tracer(name.into())
 }
 
-/// Creates a [`Tracer`] with the given instrumentation library
+/// Creates a [`Tracer`] with the given instrumentation scope
 /// via the configured [`GlobalTracerProvider`].
 ///
-/// This is a shortcut `global::tracer_provider().tracer_with_scope(...)`
+/// This is a simpler alternative to `global::tracer_provider().tracer_with_scope(...)`
 ///
 /// # Example
 ///

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -395,6 +395,35 @@ pub fn tracer(name: impl Into<Cow<'static, str>>) -> BoxedTracer {
     tracer_provider().tracer(name.into())
 }
 
+/// Creates a [`Tracer`] with the given instrumentation library
+/// via the configured [`GlobalTracerProvider`].
+///
+/// This is a shortcut `global::tracer_provider().library_tracer(...)`
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use opentelemetry::global::library_tracer;
+/// use opentelemetry::InstrumentationLibrary;
+/// use opentelemetry::KeyValue;
+///
+/// let library = Arc::new(
+///     InstrumentationLibrary::builder("io.opentelemetry")
+///         .with_version("0.17")
+///         .with_schema_url("https://opentelemetry.io/schema/1.2.0")
+///         .with_attributes(vec![(KeyValue::new("key", "value"))])
+///         .build(),
+/// );
+///
+/// let meter = library_tracer(library);
+/// ```
+///
+/// [`Tracer`]: crate::trace::Tracer
+pub fn library_tracer(library: Arc<InstrumentationLibrary>) -> BoxedTracer {
+    tracer_provider().library_tracer(library)
+}
+
 /// Sets the given [`TracerProvider`] instance as the current global provider.
 ///
 /// It returns the [`TracerProvider`] instance that was previously mounted as global provider

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -408,7 +408,7 @@ pub fn tracer(name: impl Into<Cow<'static, str>>) -> BoxedTracer {
 ///     .with_attributes(vec![(KeyValue::new("key", "value"))])
 ///     .build();
 ///
-/// let meter = tracer_with_scope(scope);
+/// let tracer = tracer_with_scope(scope);
 /// ```
 ///
 /// [`Tracer`]: crate::trace::Tracer

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -204,7 +204,7 @@ mod common;
 pub mod testing;
 
 pub use common::{
-    Array, ExportError, InstrumentationLibrary, InstrumentationLibraryBuilder, Key, KeyValue,
+    Array, ExportError, InstrumentationScope, InstrumentationScopeBuilder, Key, KeyValue,
     StringValue, Value,
 };
 

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -1,6 +1,6 @@
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::Cow;
 
-use crate::{logs::LogRecord, InstrumentationLibrary};
+use crate::{logs::LogRecord, InstrumentationScope};
 
 #[cfg(feature = "logs_level_enabled")]
 use super::Severity;
@@ -35,8 +35,7 @@ pub trait LoggerProvider {
     /// # Examples
     ///
     /// ```
-    /// use std::sync::Arc;
-    /// use opentelemetry::InstrumentationLibrary;
+    /// use opentelemetry::InstrumentationScope;
     /// use opentelemetry::logs::LoggerProvider;
     /// use opentelemetry_sdk::logs::LoggerProvider as SdkLoggerProvider;
     ///
@@ -46,15 +45,14 @@ pub trait LoggerProvider {
     /// let logger = provider.logger("my_app");
     ///
     /// // logger used in libraries/crates that optionally includes version and schema url
-    /// let library = Arc::new(
-    ///     InstrumentationLibrary::builder(env!("CARGO_PKG_NAME"))
-    ///         .with_version(env!("CARGO_PKG_VERSION"))
-    ///         .with_schema_url("https://opentelemetry.io/schema/1.0.0")
-    ///         .build(),
-    /// );
-    /// let logger = provider.library_logger(library);
+    /// let scope = InstrumentationScope::builder(env!("CARGO_PKG_NAME"))
+    ///     .with_version(env!("CARGO_PKG_VERSION"))
+    ///     .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+    ///     .build();
+    ///
+    /// let logger = provider.logger_with_scope(scope);
     /// ```
-    fn library_logger(&self, library: Arc<InstrumentationLibrary>) -> Self::Logger;
+    fn logger_with_scope(&self, scope: InstrumentationScope) -> Self::Logger;
 
     /// Returns a new logger with the given name.
     ///
@@ -62,7 +60,7 @@ pub trait LoggerProvider {
     /// providing instrumentation. If the name is empty, then an
     /// implementation-defined default name may be used instead.
     fn logger(&self, name: impl Into<Cow<'static, str>>) -> Self::Logger {
-        let library = Arc::new(InstrumentationLibrary::builder(name).build());
-        self.library_logger(library)
+        let scope = InstrumentationScope::builder(name).build();
+        self.logger_with_scope(scope)
     }
 }

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -30,7 +30,7 @@ pub trait LoggerProvider {
     /// The [`Logger`] type that this provider will return.
     type Logger: Logger;
 
-    /// Returns a new logger with the given instrumentation library.
+    /// Returns a new logger with the given instrumentation scope.
     ///
     /// # Examples
     ///

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
-use crate::{logs::LogRecord, InstrumentationLibrary, InstrumentationLibraryBuilder, KeyValue};
+use crate::{logs::LogRecord, InstrumentationLibrary};
 
 #[cfg(feature = "logs_level_enabled")]
 use super::Severity;
@@ -30,73 +30,14 @@ pub trait LoggerProvider {
     /// The [`Logger`] type that this provider will return.
     type Logger: Logger;
 
-    /// Deprecated, use [`LoggerProvider::logger_builder()`]
-    ///
-    /// Returns a new versioned logger with a given name.
-    ///
-    /// The `name` should be the application name or the name of the library
-    /// providing instrumentation. If the name is empty, then an
-    /// implementation-defined default name may be used instead.
-    /// Create a new versioned `Logger` instance.
-    #[deprecated(since = "0.23.0", note = "Please use logger_builder() instead")]
-    fn versioned_logger(
-        &self,
-        name: impl Into<Cow<'static, str>>,
-        version: Option<Cow<'static, str>>,
-        schema_url: Option<Cow<'static, str>>,
-        attributes: Option<Vec<KeyValue>>,
-    ) -> Self::Logger {
-        let mut builder = self.logger_builder(name);
-        if let Some(v) = version {
-            builder = builder.with_version(v);
-        }
-        if let Some(s) = schema_url {
-            builder = builder.with_schema_url(s);
-        }
-        if let Some(a) = attributes {
-            builder = builder.with_attributes(a);
-        }
-        builder.build()
-    }
-
-    /// Returns a new builder for creating a [`Logger`] instance
-    ///
-    /// The `name` should be the application name or the name of the library
-    /// providing instrumentation. If the name is empty, then an
-    /// implementation-defined default name may be used instead.
+    /// Returns a new logger with the given instrumentation library.
     ///
     /// # Examples
     ///
     /// ```
+    /// use std::sync::Arc;
     /// use opentelemetry::InstrumentationLibrary;
-    /// use crate::opentelemetry::logs::LoggerProvider;
-    /// use opentelemetry_sdk::logs::LoggerProvider as SdkLoggerProvider;
-    ///
-    /// let provider = SdkLoggerProvider::builder().build();
-    ///
-    /// // logger used in applications/binaries
-    /// let logger = provider.logger_builder("my_app").build();
-    ///
-    /// // logger used in libraries/crates that optionally includes version and schema url
-    /// let logger = provider.logger_builder("my_library")
-    ///     .with_version(env!("CARGO_PKG_VERSION"))
-    ///     .with_schema_url("https://opentelemetry.io/schema/1.0.0")
-    ///     .build();
-    /// ```
-    fn logger_builder(&self, name: impl Into<Cow<'static, str>>) -> LoggerBuilder<'_, Self> {
-        LoggerBuilder {
-            provider: self,
-            library_builder: InstrumentationLibrary::builder(name),
-        }
-    }
-
-    /// Returns a new versioned logger with the given instrumentation library.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use opentelemetry::InstrumentationLibrary;
-    /// use crate::opentelemetry::logs::LoggerProvider;
+    /// use opentelemetry::logs::LoggerProvider;
     /// use opentelemetry_sdk::logs::LoggerProvider as SdkLoggerProvider;
     ///
     /// let provider = SdkLoggerProvider::builder().build();
@@ -105,7 +46,7 @@ pub trait LoggerProvider {
     /// let logger = provider.logger("my_app");
     ///
     /// // logger used in libraries/crates that optionally includes version and schema url
-    /// let library = std::sync::Arc::new(
+    /// let library = Arc::new(
     ///     InstrumentationLibrary::builder(env!("CARGO_PKG_NAME"))
     ///         .with_version(env!("CARGO_PKG_VERSION"))
     ///         .with_schema_url("https://opentelemetry.io/schema/1.0.0")
@@ -121,37 +62,7 @@ pub trait LoggerProvider {
     /// providing instrumentation. If the name is empty, then an
     /// implementation-defined default name may be used instead.
     fn logger(&self, name: impl Into<Cow<'static, str>>) -> Self::Logger {
-        self.logger_builder(name).build()
-    }
-}
-
-#[derive(Debug)]
-pub struct LoggerBuilder<'a, T: LoggerProvider + ?Sized> {
-    provider: &'a T,
-    library_builder: InstrumentationLibraryBuilder,
-}
-
-impl<'a, T: LoggerProvider + ?Sized> LoggerBuilder<'a, T> {
-    pub fn with_version(mut self, version: impl Into<Cow<'static, str>>) -> Self {
-        self.library_builder = self.library_builder.with_version(version);
-        self
-    }
-
-    pub fn with_schema_url(mut self, schema_url: impl Into<Cow<'static, str>>) -> Self {
-        self.library_builder = self.library_builder.with_schema_url(schema_url);
-        self
-    }
-
-    pub fn with_attributes<I>(mut self, attributes: I) -> Self
-    where
-        I: IntoIterator<Item = KeyValue>,
-    {
-        self.library_builder = self.library_builder.with_attributes(attributes);
-        self
-    }
-
-    pub fn build(self) -> T::Logger {
-        self.provider
-            .library_logger(Arc::new(self.library_builder.build()))
+        let library = Arc::new(InstrumentationLibrary::builder(name).build());
+        self.library_logger(library)
     }
 }

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, sync::Arc, time::SystemTime};
 
 use crate::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    InstrumentationLibrary, Key, KeyValue,
+    InstrumentationLibrary, Key,
 };
 
 /// A no-op implementation of a [`LoggerProvider`].
@@ -20,16 +20,6 @@ impl LoggerProvider for NoopLoggerProvider {
     type Logger = NoopLogger;
 
     fn library_logger(&self, _library: Arc<InstrumentationLibrary>) -> Self::Logger {
-        NoopLogger(())
-    }
-
-    fn versioned_logger(
-        &self,
-        _name: impl Into<Cow<'static, str>>,
-        _version: Option<Cow<'static, str>>,
-        _schema_url: Option<Cow<'static, str>>,
-        _attributes: Option<Vec<KeyValue>>,
-    ) -> Self::Logger {
         NoopLogger(())
     }
 }

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -1,8 +1,8 @@
-use std::{borrow::Cow, sync::Arc, time::SystemTime};
+use std::{borrow::Cow, time::SystemTime};
 
 use crate::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    InstrumentationLibrary, Key,
+    InstrumentationScope, Key,
 };
 
 /// A no-op implementation of a [`LoggerProvider`].
@@ -19,7 +19,7 @@ impl NoopLoggerProvider {
 impl LoggerProvider for NoopLoggerProvider {
     type Logger = NoopLogger;
 
-    fn library_logger(&self, _library: Arc<InstrumentationLibrary>) -> Self::Logger {
+    fn logger_with_scope(&self, _scope: InstrumentationScope) -> Self::Logger {
         NoopLogger(())
     }
 }

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -6,7 +6,7 @@ use crate::metrics::{
     AsyncInstrumentBuilder, Gauge, InstrumentBuilder, InstrumentProvider, ObservableCounter,
     ObservableGauge, ObservableUpDownCounter, UpDownCounter,
 };
-use crate::InstrumentationLibrary;
+use crate::InstrumentationScope;
 
 use super::{Counter, Histogram, HistogramBuilder};
 
@@ -19,25 +19,24 @@ pub trait MeterProvider {
     ///
     /// ```
     /// use std::sync::Arc;
-    /// use opentelemetry::InstrumentationLibrary;
+    /// use opentelemetry::InstrumentationScope;
     /// use opentelemetry::metrics::MeterProvider;
     /// use opentelemetry_sdk::metrics::SdkMeterProvider;
     ///
     /// let provider = SdkMeterProvider::default();
     ///
-    /// // logger used in applications/binaries
+    /// // meter used in applications/binaries
     /// let meter = provider.meter("my_app");
     ///
-    /// // logger used in libraries/crates that optionally includes version and schema url
-    /// let library = std::sync::Arc::new(
-    ///     InstrumentationLibrary::builder(env!("CARGO_PKG_NAME"))
-    ///         .with_version(env!("CARGO_PKG_VERSION"))
-    ///         .with_schema_url("https://opentelemetry.io/schema/1.0.0")
-    ///         .build(),
-    /// );
-    /// let logger = provider.library_meter(library);
+    /// // meter used in libraries/crates that optionally includes version and schema url
+    /// let scope = InstrumentationScope::builder(env!("CARGO_PKG_NAME"))
+    ///     .with_version(env!("CARGO_PKG_VERSION"))
+    ///     .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+    ///     .build();
+    ///
+    /// let meter = provider.meter_with_scope(scope);
     /// ```
-    fn library_meter(&self, library: Arc<InstrumentationLibrary>) -> Meter;
+    fn meter_with_scope(&self, scope: InstrumentationScope) -> Meter;
 
     /// Returns a new [Meter] with the provided name and default configuration.
     ///
@@ -60,8 +59,8 @@ pub trait MeterProvider {
     /// let meter = provider.meter("my_app");
     /// ```
     fn meter(&self, name: &'static str) -> Meter {
-        let library = Arc::new(InstrumentationLibrary::builder(name).build());
-        self.library_meter(library)
+        let scope = InstrumentationScope::builder(name).build();
+        self.meter_with_scope(scope)
     }
 }
 

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -13,31 +13,6 @@ use super::{Counter, Histogram, HistogramBuilder};
 /// Provides access to named [Meter] instances, for instrumenting an application
 /// or crate.
 pub trait MeterProvider {
-    /// Returns a new [Meter] with the given instrumentation library.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::sync::Arc;
-    /// use opentelemetry::InstrumentationScope;
-    /// use opentelemetry::metrics::MeterProvider;
-    /// use opentelemetry_sdk::metrics::SdkMeterProvider;
-    ///
-    /// let provider = SdkMeterProvider::default();
-    ///
-    /// // meter used in applications/binaries
-    /// let meter = provider.meter("my_app");
-    ///
-    /// // meter used in libraries/crates that optionally includes version and schema url
-    /// let scope = InstrumentationScope::builder(env!("CARGO_PKG_NAME"))
-    ///     .with_version(env!("CARGO_PKG_VERSION"))
-    ///     .with_schema_url("https://opentelemetry.io/schema/1.0.0")
-    ///     .build();
-    ///
-    /// let meter = provider.meter_with_scope(scope);
-    /// ```
-    fn meter_with_scope(&self, scope: InstrumentationScope) -> Meter;
-
     /// Returns a new [Meter] with the provided name and default configuration.
     ///
     /// A [Meter] should be scoped at most to a single application or crate. The
@@ -62,6 +37,31 @@ pub trait MeterProvider {
         let scope = InstrumentationScope::builder(name).build();
         self.meter_with_scope(scope)
     }
+
+    /// Returns a new [Meter] with the given instrumentation scope.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use opentelemetry::InstrumentationScope;
+    /// use opentelemetry::metrics::MeterProvider;
+    /// use opentelemetry_sdk::metrics::SdkMeterProvider;
+    ///
+    /// let provider = SdkMeterProvider::default();
+    ///
+    /// // meter used in applications/binaries
+    /// let meter = provider.meter("my_app");
+    ///
+    /// // meter used in libraries/crates that optionally includes version and schema url
+    /// let scope = InstrumentationScope::builder(env!("CARGO_PKG_NAME"))
+    ///     .with_version(env!("CARGO_PKG_VERSION"))
+    ///     .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+    ///     .build();
+    ///
+    /// let meter = provider.meter_with_scope(scope);
+    /// ```
+    fn meter_with_scope(&self, scope: InstrumentationScope) -> Meter;
 }
 
 /// Provides the ability to create instruments for recording measurements or

--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -25,7 +25,7 @@ impl NoopMeterProvider {
 }
 
 impl MeterProvider for NoopMeterProvider {
-    fn library_meter(&self, _library: Arc<crate::InstrumentationLibrary>) -> Meter {
+    fn meter_with_scope(&self, _scope: crate::InstrumentationScope) -> Meter {
         Meter::new(Arc::new(NoopMeter::new()))
     }
 }

--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -25,13 +25,7 @@ impl NoopMeterProvider {
 }
 
 impl MeterProvider for NoopMeterProvider {
-    fn versioned_meter(
-        &self,
-        _name: &'static str,
-        _version: Option<&'static str>,
-        _schema_url: Option<&'static str>,
-        _attributes: Option<Vec<KeyValue>>,
-    ) -> Meter {
+    fn library_meter(&self, _library: Arc<crate::InstrumentationLibrary>) -> Meter {
         Meter::new(Arc::new(NoopMeter::new()))
     }
 }

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -44,6 +44,8 @@
 //!
 //! ```
 //! use opentelemetry::{global, trace::{Span, Tracer, TracerProvider}};
+//! use opentelemetry::InstrumentationLibrary;
+//! use std::sync::Arc;
 //!
 //! fn my_library_function() {
 //!     // Use the global tracer provider to get access to the user-specified
@@ -51,10 +53,12 @@
 //!     let tracer_provider = global::tracer_provider();
 //!
 //!     // Get a tracer for this library
-//!     let tracer = tracer_provider.tracer_builder("my_name").
-//!         with_version(env!("CARGO_PKG_VERSION")).
-//!         with_schema_url("https://opentelemetry.io/schemas/1.17.0").
-//!         build();
+//!     let library = Arc::new(InstrumentationLibrary::builder("my_name")
+//!         .with_version(env!("CARGO_PKG_VERSION"))
+//!         .with_schema_url("https://opentelemetry.io/schemas/1.17.0")
+//!         .build()
+//!     );
+//!     let tracer = tracer_provider.library_tracer(library);
 //!
 //!     // Create spans
 //!     let mut span = tracer.start("doing_work");

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -44,7 +44,7 @@
 //!
 //! ```
 //! use opentelemetry::{global, trace::{Span, Tracer, TracerProvider}};
-//! use opentelemetry::InstrumentationLibrary;
+//! use opentelemetry::InstrumentationScope;
 //! use std::sync::Arc;
 //!
 //! fn my_library_function() {
@@ -53,12 +53,12 @@
 //!     let tracer_provider = global::tracer_provider();
 //!
 //!     // Get a tracer for this library
-//!     let library = Arc::new(InstrumentationLibrary::builder("my_name")
+//!     let scope = InstrumentationScope::builder("my_name")
 //!         .with_version(env!("CARGO_PKG_VERSION"))
 //!         .with_schema_url("https://opentelemetry.io/schemas/1.17.0")
-//!         .build()
-//!     );
-//!     let tracer = tracer_provider.library_tracer(library);
+//!         .build();
+//!
+//!     let tracer = tracer_provider.tracer_with_scope(scope);
 //!
 //!     // Create spans
 //!     let mut span = tracer.start("doing_work");

--- a/opentelemetry/src/trace/noop.rs
+++ b/opentelemetry/src/trace/noop.rs
@@ -6,9 +6,9 @@
 use crate::{
     propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
     trace::{self, TraceContextExt as _},
-    Context, InstrumentationLibrary, KeyValue,
+    Context, InstrumentationScope, KeyValue,
 };
-use std::{borrow::Cow, sync::Arc, time::SystemTime};
+use std::{borrow::Cow, time::SystemTime};
 
 /// A no-op instance of a `TracerProvider`.
 #[derive(Clone, Debug, Default)]
@@ -27,7 +27,7 @@ impl trace::TracerProvider for NoopTracerProvider {
     type Tracer = NoopTracer;
 
     /// Returns a new `NoopTracer` instance.
-    fn library_tracer(&self, _library: Arc<InstrumentationLibrary>) -> Self::Tracer {
+    fn tracer_with_scope(&self, _scope: InstrumentationScope) -> Self::Tracer {
         NoopTracer::new()
     }
 }

--- a/opentelemetry/src/trace/tracer_provider.rs
+++ b/opentelemetry/src/trace/tracer_provider.rs
@@ -1,5 +1,5 @@
-use crate::{trace::Tracer, InstrumentationLibrary};
-use std::{borrow::Cow, sync::Arc};
+use crate::{trace::Tracer, InstrumentationScope};
+use std::borrow::Cow;
 
 /// Types that can create instances of [`Tracer`].
 ///
@@ -29,8 +29,8 @@ pub trait TracerProvider {
     /// let tracer = provider.tracer("my_app");
     /// ```
     fn tracer(&self, name: impl Into<Cow<'static, str>>) -> Self::Tracer {
-        let library = InstrumentationLibrary::builder(name).build();
-        self.library_tracer(Arc::new(library))
+        let scope = InstrumentationScope::builder(name).build();
+        self.tracer_with_scope(scope)
     }
 
     /// Returns a new versioned tracer with the given instrumentation library.
@@ -38,7 +38,7 @@ pub trait TracerProvider {
     /// # Examples
     ///
     /// ```
-    /// use opentelemetry::{global, InstrumentationLibrary, trace::TracerProvider};
+    /// use opentelemetry::{global, InstrumentationScope, trace::TracerProvider};
     ///
     /// let provider = global::tracer_provider();
     ///
@@ -46,14 +46,13 @@ pub trait TracerProvider {
     /// let tracer = provider.tracer("my_app");
     ///
     /// // tracer used in libraries/crates that optionally includes version and schema url
-    /// let library = std::sync::Arc::new(
-    ///     InstrumentationLibrary::builder(env!("CARGO_PKG_NAME"))
+    /// let scope =
+    ///     InstrumentationScope::builder(env!("CARGO_PKG_NAME"))
     ///         .with_version(env!("CARGO_PKG_VERSION"))
     ///         .with_schema_url("https://opentelemetry.io/schema/1.0.0")
-    ///         .build(),
-    /// );
+    ///         .build();
     ///
-    /// let tracer = provider.library_tracer(library);
+    /// let tracer = provider.tracer_with_scope(scope);
     /// ```
-    fn library_tracer(&self, library: Arc<InstrumentationLibrary>) -> Self::Tracer;
+    fn tracer_with_scope(&self, scope: InstrumentationScope) -> Self::Tracer;
 }

--- a/opentelemetry/src/trace/tracer_provider.rs
+++ b/opentelemetry/src/trace/tracer_provider.rs
@@ -33,7 +33,7 @@ pub trait TracerProvider {
         self.tracer_with_scope(scope)
     }
 
-    /// Returns a new versioned tracer with the given instrumentation library.
+    /// Returns a new versioned tracer with the given instrumentation scope.
     ///
     /// # Examples
     ///

--- a/opentelemetry/src/trace/tracer_provider.rs
+++ b/opentelemetry/src/trace/tracer_provider.rs
@@ -1,4 +1,4 @@
-use crate::{trace::Tracer, InstrumentationLibrary, InstrumentationLibraryBuilder, KeyValue};
+use crate::{trace::Tracer, InstrumentationLibrary};
 use std::{borrow::Cow, sync::Arc};
 
 /// Types that can create instances of [`Tracer`].
@@ -27,93 +27,10 @@ pub trait TracerProvider {
     ///
     /// // tracer used in applications/binaries
     /// let tracer = provider.tracer("my_app");
-    ///
-    /// // tracer used in libraries/crates that optionally includes version and schema url
-    /// let tracer = provider.tracer_builder("my_library").
-    ///     with_version(env!("CARGO_PKG_VERSION")).
-    ///     with_schema_url("https://opentelemetry.io/schema/1.0.0").
-    ///     with_attributes([KeyValue::new("key", "value")]).
-    ///     build();
     /// ```
     fn tracer(&self, name: impl Into<Cow<'static, str>>) -> Self::Tracer {
-        self.tracer_builder(name).build()
-    }
-
-    /// Deprecated, use [`TracerProvider::tracer_builder()`]
-    ///
-    /// Returns a new versioned tracer with a given name.
-    ///
-    /// The `name` should be the application name or the name of the library
-    /// providing instrumentation. If the name is empty, then an
-    /// implementation-defined default name may be used instead.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use opentelemetry::{global, trace::TracerProvider};
-    ///
-    /// let provider = global::tracer_provider();
-    ///
-    /// // tracer used in applications/binaries
-    /// let tracer = provider.tracer("my_app");
-    ///
-    /// // tracer used in libraries/crates that optionally includes version and schema url
-    /// let tracer = provider.versioned_tracer(
-    ///     "my_library",
-    ///     Some(env!("CARGO_PKG_VERSION")),
-    ///     Some("https://opentelemetry.io/schema/1.0.0"),
-    ///     None,
-    /// );
-    /// ```
-    #[deprecated(since = "0.23.0", note = "Please use tracer_builder() instead")]
-    fn versioned_tracer(
-        &self,
-        name: impl Into<Cow<'static, str>>,
-        version: Option<impl Into<Cow<'static, str>>>,
-        schema_url: Option<impl Into<Cow<'static, str>>>,
-        attributes: Option<Vec<KeyValue>>,
-    ) -> Self::Tracer {
-        let mut builder = self.tracer_builder(name);
-        if let Some(v) = version {
-            builder = builder.with_version(v);
-        }
-        if let Some(s) = schema_url {
-            builder = builder.with_version(s);
-        }
-        if let Some(a) = attributes {
-            builder = builder.with_attributes(a);
-        }
-
-        builder.build()
-    }
-
-    /// Returns a new builder for creating a [`Tracer`] instance
-    ///
-    /// The `name` should be the application name or the name of the library
-    /// providing instrumentation. If the name is empty, then an
-    /// implementation-defined default name may be used instead.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use opentelemetry::{global, trace::TracerProvider};
-    ///
-    /// let provider = global::tracer_provider();
-    ///
-    /// // tracer used in applications/binaries
-    /// let tracer = provider.tracer_builder("my_app").build();
-    ///
-    /// // tracer used in libraries/crates that optionally includes version and schema url
-    /// let tracer = provider.tracer_builder("my_library")
-    ///     .with_version(env!("CARGO_PKG_VERSION"))
-    ///     .with_schema_url("https://opentelemetry.io/schema/1.0.0")
-    ///     .build();
-    /// ```
-    fn tracer_builder(&self, name: impl Into<Cow<'static, str>>) -> TracerBuilder<'_, Self> {
-        TracerBuilder {
-            provider: self,
-            library_builder: InstrumentationLibrary::builder(name),
-        }
+        let library = InstrumentationLibrary::builder(name).build();
+        self.library_tracer(Arc::new(library))
     }
 
     /// Returns a new versioned tracer with the given instrumentation library.
@@ -139,35 +56,4 @@ pub trait TracerProvider {
     /// let tracer = provider.library_tracer(library);
     /// ```
     fn library_tracer(&self, library: Arc<InstrumentationLibrary>) -> Self::Tracer;
-}
-
-#[derive(Debug)]
-pub struct TracerBuilder<'a, T: TracerProvider + ?Sized> {
-    provider: &'a T,
-    library_builder: InstrumentationLibraryBuilder,
-}
-
-impl<'a, T: TracerProvider + ?Sized> TracerBuilder<'a, T> {
-    pub fn with_version(mut self, version: impl Into<Cow<'static, str>>) -> Self {
-        self.library_builder = self.library_builder.with_version(version);
-        self
-    }
-
-    pub fn with_schema_url(mut self, schema_url: impl Into<Cow<'static, str>>) -> Self {
-        self.library_builder = self.library_builder.with_schema_url(schema_url);
-        self
-    }
-
-    pub fn with_attributes<I>(mut self, attributes: I) -> Self
-    where
-        I: IntoIterator<Item = KeyValue>,
-    {
-        self.library_builder = self.library_builder.with_attributes(attributes);
-        self
-    }
-
-    pub fn build(self) -> T::Tracer {
-        self.provider
-            .library_tracer(Arc::new(self.library_builder.build()))
-    }
 }

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -9,7 +9,7 @@
     ~44 M /sec
 */
 
-use opentelemetry::InstrumentationLibrary;
+use opentelemetry::InstrumentationScope;
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::logs::{LogProcessor, LoggerProvider};
 use tracing::error;
@@ -24,7 +24,7 @@ impl LogProcessor for NoOpLogProcessor {
     fn emit(
         &self,
         _record: &mut opentelemetry_sdk::logs::LogRecord,
-        _library: &InstrumentationLibrary,
+        _scope: &InstrumentationScope,
     ) {
     }
 


### PR DESCRIPTION
Fixes #1527 and fixes #2164

## Changes

The consensus reached during the SIG meeting is that we'd like to unify the builder APIs across signals, limit duplication and keep our traits object-safe. 
- `opentelemetry`
    - Removed deprecated method `InstrumentationLibrary::new`
    - Renamed `InstrumentationLibrary` to `InstrumentationScope`
    - Renamed `InstrumentationLibraryBuilder` to `InstrumentationScopeBuilder`
    - Removed deprecated methods `LoggerProvider::versioned_logger` and `TracerProvider::versioned_tracer`
    - Removed methods `LoggerProvider::logger_builder`, `TracerProvider::tracer_builder` and `MeterProvider::versioned_meter`
    - Replaced these methods with `LoggerProvider::logger_with_scope`, `TracerProvider::logger_with_scope`, `MeterProvider::meter_with_scope`
    - Replaced `global::meter_with_version` with `global::meter_with_scope`
    - Added `global::tracer_with_scope`
- `opentelemetry_sdk`:
    - Removed `InstrumentationLibrary` re-export and its `Scope` alias, use `opentelemetry::InstrumentationLibrary` instead.
    - Unified builders across signals
      - Removed deprecated `LoggerProvider::versioned_logger`, `TracerProvider::versioned_tracer`
      - Removed `MeterProvider::versioned_meter`
      - Replaced these methods with `LoggerProvider::logger_with_scope`, `TracerProvider::logger_with_scope`, `MeterProvider::meter_with_scope`

## Migration guide (example for `logger` but the changes are similar across all 3 signals)

```rust
let provider = LoggerProvider::builder().build();

// Before:
let library = std::sync::Arc::new(
    InstrumentationLibrary::builder("test_logger")
        .with_version("v1.2.3")
        .with_schema_url("https://opentelemetry.io/schema/1.0.0")
        .build(),
);
let logger = provider.library_logger(library); // no longer available, use provider.logger_with_scope


// or maybe (was deprecated):
let logger = provider.versioned_logger(
  "test_logger",
  Some("v1.2.3".into()),
  Some("https://opentelemetry.io/schema/1.0.0".into()),
);

// After:
let scope = InstrumentationScope::builder("test_logger")
  .with_version("v1.2.3")
  .with_schema_url("https://opentelemetry.io/schema/1.0.0")
  .build();

let logger = provider.logger_with_scope(scope);
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
