### PR TITLE
Publish otel-appender-log : add version to semconv

### DIFF
--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -16,7 +16,7 @@ opentelemetry = { version = "0.27", path = "../opentelemetry", features = [
 ] }
 log = { workspace = true, features = ["kv", "std"] }
 serde = { workspace = true, optional = true, features = ["std"] }
-opentelemetry-semantic-conventions = { path = "../opentelemetry-semantic-conventions", optional = true, features = [
+opentelemetry-semantic-conventions = { version = "0.27", path = "../opentelemetry-semantic-conventions", optional = true, features = [
   "semconv_experimental",
 ] }
 


### PR DESCRIPTION
#2193 added semconv dependency to otel-appender-log, but version tag was missed out, which is failing the publishing. Fixing it.