### PR TITLE
Use ValueMap in ExpoHistogram

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -1,14 +1,14 @@
-use std::{collections::HashMap, f64::consts::LOG2_E, sync::Mutex, time::SystemTime};
+use std::{f64::consts::LOG2_E, mem::replace, ops::DerefMut, sync::Mutex, time::SystemTime};
 
 use once_cell::sync::Lazy;
 use opentelemetry::{otel_debug, KeyValue};
 
 use crate::metrics::{
     data::{self, Aggregation},
-    AttributeSet, Temporality,
+    Temporality,
 };
 
-use super::Number;
+use super::{Aggregator, Number, ValueMap};
 
 pub(crate) const EXPO_MAX_SCALE: i8 = 20;
 pub(crate) const EXPO_MIN_SCALE: i8 = -10;
@@ -16,33 +16,26 @@ pub(crate) const EXPO_MIN_SCALE: i8 = -10;
 /// A single data point in an exponential histogram.
 #[derive(Debug, PartialEq)]
 struct ExpoHistogramDataPoint<T> {
+    max_size: i32,
     count: usize,
     min: T,
     max: T,
     sum: T,
-
-    max_size: i32,
-    record_min_max: bool,
-    record_sum: bool,
-
     scale: i8,
-
     pos_buckets: ExpoBuckets,
     neg_buckets: ExpoBuckets,
     zero_count: u64,
 }
 
 impl<T: Number> ExpoHistogramDataPoint<T> {
-    fn new(max_size: i32, max_scale: i8, record_min_max: bool, record_sum: bool) -> Self {
+    fn new(config: &BucketConfig) -> Self {
         ExpoHistogramDataPoint {
+            max_size: config.max_size,
             count: 0,
             min: T::max(),
             max: T::min(),
             sum: T::default(),
-            max_size,
-            record_min_max,
-            record_sum,
-            scale: max_scale,
+            scale: config.max_scale,
             pos_buckets: ExpoBuckets::default(),
             neg_buckets: ExpoBuckets::default(),
             zero_count: 0,
@@ -57,17 +50,13 @@ impl<T: Number> ExpoHistogramDataPoint<T> {
     fn record(&mut self, v: T) {
         self.count += 1;
 
-        if self.record_min_max {
-            if v < self.min {
-                self.min = v;
-            }
-            if v > self.max {
-                self.max = v;
-            }
+        if v < self.min {
+            self.min = v;
         }
-        if self.record_sum {
-            self.sum += v;
+        if v > self.max {
+            self.max = v;
         }
+        self.sum += v;
 
         let abs_v = v.into_float().abs();
 
@@ -315,20 +304,49 @@ impl ExpoBuckets {
     }
 }
 
+impl<T> Aggregator for Mutex<ExpoHistogramDataPoint<T>>
+where
+    T: Number,
+{
+    type InitConfig = BucketConfig;
+
+    type PreComputedValue = T;
+
+    fn create(init: &BucketConfig) -> Self {
+        Mutex::new(ExpoHistogramDataPoint::new(init))
+    }
+
+    fn update(&self, value: T) {
+        let mut this = match self.lock() {
+            Ok(guard) => guard,
+            Err(_) => return,
+        };
+        this.record(value);
+    }
+
+    fn clone_and_reset(&self, init: &BucketConfig) -> Self {
+        let mut current = self.lock().unwrap_or_else(|err| err.into_inner());
+        let cloned = replace(current.deref_mut(), ExpoHistogramDataPoint::new(init));
+        Mutex::new(cloned)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct BucketConfig {
+    max_size: i32,
+    max_scale: i8,
+}
+
 /// An aggregator that summarizes a set of measurements as an exponential
 /// histogram.
 ///
 /// Each histogram is scoped by attributes and the aggregation cycle the
 /// measurements were made in.
-pub(crate) struct ExpoHistogram<T> {
+pub(crate) struct ExpoHistogram<T: Number> {
+    value_map: ValueMap<Mutex<ExpoHistogramDataPoint<T>>>,
+    start: Mutex<SystemTime>,
     record_sum: bool,
     record_min_max: bool,
-    max_size: i32,
-    max_scale: i8,
-
-    values: Mutex<HashMap<AttributeSet, ExpoHistogramDataPoint<T>>>,
-
-    start: Mutex<SystemTime>,
 }
 
 impl<T: Number> ExpoHistogram<T> {
@@ -340,11 +358,12 @@ impl<T: Number> ExpoHistogram<T> {
         record_sum: bool,
     ) -> Self {
         ExpoHistogram {
+            value_map: ValueMap::new(BucketConfig {
+                max_size: max_size as i32,
+                max_scale,
+            }),
             record_sum,
             record_min_max,
-            max_size: max_size as i32,
-            max_scale,
-            values: Mutex::new(HashMap::default()),
             start: Mutex::new(SystemTime::now()),
         }
     }
@@ -353,22 +372,11 @@ impl<T: Number> ExpoHistogram<T> {
         let f_value = value.into_float();
         // Ignore NaN and infinity.
         // Only makes sense if T is f64, maybe this could be no-op for other cases?
-        if f_value.is_infinite() || f_value.is_nan() {
+        if !f_value.is_finite() {
             return;
         }
 
-        let attrs: AttributeSet = attrs.into();
-        if let Ok(mut values) = self.values.lock() {
-            let v = values.entry(attrs).or_insert_with(|| {
-                ExpoHistogramDataPoint::new(
-                    self.max_size,
-                    self.max_scale,
-                    self.record_min_max,
-                    self.record_sum,
-                )
-            });
-            v.record(value)
-        }
+        self.value_map.measure(value, attrs);
     }
 
     pub(crate) fn delta(
@@ -376,11 +384,6 @@ impl<T: Number> ExpoHistogram<T> {
         dest: Option<&mut dyn Aggregation>,
     ) -> (usize, Option<Box<dyn Aggregation>>) {
         let t = SystemTime::now();
-        let start = self
-            .start
-            .lock()
-            .map(|s| *s)
-            .unwrap_or_else(|_| SystemTime::now());
 
         let h = dest.and_then(|d| d.as_mut().downcast_mut::<data::ExponentialHistogram<T>>());
         let mut new_agg = if h.is_none() {
@@ -393,59 +396,48 @@ impl<T: Number> ExpoHistogram<T> {
         };
         let h = h.unwrap_or_else(|| new_agg.as_mut().expect("present if h is none"));
         h.temporality = Temporality::Delta;
-        h.data_points.clear();
 
-        let mut values = match self.values.lock() {
-            Ok(g) => g,
-            Err(_) => return (0, None),
-        };
+        let prev_start = self
+            .start
+            .lock()
+            .map(|mut start| replace(start.deref_mut(), t))
+            .unwrap_or(t);
 
-        let n = values.len();
-        if n > h.data_points.capacity() {
-            h.data_points.reserve_exact(n - h.data_points.capacity());
-        }
-
-        for (a, b) in values.drain() {
-            h.data_points.push(data::ExponentialHistogramDataPoint {
-                attributes: a
-                    .iter()
-                    .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
-                    .collect(),
-                start_time: start,
-                time: t,
-                count: b.count,
-                min: if self.record_min_max {
-                    Some(b.min)
-                } else {
-                    None
-                },
-                max: if self.record_min_max {
-                    Some(b.max)
-                } else {
-                    None
-                },
-                sum: if self.record_sum { b.sum } else { T::default() },
-                scale: b.scale,
-                zero_count: b.zero_count,
-                positive_bucket: data::ExponentialBucket {
-                    offset: b.pos_buckets.start_bin,
-                    counts: b.pos_buckets.counts.clone(),
-                },
-                negative_bucket: data::ExponentialBucket {
-                    offset: b.neg_buckets.start_bin,
-                    counts: b.neg_buckets.counts.clone(),
-                },
-                zero_threshold: 0.0,
-                exemplars: vec![],
+        self.value_map
+            .collect_and_reset(&mut h.data_points, |attributes, attr| {
+                let b = attr.into_inner().unwrap_or_else(|err| err.into_inner());
+                data::ExponentialHistogramDataPoint {
+                    attributes,
+                    start_time: prev_start,
+                    time: t,
+                    count: b.count,
+                    min: if self.record_min_max {
+                        Some(b.min)
+                    } else {
+                        None
+                    },
+                    max: if self.record_min_max {
+                        Some(b.max)
+                    } else {
+                        None
+                    },
+                    sum: if self.record_sum { b.sum } else { T::default() },
+                    scale: b.scale,
+                    zero_count: b.zero_count,
+                    positive_bucket: data::ExponentialBucket {
+                        offset: b.pos_buckets.start_bin,
+                        counts: b.pos_buckets.counts,
+                    },
+                    negative_bucket: data::ExponentialBucket {
+                        offset: b.neg_buckets.start_bin,
+                        counts: b.neg_buckets.counts,
+                    },
+                    zero_threshold: 0.0,
+                    exemplars: vec![],
+                }
             });
-        }
 
-        // The delta collection cycle resets.
-        if let Ok(mut start) = self.start.lock() {
-            *start = t;
-        }
-
-        (n, new_agg.map(|a| Box::new(a) as Box<_>))
+        (h.data_points.len(), new_agg.map(|a| Box::new(a) as Box<_>))
     }
 
     pub(crate) fn cumulative(
@@ -453,11 +445,6 @@ impl<T: Number> ExpoHistogram<T> {
         dest: Option<&mut dyn Aggregation>,
     ) -> (usize, Option<Box<dyn Aggregation>>) {
         let t = SystemTime::now();
-        let start = self
-            .start
-            .lock()
-            .map(|s| *s)
-            .unwrap_or_else(|_| SystemTime::now());
 
         let h = dest.and_then(|d| d.as_mut().downcast_mut::<data::ExponentialHistogram<T>>());
         let mut new_agg = if h.is_none() {
@@ -471,65 +458,53 @@ impl<T: Number> ExpoHistogram<T> {
         let h = h.unwrap_or_else(|| new_agg.as_mut().expect("present if h is none"));
         h.temporality = Temporality::Cumulative;
 
-        let values = match self.values.lock() {
-            Ok(g) => g,
-            Err(_) => return (0, None),
-        };
-        h.data_points.clear();
+        let prev_start = self
+            .start
+            .lock()
+            .map(|s| *s)
+            .unwrap_or_else(|_| SystemTime::now());
 
-        let n = values.len();
-        if n > h.data_points.capacity() {
-            h.data_points.reserve_exact(n - h.data_points.capacity());
-        }
-
-        // TODO: This will use an unbounded amount of memory if there
-        // are unbounded number of attribute sets being aggregated. Attribute
-        // sets that become "stale" need to be forgotten so this will not
-        // overload the system.
-        for (a, b) in values.iter() {
-            h.data_points.push(data::ExponentialHistogramDataPoint {
-                attributes: a
-                    .iter()
-                    .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
-                    .collect(),
-                start_time: start,
-                time: t,
-                count: b.count,
-                min: if self.record_min_max {
-                    Some(b.min)
-                } else {
-                    None
-                },
-                max: if self.record_min_max {
-                    Some(b.max)
-                } else {
-                    None
-                },
-                sum: if self.record_sum { b.sum } else { T::default() },
-                scale: b.scale,
-                zero_count: b.zero_count,
-                positive_bucket: data::ExponentialBucket {
-                    offset: b.pos_buckets.start_bin,
-                    counts: b.pos_buckets.counts.clone(),
-                },
-                negative_bucket: data::ExponentialBucket {
-                    offset: b.neg_buckets.start_bin,
-                    counts: b.neg_buckets.counts.clone(),
-                },
-                zero_threshold: 0.0,
-                exemplars: vec![],
+        self.value_map
+            .collect_readonly(&mut h.data_points, |attributes, attr| {
+                let b = attr.lock().unwrap_or_else(|err| err.into_inner());
+                data::ExponentialHistogramDataPoint {
+                    attributes,
+                    start_time: prev_start,
+                    time: t,
+                    count: b.count,
+                    min: if self.record_min_max {
+                        Some(b.min)
+                    } else {
+                        None
+                    },
+                    max: if self.record_min_max {
+                        Some(b.max)
+                    } else {
+                        None
+                    },
+                    sum: if self.record_sum { b.sum } else { T::default() },
+                    scale: b.scale,
+                    zero_count: b.zero_count,
+                    positive_bucket: data::ExponentialBucket {
+                        offset: b.pos_buckets.start_bin,
+                        counts: b.pos_buckets.counts.clone(),
+                    },
+                    negative_bucket: data::ExponentialBucket {
+                        offset: b.neg_buckets.start_bin,
+                        counts: b.neg_buckets.counts.clone(),
+                    },
+                    zero_threshold: 0.0,
+                    exemplars: vec![],
+                }
             });
-        }
 
-        (n, new_agg.map(|a| Box::new(a) as Box<_>))
+        (h.data_points.len(), new_agg.map(|a| Box::new(a) as Box<_>))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::ops::Neg;
-
-    use opentelemetry::KeyValue;
 
     use crate::metrics::internal::{self, AggregateBuilder};
 
@@ -631,7 +606,10 @@ mod tests {
         ];
 
         for test in test_cases {
-            let mut dp = ExpoHistogramDataPoint::<T>::new(test.max_size, 20, true, true);
+            let mut dp = ExpoHistogramDataPoint::<T>::new(&BucketConfig {
+                max_size: test.max_size,
+                max_scale: 20,
+            });
             for v in test.values {
                 dp.record(v);
                 dp.record(-v);
@@ -644,7 +622,6 @@ mod tests {
     }
 
     fn run_min_max_sum_f64() {
-        let alice = &[KeyValue::new("user", "alice")][..];
         struct Expected {
             min: f64,
             max: f64,
@@ -692,11 +669,9 @@ mod tests {
         for test in test_cases {
             let h = ExpoHistogram::new(4, 20, true, true);
             for v in test.values {
-                h.measure(v, alice);
+                h.measure(v, &[]);
             }
-            let values = h.values.lock().unwrap();
-            let alice: AttributeSet = alice.into();
-            let dp = values.get(&alice).unwrap();
+            let dp = h.value_map.no_attribute_tracker.lock().unwrap();
 
             assert_eq!(test.expected.max, dp.max);
             assert_eq!(test.expected.min, dp.min);
@@ -706,7 +681,6 @@ mod tests {
     }
 
     fn run_min_max_sum<T: Number + From<u32>>() {
-        let alice = &[KeyValue::new("user", "alice")][..];
         struct Expected<T> {
             min: T,
             max: T,
@@ -744,11 +718,9 @@ mod tests {
         for test in test_cases {
             let h = ExpoHistogram::new(4, 20, true, true);
             for v in test.values {
-                h.measure(v, alice);
+                h.measure(v, &[]);
             }
-            let values = h.values.lock().unwrap();
-            let alice: AttributeSet = alice.into();
-            let dp = values.get(&alice).unwrap();
+            let dp = h.value_map.no_attribute_tracker.lock().unwrap();
 
             assert_eq!(test.expected.max, dp.max);
             assert_eq!(test.expected.min, dp.min);
@@ -831,7 +803,10 @@ mod tests {
             },
         ];
         for test in test_cases {
-            let mut dp = ExpoHistogramDataPoint::new(test.max_size, 20, true, true);
+            let mut dp = ExpoHistogramDataPoint::new(&BucketConfig {
+                max_size: test.max_size,
+                max_scale: 20,
+            });
             for v in test.values {
                 dp.record(v);
                 dp.record(-v);
@@ -848,7 +823,11 @@ mod tests {
         // These bins are calculated from the following formula:
         // floor( log2( value) * 2^20 ) using an arbitrary precision calculator.
 
-        let mut fdp = ExpoHistogramDataPoint::new(4, 20, true, true);
+        let cfg = BucketConfig {
+            max_size: 4,
+            max_scale: 20,
+        };
+        let mut fdp = ExpoHistogramDataPoint::new(&cfg);
         fdp.record(f64::MAX);
 
         assert_eq!(
@@ -856,7 +835,7 @@ mod tests {
             "start bin does not match for large f64 values",
         );
 
-        let mut fdp = ExpoHistogramDataPoint::new(4, 20, true, true);
+        let mut fdp = ExpoHistogramDataPoint::new(&cfg);
         fdp.record(f64::MIN_POSITIVE);
 
         assert_eq!(
@@ -864,7 +843,7 @@ mod tests {
             "start bin does not match for small positive values",
         );
 
-        let mut idp = ExpoHistogramDataPoint::new(4, 20, true, true);
+        let mut idp = ExpoHistogramDataPoint::new(&cfg);
         idp.record(i64::MAX);
 
         assert_eq!(
@@ -1210,12 +1189,13 @@ mod tests {
                 start_bin: 0,
                 counts: vec![],
             },
-            record_min_max: true,
-            record_sum: true,
             zero_count: 0,
         };
 
-        let mut ehdp = ExpoHistogramDataPoint::new(4, 20, true, true);
+        let mut ehdp = ExpoHistogramDataPoint::new(&BucketConfig {
+            max_size: 4,
+            max_scale: 20,
+        });
         ehdp.record(f64::MIN_POSITIVE);
         ehdp.record(f64::MIN_POSITIVE);
         ehdp.record(f64::MIN_POSITIVE);

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -81,7 +81,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 
-use opentelemetry::{Key, KeyValue, Value};
+use opentelemetry::KeyValue;
 
 /// Defines the window that an aggregation was calculated over.
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
@@ -146,11 +146,6 @@ impl AttributeSet {
         values.sort_unstable_by(|a, b| a.key.cmp(&b.key));
         let hash = calculate_hash(&values);
         AttributeSet(values, hash)
-    }
-
-    /// Iterate over key value pairs in the set
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&Key, &Value)> {
-        self.0.iter().map(|kv| (&kv.key, &kv.value))
     }
 
     /// Returns the underlying Vec of KeyValue pairs


### PR DESCRIPTION
Fixes #2146

## Changes

Refactored `ExpoHistogram` to use `ValueMap` for consistency and efficiency.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
