### PR TITLE
Remove default logger name 

### DIFF
--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -1,7 +1,7 @@
 use super::{BatchLogProcessor, LogProcessor, LogRecord, SimpleLogProcessor, TraceContext};
 use crate::{export::logs::LogExporter, runtime::RuntimeChannel, Resource};
 use crate::{logs::LogError, logs::LogResult};
-use opentelemetry::{otel_debug, trace::TraceContextExt, Context, InstrumentationScope};
+use opentelemetry::{otel_debug, otel_warn, trace::TraceContextExt, Context, InstrumentationScope};
 
 #[cfg(feature = "spec_unstable_logs_enabled")]
 use opentelemetry::logs::Severity;
@@ -44,17 +44,14 @@ pub struct LoggerProvider {
     inner: Arc<LoggerProviderInner>,
 }
 
-/// Default logger name if empty string is provided.
-const DEFAULT_COMPONENT_NAME: &str = "rust.opentelemetry.io/sdk/logger";
-
 impl opentelemetry::logs::LoggerProvider for LoggerProvider {
     type Logger = Logger;
 
     fn logger(&self, name: impl Into<Cow<'static, str>>) -> Self::Logger {
-        let mut name = name.into();
+        let name = name.into();
 
         if name.is_empty() {
-            name = Cow::Borrowed(DEFAULT_COMPONENT_NAME)
+            otel_warn!(name: "LoggerProvider.Logger.EmptyName",  message = "Logger name is empty; consider providing a meaningful name");
         };
 
         let scope = InstrumentationScope::builder(name).build();


### PR DESCRIPTION
## Changes
As per the specs - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#logger-creation

``
In the case where an invalid name (null or empty string) is specified, a working Logger MUST be returned as a fallback rather than returning null or throwing an exception, its name SHOULD keep the original invalid value, and a message reporting that the specified value is invalid SHOULD be logged.
``

So changed the implementation to create the instrumentation scope with empty `name` if provided and log the warning.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
