### PR TITLE
[Logs SDK] Deprecate LogData struct

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -17,6 +17,7 @@
         .with_resource(Resource::empty())
         .build();
     ```
+  - `logs::LogData` struct is deprecated, and scheduled to be removed from public API in `v0.28.0`.
 
 ## 0.27.0
 

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -45,14 +45,14 @@ const OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT: usize = 512;
 pub trait LogProcessor: Send + Sync + Debug {
     /// Called when a log record is ready to processed and exported.
     ///
-    /// This method receives a mutable reference to `LogData`. If the processor
+    /// This method receives a mutable reference to `LogRecord`. If the processor
     /// needs to handle the export asynchronously, it should clone the data to
     /// ensure it can be safely processed without lifetime issues. Any changes
     /// made to the log data in this method will be reflected in the next log
     /// processor in the chain.
     ///
     /// # Parameters
-    /// - `record`: A mutable reference to `LogData` representing the log record.
+    /// - `record`: A mutable reference to `LogRecord` representing the log record.
     /// - `instrumentation`: The instrumentation scope associated with the log record.
     fn emit(&self, data: &mut LogRecord, instrumentation: &InstrumentationScope);
     /// Force the logs lying in the cache to be exported.

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -14,7 +14,7 @@ use opentelemetry::InstrumentationScope;
 pub use record::{LogRecord, TraceContext};
 
 #[deprecated(
-    since = "0.5.0",
+    since = "0.27.1",
     note = "The struct is not used anywhere in the SDK and will be removed in the next major release."
 )]
 /// `LogData` represents a single log event without resource context.

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -13,6 +13,10 @@ pub use log_processor::{
 use opentelemetry::InstrumentationScope;
 pub use record::{LogRecord, TraceContext};
 
+#[deprecated(
+    since = "0.5.0",
+    note = "The struct is not used anywhere in the SDK and will be removed in the next major release."
+)]
 /// `LogData` represents a single log event without resource context.
 #[derive(Clone, Debug)]
 pub struct LogData {

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 /// An in-memory logs exporter that stores logs data in memory..
 ///
 /// This exporter is useful for testing and debugging purposes.
-/// It stores logs in a `Vec<LogData>`. Logs can be retrieved using
+/// It stores logs in a `Vec<OwnedLogData>`. Logs can be retrieved using
 /// `get_emitted_logs` method.
 ///
 /// # Example
@@ -65,9 +65,9 @@ pub struct OwnedLogData {
 pub struct LogDataWithResource {
     /// Log record
     pub record: LogRecord,
-    /// Instrumentation details for the emitter who produced this `LogData`.
+    /// Instrumentation details for the emitter who produced this `LogRecord`.
     pub instrumentation: InstrumentationScope,
-    /// Resource for the emitter who produced this `LogData`.
+    /// Resource for the emitter who produced this `LogRecord`.
     pub resource: Cow<'static, Resource>,
 }
 
@@ -137,7 +137,7 @@ impl InMemoryLogExporterBuilder {
 }
 
 impl InMemoryLogExporter {
-    /// Returns the logs emitted via Logger as a vector of `LogData`.
+    /// Returns the logs emitted via Logger as a vector of `LogDataWithResource`.
     ///
     /// # Example
     ///


### PR DESCRIPTION
## Changes
The struct is not used anywhere, and can be deprecated, and later removed in next major release.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
