### PR TITLE
Use static dispatch in SimpleLogProcessor

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+- *Breaking* SimpleLogProcessor modified to be generic over `LogExporter` to
+  avoid dynamic dispatch to invoke exporter. If you were using
+  `with_simple_exporter` to add `LogExporter` with SimpleLogProcessor, this is a
+  transparent change.
+  [#2338](https://github.com/open-telemetry/opentelemetry-rust/pull/2338)
+
 ## 0.27.1
 
 Released 2024-Nov-27

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -173,7 +173,7 @@ impl Builder {
     /// The `LogExporter` that this provider should use.
     pub fn with_simple_exporter<T: LogExporter + 'static>(self, exporter: T) -> Self {
         let mut processors = self.processors;
-        processors.push(Box::new(SimpleLogProcessor::new(Box::new(exporter))));
+        processors.push(Box::new(SimpleLogProcessor::new(exporter)));
 
         Builder { processors, ..self }
     }

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -77,13 +77,13 @@ pub trait LogProcessor: Send + Sync + Debug {
 /// debugging and testing. For scenarios requiring higher
 /// performance/throughput, consider using [BatchLogProcessor].
 #[derive(Debug)]
-pub struct SimpleLogProcessor {
-    exporter: Mutex<Box<dyn LogExporter>>,
+pub struct SimpleLogProcessor<T: LogExporter> {
+    exporter: Mutex<T>,
     is_shutdown: AtomicBool,
 }
 
-impl SimpleLogProcessor {
-    pub(crate) fn new(exporter: Box<dyn LogExporter>) -> Self {
+impl<T: LogExporter> SimpleLogProcessor<T> {
+    pub(crate) fn new(exporter: T) -> Self {
         SimpleLogProcessor {
             exporter: Mutex::new(exporter),
             is_shutdown: AtomicBool::new(false),
@@ -91,7 +91,7 @@ impl SimpleLogProcessor {
     }
 }
 
-impl LogProcessor for SimpleLogProcessor {
+impl<T: LogExporter> LogProcessor for SimpleLogProcessor<T> {
     fn emit(&self, record: &mut LogRecord, instrumentation: &InstrumentationScope) {
         // noop after shutdown
         if self.is_shutdown.load(std::sync::atomic::Ordering::Relaxed) {
@@ -739,7 +739,7 @@ mod tests {
         let exporter = MockLogExporter {
             resource: Arc::new(Mutex::new(None)),
         };
-        let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
+        let processor = SimpleLogProcessor::new(exporter.clone());
         let _ = LoggerProvider::builder()
             .with_log_processor(processor)
             .with_resource(Resource::new(vec![
@@ -807,7 +807,7 @@ mod tests {
         let exporter = InMemoryLogExporterBuilder::default()
             .keep_records_on_shutdown()
             .build();
-        let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
+        let processor = SimpleLogProcessor::new(exporter.clone());
 
         let mut record: LogRecord = Default::default();
         let instrumentation: InstrumentationScope = Default::default();
@@ -988,7 +988,7 @@ mod tests {
     #[test]
     fn test_simple_processor_sync_exporter_without_runtime() {
         let exporter = InMemoryLogExporterBuilder::default().build();
-        let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
+        let processor = SimpleLogProcessor::new(exporter.clone());
 
         let mut record: LogRecord = Default::default();
         let instrumentation: InstrumentationScope = Default::default();
@@ -1001,7 +1001,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_simple_processor_sync_exporter_with_runtime() {
         let exporter = InMemoryLogExporterBuilder::default().build();
-        let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
+        let processor = SimpleLogProcessor::new(exporter.clone());
 
         let mut record: LogRecord = Default::default();
         let instrumentation: InstrumentationScope = Default::default();
@@ -1014,7 +1014,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_simple_processor_sync_exporter_with_multi_thread_runtime() {
         let exporter = InMemoryLogExporterBuilder::default().build();
-        let processor = Arc::new(SimpleLogProcessor::new(Box::new(exporter.clone())));
+        let processor = Arc::new(SimpleLogProcessor::new(exporter.clone()));
 
         let mut handles = vec![];
         for _ in 0..10 {
@@ -1037,7 +1037,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn test_simple_processor_sync_exporter_with_current_thread_runtime() {
         let exporter = InMemoryLogExporterBuilder::default().build();
-        let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
+        let processor = SimpleLogProcessor::new(exporter.clone());
 
         let mut record: LogRecord = Default::default();
         let instrumentation: InstrumentationScope = Default::default();
@@ -1084,7 +1084,7 @@ mod tests {
         // Use `catch_unwind` to catch the panic caused by missing Tokio runtime
         let result = std::panic::catch_unwind(|| {
             let exporter = LogExporterThatRequiresTokio::new();
-            let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
+            let processor = SimpleLogProcessor::new(exporter.clone());
 
             let mut record: LogRecord = Default::default();
             let instrumentation: InstrumentationScope = Default::default();
@@ -1133,7 +1133,7 @@ mod tests {
     // tasks nor the exporter can proceed.
     async fn test_simple_processor_async_exporter_with_all_runtime_worker_threads_blocked() {
         let exporter = LogExporterThatRequiresTokio::new();
-        let processor = Arc::new(SimpleLogProcessor::new(Box::new(exporter.clone())));
+        let processor = Arc::new(SimpleLogProcessor::new(exporter.clone()));
 
         let concurrent_emit = 4; // number of worker threads
 
@@ -1164,7 +1164,7 @@ mod tests {
     // tasks occupy the runtime.
     async fn test_simple_processor_async_exporter_with_runtime() {
         let exporter = LogExporterThatRequiresTokio::new();
-        let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
+        let processor = SimpleLogProcessor::new(exporter.clone());
 
         let mut record: LogRecord = Default::default();
         let instrumentation: InstrumentationScope = Default::default();
@@ -1183,7 +1183,7 @@ mod tests {
     async fn test_simple_processor_async_exporter_with_multi_thread_runtime() {
         let exporter = LogExporterThatRequiresTokio::new();
 
-        let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
+        let processor = SimpleLogProcessor::new(exporter.clone());
 
         let mut record: LogRecord = Default::default();
         let instrumentation: InstrumentationScope = Default::default();
@@ -1203,7 +1203,8 @@ mod tests {
     async fn test_simple_processor_async_exporter_with_current_thread_runtime() {
         let exporter = LogExporterThatRequiresTokio::new();
 
-        let processor = SimpleLogProcessor::new(Box::new(exporter.clone()));
+        let processor = SimpleLogProcessor::new(exporter.clone());
+        
 
         let mut record: LogRecord = Default::default();
         let instrumentation: InstrumentationScope = Default::default();

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -1229,7 +1229,6 @@ mod tests {
         let exporter = LogExporterThatRequiresTokio::new();
 
         let processor = SimpleLogProcessor::new(exporter.clone());
-        
 
         let mut record: LogRecord = Default::default();
         let instrumentation: InstrumentationScope = Default::default();

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -49,7 +49,7 @@ mod tests {
         let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = LoggerProvider::builder()
             .with_resource(resource.clone())
-            .with_log_processor(SimpleLogProcessor::new(Box::new(exporter.clone())))
+            .with_log_processor(SimpleLogProcessor::new(exporter.clone()))
             .build();
 
         // Act


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-rust/issues/1942
Given this is a breaking change, we should not merge until 0.27.1 is out.

Thanks @lalitb for helping with this. I will see if I can continue this to achieve the rest of ideas mentioned in 1942 and avoid dyn dispatch completely in Log hot path (not for Batch scenario+any custom)