### PR TITLE
Refactor/metric exporters non plural

### DIFF
--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -45,7 +45,7 @@ fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
     };
 
     // Build exporter using Delta Temporality.
-    let exporter = opentelemetry_stdout::MetricsExporterBuilder::default()
+    let exporter = opentelemetry_stdout::MetricExporterBuilder::default()
         .with_temporality(Temporality::Delta)
         .build();
 

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use std::vec;
 
 fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
-    let exporter = opentelemetry_stdout::MetricsExporterBuilder::default()
+    let exporter = opentelemetry_stdout::MetricExporterBuilder::default()
         // Build exporter using Delta Temporality (Defaults to Temporality::Cumulative)
         // .with_temporality(data::Temporality::Delta)
         .build();

--- a/examples/self-diagnostics/src/main.rs
+++ b/examples/self-diagnostics/src/main.rs
@@ -1,7 +1,7 @@
 use opentelemetry::global::{self, set_error_handler, Error as OtelError};
 use opentelemetry::KeyValue;
 use opentelemetry_appender_tracing::layer;
-use opentelemetry_otlp::{LogExporter, MetricsExporter, WithExportConfig};
+use opentelemetry_otlp::{LogExporter, MetricExporter, WithExportConfig};
 use opentelemetry_sdk::metrics::PeriodicReader;
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::fmt;
@@ -109,7 +109,7 @@ fn init_logger_provider() -> opentelemetry_sdk::logs::LoggerProvider {
 }
 
 fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
-    let exporter = MetricsExporter::builder()
+    let exporter = MetricExporter::builder()
         .with_http()
         .with_endpoint("http://localhost:4318/v1/metrics")
         .build()

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -48,6 +48,10 @@ Released 2024-Sep-30
               .build()?,
       ).build();
     ```
+  - **Renamed**
+    - ([#2255](https://github.com/open-telemetry/opentelemetry-rust/pull/2255)): de-pluralize Metric types.
+      - `MetricsExporter` -> `MetricExporter`
+      - `MetricsExporterBuilder` -> `MetricExporterBuilder`
 
 ## v0.25.0
 

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -7,7 +7,7 @@ use opentelemetry::{
 };
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_otlp::{LogExporter, MetricsExporter, Protocol, SpanExporter};
+use opentelemetry_otlp::{LogExporter, MetricExporter, Protocol, SpanExporter};
 use opentelemetry_sdk::{
     logs::LoggerProvider,
     metrics::{PeriodicReader, SdkMeterProvider},
@@ -66,7 +66,7 @@ fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
 }
 
 fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, MetricError> {
-    let exporter = MetricsExporter::builder()
+    let exporter = MetricExporter::builder()
         .with_http()
         .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
         .with_endpoint("http://localhost:4318/v1/metrics")

--- a/opentelemetry-otlp/examples/basic-otlp/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp/README.md
@@ -120,7 +120,7 @@ SpanEvent #0
 ### Metric
 
 ```text
-2024-05-22T20:25:42.908Z    info    MetricsExporter {"kind": "exporter", "data_type": "metrics", "name": "logging", "resource metrics": 1, "metrics": 1, "data points": 1}
+2024-05-22T20:25:42.908Z    info    MetricExporter {"kind": "exporter", "data_type": "metrics", "name": "logging", "resource metrics": 1, "metrics": 1, "data points": 1}
 2024-05-22T20:25:42.908Z    info    ResourceMetrics #0
 Resource SchemaURL:
 Resource attributes:

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -5,7 +5,7 @@ use opentelemetry::trace::{TraceContextExt, TraceError, Tracer};
 use opentelemetry::KeyValue;
 use opentelemetry::{global, InstrumentationScope};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
-use opentelemetry_otlp::{LogExporter, MetricsExporter, SpanExporter, WithExportConfig};
+use opentelemetry_otlp::{LogExporter, MetricExporter, SpanExporter, WithExportConfig};
 use opentelemetry_sdk::logs::LoggerProvider;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::trace::Config;
@@ -34,7 +34,7 @@ fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
 }
 
 fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, MetricError> {
-    let exporter = MetricsExporter::builder().with_tonic().build()?;
+    let exporter = MetricExporter::builder().with_tonic().build()?;
 
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
 

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -83,7 +83,7 @@ impl Default for HttpConfig {
 ///
 /// // Create a metrics exporter you can use when configuring meter providers
 /// # #[cfg(feature="metrics")]
-/// let metrics_exporter = opentelemetry_otlp::MetricsExporter::builder()
+/// let metrics_exporter = opentelemetry_otlp::MetricExporter::builder()
 ///     .with_http()
 ///     .with_temporality(Temporality::default())
 ///     .build()?;
@@ -221,7 +221,7 @@ impl HttpExporterBuilder {
     pub fn build_metrics_exporter(
         mut self,
         temporality: opentelemetry_sdk::metrics::data::Temporality,
-    ) -> opentelemetry::metrics::MetricResult<crate::MetricsExporter> {
+    ) -> opentelemetry::metrics::MetricResult<crate::MetricExporter> {
         use crate::{
             OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_HEADERS,
             OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
@@ -234,7 +234,7 @@ impl HttpExporterBuilder {
             OTEL_EXPORTER_OTLP_METRICS_HEADERS,
         )?;
 
-        Ok(crate::MetricsExporter::new(client, temporality))
+        Ok(crate::MetricExporter::new(client, temporality))
     }
 }
 

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -90,7 +90,7 @@ impl TryFrom<Compression> for tonic::codec::CompressionEncoding {
 ///
 /// // Create a metric exporter you can use when configuring meter providers
 /// # #[cfg(feature="metrics")]
-/// let metric_exporter = opentelemetry_otlp::MetricsExporter::builder()
+/// let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
 ///     .with_tonic()
 ///     .with_temporality(Temporality::default())
 ///     .build()?;
@@ -274,8 +274,8 @@ impl TonicExporterBuilder {
     pub(crate) fn build_metrics_exporter(
         self,
         temporality: opentelemetry_sdk::metrics::data::Temporality,
-    ) -> opentelemetry::metrics::MetricResult<crate::MetricsExporter> {
-        use crate::MetricsExporter;
+    ) -> opentelemetry::metrics::MetricResult<crate::MetricExporter> {
+        use crate::MetricExporter;
         use metrics::TonicMetricsClient;
 
         let (channel, interceptor, compression) = self.build_channel(
@@ -287,7 +287,7 @@ impl TonicExporterBuilder {
 
         let client = TonicMetricsClient::new(channel, interceptor, compression);
 
-        Ok(MetricsExporter::new(client, temporality))
+        Ok(MetricExporter::new(client, temporality))
     }
 
     /// Build a new tonic span exporter

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -25,7 +25,7 @@
 //! telemetry.
 //!
 //! You will have to build a OTLP exporter first. Create the correct exporter based on the signal
-//! you are looking to export `SpanExporter::builder()`, `MetricsExporter::builder()`,
+//! you are looking to export `SpanExporter::builder()`, `MetricExporter::builder()`,
 //! `LogExporter::builder()` respectively for traces, metrics, and logs.
 //!
 //! Once you have the exporter, you can create your `Provider` by starting with `TracerProvider::builder()`,
@@ -124,7 +124,7 @@
 //!
 //! Generally there are two parts of configuration. One is the exporter, the other is the provider.
 //! Users can configure the exporter using [SpanExporter::builder()] for traces,
-//! and [MetricsExporter::builder()] + [opentelemetry_sdk::metrics::PeriodicReader::builder()] for metrics.
+//! and [MetricExporter::builder()] + [opentelemetry_sdk::metrics::PeriodicReader::builder()] for metrics.
 //! Once you have an exporter, you can add it to either a [opentelemetry_sdk::trace::TracerProvider::builder()] for traces,
 //! or [opentelemetry_sdk::metrics::SdkMeterProvider::builder()] for metrics.
 //!
@@ -171,7 +171,7 @@
 //!
 //!     # #[cfg(all(feature = "metrics", feature = "grpc-tonic"))]
 //!     # {
-//!     let exporter = opentelemetry_otlp::MetricsExporter::builder()
+//!     let exporter = opentelemetry_otlp::MetricExporter::builder()
 //!        .with_tonic()
 //!        .with_endpoint("http://localhost:4318/v1/metrics")
 //!        .with_protocol(Protocol::Grpc)
@@ -240,7 +240,7 @@ pub use crate::span::{
 #[cfg(feature = "metrics")]
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 pub use crate::metric::{
-    MetricsExporter, OTEL_EXPORTER_OTLP_METRICS_COMPRESSION, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
+    MetricExporter, OTEL_EXPORTER_OTLP_METRICS_COMPRESSION, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
     OTEL_EXPORTER_OTLP_METRICS_HEADERS, OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
 };
 

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -20,7 +20,7 @@ use opentelemetry::metrics::MetricResult;
 
 use opentelemetry_sdk::metrics::{
     data::{ResourceMetrics, Temporality},
-    exporter::PushMetricsExporter,
+    exporter::PushMetricExporter,
 };
 use std::fmt::{Debug, Formatter};
 
@@ -139,7 +139,7 @@ impl Debug for MetricExporter {
 }
 
 #[async_trait]
-impl PushMetricsExporter for MetricExporter {
+impl PushMetricExporter for MetricExporter {
     async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()> {
         self.client.export(metrics).await
     }

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -1,6 +1,6 @@
 //! OTEL metric exporter
 //!
-//! Defines a [MetricsExporter] to send metric data to backend via OTLP protocol.
+//! Defines a [MetricExporter] to send metric data to backend via OTLP protocol.
 //!
 
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
@@ -39,36 +39,36 @@ pub const OTEL_EXPORTER_OTLP_METRICS_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_MET
 pub const OTEL_EXPORTER_OTLP_METRICS_HEADERS: &str = "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
 
 #[derive(Debug, Default, Clone)]
-pub struct MetricsExporterBuilder<C> {
+pub struct MetricExporterBuilder<C> {
     client: C,
     temporality: Temporality,
 }
 
-impl MetricsExporterBuilder<NoExporterBuilderSet> {
+impl MetricExporterBuilder<NoExporterBuilderSet> {
     pub fn new() -> Self {
-        MetricsExporterBuilder::default()
+        MetricExporterBuilder::default()
     }
 }
 
-impl<C> MetricsExporterBuilder<C> {
+impl<C> MetricExporterBuilder<C> {
     #[cfg(feature = "grpc-tonic")]
-    pub fn with_tonic(self) -> MetricsExporterBuilder<TonicExporterBuilderSet> {
-        MetricsExporterBuilder {
+    pub fn with_tonic(self) -> MetricExporterBuilder<TonicExporterBuilderSet> {
+        MetricExporterBuilder {
             client: TonicExporterBuilderSet(TonicExporterBuilder::default()),
             temporality: self.temporality,
         }
     }
 
     #[cfg(any(feature = "http-proto", feature = "http-json"))]
-    pub fn with_http(self) -> MetricsExporterBuilder<HttpExporterBuilderSet> {
-        MetricsExporterBuilder {
+    pub fn with_http(self) -> MetricExporterBuilder<HttpExporterBuilderSet> {
+        MetricExporterBuilder {
             client: HttpExporterBuilderSet(HttpExporterBuilder::default()),
             temporality: self.temporality,
         }
     }
 
-    pub fn with_temporality(self, temporality: Temporality) -> MetricsExporterBuilder<C> {
-        MetricsExporterBuilder {
+    pub fn with_temporality(self, temporality: Temporality) -> MetricExporterBuilder<C> {
+        MetricExporterBuilder {
             client: self.client,
             temporality,
         }
@@ -76,44 +76,44 @@ impl<C> MetricsExporterBuilder<C> {
 }
 
 #[cfg(feature = "grpc-tonic")]
-impl MetricsExporterBuilder<TonicExporterBuilderSet> {
-    pub fn build(self) -> MetricResult<MetricsExporter> {
+impl MetricExporterBuilder<TonicExporterBuilderSet> {
+    pub fn build(self) -> MetricResult<MetricExporter> {
         let exporter = self.client.0.build_metrics_exporter(self.temporality)?;
         Ok(exporter)
     }
 }
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
-impl MetricsExporterBuilder<HttpExporterBuilderSet> {
-    pub fn build(self) -> MetricResult<MetricsExporter> {
+impl MetricExporterBuilder<HttpExporterBuilderSet> {
+    pub fn build(self) -> MetricResult<MetricExporter> {
         let exporter = self.client.0.build_metrics_exporter(self.temporality)?;
         Ok(exporter)
     }
 }
 
 #[cfg(feature = "grpc-tonic")]
-impl HasExportConfig for MetricsExporterBuilder<TonicExporterBuilderSet> {
+impl HasExportConfig for MetricExporterBuilder<TonicExporterBuilderSet> {
     fn export_config(&mut self) -> &mut crate::ExportConfig {
         &mut self.client.0.exporter_config
     }
 }
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
-impl HasExportConfig for MetricsExporterBuilder<HttpExporterBuilderSet> {
+impl HasExportConfig for MetricExporterBuilder<HttpExporterBuilderSet> {
     fn export_config(&mut self) -> &mut crate::ExportConfig {
         &mut self.client.0.exporter_config
     }
 }
 
 #[cfg(feature = "grpc-tonic")]
-impl HasTonicConfig for MetricsExporterBuilder<TonicExporterBuilderSet> {
+impl HasTonicConfig for MetricExporterBuilder<TonicExporterBuilderSet> {
     fn tonic_config(&mut self) -> &mut crate::TonicConfig {
         &mut self.client.0.tonic_config
     }
 }
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
-impl HasHttpConfig for MetricsExporterBuilder<HttpExporterBuilderSet> {
+impl HasHttpConfig for MetricExporterBuilder<HttpExporterBuilderSet> {
     fn http_client_config(&mut self) -> &mut crate::exporter::http::HttpConfig {
         &mut self.client.0.http_config
     }
@@ -127,19 +127,19 @@ pub trait MetricsClient: fmt::Debug + Send + Sync + 'static {
 }
 
 /// Export metrics in OTEL format.
-pub struct MetricsExporter {
+pub struct MetricExporter {
     client: Box<dyn MetricsClient>,
     temporality: Temporality,
 }
 
-impl Debug for MetricsExporter {
+impl Debug for MetricExporter {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MetricsExporter").finish()
+        f.debug_struct("MetricExporter").finish()
     }
 }
 
 #[async_trait]
-impl PushMetricsExporter for MetricsExporter {
+impl PushMetricsExporter for MetricExporter {
     async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()> {
         self.client.export(metrics).await
     }
@@ -158,15 +158,15 @@ impl PushMetricsExporter for MetricsExporter {
     }
 }
 
-impl MetricsExporter {
-    /// Obtain a builder to configure a [MetricsExporter].
-    pub fn builder() -> MetricsExporterBuilder<NoExporterBuilderSet> {
-        MetricsExporterBuilder::default()
+impl MetricExporter {
+    /// Obtain a builder to configure a [MetricExporter].
+    pub fn builder() -> MetricExporterBuilder<NoExporterBuilderSet> {
+        MetricExporterBuilder::default()
     }
 
     /// Create a new metrics exporter
-    pub fn new(client: impl MetricsClient, temporality: Temporality) -> MetricsExporter {
-        MetricsExporter {
+    pub fn new(client: impl MetricsClient, temporality: Temporality) -> MetricExporter {
+        MetricExporter {
             client: Box::new(client),
             temporality,
         }

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -5,20 +5,24 @@
 - Bump MSRV to 1.70 [#2179](https://github.com/open-telemetry/opentelemetry-rust/pull/2179)
 - Implement `LogRecord::set_trace_context` for `LogRecord`. Respect any trace context set on a `LogRecord` when emitting through a `Logger`.
 - Improved `LoggerProvider` shutdown handling to prevent redundant shutdown calls when `drop` is invoked. [#2195](https://github.com/open-telemetry/opentelemetry-rust/pull/2195)
-- **BREAKING**: [#2217](https://github.com/open-telemetry/opentelemetry-rust/pull/2217)
-  - **Replaced**: Removed `{Delta,Cumulative}TemporalitySelector::new()` in favor of directly using `Temporality` enum to simplify the configuration of MetricsExporterBuilder with different temporalities.
 - When creating new metric instruments, SDK would return a no-op instrument if the validation fails. [#2166](https://github.com/open-telemetry/opentelemetry-rust/pull/2166)
-- **Breaking change for Metrics users:** The `init` method used to create instruments has been renamed to `build`.
-
-Before:
-```rust
-let counter = meter.u64_counter("my_counter").init();
-```
-
-Now:
-```rust
-let counter = meter.u64_counter("my_counter").build();
-```
+- **BREAKING for Metrics users**:
+  - **Replaced**
+    - ([#2217](https://github.com/open-telemetry/opentelemetry-rust/pull/2217)): Removed `{Delta,Cumulative}TemporalitySelector::new()` in favor of directly using `Temporality` enum to simplify the configuration of MetricsExporterBuilder with different temporalities.
+  - **Renamed**
+    - ([#2232](https://github.com/open-telemetry/opentelemetry-rust/pull/2232)): The `init` method used to create instruments has been renamed to `build`.  
+      Before:
+      ```rust
+      let counter = meter.u64_counter("my_counter").init();
+      ```
+      Now:
+      ```rust
+      let counter = meter.u64_counter("my_counter").build();
+      ```
+    - ([#2255](https://github.com/open-telemetry/opentelemetry-rust/pull/2255)): de-pluralize Metric types.
+      - `PushMetricsExporter` -> `PushMetricExporter`
+      - `InMemoryMetricsExporter` -> `InMemoryMetricExporter`
+      - `InMemoryMetricsExporterBuilder` -> `InMemoryMetricExporterBuilder`
 - **BREAKING**: [#2220](https://github.com/open-telemetry/opentelemetry-rust/pull/2220)
   - Removed `InstrumentationLibrary` re-export and its `Scope` alias, use `opentelemetry::InstrumentationLibrary` instead.
   - Unified builders across signals

--- a/opentelemetry-sdk/src/metrics/exporter.rs
+++ b/opentelemetry-sdk/src/metrics/exporter.rs
@@ -11,7 +11,7 @@ use super::data::Temporality;
 ///
 /// This is the final component in the metric push pipeline.
 #[async_trait]
-pub trait PushMetricsExporter: Send + Sync + 'static {
+pub trait PushMetricExporter: Send + Sync + 'static {
     /// Export serializes and transmits metric data to a receiver.
     ///
     /// All retry logic must be contained in this function. The SDK does not

--- a/opentelemetry-sdk/src/metrics/exporter.rs
+++ b/opentelemetry-sdk/src/metrics/exporter.rs
@@ -29,6 +29,6 @@ pub trait PushMetricsExporter: Send + Sync + 'static {
     /// instead will return an error indicating the shutdown state.
     fn shutdown(&self) -> MetricResult<()>;
 
-    /// Access the [Temporality] of the MetricsExporter.
+    /// Access the [Temporality] of the MetricExporter.
     fn temporality(&self) -> Temporality;
 }

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -131,8 +131,8 @@ mod tests {
     use self::data::{DataPoint, HistogramDataPoint, ScopeMetrics};
     use super::*;
     use crate::metrics::data::{ResourceMetrics, Temporality};
-    use crate::testing::metrics::InMemoryMetricsExporterBuilder;
-    use crate::{runtime, testing::metrics::InMemoryMetricsExporter};
+    use crate::testing::metrics::InMemoryMetricExporterBuilder;
+    use crate::{runtime, testing::metrics::InMemoryMetricExporter};
     use opentelemetry::metrics::{Counter, Meter, UpDownCounter};
     use opentelemetry::InstrumentationScope;
     use opentelemetry::{metrics::MeterProvider as _, KeyValue};
@@ -491,7 +491,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn counter_duplicate_instrument_merge() {
         // Arrange
-        let exporter = InMemoryMetricsExporter::default();
+        let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
         let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
 
@@ -542,7 +542,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn counter_duplicate_instrument_different_meter_no_merge() {
         // Arrange
-        let exporter = InMemoryMetricsExporter::default();
+        let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
         let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
 
@@ -631,7 +631,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn instrumentation_scope_identity_test() {
         // Arrange
-        let exporter = InMemoryMetricsExporter::default();
+        let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
         let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
 
@@ -713,7 +713,7 @@ mod tests {
         // cargo test histogram_aggregation_with_invalid_aggregation_should_proceed_as_if_view_not_exist --features=testing -- --nocapture
 
         // Arrange
-        let exporter = InMemoryMetricsExporter::default();
+        let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
         let criteria = Instrument::new().name("test_histogram");
         let stream_invalid_aggregation = Stream::new()
@@ -763,7 +763,7 @@ mod tests {
         // cargo test metrics::tests::spatial_aggregation_when_view_drops_attributes_observable_counter --features=testing
 
         // Arrange
-        let exporter = InMemoryMetricsExporter::default();
+        let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
         let criteria = Instrument::new().name("my_observable_counter");
         // View drops all attributes.
@@ -838,7 +838,7 @@ mod tests {
         // cargo test spatial_aggregation_when_view_drops_attributes_counter --features=testing
 
         // Arrange
-        let exporter = InMemoryMetricsExporter::default();
+        let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
         let criteria = Instrument::new().name("my_counter");
         // View drops all attributes.
@@ -2345,7 +2345,7 @@ mod tests {
     }
 
     struct TestContext {
-        exporter: InMemoryMetricsExporter,
+        exporter: InMemoryMetricExporter,
         meter_provider: SdkMeterProvider,
 
         // Saving this on the test context for lifetime simplicity
@@ -2354,7 +2354,7 @@ mod tests {
 
     impl TestContext {
         fn new(temporality: Temporality) -> Self {
-            let exporter = InMemoryMetricsExporterBuilder::new().with_temporality(temporality);
+            let exporter = InMemoryMetricExporterBuilder::new().with_temporality(temporality);
 
             let exporter = exporter.build();
             let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
@@ -2411,7 +2411,7 @@ mod tests {
             let resource_metrics = self
                 .exporter
                 .get_finished_metrics()
-                .expect("metrics expected to be exported"); // TODO: Need to fix InMemoryMetricsExporter to return None.
+                .expect("metrics expected to be exported"); // TODO: Need to fix InMemoryMetricExporter to return None.
 
             assert!(resource_metrics.is_empty(), "no metrics should be exported");
         }

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -391,7 +391,7 @@ mod tests {
     use super::PeriodicReader;
     use crate::{
         metrics::data::ResourceMetrics, metrics::reader::MetricReader, metrics::SdkMeterProvider,
-        runtime, testing::metrics::InMemoryMetricsExporter, Resource,
+        runtime, testing::metrics::InMemoryMetricExporter, Resource,
     };
     use opentelemetry::metrics::{MeterProvider, MetricError};
     use std::sync::mpsc;
@@ -437,7 +437,7 @@ mod tests {
     #[test]
     fn unregistered_collect() {
         // Arrange
-        let exporter = InMemoryMetricsExporter::default();
+        let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
         let mut rm = ResourceMetrics {
             resource: Resource::empty(),
@@ -458,7 +458,7 @@ mod tests {
         RT: crate::runtime::Runtime,
     {
         let interval = std::time::Duration::from_millis(1);
-        let exporter = InMemoryMetricsExporter::default();
+        let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone(), runtime)
             .with_interval(interval)
             .build();

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -18,7 +18,7 @@ use opentelemetry::{
 
 use crate::runtime::Runtime;
 use crate::{
-    metrics::{exporter::PushMetricsExporter, reader::SdkProducer},
+    metrics::{exporter::PushMetricExporter, reader::SdkProducer},
     Resource,
 };
 
@@ -54,7 +54,7 @@ pub struct PeriodicReaderBuilder<E, RT> {
 
 impl<E, RT> PeriodicReaderBuilder<E, RT>
 where
-    E: PushMetricsExporter,
+    E: PushMetricExporter,
     RT: Runtime,
 {
     fn new(exporter: E, runtime: RT) -> Self {
@@ -155,7 +155,7 @@ where
 ///
 /// The [runtime] can be selected based on feature flags set for this crate.
 ///
-/// The exporter can be any exporter that implements [PushMetricsExporter] such
+/// The exporter can be any exporter that implements [PushMetricExporter] such
 /// as [opentelemetry-otlp].
 ///
 /// [collect]: MetricReader::collect
@@ -168,7 +168,7 @@ where
 /// use opentelemetry_sdk::metrics::PeriodicReader;
 /// # fn example<E, R>(get_exporter: impl Fn() -> E, get_runtime: impl Fn() -> R)
 /// # where
-/// #     E: opentelemetry_sdk::metrics::exporter::PushMetricsExporter,
+/// #     E: opentelemetry_sdk::metrics::exporter::PushMetricExporter,
 /// #     R: opentelemetry_sdk::runtime::Runtime,
 /// # {
 ///
@@ -181,7 +181,7 @@ where
 /// ```
 #[derive(Clone)]
 pub struct PeriodicReader {
-    exporter: Arc<dyn PushMetricsExporter>,
+    exporter: Arc<dyn PushMetricExporter>,
     inner: Arc<Mutex<PeriodicReaderInner>>,
 }
 
@@ -189,7 +189,7 @@ impl PeriodicReader {
     /// Configuration options for a periodic reader
     pub fn builder<E, RT>(exporter: E, runtime: RT) -> PeriodicReaderBuilder<E, RT>
     where
-        E: PushMetricsExporter,
+        E: PushMetricExporter,
         RT: Runtime,
     {
         PeriodicReaderBuilder::new(exporter, runtime)

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -18,7 +18,7 @@ use super::{
 /// flow.
 ///
 /// Typically, push-based exporters that are periodic will implement
-/// `MetricsExporter` themselves and construct a `PeriodicReader` to satisfy this
+/// `MetricExporter` themselves and construct a `PeriodicReader` to satisfy this
 /// interface.
 ///
 /// Pull-based exporters will typically implement `MetricReader` themselves,

--- a/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
@@ -26,13 +26,13 @@ use std::sync::{Arc, Mutex};
 ///# use opentelemetry_sdk::{metrics, runtime};
 ///# use opentelemetry::{KeyValue};
 ///# use opentelemetry::metrics::MeterProvider;
-///# use opentelemetry_sdk::testing::metrics::InMemoryMetricsExporter;
+///# use opentelemetry_sdk::testing::metrics::InMemoryMetricExporter;
 ///# use opentelemetry_sdk::metrics::PeriodicReader;
 ///
 ///# #[tokio::main]
 ///# async fn main() {
-/// // Create an InMemoryMetricsExporter
-///  let exporter = InMemoryMetricsExporter::default();
+/// // Create an InMemoryMetricExporter
+///  let exporter = InMemoryMetricExporter::default();
 ///
 ///  // Create a MeterProvider and register the exporter
 ///  let meter_provider = metrics::SdkMeterProvider::builder()
@@ -55,58 +55,58 @@ use std::sync::{Arc, Mutex};
 ///  }
 ///# }
 /// ```
-pub struct InMemoryMetricsExporter {
+pub struct InMemoryMetricExporter {
     metrics: Arc<Mutex<VecDeque<ResourceMetrics>>>,
     temporality: Temporality,
 }
 
-impl Clone for InMemoryMetricsExporter {
+impl Clone for InMemoryMetricExporter {
     fn clone(&self) -> Self {
-        InMemoryMetricsExporter {
+        InMemoryMetricExporter {
             metrics: self.metrics.clone(),
             temporality: self.temporality,
         }
     }
 }
 
-impl fmt::Debug for InMemoryMetricsExporter {
+impl fmt::Debug for InMemoryMetricExporter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("InMemoryMetricsExporter").finish()
+        f.debug_struct("InMemoryMetricExporter").finish()
     }
 }
 
-impl Default for InMemoryMetricsExporter {
+impl Default for InMemoryMetricExporter {
     fn default() -> Self {
-        InMemoryMetricsExporterBuilder::new().build()
+        InMemoryMetricExporterBuilder::new().build()
     }
 }
 
-/// Builder for [`InMemoryMetricsExporter`].
+/// Builder for [`InMemoryMetricExporter`].
 /// # Example
 ///
 /// ```
-/// # use opentelemetry_sdk::testing::metrics::{InMemoryMetricsExporter, InMemoryMetricsExporterBuilder};
+/// # use opentelemetry_sdk::testing::metrics::{InMemoryMetricExporter, InMemoryMetricExporterBuilder};
 ///
-/// let exporter = InMemoryMetricsExporterBuilder::new().build();
+/// let exporter = InMemoryMetricExporterBuilder::new().build();
 /// ```
-pub struct InMemoryMetricsExporterBuilder {
+pub struct InMemoryMetricExporterBuilder {
     temporality: Option<Temporality>,
 }
 
-impl fmt::Debug for InMemoryMetricsExporterBuilder {
+impl fmt::Debug for InMemoryMetricExporterBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("InMemoryMetricsExporterBuilder").finish()
+        f.debug_struct("InMemoryMetricExporterBuilder").finish()
     }
 }
 
-impl Default for InMemoryMetricsExporterBuilder {
+impl Default for InMemoryMetricExporterBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl InMemoryMetricsExporterBuilder {
-    /// Creates a new instance of the `InMemoryMetricsExporterBuilder`.
+impl InMemoryMetricExporterBuilder {
+    /// Creates a new instance of the `InMemoryMetricExporterBuilder`.
     pub fn new() -> Self {
         Self { temporality: None }
     }
@@ -117,17 +117,17 @@ impl InMemoryMetricsExporterBuilder {
         self
     }
 
-    /// Creates a new instance of the `InMemoryMetricsExporter`.
+    /// Creates a new instance of the `InMemoryMetricExporter`.
     ///
-    pub fn build(self) -> InMemoryMetricsExporter {
-        InMemoryMetricsExporter {
+    pub fn build(self) -> InMemoryMetricExporter {
+        InMemoryMetricExporter {
             metrics: Arc::new(Mutex::new(VecDeque::new())),
             temporality: self.temporality.unwrap_or_default(),
         }
     }
 }
 
-impl InMemoryMetricsExporter {
+impl InMemoryMetricExporter {
     /// Returns the finished metrics as a vector of `ResourceMetrics`.
     ///
     /// # Errors
@@ -137,9 +137,9 @@ impl InMemoryMetricsExporter {
     /// # Example
     ///
     /// ```
-    /// # use opentelemetry_sdk::testing::metrics::InMemoryMetricsExporter;
+    /// # use opentelemetry_sdk::testing::metrics::InMemoryMetricExporter;
     ///
-    /// let exporter = InMemoryMetricsExporter::default();
+    /// let exporter = InMemoryMetricExporter::default();
     /// let finished_metrics = exporter.get_finished_metrics().unwrap();
     /// ```
     pub fn get_finished_metrics(&self) -> MetricResult<Vec<ResourceMetrics>> {
@@ -154,9 +154,9 @@ impl InMemoryMetricsExporter {
     /// # Example
     ///
     /// ```
-    /// # use opentelemetry_sdk::testing::metrics::InMemoryMetricsExporter;
+    /// # use opentelemetry_sdk::testing::metrics::InMemoryMetricExporter;
     ///
-    /// let exporter = InMemoryMetricsExporter::default();
+    /// let exporter = InMemoryMetricExporter::default();
     /// exporter.reset();
     /// ```
     pub fn reset(&self) {
@@ -244,12 +244,12 @@ impl InMemoryMetricsExporter {
 }
 
 #[async_trait]
-impl PushMetricsExporter for InMemoryMetricsExporter {
+impl PushMetricsExporter for InMemoryMetricExporter {
     async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()> {
         self.metrics
             .lock()
             .map(|mut metrics_guard| {
-                metrics_guard.push_back(InMemoryMetricsExporter::clone_metrics(metrics))
+                metrics_guard.push_back(InMemoryMetricExporter::clone_metrics(metrics))
             })
             .map_err(MetricError::from)
     }

--- a/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
@@ -1,6 +1,6 @@
 use crate::metrics::data;
 use crate::metrics::data::{Histogram, Metric, ResourceMetrics, ScopeMetrics, Temporality};
-use crate::metrics::exporter::PushMetricsExporter;
+use crate::metrics::exporter::PushMetricExporter;
 use async_trait::async_trait;
 use opentelemetry::metrics::MetricError;
 use opentelemetry::metrics::MetricResult;
@@ -244,7 +244,7 @@ impl InMemoryMetricExporter {
 }
 
 #[async_trait]
-impl PushMetricsExporter for InMemoryMetricExporter {
+impl PushMetricExporter for InMemoryMetricExporter {
     async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()> {
         self.metrics
             .lock()

--- a/opentelemetry-sdk/src/testing/metrics/mod.rs
+++ b/opentelemetry-sdk/src/testing/metrics/mod.rs
@@ -3,7 +3,7 @@
 /// The `in_memory_exporter` module provides in-memory metrics exporter.
 /// For detailed usage and examples, see `in_memory_exporter`.
 pub mod in_memory_exporter;
-pub use in_memory_exporter::{InMemoryMetricsExporter, InMemoryMetricsExporterBuilder};
+pub use in_memory_exporter::{InMemoryMetricExporter, InMemoryMetricExporterBuilder};
 
 #[doc(hidden)]
 pub mod metric_reader;

--- a/opentelemetry-stdout/CHANGELOG.md
+++ b/opentelemetry-stdout/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## vNext
 
 - Bump MSRV to 1.70 [#2179](https://github.com/open-telemetry/opentelemetry-rust/pull/2179)
-- **BREAKING**: [#2217](https://github.com/open-telemetry/opentelemetry-rust/pull/2217)
-  - **Replaced**: The `MetricsExporterBuilder` interface is modified from `with_temporality_selector` to `with_temporality` example can be seen below:
+- **BREAKING**
+  - **Replaced**
+    - ([#2217](https://github.com/open-telemetry/opentelemetry-rust/pull/2217)): The `MetricsExporterBuilder` interface is modified from `with_temporality_selector` to `with_temporality` example can be seen below:
     Previous Signature:
     ```rust
     MetricsExporterBuilder::default().with_temporality_selector(DeltaTemporalitySelector::new())
@@ -13,6 +14,10 @@
     ```rust
     MetricsExporterBuilder::default().with_temporality(Temporality::Delta)
     ```
+  - **Renamed**
+    - ([#2255](https://github.com/open-telemetry/opentelemetry-rust/pull/2255)): de-pluralize Metric types.
+      - `MetricsExporter` -> `MetricExporter`
+      - `MetricsExporterBuilder` -> `MetricExporterBuilder`
 
 ## v0.26.0
 Released 2024-Sep-30

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -36,7 +36,7 @@ fn init_trace() {
 
 #[cfg(feature = "metrics")]
 fn init_metrics() -> opentelemetry_sdk::metrics::SdkMeterProvider {
-    let exporter = opentelemetry_stdout::MetricsExporter::default();
+    let exporter = opentelemetry_stdout::MetricExporter::default();
     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
     let provider = SdkMeterProvider::builder()
         .with_reader(reader)

--- a/opentelemetry-stdout/src/lib.rs
+++ b/opentelemetry-stdout/src/lib.rs
@@ -38,7 +38,7 @@
 //! }
 //!
 //! fn init_metrics() -> SdkMeterProvider {
-//!     let exporter = opentelemetry_stdout::MetricsExporter::default();
+//!     let exporter = opentelemetry_stdout::MetricExporter::default();
 //!     let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
 //!     SdkMeterProvider::builder().with_reader(reader).build()
 //! }

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -4,7 +4,7 @@ use core::{f64, fmt};
 use opentelemetry::metrics::{MetricError, MetricResult};
 use opentelemetry_sdk::metrics::{
     data::{self, ScopeMetrics, Temporality},
-    exporter::PushMetricsExporter,
+    exporter::PushMetricExporter,
 };
 use std::fmt::Debug;
 use std::sync::atomic;
@@ -34,7 +34,7 @@ impl fmt::Debug for MetricExporter {
 }
 
 #[async_trait]
-impl PushMetricsExporter for MetricExporter {
+impl PushMetricExporter for MetricExporter {
     /// Write Metrics to stdout
     async fn export(&self, metrics: &mut data::ResourceMetrics) -> MetricResult<()> {
         if self.is_shutdown.load(atomic::Ordering::SeqCst) {

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -10,31 +10,31 @@ use std::fmt::Debug;
 use std::sync::atomic;
 
 /// An OpenTelemetry exporter that writes to stdout on export.
-pub struct MetricsExporter {
+pub struct MetricExporter {
     is_shutdown: atomic::AtomicBool,
     temporality: Temporality,
 }
 
-impl MetricsExporter {
+impl MetricExporter {
     /// Create a builder to configure this exporter.
-    pub fn builder() -> MetricsExporterBuilder {
-        MetricsExporterBuilder::default()
+    pub fn builder() -> MetricExporterBuilder {
+        MetricExporterBuilder::default()
     }
 }
-impl Default for MetricsExporter {
+impl Default for MetricExporter {
     fn default() -> Self {
-        MetricsExporterBuilder::default().build()
+        MetricExporterBuilder::default().build()
     }
 }
 
-impl fmt::Debug for MetricsExporter {
+impl fmt::Debug for MetricExporter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("MetricsExporter")
+        f.write_str("MetricExporter")
     }
 }
 
 #[async_trait]
-impl PushMetricsExporter for MetricsExporter {
+impl PushMetricsExporter for MetricExporter {
     /// Write Metrics to stdout
     async fn export(&self, metrics: &mut data::ResourceMetrics) -> MetricResult<()> {
         if self.is_shutdown.load(atomic::Ordering::SeqCst) {
@@ -218,11 +218,11 @@ fn print_hist_data_points<T: Debug>(data_points: &[data::HistogramDataPoint<T>])
 
 /// Configuration for the stdout metrics exporter
 #[derive(Default)]
-pub struct MetricsExporterBuilder {
+pub struct MetricExporterBuilder {
     temporality: Option<Temporality>,
 }
 
-impl MetricsExporterBuilder {
+impl MetricExporterBuilder {
     /// Set the [Temporality] of the exporter.
     pub fn with_temporality(mut self, temporality: Temporality) -> Self {
         self.temporality = Some(temporality);
@@ -230,16 +230,16 @@ impl MetricsExporterBuilder {
     }
 
     /// Create a metrics exporter with the current configuration
-    pub fn build(self) -> MetricsExporter {
-        MetricsExporter {
+    pub fn build(self) -> MetricExporter {
+        MetricExporter {
             temporality: self.temporality.unwrap_or_default(),
             is_shutdown: atomic::AtomicBool::new(false),
         }
     }
 }
 
-impl fmt::Debug for MetricsExporterBuilder {
+impl fmt::Debug for MetricExporterBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("MetricsExporterBuilder")
+        f.write_str("MetricExporterBuilder")
     }
 }


### PR DESCRIPTION
related to comment: https://github.com/open-telemetry/opentelemetry-rust/pull/2221#issuecomment-2424967497

## Changes

De-pluralize MetricExporter types:
- `MetricsExporter{Builder}` -> `MetricExporter{Builder}`
- `InMemoryMetricsExporter{Builder}` -> `InMemoryMetricExporter{Builder}`
- `PushMetricsExporter` -> `PushMetricExporter`

As I was making these changes I noticed that there is also `InMemoryLogsExporter` and `LogExporter`. Will open another PR to address this.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
