### PR TITLE
[Metrics API] Mark KeyValue types non-exhaustive

### DIFF
--- a/opentelemetry-proto/src/transform/common.rs
+++ b/opentelemetry-proto/src/transform/common.rs
@@ -152,7 +152,9 @@ pub mod tonic {
                         Array::I64(vals) => array_into_proto(vals),
                         Array::F64(vals) => array_into_proto(vals),
                         Array::String(vals) => array_into_proto(vals),
+                        _ => unreachable!("Nonexistent array type"), // Needs to be updated when new array types are added
                     })),
+                    _ => unreachable!("Nonexistent value type"), // Needs to be updated when new value types are added
                 },
             }
         }

--- a/opentelemetry-stdout/src/common.rs
+++ b/opentelemetry-stdout/src/common.rs
@@ -144,7 +144,9 @@ impl From<opentelemetry::Value> for Value {
                 opentelemetry::Array::String(s) => {
                     Value::Array(s.into_iter().map(|s| Value::String(s.into())).collect())
                 }
+                _ => unreachable!("Nonexistent array type"), // Needs to be updated when new array types are added
             },
+            _ => unreachable!("Nonexistent value type"), // Needs to be updated when new value types are added
         }
     }
 }

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Introduced `SyncInstrument` trait to replace the individual synchronous instrument traits (`SyncCounter`, `SyncGauge`, `SyncHistogram`, `SyncUpDownCounter`) which are meant for SDK implementation. [#2207](https://github.com/open-telemetry/opentelemetry-rust/pull/2207)
 - Ensured that `observe` method on asynchronous instruments can only be called inside a callback. This was done by removing the implementation of `AsyncInstrument` trait for each of the asynchronous instruments. [#2210](https://github.com/open-telemetry/opentelemetry-rust/pull/2210)
 - Removed `PartialOrd` and `Ord` implementations for `KeyValue`. [#2215](https://github.com/open-telemetry/opentelemetry-rust/pull/2215)
+- **Breaking change for exporter authors:** Marked `KeyValue` related structs and enums as `non_exhaustive`. [#2228](https://github.com/open-telemetry/opentelemetry-rust/pull/2228)
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -7,6 +7,7 @@ use std::{fmt, hash};
 /// See the [attribute naming] spec for guidelines.
 ///
 /// [attribute naming]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attribute-naming.md
+#[non_exhaustive]
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Key(OtelString);
 
@@ -149,6 +150,7 @@ impl hash::Hash for OtelString {
 }
 
 /// A [Value::Array] containing homogeneous values.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Array {
     /// Array of bools
@@ -212,6 +214,7 @@ into_array!(
 );
 
 /// The value part of attribute [KeyValue] pairs.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value {
     /// bool values
@@ -227,6 +230,7 @@ pub enum Value {
 }
 
 /// Wrapper for string-like values
+#[non_exhaustive]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct StringValue(OtelString);
 

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -376,6 +376,7 @@ impl fmt::Display for Value {
 
 /// A key-value pair describing an attribute.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub struct KeyValue {
     /// The attribute name
     pub key: Key,


### PR DESCRIPTION
## Changes
- Mark `KeyValue` related structs and enums as `non_exhaustive` to allow us to add newer fields or variants if needed in future
- Here the list of structs and enums that were marked `non_exahustive`:
  - `struct KeyValue`
  - `struct Key`
  - `struct StringValue`
  - `enum Value`
  - `enum Array`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
