### PR TITLE
[Metrics API] Update Instrument Provider and remove `try_init` methods

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improved `LoggerProvider` shutdown handling to prevent redundant shutdown calls when `drop` is invoked. [#2195](https://github.com/open-telemetry/opentelemetry-rust/pull/2195)
 - **BREAKING**: [#2217](https://github.com/open-telemetry/opentelemetry-rust/pull/2217)
   - **Replaced**: Removed `{Delta,Cumulative}TemporalitySelector::new()` in favor of directly using `Temporality` enum to simplify the configuration of MetricExporterBuilder with different temporalities.
+- When creating new metric instruments, SDK would return a no-op instrument if the validation fails. [#2166](https://github.com/open-telemetry/opentelemetry-rust/pull/2166)
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -69,14 +69,14 @@ impl SdkMeter {
         &self,
         builder: InstrumentBuilder<'_, Counter<T>>,
         resolver: &InstrumentResolver<'_, T>,
-    ) -> Result<Counter<T>>
+    ) -> Counter<T>
     where
         T: Number,
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
             global::handle_error(err);
-            return Ok(Counter::new(Arc::new(NoopSyncInstrument::new())));
+            return Counter::new(Arc::new(NoopSyncInstrument::new()));
         }
 
         match resolver
@@ -89,10 +89,10 @@ impl SdkMeter {
             )
             .map(|i| Counter::new(Arc::new(i)))
         {
-            Ok(counter) => Ok(counter),
+            Ok(counter) => counter,
             Err(err) => {
                 global::handle_error(err);
-                Ok(Counter::new(Arc::new(NoopSyncInstrument::new())))
+                Counter::new(Arc::new(NoopSyncInstrument::new()))
             }
         }
     }
@@ -101,125 +101,143 @@ impl SdkMeter {
         &self,
         builder: AsyncInstrumentBuilder<'_, ObservableCounter<T>, T>,
         resolver: &InstrumentResolver<'_, T>,
-    ) -> Result<ObservableCounter<T>>
+    ) -> ObservableCounter<T>
     where
         T: Number,
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
             global::handle_error(err);
-            return Ok(ObservableCounter::new());
+            return ObservableCounter::new();
         }
 
-        let ms = resolver.measures(
+        match resolver.measures(
             InstrumentKind::ObservableCounter,
             builder.name,
             builder.description,
             builder.unit,
             None,
-        )?;
+        ) {
+            Ok(ms) => {
+                if ms.is_empty() {
+                    return ObservableCounter::new();
+                }
 
-        if ms.is_empty() {
-            return Ok(ObservableCounter::new());
+                let observable = Arc::new(Observable::new(ms));
+
+                for callback in builder.callbacks {
+                    let cb_inst = Arc::clone(&observable);
+                    self.pipes
+                        .register_callback(move || callback(cb_inst.as_ref()));
+                }
+
+                ObservableCounter::new()
+            }
+            Err(err) => {
+                global::handle_error(err);
+                ObservableCounter::new()
+            }
         }
-
-        let observable = Arc::new(Observable::new(ms));
-
-        for callback in builder.callbacks {
-            let cb_inst = Arc::clone(&observable);
-            self.pipes
-                .register_callback(move || callback(cb_inst.as_ref()));
-        }
-
-        Ok(ObservableCounter::new())
     }
 
     fn create_observable_updown_counter<T>(
         &self,
         builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<T>, T>,
         resolver: &InstrumentResolver<'_, T>,
-    ) -> Result<ObservableUpDownCounter<T>>
+    ) -> ObservableUpDownCounter<T>
     where
         T: Number,
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
             global::handle_error(err);
-            return Ok(ObservableUpDownCounter::new());
+            return ObservableUpDownCounter::new();
         }
 
-        let ms = resolver.measures(
+        match resolver.measures(
             InstrumentKind::ObservableUpDownCounter,
             builder.name,
             builder.description,
             builder.unit,
             None,
-        )?;
+        ) {
+            Ok(ms) => {
+                if ms.is_empty() {
+                    return ObservableUpDownCounter::new();
+                }
 
-        if ms.is_empty() {
-            return Ok(ObservableUpDownCounter::new());
+                let observable = Arc::new(Observable::new(ms));
+
+                for callback in builder.callbacks {
+                    let cb_inst = Arc::clone(&observable);
+                    self.pipes
+                        .register_callback(move || callback(cb_inst.as_ref()));
+                }
+
+                ObservableUpDownCounter::new()
+            }
+            Err(err) => {
+                global::handle_error(err);
+                ObservableUpDownCounter::new()
+            }
         }
-
-        let observable = Arc::new(Observable::new(ms));
-
-        for callback in builder.callbacks {
-            let cb_inst = Arc::clone(&observable);
-            self.pipes
-                .register_callback(move || callback(cb_inst.as_ref()));
-        }
-
-        Ok(ObservableUpDownCounter::new())
     }
 
     fn create_observable_gauge<T>(
         &self,
         builder: AsyncInstrumentBuilder<'_, ObservableGauge<T>, T>,
         resolver: &InstrumentResolver<'_, T>,
-    ) -> Result<ObservableGauge<T>>
+    ) -> ObservableGauge<T>
     where
         T: Number,
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
             global::handle_error(err);
-            return Ok(ObservableGauge::new());
+            return ObservableGauge::new();
         }
 
-        let ms = resolver.measures(
+        match resolver.measures(
             InstrumentKind::ObservableGauge,
             builder.name,
             builder.description,
             builder.unit,
             None,
-        )?;
+        ) {
+            Ok(ms) => {
+                if ms.is_empty() {
+                    return ObservableGauge::new();
+                }
 
-        if ms.is_empty() {
-            return Ok(ObservableGauge::new());
+                let observable = Arc::new(Observable::new(ms));
+
+                for callback in builder.callbacks {
+                    let cb_inst = Arc::clone(&observable);
+                    self.pipes
+                        .register_callback(move || callback(cb_inst.as_ref()));
+                }
+
+                ObservableGauge::new()
+            }
+            Err(err) => {
+                global::handle_error(err);
+                ObservableGauge::new()
+            }
         }
-
-        let observable = Arc::new(Observable::new(ms));
-
-        for callback in builder.callbacks {
-            let cb_inst = Arc::clone(&observable);
-            self.pipes
-                .register_callback(move || callback(cb_inst.as_ref()));
-        }
-
-        Ok(ObservableGauge::new())
     }
 
     fn create_updown_counter<T>(
         &self,
         builder: InstrumentBuilder<'_, UpDownCounter<T>>,
         resolver: &InstrumentResolver<'_, T>,
-    ) -> Result<UpDownCounter<T>>
+    ) -> UpDownCounter<T>
     where
         T: Number,
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
             global::handle_error(err);
-            return Ok(UpDownCounter::new(Arc::new(NoopSyncInstrument::new())));
+            return UpDownCounter::new(Arc::new(NoopSyncInstrument::new()));
         }
 
         match resolver
@@ -232,10 +250,10 @@ impl SdkMeter {
             )
             .map(|i| UpDownCounter::new(Arc::new(i)))
         {
-            Ok(updown_counter) => Ok(updown_counter),
+            Ok(updown_counter) => updown_counter,
             Err(err) => {
                 global::handle_error(err);
-                Ok(UpDownCounter::new(Arc::new(NoopSyncInstrument::new())))
+                UpDownCounter::new(Arc::new(NoopSyncInstrument::new()))
             }
         }
     }
@@ -244,14 +262,14 @@ impl SdkMeter {
         &self,
         builder: InstrumentBuilder<'_, Gauge<T>>,
         resolver: &InstrumentResolver<'_, T>,
-    ) -> Result<Gauge<T>>
+    ) -> Gauge<T>
     where
         T: Number,
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
             global::handle_error(err);
-            return Ok(Gauge::new(Arc::new(NoopSyncInstrument::new())));
+            return Gauge::new(Arc::new(NoopSyncInstrument::new()));
         }
 
         match resolver
@@ -264,10 +282,10 @@ impl SdkMeter {
             )
             .map(|i| Gauge::new(Arc::new(i)))
         {
-            Ok(gauge) => Ok(gauge),
+            Ok(gauge) => gauge,
             Err(err) => {
                 global::handle_error(err);
-                Ok(Gauge::new(Arc::new(NoopSyncInstrument::new())))
+                Gauge::new(Arc::new(NoopSyncInstrument::new()))
             }
         }
     }
@@ -276,14 +294,14 @@ impl SdkMeter {
         &self,
         builder: HistogramBuilder<'_, Histogram<T>>,
         resolver: &InstrumentResolver<'_, T>,
-    ) -> Result<Histogram<T>>
+    ) -> Histogram<T>
     where
         T: Number,
     {
         let validation_result = validate_instrument_config(builder.name.as_ref(), &builder.unit);
         if let Err(err) = validation_result {
             global::handle_error(err);
-            return Ok(Histogram::new(Arc::new(NoopSyncInstrument::new())));
+            return Histogram::new(Arc::new(NoopSyncInstrument::new()));
         }
 
         match resolver
@@ -296,10 +314,10 @@ impl SdkMeter {
             )
             .map(|i| Histogram::new(Arc::new(i)))
         {
-            Ok(histogram) => Ok(histogram),
+            Ok(histogram) => histogram,
             Err(err) => {
                 global::handle_error(err);
-                Ok(Histogram::new(Arc::new(NoopSyncInstrument::new())))
+                Histogram::new(Arc::new(NoopSyncInstrument::new()))
             }
         }
     }
@@ -307,12 +325,12 @@ impl SdkMeter {
 
 #[doc(hidden)]
 impl InstrumentProvider for SdkMeter {
-    fn u64_counter(&self, builder: InstrumentBuilder<'_, Counter<u64>>) -> Result<Counter<u64>> {
+    fn u64_counter(&self, builder: InstrumentBuilder<'_, Counter<u64>>) -> Counter<u64> {
         let resolver = InstrumentResolver::new(self, &self.u64_resolver);
         self.create_counter(builder, &resolver)
     }
 
-    fn f64_counter(&self, builder: InstrumentBuilder<'_, Counter<f64>>) -> Result<Counter<f64>> {
+    fn f64_counter(&self, builder: InstrumentBuilder<'_, Counter<f64>>) -> Counter<f64> {
         let resolver = InstrumentResolver::new(self, &self.f64_resolver);
         self.create_counter(builder, &resolver)
     }
@@ -320,7 +338,7 @@ impl InstrumentProvider for SdkMeter {
     fn u64_observable_counter(
         &self,
         builder: AsyncInstrumentBuilder<'_, ObservableCounter<u64>, u64>,
-    ) -> Result<ObservableCounter<u64>> {
+    ) -> ObservableCounter<u64> {
         let resolver = InstrumentResolver::new(self, &self.u64_resolver);
         self.create_observable_counter(builder, &resolver)
     }
@@ -328,7 +346,7 @@ impl InstrumentProvider for SdkMeter {
     fn f64_observable_counter(
         &self,
         builder: AsyncInstrumentBuilder<'_, ObservableCounter<f64>, f64>,
-    ) -> Result<ObservableCounter<f64>> {
+    ) -> ObservableCounter<f64> {
         let resolver = InstrumentResolver::new(self, &self.f64_resolver);
         self.create_observable_counter(builder, &resolver)
     }
@@ -336,7 +354,7 @@ impl InstrumentProvider for SdkMeter {
     fn i64_up_down_counter(
         &self,
         builder: InstrumentBuilder<'_, UpDownCounter<i64>>,
-    ) -> Result<UpDownCounter<i64>> {
+    ) -> UpDownCounter<i64> {
         let resolver = InstrumentResolver::new(self, &self.i64_resolver);
         self.create_updown_counter(builder, &resolver)
     }
@@ -344,7 +362,7 @@ impl InstrumentProvider for SdkMeter {
     fn f64_up_down_counter(
         &self,
         builder: InstrumentBuilder<'_, UpDownCounter<f64>>,
-    ) -> Result<UpDownCounter<f64>> {
+    ) -> UpDownCounter<f64> {
         let resolver = InstrumentResolver::new(self, &self.f64_resolver);
         self.create_updown_counter(builder, &resolver)
     }
@@ -352,7 +370,7 @@ impl InstrumentProvider for SdkMeter {
     fn i64_observable_up_down_counter(
         &self,
         builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<i64>, i64>,
-    ) -> Result<ObservableUpDownCounter<i64>> {
+    ) -> ObservableUpDownCounter<i64> {
         let resolver = InstrumentResolver::new(self, &self.i64_resolver);
         self.create_observable_updown_counter(builder, &resolver)
     }
@@ -360,22 +378,22 @@ impl InstrumentProvider for SdkMeter {
     fn f64_observable_up_down_counter(
         &self,
         builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<f64>, f64>,
-    ) -> Result<ObservableUpDownCounter<f64>> {
+    ) -> ObservableUpDownCounter<f64> {
         let resolver = InstrumentResolver::new(self, &self.f64_resolver);
         self.create_observable_updown_counter(builder, &resolver)
     }
 
-    fn u64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<u64>>) -> Result<Gauge<u64>> {
+    fn u64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<u64>>) -> Gauge<u64> {
         let resolver = InstrumentResolver::new(self, &self.u64_resolver);
         self.create_gauge(builder, &resolver)
     }
 
-    fn f64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<f64>>) -> Result<Gauge<f64>> {
+    fn f64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<f64>>) -> Gauge<f64> {
         let resolver = InstrumentResolver::new(self, &self.f64_resolver);
         self.create_gauge(builder, &resolver)
     }
 
-    fn i64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<i64>>) -> Result<Gauge<i64>> {
+    fn i64_gauge(&self, builder: InstrumentBuilder<'_, Gauge<i64>>) -> Gauge<i64> {
         let resolver = InstrumentResolver::new(self, &self.i64_resolver);
         self.create_gauge(builder, &resolver)
     }
@@ -383,7 +401,7 @@ impl InstrumentProvider for SdkMeter {
     fn u64_observable_gauge(
         &self,
         builder: AsyncInstrumentBuilder<'_, ObservableGauge<u64>, u64>,
-    ) -> Result<ObservableGauge<u64>> {
+    ) -> ObservableGauge<u64> {
         let resolver = InstrumentResolver::new(self, &self.u64_resolver);
         self.create_observable_gauge(builder, &resolver)
     }
@@ -391,7 +409,7 @@ impl InstrumentProvider for SdkMeter {
     fn i64_observable_gauge(
         &self,
         builder: AsyncInstrumentBuilder<'_, ObservableGauge<i64>, i64>,
-    ) -> Result<ObservableGauge<i64>> {
+    ) -> ObservableGauge<i64> {
         let resolver = InstrumentResolver::new(self, &self.i64_resolver);
         self.create_observable_gauge(builder, &resolver)
     }
@@ -399,23 +417,17 @@ impl InstrumentProvider for SdkMeter {
     fn f64_observable_gauge(
         &self,
         builder: AsyncInstrumentBuilder<'_, ObservableGauge<f64>, f64>,
-    ) -> Result<ObservableGauge<f64>> {
+    ) -> ObservableGauge<f64> {
         let resolver = InstrumentResolver::new(self, &self.f64_resolver);
         self.create_observable_gauge(builder, &resolver)
     }
 
-    fn f64_histogram(
-        &self,
-        builder: HistogramBuilder<'_, Histogram<f64>>,
-    ) -> Result<Histogram<f64>> {
+    fn f64_histogram(&self, builder: HistogramBuilder<'_, Histogram<f64>>) -> Histogram<f64> {
         let resolver = InstrumentResolver::new(self, &self.f64_resolver);
         self.create_histogram(builder, &resolver)
     }
 
-    fn u64_histogram(
-        &self,
-        builder: HistogramBuilder<'_, Histogram<u64>>,
-    ) -> Result<Histogram<u64>> {
+    fn u64_histogram(&self, builder: HistogramBuilder<'_, Histogram<u64>>) -> Histogram<u64> {
         let resolver = InstrumentResolver::new(self, &self.u64_resolver);
         self.create_histogram(builder, &resolver)
     }

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Introduced `SyncInstrument` trait to replace the individual synchronous instrument traits (`SyncCounter`, `SyncGauge`, `SyncHistogram`, `SyncUpDownCounter`) which are meant for SDK implementation. [#2207](https://github.com/open-telemetry/opentelemetry-rust/pull/2207)
 - Ensured that `observe` method on asynchronous instruments can only be called inside a callback. This was done by removing the implementation of `AsyncInstrument` trait for each of the asynchronous instruments. [#2210](https://github.com/open-telemetry/opentelemetry-rust/pull/2210)
 - Removed `PartialOrd` and `Ord` implementations for `KeyValue`. [#2215](https://github.com/open-telemetry/opentelemetry-rust/pull/2215)
+- Remove `try_init` methods from the instrument builders. Users should only use `init` method to create instruments. [#2227](https://github.com/open-telemetry/opentelemetry-rust/pull/2227)
+- Updated the return types of `InstrumentProvider` trait methods to return the instrument instead of a `Result`. [#2227](https://github.com/open-telemetry/opentelemetry-rust/pull/2227)
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -1,6 +1,6 @@
 use gauge::{Gauge, ObservableGauge};
 
-use crate::metrics::{Meter, Result};
+use crate::metrics::Meter;
 use crate::KeyValue;
 use core::fmt;
 use std::borrow::Cow;
@@ -95,34 +95,24 @@ impl<'a, T> HistogramBuilder<'a, T> {
 }
 
 impl<'a> HistogramBuilder<'a, Histogram<f64>> {
-    /// Validate the instrument configuration and creates a new instrument.
-    pub fn try_init(self) -> Result<Histogram<f64>> {
-        self.instrument_provider.f64_histogram(self)
-    }
-
     /// Creates a new instrument.
     ///
     /// Validates the instrument configuration and creates a new instrument. In
-    /// case of invalid configuration, an instrument that is no-op is returned
+    /// case of invalid configuration, a no-op instrument is returned
     /// and an error is logged using internal logging.
     pub fn init(self) -> Histogram<f64> {
-        self.try_init().unwrap()
+        self.instrument_provider.f64_histogram(self)
     }
 }
 
 impl<'a> HistogramBuilder<'a, Histogram<u64>> {
-    /// Validate the instrument configuration and creates a new instrument.
-    pub fn try_init(self) -> Result<Histogram<u64>> {
-        self.instrument_provider.u64_histogram(self)
-    }
-
     /// Creates a new instrument.
     ///
     /// Validates the instrument configuration and creates a new instrument. In
-    /// case of invalid configuration, an instrument that is no-op is returned
+    /// case of invalid configuration, a no-op instrument is returned
     /// and an error is logged using internal logging.
     pub fn init(self) -> Histogram<u64> {
-        self.try_init().unwrap()
+        self.instrument_provider.u64_histogram(self)
     }
 }
 
@@ -179,18 +169,10 @@ macro_rules! build_instrument {
     ($name:ident, $inst:ty) => {
         impl<'a> InstrumentBuilder<'a, $inst> {
             #[doc = concat!("Validates the instrument configuration and creates a new `",  stringify!($inst), "`.")]
-            pub fn try_init(self) -> Result<$inst> {
-                self.instrument_provider.$name(self)
-            }
-
-            #[doc = concat!("Validates the instrument configuration and creates a new `",  stringify!($inst), "`.")]
-            ///
-            /// # Panics
-            ///
-            /// Panics if the instrument cannot be created. Use
-            /// [`try_init`](InstrumentBuilder::try_init) if you want to handle errors.
+            /// In case of invalid configuration, a no-op instrument is returned
+            /// and an error is logged using internal logging.
             pub fn init(self) -> $inst {
-                self.try_init().unwrap()
+                self.instrument_provider.$name(self)
             }
         }
     };
@@ -305,18 +287,10 @@ macro_rules! build_async_instrument {
     ($name:ident, $inst:ty, $measurement:ty) => {
         impl<'a> AsyncInstrumentBuilder<'a, $inst, $measurement> {
             #[doc = concat!("Validates the instrument configuration and creates a new `",  stringify!($inst), "`.")]
-            pub fn try_init(self) -> Result<$inst> {
-                self.instrument_provider.$name(self)
-            }
-
-            #[doc = concat!("Validates the instrument configuration and creates a new `",  stringify!($inst), "`.")]
-            ///
-            /// # Panics
-            ///
-            /// Panics if the instrument cannot be created. Use
-            /// [`try_init`](InstrumentBuilder::try_init) if you want to handle errors.
+            /// In case of invalid configuration, a no-op instrument is returned
+            /// and an error is logged using internal logging.
             pub fn init(self) -> $inst {
-                self.try_init().unwrap()
+                self.instrument_provider.$name(self)
             }
         }
     };

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -95,120 +95,110 @@ impl Eq for KeyValue {}
 /// SDK implemented trait for creating instruments
 pub trait InstrumentProvider {
     /// creates an instrument for recording increasing values.
-    fn u64_counter(&self, _builder: InstrumentBuilder<'_, Counter<u64>>) -> Result<Counter<u64>> {
-        Ok(Counter::new(Arc::new(noop::NoopSyncInstrument::new())))
+    fn u64_counter(&self, _builder: InstrumentBuilder<'_, Counter<u64>>) -> Counter<u64> {
+        Counter::new(Arc::new(noop::NoopSyncInstrument::new()))
     }
 
     /// creates an instrument for recording increasing values.
-    fn f64_counter(&self, _builder: InstrumentBuilder<'_, Counter<f64>>) -> Result<Counter<f64>> {
-        Ok(Counter::new(Arc::new(noop::NoopSyncInstrument::new())))
+    fn f64_counter(&self, _builder: InstrumentBuilder<'_, Counter<f64>>) -> Counter<f64> {
+        Counter::new(Arc::new(noop::NoopSyncInstrument::new()))
     }
 
     /// creates an instrument for recording increasing values via callback.
     fn u64_observable_counter(
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableCounter<u64>, u64>,
-    ) -> Result<ObservableCounter<u64>> {
-        Ok(ObservableCounter::new())
+    ) -> ObservableCounter<u64> {
+        ObservableCounter::new()
     }
 
     /// creates an instrument for recording increasing values via callback.
     fn f64_observable_counter(
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableCounter<f64>, f64>,
-    ) -> Result<ObservableCounter<f64>> {
-        Ok(ObservableCounter::new())
+    ) -> ObservableCounter<f64> {
+        ObservableCounter::new()
     }
 
     /// creates an instrument for recording changes of a value.
     fn i64_up_down_counter(
         &self,
         _builder: InstrumentBuilder<'_, UpDownCounter<i64>>,
-    ) -> Result<UpDownCounter<i64>> {
-        Ok(UpDownCounter::new(
-            Arc::new(noop::NoopSyncInstrument::new()),
-        ))
+    ) -> UpDownCounter<i64> {
+        UpDownCounter::new(Arc::new(noop::NoopSyncInstrument::new()))
     }
 
     /// creates an instrument for recording changes of a value.
     fn f64_up_down_counter(
         &self,
         _builder: InstrumentBuilder<'_, UpDownCounter<f64>>,
-    ) -> Result<UpDownCounter<f64>> {
-        Ok(UpDownCounter::new(
-            Arc::new(noop::NoopSyncInstrument::new()),
-        ))
+    ) -> UpDownCounter<f64> {
+        UpDownCounter::new(Arc::new(noop::NoopSyncInstrument::new()))
     }
 
     /// creates an instrument for recording changes of a value.
     fn i64_observable_up_down_counter(
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<i64>, i64>,
-    ) -> Result<ObservableUpDownCounter<i64>> {
-        Ok(ObservableUpDownCounter::new())
+    ) -> ObservableUpDownCounter<i64> {
+        ObservableUpDownCounter::new()
     }
 
     /// creates an instrument for recording changes of a value via callback.
     fn f64_observable_up_down_counter(
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableUpDownCounter<f64>, f64>,
-    ) -> Result<ObservableUpDownCounter<f64>> {
-        Ok(ObservableUpDownCounter::new())
+    ) -> ObservableUpDownCounter<f64> {
+        ObservableUpDownCounter::new()
     }
 
     /// creates an instrument for recording independent values.
-    fn u64_gauge(&self, _builder: InstrumentBuilder<'_, Gauge<u64>>) -> Result<Gauge<u64>> {
-        Ok(Gauge::new(Arc::new(noop::NoopSyncInstrument::new())))
+    fn u64_gauge(&self, _builder: InstrumentBuilder<'_, Gauge<u64>>) -> Gauge<u64> {
+        Gauge::new(Arc::new(noop::NoopSyncInstrument::new()))
     }
 
     /// creates an instrument for recording independent values.
-    fn f64_gauge(&self, _builder: InstrumentBuilder<'_, Gauge<f64>>) -> Result<Gauge<f64>> {
-        Ok(Gauge::new(Arc::new(noop::NoopSyncInstrument::new())))
+    fn f64_gauge(&self, _builder: InstrumentBuilder<'_, Gauge<f64>>) -> Gauge<f64> {
+        Gauge::new(Arc::new(noop::NoopSyncInstrument::new()))
     }
 
     /// creates an instrument for recording independent values.
-    fn i64_gauge(&self, _builder: InstrumentBuilder<'_, Gauge<i64>>) -> Result<Gauge<i64>> {
-        Ok(Gauge::new(Arc::new(noop::NoopSyncInstrument::new())))
+    fn i64_gauge(&self, _builder: InstrumentBuilder<'_, Gauge<i64>>) -> Gauge<i64> {
+        Gauge::new(Arc::new(noop::NoopSyncInstrument::new()))
     }
 
     /// creates an instrument for recording the current value via callback.
     fn u64_observable_gauge(
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableGauge<u64>, u64>,
-    ) -> Result<ObservableGauge<u64>> {
-        Ok(ObservableGauge::new())
+    ) -> ObservableGauge<u64> {
+        ObservableGauge::new()
     }
 
     /// creates an instrument for recording the current value via callback.
     fn i64_observable_gauge(
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableGauge<i64>, i64>,
-    ) -> Result<ObservableGauge<i64>> {
-        Ok(ObservableGauge::new())
+    ) -> ObservableGauge<i64> {
+        ObservableGauge::new()
     }
 
     /// creates an instrument for recording the current value via callback.
     fn f64_observable_gauge(
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableGauge<f64>, f64>,
-    ) -> Result<ObservableGauge<f64>> {
-        Ok(ObservableGauge::new())
+    ) -> ObservableGauge<f64> {
+        ObservableGauge::new()
     }
 
     /// creates an instrument for recording a distribution of values.
-    fn f64_histogram(
-        &self,
-        _builder: HistogramBuilder<'_, Histogram<f64>>,
-    ) -> Result<Histogram<f64>> {
-        Ok(Histogram::new(Arc::new(noop::NoopSyncInstrument::new())))
+    fn f64_histogram(&self, _builder: HistogramBuilder<'_, Histogram<f64>>) -> Histogram<f64> {
+        Histogram::new(Arc::new(noop::NoopSyncInstrument::new()))
     }
 
     /// creates an instrument for recording a distribution of values.
-    fn u64_histogram(
-        &self,
-        _builder: HistogramBuilder<'_, Histogram<u64>>,
-    ) -> Result<Histogram<u64>> {
-        Ok(Histogram::new(Arc::new(noop::NoopSyncInstrument::new())))
+    fn u64_histogram(&self, _builder: HistogramBuilder<'_, Histogram<u64>>) -> Histogram<u64> {
+        Histogram::new(Arc::new(noop::NoopSyncInstrument::new()))
     }
 }
 


### PR DESCRIPTION
Towards #1699

## Changes
- Update `InstrumentProvider` trait methods to return the individual instruments instead of a `Result`
- Remove `try_init` methods from the all the instrument builders

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
