### PR TITLE
Hashed utility for ValueMap to improve hashing performance

### DIFF
--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -29,7 +29,6 @@ tokio = { workspace = true, features = ["rt", "time"], optional = true }
 tokio-stream = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 tracing = {workspace = true, optional = true}
-rustc-hash = "2.0.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true, features = ["rt", "time"], optional = true }
 tokio-stream = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 tracing = {workspace = true, optional = true}
+rustc-hash = "2.0.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-sdk/src/metrics/internal/hashed.rs
+++ b/opentelemetry-sdk/src/metrics/internal/hashed.rs
@@ -1,0 +1,146 @@
+use std::{
+    borrow::{Borrow, Cow},
+    hash::{BuildHasher, Hash, Hasher},
+    ops::Deref,
+};
+
+use rustc_hash::*;
+
+/// Hash value only once, works with references and owned types.
+pub(crate) struct Hashed<'a, T>
+where
+    T: ToOwned + ?Sized,
+{
+    value: Cow<'a, T>,
+    hash: u64,
+}
+
+impl<'a, T> Hashed<'a, T>
+where
+    T: ToOwned + Hash + ?Sized,
+{
+    pub(crate) fn from_borrowed(value: &'a T) -> Self {
+        let mut hasher = FxHasher::default();
+        value.hash(&mut hasher);
+        Self {
+            value: Cow::Borrowed(value),
+            hash: hasher.finish(),
+        }
+    }
+
+    pub(crate) fn from_owned(value: <T as ToOwned>::Owned) -> Self {
+        let hash = calc_hash(value.borrow());
+        Self {
+            value: Cow::Owned(value),
+            hash,
+        }
+    }
+
+    pub(crate) fn mutate(self, f: impl FnOnce(&mut <T as ToOwned>::Owned)) -> Hashed<'static, T> {
+        let mut value = self.value.into_owned();
+        f(&mut value);
+        let hash = calc_hash(value.borrow());
+        Hashed {
+            value: Cow::Owned(value),
+            hash,
+        }
+    }
+
+    pub(crate) fn into_owned(self) -> Hashed<'static, T> {
+        let value = self.value.into_owned();
+        Hashed {
+            value: Cow::Owned(value),
+            hash: self.hash,
+        }
+    }
+
+    pub(crate) fn into_inner_owned(self) -> T::Owned {
+        self.value.into_owned()
+    }
+}
+
+fn calc_hash<T>(value: T) -> u64
+where
+    T: Hash,
+{
+    let mut hasher = FxHasher::default();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+impl<T> Clone for Hashed<'_, T>
+where
+    T: ToOwned + ?Sized,
+{
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+            hash: self.hash,
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.value.clone_from(&source.value);
+        self.hash = source.hash;
+    }
+}
+
+impl<T> Hash for Hashed<'_, T>
+where
+    T: ToOwned + Hash + ?Sized,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.hash);
+    }
+}
+
+impl<T> PartialEq for Hashed<'_, T>
+where
+    T: ToOwned + PartialEq + ?Sized,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.value.as_ref() == other.value.as_ref()
+    }
+}
+
+impl<T> Eq for Hashed<'_, T> where T: ToOwned + Eq + ?Sized {}
+
+impl<T> Deref for Hashed<'_, T>
+where
+    T: ToOwned + ?Sized,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.value.deref()
+    }
+}
+
+/// Used to make [`Hashed`] values no-op in [`HashMap`](std::collections::HashMap) or [`HashSet`](std::collections::HashSet).
+/// For all other keys types (except for [`u64`]) it will panic.
+#[derive(Default, Clone)]
+pub(crate) struct HashedNoOpBuilder {
+    hashed: u64,
+}
+
+impl Hasher for HashedNoOpBuilder {
+    fn finish(&self) -> u64 {
+        self.hashed
+    }
+
+    fn write(&mut self, _bytes: &[u8]) {
+        panic!("Only works with `Hashed` value")
+    }
+
+    fn write_u64(&mut self, i: u64) {
+        self.hashed = i;
+    }
+}
+
+impl BuildHasher for HashedNoOpBuilder {
+    type Hasher = HashedNoOpBuilder;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        HashedNoOpBuilder::default()
+    }
+}

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -152,11 +152,6 @@ impl AttributeSet {
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&Key, &Value)> {
         self.0.iter().map(|kv| (&kv.key, &kv.value))
     }
-
-    /// Returns the underlying Vec of KeyValue pairs
-    pub(crate) fn into_vec(self) -> Vec<KeyValue> {
-        self.0
-    }
 }
 
 impl Hash for AttributeSet {


### PR DESCRIPTION
## Changes

Remove redundant hashing in `ValueMap`, by using new `Hashed` type. It's similar to `AttributeSet`, but is generic, and support owned and non-owned types (similar to `Cow` type).

On happy path, there's very low performance increase, but `Counter_Overflow` has improved significantly.

The whole reason for this PR, is not 2% percent performance increase, but being able to reuse same hashed results when implementing sharding #2297.

<details>
<summary>cargo bench --bench metrics_counter</summary>

```
Counter_Created
Counter_Add_Sorted      time:   [121.68 ns 121.86 ns 122.08 ns]
                        change: [-3.1490% -2.7896% -2.4834%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

Counter_Created
Counter_Add_Unsorted    time:   [125.76 ns 126.25 ns 126.88 ns]
                        change: [-5.3282% -4.3370% -3.5178%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

Counter_Created
Counter_Overflow        time:   [420.32 ns 420.48 ns 420.64 ns]
                        change: [-36.270% -36.208% -36.146%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

Benchmarking ThreadLocal_Random_Generator_5: Collecting 100 samples in estimated 5.0001 s (152M ThreadLocal_Random_Generator_5
                        time:   [32.440 ns 32.468 ns 32.521 ns]
                        change: [-0.0468% +0.0284% +0.1066%] (p = 0.51 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
```
</details>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
