### PR TITLE
refactor: update metrics Result to be MetricResult

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ For a deeper discussion, see:
 
 Currently, the Opentelemetry Rust SDK has two ways to handle errors. In the situation where errors are not allowed to return. One should call global error handler to process the errors. Otherwise, one should return the errors.
 
-The Opentelemetry Rust SDK comes with an error type `opentelemetry::Error`. For different function, one error has been defined. All error returned by trace module MUST be wrapped in `opentelemetry::trace::TraceError`. All errors returned by metrics module MUST be wrapped in `opentelemetry::metrics::MetricsError`. All errors returned by logs module MUST be wrapped in `opentelemetry::logs::LogsError`.
+The Opentelemetry Rust SDK comes with an error type `opentelemetry::Error`. For different function, one error has been defined. All error returned by trace module MUST be wrapped in `opentelemetry::trace::TraceError`. All errors returned by metrics module MUST be wrapped in `opentelemetry::metrics::MetricError`. All errors returned by logs module MUST be wrapped in `opentelemetry::logs::LogsError`.
 
 For users that want to implement their own exporters. It's RECOMMENDED to wrap all errors from the exporter into a crate-level error type, and implement `ExporterError` trait.
 

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -1,7 +1,7 @@
 use once_cell::sync::Lazy;
 use opentelemetry::{
     global,
-    metrics::MetricsError,
+    metrics::MetricError,
     trace::{TraceContextExt, TraceError, Tracer},
     InstrumentationScope, KeyValue,
 };
@@ -65,7 +65,7 @@ fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
         .build())
 }
 
-fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, MetricsError> {
+fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, MetricError> {
     let exporter = MetricsExporter::builder()
         .with_http()
         .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -1,6 +1,6 @@
 use once_cell::sync::Lazy;
 use opentelemetry::logs::LogError;
-use opentelemetry::metrics::MetricsError;
+use opentelemetry::metrics::MetricError;
 use opentelemetry::trace::{TraceContextExt, TraceError, Tracer};
 use opentelemetry::KeyValue;
 use opentelemetry::{global, InstrumentationScope};
@@ -33,7 +33,7 @@ fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
         .build())
 }
 
-fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, MetricsError> {
+fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, MetricError> {
     let exporter = MetricsExporter::builder().with_tonic().build()?;
 
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();

--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use http::{header::CONTENT_TYPE, Method};
-use opentelemetry::metrics::{MetricsError, Result};
+use opentelemetry::metrics::{MetricResult, MetricsError};
 use opentelemetry_sdk::metrics::data::ResourceMetrics;
 
 use crate::{metric::MetricsClient, Error};
@@ -11,7 +11,7 @@ use super::OtlpHttpClient;
 
 #[async_trait]
 impl MetricsClient for OtlpHttpClient {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> Result<()> {
+    async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()> {
         let client = self
             .client
             .lock()
@@ -41,7 +41,7 @@ impl MetricsClient for OtlpHttpClient {
         Ok(())
     }
 
-    fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> MetricResult<()> {
         let _ = self.client.lock()?.take();
 
         Ok(())

--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use http::{header::CONTENT_TYPE, Method};
-use opentelemetry::metrics::{MetricResult, MetricsError};
+use opentelemetry::metrics::{MetricError, MetricResult};
 use opentelemetry_sdk::metrics::data::ResourceMetrics;
 
 use crate::{metric::MetricsClient, Error};
@@ -18,7 +18,7 @@ impl MetricsClient for OtlpHttpClient {
             .map_err(Into::into)
             .and_then(|g| match &*g {
                 Some(client) => Ok(Arc::clone(client)),
-                _ => Err(MetricsError::Other("exporter is already shut down".into())),
+                _ => Err(MetricError::Other("exporter is already shut down".into())),
             })?;
 
         let (body, content_type) = self.build_metrics_export_body(metrics)?;
@@ -36,7 +36,7 @@ impl MetricsClient for OtlpHttpClient {
         client
             .send(request)
             .await
-            .map_err(|e| MetricsError::ExportErr(Box::new(Error::RequestFailed(e))))?;
+            .map_err(|e| MetricError::ExportErr(Box::new(Error::RequestFailed(e))))?;
 
         Ok(())
     }

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -320,7 +320,7 @@ impl OtlpHttpClient {
             #[cfg(feature = "http-json")]
             Protocol::HttpJson => match serde_json::to_string_pretty(&req) {
                 Ok(json) => Ok((json.into(), "application/json")),
-                Err(e) => Err(opentelemetry::metrics::MetricsError::Other(e.to_string())),
+                Err(e) => Err(opentelemetry::metrics::MetricError::Other(e.to_string())),
             },
             _ => Ok((req.encode_to_vec(), "application/x-protobuf")),
         }

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -221,7 +221,7 @@ impl HttpExporterBuilder {
     pub fn build_metrics_exporter(
         mut self,
         temporality: opentelemetry_sdk::metrics::data::Temporality,
-    ) -> opentelemetry::metrics::Result<crate::MetricsExporter> {
+    ) -> opentelemetry::metrics::MetricResult<crate::MetricsExporter> {
         use crate::{
             OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_HEADERS,
             OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
@@ -311,7 +311,7 @@ impl OtlpHttpClient {
     fn build_metrics_export_body(
         &self,
         metrics: &mut opentelemetry_sdk::metrics::data::ResourceMetrics,
-    ) -> opentelemetry::metrics::Result<(Vec<u8>, &'static str)> {
+    ) -> opentelemetry::metrics::MetricResult<(Vec<u8>, &'static str)> {
         use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 
         let req: ExportMetricsServiceRequest = (&*metrics).into();

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::sync::Mutex;
 
 use async_trait::async_trait;
-use opentelemetry::metrics::{MetricResult, MetricsError};
+use opentelemetry::metrics::{MetricError, MetricResult};
 use opentelemetry_proto::tonic::collector::metrics::v1::{
     metrics_service_client::MetricsServiceClient, ExportMetricsServiceRequest,
 };
@@ -62,14 +62,14 @@ impl MetricsClient for TonicMetricsClient {
                             .interceptor
                             .call(Request::new(()))
                             .map_err(|e| {
-                                MetricsError::Other(format!(
+                                MetricError::Other(format!(
                                     "unexpected status while exporting {e:?}"
                                 ))
                             })?
                             .into_parts();
                         Ok((inner.client.clone(), m, e))
                     }
-                    None => Err(MetricsError::Other("exporter is already shut down".into())),
+                    None => Err(MetricError::Other("exporter is already shut down".into())),
                 })?;
 
         client

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::sync::Mutex;
 
 use async_trait::async_trait;
-use opentelemetry::metrics::{MetricsError, Result};
+use opentelemetry::metrics::{MetricResult, MetricsError};
 use opentelemetry_proto::tonic::collector::metrics::v1::{
     metrics_service_client::MetricsServiceClient, ExportMetricsServiceRequest,
 };
@@ -51,7 +51,7 @@ impl TonicMetricsClient {
 
 #[async_trait]
 impl MetricsClient for TonicMetricsClient {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> Result<()> {
+    async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()> {
         let (mut client, metadata, extensions) =
             self.inner
                 .lock()
@@ -84,7 +84,7 @@ impl MetricsClient for TonicMetricsClient {
         Ok(())
     }
 
-    fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> MetricResult<()> {
         let _ = self.inner.lock()?.take();
 
         Ok(())

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -274,7 +274,7 @@ impl TonicExporterBuilder {
     pub(crate) fn build_metrics_exporter(
         self,
         temporality: opentelemetry_sdk::metrics::data::Temporality,
-    ) -> opentelemetry::metrics::Result<crate::MetricsExporter> {
+    ) -> opentelemetry::metrics::MetricResult<crate::MetricsExporter> {
         use crate::MetricsExporter;
         use metrics::TonicMetricsClient;
 

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -16,7 +16,7 @@ use crate::NoExporterBuilderSet;
 
 use async_trait::async_trait;
 use core::fmt;
-use opentelemetry::metrics::Result;
+use opentelemetry::metrics::MetricResult;
 
 use opentelemetry_sdk::metrics::{
     data::{ResourceMetrics, Temporality},
@@ -77,7 +77,7 @@ impl<C> MetricsExporterBuilder<C> {
 
 #[cfg(feature = "grpc-tonic")]
 impl MetricsExporterBuilder<TonicExporterBuilderSet> {
-    pub fn build(self) -> Result<MetricsExporter> {
+    pub fn build(self) -> MetricResult<MetricsExporter> {
         let exporter = self.client.0.build_metrics_exporter(self.temporality)?;
         Ok(exporter)
     }
@@ -85,7 +85,7 @@ impl MetricsExporterBuilder<TonicExporterBuilderSet> {
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
 impl MetricsExporterBuilder<HttpExporterBuilderSet> {
-    pub fn build(self) -> Result<MetricsExporter> {
+    pub fn build(self) -> MetricResult<MetricsExporter> {
         let exporter = self.client.0.build_metrics_exporter(self.temporality)?;
         Ok(exporter)
     }
@@ -122,8 +122,8 @@ impl HasHttpConfig for MetricsExporterBuilder<HttpExporterBuilderSet> {
 /// An interface for OTLP metrics clients
 #[async_trait]
 pub trait MetricsClient: fmt::Debug + Send + Sync + 'static {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> Result<()>;
-    fn shutdown(&self) -> Result<()>;
+    async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()>;
+    fn shutdown(&self) -> MetricResult<()>;
 }
 
 /// Export metrics in OTEL format.
@@ -140,16 +140,16 @@ impl Debug for MetricsExporter {
 
 #[async_trait]
 impl PushMetricsExporter for MetricsExporter {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> Result<()> {
+    async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()> {
         self.client.export(metrics).await
     }
 
-    async fn force_flush(&self) -> Result<()> {
+    async fn force_flush(&self) -> MetricResult<()> {
         // this component is stateless
         Ok(())
     }
 
-    fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> MetricResult<()> {
         self.client.shutdown()
     }
 

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -8,7 +8,7 @@ pub mod tonic {
     use std::any::Any;
     use std::fmt;
 
-    use opentelemetry::{global, metrics::MetricsError, Key, Value};
+    use opentelemetry::{global, metrics::MetricError, Key, Value};
     use opentelemetry_sdk::metrics::data::{
         self, Exemplar as SdkExemplar, ExponentialHistogram as SdkExponentialHistogram,
         Gauge as SdkGauge, Histogram as SdkHistogram, Metric as SdkMetric,
@@ -97,7 +97,7 @@ pub mod tonic {
                 Temporality::Cumulative => AggregationTemporality::Cumulative,
                 Temporality::Delta => AggregationTemporality::Delta,
                 other => {
-                    opentelemetry::global::handle_error(MetricsError::Other(format!(
+                    opentelemetry::global::handle_error(MetricError::Other(format!(
                         "Unknown temporality {:?}, using default instead.",
                         other
                     )));
@@ -184,7 +184,7 @@ pub mod tonic {
             } else if let Some(gauge) = data.downcast_ref::<SdkGauge<f64>>() {
                 Ok(TonicMetricData::Gauge(gauge.into()))
             } else {
-                global::handle_error(MetricsError::Other("unknown aggregator".into()));
+                global::handle_error(MetricError::Other("unknown aggregator".into()));
                 Err(())
             }
         }

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Weak};
 
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use opentelemetry::{
-    metrics::{Counter, Histogram, MeterProvider as _, Result},
+    metrics::{Counter, Histogram, MeterProvider as _, MetricResult},
     Key, KeyValue,
 };
 use opentelemetry_sdk::{
@@ -25,15 +25,15 @@ impl MetricReader for SharedReader {
         self.0.register_pipeline(pipeline)
     }
 
-    fn collect(&self, rm: &mut ResourceMetrics) -> Result<()> {
+    fn collect(&self, rm: &mut ResourceMetrics) -> MetricResult<()> {
         self.0.collect(rm)
     }
 
-    fn force_flush(&self) -> Result<()> {
+    fn force_flush(&self) -> MetricResult<()> {
         self.0.force_flush()
     }
 
-    fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> MetricResult<()> {
         self.0.shutdown()
     }
 

--- a/opentelemetry-sdk/src/metrics/aggregation.rs
+++ b/opentelemetry-sdk/src/metrics/aggregation.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::metrics::internal::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
-use opentelemetry::metrics::{MetricResult, MetricsError};
+use opentelemetry::metrics::{MetricError, MetricResult};
 
 /// The way recorded measurements are summarized.
 #[derive(Clone, Debug, PartialEq)]
@@ -118,7 +118,7 @@ impl Aggregation {
             Aggregation::ExplicitBucketHistogram { boundaries, .. } => {
                 for x in boundaries.windows(2) {
                     if x[0] >= x[1] {
-                        return Err(MetricsError::Config(format!(
+                        return Err(MetricError::Config(format!(
                             "aggregation: explicit bucket histogram: non-monotonic boundaries: {:?}",
                             boundaries,
                         )));
@@ -129,13 +129,13 @@ impl Aggregation {
             }
             Aggregation::Base2ExponentialHistogram { max_scale, .. } => {
                 if *max_scale > EXPO_MAX_SCALE {
-                    return Err(MetricsError::Config(format!(
+                    return Err(MetricError::Config(format!(
                         "aggregation: exponential histogram: max scale ({}) is greater than 20",
                         max_scale,
                     )));
                 }
                 if *max_scale < EXPO_MIN_SCALE {
-                    return Err(MetricsError::Config(format!(
+                    return Err(MetricError::Config(format!(
                         "aggregation: exponential histogram: max scale ({}) is less than -10",
                         max_scale,
                     )));
@@ -153,7 +153,7 @@ mod tests {
         internal::{EXPO_MAX_SCALE, EXPO_MIN_SCALE},
         Aggregation,
     };
-    use opentelemetry::metrics::{MetricResult, MetricsError};
+    use opentelemetry::metrics::{MetricError, MetricResult};
 
     #[test]
     fn validate_aggregation() {
@@ -163,7 +163,7 @@ mod tests {
             check: Box<dyn Fn(MetricResult<()>) -> bool>,
         }
         let ok = Box::new(|result: MetricResult<()>| result.is_ok());
-        let config_error = Box::new(|result| matches!(result, Err(MetricsError::Config(_))));
+        let config_error = Box::new(|result| matches!(result, Err(MetricError::Config(_))));
 
         let test_cases: Vec<TestCase> = vec![
             TestCase {

--- a/opentelemetry-sdk/src/metrics/aggregation.rs
+++ b/opentelemetry-sdk/src/metrics/aggregation.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::metrics::internal::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
-use opentelemetry::metrics::{MetricsError, Result};
+use opentelemetry::metrics::{MetricResult, MetricsError};
 
 /// The way recorded measurements are summarized.
 #[derive(Clone, Debug, PartialEq)]
@@ -109,7 +109,7 @@ impl fmt::Display for Aggregation {
 
 impl Aggregation {
     /// Validate that this aggregation has correct configuration
-    pub fn validate(&self) -> Result<()> {
+    pub fn validate(&self) -> MetricResult<()> {
         match self {
             Aggregation::Drop => Ok(()),
             Aggregation::Default => Ok(()),
@@ -153,16 +153,16 @@ mod tests {
         internal::{EXPO_MAX_SCALE, EXPO_MIN_SCALE},
         Aggregation,
     };
-    use opentelemetry::metrics::{MetricsError, Result};
+    use opentelemetry::metrics::{MetricResult, MetricsError};
 
     #[test]
     fn validate_aggregation() {
         struct TestCase {
             name: &'static str,
             input: Aggregation,
-            check: Box<dyn Fn(Result<()>) -> bool>,
+            check: Box<dyn Fn(MetricResult<()>) -> bool>,
         }
-        let ok = Box::new(|result: Result<()>| result.is_ok());
+        let ok = Box::new(|result: MetricResult<()>| result.is_ok());
         let config_error = Box::new(|result| matches!(result, Err(MetricsError::Config(_))));
 
         let test_cases: Vec<TestCase> = vec![

--- a/opentelemetry-sdk/src/metrics/exporter.rs
+++ b/opentelemetry-sdk/src/metrics/exporter.rs
@@ -1,7 +1,7 @@
 //! Interfaces for exporting metrics
 use async_trait::async_trait;
 
-use opentelemetry::metrics::Result;
+use opentelemetry::metrics::MetricResult;
 
 use crate::metrics::data::ResourceMetrics;
 
@@ -18,16 +18,16 @@ pub trait PushMetricsExporter: Send + Sync + 'static {
     /// implement any retry logic. All errors returned by this function are
     /// considered unrecoverable and will be reported to a configured error
     /// Handler.
-    async fn export(&self, metrics: &mut ResourceMetrics) -> Result<()>;
+    async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()>;
 
     /// Flushes any metric data held by an exporter.
-    async fn force_flush(&self) -> Result<()>;
+    async fn force_flush(&self) -> MetricResult<()>;
 
     /// Releases any held computational resources.
     ///
     /// After Shutdown is called, calls to Export will perform no operation and
     /// instead will return an error indicating the shutdown state.
-    fn shutdown(&self) -> Result<()>;
+    fn shutdown(&self) -> MetricResult<()>;
 
     /// Access the [Temporality] of the MetricsExporter.
     fn temporality(&self) -> Temporality;

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -16,7 +16,7 @@ use aggregate::is_under_cardinality_limit;
 pub(crate) use aggregate::{AggregateBuilder, ComputeAggregation, Measure};
 pub(crate) use exponential_histogram::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
 use once_cell::sync::Lazy;
-use opentelemetry::metrics::MetricsError;
+use opentelemetry::metrics::MetricError;
 use opentelemetry::{global, otel_warn, KeyValue};
 
 use crate::metrics::AttributeSet;
@@ -146,7 +146,7 @@ impl<AU: AtomicallyUpdate<T>, T: Number, O: Operation> ValueMap<AU, T, O> {
             let new_tracker = AU::new_atomic_tracker(self.buckets_count);
             O::update_tracker(&new_tracker, measurement, index);
             trackers.insert(STREAM_OVERFLOW_ATTRIBUTES.clone(), Arc::new(new_tracker));
-            global::handle_error(MetricsError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow. Subsequent overflows to same metric until next collect will not be logged.".into()));
+            global::handle_error(MetricError::Other("Warning: Maximum data points for metric stream exceeded. Entry added to overflow. Subsequent overflows to same metric until next collect will not be logged.".into()));
             otel_warn!( name: "ValueMap.measure",
                 message = "Maximum data points for metric stream exceeded. Entry added to overflow. Subsequent overflows to same metric until next collect will not be logged."
             );

--- a/opentelemetry-sdk/src/metrics/manual_reader.rs
+++ b/opentelemetry-sdk/src/metrics/manual_reader.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use opentelemetry::{
-    metrics::{MetricsError, Result},
+    metrics::{MetricResult, MetricsError},
     otel_debug,
 };
 
@@ -88,7 +88,7 @@ impl MetricReader for ManualReader {
     /// callbacks necessary and returning the results.
     ///
     /// Returns an error if called after shutdown.
-    fn collect(&self, rm: &mut ResourceMetrics) -> Result<()> {
+    fn collect(&self, rm: &mut ResourceMetrics) -> MetricResult<()> {
         let inner = self.inner.lock()?;
         match &inner.sdk_producer.as_ref().and_then(|w| w.upgrade()) {
             Some(producer) => producer.produce(rm)?,
@@ -103,12 +103,12 @@ impl MetricReader for ManualReader {
     }
 
     /// ForceFlush is a no-op, it always returns nil.
-    fn force_flush(&self) -> Result<()> {
+    fn force_flush(&self) -> MetricResult<()> {
         Ok(())
     }
 
     /// Closes any connections and frees any resources used by the reader.
-    fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> MetricResult<()> {
         let mut inner = self.inner.lock()?;
 
         // Any future call to collect will now return an error.

--- a/opentelemetry-sdk/src/metrics/manual_reader.rs
+++ b/opentelemetry-sdk/src/metrics/manual_reader.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use opentelemetry::{
-    metrics::{MetricResult, MetricsError},
+    metrics::{MetricError, MetricResult},
     otel_debug,
 };
 
@@ -93,7 +93,7 @@ impl MetricReader for ManualReader {
         match &inner.sdk_producer.as_ref().and_then(|w| w.upgrade()) {
             Some(producer) => producer.produce(rm)?,
             None => {
-                return Err(MetricsError::Other(
+                return Err(MetricError::Other(
                     "reader is shut down or not registered".into(),
                 ))
             }

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -5,8 +5,8 @@ use opentelemetry::{
     global,
     metrics::{
         AsyncInstrumentBuilder, Counter, Gauge, Histogram, HistogramBuilder, InstrumentBuilder,
-        InstrumentProvider, MetricsError, ObservableCounter, ObservableGauge,
-        ObservableUpDownCounter, Result, UpDownCounter,
+        InstrumentProvider, MetricResult, MetricsError, ObservableCounter, ObservableGauge,
+        ObservableUpDownCounter, UpDownCounter,
     },
     otel_error, InstrumentationScope,
 };
@@ -493,11 +493,11 @@ impl InstrumentProvider for SdkMeter {
     }
 }
 
-fn validate_instrument_config(name: &str, unit: &Option<Cow<'static, str>>) -> Result<()> {
+fn validate_instrument_config(name: &str, unit: &Option<Cow<'static, str>>) -> MetricResult<()> {
     validate_instrument_name(name).and_then(|_| validate_instrument_unit(unit))
 }
 
-fn validate_instrument_name(name: &str) -> Result<()> {
+fn validate_instrument_name(name: &str) -> MetricResult<()> {
     if name.is_empty() {
         return Err(MetricsError::InvalidInstrumentConfiguration(
             INSTRUMENT_NAME_EMPTY,
@@ -523,7 +523,7 @@ fn validate_instrument_name(name: &str) -> Result<()> {
     Ok(())
 }
 
-fn validate_instrument_unit(unit: &Option<Cow<'static, str>>) -> Result<()> {
+fn validate_instrument_unit(unit: &Option<Cow<'static, str>>) -> MetricResult<()> {
     if let Some(unit) = unit {
         if unit.len() > INSTRUMENT_UNIT_NAME_MAX_LENGTH {
             return Err(MetricsError::InvalidInstrumentConfiguration(
@@ -567,7 +567,7 @@ where
         description: Option<Cow<'static, str>>,
         unit: Option<Cow<'static, str>>,
         boundaries: Option<Vec<f64>>,
-    ) -> Result<ResolvedMeasures<T>> {
+    ) -> MetricResult<ResolvedMeasures<T>> {
         let aggregators = self.measures(kind, name, description, unit, boundaries)?;
         Ok(ResolvedMeasures {
             measures: aggregators,
@@ -581,7 +581,7 @@ where
         description: Option<Cow<'static, str>>,
         unit: Option<Cow<'static, str>>,
         boundaries: Option<Vec<f64>>,
-    ) -> Result<Vec<Arc<dyn internal::Measure<T>>>> {
+    ) -> MetricResult<Vec<Arc<dyn internal::Measure<T>>>> {
         let inst = Instrument {
             name,
             description: description.unwrap_or_default(),

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -5,7 +5,7 @@ use opentelemetry::{
     global,
     metrics::{
         AsyncInstrumentBuilder, Counter, Gauge, Histogram, HistogramBuilder, InstrumentBuilder,
-        InstrumentProvider, MetricResult, MetricsError, ObservableCounter, ObservableGauge,
+        InstrumentProvider, MetricError, MetricResult, ObservableCounter, ObservableGauge,
         ObservableUpDownCounter, UpDownCounter,
     },
     otel_error, InstrumentationScope,
@@ -499,24 +499,24 @@ fn validate_instrument_config(name: &str, unit: &Option<Cow<'static, str>>) -> M
 
 fn validate_instrument_name(name: &str) -> MetricResult<()> {
     if name.is_empty() {
-        return Err(MetricsError::InvalidInstrumentConfiguration(
+        return Err(MetricError::InvalidInstrumentConfiguration(
             INSTRUMENT_NAME_EMPTY,
         ));
     }
     if name.len() > INSTRUMENT_NAME_MAX_LENGTH {
-        return Err(MetricsError::InvalidInstrumentConfiguration(
+        return Err(MetricError::InvalidInstrumentConfiguration(
             INSTRUMENT_NAME_LENGTH,
         ));
     }
     if name.starts_with(|c: char| !c.is_ascii_alphabetic()) {
-        return Err(MetricsError::InvalidInstrumentConfiguration(
+        return Err(MetricError::InvalidInstrumentConfiguration(
             INSTRUMENT_NAME_FIRST_ALPHABETIC,
         ));
     }
     if name.contains(|c: char| {
         !c.is_ascii_alphanumeric() && !INSTRUMENT_NAME_ALLOWED_NON_ALPHANUMERIC_CHARS.contains(&c)
     }) {
-        return Err(MetricsError::InvalidInstrumentConfiguration(
+        return Err(MetricError::InvalidInstrumentConfiguration(
             INSTRUMENT_NAME_INVALID_CHAR,
         ));
     }
@@ -526,12 +526,12 @@ fn validate_instrument_name(name: &str) -> MetricResult<()> {
 fn validate_instrument_unit(unit: &Option<Cow<'static, str>>) -> MetricResult<()> {
     if let Some(unit) = unit {
         if unit.len() > INSTRUMENT_UNIT_NAME_MAX_LENGTH {
-            return Err(MetricsError::InvalidInstrumentConfiguration(
+            return Err(MetricError::InvalidInstrumentConfiguration(
                 INSTRUMENT_UNIT_LENGTH,
             ));
         }
         if unit.contains(|c: char| !c.is_ascii()) {
-            return Err(MetricsError::InvalidInstrumentConfiguration(
+            return Err(MetricError::InvalidInstrumentConfiguration(
                 INSTRUMENT_UNIT_INVALID_CHAR,
             ));
         }
@@ -598,7 +598,7 @@ where
 mod tests {
     use std::borrow::Cow;
 
-    use opentelemetry::metrics::MetricsError;
+    use opentelemetry::metrics::MetricError;
 
     use super::{
         validate_instrument_name, validate_instrument_unit, INSTRUMENT_NAME_FIRST_ALPHABETIC,
@@ -621,13 +621,13 @@ mod tests {
             ("allow.dots.ok", ""),
         ];
         for (name, expected_error) in instrument_name_test_cases {
-            let assert = |result: Result<_, MetricsError>| {
+            let assert = |result: Result<_, MetricError>| {
                 if expected_error.is_empty() {
                     assert!(result.is_ok());
                 } else {
                     assert!(matches!(
                         result.unwrap_err(),
-                        MetricsError::InvalidInstrumentConfiguration(msg) if msg == expected_error
+                        MetricError::InvalidInstrumentConfiguration(msg) if msg == expected_error
                     ));
                 }
             };
@@ -652,13 +652,13 @@ mod tests {
         ];
 
         for (unit, expected_error) in instrument_unit_test_cases {
-            let assert = |result: Result<_, MetricsError>| {
+            let assert = |result: Result<_, MetricError>| {
                 if expected_error.is_empty() {
                     assert!(result.is_ok());
                 } else {
                     assert!(matches!(
                         result.unwrap_err(),
-                        MetricsError::InvalidInstrumentConfiguration(msg) if msg == expected_error
+                        MetricError::InvalidInstrumentConfiguration(msg) if msg == expected_error
                     ));
                 }
             };

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use opentelemetry::{
-    metrics::{Meter, MeterProvider, MetricResult, MetricsError},
+    metrics::{Meter, MeterProvider, MetricError, MetricResult},
     otel_debug, otel_error, InstrumentationScope,
 };
 
@@ -125,7 +125,7 @@ impl SdkMeterProviderInner {
         {
             self.pipes.shutdown()
         } else {
-            Err(MetricsError::Other(
+            Err(MetricError::Other(
                 "metrics provider already shut down".into(),
             ))
         }

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use opentelemetry::{
-    metrics::{Meter, MeterProvider, MetricsError, Result},
+    metrics::{Meter, MeterProvider, MetricResult, MetricsError},
     otel_debug, otel_error, InstrumentationScope,
 };
 
@@ -91,7 +91,7 @@ impl SdkMeterProvider {
     ///     Ok(())
     /// }
     /// ```
-    pub fn force_flush(&self) -> Result<()> {
+    pub fn force_flush(&self) -> MetricResult<()> {
         self.inner.force_flush()
     }
 
@@ -107,17 +107,17 @@ impl SdkMeterProvider {
     ///
     /// There is no guaranteed that all telemetry be flushed or all resources have
     /// been released on error.
-    pub fn shutdown(&self) -> Result<()> {
+    pub fn shutdown(&self) -> MetricResult<()> {
         self.inner.shutdown()
     }
 }
 
 impl SdkMeterProviderInner {
-    fn force_flush(&self) -> Result<()> {
+    fn force_flush(&self) -> MetricResult<()> {
         self.pipes.force_flush()
     }
 
-    fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> MetricResult<()> {
         if self
             .is_shutdown
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -7,7 +7,7 @@ use std::{
 
 use opentelemetry::{
     global,
-    metrics::{MetricResult, MetricsError},
+    metrics::{MetricError, MetricResult},
     InstrumentationScope, KeyValue,
 };
 
@@ -253,7 +253,7 @@ where
         let mut errs = vec![];
         let kind = match inst.kind {
             Some(kind) => kind,
-            None => return Err(MetricsError::Other("instrument must have a kind".into())),
+            None => return Err(MetricError::Other("instrument must have a kind".into())),
         };
 
         // The cache will return the same Aggregator instance. Use stream ids to de duplicate.
@@ -286,7 +286,7 @@ where
             if errs.is_empty() {
                 return Ok(measures);
             } else {
-                return Err(MetricsError::Other(format!("{errs:?}")));
+                return Err(MetricError::Other(format!("{errs:?}")));
             }
         }
 
@@ -315,12 +315,12 @@ where
                     }
                     Ok(measures)
                 } else {
-                    Err(MetricsError::Other(format!("{errs:?}")))
+                    Err(MetricError::Other(format!("{errs:?}")))
                 }
             }
             Err(err) => {
                 errs.push(err);
-                Err(MetricsError::Other(format!("{errs:?}")))
+                Err(MetricError::Other(format!("{errs:?}")))
             }
         }
     }
@@ -355,7 +355,7 @@ where
         }
 
         if let Err(err) = is_aggregator_compatible(&kind, &agg) {
-            return Err(MetricsError::Other(format!(
+            return Err(MetricError::Other(format!(
                 "creating aggregator with instrumentKind: {:?}, aggregation {:?}: {:?}",
                 kind, stream.aggregation, err,
             )));
@@ -400,7 +400,7 @@ where
 
         match cached {
             Ok(opt) => Ok(opt.clone()),
-            Err(err) => Err(MetricsError::Other(err.to_string())),
+            Err(err) => Err(MetricError::Other(err.to_string())),
         }
     }
 
@@ -414,7 +414,7 @@ where
                     return;
                 }
 
-                global::handle_error(MetricsError::Other(format!(
+                global::handle_error(MetricError::Other(format!(
                     "duplicate metric stream definitions, names: ({} and {}), descriptions: ({} and {}), kinds: ({:?} and {:?}), units: ({:?} and {:?}), and numbers: ({} and {})",
                     existing.name, id.name,
                     existing.description, id.description,
@@ -573,7 +573,7 @@ fn is_aggregator_compatible(
             ) {
                 return Ok(());
             }
-            Err(MetricsError::Other("incompatible aggregation".into()))
+            Err(MetricError::Other("incompatible aggregation".into()))
         }
         Aggregation::Sum => {
             match kind {
@@ -585,7 +585,7 @@ fn is_aggregator_compatible(
                 _ => {
                     // TODO: review need for aggregation check after
                     // https://github.com/open-telemetry/opentelemetry-specification/issues/2710
-                    Err(MetricsError::Other("incompatible aggregation".into()))
+                    Err(MetricError::Other("incompatible aggregation".into()))
                 }
             }
         }
@@ -595,7 +595,7 @@ fn is_aggregator_compatible(
                 _ => {
                     // TODO: review need for aggregation check after
                     // https://github.com/open-telemetry/opentelemetry-specification/issues/2710
-                    Err(MetricsError::Other("incompatible aggregation".into()))
+                    Err(MetricError::Other("incompatible aggregation".into()))
                 }
             }
         }
@@ -650,7 +650,7 @@ impl Pipelines {
         if errs.is_empty() {
             Ok(())
         } else {
-            Err(MetricsError::Other(format!("{errs:?}")))
+            Err(MetricError::Other(format!("{errs:?}")))
         }
     }
 
@@ -666,7 +666,7 @@ impl Pipelines {
         if errs.is_empty() {
             Ok(())
         } else {
-            Err(MetricsError::Other(format!("{errs:?}")))
+            Err(MetricError::Other(format!("{errs:?}")))
         }
     }
 }
@@ -717,7 +717,7 @@ where
             }
             Ok(measures)
         } else {
-            Err(MetricsError::Other(format!("{errs:?}")))
+            Err(MetricError::Other(format!("{errs:?}")))
         }
     }
 }

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -1,7 +1,7 @@
 //! Interfaces for reading and producing metrics
 use std::{fmt, sync::Weak};
 
-use opentelemetry::metrics::Result;
+use opentelemetry::metrics::MetricResult;
 
 use super::{
     data::{ResourceMetrics, Temporality},
@@ -34,13 +34,13 @@ pub trait MetricReader: fmt::Debug + Send + Sync + 'static {
     /// SDK and stores it in the provided [ResourceMetrics] reference.
     ///
     /// An error is returned if this is called after shutdown.
-    fn collect(&self, rm: &mut ResourceMetrics) -> Result<()>;
+    fn collect(&self, rm: &mut ResourceMetrics) -> MetricResult<()>;
 
     /// Flushes all metric measurements held in an export pipeline.
     ///
     /// There is no guaranteed that all telemetry be flushed or all resources have
     /// been released on error.
-    fn force_flush(&self) -> Result<()>;
+    fn force_flush(&self) -> MetricResult<()>;
 
     /// Flushes all metric measurements held in an export pipeline and releases any
     /// held computational resources.
@@ -50,7 +50,7 @@ pub trait MetricReader: fmt::Debug + Send + Sync + 'static {
     ///
     /// After `shutdown` is called, calls to `collect` will perform no operation and
     /// instead will return an error indicating the shutdown state.
-    fn shutdown(&self) -> Result<()>;
+    fn shutdown(&self) -> MetricResult<()>;
 
     /// The output temporality, a function of instrument kind.
     /// This SHOULD be obtained from the exporter.
@@ -62,5 +62,5 @@ pub trait MetricReader: fmt::Debug + Send + Sync + 'static {
 /// Produces metrics for a [MetricReader].
 pub(crate) trait SdkProducer: fmt::Debug + Send + Sync {
     /// Returns aggregated metrics from a single collection.
-    fn produce(&self, rm: &mut ResourceMetrics) -> Result<()>;
+    fn produce(&self, rm: &mut ResourceMetrics) -> MetricResult<()>;
 }

--- a/opentelemetry-sdk/src/metrics/view.rs
+++ b/opentelemetry-sdk/src/metrics/view.rs
@@ -2,7 +2,7 @@ use super::instrument::{Instrument, Stream};
 use glob::Pattern;
 use opentelemetry::{
     global,
-    metrics::{MetricsError, Result},
+    metrics::{MetricResult, MetricsError},
 };
 
 fn empty_view(_inst: &Instrument) -> Option<Stream> {
@@ -100,7 +100,7 @@ impl View for Box<dyn View> {
 /// let view = new_view(criteria, mask);
 /// # drop(view);
 /// ```
-pub fn new_view(criteria: Instrument, mask: Stream) -> Result<Box<dyn View>> {
+pub fn new_view(criteria: Instrument, mask: Stream) -> MetricResult<Box<dyn View>> {
     if criteria.is_empty() {
         global::handle_error(MetricsError::Config(format!(
             "no criteria provided, dropping view. mask: {mask:?}"

--- a/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
@@ -2,8 +2,8 @@ use crate::metrics::data;
 use crate::metrics::data::{Histogram, Metric, ResourceMetrics, ScopeMetrics, Temporality};
 use crate::metrics::exporter::PushMetricsExporter;
 use async_trait::async_trait;
+use opentelemetry::metrics::MetricResult;
 use opentelemetry::metrics::MetricsError;
-use opentelemetry::metrics::Result;
 use std::collections::VecDeque;
 use std::fmt;
 use std::sync::{Arc, Mutex};
@@ -142,7 +142,7 @@ impl InMemoryMetricsExporter {
     /// let exporter = InMemoryMetricsExporter::default();
     /// let finished_metrics = exporter.get_finished_metrics().unwrap();
     /// ```
-    pub fn get_finished_metrics(&self) -> Result<Vec<ResourceMetrics>> {
+    pub fn get_finished_metrics(&self) -> MetricResult<Vec<ResourceMetrics>> {
         self.metrics
             .lock()
             .map(|metrics_guard| metrics_guard.iter().map(Self::clone_metrics).collect())
@@ -245,7 +245,7 @@ impl InMemoryMetricsExporter {
 
 #[async_trait]
 impl PushMetricsExporter for InMemoryMetricsExporter {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> Result<()> {
+    async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()> {
         self.metrics
             .lock()
             .map(|mut metrics_guard| {
@@ -254,11 +254,11 @@ impl PushMetricsExporter for InMemoryMetricsExporter {
             .map_err(MetricsError::from)
     }
 
-    async fn force_flush(&self) -> Result<()> {
+    async fn force_flush(&self) -> MetricResult<()> {
         Ok(()) // In this implementation, flush does nothing
     }
 
-    fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> MetricResult<()> {
         self.metrics
             .lock()
             .map(|mut metrics_guard| metrics_guard.clear())

--- a/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
@@ -2,8 +2,8 @@ use crate::metrics::data;
 use crate::metrics::data::{Histogram, Metric, ResourceMetrics, ScopeMetrics, Temporality};
 use crate::metrics::exporter::PushMetricsExporter;
 use async_trait::async_trait;
+use opentelemetry::metrics::MetricError;
 use opentelemetry::metrics::MetricResult;
-use opentelemetry::metrics::MetricsError;
 use std::collections::VecDeque;
 use std::fmt;
 use std::sync::{Arc, Mutex};
@@ -132,7 +132,7 @@ impl InMemoryMetricsExporter {
     ///
     /// # Errors
     ///
-    /// Returns a `MetricsError` if the internal lock cannot be acquired.
+    /// Returns a `MetricError` if the internal lock cannot be acquired.
     ///
     /// # Example
     ///
@@ -146,7 +146,7 @@ impl InMemoryMetricsExporter {
         self.metrics
             .lock()
             .map(|metrics_guard| metrics_guard.iter().map(Self::clone_metrics).collect())
-            .map_err(MetricsError::from)
+            .map_err(MetricError::from)
     }
 
     /// Clears the internal storage of finished metrics.
@@ -251,7 +251,7 @@ impl PushMetricsExporter for InMemoryMetricsExporter {
             .map(|mut metrics_guard| {
                 metrics_guard.push_back(InMemoryMetricsExporter::clone_metrics(metrics))
             })
-            .map_err(MetricsError::from)
+            .map_err(MetricError::from)
     }
 
     async fn force_flush(&self) -> MetricResult<()> {
@@ -262,7 +262,7 @@ impl PushMetricsExporter for InMemoryMetricsExporter {
         self.metrics
             .lock()
             .map(|mut metrics_guard| metrics_guard.clear())
-            .map_err(MetricsError::from)?;
+            .map_err(MetricError::from)?;
 
         Ok(())
     }

--- a/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
+++ b/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
@@ -6,7 +6,7 @@ use crate::metrics::{
     reader::MetricReader,
     InstrumentKind,
 };
-use opentelemetry::metrics::Result;
+use opentelemetry::metrics::MetricResult;
 
 #[derive(Debug, Clone)]
 pub struct TestMetricReader {
@@ -36,15 +36,15 @@ impl Default for TestMetricReader {
 impl MetricReader for TestMetricReader {
     fn register_pipeline(&self, _pipeline: Weak<Pipeline>) {}
 
-    fn collect(&self, _rm: &mut ResourceMetrics) -> Result<()> {
+    fn collect(&self, _rm: &mut ResourceMetrics) -> MetricResult<()> {
         Ok(())
     }
 
-    fn force_flush(&self) -> Result<()> {
+    fn force_flush(&self) -> MetricResult<()> {
         Ok(())
     }
 
-    fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> MetricResult<()> {
         let result = self.force_flush();
         {
             let mut is_shutdown = self.is_shutdown.lock().unwrap();

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use core::{f64, fmt};
-use opentelemetry::metrics::{MetricsError, Result};
+use opentelemetry::metrics::{MetricResult, MetricsError};
 use opentelemetry_sdk::metrics::{
     data::{self, ScopeMetrics, Temporality},
     exporter::PushMetricsExporter,
@@ -36,7 +36,7 @@ impl fmt::Debug for MetricsExporter {
 #[async_trait]
 impl PushMetricsExporter for MetricsExporter {
     /// Write Metrics to stdout
-    async fn export(&self, metrics: &mut data::ResourceMetrics) -> Result<()> {
+    async fn export(&self, metrics: &mut data::ResourceMetrics) -> MetricResult<()> {
         if self.is_shutdown.load(atomic::Ordering::SeqCst) {
             Err(MetricsError::Other("exporter is shut down".into()))
         } else {
@@ -54,12 +54,12 @@ impl PushMetricsExporter for MetricsExporter {
         }
     }
 
-    async fn force_flush(&self) -> Result<()> {
+    async fn force_flush(&self) -> MetricResult<()> {
         // exporter holds no state, nothing to flush
         Ok(())
     }
 
-    fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> MetricResult<()> {
         self.is_shutdown.store(true, atomic::Ordering::SeqCst);
         Ok(())
     }

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use core::{f64, fmt};
-use opentelemetry::metrics::{MetricResult, MetricsError};
+use opentelemetry::metrics::{MetricError, MetricResult};
 use opentelemetry_sdk::metrics::{
     data::{self, ScopeMetrics, Temporality},
     exporter::PushMetricsExporter,
@@ -38,7 +38,7 @@ impl PushMetricsExporter for MetricsExporter {
     /// Write Metrics to stdout
     async fn export(&self, metrics: &mut data::ResourceMetrics) -> MetricResult<()> {
         if self.is_shutdown.load(atomic::Ordering::SeqCst) {
-            Err(MetricsError::Other("exporter is shut down".into()))
+            Err(MetricError::Other("exporter is shut down".into()))
         } else {
             println!("Metrics");
             println!("Resource");

--- a/opentelemetry/src/global/error_handler.rs
+++ b/opentelemetry/src/global/error_handler.rs
@@ -4,7 +4,7 @@ use std::sync::RwLock;
 #[cfg(feature = "logs")]
 use crate::logs::LogError;
 #[cfg(feature = "metrics")]
-use crate::metrics::MetricsError;
+use crate::metrics::MetricError;
 use crate::propagation::PropagationError;
 #[cfg(feature = "trace")]
 use crate::trace::TraceError;
@@ -25,7 +25,7 @@ pub enum Error {
     #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
     #[error(transparent)]
     /// An issue raised by the metrics module.
-    Metric(#[from] MetricsError),
+    Metric(#[from] MetricError),
 
     #[cfg(feature = "logs")]
     #[cfg_attr(docsrs, doc(cfg(feature = "logs")))]

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -22,12 +22,12 @@ pub use instruments::{
 pub use meter::{Meter, MeterProvider};
 
 /// A specialized `Result` type for metric operations.
-pub type MetricResult<T> = result::Result<T, MetricsError>;
+pub type MetricResult<T> = result::Result<T, MetricError>;
 
 /// Errors returned by the metrics API.
 #[derive(Error, Debug)]
 #[non_exhaustive]
-pub enum MetricsError {
+pub enum MetricError {
     /// Other errors not covered by specific cases.
     #[error("Metrics error: {0}")]
     Other(String),
@@ -44,15 +44,15 @@ pub enum MetricsError {
     InvalidInstrumentConfiguration(&'static str),
 }
 
-impl<T: ExportError> From<T> for MetricsError {
+impl<T: ExportError> From<T> for MetricError {
     fn from(err: T) -> Self {
-        MetricsError::ExportErr(Box::new(err))
+        MetricError::ExportErr(Box::new(err))
     }
 }
 
-impl<T> From<PoisonError<T>> for MetricsError {
+impl<T> From<PoisonError<T>> for MetricError {
     fn from(err: PoisonError<T>) -> Self {
-        MetricsError::Other(err.to_string())
+        MetricError::Other(err.to_string())
     }
 }
 

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -22,7 +22,7 @@ pub use instruments::{
 pub use meter::{Meter, MeterProvider};
 
 /// A specialized `Result` type for metric operations.
-pub type Result<T> = result::Result<T, MetricsError>;
+pub type MetricResult<T> = result::Result<T, MetricsError>;
 
 /// Errors returned by the metrics API.
 #[derive(Error, Debug)]


### PR DESCRIPTION
related to comment: https://github.com/open-telemetry/opentelemetry-rust/pull/2221#issuecomment-2424967497

## Changes

Make the `MetricResult` / `MetricError` consistent with `LogResult` / `LogError`, and `TraceResult` / `TraceError`

Another option could be to have all signals type be `Result` / `Error`, and determine which one is used from the module path `metrics::Result<()>` / `metrics::Error`?

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
