### PR TITLE
[CI fix] msrv patch for rustls

### DIFF
--- a/scripts/patch_dependencies.sh
+++ b/scripts/patch_dependencies.sh
@@ -8,3 +8,4 @@ function patch_version() {
 
 patch_version url 2.5.2 #https://github.com/servo/rust-url/issues/992
 patch_version rustls-native-certs 0.8.0 #0.8.1 needs rustc 1.71 or newer
+patch_version rutls 0.23.17 #0.23.18 needs rustc 1.71 or newer

--- a/scripts/patch_dependencies.sh
+++ b/scripts/patch_dependencies.sh
@@ -8,4 +8,4 @@ function patch_version() {
 
 patch_version url 2.5.2 #https://github.com/servo/rust-url/issues/992
 patch_version rustls-native-certs 0.8.0 #0.8.1 needs rustc 1.71 or newer
-patch_version rutls 0.23.17 #0.23.18 needs rustc 1.71 or newer
+patch_version rustls 0.23.17 #0.23.18 needs rustc 1.71 or newer


### PR DESCRIPTION
## Changes
Rustls 0.23.18 requires Rust 1.71.1. Applying an MSRV patch to downgrade to use Rustls 0.23.17.


Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
