### PR TITLE
fix: AtomicI64, AtomicU64 for build mipsel processor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,11 +53,10 @@ tracing = { version = ">=0.1.40", default-features = false }
 tracing-core = { version = ">=0.1.33", default-features = false } 
 tracing-subscriber = { version = "0.3", default-features = false }
 url = { version = "2.5", default-features = false }
+portable-atomic = "1.9.0"
 
 # Aviod use of crates.io version of these crates through the tracing-opentelemetry dependencies
 [patch.crates-io]
 opentelemetry = { path = "opentelemetry" }
 opentelemetry_sdk = { path = "opentelemetry-sdk" }
 opentelemetry-stdout = { path = "opentelemetry-stdout" }
-url = { version = "2.5.2", default-features = false } #https://github.com/servo/rust-url/issues/992
-portable-atomic = "1.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,5 @@ url = { version = "2.5", default-features = false }
 opentelemetry = { path = "opentelemetry" }
 opentelemetry_sdk = { path = "opentelemetry-sdk" }
 opentelemetry-stdout = { path = "opentelemetry-stdout" }
+url = { version = "2.5.2", default-features = false } #https://github.com/servo/rust-url/issues/992
+portable-atomic = "1.9.0"

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -28,6 +28,8 @@ tokio = { workspace = true, features = ["rt", "time"], optional = true }
 tokio-stream = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 tracing = {workspace = true, optional = true}
+
+[target.'cfg(any(target_arch = "powerpc", target_arch = "mips"))'.dependencies]
 portable-atomic = {workspace = true}
 
 [package.metadata.docs.rs]

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { workspace = true, features = ["rt", "time"], optional = true }
 tokio-stream = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 tracing = {workspace = true, optional = true}
+portable-atomic = {workspace = true}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -16,6 +16,7 @@ use aggregate::{is_under_cardinality_limit, STREAM_CARDINALITY_LIMIT};
 pub(crate) use aggregate::{AggregateBuilder, AggregateFns, ComputeAggregation, Measure};
 pub(crate) use exponential_histogram::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
 use opentelemetry::{otel_warn, KeyValue};
+use portable_atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize};
 
 // TODO Replace it with LazyLock once it is stable
 pub(crate) static STREAM_OVERFLOW_ATTRIBUTES: OnceLock<Vec<KeyValue>> = OnceLock::new();
@@ -439,8 +440,8 @@ mod tests {
     #[test]
     fn can_add_and_get_u64_atomic_value() {
         let atomic = u64::new_atomic_tracker(0);
-        atomic.add(15);
-        atomic.add(10);
+        atomic.add(15, Ordering::Relaxed);
+        atomic.add(10, Ordering::Relaxed);
 
         let value = atomic.get_value();
         assert_eq!(value, 25);
@@ -449,7 +450,7 @@ mod tests {
     #[test]
     fn can_reset_u64_atomic_value() {
         let atomic = u64::new_atomic_tracker(0);
-        atomic.add(15);
+        atomic.add(15, Ordering::Relaxed);
 
         let value = atomic.get_and_reset_value();
         let value2 = atomic.get_value();
@@ -478,8 +479,8 @@ mod tests {
     #[test]
     fn can_add_and_get_i64_atomic_value() {
         let atomic = i64::new_atomic_tracker(0);
-        atomic.add(15);
-        atomic.add(-10);
+        atomic.add(15, Ordering::Relaxed);
+        atomic.add(-10, Ordering::Relaxed);
 
         let value = atomic.get_value();
         assert_eq!(value, 5);
@@ -488,7 +489,7 @@ mod tests {
     #[test]
     fn can_reset_i64_atomic_value() {
         let atomic = i64::new_atomic_tracker(0);
-        atomic.add(15);
+        atomic.add(15, Ordering::Relaxed);
 
         let value = atomic.get_and_reset_value();
         let value2 = atomic.get_value();

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -440,8 +440,8 @@ mod tests {
     #[test]
     fn can_add_and_get_u64_atomic_value() {
         let atomic = u64::new_atomic_tracker(0);
-        atomic.add(15, Ordering::Relaxed);
-        atomic.add(10, Ordering::Relaxed);
+        atomic.add(15);
+        atomic.add(10);
 
         let value = atomic.get_value();
         assert_eq!(value, 25);
@@ -450,7 +450,7 @@ mod tests {
     #[test]
     fn can_reset_u64_atomic_value() {
         let atomic = u64::new_atomic_tracker(0);
-        atomic.add(15, Ordering::Relaxed);
+        atomic.add(15);
 
         let value = atomic.get_and_reset_value();
         let value2 = atomic.get_value();
@@ -479,8 +479,8 @@ mod tests {
     #[test]
     fn can_add_and_get_i64_atomic_value() {
         let atomic = i64::new_atomic_tracker(0);
-        atomic.add(15, Ordering::Relaxed);
-        atomic.add(-10, Ordering::Relaxed);
+        atomic.add(15);
+        atomic.add(-10);
 
         let value = atomic.get_value();
         assert_eq!(value, 5);
@@ -489,7 +489,7 @@ mod tests {
     #[test]
     fn can_reset_i64_atomic_value() {
         let atomic = i64::new_atomic_tracker(0);
-        atomic.add(15, Ordering::Relaxed);
+        atomic.add(15);
 
         let value = atomic.get_and_reset_value();
         let value2 = atomic.get_value();

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -9,7 +9,14 @@ use core::fmt;
 use std::collections::{HashMap, HashSet};
 use std::mem::swap;
 use std::ops::{Add, AddAssign, DerefMut, Sub};
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::Ordering;
+
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize};
+
+#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
+use portable_atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize};
+
 use std::sync::{Arc, OnceLock, RwLock};
 
 use aggregate::{is_under_cardinality_limit, STREAM_CARDINALITY_LIMIT};
@@ -17,15 +24,8 @@ pub(crate) use aggregate::{AggregateBuilder, AggregateFns, ComputeAggregation, M
 pub(crate) use exponential_histogram::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
 use opentelemetry::{otel_warn, KeyValue};
 
-#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
-use portable_atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize};
-
 // TODO Replace it with LazyLock once it is stable
 pub(crate) static STREAM_OVERFLOW_ATTRIBUTES: OnceLock<Vec<KeyValue>> = OnceLock::new();
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize};
-
-use crate::metrics::AttributeSet;
 
 #[inline]
 fn stream_overflow_attributes() -> &'static Vec<KeyValue> {


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes
- Use portable-atomic for mipsel processor. Because when build for mipsel architecture, it don't have `AtomicI64`, `AtomicU64` in std.

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
