### PR TITLE
Exclude benchmark setup duration using iter_batched

### DIFF
--- a/opentelemetry-sdk/benches/metrics_counter.rs
+++ b/opentelemetry-sdk/benches/metrics_counter.rs
@@ -12,7 +12,7 @@
     | ThreadLocal_Random_Generator_5 |  37 ns      |
 */
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use opentelemetry::{
     metrics::{Counter, MeterProvider as _},
     KeyValue,
@@ -57,62 +57,72 @@ fn criterion_benchmark(c: &mut Criterion) {
 fn counter_add_sorted(c: &mut Criterion) {
     let counter = create_counter("Counter_Add_Sorted");
     c.bench_function("Counter_Add_Sorted", |b| {
-        b.iter(|| {
-            // 4*4*10*10 = 1600 time series.
-            let rands = CURRENT_RNG.with(|rng| {
-                let mut rng = rng.borrow_mut();
-                [
-                    rng.gen_range(0..4),
-                    rng.gen_range(0..4),
-                    rng.gen_range(0..10),
-                    rng.gen_range(0..10),
-                ]
-            });
-            let index_first_attribute = rands[0];
-            let index_second_attribute = rands[1];
-            let index_third_attribute = rands[2];
-            let index_fourth_attribute = rands[3];
-            counter.add(
-                1,
-                &[
-                    KeyValue::new("attribute1", ATTRIBUTE_VALUES[index_first_attribute]),
-                    KeyValue::new("attribute2", ATTRIBUTE_VALUES[index_second_attribute]),
-                    KeyValue::new("attribute3", ATTRIBUTE_VALUES[index_third_attribute]),
-                    KeyValue::new("attribute4", ATTRIBUTE_VALUES[index_fourth_attribute]),
-                ],
-            );
-        });
+        b.iter_batched(
+            || {
+                // 4*4*10*10 = 1600 time series.
+                CURRENT_RNG.with(|rng| {
+                    let mut rng = rng.borrow_mut();
+                    [
+                        rng.gen_range(0..4),
+                        rng.gen_range(0..4),
+                        rng.gen_range(0..10),
+                        rng.gen_range(0..10),
+                    ]
+                })
+            },
+            |rands| {
+                let index_first_attribute = rands[0];
+                let index_second_attribute = rands[1];
+                let index_third_attribute = rands[2];
+                let index_fourth_attribute = rands[3];
+                counter.add(
+                    1,
+                    &[
+                        KeyValue::new("attribute1", ATTRIBUTE_VALUES[index_first_attribute]),
+                        KeyValue::new("attribute2", ATTRIBUTE_VALUES[index_second_attribute]),
+                        KeyValue::new("attribute3", ATTRIBUTE_VALUES[index_third_attribute]),
+                        KeyValue::new("attribute4", ATTRIBUTE_VALUES[index_fourth_attribute]),
+                    ],
+                );
+            },
+            BatchSize::LargeInput,
+        );
     });
 }
 
 fn counter_add_unsorted(c: &mut Criterion) {
     let counter = create_counter("Counter_Add_Unsorted");
     c.bench_function("Counter_Add_Unsorted", |b| {
-        b.iter(|| {
-            // 4*4*10*10 = 1600 time series.
-            let rands = CURRENT_RNG.with(|rng| {
-                let mut rng = rng.borrow_mut();
-                [
-                    rng.gen_range(0..4),
-                    rng.gen_range(0..4),
-                    rng.gen_range(0..10),
-                    rng.gen_range(0..10),
-                ]
-            });
-            let index_first_attribute = rands[0];
-            let index_second_attribute = rands[1];
-            let index_third_attribute = rands[2];
-            let index_fourth_attribute = rands[3];
-            counter.add(
-                1,
-                &[
-                    KeyValue::new("attribute2", ATTRIBUTE_VALUES[index_second_attribute]),
-                    KeyValue::new("attribute3", ATTRIBUTE_VALUES[index_third_attribute]),
-                    KeyValue::new("attribute1", ATTRIBUTE_VALUES[index_first_attribute]),
-                    KeyValue::new("attribute4", ATTRIBUTE_VALUES[index_fourth_attribute]),
-                ],
-            );
-        });
+        b.iter_batched(
+            || {
+                // 4*4*10*10 = 1600 time series.
+                CURRENT_RNG.with(|rng| {
+                    let mut rng = rng.borrow_mut();
+                    [
+                        rng.gen_range(0..4),
+                        rng.gen_range(0..4),
+                        rng.gen_range(0..10),
+                        rng.gen_range(0..10),
+                    ]
+                })
+            },
+            |rands| {
+                let index_first_attribute = rands[0];
+                let index_second_attribute = rands[1];
+                let index_third_attribute = rands[2];
+                let index_fourth_attribute = rands[3];
+                counter.add(
+                    1,
+                    &[
+                        KeyValue::new("attribute2", ATTRIBUTE_VALUES[index_second_attribute]),
+                        KeyValue::new("attribute3", ATTRIBUTE_VALUES[index_third_attribute]),
+                        KeyValue::new("attribute1", ATTRIBUTE_VALUES[index_first_attribute]),
+                        KeyValue::new("attribute4", ATTRIBUTE_VALUES[index_fourth_attribute]),
+                    ],
+                );
+            },
+            BatchSize::LargeInput,
+        );
     });
 }
 

--- a/opentelemetry-sdk/benches/metrics_counter.rs
+++ b/opentelemetry-sdk/benches/metrics_counter.rs
@@ -85,7 +85,7 @@ fn counter_add_sorted(c: &mut Criterion) {
                     ],
                 );
             },
-            BatchSize::LargeInput,
+            BatchSize::SmallInput,
         );
     });
 }
@@ -121,7 +121,7 @@ fn counter_add_unsorted(c: &mut Criterion) {
                     ],
                 );
             },
-            BatchSize::LargeInput,
+            BatchSize::SmallInput,
         );
     });
 }


### PR DESCRIPTION
Fixes #1805
Design discussion issue (if applicable) #

## Changes

Use [iter_batched](https://docs.rs/criterion/latest/criterion/struct.Bencher.html#method.iter_batched) for benchmarking `Counter_Add_Sorted` and `Counter_Add_Unsorted` to exclude the setup duration from the benchmark results.

With `LargeInput`
```
Counter_Created
Counter_Add_Sorted      time:   [170.49 ns 170.63 ns 170.89 ns]
                        change: [-11.149% -10.899% -10.583%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

Counter_Created
Counter_Add_Unsorted    time:   [172.93 ns 172.97 ns 173.01 ns]
                        change: [-11.878% -11.673% -11.426%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
```

With `SmallInput`
```
Counter_Created
Counter_Add_Sorted      time:   [167.97 ns 168.04 ns 168.11 ns]
                        change: [-2.0473% -1.7160% -1.4582%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe

Counter_Created
Counter_Add_Unsorted    time:   [171.76 ns 171.94 ns 172.18 ns]
                        change: [-1.0523% -0.8236% -0.6261%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

```

OS: Ubuntu 24.04 (6.8.0-1014-azure)
Hardware: AMD EPYC 7763 64-Core (16) @ 2.44 GHz
RAM: 64.0 GB

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
