### PR TITLE
feat: update otel versions for prometheus to 0.27

### DIFF
--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## vNext
 
-- Bump MSRV to 1.70 [#2179](https://github.com/open-telemetry/opentelemetry-rust/pull/2179)
-- Update `opentelemetry` dependency version to 0.26
-- Update `opentelemetry_sdk` dependency version to 0.26
-- Update `opentelemetry-semantic-conventions` dependency version to 0.26
+## v0.27.0
+
+- Update `opentelemetry` dependency version to 0.27
+- Update `opentelemetry_sdk` dependency version to 0.27
+- Update `opentelemetry-semantic-conventions` dependency version to 0.27
 
 
 ## v0.17.0

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-prometheus"
-version = "0.17.0"
+version = "0.27.0"
 description = "Prometheus exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"
@@ -21,17 +21,20 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 once_cell = { workspace = true }
-opentelemetry = { version = "0.26", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.26", default-features = false, features = ["metrics"] }
+opentelemetry = { version = "0.27", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.27", default-features = false, features = ["metrics", "spec_unstable_metrics_views"] }
 prometheus = "0.13"
 protobuf = "2.14"
+tracing = {workspace = true, optional = true} # optional for opentelemetry internal logging
 
 [dev-dependencies]
-opentelemetry-semantic-conventions = { version = "0.26" }
+opentelemetry-semantic-conventions = { version = "0.27" }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["full"] }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
+default = ["internal-logs"]
 prometheus-encoding = []
+internal-logs = ["tracing"]

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 once_cell = { workspace = true }
 opentelemetry = { version = "0.27", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.27", default-features = false, features = ["metrics", "spec_unstable_metrics_views"] }
+opentelemetry_sdk = { version = "0.27", default-features = false, features = ["metrics"] }
 prometheus = "0.13"
 protobuf = "2.14"
 tracing = {workspace = true, optional = true} # optional for opentelemetry internal logging

--- a/opentelemetry-prometheus/README.md
+++ b/opentelemetry-prometheus/README.md
@@ -7,7 +7,7 @@
 [`Prometheus`] integration for applications instrumented with [`OpenTelemetry`]. 
 
 **The development of prometheus exporter has halt until the Opentelemetry metrics API and SDK reaches 1.0. Current 
-implementation is based on Opentelemetry API and SDK 0.24**.
+implementation is based on Opentelemetry API and SDK 0.27**.
 
 [![Crates.io: opentelemetry-prometheus](https://img.shields.io/crates/v/opentelemetry-prometheus.svg)](https://crates.io/crates/opentelemetry-prometheus)
 [![Documentation](https://docs.rs/opentelemetry-prometheus/badge.svg)](https://docs.rs/opentelemetry-prometheus)

--- a/opentelemetry-prometheus/examples/hyper.rs
+++ b/opentelemetry-prometheus/examples/hyper.rs
@@ -85,17 +85,17 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         http_counter: meter
             .u64_counter("http_requests_total")
             .with_description("Total number of HTTP requests made.")
-            .init(),
+            .build(),
         http_body_gauge: meter
             .u64_histogram("example.http_response_size")
             .with_unit("By")
             .with_description("The metrics HTTP response sizes in bytes.")
-            .init(),
+            .build(),
         http_req_histogram: meter
             .f64_histogram("example.http_request_duration")
             .with_unit("ms")
             .with_description("The HTTP request latencies in milliseconds.")
-            .init(),
+            .build(),
     });
 
     let addr: SocketAddr = ([127, 0, 0, 1], 3000).into();

--- a/opentelemetry-prometheus/src/config.rs
+++ b/opentelemetry-prometheus/src/config.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 use once_cell::sync::OnceCell;
-use opentelemetry::metrics::{MetricsError, Result};
-use opentelemetry_sdk::metrics::ManualReaderBuilder;
+use opentelemetry_sdk::metrics::{ManualReaderBuilder, MetricError, MetricResult};
 use std::sync::{Arc, Mutex};
 
 use crate::{Collector, PrometheusExporter, ResourceSelector};
@@ -116,7 +115,7 @@ impl ExporterBuilder {
     }
 
     /// Creates a new [PrometheusExporter] from this configuration.
-    pub fn build(self) -> Result<PrometheusExporter> {
+    pub fn build(self) -> MetricResult<PrometheusExporter> {
         let reader = Arc::new(self.reader.build());
 
         let collector = Collector {
@@ -135,7 +134,7 @@ impl ExporterBuilder {
         let registry = self.registry.unwrap_or_default();
         registry
             .register(Box::new(collector))
-            .map_err(|e| MetricsError::Other(e.to_string()))?;
+            .map_err(|e| MetricError::Other(e.to_string()))?;
 
         Ok(PrometheusExporter { reader })
     }

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -276,7 +276,7 @@ impl prometheus::core::Collector for Collector {
             Ok(guard) => guard,
             Err(err) => {
                 otel_error!(
-                    name: "OpenTelemetryPrometheus.AcquireLockError",
+                    name: "MetricScrapeFailed",
                     message = err.to_string(),
                 );
                 return Vec::new();
@@ -289,7 +289,7 @@ impl prometheus::core::Collector for Collector {
         };
         if let Err(err) = self.reader.collect(&mut metrics) {
             otel_error!(
-                name: "OpenTelemetryPrometheus.ReaderError",
+                name: "MetricScrapeFailed",
                 message = err.to_string(),
             );
             return vec![];
@@ -422,7 +422,7 @@ fn validate_metrics(
     if let Some(existing) = mfs.get(name) {
         if existing.get_field_type() != metric_type {
             otel_warn!(
-                name: "OpenTelemetryPrometheus.MetricValidation",
+                name: "MetricValidationFailed",
                 message = "Instrument type conflict, using existing type definition",
                 metric_type = format!("Instrument {name}, Existing: {:?}, dropped: {:?}", existing.get_field_type(), metric_type).as_str(),
             );
@@ -430,7 +430,7 @@ fn validate_metrics(
         }
         if existing.get_help() != description {
             otel_warn!(
-                name: "OpenTelemetryPrometheus.MetricValidation",
+                name: "MetricValidationFailed",
                 message = "Instrument description conflict, using existing",
                 metric_description = format!("Instrument {name}, Existing: {:?}, dropped: {:?}", existing.get_help().to_string(), description.to_string()).as_str(),
             );

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -28,11 +28,11 @@
 //! let counter = meter
 //!     .u64_counter("a.counter")
 //!     .with_description("Counts things")
-//!     .init();
+//!     .build();
 //! let histogram = meter
 //!     .u64_histogram("a.histogram")
 //!     .with_description("Records values")
-//!     .init();
+//!     .build();
 //!
 //! counter.add(100, &[KeyValue::new("key", "value")]);
 //! histogram.record(100, &[KeyValue::new("key", "value")]);
@@ -97,18 +97,14 @@
 #![cfg_attr(test, deny(warnings))]
 
 use once_cell::sync::{Lazy, OnceCell};
-use opentelemetry::{
-    global,
-    metrics::{MetricsError, Result},
-    Key, Value,
-};
+use opentelemetry::{otel_error, InstrumentationScope, Key, Value};
 use opentelemetry_sdk::{
     metrics::{
-        data::{self, ResourceMetrics, Temporality},
-        reader::{MetricReader, TemporalitySelector},
-        InstrumentKind, ManualReader, Pipeline,
+        data::{self, ResourceMetrics},
+        reader::MetricReader,
+        InstrumentKind, ManualReader, MetricResult, Pipeline, Temporality,
     },
-    Resource, Scope,
+    Resource,
 };
 use prometheus::{
     core::Desc,
@@ -152,29 +148,25 @@ pub struct PrometheusExporter {
     reader: Arc<ManualReader>,
 }
 
-impl TemporalitySelector for PrometheusExporter {
-    /// Note: Prometheus only supports cumulative temporality so this will always be
-    /// [Temporality::Cumulative].
-    fn temporality(&self, kind: InstrumentKind) -> Temporality {
-        self.reader.temporality(kind)
-    }
-}
-
 impl MetricReader for PrometheusExporter {
     fn register_pipeline(&self, pipeline: Weak<Pipeline>) {
         self.reader.register_pipeline(pipeline)
     }
 
-    fn collect(&self, rm: &mut ResourceMetrics) -> Result<()> {
+    fn collect(&self, rm: &mut ResourceMetrics) -> MetricResult<()> {
         self.reader.collect(rm)
     }
 
-    fn force_flush(&self) -> Result<()> {
+    fn force_flush(&self) -> MetricResult<()> {
         self.reader.force_flush()
     }
 
-    fn shutdown(&self) -> Result<()> {
+    fn shutdown(&self) -> MetricResult<()> {
         self.reader.shutdown()
+    }
+
+    fn temporality(&self, kind: InstrumentKind) -> Temporality {
+        self.reader.temporality(kind)
     }
 }
 
@@ -193,7 +185,7 @@ struct Collector {
 
 #[derive(Default)]
 struct CollectorInner {
-    scope_infos: HashMap<Scope, MetricFamily>,
+    scope_infos: HashMap<InstrumentationScope, MetricFamily>,
     metric_families: HashMap<String, MetricFamily>,
 }
 
@@ -281,7 +273,10 @@ impl prometheus::core::Collector for Collector {
         let mut inner = match self.inner.lock() {
             Ok(guard) => guard,
             Err(err) => {
-                global::handle_error(err);
+                otel_error!(
+                    name: "OpenTelemetry error occurred.",
+                    message = err.to_string(),
+                );
                 return Vec::new();
             }
         };
@@ -291,7 +286,10 @@ impl prometheus::core::Collector for Collector {
             scope_metrics: vec![],
         };
         if let Err(err) = self.reader.collect(&mut metrics) {
-            global::handle_error(err);
+            otel_error!(
+                name: "OpenTelemetry metrics error occurred.",
+                message = err.to_string(),
+            );
             return vec![];
         }
         let mut res = Vec::with_capacity(metrics.scope_metrics.len() + 1);
@@ -311,7 +309,7 @@ impl prometheus::core::Collector for Collector {
 
         for scope_metrics in metrics.scope_metrics {
             let scope_labels = if !self.disable_scope_info {
-                if !scope_metrics.scope.attributes.is_empty() {
+                if scope_metrics.scope.attributes().count() > 0 {
                     let scope_info = inner
                         .scope_infos
                         .entry(scope_metrics.scope.clone())
@@ -320,12 +318,12 @@ impl prometheus::core::Collector for Collector {
                 }
 
                 let mut labels =
-                    Vec::with_capacity(1 + scope_metrics.scope.version.is_some() as usize);
+                    Vec::with_capacity(1 + scope_metrics.scope.version().is_some() as usize);
                 let mut name = LabelPair::new();
                 name.set_name(SCOPE_INFO_KEYS[0].into());
-                name.set_value(scope_metrics.scope.name.to_string());
+                name.set_value(scope_metrics.scope.name().to_string());
                 labels.push(name);
-                if let Some(version) = &scope_metrics.scope.version {
+                if let Some(version) = &scope_metrics.scope.version() {
                     let mut l_version = LabelPair::new();
                     l_version.set_name(SCOPE_INFO_KEYS[1].into());
                     l_version.set_value(version.to_string());
@@ -421,11 +419,17 @@ fn validate_metrics(
 ) -> (bool, Option<String>) {
     if let Some(existing) = mfs.get(name) {
         if existing.get_field_type() != metric_type {
-            global::handle_error(MetricsError::Other(format!("Instrument type conflict, using existing type definition. Instrument {name}, Existing: {:?}, dropped: {:?}", existing.get_field_type(), metric_type)));
+            otel_error!(
+                name: "OpenTelemetry metrics error occurred.",
+                message = format!("Instrument type conflict, using existing type definition. Instrument {name}, Existing: {:?}, dropped: {:?}", existing.get_field_type(), metric_type).as_str(),
+            );
             return (true, None);
         }
         if existing.get_help() != description {
-            global::handle_error(MetricsError::Other(format!("Instrument description conflict, using existing. Instrument {name}, Existing: {:?}, dropped: {:?}", existing.get_help(), description)));
+            otel_error!(
+                name: "OpenTelemetry metrics error occurred.",
+                message = format!("Instrument description conflict, using existing. Instrument {name}, Existing: {:?}, dropped: {:?}", existing.get_help().to_string(), description.to_string()).as_str(),
+            );
             return (false, Some(existing.get_help().to_string()));
         }
         (false, None)
@@ -578,16 +582,16 @@ fn create_info_metric(
     mf
 }
 
-fn create_scope_info_metric(scope: &Scope) -> MetricFamily {
+fn create_scope_info_metric(scope: &InstrumentationScope) -> MetricFamily {
     let mut g = prometheus::proto::Gauge::default();
     g.set_value(1.0);
 
-    let mut labels = Vec::with_capacity(1 + scope.version.is_some() as usize);
+    let mut labels = Vec::with_capacity(1 + scope.version().is_some() as usize);
     let mut name = LabelPair::new();
     name.set_name(SCOPE_INFO_KEYS[0].into());
-    name.set_value(scope.name.to_string());
+    name.set_value(scope.name().to_string());
     labels.push(name);
-    if let Some(version) = &scope.version {
+    if let Some(version) = &scope.version() {
         let mut v_label = LabelPair::new();
         v_label.set_name(SCOPE_INFO_KEYS[1].into());
         v_label.set_value(version.to_string());

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -7,13 +7,22 @@ use opentelemetry::metrics::{Meter, MeterProvider as _};
 use opentelemetry::KeyValue;
 use opentelemetry::{InstrumentationScope, Key};
 use opentelemetry_prometheus::{ExporterBuilder, ResourceSelector};
-use opentelemetry_sdk::metrics::{new_view, Aggregation, Instrument, SdkMeterProvider, Stream};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::resource::{
     EnvResourceDetector, SdkProvidedResourceDetector, TelemetryResourceDetector,
 };
 use opentelemetry_sdk::Resource;
 use opentelemetry_semantic_conventions::resource::{SERVICE_NAME, TELEMETRY_SDK_VERSION};
 use prometheus::{Encoder, TextEncoder};
+
+const BOUNDARIES: &[f64] = &[
+    0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 1000.0,
+];
+
+const BYTES_BOUNDARIES: &[f64] = &[
+    0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0,
+    10000.0,
+];
 
 #[ignore = "https://github.com/open-telemetry/opentelemetry-rust/pull/2224"]
 #[test]
@@ -123,6 +132,7 @@ fn prometheus_exporter_integration() {
                     .f64_histogram("histogram_baz")
                     .with_description("a very nice histogram")
                     .with_unit("By")
+                    .with_boundaries(BOUNDARIES.to_vec())
                     .build();
                 histogram.record(23.0, &attrs);
                 histogram.record(7.0, &attrs);
@@ -185,6 +195,7 @@ fn prometheus_exporter_integration() {
                 let histogram = meter
                     .f64_histogram("invalid.hist.name")
                     .with_description("a histogram with an invalid name")
+                    .with_boundaries(BOUNDARIES.to_vec())
                     .build();
                 histogram.record(23.0, &attrs);
             }),
@@ -374,18 +385,6 @@ fn prometheus_exporter_integration() {
         let provider = SdkMeterProvider::builder()
             .with_resource(res)
             .with_reader(exporter)
-            .with_view(
-                new_view(
-                    Instrument::new().name("histogram_*"),
-                    Stream::new().aggregation(Aggregation::ExplicitBucketHistogram {
-                        boundaries: vec![
-                            0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 1000.0,
-                        ],
-                        record_min_max: true,
-                    }),
-                )
-                .unwrap(),
-            )
             .build();
 
         let scope = InstrumentationScope::builder("testmeter")
@@ -559,6 +558,7 @@ fn duplicate_metrics() {
                     .u64_histogram("foo")
                     .with_unit("By")
                     .with_description("meter histogram foo")
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
                     .build();
 
                 foo_a.record(100, &[KeyValue::new("A", "B")]);
@@ -567,6 +567,7 @@ fn duplicate_metrics() {
                     .u64_histogram("foo")
                     .with_unit("By")
                     .with_description("meter histogram foo")
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
                     .build();
 
                 foo_b.record(100, &[KeyValue::new("A", "B")]);
@@ -631,6 +632,7 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("By")
                     .with_description("meter a bar")
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
                     .build();
 
                 bar_a.record(100, &[KeyValue::new("A", "B")]);
@@ -639,6 +641,7 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("By")
                     .with_description("meter b bar")
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
                     .build();
 
                 bar_b.record(100, &[KeyValue::new("A", "B")]);
@@ -702,6 +705,7 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("By")
                     .with_description("meter histogram bar")
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
                     .build();
 
                 bar_a.record(100, &[KeyValue::new("A", "B")]);
@@ -710,6 +714,7 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("ms")
                     .with_description("meter histogram bar")
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
                     .build();
 
                 bar_b.record(100, &[KeyValue::new("A", "B")]);
@@ -759,6 +764,7 @@ fn duplicate_metrics() {
                     .u64_histogram("foo")
                     .with_unit("By")
                     .with_description("meter histogram foo")
+                    .with_boundaries(BOUNDARIES.to_vec())
                     .build();
 
                 foo_histogram_a.record(100, &[KeyValue::new("A", "B")]);

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use opentelemetry::metrics::{Meter, MeterProvider as _};
-use opentelemetry::Key;
 use opentelemetry::KeyValue;
+use opentelemetry::{InstrumentationScope, Key};
 use opentelemetry_prometheus::{ExporterBuilder, ResourceSelector};
 use opentelemetry_sdk::metrics::{new_view, Aggregation, Instrument, SdkMeterProvider, Stream};
 use opentelemetry_sdk::resource::{
@@ -56,7 +56,7 @@ fn prometheus_exporter_integration() {
                     .f64_counter("foo")
                     .with_description("a simple counter")
                     .with_unit("ms")
-                    .init();
+                    .build();
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -85,7 +85,7 @@ fn prometheus_exporter_integration() {
                     .f64_counter("foo")
                     .with_description("a simple counter without a total suffix")
                     .with_unit("ms")
-                    .init();
+                    .build();
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -108,7 +108,7 @@ fn prometheus_exporter_integration() {
                     .f64_up_down_counter("bar")
                     .with_description("a fun little gauge")
                     .with_unit("1")
-                    .init();
+                    .build();
                 gauge.add(1.0, &attrs);
                 gauge.add(-0.25, &attrs);
             }),
@@ -123,7 +123,7 @@ fn prometheus_exporter_integration() {
                     .f64_histogram("histogram_baz")
                     .with_description("a very nice histogram")
                     .with_unit("By")
-                    .init();
+                    .build();
                 histogram.record(23.0, &attrs);
                 histogram.record(7.0, &attrs);
                 histogram.record(101.0, &attrs);
@@ -149,7 +149,7 @@ fn prometheus_exporter_integration() {
                     .with_description("a sanitary counter")
                     // This unit is not added to
                     .with_unit("By")
-                    .init();
+                    .build();
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -165,7 +165,7 @@ fn prometheus_exporter_integration() {
                 let mut gauge = meter
                     .f64_up_down_counter("bar")
                     .with_description("a fun little gauge")
-                    .init();
+                    .build();
                 gauge.add(100., &attrs);
                 gauge.add(-25.0, &attrs);
 
@@ -173,19 +173,19 @@ fn prometheus_exporter_integration() {
                 gauge = meter
                     .f64_up_down_counter("invalid.gauge.name")
                     .with_description("a gauge with an invalid name")
-                    .init();
+                    .build();
                 gauge.add(100.0, &attrs);
 
                 let counter = meter
                     .f64_counter("0invalid.counter.name")
                     .with_description("a counter with an invalid name")
-                    .init();
+                    .build();
                 counter.add(100.0, &attrs);
 
                 let histogram = meter
                     .f64_histogram("invalid.hist.name")
                     .with_description("a histogram with an invalid name")
-                    .init();
+                    .build();
                 histogram.record(23.0, &attrs);
             }),
             ..Default::default()
@@ -204,7 +204,7 @@ fn prometheus_exporter_integration() {
                 let counter = meter
                     .f64_counter("foo")
                     .with_description("a simple counter")
-                    .init();
+                    .build();
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -225,7 +225,7 @@ fn prometheus_exporter_integration() {
                 let counter = meter
                     .f64_counter("foo")
                     .with_description("a simple counter")
-                    .init();
+                    .build();
                 counter.add(5., &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -246,7 +246,7 @@ fn prometheus_exporter_integration() {
                 let counter = meter
                     .f64_counter("foo")
                     .with_description("a simple counter")
-                    .init();
+                    .build();
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -263,7 +263,7 @@ fn prometheus_exporter_integration() {
                     .i64_up_down_counter("bar")
                     .with_description("a fun little gauge")
                     .with_unit("1")
-                    .init();
+                    .build();
                 gauge.add(2, &attrs);
                 gauge.add(-1, &attrs);
             }),
@@ -281,7 +281,7 @@ fn prometheus_exporter_integration() {
                     .u64_counter("bar")
                     .with_description("a fun little counter")
                     .with_unit("By")
-                    .init();
+                    .build();
                 counter.add(2, &attrs);
                 counter.add(1, &attrs);
             }),
@@ -301,7 +301,7 @@ fn prometheus_exporter_integration() {
                 let counter = meter
                     .f64_counter("foo")
                     .with_description("a simple counter")
-                    .init();
+                    .build();
 
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
@@ -319,7 +319,7 @@ fn prometheus_exporter_integration() {
                     .i64_up_down_counter("bar")
                     .with_description("a fun little gauge")
                     .with_unit("1")
-                    .init();
+                    .build();
                 gauge.add(2, &attrs);
                 gauge.add(-1, &attrs);
             }),
@@ -336,7 +336,7 @@ fn prometheus_exporter_integration() {
                     .i64_up_down_counter("bar")
                     .with_description("a fun little gauge")
                     .with_unit("1")
-                    .init();
+                    .build();
                 gauge.add(2, &attrs);
                 gauge.add(-1, &attrs);
             }),
@@ -387,12 +387,15 @@ fn prometheus_exporter_integration() {
                 .unwrap(),
             )
             .build();
-        let meter = provider.versioned_meter(
-            "testmeter",
-            Some("v0.1.0"),
-            None::<&'static str>,
-            Some(vec![KeyValue::new("k", "v")]),
-        );
+
+        let scope = InstrumentationScope::builder("testmeter")
+            .with_version("v0.1.0")
+            .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+            .with_attributes(vec![KeyValue::new("k", "v")])
+            .build();
+
+        let meter = provider.meter_with_scope(scope);
+
         (tc.record_metrics)(meter);
 
         let content = fs::read_to_string(Path::new("./tests/data").join(tc.expected_file))
@@ -449,30 +452,32 @@ fn multiple_scopes() {
         .with_resource(resource)
         .build();
 
+    let scope_foo = InstrumentationScope::builder("meterfoo")
+        .with_version("v0.1.0")
+        .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+        .with_attributes(vec![KeyValue::new("k", "v")])
+        .build();
+
     let foo_counter = provider
-        .versioned_meter(
-            "meterfoo",
-            Some("v0.1.0"),
-            None::<&'static str>,
-            Some(vec![KeyValue::new("k", "v")]),
-        )
+        .meter_with_scope(scope_foo)
         .u64_counter("foo")
         .with_unit("ms")
         .with_description("meter foo counter")
-        .init();
+        .build();
     foo_counter.add(100, &[KeyValue::new("type", "foo")]);
 
+    let scope_bar = InstrumentationScope::builder("meterbar")
+        .with_version("v0.1.0")
+        .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+        .with_attributes(vec![KeyValue::new("k", "v")])
+        .build();
+
     let bar_counter = provider
-        .versioned_meter(
-            "meterbar",
-            Some("v0.1.0"),
-            None::<&'static str>,
-            Some(vec![KeyValue::new("k", "v")]),
-        )
+        .meter_with_scope(scope_bar)
         .u64_counter("bar")
         .with_unit("ms")
         .with_description("meter bar counter")
-        .init();
+        .build();
     bar_counter.add(200, &[KeyValue::new("type", "bar")]);
 
     let content = fs::read_to_string("./tests/data/multi_scopes.txt").unwrap();
@@ -510,7 +515,7 @@ fn duplicate_metrics() {
                     .u64_counter("foo")
                     .with_unit("By")
                     .with_description("meter counter foo")
-                    .init();
+                    .build();
 
                 foo_a.add(100, &[KeyValue::new("A", "B")]);
 
@@ -518,7 +523,7 @@ fn duplicate_metrics() {
                     .u64_counter("foo")
                     .with_unit("By")
                     .with_description("meter counter foo")
-                    .init();
+                    .build();
 
                 foo_b.add(100, &[KeyValue::new("A", "B")]);
             }),
@@ -532,7 +537,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("foo")
                     .with_unit("By")
                     .with_description("meter gauge foo")
-                    .init();
+                    .build();
 
                 foo_a.add(100, &[KeyValue::new("A", "B")]);
 
@@ -540,7 +545,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("foo")
                     .with_unit("By")
                     .with_description("meter gauge foo")
-                    .init();
+                    .build();
 
                 foo_b.add(100, &[KeyValue::new("A", "B")]);
             }),
@@ -554,7 +559,7 @@ fn duplicate_metrics() {
                     .u64_histogram("foo")
                     .with_unit("By")
                     .with_description("meter histogram foo")
-                    .init();
+                    .build();
 
                 foo_a.record(100, &[KeyValue::new("A", "B")]);
 
@@ -562,7 +567,7 @@ fn duplicate_metrics() {
                     .u64_histogram("foo")
                     .with_unit("By")
                     .with_description("meter histogram foo")
-                    .init();
+                    .build();
 
                 foo_b.record(100, &[KeyValue::new("A", "B")]);
             }),
@@ -576,7 +581,7 @@ fn duplicate_metrics() {
                     .u64_counter("bar")
                     .with_unit("By")
                     .with_description("meter a bar")
-                    .init();
+                    .build();
 
                 bar_a.add(100, &[KeyValue::new("type", "bar")]);
 
@@ -584,7 +589,7 @@ fn duplicate_metrics() {
                     .u64_counter("bar")
                     .with_unit("By")
                     .with_description("meter b bar")
-                    .init();
+                    .build();
 
                 bar_b.add(100, &[KeyValue::new("type", "bar")]);
             }),
@@ -601,7 +606,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("bar")
                     .with_unit("By")
                     .with_description("meter a bar")
-                    .init();
+                    .build();
 
                 bar_a.add(100, &[KeyValue::new("type", "bar")]);
 
@@ -609,7 +614,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("bar")
                     .with_unit("By")
                     .with_description("meter b bar")
-                    .init();
+                    .build();
 
                 bar_b.add(100, &[KeyValue::new("type", "bar")]);
             }),
@@ -626,7 +631,7 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("By")
                     .with_description("meter a bar")
-                    .init();
+                    .build();
 
                 bar_a.record(100, &[KeyValue::new("A", "B")]);
 
@@ -634,7 +639,7 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("By")
                     .with_description("meter b bar")
-                    .init();
+                    .build();
 
                 bar_b.record(100, &[KeyValue::new("A", "B")]);
             }),
@@ -651,7 +656,7 @@ fn duplicate_metrics() {
                     .u64_counter("bar")
                     .with_unit("By")
                     .with_description("meter bar")
-                    .init();
+                    .build();
 
                 baz_a.add(100, &[KeyValue::new("type", "bar")]);
 
@@ -659,7 +664,7 @@ fn duplicate_metrics() {
                     .u64_counter("bar")
                     .with_unit("ms")
                     .with_description("meter bar")
-                    .init();
+                    .build();
 
                 baz_b.add(100, &[KeyValue::new("type", "bar")]);
             }),
@@ -674,7 +679,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("bar")
                     .with_unit("By")
                     .with_description("meter gauge bar")
-                    .init();
+                    .build();
 
                 bar_a.add(100, &[KeyValue::new("type", "bar")]);
 
@@ -682,7 +687,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("bar")
                     .with_unit("ms")
                     .with_description("meter gauge bar")
-                    .init();
+                    .build();
 
                 bar_b.add(100, &[KeyValue::new("type", "bar")]);
             }),
@@ -697,7 +702,7 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("By")
                     .with_description("meter histogram bar")
-                    .init();
+                    .build();
 
                 bar_a.record(100, &[KeyValue::new("A", "B")]);
 
@@ -705,7 +710,7 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("ms")
                     .with_description("meter histogram bar")
-                    .init();
+                    .build();
 
                 bar_b.record(100, &[KeyValue::new("A", "B")]);
             }),
@@ -720,7 +725,7 @@ fn duplicate_metrics() {
                     .u64_counter("foo")
                     .with_unit("By")
                     .with_description("meter foo")
-                    .init();
+                    .build();
 
                 counter.add(100, &[KeyValue::new("type", "foo")]);
 
@@ -728,7 +733,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("foo_total")
                     .with_unit("By")
                     .with_description("meter foo")
-                    .init();
+                    .build();
 
                 gauge.add(200, &[KeyValue::new("type", "foo")]);
             }),
@@ -746,7 +751,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("foo")
                     .with_unit("By")
                     .with_description("meter gauge foo")
-                    .init();
+                    .build();
 
                 foo_a.add(100, &[KeyValue::new("A", "B")]);
 
@@ -754,7 +759,7 @@ fn duplicate_metrics() {
                     .u64_histogram("foo")
                     .with_unit("By")
                     .with_description("meter histogram foo")
-                    .init();
+                    .build();
 
                 foo_histogram_a.record(100, &[KeyValue::new("A", "B")]);
             }),
@@ -794,18 +799,20 @@ fn duplicate_metrics() {
             .with_reader(exporter)
             .build();
 
-        let meter_a = provider.versioned_meter(
-            "ma",
-            Some("v0.1.0"),
-            None::<&'static str>,
-            Some(vec![KeyValue::new("k", "v")]),
-        );
-        let meter_b = provider.versioned_meter(
-            "mb",
-            Some("v0.1.0"),
-            None::<&'static str>,
-            Some(vec![KeyValue::new("k", "v")]),
-        );
+        let scope_ma = InstrumentationScope::builder("ma")
+            .with_version("v0.1.0")
+            .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+            .with_attributes(vec![KeyValue::new("k", "v")])
+            .build();
+
+        let scope_mb = InstrumentationScope::builder("mb")
+            .with_version("v0.1.0")
+            .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+            .with_attributes(vec![KeyValue::new("k", "v")])
+            .build();
+
+        let meter_a = provider.meter_with_scope(scope_ma);
+        let meter_b = provider.meter_with_scope(scope_mb);
 
         (tc.record_metrics)(meter_a, meter_b);
 


### PR DESCRIPTION
## Changes

- Update `opentelemetry` dependency version to 0.27
- Update `opentelemetry_sdk` dependency version to 0.27
- Update `opentelemetry-semantic-conventions` dependency version to 0.27

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
