### PR TITLE
AttributeSet cleanup, better perf for overflows

### DIFF
--- a/opentelemetry-sdk/benches/metrics_counter.rs
+++ b/opentelemetry-sdk/benches/metrics_counter.rs
@@ -9,7 +9,7 @@
     |--------------------------------|-------------|
     | Counter_Add_Sorted             | 172 ns      |
     | Counter_Add_Unsorted           | 183 ns      |
-    | Counter_Overflow               | 898 ns      |
+    | Counter_Overflow               | 562 ns      |
     | ThreadLocal_Random_Generator_5 |  37 ns      |
 */
 

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -197,6 +197,9 @@ fn prepare_data<T>(data: &mut Vec<T>, list_len: usize) {
 }
 
 fn sort_and_dedup(attributes: &[KeyValue]) -> Vec<KeyValue> {
+    // Use newly allocated vec here as incoming attributes are immutable so
+    // cannot sort/de-dup in-place. TODO: This allocation can be avoided by
+    // leveraging a ThreadLocal vec.
     let mut sorted = attributes.to_vec();
     sorted.sort_unstable_by(|a, b| a.key.cmp(&b.key));
     sorted.dedup_by(|a, b| a.key == b.key);

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -18,8 +18,6 @@ pub(crate) use exponential_histogram::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
 use once_cell::sync::Lazy;
 use opentelemetry::{otel_warn, KeyValue};
 
-use crate::metrics::AttributeSet;
-
 pub(crate) static STREAM_OVERFLOW_ATTRIBUTES: Lazy<Vec<KeyValue>> =
     Lazy::new(|| vec![KeyValue::new("otel.metric.overflow", "true")]);
 
@@ -95,7 +93,7 @@ where
         }
 
         // Try to retrieve and update the tracker with the attributes sorted.
-        let sorted_attrs = AttributeSet::from(attributes).into_vec();
+        let sorted_attrs = sort_and_dedup(attributes);
         if let Some(tracker) = trackers.get(sorted_attrs.as_slice()) {
             tracker.update(value);
             return;
@@ -196,6 +194,13 @@ fn prepare_data<T>(data: &mut Vec<T>, list_len: usize) {
     if total_len > data.capacity() {
         data.reserve_exact(total_len - data.capacity());
     }
+}
+
+fn sort_and_dedup(attributes: &[KeyValue]) -> Vec<KeyValue> {
+    let mut sorted = attributes.to_vec();
+    sorted.sort_unstable_by(|a, b| a.key.cmp(&b.key));
+    sorted.dedup_by(|a, b| a.key == b.key);
+    sorted
 }
 
 /// Marks a type that can have a value added and retrieved atomically. Required since

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -77,11 +77,7 @@ pub use view::*;
 // #[cfg(not(feature = "spec_unstable_metrics_views"))]
 // pub(crate) use view::*;
 
-use std::collections::hash_map::DefaultHasher;
-use std::collections::HashSet;
-use std::hash::{Hash, Hasher};
-
-use opentelemetry::KeyValue;
+use std::hash::Hash;
 
 /// Defines the window that an aggregation was calculated over.
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
@@ -104,60 +100,6 @@ pub enum Temporality {
     /// Delta aggregation temporality, which allows them to shed memory
     /// following a cardinality explosion, thus use less memory.
     LowMemory,
-}
-
-/// A unique set of attributes that can be used as instrument identifiers.
-///
-/// This must implement [Hash], [PartialEq], and [Eq] so it may be used as
-/// HashMap keys and other de-duplication methods.
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub(crate) struct AttributeSet(Vec<KeyValue>, u64);
-
-impl From<&[KeyValue]> for AttributeSet {
-    fn from(values: &[KeyValue]) -> Self {
-        let mut seen_keys = HashSet::with_capacity(values.len());
-        let vec = values
-            .iter()
-            .rev()
-            .filter_map(|kv| {
-                if seen_keys.insert(kv.key.clone()) {
-                    Some(kv.clone())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-
-        AttributeSet::new(vec)
-    }
-}
-
-fn calculate_hash(values: &[KeyValue]) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    values.iter().fold(&mut hasher, |mut hasher, item| {
-        item.hash(&mut hasher);
-        hasher
-    });
-    hasher.finish()
-}
-
-impl AttributeSet {
-    fn new(mut values: Vec<KeyValue>) -> Self {
-        values.sort_unstable_by(|a, b| a.key.cmp(&b.key));
-        let hash = calculate_hash(&values);
-        AttributeSet(values, hash)
-    }
-
-    /// Returns the underlying Vec of KeyValue pairs
-    pub(crate) fn into_vec(self) -> Vec<KeyValue> {
-        self.0
-    }
-}
-
-impl Hash for AttributeSet {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write_u64(self.1)
-    }
 }
 
 #[cfg(all(test, feature = "testing"))]


### PR DESCRIPTION
With https://github.com/open-telemetry/opentelemetry-rust/pull/2282 merged, the last known usage of AttributeSet is removed. This PR removes it, and makes an improvement to the dedup+sort by doing a single vec! allocation and sorting first, and then de-duping in-place. The overflow benchmark improves 30%, but still allocates the vec. Left a TODO to make this also go away by leveraging a threadlocal vec. 

Why is it important to get the allocation to be zero for the overflow scenario?
Imagine OTel is used by a web application to report metrics, and one of the dimension is obtained from the request. If a malicious user DDoS the application by passing unique values with each request, we certainly don't want OTel Metrics to cause OOM and crash the app. This is already handled as we have CardinalityLimit enforced. But we still allocate a vec and drop it right after - this is something we can avoid. Once we know the limit is hit, then OTel SDK should be operating without any heap allocation, wherever feasible. 

There are other issues in this area - especially about dropping read lock and acquiring write lock - this can be avoided too, as once we know both incoming and sorted order fails *and* cardinality limit is reached - then we can avoid write lock completely. This require some more refactoring, so will be a separate PR.