### PR TITLE
Add `name` attribute in logging macros 

### DIFF
--- a/opentelemetry/src/global/internal_logging.rs
+++ b/opentelemetry/src/global/internal_logging.rs
@@ -26,7 +26,7 @@ macro_rules! otel_info {
     (name: $name:expr $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
-            tracing::info!( name: $name, name = $name, target: env!("CARGO_PKG_NAME"), "");
+            tracing::info!( name: $name, target: env!("CARGO_PKG_NAME"), name = $name, "");
         }
         #[cfg(not(feature = "internal-logs"))]
         {
@@ -36,7 +36,7 @@ macro_rules! otel_info {
     (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
-            tracing::info!(name: $name, name = $name, target: env!("CARGO_PKG_NAME"), $($key = $value),+, "");
+            tracing::info!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, $($key = $value),+, "");
         }
         #[cfg(not(feature = "internal-logs"))]
         {
@@ -138,7 +138,7 @@ macro_rules! otel_error {
     (name: $name:expr $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
-            tracing::error!(name: $name, name = $name, target: env!("CARGO_PKG_NAME"), "");
+            tracing::error!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, "");
         }
         #[cfg(not(feature = "internal-logs"))]
         {

--- a/opentelemetry/src/global/internal_logging.rs
+++ b/opentelemetry/src/global/internal_logging.rs
@@ -16,12 +16,17 @@
 /// use opentelemetry::otel_info;
 /// otel_info!(name: "sdk_start", version = "1.0.0", schema_url = "http://example.com");
 /// ```
+///
+
+// TODO: Remove `name` attribute duplication in logging macros below once `tracing::Fmt` supports displaying `name`.
+// See issue: https://github.com/tokio-rs/tracing/issues/2774
+
 #[macro_export]
 macro_rules! otel_info {
     (name: $name:expr $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
-            tracing::info!( name: $name, target: env!("CARGO_PKG_NAME"), "");
+            tracing::info!( name: $name, name = $name, target: env!("CARGO_PKG_NAME"), "");
         }
         #[cfg(not(feature = "internal-logs"))]
         {
@@ -31,7 +36,7 @@ macro_rules! otel_info {
     (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
-            tracing::info!(name: $name, target: env!("CARGO_PKG_NAME"), $($key = $value),+, "");
+            tracing::info!(name: $name, name = $name, target: env!("CARGO_PKG_NAME"), $($key = $value),+, "");
         }
         #[cfg(not(feature = "internal-logs"))]
         {
@@ -56,7 +61,7 @@ macro_rules! otel_warn {
     (name: $name:expr $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
-            tracing::warn!(name: $name, target: env!("CARGO_PKG_NAME"), "");
+            tracing::warn!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, "");
         }
         #[cfg(not(feature = "internal-logs"))]
         {
@@ -68,6 +73,7 @@ macro_rules! otel_warn {
         {
             tracing::warn!(name: $name,
                             target: env!("CARGO_PKG_NAME"),
+                            name = $name,
                             $($key = {
                                     $value
                             }),+,
@@ -97,7 +103,7 @@ macro_rules! otel_debug {
     (name: $name:expr $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
-            tracing::debug!(name: $name, target: env!("CARGO_PKG_NAME"),"");
+            tracing::debug!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, "");
         }
         #[cfg(not(feature = "internal-logs"))]
         {
@@ -107,7 +113,7 @@ macro_rules! otel_debug {
     (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
-            tracing::debug!(name: $name, target: env!("CARGO_PKG_NAME"), $($key = $value),+, "");
+            tracing::debug!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, $($key = $value),+, "");
         }
         #[cfg(not(feature = "internal-logs"))]
         {
@@ -132,7 +138,7 @@ macro_rules! otel_error {
     (name: $name:expr $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
-            tracing::error!(name: $name, target: env!("CARGO_PKG_NAME"), "");
+            tracing::error!(name: $name, name = $name, target: env!("CARGO_PKG_NAME"), "");
         }
         #[cfg(not(feature = "internal-logs"))]
         {
@@ -144,6 +150,7 @@ macro_rules! otel_error {
         {
             tracing::error!(name: $name,
                             target: env!("CARGO_PKG_NAME"),
+                            name = $name,
                             $($key = {
                                     $value
                             }),+,


### PR DESCRIPTION
## Changes

Add `name` attribute in logging macros till `tracing::fmt` starts supporting `name` metadata.
See issue: https://github.com/tokio-rs/tracing/issues/2774

This will cause the name attribute duplicated for all other consumers, but should be fine for now.

o/p before change:
```rust
2024-11-06T21:29:27.830573Z  INFO main self_diagnostics: Starting self-diagnostics example
2024-11-06T21:29:27.831787Z ERROR main opentelemetry_sdk:  meter_name="example" instrument_name="my_counter with_space" Measurements from this Counter will be ignored. reason="Invalid instrument configuration: characters in instrument name must be ASCII and belong to the alphanumeric characters, '_', '.', '-' and '/'"
2024-11-06T21:29:27.832706Z  INFO main self_diagnostics: Shutdown complete. Bye!
```
o/p after change:
```rust
     Running `/home/labhas/obs/ot/lalit/rust/opentelemetry-rust/target/debug/self-diagnostics`
2024-11-06T21:22:23.864454Z  INFO main self_diagnostics: Starting self-diagnostics example
2024-11-06T21:22:23.864738Z ERROR main opentelemetry_sdk:  name="InstrumentCreationFailed" meter_name="example" instrument_name="my_counter with_space" Measurements from this Counter will be ignored. reason="Invalid instrument configuration: characters in instrument name must be ASCII and belong to the alphanumeric characters, '_', '.', '-' and '/'"
2024-11-06T21:22:23.865594Z  INFO main self_diagnostics: Shutdown complete. Bye!
```
Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
