### PR TITLE
[chore] Revert pinning of pin-project-lite crate after upstream fix, and CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-05-01
+          toolchain: nightly-2024-06-30
           components: rustfmt
       - name: external-type-check
         run: |
-          cargo install cargo-check-external-types
+          cargo install cargo-check-external-types@0.1.13
           cd ${{ matrix.example }}
           cargo check-external-types --config allowed-external-types.toml
   non-default-examples:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ hyper-util = "0.1"
 log = "0.4.21"
 once_cell = "1.13"
 ordered-float = "4.0"
-pin-project-lite = "=0.2.14" # 0.2.15 is failing for cargo-check-external-types
+pin-project-lite = "0.2"
 prost = "0.13"
 prost-build = "0.13"
 prost-types = "0.13"


### PR DESCRIPTION
## Changes

Two separate changes:

- Revert the changes in #2239 as the underlying issue in `cargo-check-external-types` is fixed in it's new release. Ref - https://github.com/taiki-e/pin-project-lite/issues/86

- CI build fix. - use the correct nightly build as required for latest cargo-check-external-types@0.1.13 ( to fix the CI as [here](https://github.com/open-telemetry/opentelemetry-rust/actions/runs/11619565547/job/32359459714?pr=2263))

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
