### PR TITLE
refactor: InMemoryLogsExporter non plural

### DIFF
--- a/examples/self-diagnostics/README.md
+++ b/examples/self-diagnostics/README.md
@@ -65,7 +65,7 @@ cargo run
 
 - If the docker instance for collector is running, below error should be logged into the container. There won't be any logs from the `hyper`, `reqwest` and `tonic` crates.
 ```
-otel-collector-1  | 2024-06-05T17:09:46.926Z    info    LogsExporter    {"kind": "exporter", "data_type": "logs", "name": "logging", "resource logs": 1, "log records": 1}
+otel-collector-1  | 2024-06-05T17:09:46.926Z    info    LogExporter    {"kind": "exporter", "data_type": "logs", "name": "logging", "resource logs": 1, "log records": 1}
 otel-collector-1  | 2024-06-05T17:09:46.926Z    info    ResourceLog #0
 otel-collector-1  | Resource SchemaURL:
 otel-collector-1  | Resource attributes:

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -753,13 +753,13 @@ mod tests {
     use super::OpenTelemetryLogBridge;
 
     use opentelemetry::{logs::AnyValue, StringValue};
-    use opentelemetry_sdk::{logs::LoggerProvider, testing::logs::InMemoryLogsExporter};
+    use opentelemetry_sdk::{logs::LoggerProvider, testing::logs::InMemoryLogExporter};
 
     use log::Log;
 
     #[test]
     fn logbridge_with_default_metadata_is_enabled() {
-        let exporter = InMemoryLogsExporter::default();
+        let exporter = InMemoryLogExporter::default();
 
         let logger_provider = LoggerProvider::builder()
             .with_simple_exporter(exporter)
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn logbridge_with_record_can_log() {
-        let exporter = InMemoryLogsExporter::default();
+        let exporter = InMemoryLogExporter::default();
 
         let logger_provider = LoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
@@ -892,7 +892,7 @@ mod tests {
             }
         }
 
-        let exporter = InMemoryLogsExporter::default();
+        let exporter = InMemoryLogExporter::default();
 
         let logger_provider = LoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
@@ -1158,7 +1158,7 @@ mod tests {
             CODE_FILEPATH, CODE_LINENO, CODE_NAMESPACE,
         };
 
-        let exporter = InMemoryLogsExporter::default();
+        let exporter = InMemoryLogExporter::default();
 
         let logger_provider = LoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
@@ -1201,7 +1201,7 @@ mod tests {
 
     #[test]
     fn test_flush() {
-        let exporter = InMemoryLogsExporter::default();
+        let exporter = InMemoryLogExporter::default();
 
         let logger_provider = LoggerProvider::builder()
             .with_simple_exporter(exporter)

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -216,7 +216,7 @@ mod tests {
     use opentelemetry::{logs::AnyValue, Key};
     use opentelemetry_sdk::export::logs::{LogBatch, LogExporter};
     use opentelemetry_sdk::logs::{LogRecord, LoggerProvider};
-    use opentelemetry_sdk::testing::logs::InMemoryLogsExporter;
+    use opentelemetry_sdk::testing::logs::InMemoryLogExporter;
     use opentelemetry_sdk::trace;
     use opentelemetry_sdk::trace::{Sampler, TracerProvider};
     use tracing::{error, warn};
@@ -231,7 +231,7 @@ mod tests {
     }
 
     fn create_tracing_subscriber(
-        _exporter: InMemoryLogsExporter,
+        _exporter: InMemoryLogExporter,
         logger_provider: &LoggerProvider,
     ) -> impl tracing::Subscriber {
         let level_filter = tracing_subscriber::filter::LevelFilter::WARN; // Capture WARN and ERROR levels
@@ -309,7 +309,7 @@ mod tests {
     #[test]
     fn tracing_appender_standalone() {
         // Arrange
-        let exporter: InMemoryLogsExporter = InMemoryLogsExporter::default();
+        let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = LoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
             .build();
@@ -389,7 +389,7 @@ mod tests {
     #[test]
     fn tracing_appender_inside_tracing_context() {
         // Arrange
-        let exporter: InMemoryLogsExporter = InMemoryLogsExporter::default();
+        let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = LoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
             .build();
@@ -500,7 +500,7 @@ mod tests {
     #[test]
     fn tracing_appender_standalone_with_tracing_log() {
         // Arrange
-        let exporter: InMemoryLogsExporter = InMemoryLogsExporter::default();
+        let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = LoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
             .build();
@@ -565,7 +565,7 @@ mod tests {
     #[test]
     fn tracing_appender_inside_tracing_context_with_tracing_log() {
         // Arrange
-        let exporter: InMemoryLogsExporter = InMemoryLogsExporter::default();
+        let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = LoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
             .build();

--- a/opentelemetry-otlp/examples/basic-otlp/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp/README.md
@@ -150,7 +150,7 @@ Value: 10
 ### Logs
 
 ```text
-2024-05-22T20:25:42.914Z    info    LogsExporter    {"kind": "exporter", "data_type": "logs", "name": "logging", "resource logs": 2, "log records": 2}
+2024-05-22T20:25:42.914Z    info    LogExporter    {"kind": "exporter", "data_type": "logs", "name": "logging", "resource logs": 2, "log records": 2}
 2024-05-22T20:25:42.914Z    info    ResourceLog #0
 Resource SchemaURL:
 Resource attributes:

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -309,7 +309,7 @@ mod tests {
         resource::{
             SERVICE_NAME, TELEMETRY_SDK_LANGUAGE, TELEMETRY_SDK_NAME, TELEMETRY_SDK_VERSION,
         },
-        testing::logs::InMemoryLogsExporter,
+        testing::logs::InMemoryLogExporter,
         trace::TracerProvider,
         Resource,
     };
@@ -480,7 +480,7 @@ mod tests {
 
     #[test]
     fn trace_context_test() {
-        let exporter = InMemoryLogsExporter::default();
+        let exporter = InMemoryLogExporter::default();
 
         let logger_provider = LoggerProvider::builder()
             .with_simple_exporter(exporter.clone())

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -533,7 +533,7 @@ mod tests {
     };
     use crate::export::logs::{LogBatch, LogExporter};
     use crate::logs::LogRecord;
-    use crate::testing::logs::InMemoryLogsExporterBuilder;
+    use crate::testing::logs::InMemoryLogExporterBuilder;
     use crate::{
         logs::{
             log_processor::{
@@ -543,7 +543,7 @@ mod tests {
             BatchConfig, BatchConfigBuilder, LogProcessor, LoggerProvider, SimpleLogProcessor,
         },
         runtime,
-        testing::logs::InMemoryLogsExporter,
+        testing::logs::InMemoryLogExporter,
         Resource,
     };
     use async_trait::async_trait;
@@ -690,7 +690,7 @@ mod tests {
         ];
         temp_env::with_vars(env_vars.clone(), || {
             let builder =
-                BatchLogProcessor::builder(InMemoryLogsExporter::default(), runtime::Tokio);
+                BatchLogProcessor::builder(InMemoryLogExporter::default(), runtime::Tokio);
 
             assert_eq!(builder.config.max_export_batch_size, 500);
             assert_eq!(
@@ -711,7 +711,7 @@ mod tests {
 
         temp_env::with_vars(env_vars, || {
             let builder =
-                BatchLogProcessor::builder(InMemoryLogsExporter::default(), runtime::Tokio);
+                BatchLogProcessor::builder(InMemoryLogExporter::default(), runtime::Tokio);
             assert_eq!(builder.config.max_export_batch_size, 120);
             assert_eq!(builder.config.max_queue_size, 120);
         });
@@ -726,7 +726,7 @@ mod tests {
             .with_max_queue_size(4)
             .build();
 
-        let builder = BatchLogProcessor::builder(InMemoryLogsExporter::default(), runtime::Tokio)
+        let builder = BatchLogProcessor::builder(InMemoryLogExporter::default(), runtime::Tokio)
             .with_batch_config(expected);
 
         let actual = &builder.config;
@@ -784,7 +784,7 @@ mod tests {
     async fn test_batch_shutdown() {
         // assert we will receive an error
         // setup
-        let exporter = InMemoryLogsExporterBuilder::default()
+        let exporter = InMemoryLogExporterBuilder::default()
             .keep_records_on_shutdown()
             .build();
         let processor = BatchLogProcessor::new(
@@ -806,7 +806,7 @@ mod tests {
 
     #[test]
     fn test_simple_shutdown() {
-        let exporter = InMemoryLogsExporterBuilder::default()
+        let exporter = InMemoryLogExporterBuilder::default()
             .keep_records_on_shutdown()
             .build();
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
@@ -831,7 +831,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     #[ignore = "See issue https://github.com/open-telemetry/opentelemetry-rust/issues/1968"]
     async fn test_batch_log_processor_shutdown_with_async_runtime_current_flavor_multi_thread() {
-        let exporter = InMemoryLogsExporterBuilder::default().build();
+        let exporter = InMemoryLogExporterBuilder::default().build();
         let processor = BatchLogProcessor::new(
             Box::new(exporter.clone()),
             BatchConfig::default(),
@@ -846,7 +846,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_batch_log_processor_shutdown_with_async_runtime_current_flavor_current_thread() {
-        let exporter = InMemoryLogsExporterBuilder::default().build();
+        let exporter = InMemoryLogExporterBuilder::default().build();
         let processor = BatchLogProcessor::new(
             Box::new(exporter.clone()),
             BatchConfig::default(),
@@ -858,7 +858,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_log_processor_shutdown_with_async_runtime_multi_flavor_multi_thread() {
-        let exporter = InMemoryLogsExporterBuilder::default().build();
+        let exporter = InMemoryLogExporterBuilder::default().build();
         let processor = BatchLogProcessor::new(
             Box::new(exporter.clone()),
             BatchConfig::default(),
@@ -870,7 +870,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_log_processor_shutdown_with_async_runtime_multi_flavor_current_thread() {
-        let exporter = InMemoryLogsExporterBuilder::default().build();
+        let exporter = InMemoryLogExporterBuilder::default().build();
         let processor = BatchLogProcessor::new(
             Box::new(exporter.clone()),
             BatchConfig::default(),
@@ -989,7 +989,7 @@ mod tests {
 
     #[test]
     fn test_simple_processor_sync_exporter_without_runtime() {
-        let exporter = InMemoryLogsExporterBuilder::default().build();
+        let exporter = InMemoryLogExporterBuilder::default().build();
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
@@ -1002,7 +1002,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_simple_processor_sync_exporter_with_runtime() {
-        let exporter = InMemoryLogsExporterBuilder::default().build();
+        let exporter = InMemoryLogExporterBuilder::default().build();
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();
@@ -1015,7 +1015,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_simple_processor_sync_exporter_with_multi_thread_runtime() {
-        let exporter = InMemoryLogsExporterBuilder::default().build();
+        let exporter = InMemoryLogExporterBuilder::default().build();
         let processor = Arc::new(SimpleLogProcessor::new(Box::new(exporter.clone())));
 
         let mut handles = vec![];
@@ -1038,7 +1038,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_simple_processor_sync_exporter_with_current_thread_runtime() {
-        let exporter = InMemoryLogsExporterBuilder::default().build();
+        let exporter = InMemoryLogExporterBuilder::default().build();
         let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
 
         let mut record: LogRecord = Default::default();

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -23,7 +23,7 @@ pub struct LogData {
 #[cfg(all(test, feature = "testing"))]
 mod tests {
     use super::*;
-    use crate::testing::logs::InMemoryLogsExporter;
+    use crate::testing::logs::InMemoryLogExporter;
     use crate::Resource;
     use opentelemetry::logs::LogRecord;
     use opentelemetry::logs::{Logger, LoggerProvider as _, Severity};
@@ -40,7 +40,7 @@ mod tests {
             KeyValue::new("k3", "v3"),
             KeyValue::new("k4", "v4"),
         ]);
-        let exporter: InMemoryLogsExporter = InMemoryLogsExporter::default();
+        let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = LoggerProvider::builder()
             .with_resource(resource.clone())
             .with_log_processor(SimpleLogProcessor::new(Box::new(exporter.clone())))

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -17,12 +17,12 @@ use std::sync::{Arc, Mutex};
 /// ```no_run
 ///# use opentelemetry_sdk::logs::{BatchLogProcessor, LoggerProvider};
 ///# use opentelemetry_sdk::runtime;
-///# use opentelemetry_sdk::testing::logs::InMemoryLogsExporter;
+///# use opentelemetry_sdk::testing::logs::InMemoryLogExporter;
 ///
 ///# #[tokio::main]
 ///# async fn main() {
-///    // Create an InMemoryLogsExporter
-///    let exporter: InMemoryLogsExporter = InMemoryLogsExporter::default();
+///    // Create an InMemoryLogExporter
+///    let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
 ///    //Create a LoggerProvider and register the exporter
 ///    let logger_provider = LoggerProvider::builder()
 ///        .with_log_processor(BatchLogProcessor::builder(exporter.clone(), runtime::Tokio).build())
@@ -38,15 +38,15 @@ use std::sync::{Arc, Mutex};
 /// ```
 ///
 #[derive(Clone, Debug)]
-pub struct InMemoryLogsExporter {
+pub struct InMemoryLogExporter {
     logs: Arc<Mutex<Vec<OwnedLogData>>>,
     resource: Arc<Mutex<Resource>>,
     should_reset_on_shutdown: bool,
 }
 
-impl Default for InMemoryLogsExporter {
+impl Default for InMemoryLogExporter {
     fn default() -> Self {
-        InMemoryLogsExporterBuilder::new().build()
+        InMemoryLogExporterBuilder::new().build()
     }
 }
 
@@ -71,18 +71,18 @@ pub struct LogDataWithResource {
     pub resource: Cow<'static, Resource>,
 }
 
-///Builder for ['InMemoryLogsExporter'].
+///Builder for ['InMemoryLogExporter'].
 /// # Example
 ///
 /// ```no_run
-///# use opentelemetry_sdk::testing::logs::{InMemoryLogsExporter, InMemoryLogsExporterBuilder};
+///# use opentelemetry_sdk::testing::logs::{InMemoryLogExporter, InMemoryLogExporterBuilder};
 ///# use opentelemetry_sdk::logs::{BatchLogProcessor, LoggerProvider};
 ///# use opentelemetry_sdk::runtime;
 ///
 ///# #[tokio::main]
 ///# async fn main() {
-///    //Create an InMemoryLogsExporter
-///    let exporter: InMemoryLogsExporter = InMemoryLogsExporterBuilder::default().build();
+///    //Create an InMemoryLogExporter
+///    let exporter: InMemoryLogExporter = InMemoryLogExporterBuilder::default().build();
 ///    //Create a LoggerProvider and register the exporter
 ///    let logger_provider = LoggerProvider::builder()
 ///        .with_log_processor(BatchLogProcessor::builder(exporter.clone(), runtime::Tokio).build())
@@ -98,18 +98,18 @@ pub struct LogDataWithResource {
 /// ```
 ///
 #[derive(Debug, Clone)]
-pub struct InMemoryLogsExporterBuilder {
+pub struct InMemoryLogExporterBuilder {
     reset_on_shutdown: bool,
 }
 
-impl Default for InMemoryLogsExporterBuilder {
+impl Default for InMemoryLogExporterBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl InMemoryLogsExporterBuilder {
-    /// Creates a new instance of `InMemoryLogsExporter`.
+impl InMemoryLogExporterBuilder {
+    /// Creates a new instance of `InMemoryLogExporter`.
     ///
     pub fn new() -> Self {
         Self {
@@ -117,17 +117,17 @@ impl InMemoryLogsExporterBuilder {
         }
     }
 
-    /// Creates a new instance of `InMemoryLogsExporter`.
+    /// Creates a new instance of `InMemoryLogExporter`.
     ///
-    pub fn build(&self) -> InMemoryLogsExporter {
-        InMemoryLogsExporter {
+    pub fn build(&self) -> InMemoryLogExporter {
+        InMemoryLogExporter {
             logs: Arc::new(Mutex::new(Vec::new())),
             resource: Arc::new(Mutex::new(Resource::default())),
             should_reset_on_shutdown: self.reset_on_shutdown,
         }
     }
 
-    /// If set, the records will not be [`InMemoryLogsExporter::reset`] on shutdown.
+    /// If set, the records will not be [`InMemoryLogExporter::reset`] on shutdown.
     #[cfg(test)]
     pub(crate) fn keep_records_on_shutdown(self) -> Self {
         Self {
@@ -136,15 +136,15 @@ impl InMemoryLogsExporterBuilder {
     }
 }
 
-impl InMemoryLogsExporter {
+impl InMemoryLogExporter {
     /// Returns the logs emitted via Logger as a vector of `LogData`.
     ///
     /// # Example
     ///
     /// ```
-    /// use opentelemetry_sdk::testing::logs::{InMemoryLogsExporter, InMemoryLogsExporterBuilder};
+    /// use opentelemetry_sdk::testing::logs::{InMemoryLogExporter, InMemoryLogExporterBuilder};
     ///
-    /// let exporter = InMemoryLogsExporterBuilder::default().build();
+    /// let exporter = InMemoryLogExporterBuilder::default().build();
     /// let emitted_logs = exporter.get_emitted_logs().unwrap();
     /// ```
     ///
@@ -167,9 +167,9 @@ impl InMemoryLogsExporter {
     /// # Example
     ///
     /// ```
-    /// use opentelemetry_sdk::testing::logs::{InMemoryLogsExporter, InMemoryLogsExporterBuilder};
+    /// use opentelemetry_sdk::testing::logs::{InMemoryLogExporter, InMemoryLogExporterBuilder};
     ///
-    /// let exporter = InMemoryLogsExporterBuilder::default().build();
+    /// let exporter = InMemoryLogExporterBuilder::default().build();
     /// exporter.reset();
     /// ```
     ///
@@ -183,7 +183,7 @@ impl InMemoryLogsExporter {
 }
 
 #[async_trait]
-impl LogExporter for InMemoryLogsExporter {
+impl LogExporter for InMemoryLogExporter {
     async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()> {
         let mut logs_guard = self.logs.lock().map_err(LogError::from)?;
         for (log_record, instrumentation) in batch.iter() {

--- a/opentelemetry-sdk/src/testing/logs/mod.rs
+++ b/opentelemetry-sdk/src/testing/logs/mod.rs
@@ -3,4 +3,4 @@
 /// The `in_memory_exporter` module provides in-memory log exporter.
 /// For detailed usage and examples, see `in_memory_exporter`.
 pub mod in_memory_exporter;
-pub use in_memory_exporter::{InMemoryLogsExporter, InMemoryLogsExporterBuilder};
+pub use in_memory_exporter::{InMemoryLogExporter, InMemoryLogExporterBuilder};

--- a/opentelemetry-stdout/src/logs/exporter.rs
+++ b/opentelemetry-stdout/src/logs/exporter.rs
@@ -25,7 +25,7 @@ impl Default for LogExporter {
 
 impl fmt::Debug for LogExporter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("LogsExporter")
+        f.write_str("LogExporter")
     }
 }
 


### PR DESCRIPTION
related to comments: 
- https://github.com/open-telemetry/opentelemetry-rust/pull/2255#issue-2615905277
- https://github.com/open-telemetry/opentelemetry-rust/pull/2221#issuecomment-2424967497

## Changes

De-pluralize Log Exporter types:
- `InMemoryLogsExporter` -> `InMemoryLogExporter`
- Fix rename on `LogExporter` Debug impl.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
