### PR TITLE
Replace once_cell::Lazy with std::sync::OnceLock for global Initialization in otel-sdk crate

### DIFF
--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -17,7 +17,6 @@ async-trait = { workspace = true, optional = true }
 futures-channel = "0.3"
 futures-executor = { workspace = true }
 futures-util = { workspace = true, features = ["std", "sink", "async-await-macro"] }
-once_cell = { workspace = true }
 percent-encoding = { version = "2.0", optional = true }
 rand = { workspace = true, features = ["std", "std_rng","small_rng"], optional = true }
 glob = { version = "0.3.1", optional =true}

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -15,10 +15,10 @@ use std::{
     },
 };
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 // a no nop logger provider used as placeholder when the provider is shutdown
-static NOOP_LOGGER_PROVIDER: Lazy<LoggerProvider> = Lazy::new(|| LoggerProvider {
+static NOOP_LOGGER_PROVIDER: LazyLock<LoggerProvider> = LazyLock::new(|| LoggerProvider {
     inner: Arc::new(LoggerProviderInner {
         processors: Vec::new(),
         resource: Resource::empty(),

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -1,7 +1,7 @@
 use std::{f64::consts::LOG2_E, mem::replace, ops::DerefMut, sync::Mutex, time::SystemTime};
 
-use once_cell::sync::Lazy;
 use opentelemetry::{otel_debug, KeyValue};
+use std::sync::LazyLock;
 
 use crate::metrics::{
     data::{self, Aggregation},
@@ -166,7 +166,7 @@ fn scale_change(max_size: i32, bin: i32, start_bin: i32, length: i32) -> u32 {
 }
 
 /// Constants used in calculating the logarithm index.
-static SCALE_FACTORS: Lazy<[f64; 21]> = Lazy::new(|| {
+static SCALE_FACTORS: LazyLock<[f64; 21]> = LazyLock::new(|| {
     [
         LOG2_E * 2f64.powi(0),
         LOG2_E * 2f64.powi(1),

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -1,7 +1,7 @@
 use std::{f64::consts::LOG2_E, mem::replace, ops::DerefMut, sync::Mutex, time::SystemTime};
 
 use opentelemetry::{otel_debug, KeyValue};
-use std::sync::LazyLock;
+use std::sync::OnceLock;
 
 use crate::metrics::{
     data::{self, Aggregation},
@@ -131,7 +131,7 @@ impl<T: Number> ExpoHistogramDataPoint<T> {
             }
             return (exp - correction) >> -self.scale;
         }
-        (exp << self.scale) + (frac.ln() * SCALE_FACTORS[self.scale as usize]) as i32 - 1
+        (exp << self.scale) + (frac.ln() * scale_factors()[self.scale as usize]) as i32 - 1
     }
 }
 
@@ -165,32 +165,38 @@ fn scale_change(max_size: i32, bin: i32, start_bin: i32, length: i32) -> u32 {
     count
 }
 
-/// Constants used in calculating the logarithm index.
-static SCALE_FACTORS: LazyLock<[f64; 21]> = LazyLock::new(|| {
-    [
-        LOG2_E * 2f64.powi(0),
-        LOG2_E * 2f64.powi(1),
-        LOG2_E * 2f64.powi(2),
-        LOG2_E * 2f64.powi(3),
-        LOG2_E * 2f64.powi(4),
-        LOG2_E * 2f64.powi(5),
-        LOG2_E * 2f64.powi(6),
-        LOG2_E * 2f64.powi(7),
-        LOG2_E * 2f64.powi(8),
-        LOG2_E * 2f64.powi(9),
-        LOG2_E * 2f64.powi(10),
-        LOG2_E * 2f64.powi(11),
-        LOG2_E * 2f64.powi(12),
-        LOG2_E * 2f64.powi(13),
-        LOG2_E * 2f64.powi(14),
-        LOG2_E * 2f64.powi(15),
-        LOG2_E * 2f64.powi(16),
-        LOG2_E * 2f64.powi(17),
-        LOG2_E * 2f64.powi(18),
-        LOG2_E * 2f64.powi(19),
-        LOG2_E * 2f64.powi(20),
-    ]
-});
+// TODO - replace it with LazyLock once it is stable
+static SCALE_FACTORS: OnceLock<[f64; 21]> = OnceLock::new();
+
+/// returns constants used in calculating the logarithm index.
+#[inline]
+fn scale_factors() -> &'static [f64; 21] {
+    SCALE_FACTORS.get_or_init(|| {
+        [
+            LOG2_E * 2f64.powi(0),
+            LOG2_E * 2f64.powi(1),
+            LOG2_E * 2f64.powi(2),
+            LOG2_E * 2f64.powi(3),
+            LOG2_E * 2f64.powi(4),
+            LOG2_E * 2f64.powi(5),
+            LOG2_E * 2f64.powi(6),
+            LOG2_E * 2f64.powi(7),
+            LOG2_E * 2f64.powi(8),
+            LOG2_E * 2f64.powi(9),
+            LOG2_E * 2f64.powi(10),
+            LOG2_E * 2f64.powi(11),
+            LOG2_E * 2f64.powi(12),
+            LOG2_E * 2f64.powi(13),
+            LOG2_E * 2f64.powi(14),
+            LOG2_E * 2f64.powi(15),
+            LOG2_E * 2f64.powi(16),
+            LOG2_E * 2f64.powi(17),
+            LOG2_E * 2f64.powi(18),
+            LOG2_E * 2f64.powi(19),
+            LOG2_E * 2f64.powi(20),
+        ]
+    })
+}
 
 /// Breaks the number into a normalized fraction and a base-2 exponent.
 ///

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -15,11 +15,11 @@ use std::sync::{Arc, RwLock};
 use aggregate::is_under_cardinality_limit;
 pub(crate) use aggregate::{AggregateBuilder, ComputeAggregation, Measure};
 pub(crate) use exponential_histogram::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
-use once_cell::sync::Lazy;
 use opentelemetry::{otel_warn, KeyValue};
+use std::sync::LazyLock;
 
-pub(crate) static STREAM_OVERFLOW_ATTRIBUTES: Lazy<Vec<KeyValue>> =
-    Lazy::new(|| vec![KeyValue::new("otel.metric.overflow", "true")]);
+pub(crate) static STREAM_OVERFLOW_ATTRIBUTES: LazyLock<Vec<KeyValue>> =
+    LazyLock::new(|| vec![KeyValue::new("otel.metric.overflow", "true")]);
 
 pub(crate) trait Aggregator {
     /// A static configuration that is needed in order to initialize aggregator.

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use exponential_histogram::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
 use opentelemetry::{otel_warn, KeyValue};
 use std::sync::OnceLock;
 
+// TODO Replace it with LazyLock once it is stable
 pub(crate) static STREAM_OVERFLOW_ATTRIBUTES: OnceLock<Vec<KeyValue>> = OnceLock::new();
 
 #[inline]

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -16,7 +16,6 @@ use aggregate::{is_under_cardinality_limit, STREAM_CARDINALITY_LIMIT};
 pub(crate) use aggregate::{AggregateBuilder, ComputeAggregation, Measure};
 pub(crate) use exponential_histogram::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
 use opentelemetry::{otel_warn, KeyValue};
-use std::sync::OnceLock;
 
 // TODO Replace it with LazyLock once it is stable
 pub(crate) static STREAM_OVERFLOW_ATTRIBUTES: OnceLock<Vec<KeyValue>> = OnceLock::new();

--- a/opentelemetry-sdk/src/propagation/baggage.rs
+++ b/opentelemetry-sdk/src/propagation/baggage.rs
@@ -1,4 +1,3 @@
-use once_cell::sync::Lazy;
 use opentelemetry::{
     baggage::{BaggageExt, KeyValueMetadata},
     otel_warn,
@@ -7,10 +6,11 @@ use opentelemetry::{
 };
 use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
 use std::iter;
+use std::sync::LazyLock;
 
 static BAGGAGE_HEADER: &str = "baggage";
 const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b';').add(b',').add(b'=');
-static BAGGAGE_FIELDS: Lazy<[String; 1]> = Lazy::new(|| [BAGGAGE_HEADER.to_owned()]);
+static BAGGAGE_FIELDS: LazyLock<[String; 1]> = LazyLock::new(|| [BAGGAGE_HEADER.to_owned()]);
 
 /// Propagates name-value pairs in [W3C Baggage] format.
 ///

--- a/opentelemetry-sdk/src/propagation/trace_context.rs
+++ b/opentelemetry-sdk/src/propagation/trace_context.rs
@@ -1,21 +1,21 @@
 //! # W3C Trace Context Propagator
 //!
 
-use once_cell::sync::Lazy;
 use opentelemetry::{
     propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
     trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState},
     Context,
 };
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 const SUPPORTED_VERSION: u8 = 0;
 const MAX_VERSION: u8 = 254;
 const TRACEPARENT_HEADER: &str = "traceparent";
 const TRACESTATE_HEADER: &str = "tracestate";
 
-static TRACE_CONTEXT_HEADER_FIELDS: Lazy<[String; 2]> =
-    Lazy::new(|| [TRACEPARENT_HEADER.to_owned(), TRACESTATE_HEADER.to_owned()]);
+static TRACE_CONTEXT_HEADER_FIELDS: LazyLock<[String; 2]> =
+    LazyLock::new(|| [TRACEPARENT_HEADER.to_owned(), TRACESTATE_HEADER.to_owned()]);
 
 /// Propagates `SpanContext`s in [W3C TraceContext] format under `traceparent` and `tracestate` header.
 ///

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -73,27 +73,34 @@ use opentelemetry::InstrumentationScope;
 use opentelemetry::{otel_debug, trace::TraceResult};
 use std::borrow::Cow;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::sync::{LazyLock, OnceLock};
+use std::sync::{Arc, OnceLock};
 
 use super::IdGenerator;
 
+// TODO Replace with LazyLock once it is stable
 static PROVIDER_RESOURCE: OnceLock<Resource> = OnceLock::new();
 
 // a no nop tracer provider used as placeholder when the provider is shutdown
-static NOOP_TRACER_PROVIDER: LazyLock<TracerProvider> = LazyLock::new(|| TracerProvider {
-    inner: Arc::new(TracerProviderInner {
-        processors: Vec::new(),
-        config: Config {
-            // cannot use default here as the default resource is not empty
-            sampler: Box::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn))),
-            id_generator: Box::<RandomIdGenerator>::default(),
-            span_limits: SpanLimits::default(),
-            resource: Cow::Owned(Resource::empty()),
-        },
-        is_shutdown: AtomicBool::new(true),
-    }),
-});
+// TODO Replace with LazyLock once it is stable
+static NOOP_TRACER_PROVIDER: OnceLock<TracerProvider> = OnceLock::new();
+#[inline]
+fn noop_tracer_provider() -> &'static TracerProvider {
+    NOOP_TRACER_PROVIDER.get_or_init(|| {
+        TracerProvider {
+            inner: Arc::new(TracerProviderInner {
+                processors: Vec::new(),
+                config: Config {
+                    // cannot use default here as the default resource is not empty
+                    sampler: Box::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn))),
+                    id_generator: Box::<RandomIdGenerator>::default(),
+                    span_limits: SpanLimits::default(),
+                    resource: Cow::Owned(Resource::empty()),
+                },
+                is_shutdown: AtomicBool::new(true),
+            }),
+        }
+    })
+}
 
 /// TracerProvider inner type
 #[derive(Debug)]
@@ -269,7 +276,7 @@ impl opentelemetry::trace::TracerProvider for TracerProvider {
 
     fn tracer_with_scope(&self, scope: InstrumentationScope) -> Self::Tracer {
         if self.inner.is_shutdown.load(Ordering::Relaxed) {
-            return Tracer::new(scope, NOOP_TRACER_PROVIDER.clone());
+            return Tracer::new(scope, noop_tracer_provider().clone());
         }
         Tracer::new(scope, self.clone())
     }

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -398,8 +398,13 @@ impl Builder {
         // For the uncommon case where there are multiple tracer providers with different resource
         // configurations, users can optionally provide their own borrowed static resource.
         if matches!(config.resource, Cow::Owned(_)) {
-            let owned_resource = config.resource.clone().into_owned();
-            config.resource = Cow::Borrowed(PROVIDER_RESOURCE.get_or_init(|| owned_resource));
+            config.resource =
+                match PROVIDER_RESOURCE.get_or_init(|| config.resource.clone().into_owned()) {
+                    static_resource if *static_resource == *config.resource.as_ref() => {
+                        Cow::Borrowed(static_resource)
+                    }
+                    _ => config.resource, // Use the new resource if different
+                };
         }
 
         // Create a new vector to hold the modified processors

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -77,7 +77,6 @@ use std::sync::{Arc, OnceLock};
 
 use super::IdGenerator;
 
-// TODO Replace with LazyLock once it is stable
 static PROVIDER_RESOURCE: OnceLock<Resource> = OnceLock::new();
 
 // a no nop tracer provider used as placeholder when the provider is shutdown


### PR DESCRIPTION
## Changes

changes similar to #2326 for otel-sdk.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
