### PR TITLE
Move Views under feature flag

### DIFF
--- a/examples/metrics-advanced/Cargo.toml
+++ b/examples/metrics-advanced/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 opentelemetry = { path = "../../opentelemetry", features = ["metrics"] }
-opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["metrics", "rt-tokio"] }
+opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["spec_unstable_metrics_views", "rt-tokio"] }
 opentelemetry-stdout = { path = "../../opentelemetry-stdout", features = ["metrics"] }
 tokio = { workspace = true, features = ["full"] }
 serde_json = { workspace = true }

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -49,6 +49,8 @@
 
 - **BREAKING**: `Temporality` enum moved from `opentelemetry_sdk::metrics::data::Temporality` to `opentelemetry_sdk::metrics::Temporality`.
 
+- **BREAKING**: `Views` are now an opt-in ONLY feature. Please include the feature `spec_unstable_metrics_views` to enable `Views`. It will be stabilized post 1.0 stable release of the SDK. [#2295](https://github.com/open-telemetry/opentelemetry-rust/issues/2295)
+
 - Added a new `PeriodicReader` implementation (`PeriodicReaderWithOwnThread`)
   that does not rely on an async runtime, and instead creates own Thread. This
   is under feature flag "experimental_metrics_periodic_reader_no_runtime". The

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -53,6 +53,7 @@ rt-tokio = ["tokio", "tokio-stream"]
 rt-tokio-current-thread = ["tokio", "tokio-stream"]
 rt-async-std = ["async-std"]
 internal-logs = ["tracing"]
+spec_unstable_metrics_views = ["metrics"]
 
 [[bench]]
 name = "context"

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -83,6 +83,7 @@ impl InstrumentKind {
 /// ```
 #[derive(Clone, Default, Debug, PartialEq)]
 #[non_exhaustive]
+#[allow(unreachable_pub)]
 pub struct Instrument {
     /// The human-readable identifier of the instrument.
     pub name: Cow<'static, str>,
@@ -96,6 +97,7 @@ pub struct Instrument {
     pub scope: InstrumentationScope,
 }
 
+#[cfg(feature = "spec_unstable_metrics_views")]
 impl Instrument {
     /// Create a new instrument with default values
     pub fn new() -> Self {
@@ -185,6 +187,7 @@ impl Instrument {
 /// ```
 #[derive(Default, Debug)]
 #[non_exhaustive]
+#[allow(unreachable_pub)]
 pub struct Stream {
     /// The human-readable identifier of the stream.
     pub name: Cow<'static, str>,
@@ -202,6 +205,7 @@ pub struct Stream {
     pub allowed_attribute_keys: Option<Arc<HashSet<Key>>>,
 }
 
+#[cfg(feature = "spec_unstable_metrics_views")]
 impl Stream {
     /// Create a new stream with empty values.
     pub fn new() -> Self {

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -215,6 +215,7 @@ impl MeterProviderBuilder {
         self
     }
 
+    #[cfg(feature = "spec_unstable_metrics_views")]
     /// Associates a [View] with a [MeterProvider].
     ///
     /// [View]s are appended to existing ones in a [MeterProvider] if this option is

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -56,12 +56,22 @@ pub(crate) mod view;
 
 pub use aggregation::*;
 pub use error::{MetricError, MetricResult};
-pub use instrument::*;
 pub use manual_reader::*;
 pub use meter_provider::*;
 pub use periodic_reader::*;
 pub use pipeline::Pipeline;
+
+pub use instrument::InstrumentKind;
+
+#[cfg(feature = "spec_unstable_metrics_views")]
+pub use instrument::*;
+// #[cfg(not(feature = "spec_unstable_metrics_views"))]
+// pub(crate) use instrument::*;
+
+#[cfg(feature = "spec_unstable_metrics_views")]
 pub use view::*;
+// #[cfg(not(feature = "spec_unstable_metrics_views"))]
+// pub(crate) use view::*;
 
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;

--- a/opentelemetry-sdk/src/metrics/view.rs
+++ b/opentelemetry-sdk/src/metrics/view.rs
@@ -1,7 +1,10 @@
 use super::instrument::{Instrument, Stream};
+#[cfg(feature = "spec_unstable_metrics_views")]
 use crate::metrics::{MetricError, MetricResult};
+#[cfg(feature = "spec_unstable_metrics_views")]
 use glob::Pattern;
 
+#[cfg(feature = "spec_unstable_metrics_views")]
 fn empty_view(_inst: &Instrument) -> Option<Stream> {
     None
 }
@@ -42,6 +45,7 @@ fn empty_view(_inst: &Instrument) -> Option<Stream> {
 /// let provider = SdkMeterProvider::builder().with_view(my_view).build();
 /// # drop(provider)
 /// ```
+#[allow(unreachable_pub)]
 pub trait View: Send + Sync + 'static {
     /// Defines how data should be collected for certain instruments.
     ///
@@ -65,6 +69,7 @@ impl View for Box<dyn View> {
     }
 }
 
+#[cfg(feature = "spec_unstable_metrics_views")]
 /// Creates a [View] that applies the [Stream] mask for all instruments that
 /// match criteria.
 ///


### PR DESCRIPTION
Fixes #2295 

## Changes
- Move `Views` under `spec_unstable_metrics_views` feature flag

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
