### PR TITLE
Fix integration tests failure for traces.

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/expected/failed_traces.json
+++ b/opentelemetry-otlp/tests/integration_test/expected/failed_traces.json
@@ -21,6 +21,7 @@
               "traceId": "9b458af7378cba65253d7042d34fc72e",
               "spanId": "cd7cf7bf939930b7",
               "parentSpanId": "",
+              "flags": 1,
               "name": "Sub operation...",
               "kind": 1,
               "startTimeUnixNano": "1703985537070566698",
@@ -40,32 +41,12 @@
                 }
               ],
               "status": {}
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "service.name",
-            "value": {
-              "stringValue": "basic-otlp-tracing-example"
-            }
-          }
-        ]
-      },
-      "scopeSpans": [
-        {
-          "scope": {
-            "name": "ex.com/basic"
-          },
-          "spans": [
+            },
             {
               "traceId": "9b458af7378cba65253d7042d34fc72e",
               "spanId": "d58cf2d702a061e0",
               "parentSpanId": "cd7cf7bf939930b7",
+              "flags": 1,
               "name": "operation",
               "kind": 1,
               "startTimeUnixNano": "1703985537070558635",

--- a/opentelemetry-otlp/tests/integration_test/expected/traces.json
+++ b/opentelemetry-otlp/tests/integration_test/expected/traces.json
@@ -21,6 +21,7 @@
               "traceId": "9b458af7378cba65253d7042d34fc72e",
               "spanId": "cd7cf7bf939930b7",
               "parentSpanId": "d58cf2d702a061e0",
+              "flags": 1,
               "name": "Sub operation...",
               "kind": 1,
               "startTimeUnixNano": "1703985537070566698",
@@ -40,32 +41,12 @@
                 }
               ],
               "status": {}
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "service.name",
-            "value": {
-              "stringValue": "basic-otlp-tracing-example"
-            }
-          }
-        ]
-      },
-      "scopeSpans": [
-        {
-          "scope": {
-            "name": "ex.com/basic"
-          },
-          "spans": [
+            },
             {
               "traceId": "9b458af7378cba65253d7042d34fc72e",
               "spanId": "d58cf2d702a061e0",
               "parentSpanId": "",
+              "flags": 1,
               "name": "operation",
               "kind": 1,
               "startTimeUnixNano": "1703985537070558635",
@@ -87,12 +68,6 @@
                       "key": "bogons",
                       "value": {
                         "intValue": "100"
-                      }
-                    },
-                    {
-                      "key": "number/int",
-                      "value": {
-                        "intValue": 100
                       }
                     }
                   ]

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -1,1 +1,1 @@
-cargo test ./opentelemetry-otlp/tests/integration_test/tests -- --ignored
+cd ./opentelemetry-otlp/tests/integration_test/tests  && cargo test -- --ignored


### PR DESCRIPTION
## Changes

The integration tests were not running for long (fix in #1219), so the below changes got missed out there:

- Update OTLP proto version to 1.1.0 #1482 (adding `flag`)
- Group Logs and Spans by Resource and Instrumentation Scope in OTLP Exporter #1873 (grouping logs and traces)

Fixing these test to align with the above changes.


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
