### PR TITLE
fix: url needs std specified to compile idna

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,4 +47,4 @@ tokio-stream = "0.1"
 tracing = { version = "0.1", default-features = false }
 tracing-core = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
-url = { version = "2.5.2", default-features = false } #https://github.com/servo/rust-url/issues/992
+url = { version = "2.5.2", features = ["std"], default-features = false } #https://github.com/servo/rust-url/issues/992


### PR DESCRIPTION
## Changes
idna dep of url is failing to compile on stable because default_features is false. std is a default feature that disables the unstable use of error_in_core.
```
error[E0658]: use of unstable library feature 'error_in_core'
error: could not compile `idna` (lib) due to previous error
```
https://github.com/rust-lang/rust/issues/103765
https://github.com/servo/rust-url/blob/main/url/Cargo.toml#L35

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
