### PR TITLE
adds timestamps

### DIFF
--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -173,6 +173,8 @@ where
         log_record.set_event_name(meta.name());
         log_record.set_severity_number(severity_of_level(meta.level()));
         log_record.set_severity_text(meta.level().as_str());
+        log_record.set_timestamp(std::time::SystemTime::now());
+        log_record.set_observed_timestamp(std::time::SystemTime::now());
         let mut visitor = EventVisitor::new(&mut log_record);
         #[cfg(feature = "experimental_metadata_attributes")]
         visitor.visit_experimental_metadata(meta);


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Unset timestamps in logs break services such as Quickwit, although if my understanding is correct these timestamps _must_ be set as a part of OTEL spec.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
