### PR TITLE
feat: replace OtlpPipeline with exporter builders

### DIFF
--- a/examples/self-diagnostics/src/main.rs
+++ b/examples/self-diagnostics/src/main.rs
@@ -110,7 +110,7 @@ fn init_logger_provider() -> opentelemetry_sdk::logs::LoggerProvider {
 
 fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
     let exporter = MetricsExporter::builder()
-        .with_tonic()
+        .with_http()
         .with_endpoint("http://localhost:4318/v1/metrics")
         .build()
         .unwrap();

--- a/examples/tracing-jaeger/src/main.rs
+++ b/examples/tracing-jaeger/src/main.rs
@@ -4,27 +4,26 @@ use opentelemetry::{
     trace::{TraceContextExt, TraceError, Tracer},
     KeyValue,
 };
-use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::trace::TracerProvider;
 use opentelemetry_sdk::{runtime, trace as sdktrace, Resource};
 use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 
 use std::error::Error;
 
 fn init_tracer_provider() -> Result<opentelemetry_sdk::trace::TracerProvider, TraceError> {
-    opentelemetry_otlp::new_pipeline()
-        .tracing()
-        .with_exporter(
-            opentelemetry_otlp::new_exporter()
-                .tonic()
-                .with_endpoint("http://localhost:4317"),
-        )
-        .with_trace_config(
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .build()?;
+
+    Ok(TracerProvider::builder()
+        .with_batch_exporter(exporter, runtime::Tokio)
+        .with_config(
             sdktrace::Config::default().with_resource(Resource::new(vec![KeyValue::new(
                 SERVICE_NAME,
                 "tracing-jaeger",
             )])),
         )
-        .install_batch(runtime::Tokio)
+        .build())
 }
 
 #[tokio::main]

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -10,8 +10,8 @@ Released 2024-Sep-30
 - Update `opentelemetry-http` dependency version to 0.26
 - Update `opentelemetry-proto` dependency version to 0.26
 - Bump MSRV to 1.71.1 [2140](https://github.com/open-telemetry/opentelemetry-rust/pull/2140)
-- **BREAKING**: [#2217](https://github.com/open-telemetry/opentelemetry-rust/pull/2217)
-  - **Replaced**: The `MetricsExporterBuilder` interface is modified from `with_temporality_selector` to `with_temporality` example can be seen below:
+- **BREAKING**: 
+  - ([#2217](https://github.com/open-telemetry/opentelemetry-rust/pull/2217)) **Replaced**: The `MetricsExporterBuilder` interface is modified from `with_temporality_selector` to `with_temporality` example can be seen below:
     Previous Signature:
     ```rust
     MetricsExporterBuilder::default().with_temporality_selector(DeltaTemporalitySelector::new())
@@ -19,6 +19,34 @@ Released 2024-Sep-30
     Updated Signature:
     ```rust
     MetricsExporterBuilder::default().with_temporality(Temporality::Delta)
+    ```
+  - ([#2221](https://github.com/open-telemetry/opentelemetry-rust/pull/2221)) **Replaced**:
+    - The `opentelemetry_otlp::new_pipeline().{trace,logging,metrics}()` interface is now replaced with `{TracerProvider,SdkMeterProvider,LoggerProvider}::builder()`.
+    - The `opentelemetry_otlp::new_exporter()` interface is now replaced with `{SpanExporter,MetricsExporter,LogExporter}::builder()`.
+
+    Pull request [#2221](https://github.com/open-telemetry/opentelemetry-rust/pull/2221) has a detailed migration guide in the description. See example below,
+    and [basic-otlp](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-otlp/examples/basic-otlp/src/main.rs) for more details:
+
+    Previous Signature:
+    ```rust
+    let logger_provider: LoggerProvider = opentelemetry_otlp::new_pipeline()
+      .logging()
+      .with_exporter(
+          opentelemetry_otlp::new_exporter()
+              .tonic()
+              .with_endpoint("http://localhost:4317")
+      )
+      .install_batch(runtime::Tokio)?;
+    ```
+    Updated Signature:
+    ```rust
+    let logger_provider: LoggerProvider = LoggerProvider::builder()
+      .install_batch_exporter(
+          LogExporter::builder()
+              .with_tonic()
+              .with_endpoint("http://localhost:4317")
+              .build()?,
+      ).build();
     ```
 
 ## v0.25.0

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -6,9 +6,14 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
-use opentelemetry_otlp::Protocol;
-use opentelemetry_otlp::{HttpExporterBuilder, WithExportConfig};
-use opentelemetry_sdk::trace::{self as sdktrace, Config};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_otlp::{LogExporter, MetricsExporter, Protocol, SpanExporter};
+use opentelemetry_sdk::{
+    logs::LoggerProvider,
+    metrics::{PeriodicReader, SdkMeterProvider},
+    runtime,
+    trace::{self as sdktrace, Config, TracerProvider},
+};
 use opentelemetry_sdk::{
     logs::{self as sdklogs},
     Resource,
@@ -17,6 +22,9 @@ use std::error::Error;
 use tracing::info;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
+
+#[cfg(feature = "hyper")]
+use opentelemetry_otlp::WithHttpConfig;
 
 #[cfg(feature = "hyper")]
 mod hyper;
@@ -28,47 +36,46 @@ static RESOURCE: Lazy<Resource> = Lazy::new(|| {
     )])
 });
 
-fn http_exporter() -> HttpExporterBuilder {
-    let exporter = opentelemetry_otlp::new_exporter().http();
-    #[cfg(feature = "hyper")]
-    let exporter = exporter.with_http_client(hyper::HyperClient::default());
-    exporter
-}
-
 fn init_logs() -> Result<sdklogs::LoggerProvider, opentelemetry::logs::LogError> {
-    opentelemetry_otlp::new_pipeline()
-        .logging()
+    let exporter_builder = LogExporter::builder()
+        .with_http()
+        .with_endpoint("http://localhost:4318/v1/logs")
+        .with_protocol(Protocol::HttpBinary);
+
+    #[cfg(feature = "hyper")]
+    let exporter_builder = exporter_builder.with_http_client(hyper::HyperClient::default());
+
+    let exporter = exporter_builder.build()?;
+
+    Ok(LoggerProvider::builder()
+        .with_batch_exporter(exporter, runtime::Tokio)
         .with_resource(RESOURCE.clone())
-        .with_exporter(
-            http_exporter()
-                .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
-                .with_endpoint("http://localhost:4318/v1/logs"),
-        )
-        .install_batch(opentelemetry_sdk::runtime::Tokio)
+        .build())
 }
 
 fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
-    opentelemetry_otlp::new_pipeline()
-        .tracing()
-        .with_exporter(
-            http_exporter()
-                .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
-                .with_endpoint("http://localhost:4318/v1/traces"),
-        )
-        .with_trace_config(Config::default().with_resource(RESOURCE.clone()))
-        .install_batch(opentelemetry_sdk::runtime::Tokio)
+    let exporter = SpanExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
+        .with_endpoint("http://localhost:4318/v1/traces")
+        .build()?;
+    Ok(TracerProvider::builder()
+        .with_batch_exporter(exporter, runtime::Tokio)
+        .with_config(Config::default().with_resource(RESOURCE.clone()))
+        .build())
 }
 
 fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, MetricsError> {
-    opentelemetry_otlp::new_pipeline()
-        .metrics(opentelemetry_sdk::runtime::Tokio)
-        .with_exporter(
-            http_exporter()
-                .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
-                .with_endpoint("http://localhost:4318/v1/metrics"),
-        )
+    let exporter = MetricsExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
+        .with_endpoint("http://localhost:4318/v1/metrics")
+        .build()?;
+
+    Ok(SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(exporter, runtime::Tokio).build())
         .with_resource(RESOURCE.clone())
-        .build()
+        .build())
 }
 
 #[tokio::main]

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -34,7 +34,6 @@ mod logs;
 mod trace;
 
 /// Configuration of the http transport
-#[cfg(any(feature = "http-proto", feature = "http-json"))]
 #[derive(Debug)]
 #[cfg_attr(
     all(
@@ -380,14 +379,12 @@ fn add_header_from_string(input: &str, headers: &mut HashMap<HeaderName, HeaderV
 }
 
 /// Expose interface for modifying builder config.
-#[cfg(any(feature = "http-proto", feature = "http-json"))]
 pub trait HasHttpConfig {
     /// Return a mutable reference to the config within the exporter builders.
     fn http_client_config(&mut self) -> &mut HttpConfig;
 }
 
 /// Expose interface for modifying builder config.
-#[cfg(any(feature = "http-proto", feature = "http-json"))]
 impl HasHttpConfig for HttpExporterBuilder {
     fn http_client_config(&mut self) -> &mut HttpConfig {
         &mut self.http_config

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -69,7 +69,7 @@ pub(crate) mod tonic;
 pub struct ExportConfig {
     /// The address of the OTLP collector. If it's not provided via builder or environment variables.
     /// Default address will be used based on the protocol.
-    pub endpoint: String,
+    pub endpoint: Option<String>,
 
     /// The protocol to use when communicating with the collector.
     pub protocol: Protocol,
@@ -83,7 +83,7 @@ impl Default for ExportConfig {
         let protocol = default_protocol();
 
         ExportConfig {
-            endpoint: "".to_string(),
+            endpoint: None,
             // don't use default_endpoint(protocol) here otherwise we
             // won't know if user provided a value
             protocol,
@@ -199,7 +199,7 @@ pub trait WithExportConfig {
 
 impl<B: HasExportConfig> WithExportConfig for B {
     fn with_endpoint<T: Into<String>>(mut self, endpoint: T) -> Self {
-        self.export_config().endpoint = endpoint.into();
+        self.export_config().endpoint = Some(endpoint.into());
         self
     }
 
@@ -295,7 +295,7 @@ mod tests {
     fn test_default_http_endpoint() {
         let exporter_builder = crate::HttpExporterBuilder::default();
 
-        assert_eq!(exporter_builder.exporter_config.endpoint, "");
+        assert_eq!(exporter_builder.exporter_config.endpoint, None);
     }
 
     #[cfg(feature = "grpc-tonic")]
@@ -303,7 +303,7 @@ mod tests {
     fn test_default_tonic_endpoint() {
         let exporter_builder = crate::TonicExporterBuilder::default();
 
-        assert_eq!(exporter_builder.exporter_config.endpoint, "");
+        assert_eq!(exporter_builder.exporter_config.endpoint, None);
     }
 
     #[test]

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -144,12 +144,13 @@ fn default_headers() -> std::collections::HashMap<String, String> {
     headers
 }
 
-/// Provide access to the export config field within the exporter builders.
+/// Provide access to the [ExportConfig] field within the exporter builders.
 pub trait HasExportConfig {
-    /// Return a mutable reference to the export config within the exporter builders.
+    /// Return a mutable reference to the [ExportConfig] within the exporter builders.
     fn export_config(&mut self) -> &mut ExportConfig;
 }
 
+/// Provide [ExportConfig] access to the [TonicExporterBuilder].
 #[cfg(feature = "grpc-tonic")]
 impl HasExportConfig for TonicExporterBuilder {
     fn export_config(&mut self) -> &mut ExportConfig {
@@ -157,6 +158,7 @@ impl HasExportConfig for TonicExporterBuilder {
     }
 }
 
+/// Provide [ExportConfig] access to the [HttpExporterBuilder].
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
 impl HasExportConfig for HttpExporterBuilder {
     fn export_config(&mut self) -> &mut ExportConfig {
@@ -164,7 +166,7 @@ impl HasExportConfig for HttpExporterBuilder {
     }
 }
 
-/// Expose methods to override export configuration.
+/// Expose methods to override [ExportConfig].
 ///
 /// This trait will be implemented for every struct that implemented [`HasExportConfig`] trait.
 ///
@@ -173,8 +175,8 @@ impl HasExportConfig for HttpExporterBuilder {
 /// # #[cfg(all(feature = "trace", feature = "grpc-tonic"))]
 /// # {
 /// use crate::opentelemetry_otlp::WithExportConfig;
-/// let exporter_builder = opentelemetry_otlp::new_exporter()
-///     .tonic()
+/// let exporter_builder = opentelemetry_otlp::SpanExporter::builder()
+///     .with_tonic()
 ///     .with_endpoint("http://localhost:7201");
 /// # }
 /// ```
@@ -183,11 +185,11 @@ pub trait WithExportConfig {
     fn with_endpoint<T: Into<String>>(self, endpoint: T) -> Self;
     /// Set the protocol to use when communicating with the collector.
     ///
-    /// Note that protocols that are not supported by exporters will be ignore. The exporter
+    /// Note that protocols that are not supported by exporters will be ignored. The exporter
     /// will use default protocol in this case.
     ///
     /// ## Note
-    /// All exporters in this crate are only support one protocol thus choosing the protocol is an no-op at the moment
+    /// All exporters in this crate only support one protocol, thus choosing the protocol is an no-op at the moment.
     fn with_protocol(self, protocol: Protocol) -> Self;
     /// Set the timeout to the collector.
     fn with_timeout(self, timeout: Duration) -> Self;
@@ -291,7 +293,7 @@ mod tests {
     #[cfg(any(feature = "http-proto", feature = "http-json"))]
     #[test]
     fn test_default_http_endpoint() {
-        let exporter_builder = crate::new_exporter().http();
+        let exporter_builder = crate::HttpExporterBuilder::default();
 
         assert_eq!(exporter_builder.exporter_config.endpoint, "");
     }
@@ -299,7 +301,7 @@ mod tests {
     #[cfg(feature = "grpc-tonic")]
     #[test]
     fn test_default_tonic_endpoint() {
-        let exporter_builder = crate::new_exporter().tonic();
+        let exporter_builder = crate::TonicExporterBuilder::default();
 
         assert_eq!(exporter_builder.exporter_config.endpoint, "");
     }

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -25,7 +25,7 @@ mod logs;
 mod metrics;
 
 #[cfg(feature = "trace")]
-mod trace;
+pub(crate) mod trace;
 
 /// Configuration for [tonic]
 ///
@@ -34,14 +34,14 @@ mod trace;
 #[non_exhaustive]
 pub struct TonicConfig {
     /// Custom metadata entries to send to the collector.
-    pub metadata: Option<MetadataMap>,
-
+    pub(crate) metadata: Option<MetadataMap>,
     /// TLS settings for the collector endpoint.
     #[cfg(feature = "tls")]
-    pub tls_config: Option<ClientTlsConfig>,
-
+    pub(crate) tls_config: Option<ClientTlsConfig>,
     /// The compression algorithm to use when communicating with the collector.
-    pub compression: Option<Compression>,
+    pub(crate) compression: Option<Compression>,
+    pub(crate) channel: Option<tonic::transport::Channel>,
+    pub(crate) interceptor: Option<BoxInterceptor>,
 }
 
 impl TryFrom<Compression> for tonic::codec::CompressionEncoding {
@@ -67,21 +67,6 @@ impl TryFrom<Compression> for tonic::codec::CompressionEncoding {
     }
 }
 
-fn resolve_compression(
-    tonic_config: &TonicConfig,
-    env_override: &str,
-) -> Result<Option<CompressionEncoding>, crate::Error> {
-    if let Some(compression) = tonic_config.compression {
-        Ok(Some(compression.try_into()?))
-    } else if let Ok(compression) = env::var(env_override) {
-        Ok(Some(compression.parse::<Compression>()?.try_into()?))
-    } else if let Ok(compression) = env::var(OTEL_EXPORTER_OTLP_COMPRESSION) {
-        Ok(Some(compression.parse::<Compression>()?.try_into()?))
-    } else {
-        Ok(None)
-    }
-}
-
 /// Configuration for the [tonic] OTLP GRPC exporter.
 ///
 /// It allows you to
@@ -101,28 +86,25 @@ fn resolve_compression(
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// // Create a span exporter you can use to when configuring tracer providers
 /// # #[cfg(feature="trace")]
-/// let span_exporter = opentelemetry_otlp::new_exporter().tonic().build_span_exporter()?;
+/// let span_exporter = opentelemetry_otlp::SpanExporter::builder().with_tonic().build()?;
 ///
-/// // Create a metrics exporter you can use when configuring meter providers
+/// // Create a metric exporter you can use when configuring meter providers
 /// # #[cfg(feature="metrics")]
-/// let metrics_exporter = opentelemetry_otlp::new_exporter()
-///     .tonic()
-///     .build_metrics_exporter(
-///         Temporality::default(),
-///     )?;
+/// let metric_exporter = opentelemetry_otlp::MetricsExporter::builder()
+///     .with_tonic()
+///     .with_temporality(Temporality::default())
+///     .build()?;
 ///
 /// // Create a log exporter you can use when configuring logger providers
 /// # #[cfg(feature="logs")]
-/// let log_exporter = opentelemetry_otlp::new_exporter().tonic().build_log_exporter()?;
+/// let log_exporter = opentelemetry_otlp::LogExporter::builder().with_tonic().build()?;
 /// # Ok(())
 /// # }
 /// ```
 #[derive(Debug)]
 pub struct TonicExporterBuilder {
-    pub(crate) exporter_config: ExportConfig,
     pub(crate) tonic_config: TonicConfig,
-    pub(crate) channel: Option<tonic::transport::Channel>,
-    pub(crate) interceptor: Option<BoxInterceptor>,
+    pub(crate) exporter_config: ExportConfig,
 }
 
 pub(crate) struct BoxInterceptor(Box<dyn Interceptor + Send + Sync>);
@@ -140,80 +122,28 @@ impl Debug for BoxInterceptor {
 
 impl Default for TonicExporterBuilder {
     fn default() -> Self {
-        let tonic_config = TonicConfig {
-            metadata: Some(MetadataMap::from_headers(
-                (&default_headers())
-                    .try_into()
-                    .expect("Invalid tonic headers"),
-            )),
-            #[cfg(feature = "tls")]
-            tls_config: None,
-            compression: None,
-        };
-
         TonicExporterBuilder {
+            tonic_config: TonicConfig {
+                metadata: Some(MetadataMap::from_headers(
+                    (&default_headers())
+                        .try_into()
+                        .expect("Invalid tonic headers"),
+                )),
+                #[cfg(feature = "tls")]
+                tls_config: None,
+                compression: None,
+                channel: Option::default(),
+                interceptor: Option::default(),
+            },
             exporter_config: ExportConfig {
                 protocol: crate::Protocol::Grpc,
                 ..Default::default()
             },
-            tonic_config,
-            channel: Option::default(),
-            interceptor: Option::default(),
         }
     }
 }
 
 impl TonicExporterBuilder {
-    /// Set the TLS settings for the collector endpoint.
-    #[cfg(feature = "tls")]
-    pub fn with_tls_config(mut self, tls_config: ClientTlsConfig) -> Self {
-        self.tonic_config.tls_config = Some(tls_config);
-        self
-    }
-
-    /// Set custom metadata entries to send to the collector.
-    pub fn with_metadata(mut self, metadata: MetadataMap) -> Self {
-        // extending metadata maps is harder than just casting back/forth
-        let incoming_headers = metadata.into_headers();
-        let mut existing_headers = self
-            .tonic_config
-            .metadata
-            .unwrap_or_default()
-            .into_headers();
-        existing_headers.extend(incoming_headers);
-
-        self.tonic_config.metadata = Some(MetadataMap::from_headers(existing_headers));
-        self
-    }
-
-    /// Set the compression algorithm to use when communicating with the collector.
-    pub fn with_compression(mut self, compression: Compression) -> Self {
-        self.tonic_config.compression = Some(compression);
-        self
-    }
-
-    /// Use `channel` as tonic's transport channel.
-    /// this will override tls config and should only be used
-    /// when working with non-HTTP transports.
-    ///
-    /// Users MUST make sure the [`ExportConfig::timeout`] is
-    /// the same as the channel's timeout.
-    pub fn with_channel(mut self, channel: tonic::transport::Channel) -> Self {
-        self.channel = Some(channel);
-        self
-    }
-
-    /// Use a custom `interceptor` to modify each outbound request.
-    /// this can be used to modify the grpc metadata, for example
-    /// to inject auth tokens.
-    pub fn with_interceptor<I>(mut self, interceptor: I) -> Self
-    where
-        I: tonic::service::Interceptor + Clone + Send + Sync + 'static,
-    {
-        self.interceptor = Some(BoxInterceptor(Box::new(interceptor)));
-        self
-    }
-
     fn build_channel(
         self,
         signal_endpoint_var: &str,
@@ -221,12 +151,11 @@ impl TonicExporterBuilder {
         signal_compression_var: &str,
         signal_headers_var: &str,
     ) -> Result<(Channel, BoxInterceptor, Option<CompressionEncoding>), crate::Error> {
-        let tonic_config = self.tonic_config;
-        let compression = resolve_compression(&tonic_config, signal_compression_var)?;
+        let compression = self.resolve_compression(signal_compression_var)?;
 
         let headers_from_env = parse_headers_from_env(signal_headers_var);
         let metadata = merge_metadata_with_headers_from_env(
-            tonic_config.metadata.unwrap_or_default(),
+            self.tonic_config.metadata.unwrap_or_default(),
             headers_from_env,
         );
 
@@ -245,7 +174,7 @@ impl TonicExporterBuilder {
             Ok(req)
         };
 
-        let interceptor = match self.interceptor {
+        let interceptor = match self.tonic_config.interceptor {
             Some(mut interceptor) => {
                 BoxInterceptor(Box::new(move |req| interceptor.call(add_metadata(req)?)))
             }
@@ -253,7 +182,7 @@ impl TonicExporterBuilder {
         };
 
         // If a custom channel was provided, use that channel instead of creating one
-        if let Some(channel) = self.channel {
+        if let Some(channel) = self.tonic_config.channel {
             return Ok((channel, interceptor, compression));
         }
 
@@ -291,7 +220,7 @@ impl TonicExporterBuilder {
         };
 
         #[cfg(feature = "tls")]
-        let channel = match tonic_config.tls_config {
+        let channel = match self.tonic_config.tls_config {
             Some(tls_config) => endpoint
                 .tls_config(tls_config)
                 .map_err(crate::Error::from)?,
@@ -306,9 +235,24 @@ impl TonicExporterBuilder {
         Ok((channel, interceptor, compression))
     }
 
+    fn resolve_compression(
+        &self,
+        env_override: &str,
+    ) -> Result<Option<CompressionEncoding>, crate::Error> {
+        if let Some(compression) = self.tonic_config.compression {
+            Ok(Some(compression.try_into()?))
+        } else if let Ok(compression) = env::var(env_override) {
+            Ok(Some(compression.parse::<Compression>()?.try_into()?))
+        } else if let Ok(compression) = env::var(OTEL_EXPORTER_OTLP_COMPRESSION) {
+            Ok(Some(compression.parse::<Compression>()?.try_into()?))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Build a new tonic log exporter
     #[cfg(feature = "logs")]
-    pub fn build_log_exporter(
+    pub(crate) fn build_log_exporter(
         self,
     ) -> Result<crate::logs::LogExporter, opentelemetry::logs::LogError> {
         use crate::exporter::tonic::logs::TonicLogsClient;
@@ -327,7 +271,7 @@ impl TonicExporterBuilder {
 
     /// Build a new tonic metrics exporter
     #[cfg(feature = "metrics")]
-    pub fn build_metrics_exporter(
+    pub(crate) fn build_metrics_exporter(
         self,
         temporality: opentelemetry_sdk::metrics::data::Temporality,
     ) -> opentelemetry::metrics::Result<crate::MetricsExporter> {
@@ -348,7 +292,7 @@ impl TonicExporterBuilder {
 
     /// Build a new tonic span exporter
     #[cfg(feature = "trace")]
-    pub fn build_span_exporter(
+    pub(crate) fn build_span_exporter(
         self,
     ) -> Result<crate::SpanExporter, opentelemetry::trace::TraceError> {
         use crate::exporter::tonic::trace::TonicTracesClient;
@@ -396,9 +340,105 @@ fn parse_headers_from_env(signal_headers_var: &str) -> HeaderMap {
         .unwrap_or_default()
 }
 
+/// Expose interface for modifying [TonicConfig] fields within the exporter builders.
+pub trait HasTonicConfig {
+    /// Return a mutable reference to the export config within the exporter builders.
+    fn tonic_config(&mut self) -> &mut TonicConfig;
+}
+
+/// Expose interface for modifying [TonicConfig] fields within the [TonicExporterBuilder].
+impl HasTonicConfig for TonicExporterBuilder {
+    fn tonic_config(&mut self) -> &mut TonicConfig {
+        &mut self.tonic_config
+    }
+}
+
+/// Expose methods to override [TonicConfig].
+///
+/// This trait will be implemented for every struct that implemented [`HasTonicConfig`] trait.
+///
+/// ## Examples
+/// ```
+/// # #[cfg(all(feature = "trace", feature = "grpc-tonic"))]
+/// # {
+/// use crate::opentelemetry_otlp::{WithExportConfig, WithTonicConfig};
+/// let exporter_builder = opentelemetry_otlp::SpanExporter::builder()
+///     .with_tonic()
+///     .with_compression(opentelemetry_otlp::Compression::Gzip);
+/// # }
+/// ```
+pub trait WithTonicConfig {
+    /// Set the TLS settings for the collector endpoint.
+    #[cfg(feature = "tls")]
+    fn with_tls_config(self, tls_config: ClientTlsConfig) -> Self;
+
+    /// Set custom metadata entries to send to the collector.
+    fn with_metadata(self, metadata: MetadataMap) -> Self;
+
+    /// Set the compression algorithm to use when communicating with the collector.
+    fn with_compression(self, compression: Compression) -> Self;
+
+    /// Use `channel` as tonic's transport channel.
+    /// this will override tls config and should only be used
+    /// when working with non-HTTP transports.
+    ///
+    /// Users MUST make sure the [`ExportConfig::timeout`] is
+    /// the same as the channel's timeout.
+    fn with_channel(self, channel: tonic::transport::Channel) -> Self;
+
+    /// Use a custom `interceptor` to modify each outbound request.
+    /// this can be used to modify the grpc metadata, for example
+    /// to inject auth tokens.
+    fn with_interceptor<I>(self, interceptor: I) -> Self
+    where
+        I: tonic::service::Interceptor + Clone + Send + Sync + 'static;
+}
+
+impl<B: HasTonicConfig> WithTonicConfig for B {
+    #[cfg(feature = "tls")]
+    fn with_tls_config(mut self, tls_config: ClientTlsConfig) -> Self {
+        self.tonic_config().tls_config = Some(tls_config);
+        self
+    }
+
+    /// Set custom metadata entries to send to the collector.
+    fn with_metadata(mut self, metadata: MetadataMap) -> Self {
+        // extending metadata maps is harder than just casting back/forth
+        let mut existing_headers = self
+            .tonic_config()
+            .metadata
+            .clone()
+            .unwrap_or_default()
+            .into_headers();
+        existing_headers.extend(metadata.into_headers());
+
+        self.tonic_config().metadata = Some(MetadataMap::from_headers(existing_headers));
+        self
+    }
+
+    fn with_compression(mut self, compression: Compression) -> Self {
+        self.tonic_config().compression = Some(compression);
+        self
+    }
+
+    fn with_channel(mut self, channel: tonic::transport::Channel) -> Self {
+        self.tonic_config().channel = Some(channel);
+        self
+    }
+
+    fn with_interceptor<I>(mut self, interceptor: I) -> Self
+    where
+        I: tonic::service::Interceptor + Clone + Send + Sync + 'static,
+    {
+        self.tonic_config().interceptor = Some(BoxInterceptor(Box::new(interceptor)));
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::exporter::tests::run_env_test;
+    use crate::exporter::tonic::WithTonicConfig;
     #[cfg(feature = "grpc-tonic")]
     use crate::exporter::Compression;
     use crate::TonicExporterBuilder;
@@ -413,7 +453,9 @@ mod tests {
         metadata.insert("foo", "bar".parse().unwrap());
         let builder = TonicExporterBuilder::default().with_metadata(metadata);
         let result = builder.tonic_config.metadata.unwrap();
-        let foo = result.get("foo").unwrap();
+        let foo = result
+            .get("foo")
+            .expect("there to always be an entry for foo");
         assert_eq!(foo, &MetadataValue::try_from("bar").unwrap());
         assert!(result.get("User-Agent").is_some());
 

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -496,7 +496,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "grpc-tonic")]
     fn test_convert_compression() {
         #[cfg(feature = "gzip-tonic")]
         assert!(tonic::codec::CompressionEncoding::try_from(Compression::Gzip).is_ok());

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -36,12 +36,11 @@
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //!     // First, create a OTLP exporter builder. Configure it as you need.
-//!     let otlp_exporter = opentelemetry_otlp::new_exporter().tonic();
+//!     let otlp_exporter = opentelemetry_otlp::SpanExporter::builder().with_tonic().build()?;
 //!     // Then pass it into pipeline builder
-//!     let _ = opentelemetry_otlp::new_pipeline()
-//!         .tracing()
-//!         .with_exporter(otlp_exporter)
-//!         .install_simple()?;
+//!     let _ = opentelemetry_sdk::trace::TracerProvider::builder()
+//!         .with_simple_exporter(otlp_exporter)
+//!         .build();
 //!     let tracer = global::tracer("my_tracer");
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...
@@ -70,10 +69,15 @@
 //! # #[cfg(all(feature = "trace", feature = "grpc-tonic"))]
 //! # {
 //! # fn main() -> Result<(), opentelemetry::trace::TraceError> {
-//! let tracer = opentelemetry_otlp::new_pipeline()
-//!     .tracing()
-//!     .with_exporter(opentelemetry_otlp::new_exporter().tonic())
-//!     .install_batch(opentelemetry_sdk::runtime::AsyncStd)?;
+//! let tracer = opentelemetry_sdk::trace::TracerProvider::builder()
+//!        .with_batch_exporter(
+//!            opentelemetry_otlp::SpanExporter::builder()
+//!                .with_tonic()
+//!                .build()?,
+//!            opentelemetry_sdk::runtime::AsyncStd,
+//!         )
+//!        .build();
+//!
 //! # Ok(())
 //! # }
 //! # }
@@ -115,18 +119,18 @@
 //!
 //! Example showing how to override all configuration options.
 //!
-//! Generally there are two parts of configuration. One is metrics config
-//! or tracing config. Users can config it via [`OtlpTracePipeline`]
-//! or [`OtlpMetricPipeline`]. The other is exporting configuration.
-//! Users can set those configurations using [`OtlpExporterPipeline`] based
-//! on the choice of exporters.
+//! Generally there are two parts of configuration. One is the exporter, the other is the provider.
+//! Users can configure the exporter using [SpanExporter::builder()] for traces,
+//! and [MetricsExporter::builder()] + [opentelemetry_sdk::metrics::PeriodicReader::builder()] for metrics.
+//! Once you have an exporter, you can add it to either a [opentelemetry_sdk::trace::TracerProvider::builder()] for traces,
+//! or [opentelemetry_sdk::metrics::SdkMeterProvider::builder()] for metrics.
 //!
 //! ```no_run
 //! use opentelemetry::{global, KeyValue, trace::Tracer};
 //! use opentelemetry_sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
 //! # #[cfg(feature = "metrics")]
 //! use opentelemetry_sdk::metrics::data::Temporality;
-//! use opentelemetry_otlp::{Protocol, WithExportConfig, ExportConfig};
+//! use opentelemetry_otlp::{Protocol, WithExportConfig, WithTonicConfig};
 //! use std::time::Duration;
 //! # #[cfg(feature = "grpc-tonic")]
 //! use tonic::metadata::*;
@@ -139,26 +143,24 @@
 //!     map.insert("x-host", "example.com".parse().unwrap());
 //!     map.insert("x-number", "123".parse().unwrap());
 //!     map.insert_bin("trace-proto-bin", MetadataValue::from_bytes(b"[binary data]"));
+//!     let exporter = opentelemetry_otlp::SpanExporter::builder()
+//!         .with_tonic()
+//!         .with_endpoint("http://localhost:4317")
+//!         .with_timeout(Duration::from_secs(3))
+//!         .with_metadata(map)
+//!         .build()?;
 //!
-//!     let tracer_provider = opentelemetry_otlp::new_pipeline()
-//!         .tracing()
-//!         .with_exporter(
-//!             opentelemetry_otlp::new_exporter()
-//!             .tonic()
-//!             .with_endpoint("http://localhost:4317")
-//!             .with_timeout(Duration::from_secs(3))
-//!             .with_metadata(map)
-//!          )
-//!         .with_trace_config(
-//!             trace::config()
+//!     let tracer_provider = opentelemetry_sdk::trace::TracerProvider::builder()
+//!         .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+//!         .with_config(
+//!             trace::Config::default()
 //!                 .with_sampler(Sampler::AlwaysOn)
 //!                 .with_id_generator(RandomIdGenerator::default())
 //!                 .with_max_events_per_span(64)
 //!                 .with_max_attributes_per_span(16)
 //!                 .with_max_events_per_span(16)
 //!                 .with_resource(Resource::new(vec![KeyValue::new("service.name", "example")])),
-//!         )
-//!         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+//!         ).build();
 //!     global::set_tracer_provider(tracer_provider);
 //!     let tracer = global::tracer("tracer-name");
 //!         # tracer
@@ -166,23 +168,22 @@
 //!
 //!     # #[cfg(all(feature = "metrics", feature = "grpc-tonic"))]
 //!     # {
-//!     let export_config = ExportConfig {
-//!         endpoint: "http://localhost:4317".to_string(),
-//!         timeout: Duration::from_secs(3),
-//!         protocol: Protocol::Grpc
-//!     };
+//!     let exporter = opentelemetry_otlp::MetricsExporter::builder()
+//!        .with_tonic()
+//!        .with_endpoint("http://localhost:4318/v1/metrics")
+//!        .with_protocol(Protocol::Grpc)
+//!        .with_timeout(Duration::from_secs(3))
+//!        .build()
+//!        .unwrap();
 //!
-//!     let meter = opentelemetry_otlp::new_pipeline()
-//!         .metrics(opentelemetry_sdk::runtime::Tokio)
-//!         .with_exporter(
-//!             opentelemetry_otlp::new_exporter()
-//!                 .tonic()
-//!                 .with_export_config(export_config),
-//!                 // can also config it using with_* functions like the tracing part above.
-//!         )
-//!         .with_resource(Resource::new(vec![KeyValue::new("service.name", "example")]))
-//!         .with_period(Duration::from_secs(3))
+//!    let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::Tokio)
+//!        .with_interval(std::time::Duration::from_secs(3))
 //!         .with_timeout(Duration::from_secs(10))
+//!        .build();
+//!
+//!    let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+//!        .with_reader(reader)
+//!         .with_resource(Resource::new(vec![KeyValue::new("service.name", "example")]))
 //!         .build();
 //!     # }
 //!
@@ -215,34 +216,43 @@
 
 mod exporter;
 #[cfg(feature = "logs")]
+#[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 mod logs;
 #[cfg(feature = "metrics")]
+#[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 mod metric;
 #[cfg(feature = "trace")]
+#[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 mod span;
 
 pub use crate::exporter::Compression;
 pub use crate::exporter::ExportConfig;
 #[cfg(feature = "trace")]
+#[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 pub use crate::span::{
-    OtlpTracePipeline, SpanExporter, SpanExporterBuilder, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
-    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_HEADERS,
-    OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
+    SpanExporter, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
+    OTEL_EXPORTER_OTLP_TRACES_HEADERS, OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
 };
 
 #[cfg(feature = "metrics")]
+#[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 pub use crate::metric::{
-    MetricsExporter, MetricsExporterBuilder, OtlpMetricPipeline,
-    OTEL_EXPORTER_OTLP_METRICS_COMPRESSION, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
+    MetricsExporter, OTEL_EXPORTER_OTLP_METRICS_COMPRESSION, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
     OTEL_EXPORTER_OTLP_METRICS_HEADERS, OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
 };
 
 #[cfg(feature = "logs")]
+#[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 pub use crate::logs::{
-    LogExporter, LogExporterBuilder, OtlpLogPipeline, OTEL_EXPORTER_OTLP_LOGS_COMPRESSION,
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, OTEL_EXPORTER_OTLP_LOGS_HEADERS,
-    OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
+    LogExporter, OTEL_EXPORTER_OTLP_LOGS_COMPRESSION, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
+    OTEL_EXPORTER_OTLP_LOGS_HEADERS, OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
 };
+
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
+pub use crate::exporter::http::{HasHttpConfig, WithHttpConfig};
+
+#[cfg(feature = "grpc-tonic")]
+pub use crate::exporter::tonic::{HasTonicConfig, WithTonicConfig};
 
 pub use crate::exporter::{
     HasExportConfig, WithExportConfig, OTEL_EXPORTER_OTLP_COMPRESSION, OTEL_EXPORTER_OTLP_ENDPOINT,
@@ -253,6 +263,24 @@ pub use crate::exporter::{
 
 use opentelemetry_sdk::export::ExportError;
 
+/// Type to indicate the builder does not have a client set.
+#[derive(Debug, Default, Clone)]
+pub struct NoExporterBuilderSet;
+
+/// Type to hold the [TonicExporterBuilder] and indicate it has been set.
+///
+/// Allowing access to [TonicExporterBuilder] specific configuration methods.
+#[cfg(feature = "grpc-tonic")]
+#[derive(Debug, Default)]
+pub struct TonicExporterBuilderSet(TonicExporterBuilder);
+
+/// Type to hold the [HttpExporterBuilder] and indicate it has been set.
+///
+/// Allowing access to [HttpExporterBuilder] specific configuration methods.
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
+#[derive(Debug, Default)]
+pub struct HttpExporterBuilderSet(HttpExporterBuilder);
+
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
 pub use crate::exporter::http::HttpExporterBuilder;
 
@@ -261,55 +289,6 @@ pub use crate::exporter::tonic::{TonicConfig, TonicExporterBuilder};
 
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
-
-/// General builder for both tracing and metrics.
-#[derive(Debug)]
-pub struct OtlpPipeline;
-
-/// Build a OTLP metrics or tracing exporter builder. See functions below to understand
-/// what's currently supported.
-#[derive(Debug)]
-pub struct OtlpExporterPipeline;
-
-impl OtlpExporterPipeline {
-    /// Use tonic as grpc layer, return a `TonicExporterBuilder` to config tonic and build the exporter.
-    ///
-    /// This exporter can be used in both `tracing` and `metrics` pipeline.
-    #[cfg(feature = "grpc-tonic")]
-    pub fn tonic(self) -> TonicExporterBuilder {
-        TonicExporterBuilder::default()
-    }
-
-    /// Use HTTP as transport layer, return a `HttpExporterBuilder` to config the http transport
-    /// and build the exporter.
-    ///
-    /// This exporter can be used in both `tracing` and `metrics` pipeline.
-    #[cfg(any(feature = "http-proto", feature = "http-json"))]
-    pub fn http(self) -> HttpExporterBuilder {
-        HttpExporterBuilder::default()
-    }
-}
-
-/// Create a new pipeline builder with the recommended configuration.
-///
-/// ## Examples
-///
-/// ```no_run
-/// fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-///     # #[cfg(feature = "trace")]
-///     let tracing_builder = opentelemetry_otlp::new_pipeline().tracing();
-///
-///     Ok(())
-/// }
-/// ```
-pub fn new_pipeline() -> OtlpPipeline {
-    OtlpPipeline
-}
-
-/// Create a builder to build OTLP metrics exporter or tracing exporter.
-pub fn new_exporter() -> OtlpExporterPipeline {
-    OtlpExporterPipeline
-}
 
 /// Wrap type for errors from this crate.
 #[derive(thiserror::Error, Debug)]

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -21,12 +21,15 @@
 //! $ docker run -p 4317:4317 otel/opentelemetry-collector:latest
 //! ```
 //!
-//! Then install a new pipeline with the recommended defaults to start exporting
-//! telemetry. You will have to build a OTLP exporter first.
+//! Then create a new `Exporter`, and `Provider` with the recommended defaults to start exporting
+//! telemetry.
 //!
-//! Exporting pipelines can be started with `new_pipeline().tracing()` and
-//! `new_pipeline().metrics()`, and `new_pipeline().logging()` respectively for
-//! traces, metrics and logs.
+//! You will have to build a OTLP exporter first. Create the correct exporter based on the signal
+//! you are looking to export `SpanExporter::builder()`, `MetricsExporter::builder()`,
+//! `LogExporter::builder()` respectively for traces, metrics, and logs.
+//!
+//! Once you have the exporter, you can create your `Provider` by starting with `TracerProvider::builder()`,
+//! `SdkMeterProvider::builder()`, and `LoggerProvider::builder()` respectively for traces, metrics, and logs.
 //!
 //! ```no_run
 //! # #[cfg(all(feature = "trace", feature = "grpc-tonic"))]
@@ -37,7 +40,7 @@
 //! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //!     // First, create a OTLP exporter builder. Configure it as you need.
 //!     let otlp_exporter = opentelemetry_otlp::SpanExporter::builder().with_tonic().build()?;
-//!     // Then pass it into pipeline builder
+//!     // Then pass it into provider builder
 //!     let _ = opentelemetry_sdk::trace::TracerProvider::builder()
 //!         .with_simple_exporter(otlp_exporter)
 //!         .build();
@@ -74,7 +77,7 @@
 //!            opentelemetry_otlp::SpanExporter::builder()
 //!                .with_tonic()
 //!                .build()?,
-//!            opentelemetry_sdk::runtime::AsyncStd,
+//!            opentelemetry_sdk::runtime::Tokio,
 //!         )
 //!        .build();
 //!

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -2,20 +2,20 @@
 //!
 //! Defines a [LogExporter] to send logs via the OpenTelemetry Protocol (OTLP)
 
-#[cfg(feature = "grpc-tonic")]
-use crate::exporter::tonic::TonicExporterBuilder;
-
-#[cfg(feature = "http-proto")]
-use crate::exporter::http::HttpExporterBuilder;
-
-use crate::{NoExporterConfig, OtlpPipeline};
 use async_trait::async_trait;
 use std::fmt::Debug;
 
-use opentelemetry::logs::{LogError, LogResult};
+use opentelemetry::logs::LogResult;
 
 use opentelemetry_sdk::export::logs::LogBatch;
-use opentelemetry_sdk::{runtime::RuntimeChannel, Resource};
+
+use crate::{HasExportConfig, NoExporterBuilderSet};
+
+#[cfg(feature = "grpc-tonic")]
+use crate::{HasTonicConfig, TonicExporterBuilder, TonicExporterBuilderSet};
+
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
+use crate::{HasHttpConfig, HttpExporterBuilder, HttpExporterBuilderSet};
 
 /// Compression algorithm to use, defaults to none.
 pub const OTEL_EXPORTER_OTLP_LOGS_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_LOGS_COMPRESSION";
@@ -32,53 +32,73 @@ pub const OTEL_EXPORTER_OTLP_LOGS_TIMEOUT: &str = "OTEL_EXPORTER_OTLP_LOGS_TIMEO
 /// Note: this is only supported for HTTP.
 pub const OTEL_EXPORTER_OTLP_LOGS_HEADERS: &str = "OTEL_EXPORTER_OTLP_LOGS_HEADERS";
 
-impl OtlpPipeline {
-    /// Create a OTLP logging pipeline.
-    pub fn logging(self) -> OtlpLogPipeline<NoExporterConfig> {
-        OtlpLogPipeline {
-            resource: None,
-            exporter_builder: NoExporterConfig(()),
-            batch_config: None,
+#[derive(Debug, Default, Clone)]
+pub struct LogExporterBuilder<C> {
+    client: C,
+    endpoint: Option<String>,
+}
+
+impl LogExporterBuilder<NoExporterBuilderSet> {
+    pub fn new() -> Self {
+        LogExporterBuilder::default()
+    }
+
+    #[cfg(feature = "grpc-tonic")]
+    pub fn with_tonic(self) -> LogExporterBuilder<TonicExporterBuilderSet> {
+        LogExporterBuilder {
+            client: TonicExporterBuilderSet(TonicExporterBuilder::default()),
+            endpoint: self.endpoint,
         }
     }
-}
 
-/// OTLP log exporter builder
-#[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
-#[non_exhaustive]
-pub enum LogExporterBuilder {
-    /// Tonic log exporter builder
-    #[cfg(feature = "grpc-tonic")]
-    Tonic(TonicExporterBuilder),
-    /// Http log exporter builder
-    #[cfg(feature = "http-proto")]
-    Http(HttpExporterBuilder),
-}
-
-impl LogExporterBuilder {
-    /// Build a OTLP log exporter using the given configuration.
-    pub fn build_log_exporter(self) -> Result<LogExporter, LogError> {
-        match self {
-            #[cfg(feature = "grpc-tonic")]
-            LogExporterBuilder::Tonic(builder) => builder.build_log_exporter(),
-            #[cfg(feature = "http-proto")]
-            LogExporterBuilder::Http(builder) => builder.build_log_exporter(),
+    #[cfg(any(feature = "http-proto", feature = "http-json"))]
+    pub fn with_http(self) -> LogExporterBuilder<HttpExporterBuilderSet> {
+        LogExporterBuilder {
+            client: HttpExporterBuilderSet(HttpExporterBuilder::default()),
+            endpoint: self.endpoint,
         }
     }
 }
 
 #[cfg(feature = "grpc-tonic")]
-impl From<TonicExporterBuilder> for LogExporterBuilder {
-    fn from(exporter: TonicExporterBuilder) -> Self {
-        LogExporterBuilder::Tonic(exporter)
+impl LogExporterBuilder<TonicExporterBuilderSet> {
+    pub fn build(self) -> Result<LogExporter, opentelemetry::logs::LogError> {
+        self.client.0.build_log_exporter()
     }
 }
 
-#[cfg(feature = "http-proto")]
-impl From<HttpExporterBuilder> for LogExporterBuilder {
-    fn from(exporter: HttpExporterBuilder) -> Self {
-        LogExporterBuilder::Http(exporter)
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
+impl LogExporterBuilder<HttpExporterBuilderSet> {
+    pub fn build(self) -> Result<LogExporter, opentelemetry::logs::LogError> {
+        self.client.0.build_log_exporter()
+    }
+}
+
+#[cfg(feature = "grpc-tonic")]
+impl HasExportConfig for LogExporterBuilder<TonicExporterBuilderSet> {
+    fn export_config(&mut self) -> &mut crate::ExportConfig {
+        &mut self.client.0.exporter_config
+    }
+}
+
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
+impl HasExportConfig for LogExporterBuilder<HttpExporterBuilderSet> {
+    fn export_config(&mut self) -> &mut crate::ExportConfig {
+        &mut self.client.0.exporter_config
+    }
+}
+
+#[cfg(feature = "grpc-tonic")]
+impl HasTonicConfig for LogExporterBuilder<TonicExporterBuilderSet> {
+    fn tonic_config(&mut self) -> &mut crate::TonicConfig {
+        &mut self.client.0.tonic_config
+    }
+}
+
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
+impl HasHttpConfig for LogExporterBuilder<HttpExporterBuilderSet> {
+    fn http_client_config(&mut self) -> &mut crate::exporter::http::HttpConfig {
+        &mut self.client.0.http_config
     }
 }
 
@@ -89,6 +109,11 @@ pub struct LogExporter {
 }
 
 impl LogExporter {
+    /// Obtain a builder to configure a [LogExporter].
+    pub fn builder() -> LogExporterBuilder<NoExporterBuilderSet> {
+        LogExporterBuilder::default()
+    }
+
     /// Create a new log exporter
     pub fn new(client: impl opentelemetry_sdk::export::logs::LogExporter + 'static) -> Self {
         LogExporter {
@@ -106,107 +131,4 @@ impl opentelemetry_sdk::export::logs::LogExporter for LogExporter {
     fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
         self.client.set_resource(resource);
     }
-}
-
-/// Recommended configuration for an OTLP exporter pipeline.
-#[derive(Debug)]
-pub struct OtlpLogPipeline<EB> {
-    exporter_builder: EB,
-    resource: Option<Resource>,
-    batch_config: Option<opentelemetry_sdk::logs::BatchConfig>,
-}
-
-impl<EB> OtlpLogPipeline<EB> {
-    /// Set the Resource associated with log provider.
-    pub fn with_resource(self, resource: Resource) -> Self {
-        OtlpLogPipeline {
-            resource: Some(resource),
-            ..self
-        }
-    }
-
-    /// Set the batch log processor configuration, and it will override the env vars.
-    pub fn with_batch_config(mut self, batch_config: opentelemetry_sdk::logs::BatchConfig) -> Self {
-        self.batch_config = Some(batch_config);
-        self
-    }
-}
-
-impl OtlpLogPipeline<NoExporterConfig> {
-    /// Set the OTLP log exporter builder.
-    pub fn with_exporter<B: Into<LogExporterBuilder>>(
-        self,
-        pipeline: B,
-    ) -> OtlpLogPipeline<LogExporterBuilder> {
-        OtlpLogPipeline {
-            exporter_builder: pipeline.into(),
-            resource: self.resource,
-            batch_config: self.batch_config,
-        }
-    }
-}
-
-impl OtlpLogPipeline<LogExporterBuilder> {
-    /// Install the configured log exporter.
-    ///
-    /// Returns a [`LoggerProvider`].
-    ///
-    /// [`LoggerProvider`]: opentelemetry_sdk::logs::LoggerProvider
-    pub fn install_simple(self) -> Result<opentelemetry_sdk::logs::LoggerProvider, LogError> {
-        Ok(build_simple_with_exporter(
-            self.exporter_builder.build_log_exporter()?,
-            self.resource,
-        ))
-    }
-
-    /// Install the configured log exporter and a batch log processor using the
-    /// specified runtime.
-    ///
-    /// Returns a [`LoggerProvider`].
-    ///
-    /// [`LoggerProvider`]: opentelemetry_sdk::logs::LoggerProvider
-    pub fn install_batch<R: RuntimeChannel>(
-        self,
-        runtime: R,
-    ) -> Result<opentelemetry_sdk::logs::LoggerProvider, LogError> {
-        Ok(build_batch_with_exporter(
-            self.exporter_builder.build_log_exporter()?,
-            self.resource,
-            runtime,
-            self.batch_config,
-        ))
-    }
-}
-
-fn build_simple_with_exporter(
-    exporter: LogExporter,
-    resource: Option<Resource>,
-) -> opentelemetry_sdk::logs::LoggerProvider {
-    let mut provider_builder =
-        opentelemetry_sdk::logs::LoggerProvider::builder().with_simple_exporter(exporter);
-    if let Some(resource) = resource {
-        provider_builder = provider_builder.with_resource(resource);
-    }
-    // logger would be created in the appenders like
-    // opentelemetry-appender-tracing, opentelemetry-appender-log etc.
-    provider_builder.build()
-}
-
-fn build_batch_with_exporter<R: RuntimeChannel>(
-    exporter: LogExporter,
-    resource: Option<Resource>,
-    runtime: R,
-    batch_config: Option<opentelemetry_sdk::logs::BatchConfig>,
-) -> opentelemetry_sdk::logs::LoggerProvider {
-    let mut provider_builder = opentelemetry_sdk::logs::LoggerProvider::builder();
-    let batch_processor = opentelemetry_sdk::logs::BatchLogProcessor::builder(exporter, runtime)
-        .with_batch_config(batch_config.unwrap_or_default())
-        .build();
-    provider_builder = provider_builder.with_log_processor(batch_processor);
-
-    if let Some(resource) = resource {
-        provider_builder = provider_builder.with_resource(resource);
-    }
-    // logger would be created in the tracing appender
-    provider_builder.build()
 }

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -67,7 +67,6 @@ impl<C> MetricsExporterBuilder<C> {
         }
     }
 
-    #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
     pub fn with_temporality(self, temporality: Temporality) -> MetricsExporterBuilder<C> {
         MetricsExporterBuilder {
             client: self.client,

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -5,20 +5,21 @@
 use std::fmt::Debug;
 
 use futures_core::future::BoxFuture;
-use opentelemetry::trace::TraceError;
-use opentelemetry_sdk::{
-    self as sdk,
-    export::trace::{ExportResult, SpanData},
-};
-use sdk::runtime::RuntimeChannel;
+use opentelemetry_sdk::export::trace::{ExportResult, SpanData};
 
 #[cfg(feature = "grpc-tonic")]
-use crate::exporter::tonic::TonicExporterBuilder;
+use crate::{
+    exporter::tonic::{HasTonicConfig, TonicExporterBuilder},
+    TonicExporterBuilderSet,
+};
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
-use crate::exporter::http::HttpExporterBuilder;
+use crate::{
+    exporter::http::{HasHttpConfig, HttpExporterBuilder},
+    HttpExporterBuilderSet,
+};
 
-use crate::{NoExporterConfig, OtlpPipeline};
+use crate::{exporter::HasExportConfig, NoExporterBuilderSet};
 
 /// Target to which the exporter is going to send spans, defaults to https://localhost:4317/v1/traces.
 /// Learn about the relationship between this constant and default/metrics/logs at
@@ -34,167 +35,72 @@ pub const OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_TRAC
 /// Note: this is only supported for HTTP.
 pub const OTEL_EXPORTER_OTLP_TRACES_HEADERS: &str = "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
 
-impl OtlpPipeline {
-    /// Create a OTLP tracing pipeline.
-    pub fn tracing(self) -> OtlpTracePipeline<NoExporterConfig> {
-        OtlpTracePipeline {
-            exporter_builder: NoExporterConfig(()),
-            trace_config: None,
-            batch_config: None,
-        }
-    }
+#[derive(Debug, Default, Clone)]
+pub struct SpanExporterBuilder<C> {
+    client: C,
 }
 
-/// Recommended configuration for an OTLP exporter pipeline.
-///
-/// ## Examples
-///
-/// ```no_run
-/// let tracing_pipeline = opentelemetry_otlp::new_pipeline().tracing();
-/// ```
-#[derive(Debug)]
-pub struct OtlpTracePipeline<EB> {
-    exporter_builder: EB,
-    trace_config: Option<sdk::trace::Config>,
-    batch_config: Option<sdk::trace::BatchConfig>,
-}
-
-impl<EB> OtlpTracePipeline<EB> {
-    /// Set the trace provider configuration.
-    pub fn with_trace_config(mut self, trace_config: sdk::trace::Config) -> Self {
-        self.trace_config = Some(trace_config);
-        self
+impl SpanExporterBuilder<NoExporterBuilderSet> {
+    pub fn new() -> Self {
+        SpanExporterBuilder::default()
     }
 
-    /// Set the batch span processor configuration, and it will override the env vars.
-    pub fn with_batch_config(mut self, batch_config: sdk::trace::BatchConfig) -> Self {
-        self.batch_config = Some(batch_config);
-        self
-    }
-}
-
-impl OtlpTracePipeline<NoExporterConfig> {
-    /// Set the OTLP span exporter builder.
-    ///
-    /// Note that the pipeline will not build the exporter until [`install_batch`] or [`install_simple`]
-    /// is called.
-    ///
-    /// [`install_batch`]: OtlpTracePipeline::install_batch
-    /// [`install_simple`]: OtlpTracePipeline::install_simple
-    pub fn with_exporter<B: Into<SpanExporterBuilder>>(
-        self,
-        pipeline: B,
-    ) -> OtlpTracePipeline<SpanExporterBuilder> {
-        OtlpTracePipeline {
-            exporter_builder: pipeline.into(),
-            trace_config: self.trace_config,
-            batch_config: self.batch_config,
-        }
-    }
-}
-
-impl OtlpTracePipeline<SpanExporterBuilder> {
-    /// Install the configured span exporter.
-    ///
-    /// Returns a [`TracerProvider`].
-    ///
-    /// [`TracerProvider`]: opentelemetry::trace::TracerProvider
-    pub fn install_simple(self) -> Result<sdk::trace::TracerProvider, TraceError> {
-        Ok(build_simple_with_exporter(
-            self.exporter_builder.build_span_exporter()?,
-            self.trace_config,
-        ))
-    }
-
-    /// Install the configured span exporter and a batch span processor using the
-    /// specified runtime.
-    ///
-    /// Returns a [`TracerProvider`].
-    ///
-    /// `install_batch` will panic if not called within a tokio runtime
-    ///
-    /// [`TracerProvider`]: opentelemetry::trace::TracerProvider
-    pub fn install_batch<R: RuntimeChannel>(
-        self,
-        runtime: R,
-    ) -> Result<sdk::trace::TracerProvider, TraceError> {
-        Ok(build_batch_with_exporter(
-            self.exporter_builder.build_span_exporter()?,
-            self.trace_config,
-            runtime,
-            self.batch_config,
-        ))
-    }
-}
-
-fn build_simple_with_exporter(
-    exporter: SpanExporter,
-    trace_config: Option<sdk::trace::Config>,
-) -> sdk::trace::TracerProvider {
-    let mut provider_builder = sdk::trace::TracerProvider::builder().with_simple_exporter(exporter);
-    if let Some(config) = trace_config {
-        provider_builder = provider_builder.with_config(config);
-    }
-
-    provider_builder.build()
-}
-
-fn build_batch_with_exporter<R: RuntimeChannel>(
-    exporter: SpanExporter,
-    trace_config: Option<sdk::trace::Config>,
-    runtime: R,
-    batch_config: Option<sdk::trace::BatchConfig>,
-) -> sdk::trace::TracerProvider {
-    let mut provider_builder = sdk::trace::TracerProvider::builder();
-    let batch_processor = sdk::trace::BatchSpanProcessor::builder(exporter, runtime)
-        .with_batch_config(batch_config.unwrap_or_default())
-        .build();
-    provider_builder = provider_builder.with_span_processor(batch_processor);
-
-    if let Some(config) = trace_config {
-        provider_builder = provider_builder.with_config(config);
-    }
-    provider_builder.build()
-}
-
-/// OTLP span exporter builder.
-#[derive(Debug)]
-// This enum only used during initialization stage of application. The overhead should be OK.
-// Users can also disable the unused features to make the overhead on object size smaller.
-#[allow(clippy::large_enum_variant)]
-#[non_exhaustive]
-pub enum SpanExporterBuilder {
-    /// Tonic span exporter builder
     #[cfg(feature = "grpc-tonic")]
-    Tonic(TonicExporterBuilder),
-    /// Http span exporter builder
-    #[cfg(any(feature = "http-proto", feature = "http-json"))]
-    Http(HttpExporterBuilder),
-}
+    pub fn with_tonic(self) -> SpanExporterBuilder<TonicExporterBuilderSet> {
+        SpanExporterBuilder {
+            client: TonicExporterBuilderSet(TonicExporterBuilder::default()),
+        }
+    }
 
-impl SpanExporterBuilder {
-    /// Build a OTLP span exporter using the given tonic configuration and exporter configuration.
-    pub fn build_span_exporter(self) -> Result<SpanExporter, TraceError> {
-        match self {
-            #[cfg(feature = "grpc-tonic")]
-            SpanExporterBuilder::Tonic(builder) => builder.build_span_exporter(),
-            #[cfg(any(feature = "http-proto", feature = "http-json"))]
-            SpanExporterBuilder::Http(builder) => builder.build_span_exporter(),
+    #[cfg(any(feature = "http-proto", feature = "http-json"))]
+    pub fn with_http(self) -> SpanExporterBuilder<HttpExporterBuilderSet> {
+        SpanExporterBuilder {
+            client: HttpExporterBuilderSet(HttpExporterBuilder::default()),
         }
     }
 }
 
 #[cfg(feature = "grpc-tonic")]
-impl From<TonicExporterBuilder> for SpanExporterBuilder {
-    fn from(exporter: TonicExporterBuilder) -> Self {
-        SpanExporterBuilder::Tonic(exporter)
+impl SpanExporterBuilder<TonicExporterBuilderSet> {
+    pub fn build(self) -> Result<SpanExporter, opentelemetry::trace::TraceError> {
+        let span_exporter = self.client.0.build_span_exporter()?;
+        Ok(SpanExporter::new(span_exporter))
     }
 }
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
-impl From<HttpExporterBuilder> for SpanExporterBuilder {
-    fn from(exporter: HttpExporterBuilder) -> Self {
-        SpanExporterBuilder::Http(exporter)
+impl SpanExporterBuilder<HttpExporterBuilderSet> {
+    pub fn build(self) -> Result<SpanExporter, opentelemetry::trace::TraceError> {
+        let span_exporter = self.client.0.build_span_exporter()?;
+        Ok(SpanExporter::new(span_exporter))
+    }
+}
+
+#[cfg(feature = "grpc-tonic")]
+impl HasExportConfig for SpanExporterBuilder<TonicExporterBuilderSet> {
+    fn export_config(&mut self) -> &mut crate::ExportConfig {
+        &mut self.client.0.exporter_config
+    }
+}
+
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
+impl HasExportConfig for SpanExporterBuilder<HttpExporterBuilderSet> {
+    fn export_config(&mut self) -> &mut crate::ExportConfig {
+        &mut self.client.0.exporter_config
+    }
+}
+
+#[cfg(feature = "grpc-tonic")]
+impl HasTonicConfig for SpanExporterBuilder<TonicExporterBuilderSet> {
+    fn tonic_config(&mut self) -> &mut crate::TonicConfig {
+        &mut self.client.0.tonic_config
+    }
+}
+
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
+impl HasHttpConfig for SpanExporterBuilder<HttpExporterBuilderSet> {
+    fn http_client_config(&mut self) -> &mut crate::exporter::http::HttpConfig {
+        &mut self.client.0.http_config
     }
 }
 
@@ -203,6 +109,11 @@ impl From<HttpExporterBuilder> for SpanExporterBuilder {
 pub struct SpanExporter(Box<dyn opentelemetry_sdk::export::trace::SpanExporter>);
 
 impl SpanExporter {
+    /// Obtain a builder to configure a [SpanExporter].
+    pub fn builder() -> SpanExporterBuilder<NoExporterBuilderSet> {
+        SpanExporterBuilder::default()
+    }
+
     /// Build a new span exporter from a client
     pub fn new(client: impl opentelemetry_sdk::export::trace::SpanExporter + 'static) -> Self {
         SpanExporter(Box::new(client))

--- a/opentelemetry-otlp/tests/integration_test/tests/traces.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/traces.rs
@@ -16,16 +16,18 @@ use std::io::Write;
 use std::os::unix::fs::MetadataExt;
 
 fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
-    opentelemetry_otlp::new_pipeline()
-        .tracing()
-        .with_exporter(opentelemetry_otlp::new_exporter().tonic())
-        .with_trace_config(
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .build()?;
+    Ok(opentelemetry_sdk::trace::TracerProvider::builder()
+        .with_batch_exporter(exporter, runtime::Tokio)
+        .with_config(
             sdktrace::Config::default().with_resource(Resource::new(vec![KeyValue::new(
                 opentelemetry_semantic_conventions::resource::SERVICE_NAME,
                 "basic-otlp-tracing-example",
             )])),
         )
-        .install_batch(runtime::Tokio)
+        .build())
 }
 
 const LEMONS_KEY: Key = Key::from_static_str("lemons");

--- a/opentelemetry-otlp/tests/smoke.rs
+++ b/opentelemetry-otlp/tests/smoke.rs
@@ -2,7 +2,7 @@ use futures_util::StreamExt;
 use opentelemetry::global;
 use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::trace::{Span, SpanKind, Tracer};
-use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_otlp::{WithExportConfig, WithTonicConfig};
 use opentelemetry_proto::tonic::collector::trace::v1::{
     trace_service_server::{TraceService, TraceServiceServer},
     ExportTraceServiceRequest, ExportTraceServiceResponse,
@@ -84,23 +84,26 @@ async fn smoke_tracer() {
         println!("Installing tracer provider...");
         let mut metadata = tonic::metadata::MetadataMap::new();
         metadata.insert("x-header-key", "header-value".parse().unwrap());
-        let tracer_provider = opentelemetry_otlp::new_pipeline()
-            .tracing()
-            .with_exporter(
+        let tracer_provider = opentelemetry_sdk::trace::TracerProvider::builder()
+            .with_batch_exporter(
                 #[cfg(feature = "gzip-tonic")]
-                opentelemetry_otlp::new_exporter()
-                    .tonic()
+                opentelemetry_otlp::SpanExporter::builder()
+                    .with_tonic()
                     .with_compression(opentelemetry_otlp::Compression::Gzip)
                     .with_endpoint(format!("http://{}", addr))
-                    .with_metadata(metadata),
+                    .with_metadata(metadata)
+                    .build()
+                    .expect("gzip-tonic SpanExporter failed to build"),
                 #[cfg(not(feature = "gzip-tonic"))]
-                opentelemetry_otlp::new_exporter()
-                    .tonic()
+                opentelemetry_otlp::SpanExporter::builder()
+                    .with_tonic()
                     .with_endpoint(format!("http://{}", addr))
-                    .with_metadata(metadata),
+                    .with_metadata(metadata)
+                    .build()
+                    .expect("NON gzip-tonic SpanExporter failed to build"),
+                opentelemetry_sdk::runtime::Tokio,
             )
-            .install_batch(opentelemetry_sdk::runtime::Tokio)
-            .expect("failed to install");
+            .build();
 
         global::set_tracer_provider(tracer_provider);
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Implement `LogRecord::set_trace_context` for `LogRecord`. Respect any trace context set on a `LogRecord` when emitting through a `Logger`.
 - Improved `LoggerProvider` shutdown handling to prevent redundant shutdown calls when `drop` is invoked. [#2195](https://github.com/open-telemetry/opentelemetry-rust/pull/2195)
 - **BREAKING**: [#2217](https://github.com/open-telemetry/opentelemetry-rust/pull/2217)
-  - **Replaced**: Removed `{Delta,Cumulative}TemporalitySelector::new()` in favor of directly using `Temporality` enum to simplify the configuration of MetricExporterBuilder with different temporalities.
+  - **Replaced**: Removed `{Delta,Cumulative}TemporalitySelector::new()` in favor of directly using `Temporality` enum to simplify the configuration of MetricsExporterBuilder with different temporalities.
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry-sdk/src/metrics/exporter.rs
+++ b/opentelemetry-sdk/src/metrics/exporter.rs
@@ -29,6 +29,6 @@ pub trait PushMetricsExporter: Send + Sync + 'static {
     /// instead will return an error indicating the shutdown state.
     fn shutdown(&self) -> Result<()>;
 
-    /// Access the [Temporality] of the MetricExporter.
+    /// Access the [Temporality] of the MetricsExporter.
     fn temporality(&self) -> Temporality;
 }

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -18,7 +18,7 @@ use super::{
 /// flow.
 ///
 /// Typically, push-based exporters that are periodic will implement
-/// `MetricExporter` themselves and construct a `PeriodicReader` to satisfy this
+/// `MetricsExporter` themselves and construct a `PeriodicReader` to satisfy this
 /// interface.
 ///
 /// Pull-based exporters will typically implement `MetricReader` themselves,

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -440,7 +440,7 @@ mod tests {
             assert_telemetry_resource(&default_config_provider);
         });
 
-        // If user provided a resource, use that.
+        // If user provided config, use that.
         let custom_config_provider = super::TracerProvider::builder()
             .with_config(Config {
                 resource: Cow::Owned(Resource::new(vec![KeyValue::new(


### PR DESCRIPTION
Fixes #1810

# Migration Guide

To move from `opentelemetry_otlp::new_exporter()`, and `opentelemetry_otlp::new_pipeline().{tracing,metrics,logging}()`, you will need to select the `Exporter`, and `Provider` for the signal you are using.

Below there is a guide with details about Exporters and Providers. There are also Examples for each type of signal.

## Exporter Guide
The following are the available exporters:
- SpanExporter
- MetricsExporter
- LogExporter

The exporter interface should have the same options as with the old method. For example, a tonic grpc exporter being configured old vs new:
```rust
// old
let old_exporter = opentelemetry_otlp::new_exporter()
  .tonic()
  .with_endpoint("http://localhost:4317");

// new
let new_exporter = SpanExporter::builder()
  .tonic()
  .with_endpoint("http://localhost:4317")
  .build()?; // note: you need to build the exporter after setting configuration.
```

## Provider Guide
The following are the available providers:
- TracingProvider
- SdkMeterProvider
- LoggerProvider

The provider interface should be similar to the old method. For example, a `TracerProvider` being configured old vs new:
```rust
// old
let tracer_provider: TracerProvider = opentelemetry_otlp::new_pipeline()
    .tracing()
    .with_exporter(old_exporter /* ^^ See exporter guide above ^^ */)
    .with_trace_config(Config::default().with_resource(RESOURCE.clone()))
    .install_batch(runtime::Tokio)?;

// new
let tracer_provider: TracerProvider = TracerProvider::builder()
    .with_batch_exporter(new_exporter /* ^^ See exporter guide above ^^ */, runtime::Tokio)
    .with_config(Config::default().with_resource(RESOURCE.clone()))
    .build(); // note: you need to build the provider after setting configuration.
```

# Signal Examples
### Trace Example
```rust
// old
fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
    opentelemetry_otlp::new_pipeline()
        .tracing()
        .with_exporter(
            opentelemetry_otlp::new_exporter()
                .tonic()
                .with_endpoint("http://localhost:4317"),
        )
        .with_trace_config(Config::default().with_resource(RESOURCE.clone()))
        .install_batch(runtime::Tokio)
}

// new
fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
    let exporter = SpanExporter::builder()
        .with_tonic()
        .with_endpoint("http://localhost:4317")
        .build()?;
    Ok(sdktrace::TracerProvider::builder()
        .with_config(Config::default().with_resource(RESOURCE.clone()))
        .with_batch_exporter(exporter, runtime::Tokio)
        .build())
}
```

### Metric Example
```rust
// old
fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, MetricsError> {
    let export_config = ExportConfig {
        endpoint: "http://localhost:4317".to_string(),
        ..ExportConfig::default()
    };
    opentelemetry_otlp::new_pipeline()
        .metrics(runtime::Tokio)
        .with_exporter(
            opentelemetry_otlp::new_exporter()
                .tonic()
                .with_export_config(export_config),
        )
}

// new
fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, MetricsError> {
    let exporter = MetricsExporter::builder().with_tonic().build()?;

    let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();

    Ok(SdkMeterProvider::builder()
        .with_reader(reader)
        .with_resource(RESOURCE.clone())
        .build())
}
```
### Log Example
```rust
// old
fn init_logs() -> Result<opentelemetry_sdk::logs::LoggerProvider, LogError> {
    opentelemetry_otlp::new_pipeline()
        .logging()
        .with_resource(RESOURCE.clone())
        .with_exporter(
            opentelemetry_otlp::new_exporter()
                .tonic()
                .with_endpoint("http://localhost:4317"),
        )
        .install_batch(runtime::Tokio)
        .with_batch_exporter(exporter, runtime::Tokio)
        .build())
}

// new
fn init_logs() -> Result<opentelemetry_sdk::logs::LoggerProvider, LogError> {
    let exporter = LogExporter::builder()
        .with_tonic()
        .with_endpoint("http://localhost:4317")
        .build()?;
  
    Ok(LoggerProvider::builder()
        .with_resource(RESOURCE.clone())
        .with_exporter(
            exporter,
        )
        .with_batch_exporter(exporter, runtime::Tokio)
        .build())
}
```

## Changes

Started to replace the `OTLPPipeline` pattern in the `opentelemetry-otlp` crate.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
