### PR TITLE
Refactor/deprecate trace config

### DIFF
--- a/examples/tracing-jaeger/src/main.rs
+++ b/examples/tracing-jaeger/src/main.rs
@@ -5,7 +5,7 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_sdk::trace::TracerProvider;
-use opentelemetry_sdk::{runtime, trace as sdktrace, Resource};
+use opentelemetry_sdk::{runtime, Resource};
 use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 
 use std::error::Error;
@@ -17,12 +17,10 @@ fn init_tracer_provider() -> Result<opentelemetry_sdk::trace::TracerProvider, Tr
 
     Ok(TracerProvider::builder()
         .with_batch_exporter(exporter, runtime::Tokio)
-        .with_config(
-            sdktrace::Config::default().with_resource(Resource::new(vec![KeyValue::new(
-                SERVICE_NAME,
-                "tracing-jaeger",
-            )])),
-        )
+        .with_resource(Resource::new(vec![KeyValue::new(
+            SERVICE_NAME,
+            "tracing-jaeger",
+        )]))
         .build())
 }
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -217,7 +217,6 @@ mod tests {
     use opentelemetry_sdk::export::logs::{LogBatch, LogExporter};
     use opentelemetry_sdk::logs::{LogRecord, LogResult, LoggerProvider};
     use opentelemetry_sdk::testing::logs::InMemoryLogExporter;
-    use opentelemetry_sdk::trace;
     use opentelemetry_sdk::trace::{Sampler, TracerProvider};
     use tracing::{error, warn};
     use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
@@ -402,7 +401,7 @@ mod tests {
 
         // setup tracing as well.
         let tracer_provider = TracerProvider::builder()
-            .with_config(trace::Config::default().with_sampler(Sampler::AlwaysOn))
+            .with_sampler(Sampler::AlwaysOn)
             .build();
         let tracer = tracer_provider.tracer("test-tracer");
 
@@ -579,7 +578,7 @@ mod tests {
 
         // setup tracing as well.
         let tracer_provider = TracerProvider::builder()
-            .with_config(trace::Config::default().with_sampler(Sampler::AlwaysOn))
+            .with_sampler(Sampler::AlwaysOn)
             .build();
         let tracer = tracer_provider.tracer("test-tracer");
 

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -12,7 +12,7 @@ use opentelemetry_sdk::{
     logs::LoggerProvider,
     metrics::{MetricError, PeriodicReader, SdkMeterProvider},
     runtime,
-    trace::{self as sdktrace, Config, TracerProvider},
+    trace::{self as sdktrace, TracerProvider},
 };
 use opentelemetry_sdk::{
     logs::{self as sdklogs},
@@ -52,7 +52,7 @@ fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
 
     Ok(TracerProvider::builder()
         .with_batch_exporter(exporter, runtime::Tokio)
-        .with_config(Config::default().with_resource(RESOURCE.clone()))
+        .with_resource(RESOURCE.clone())
         .build())
 }
 

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -8,7 +8,6 @@ use opentelemetry_sdk::logs::LogError;
 use opentelemetry_sdk::logs::LoggerProvider;
 use opentelemetry_sdk::metrics::MetricError;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
-use opentelemetry_sdk::trace::Config;
 use opentelemetry_sdk::{runtime, trace as sdktrace, Resource};
 use std::error::Error;
 use tracing::info;
@@ -28,7 +27,7 @@ fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
         .with_endpoint("http://localhost:4317")
         .build()?;
     Ok(sdktrace::TracerProvider::builder()
-        .with_config(Config::default().with_resource(RESOURCE.clone()))
+        .with_resource(RESOURCE.clone())
         .with_batch_exporter(exporter, runtime::Tokio)
         .build())
 }

--- a/opentelemetry-otlp/tests/integration_test/tests/traces.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/traces.rs
@@ -21,12 +21,10 @@ fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
         .build()?;
     Ok(opentelemetry_sdk::trace::TracerProvider::builder()
         .with_batch_exporter(exporter, runtime::Tokio)
-        .with_config(
-            sdktrace::Config::default().with_resource(Resource::new(vec![KeyValue::new(
-                opentelemetry_semantic_conventions::resource::SERVICE_NAME,
-                "basic-otlp-tracing-example",
-            )])),
-        )
+        .with_resource(Resource::new(vec![KeyValue::new(
+            opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+            "basic-otlp-tracing-example",
+        )]))
         .build())
 }
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## vNext
 
+- **DEPRECATED**:
+  - `trace::Config` methods are moving onto `TracerProvider` Builder to be consistent with other signals. See https://github.com/open-telemetry/opentelemetry-rust/pull/2303 for migration guide.
+    `trace::Config` is scheduled to be removed from public API in `v0.28.0`.
+    example:
+    ```rust
+    // old
+    let tracer_provider: TracerProvider = TracerProvider::builder()
+        .with_config(Config::default().with_resource(Resource::empty()))
+        .build();
+
+    // new
+    let tracer_provider: TracerProvider = TracerProvider::builder()
+        .with_resource(Resource::empty())
+        .build();
+    ```
+
 ## 0.27.0
 
 Released 2024-Nov-11

--- a/opentelemetry-sdk/benches/context.rs
+++ b/opentelemetry-sdk/benches/context.rs
@@ -10,7 +10,6 @@ use opentelemetry::{
 };
 use opentelemetry_sdk::{
     export::trace::{ExportResult, SpanData, SpanExporter},
-    trace,
     trace::{Sampler, TracerProvider},
 };
 #[cfg(not(target_os = "windows"))]
@@ -127,9 +126,7 @@ impl Display for Environment {
 
 fn parent_sampled_tracer(inner_sampler: Sampler) -> (TracerProvider, BoxedTracer) {
     let provider = TracerProvider::builder()
-        .with_config(
-            trace::Config::default().with_sampler(Sampler::ParentBased(Box::new(inner_sampler))),
-        )
+        .with_sampler(Sampler::ParentBased(Box::new(inner_sampler)))
         .with_simple_exporter(NoopExporter)
         .build();
     let tracer = provider.tracer(module_path!());

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -25,7 +25,6 @@ use opentelemetry::trace::Tracer;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::{InstrumentationScope, Key};
 use opentelemetry_sdk::logs::{LogProcessor, LogRecord, LogResult, Logger, LoggerProvider};
-use opentelemetry_sdk::trace;
 use opentelemetry_sdk::trace::{Sampler, TracerProvider};
 
 #[derive(Debug)]
@@ -65,7 +64,7 @@ fn log_benchmark_group<F: Fn(&Logger)>(c: &mut Criterion, name: &str, f: F) {
 
         // setup tracing as well.
         let tracer_provider = TracerProvider::builder()
-            .with_config(trace::Config::default().with_sampler(Sampler::AlwaysOn))
+            .with_sampler(Sampler::AlwaysOn)
             .build();
         let tracer = tracer_provider.tracer("bench-tracer");
 

--- a/opentelemetry-sdk/benches/span_builder.rs
+++ b/opentelemetry-sdk/benches/span_builder.rs
@@ -54,7 +54,7 @@ fn span_builder_benchmark_group(c: &mut Criterion) {
 
 fn not_sampled_provider() -> (sdktrace::TracerProvider, sdktrace::Tracer) {
     let provider = sdktrace::TracerProvider::builder()
-        .with_config(sdktrace::Config::default().with_sampler(sdktrace::Sampler::AlwaysOff))
+        .with_sampler(sdktrace::Sampler::AlwaysOff)
         .with_simple_exporter(NoopExporter)
         .build();
     let tracer = provider.tracer("not-sampled");

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -70,7 +70,7 @@ fn trace_benchmark_group<F: Fn(&sdktrace::Tracer)>(c: &mut Criterion, name: &str
 
     group.bench_function("always-sample", |b| {
         let provider = sdktrace::TracerProvider::builder()
-            .with_config(sdktrace::Config::default().with_sampler(sdktrace::Sampler::AlwaysOn))
+            .with_sampler(sdktrace::Sampler::AlwaysOn)
             .with_simple_exporter(VoidExporter)
             .build();
         let always_sample = provider.tracer("always-sample");
@@ -80,7 +80,7 @@ fn trace_benchmark_group<F: Fn(&sdktrace::Tracer)>(c: &mut Criterion, name: &str
 
     group.bench_function("never-sample", |b| {
         let provider = sdktrace::TracerProvider::builder()
-            .with_config(sdktrace::Config::default().with_sampler(sdktrace::Sampler::AlwaysOff))
+            .with_sampler(sdktrace::Sampler::AlwaysOff)
             .with_simple_exporter(VoidExporter)
             .build();
         let never_sample = provider.tracer("never-sample");

--- a/opentelemetry-sdk/src/resource/mod.rs
+++ b/opentelemetry-sdk/src/resource/mod.rs
@@ -95,6 +95,14 @@ impl Resource {
         }
     }
 
+    /// Create a new `Resource::default()` and merge with provided key value pairs.
+    ///
+    /// Values are de-duplicated by key, and the first key-value pair with a non-empty string value
+    /// will be retained
+    pub fn new_with_defaults<T: IntoIterator<Item = KeyValue>>(keys: T) -> Self {
+        Resource::default().merge(&mut Resource::new(keys))
+    }
+
     /// Create a new `Resource` from a key value pairs and [schema url].
     ///
     /// Values are de-duplicated by key, and the first key-value pair with a non-empty string value

--- a/opentelemetry-sdk/src/trace/config.rs
+++ b/opentelemetry-sdk/src/trace/config.rs
@@ -56,7 +56,7 @@ impl Config {
     /// Specify the number of events to be recorded per span.
     #[deprecated(
         since = "0.27.1",
-        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+        note = "Config is becoming private. Please use Builder::with_max_events_per_span(...) instead."
     )]
     pub fn with_max_events_per_span(mut self, max_events: u32) -> Self {
         self.span_limits.max_events_per_span = max_events;
@@ -66,7 +66,7 @@ impl Config {
     /// Specify the number of attributes to be recorded per span.
     #[deprecated(
         since = "0.27.1",
-        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+        note = "Config is becoming private. Please use Builder::with_max_attributes_per_span(...) instead."
     )]
     pub fn with_max_attributes_per_span(mut self, max_attributes: u32) -> Self {
         self.span_limits.max_attributes_per_span = max_attributes;
@@ -76,7 +76,7 @@ impl Config {
     /// Specify the number of events to be recorded per span.
     #[deprecated(
         since = "0.27.1",
-        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+        note = "Config is becoming private. Please use Builder::with_max_links_per_span(...) instead."
     )]
     pub fn with_max_links_per_span(mut self, max_links: u32) -> Self {
         self.span_limits.max_links_per_span = max_links;
@@ -86,7 +86,7 @@ impl Config {
     /// Specify the number of attributes one event can have.
     #[deprecated(
         since = "0.27.1",
-        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+        note = "Config is becoming private. Please use Builder::with_max_attributes_per_event(...) instead."
     )]
     pub fn with_max_attributes_per_event(mut self, max_attributes: u32) -> Self {
         self.span_limits.max_attributes_per_event = max_attributes;
@@ -96,7 +96,7 @@ impl Config {
     /// Specify the number of attributes one link can have.
     #[deprecated(
         since = "0.27.1",
-        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+        note = "Config is becoming private. Please use Builder::with_max_attributes_per_link(...) instead."
     )]
     pub fn with_max_attributes_per_link(mut self, max_attributes: u32) -> Self {
         self.span_limits.max_attributes_per_link = max_attributes;
@@ -106,7 +106,7 @@ impl Config {
     /// Specify all limit via the span_limits
     #[deprecated(
         since = "0.27.1",
-        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+        note = "Config is becoming private. Please use Builder::with_span_limits(...) instead."
     )]
     pub fn with_span_limits(mut self, span_limits: SpanLimits) -> Self {
         self.span_limits = span_limits;
@@ -116,7 +116,7 @@ impl Config {
     /// Specify the attributes representing the entity that produces telemetry
     #[deprecated(
         since = "0.27.1",
-        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+        note = "Config is becoming private. Please use Builder::with_resource(...) instead."
     )]
     pub fn with_resource(mut self, resource: Resource) -> Self {
         self.resource = Cow::Owned(resource);

--- a/opentelemetry-sdk/src/trace/config.rs
+++ b/opentelemetry-sdk/src/trace/config.rs
@@ -53,7 +53,7 @@ impl Config {
         self
     }
 
-    /// Specify the number of events to be recorded per span.
+    /// Specify the maximum number of events that can be recorded per span.
     #[deprecated(
         since = "0.27.1",
         note = "Config is becoming private. Please use Builder::with_max_events_per_span(...) instead."
@@ -63,7 +63,7 @@ impl Config {
         self
     }
 
-    /// Specify the number of attributes to be recorded per span.
+    /// Specify the maximum number of attributes that can be recorded per span.
     #[deprecated(
         since = "0.27.1",
         note = "Config is becoming private. Please use Builder::with_max_attributes_per_span(...) instead."
@@ -73,7 +73,7 @@ impl Config {
         self
     }
 
-    /// Specify the number of events to be recorded per span.
+    /// Specify the maximum number of links that can be recorded per span.
     #[deprecated(
         since = "0.27.1",
         note = "Config is becoming private. Please use Builder::with_max_links_per_span(...) instead."
@@ -83,7 +83,7 @@ impl Config {
         self
     }
 
-    /// Specify the number of attributes one event can have.
+    /// Specify the maximum number of attributes one event can have.
     #[deprecated(
         since = "0.27.1",
         note = "Config is becoming private. Please use Builder::with_max_attributes_per_event(...) instead."
@@ -93,7 +93,7 @@ impl Config {
         self
     }
 
-    /// Specify the number of attributes one link can have.
+    /// Specify the maximum number of attributes one link can have.
     #[deprecated(
         since = "0.27.1",
         note = "Config is becoming private. Please use Builder::with_max_attributes_per_link(...) instead."

--- a/opentelemetry-sdk/src/trace/config.rs
+++ b/opentelemetry-sdk/src/trace/config.rs
@@ -34,54 +34,90 @@ pub struct Config {
 
 impl Config {
     /// Specify the sampler to be used.
+    #[deprecated(
+        since = "0.27.1",
+        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+    )]
     pub fn with_sampler<T: crate::trace::ShouldSample + 'static>(mut self, sampler: T) -> Self {
         self.sampler = Box::new(sampler);
         self
     }
 
     /// Specify the id generator to be used.
+    #[deprecated(
+        since = "0.27.1",
+        note = "Config is becoming private. Please use Builder::with_id_generator(...) instead."
+    )]
     pub fn with_id_generator<T: IdGenerator + 'static>(mut self, id_generator: T) -> Self {
         self.id_generator = Box::new(id_generator);
         self
     }
 
     /// Specify the number of events to be recorded per span.
+    #[deprecated(
+        since = "0.27.1",
+        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+    )]
     pub fn with_max_events_per_span(mut self, max_events: u32) -> Self {
         self.span_limits.max_events_per_span = max_events;
         self
     }
 
     /// Specify the number of attributes to be recorded per span.
+    #[deprecated(
+        since = "0.27.1",
+        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+    )]
     pub fn with_max_attributes_per_span(mut self, max_attributes: u32) -> Self {
         self.span_limits.max_attributes_per_span = max_attributes;
         self
     }
 
     /// Specify the number of events to be recorded per span.
+    #[deprecated(
+        since = "0.27.1",
+        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+    )]
     pub fn with_max_links_per_span(mut self, max_links: u32) -> Self {
         self.span_limits.max_links_per_span = max_links;
         self
     }
 
     /// Specify the number of attributes one event can have.
+    #[deprecated(
+        since = "0.27.1",
+        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+    )]
     pub fn with_max_attributes_per_event(mut self, max_attributes: u32) -> Self {
         self.span_limits.max_attributes_per_event = max_attributes;
         self
     }
 
     /// Specify the number of attributes one link can have.
+    #[deprecated(
+        since = "0.27.1",
+        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+    )]
     pub fn with_max_attributes_per_link(mut self, max_attributes: u32) -> Self {
         self.span_limits.max_attributes_per_link = max_attributes;
         self
     }
 
     /// Specify all limit via the span_limits
+    #[deprecated(
+        since = "0.27.1",
+        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+    )]
     pub fn with_span_limits(mut self, span_limits: SpanLimits) -> Self {
         self.span_limits = span_limits;
         self
     }
 
     /// Specify the attributes representing the entity that produces telemetry
+    #[deprecated(
+        since = "0.27.1",
+        note = "Config is becoming private. Please use Builder::with_sampler(...) instead."
+    )]
     pub fn with_resource(mut self, resource: Resource) -> Self {
         self.resource = Cow::Owned(resource);
         self

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -240,7 +240,7 @@ mod tests {
     fn trace_state_for_dropped_sampler() {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = TracerProvider::builder()
-            .with_config(Config::default().with_sampler(Sampler::AlwaysOff))
+            .with_sampler(Sampler::AlwaysOff)
             .with_span_processor(SimpleSpanProcessor::new(Box::new(exporter.clone())))
             .build();
 
@@ -293,7 +293,7 @@ mod tests {
     fn trace_state_for_record_only_sampler() {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = TracerProvider::builder()
-            .with_config(Config::default().with_sampler(TestRecordOnlySampler::default()))
+            .with_sampler(TestRecordOnlySampler::default())
             .with_span_processor(SimpleSpanProcessor::new(Box::new(exporter.clone())))
             .build();
 

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -308,6 +308,10 @@ impl Builder {
     }
 
     /// The sdk [`crate::trace::Config`] that this provider will use.
+    #[deprecated(
+        since = "0.27.1",
+        note = "Config is becoming a private type. Use Builder::with_{config_name}(resource) instead. ex: Builder::with_resource(resource)"
+    )]
     pub fn with_config(self, config: crate::trace::Config) -> Self {
         Builder { config, ..self }
     }

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -285,7 +285,7 @@ impl opentelemetry::trace::Tracer for Tracer {
 mod tests {
     use crate::{
         testing::trace::TestSpan,
-        trace::{Config, Sampler, ShouldSample},
+        trace::{Sampler, ShouldSample},
     };
     use opentelemetry::{
         trace::{
@@ -326,9 +326,8 @@ mod tests {
     fn allow_sampler_to_change_trace_state() {
         // Setup
         let sampler = TestSampler {};
-        let config = Config::default().with_sampler(sampler);
         let tracer_provider = crate::trace::TracerProvider::builder()
-            .with_config(config)
+            .with_sampler(sampler)
             .build();
         let tracer = tracer_provider.tracer("test");
         let trace_state = TraceState::from_key_value(vec![("foo", "bar")]).unwrap();
@@ -351,9 +350,8 @@ mod tests {
     #[test]
     fn drop_parent_based_children() {
         let sampler = Sampler::ParentBased(Box::new(Sampler::AlwaysOn));
-        let config = Config::default().with_sampler(sampler);
         let tracer_provider = crate::trace::TracerProvider::builder()
-            .with_config(config)
+            .with_sampler(sampler)
             .build();
 
         let context = Context::current_with_span(TestSpan(SpanContext::empty_context()));
@@ -366,9 +364,8 @@ mod tests {
     #[test]
     fn uses_current_context_for_builders_if_unset() {
         let sampler = Sampler::ParentBased(Box::new(Sampler::AlwaysOn));
-        let config = Config::default().with_sampler(sampler);
         let tracer_provider = crate::trace::TracerProvider::builder()
-            .with_config(config)
+            .with_sampler(sampler)
             .build();
         let tracer = tracer_provider.tracer("test");
 

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -12,7 +12,6 @@ use opentelemetry_sdk::runtime;
 #[cfg(feature = "metrics")]
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 
-use opentelemetry_sdk::trace::Config;
 #[cfg(feature = "trace")]
 use opentelemetry_sdk::trace::TracerProvider;
 use opentelemetry_sdk::Resource;
@@ -29,7 +28,7 @@ fn init_trace() {
     let exporter = opentelemetry_stdout::SpanExporter::default();
     let provider = TracerProvider::builder()
         .with_simple_exporter(exporter)
-        .with_config(Config::default().with_resource(RESOURCE.clone()))
+        .with_resource(RESOURCE.clone())
         .build();
     global::set_tracer_provider(provider);
 }

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -106,6 +106,7 @@ impl ZipkinPipelineBuilder {
                 ));
                 cfg
             } else {
+                #[allow(deprecated)]
                 Config::default().with_resource(Resource::empty())
             };
             (config, Endpoint::new(service_name, self.service_addr))
@@ -116,6 +117,7 @@ impl ZipkinPipelineBuilder {
                 .unwrap()
                 .to_string();
             (
+                #[allow(deprecated)]
                 Config::default().with_resource(Resource::empty()),
                 Endpoint::new(service_name, self.service_addr),
             )
@@ -138,6 +140,7 @@ impl ZipkinPipelineBuilder {
     }
 
     /// Install the Zipkin trace exporter pipeline with a simple span processor.
+    #[allow(deprecated)]
     pub fn install_simple(mut self) -> Result<Tracer, TraceError> {
         let (config, endpoint) = self.init_config_and_endpoint();
         let exporter = self.init_exporter_with_endpoint(endpoint)?;
@@ -155,6 +158,7 @@ impl ZipkinPipelineBuilder {
 
     /// Install the Zipkin trace exporter pipeline with a batch span processor using the specified
     /// runtime.
+    #[allow(deprecated)]
     pub fn install_batch<R: RuntimeChannel>(mut self, runtime: R) -> Result<Tracer, TraceError> {
         let (config, endpoint) = self.init_config_and_endpoint();
         let exporter = self.init_exporter_with_endpoint(endpoint)?;

--- a/stress/src/traces.rs
+++ b/stress/src/traces.rs
@@ -23,7 +23,7 @@ mod throughput;
 
 lazy_static! {
     static ref PROVIDER: sdktrace::TracerProvider = sdktrace::TracerProvider::builder()
-        .with_config(sdktrace::Config::default().with_sampler(sdktrace::Sampler::AlwaysOn))
+        .with_sampler(sdktrace::Sampler::AlwaysOn)
         .with_span_processor(NoOpSpanProcessor {})
         .build();
     static ref TRACER: sdktrace::Tracer = PROVIDER.tracer("stress");


### PR DESCRIPTION
resolves: #2294 

## Changes
Moving away from `trace::Config` and `.with_config(...)` to remain consistent with the MeterProvider, and `LoggerProvider`.

# Migration Guide

Moving away from `TracerProvider::builder().with_config(trace::Config::default())`.

## Simple Example
The provider interface should be similar to the old method. For example, a `TracerProvider` being configured.
```rust
// old
let tracer_provider: TracerProvider = TracerProvider::builder()
    .with_config(Config::default().with_resource(Resource::empty()))
    .build();

// new
let tracer_provider: TracerProvider = TracerProvider::builder()
    .with_resource(Resource::empty())
    .build();
```

## Advanced Example
```rust
// old
let tracer_provider = TracerProvider::builder()
    .with_config(
        Config::default()
            .with_resource(Resource::empty())
            .with_sampler(Sampler::AlwaysOn)
            .with_max_events_per_span(16),
    )
    .build();

// new
let tracer_provider = TracerProvider::builder()
    .with_resource(Resource::empty())
    .with_sampler(Sampler::AlwaysOn)
    .with_max_events_per_span(16)
    .build();
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
