### PR TITLE
[Logs API] Mark Anyvalue enum as non-exhaustive

### DIFF
--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -51,6 +51,7 @@ pub mod tonic {
                         .collect(),
                 }),
                 LogsAnyValue::Bytes(v) => Value::BytesValue(*v),
+                _ => unreachable!("Nonexistent value type"),
             }
         }
     }

--- a/opentelemetry-stdout/src/common.rs
+++ b/opentelemetry-stdout/src/common.rs
@@ -169,6 +169,7 @@ impl From<opentelemetry::logs::AnyValue> for Value {
                     .collect(),
             ),
             opentelemetry::logs::AnyValue::Bytes(b) => Value::BytesValue(*b),
+            _ => unreachable!("Nonexistent value type"),
         }
     }
 }

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Introduced `SyncInstrument` trait to replace the individual synchronous instrument traits (`SyncCounter`, `SyncGauge`, `SyncHistogram`, `SyncUpDownCounter`) which are meant for SDK implementation. [#2207](https://github.com/open-telemetry/opentelemetry-rust/pull/2207)
 - Ensured that `observe` method on asynchronous instruments can only be called inside a callback. This was done by removing the implementation of `AsyncInstrument` trait for each of the asynchronous instruments. [#2210](https://github.com/open-telemetry/opentelemetry-rust/pull/2210)
 - Removed `PartialOrd` and `Ord` implementations for `KeyValue`. [#2215](https://github.com/open-telemetry/opentelemetry-rust/pull/2215)
+- - **Breaking change for log exporter authors:** Marked `AnyValue` enum as `non_exhaustive`.
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Introduced `SyncInstrument` trait to replace the individual synchronous instrument traits (`SyncCounter`, `SyncGauge`, `SyncHistogram`, `SyncUpDownCounter`) which are meant for SDK implementation. [#2207](https://github.com/open-telemetry/opentelemetry-rust/pull/2207)
 - Ensured that `observe` method on asynchronous instruments can only be called inside a callback. This was done by removing the implementation of `AsyncInstrument` trait for each of the asynchronous instruments. [#2210](https://github.com/open-telemetry/opentelemetry-rust/pull/2210)
 - Removed `PartialOrd` and `Ord` implementations for `KeyValue`. [#2215](https://github.com/open-telemetry/opentelemetry-rust/pull/2215)
-- - **Breaking change for log exporter authors:** Marked `AnyValue` enum as `non_exhaustive`.
+- - **Breaking change for log exporter authors:** Marked `AnyValue` enum as `non_exhaustive`. [#2230](https://github.com/open-telemetry/opentelemetry-rust/pull/2230)
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -62,6 +62,7 @@ pub trait LogRecord {
 
 /// Value types for representing arbitrary values in a log record.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum AnyValue {
     /// An integer value
     Int(i64),


### PR DESCRIPTION
## Changes
Mark AnyValue enum non-exhaustive (in-line with the changes in #2228)

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
