### PR TITLE
[Metrics API] Rename `init` to `build`

### DIFF
--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .f64_histogram("my_histogram")
         .with_unit("ms")
         .with_description("My histogram example description")
-        .init();
+        .build();
 
     // Record measurements using the histogram instrument.
     histogram.record(
@@ -91,7 +91,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     );
 
     // Example 2 - Drop unwanted attributes using view.
-    let counter = meter.u64_counter("my_counter").init();
+    let counter = meter.u64_counter("my_counter").build();
 
     // Record measurements using the Counter instrument.
     // Though we are passing 4 attributes here, only 1 will be used
@@ -115,7 +115,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .f64_histogram("my_second_histogram")
         .with_unit("ms")
         .with_description("My histogram example description")
-        .init();
+        .build();
 
     // Record measurements using the histogram instrument.
     // The values recorded are in the range of 1.2 to 1.5, warranting

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let meter = global::meter("mylibraryname");
 
     // Create a Counter Instrument.
-    let counter = meter.u64_counter("my_counter").init();
+    let counter = meter.u64_counter("my_counter").build();
 
     // Record measurements using the Counter instrument.
     counter.add(
@@ -56,10 +56,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
                 ],
             )
         })
-        .init();
+        .build();
 
     // Create a UpCounter Instrument.
-    let updown_counter = meter.i64_up_down_counter("my_updown_counter").init();
+    let updown_counter = meter.i64_up_down_counter("my_updown_counter").build();
 
     // Record measurements using the UpCounter instrument.
     updown_counter.add(
@@ -84,7 +84,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
                 ],
             )
         })
-        .init();
+        .build();
 
     // Create a Histogram Instrument.
     let histogram = meter
@@ -93,7 +93,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         // Setting boundaries is optional. By default, the boundaries are set to
         // [0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0, 10000.0]
         .with_boundaries(vec![0.0, 5.0, 10.0, 15.0, 20.0, 25.0])
-        .init();
+        .build();
 
     // Record measurements using the histogram instrument.
     histogram.record(
@@ -111,7 +111,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .f64_gauge("my_gauge")
         .with_description("A gauge set to 1.0")
         .with_unit("myunit")
-        .init();
+        .build();
 
     gauge.record(
         1.0,
@@ -135,7 +135,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
                 ],
             )
         })
-        .init();
+        .build();
 
     // Metrics are exported by default every 30 seconds when using stdout exporter,
     // however shutting down the MeterProvider here instantly flushes

--- a/examples/self-diagnostics/src/main.rs
+++ b/examples/self-diagnostics/src/main.rs
@@ -137,7 +137,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Create a meter from the above MeterProvider.
     let meter = global::meter("example");
     // Create a Counter Instrument.
-    let counter = meter.u64_counter("my_counter").init();
+    let counter = meter.u64_counter("my_counter").build();
 
     // Record measurements with unique key-value pairs to exceed the cardinality limit
     // of 2000 and trigger error message

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -136,7 +136,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .u64_counter("test_counter")
         .with_description("a simple counter for demo purposes.")
         .with_unit("my_unit")
-        .init();
+        .build();
     for _ in 0..10 {
         counter.add(1, &[KeyValue::new("test_key", "test_value")]);
     }

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -127,7 +127,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .u64_counter("test_counter")
         .with_description("a simple counter for demo purposes.")
         .with_unit("my_unit")
-        .init();
+        .build();
     for _ in 0..10 {
         counter.add(1, &[KeyValue::new("test_key", "test_value")]);
     }

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -8,6 +8,17 @@
 - **BREAKING**: [#2217](https://github.com/open-telemetry/opentelemetry-rust/pull/2217)
   - **Replaced**: Removed `{Delta,Cumulative}TemporalitySelector::new()` in favor of directly using `Temporality` enum to simplify the configuration of MetricExporterBuilder with different temporalities.
 - When creating new metric instruments, SDK would return a no-op instrument if the validation fails. [#2166](https://github.com/open-telemetry/opentelemetry-rust/pull/2166)
+- **Breaking change for Metrics users:** The `init` method used to create instruments has been renamed to `build`.
+
+Before:
+```rust
+let counter = meter.u64_counter("my_counter").init();
+```
+
+Now:
+```rust
+let counter = meter.u64_counter("my_counter").build();
+```
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -125,7 +125,7 @@ fn bench_counter(view: Option<Box<dyn View>>, temporality: &str) -> (SharedReade
         builder = builder.with_view(view);
     }
     let provider = builder.build();
-    let cntr = provider.meter("test").u64_counter("hello").init();
+    let cntr = provider.meter("test").u64_counter("hello").build();
 
     (rdr, cntr)
 }
@@ -344,7 +344,7 @@ fn bench_histogram(bound_count: usize) -> (SharedReader, Histogram<u64>) {
     let mtr = builder.build().meter("test_meter");
     let hist = mtr
         .u64_histogram(format!("histogram_{}", bound_count))
-        .init();
+        .build();
 
     (r, hist)
 }
@@ -384,7 +384,7 @@ fn benchmark_collect_histogram(b: &mut Bencher, n: usize) {
         .meter("sdk/metric/bench/histogram");
 
     for i in 0..n {
-        let h = mtr.u64_histogram(format!("fake_data_{i}")).init();
+        let h = mtr.u64_histogram(format!("fake_data_{i}")).build();
         h.record(1, &[]);
     }
 

--- a/opentelemetry-sdk/benches/metrics_counter.rs
+++ b/opentelemetry-sdk/benches/metrics_counter.rs
@@ -44,7 +44,7 @@ fn create_counter(name: &'static str) -> Counter<u64> {
     let meter = meter_provider.meter("benchmarks");
 
     println!("Counter_Created");
-    meter.u64_counter(name).init()
+    meter.u64_counter(name).build()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/opentelemetry-sdk/benches/metrics_gauge.rs
+++ b/opentelemetry-sdk/benches/metrics_gauge.rs
@@ -39,7 +39,7 @@ fn create_gauge() -> Gauge<u64> {
         .build();
     let meter = meter_provider.meter("benchmarks");
 
-    meter.u64_gauge("gauge_bench").init()
+    meter.u64_gauge("gauge_bench").build()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/opentelemetry-sdk/benches/metrics_histogram.rs
+++ b/opentelemetry-sdk/benches/metrics_histogram.rs
@@ -42,7 +42,7 @@ fn create_histogram(name: &'static str) -> Histogram<u64> {
         .build();
     let meter = meter_provider.meter("benchmarks");
 
-    meter.u64_histogram(name).init()
+    meter.u64_histogram(name).build()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -60,7 +60,7 @@
 //! let meter = global::meter("my_service");
 //!
 //! // create an instrument
-//! let counter = meter.u64_counter("my_counter").init();
+//! let counter = meter.u64_counter("my_counter").build();
 //!
 //! // record a measurement
 //! counter.add(1, &[KeyValue::new("http.client_ip", "83.164.160.102")]);

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -409,7 +409,7 @@ mod tests {
         assert!(!reader.is_shutdown());
         // create a meter and an instrument
         let meter = global::meter("test");
-        let counter = meter.u64_counter("test_counter").init();
+        let counter = meter.u64_counter("test_counter").build();
         // no need to drop a meter for meter_provider shutdown
         let shutdown_res = provider.shutdown();
         assert!(shutdown_res.is_ok());

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -27,7 +27,7 @@
 //! let counter = meter
 //!     .u64_counter("power_consumption")
 //!     .with_unit("kWh")
-//!     .init();
+//!     .build();
 //!
 //! // use instruments to record measurements
 //! counter.add(10, &[KeyValue::new("rate", "standard")]);
@@ -161,16 +161,16 @@ mod tests {
         ];
         for name in invalid_instrument_names {
             let test_context = TestContext::new(Temporality::Cumulative);
-            let counter = test_context.meter().u64_counter(name).init();
+            let counter = test_context.meter().u64_counter(name).build();
             counter.add(1, &[]);
 
-            let up_down_counter = test_context.meter().i64_up_down_counter(name).init();
+            let up_down_counter = test_context.meter().i64_up_down_counter(name).build();
             up_down_counter.add(1, &[]);
 
-            let gauge = test_context.meter().f64_gauge(name).init();
+            let gauge = test_context.meter().f64_gauge(name).build();
             gauge.record(1.9, &[]);
 
-            let histogram = test_context.meter().f64_histogram(name).init();
+            let histogram = test_context.meter().f64_histogram(name).build();
             histogram.record(1.0, &[]);
 
             let _observable_counter = test_context
@@ -179,7 +179,7 @@ mod tests {
                 .with_callback(move |observer| {
                     observer.observe(1, &[]);
                 })
-                .init();
+                .build();
 
             let _observable_gauge = test_context
                 .meter()
@@ -187,7 +187,7 @@ mod tests {
                 .with_callback(move |observer| {
                     observer.observe(1.0, &[]);
                 })
-                .init();
+                .build();
 
             let _observable_up_down_counter = test_context
                 .meter()
@@ -195,7 +195,7 @@ mod tests {
                 .with_callback(move |observer| {
                     observer.observe(1, &[]);
                 })
-                .init();
+                .build();
 
             test_context.flush_metrics();
 
@@ -445,7 +445,7 @@ mod tests {
                     *index += 1;
                 }
             })
-            .init();
+            .build();
 
         for (iter, v) in values_clone.iter().enumerate() {
             test_context.flush_metrics();
@@ -500,13 +500,13 @@ mod tests {
             .u64_counter("my_counter")
             .with_unit("my_unit")
             .with_description("my_description")
-            .init();
+            .build();
 
         let counter_duplicated = meter
             .u64_counter("my_counter")
             .with_unit("my_unit")
             .with_description("my_description")
-            .init();
+            .build();
 
         let attribute = vec![KeyValue::new("key1", "value1")];
         counter.add(10, &attribute);
@@ -552,13 +552,13 @@ mod tests {
             .u64_counter("my_counter")
             .with_unit("my_unit")
             .with_description("my_description")
-            .init();
+            .build();
 
         let counter2 = meter2
             .u64_counter("my_counter")
             .with_unit("my_unit")
             .with_description("my_description")
-            .init();
+            .build();
 
         let attribute = vec![KeyValue::new("key1", "value1")];
         counter1.add(10, &attribute);
@@ -653,13 +653,13 @@ mod tests {
             .u64_counter("my_counter")
             .with_unit("my_unit")
             .with_description("my_description")
-            .init();
+            .build();
 
         let counter2 = meter2
             .u64_counter("my_counter")
             .with_unit("my_unit")
             .with_description("my_description")
-            .init();
+            .build();
 
         let attribute = vec![KeyValue::new("key1", "value1")];
         counter1.add(10, &attribute);
@@ -736,7 +736,7 @@ mod tests {
         let histogram = meter
             .f64_histogram("test_histogram")
             .with_unit("test_unit")
-            .init();
+            .build();
 
         histogram.record(1.5, &[KeyValue::new("key1", "value1")]);
         meter_provider.force_flush().unwrap();
@@ -805,7 +805,7 @@ mod tests {
                     ],
                 );
             })
-            .init();
+            .build();
 
         meter_provider.force_flush().unwrap();
 
@@ -853,7 +853,7 @@ mod tests {
 
         // Act
         let meter = meter_provider.meter("test");
-        let counter = meter.u64_counter("my_counter").init();
+        let counter = meter.u64_counter("my_counter").build();
 
         // Normally, this would generate 3 time-series, but since the view
         // drops all attributes, we expect only 1 time-series.
@@ -1135,7 +1135,7 @@ mod tests {
         // Create instrument and emit measurements
         match instrument_name {
             "counter" => {
-                let counter = test_context.meter().u64_counter("test_counter").init();
+                let counter = test_context.meter().u64_counter("test_counter").build();
                 counter.add(5, &[]);
                 counter.add(10, attributes);
             }
@@ -1143,17 +1143,17 @@ mod tests {
                 let updown_counter = test_context
                     .meter()
                     .i64_up_down_counter("test_updowncounter")
-                    .init();
+                    .build();
                 updown_counter.add(15, &[]);
                 updown_counter.add(20, attributes);
             }
             "histogram" => {
-                let histogram = test_context.meter().u64_histogram("test_histogram").init();
+                let histogram = test_context.meter().u64_histogram("test_histogram").build();
                 histogram.record(25, &[]);
                 histogram.record(30, attributes);
             }
             "gauge" => {
-                let gauge = test_context.meter().u64_gauge("test_gauge").init();
+                let gauge = test_context.meter().u64_gauge("test_gauge").build();
                 gauge.record(35, &[]);
                 gauge.record(40, attributes);
             }
@@ -1274,7 +1274,7 @@ mod tests {
                             has_run.store(true, Ordering::SeqCst);
                         }
                     })
-                    .init();
+                    .build();
             }
             "updown_counter" => {
                 let has_run = AtomicBool::new(false);
@@ -1288,7 +1288,7 @@ mod tests {
                             has_run.store(true, Ordering::SeqCst);
                         }
                     })
-                    .init();
+                    .build();
             }
             "gauge" => {
                 let has_run = AtomicBool::new(false);
@@ -1302,7 +1302,7 @@ mod tests {
                             has_run.store(true, Ordering::SeqCst);
                         }
                     })
-                    .init();
+                    .build();
             }
             _ => panic!("Incorrect instrument kind provided"),
         };
@@ -1427,7 +1427,7 @@ mod tests {
     fn counter_f64_multithreaded_aggregation_helper(temporality: Temporality) {
         // Arrange
         let mut test_context = TestContext::new(temporality);
-        let counter = Arc::new(test_context.meter().f64_counter("test_counter").init());
+        let counter = Arc::new(test_context.meter().f64_counter("test_counter").build());
 
         for i in 0..10 {
             thread::scope(|s| {
@@ -1480,7 +1480,7 @@ mod tests {
     fn histogram_multithreaded_aggregation_helper(temporality: Temporality) {
         // Arrange
         let mut test_context = TestContext::new(temporality);
-        let histogram = Arc::new(test_context.meter().u64_histogram("test_histogram").init());
+        let histogram = Arc::new(test_context.meter().u64_histogram("test_histogram").build());
 
         for i in 0..10 {
             thread::scope(|s| {
@@ -1617,7 +1617,7 @@ mod tests {
     fn histogram_f64_multithreaded_aggregation_helper(temporality: Temporality) {
         // Arrange
         let mut test_context = TestContext::new(temporality);
-        let histogram = Arc::new(test_context.meter().f64_histogram("test_histogram").init());
+        let histogram = Arc::new(test_context.meter().f64_histogram("test_histogram").build());
 
         for i in 0..10 {
             thread::scope(|s| {
@@ -1754,7 +1754,7 @@ mod tests {
     fn histogram_aggregation_helper(temporality: Temporality) {
         // Arrange
         let mut test_context = TestContext::new(temporality);
-        let histogram = test_context.meter().u64_histogram("my_histogram").init();
+        let histogram = test_context.meter().u64_histogram("my_histogram").build();
 
         // Act
         let mut rand = rngs::SmallRng::from_entropy();
@@ -1862,7 +1862,7 @@ mod tests {
             .meter()
             .u64_histogram("test_histogram")
             .with_boundaries(vec![1.0, 2.5, 5.5])
-            .init();
+            .build();
         histogram.record(1, &[KeyValue::new("key1", "value1")]);
         histogram.record(2, &[KeyValue::new("key1", "value1")]);
         histogram.record(3, &[KeyValue::new("key1", "value1")]);
@@ -1910,7 +1910,7 @@ mod tests {
     fn gauge_aggregation_helper(temporality: Temporality) {
         // Arrange
         let mut test_context = TestContext::new(temporality);
-        let gauge = test_context.meter().i64_gauge("my_gauge").init();
+        let gauge = test_context.meter().i64_gauge("my_gauge").build();
 
         // Act
         gauge.record(1, &[KeyValue::new("key1", "value1")]);
@@ -1979,7 +1979,7 @@ mod tests {
                 observer.observe(4, &[KeyValue::new("key1", "value1")]);
                 observer.observe(5, &[KeyValue::new("key2", "value2")]);
             })
-            .init();
+            .build();
 
         test_context.flush_metrics();
 
@@ -2378,7 +2378,7 @@ mod tests {
             if let Some(unit_name) = unit {
                 counter_builder = counter_builder.with_unit(unit_name);
             }
-            counter_builder.init()
+            counter_builder.build()
         }
 
         fn i64_up_down_counter(
@@ -2392,7 +2392,7 @@ mod tests {
             if let Some(unit_name) = unit {
                 updown_counter_builder = updown_counter_builder.with_unit(unit_name);
             }
-            updown_counter_builder.init()
+            updown_counter_builder.build()
         }
 
         fn meter(&self) -> Meter {

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -469,7 +469,7 @@ mod tests {
             .with_callback(move |_| {
                 sender.send(()).expect("channel should still be open");
             })
-            .init();
+            .build();
 
         // Assert
         receiver

--- a/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
@@ -41,7 +41,7 @@ use std::sync::{Arc, Mutex};
 ///
 ///  // Create and record metrics using the MeterProvider
 ///  let meter = meter_provider.meter("example");
-///  let counter = meter.u64_counter("my_counter").init();
+///  let counter = meter.u64_counter("my_counter").build();
 ///  counter.add(1, &[KeyValue::new("key", "value")]);
 ///
 ///  meter_provider.force_flush().unwrap();

--- a/opentelemetry-semantic-conventions/src/metric.rs
+++ b/opentelemetry-semantic-conventions/src/metric.rs
@@ -25,7 +25,7 @@
 //!     .u64_histogram(semconv::metric::HTTP_SERVER_REQUEST_DURATION)
 //!     .with_unit("By")
 //!     .with_description("Duration of HTTP server requests.")
-//!     .init();
+//!     .build();
 //! ```
 
 /// ## Description

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -114,7 +114,7 @@ fn emit_span() {
 #[cfg(feature = "metrics")]
 fn emit_metrics() {
     let meter = global::meter("stdout-example");
-    let c = meter.u64_counter("example_counter").init();
+    let c = meter.u64_counter("example_counter").build();
     c.add(
         1,
         &[
@@ -151,7 +151,7 @@ fn emit_metrics() {
         ],
     );
 
-    let h = meter.f64_histogram("example_histogram").init();
+    let h = meter.f64_histogram("example_histogram").build();
     h.record(
         1.0,
         &[

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -12,6 +12,17 @@
 - Updated the return types of `InstrumentProvider` trait methods to return the instrument instead of a `Result`. [#2227](https://github.com/open-telemetry/opentelemetry-rust/pull/2227)
 - **Breaking change for exporter authors:** Marked `KeyValue` related structs and enums as `non_exhaustive`. [#2228](https://github.com/open-telemetry/opentelemetry-rust/pull/2228)
 - **Breaking change for log exporter authors:** Marked `AnyValue` enum as `non_exhaustive`. [#2230](https://github.com/open-telemetry/opentelemetry-rust/pull/2230)
+- **Breaking change for Metrics users:** The `init` method used to create instruments has been renamed to `build`.
+
+Before:
+```rust
+let counter = meter.u64_counter("my_counter").init();
+```
+
+Now:
+```rust
+let counter = meter.u64_counter("my_counter").build();
+```
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry/benches/metrics.rs
+++ b/opentelemetry/benches/metrics.rs
@@ -22,7 +22,7 @@ use opentelemetry::{global, metrics::Counter, KeyValue};
 fn create_counter() -> Counter<u64> {
     let meter = global::meter("benchmarks");
 
-    meter.u64_counter("counter_bench").init()
+    meter.u64_counter("counter_bench").build()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/opentelemetry/src/global/mod.rs
+++ b/opentelemetry/src/global/mod.rs
@@ -96,7 +96,7 @@
 //!     let meter = global::meter("my-component");
 //!     // It is recommended to reuse the same counter instance for the
 //!     // lifetime of the application
-//!     let counter = meter.u64_counter("my_counter").init();
+//!     let counter = meter.u64_counter("my_counter").build();
 //!
 //!     // record measurements
 //!     counter.add(1, &[KeyValue::new("mykey", "myvalue")]);

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -78,7 +78,7 @@
 //! let meter = global::meter("my_service");
 //!
 //! // create an instrument
-//! let counter = meter.u64_counter("my_counter").init();
+//! let counter = meter.u64_counter("my_counter").build();
 //!
 //! // record a measurement
 //! counter.add(1, &[KeyValue::new("http.client_ip", "83.164.160.102")]);

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -100,7 +100,7 @@ impl<'a> HistogramBuilder<'a, Histogram<f64>> {
     /// Validates the instrument configuration and creates a new instrument. In
     /// case of invalid configuration, a no-op instrument is returned
     /// and an error is logged using internal logging.
-    pub fn init(self) -> Histogram<f64> {
+    pub fn build(self) -> Histogram<f64> {
         self.instrument_provider.f64_histogram(self)
     }
 }
@@ -111,7 +111,7 @@ impl<'a> HistogramBuilder<'a, Histogram<u64>> {
     /// Validates the instrument configuration and creates a new instrument. In
     /// case of invalid configuration, a no-op instrument is returned
     /// and an error is logged using internal logging.
-    pub fn init(self) -> Histogram<u64> {
+    pub fn build(self) -> Histogram<u64> {
         self.instrument_provider.u64_histogram(self)
     }
 }
@@ -171,7 +171,7 @@ macro_rules! build_instrument {
             #[doc = concat!("Validates the instrument configuration and creates a new `",  stringify!($inst), "`.")]
             /// In case of invalid configuration, a no-op instrument is returned
             /// and an error is logged using internal logging.
-            pub fn init(self) -> $inst {
+            pub fn build(self) -> $inst {
                 self.instrument_provider.$name(self)
             }
         }
@@ -289,7 +289,7 @@ macro_rules! build_async_instrument {
             #[doc = concat!("Validates the instrument configuration and creates a new `",  stringify!($inst), "`.")]
             /// In case of invalid configuration, a no-op instrument is returned
             /// and an error is logged using internal logging.
-            pub fn init(self) -> $inst {
+            pub fn build(self) -> $inst {
                 self.instrument_provider.$name(self)
             }
         }

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -86,7 +86,7 @@ pub trait MeterProvider {
 /// // Synchronous Instruments
 ///
 /// // u64 Counter
-/// let u64_counter = meter.u64_counter("my_u64_counter").init();
+/// let u64_counter = meter.u64_counter("my_u64_counter").build();
 /// u64_counter.add(
 ///     10,
 ///     &[
@@ -96,7 +96,7 @@ pub trait MeterProvider {
 /// );
 ///
 /// // f64 Counter
-/// let f64_counter = meter.f64_counter("my_f64_counter").init();
+/// let f64_counter = meter.f64_counter("my_f64_counter").build();
 /// f64_counter.add(
 ///     3.15,
 ///     &[
@@ -120,7 +120,7 @@ pub trait MeterProvider {
 ///             ],
 ///         )
 ///     })
-///     .init();
+///     .build();
 ///
 /// // f64 Observable Counter
 /// let _observable_f64_counter = meter
@@ -136,10 +136,10 @@ pub trait MeterProvider {
 ///             ],
 ///         )
 ///     })
-///     .init();
+///     .build();
 ///
 /// // i64 UpDownCounter
-/// let updown_i64_counter = meter.i64_up_down_counter("my_updown_i64_counter").init();
+/// let updown_i64_counter = meter.i64_up_down_counter("my_updown_i64_counter").build();
 /// updown_i64_counter.add(
 ///     -10,
 ///     &[
@@ -149,7 +149,7 @@ pub trait MeterProvider {
 /// );
 ///
 /// // f64 UpDownCounter
-/// let updown_f64_counter = meter.f64_up_down_counter("my_updown_f64_counter").init();
+/// let updown_f64_counter = meter.f64_up_down_counter("my_updown_f64_counter").build();
 /// updown_f64_counter.add(
 ///     -10.67,
 ///     &[
@@ -172,7 +172,7 @@ pub trait MeterProvider {
 ///             ],
 ///         )
 ///     })
-///     .init();
+///     .build();
 ///
 /// // f64 Observable UpDownCounter
 /// let _observable_updown_f64_counter = meter
@@ -188,10 +188,10 @@ pub trait MeterProvider {
 ///             ],
 ///         )
 ///     })
-///     .init();
+///     .build();
 ///
 /// // i64 Gauge
-/// let gauge = meter.i64_gauge("my_gauge").init();
+/// let gauge = meter.i64_gauge("my_gauge").build();
 /// gauge.record(
 /// -10,
 /// &[
@@ -201,7 +201,7 @@ pub trait MeterProvider {
 /// );
 ///
 /// // u64 Gauge
-/// let gauge = meter.u64_gauge("my_gauge").init();
+/// let gauge = meter.u64_gauge("my_gauge").build();
 /// gauge.record(
 /// 101,
 /// &[
@@ -211,7 +211,7 @@ pub trait MeterProvider {
 /// );
 ///
 /// // f64 Gauge
-/// let gauge = meter.f64_gauge("my_gauge").init();
+/// let gauge = meter.f64_gauge("my_gauge").build();
 /// gauge.record(
 /// 12.5,
 /// &[
@@ -234,7 +234,7 @@ pub trait MeterProvider {
 ///             ],
 ///         )
 ///     })
-///     .init();
+///     .build();
 ///
 /// // f64 Observable Gauge
 /// let _observable_f64_gauge = meter
@@ -250,7 +250,7 @@ pub trait MeterProvider {
 ///             ],
 ///         )
 ///     })
-///     .init();
+///     .build();
 ///
 /// // i64 Observable Gauge
 /// let _observable_i64_gauge = meter
@@ -266,10 +266,10 @@ pub trait MeterProvider {
 ///             ],
 ///         )
 ///     })
-///     .init();
+///     .build();
 ///
 /// // f64 Histogram
-/// let f64_histogram = meter.f64_histogram("my_f64_histogram").init();
+/// let f64_histogram = meter.f64_histogram("my_f64_histogram").build();
 /// f64_histogram.record(
 ///     10.5,
 ///     &[
@@ -279,7 +279,7 @@ pub trait MeterProvider {
 /// );
 ///
 /// // u64 Histogram
-/// let u64_histogram = meter.u64_histogram("my_u64_histogram").init();
+/// let u64_histogram = meter.u64_histogram("my_u64_histogram").build();
 /// u64_histogram.record(
 ///     12,
 ///     &[

--- a/stress/src/metrics_counter.rs
+++ b/stress/src/metrics_counter.rs
@@ -31,7 +31,7 @@ lazy_static! {
         "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
         "value10"
     ];
-    static ref COUNTER: Counter<u64> = PROVIDER.meter("test").u64_counter("hello").init();
+    static ref COUNTER: Counter<u64> = PROVIDER.meter("test").u64_counter("hello").build();
 }
 
 thread_local! {

--- a/stress/src/metrics_gauge.rs
+++ b/stress/src/metrics_gauge.rs
@@ -28,7 +28,7 @@ lazy_static! {
         "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
         "value10"
     ];
-    static ref GAUGE: Gauge<u64> = PROVIDER.meter("test").u64_gauge("test_gauge").init();
+    static ref GAUGE: Gauge<u64> = PROVIDER.meter("test").u64_gauge("test_gauge").build();
 }
 
 thread_local! {

--- a/stress/src/metrics_histogram.rs
+++ b/stress/src/metrics_histogram.rs
@@ -31,7 +31,7 @@ lazy_static! {
         "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
         "value10"
     ];
-    static ref HISTOGRAM: Histogram<u64> = PROVIDER.meter("test").u64_histogram("hello").init();
+    static ref HISTOGRAM: Histogram<u64> = PROVIDER.meter("test").u64_histogram("hello").build();
 }
 
 thread_local! {

--- a/stress/src/metrics_overflow.rs
+++ b/stress/src/metrics_overflow.rs
@@ -24,7 +24,7 @@ lazy_static! {
     static ref PROVIDER: SdkMeterProvider = SdkMeterProvider::builder()
         .with_reader(ManualReader::builder().build())
         .build();
-    static ref COUNTER: Counter<u64> = PROVIDER.meter("test").u64_counter("hello").init();
+    static ref COUNTER: Counter<u64> = PROVIDER.meter("test").u64_counter("hello").build();
 }
 
 thread_local! {


### PR DESCRIPTION
Towards #1699 

## Changes
- Rename `init` method to `build`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
