### PR TITLE
Empty MeterName retained as is instead of using default name

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -18,6 +18,9 @@
         .build();
     ```
   - `logs::LogData` struct is deprecated, and scheduled to be removed from public API in `v0.28.0`.
+  - Bug fix: Empty Meter names are retained as-is instead of replacing with
+    "rust.opentelemetry.io/sdk/meter"
+    [#2334](https://github.com/open-telemetry/opentelemetry-rust/pull/2334)
 
 ## 0.27.0
 

--- a/opentelemetry/src/global/metrics.rs
+++ b/opentelemetry/src/global/metrics.rs
@@ -40,8 +40,6 @@ pub fn meter_provider() -> GlobalMeterProvider {
 
 /// Creates a named [`Meter`] via the currently configured global [`MeterProvider`].
 ///
-/// If the name is an empty string, the provider will use a default name.
-///
 /// This is a more convenient way of expressing `global::meter_provider().meter(name)`.
 pub fn meter(name: &'static str) -> Meter {
     meter_provider().meter(name)

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -19,8 +19,6 @@ pub trait MeterProvider {
     /// name needs to be unique so it does not collide with other names used by
     /// an application, nor other applications.
     ///
-    /// If the name is empty, then an implementation defined default name will
-    /// be used instead.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-rust/pull/2316 for Metrics.