### PR TITLE
InternalLog fixes for GlobalMeterProvider

### DIFF
--- a/opentelemetry/src/global/metrics.rs
+++ b/opentelemetry/src/global/metrics.rs
@@ -21,21 +21,24 @@ where
 {
     // Try to set the global meter provider. If the RwLock is poisoned, we'll log an error.
     let mut global_provider = global_meter_provider().write();
-
     if let Ok(ref mut provider) = global_provider {
         **provider = Arc::new(new_provider);
         otel_info!(name: "MeterProvider.GlobalSet", message = "Global meter provider is set. Meters can now be created using global::meter() or global::meter_with_scope().");
     } else {
-        otel_error!(name: "MeterProvider.GlobalSetFailed", message = "Global meter provider is not set due to lock poison. Meters created using global::meter() or global::meter_with_scope() will not function.");
+        otel_error!(name: "MeterProvider.GlobalSetFailed", message = "Setting global meter provider failed. Meters created using global::meter() or global::meter_with_scope() will not function. Report this issue in OpenTelemetry repo.");
     }
 }
 
 /// Returns an instance of the currently configured global [`MeterProvider`].
 pub fn meter_provider() -> GlobalMeterProvider {
-    global_meter_provider()
-        .read()
-        .expect("GLOBAL_METER_PROVIDER RwLock poisoned")
-        .clone()
+    // Try to get the global meter provider. If the RwLock is poisoned, we'll log an error and return a NoopMeterProvider.
+    let global_provider = global_meter_provider().read();
+    if let Ok(provider) = global_provider {
+        provider.clone()
+    } else {
+        otel_error!(name: "MeterProvider.GlobalGetFailed", message = "Getting global meter provider failed. Meters created using global::meter() or global::meter_with_scope() will not function. Report this issue in OpenTelemetry repo.");
+        Arc::new(crate::metrics::noop::NoopMeterProvider::new())
+    }
 }
 
 /// Creates a named [`Meter`] via the currently configured global [`MeterProvider`].


### PR DESCRIPTION
Addresses https://github.com/open-telemetry/opentelemetry-rust/pull/2331#discussion_r1855278739
Adds log when Get fails due to posion.