### PR TITLE
Remove redundant generic argument from Aggregator

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -14,7 +14,7 @@ struct HistogramTracker<T> {
     buckets: Mutex<Buckets<T>>,
 }
 
-impl<T> Aggregator<T> for HistogramTracker<T>
+impl<T> Aggregator for HistogramTracker<T>
 where
     T: Number,
 {
@@ -88,7 +88,7 @@ impl<T: Number> Buckets<T> {
 /// Summarizes a set of measurements as a histogram with explicitly defined
 /// buckets.
 pub(crate) struct Histogram<T: Number> {
-    value_map: ValueMap<T, HistogramTracker<T>>,
+    value_map: ValueMap<HistogramTracker<T>>,
     bounds: Vec<f64>,
     record_min_max: bool,
     record_sum: bool,

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -17,7 +17,7 @@ where
     pub(crate) value: T::AtomicTracker,
 }
 
-impl<T> Aggregator<T> for Assign<T>
+impl<T> Aggregator for Assign<T>
 where
     T: Number,
 {
@@ -37,7 +37,7 @@ where
 
 /// Summarizes a set of measurements as the last one made.
 pub(crate) struct LastValue<T: Number> {
-    value_map: ValueMap<T, Assign<T>>,
+    value_map: ValueMap<Assign<T>>,
     start: Mutex<SystemTime>,
 }
 

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -22,10 +22,7 @@ use crate::metrics::AttributeSet;
 pub(crate) static STREAM_OVERFLOW_ATTRIBUTES: Lazy<Vec<KeyValue>> =
     Lazy::new(|| vec![KeyValue::new("otel.metric.overflow", "true")]);
 
-pub(crate) trait Aggregator<T>
-where
-    T: Number,
-{
+pub(crate) trait Aggregator {
     /// A static configuration that is needed in order to initialize aggregator.
     /// E.g. bucket_size at creation time .
     type InitConfig;
@@ -46,10 +43,9 @@ where
 ///
 /// This structure is parametrized by an `Operation` that indicates how
 /// updates to the underlying value trackers should be performed.
-pub(crate) struct ValueMap<T, A>
+pub(crate) struct ValueMap<A>
 where
-    T: Number,
-    A: Aggregator<T>,
+    A: Aggregator,
 {
     /// Trackers store the values associated with different attribute sets.
     trackers: RwLock<HashMap<Vec<KeyValue>, Arc<A>>>,
@@ -63,10 +59,9 @@ where
     config: A::InitConfig,
 }
 
-impl<T, A> ValueMap<T, A>
+impl<A> ValueMap<A>
 where
-    T: Number,
-    A: Aggregator<T>,
+    A: Aggregator,
 {
     fn new(config: A::InitConfig) -> Self {
         ValueMap {

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -11,7 +11,7 @@ use std::{
 
 /// Summarizes a set of pre-computed sums as their arithmetic sum.
 pub(crate) struct PrecomputedSum<T: Number> {
-    value_map: ValueMap<T, Assign<T>>,
+    value_map: ValueMap<Assign<T>>,
     monotonic: bool,
     start: Mutex<SystemTime>,
     reported: Mutex<HashMap<Vec<KeyValue>, T>>,

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -17,7 +17,7 @@ where
     value: T::AtomicTracker,
 }
 
-impl<T> Aggregator<T> for Increment<T>
+impl<T> Aggregator for Increment<T>
 where
     T: Number,
 {
@@ -37,7 +37,7 @@ where
 
 /// Summarizes a set of measurements made as their arithmetic sum.
 pub(crate) struct Sum<T: Number> {
-    value_map: ValueMap<T, Increment<T>>,
+    value_map: ValueMap<Increment<T>>,
     monotonic: bool,
     start: Mutex<SystemTime>,
 }


### PR DESCRIPTION
Basically remove reduntant code (it was introduced in initial revision, but during review process interface changes, so it left here by accident), and simplify Aggregator trait.

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
