### PR TITLE
Emit internal log for global meter provider

### DIFF
--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -31,7 +31,7 @@ tracing = {workspace = true, optional = true} # optional for opentelemetry inter
 js-sys = "0.3.63"
 
 [features]
-default = ["trace", "metrics", "logs"]
+default = ["trace", "metrics", "logs", "internal-logs"]
 trace = ["pin-project-lite", "futures-sink", "futures-core", "thiserror"]
 metrics = []
 testing = ["trace", "metrics"]


### PR DESCRIPTION
Continuing from https://github.com/open-telemetry/opentelemetry-rust/pull/2330.
Also realized the `opentelemetry` crate did not internal-logs ff enabled by default, and fixed it.