### PR TITLE
Preallocate and keep memory for HashMap in Metric aggregation

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -12,7 +12,7 @@ use super::{
     precomputed_sum::PrecomputedSum, sum::Sum, Number,
 };
 
-pub(crate) const STREAM_CARDINALITY_LIMIT: u32 = 2000;
+pub(crate) const STREAM_CARDINALITY_LIMIT: usize = 2000;
 
 /// Checks whether aggregator has hit cardinality limit for metric streams
 pub(crate) fn is_under_cardinality_limit(size: usize) -> bool {

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -16,7 +16,7 @@ pub(crate) const STREAM_CARDINALITY_LIMIT: usize = 2000;
 
 /// Checks whether aggregator has hit cardinality limit for metric streams
 pub(crate) fn is_under_cardinality_limit(size: usize) -> bool {
-    size < STREAM_CARDINALITY_LIMIT as usize
+    size < STREAM_CARDINALITY_LIMIT
 }
 
 /// Receives measurements to be aggregated.

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -12,7 +12,7 @@ use super::{
     precomputed_sum::PrecomputedSum, sum::Sum, Number,
 };
 
-const STREAM_CARDINALITY_LIMIT: u32 = 2000;
+pub(crate) const STREAM_CARDINALITY_LIMIT: u32 = 2000;
 
 /// Checks whether aggregator has hit cardinality limit for metric streams
 pub(crate) fn is_under_cardinality_limit(size: usize) -> bool {

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -75,6 +75,8 @@ where
             trackers: RwLock::new(HashMap::with_capacity(
                 1 + STREAM_CARDINALITY_LIMIT as usize,
             )),
+            // TODO: For cumulative, this is not required, so avoid this
+            // pre-allocation.
             trackers_for_collect: RwLock::new(HashMap::with_capacity(
                 1 + STREAM_CARDINALITY_LIMIT as usize,
             )),

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -72,8 +72,12 @@ where
 {
     fn new(config: A::InitConfig) -> Self {
         ValueMap {
-            trackers: RwLock::new(HashMap::with_capacity(STREAM_CARDINALITY_LIMIT as usize)),
-            trackers_for_collect: RwLock::new(HashMap::with_capacity(STREAM_CARDINALITY_LIMIT as usize)),
+            trackers: RwLock::new(HashMap::with_capacity(
+                1 + STREAM_CARDINALITY_LIMIT as usize,
+            )),
+            trackers_for_collect: RwLock::new(HashMap::with_capacity(
+                1 + STREAM_CARDINALITY_LIMIT as usize,
+            )),
             has_no_attribute_value: AtomicBool::new(false),
             no_attribute_tracker: A::create(&config),
             count: AtomicUsize::new(0),

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -50,7 +50,7 @@ rand = { version = "0.8.4", features = ["small_rng"] }
 tracing = { workspace = true, features = ["std"]}
 tracing-subscriber = { workspace = true, features = ["registry", "std"] }
 num-format = "0.4.4"
-sysinfo = { version = "0.32.00", optional = true }
+sysinfo = { version = "0.32.0", optional = true }
 
 [features]
 stats = ["sysinfo"]

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -50,7 +50,7 @@ rand = { version = "0.8.4", features = ["small_rng"] }
 tracing = { workspace = true, features = ["std"]}
 tracing-subscriber = { workspace = true, features = ["registry", "std"] }
 num-format = "0.4.4"
-sysinfo = { version = "0.32.0", optional = true }
+sysinfo = { version = "0.30.12", optional = true }
 
 [features]
 stats = ["sysinfo"]

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -50,7 +50,7 @@ rand = { version = "0.8.4", features = ["small_rng"] }
 tracing = { workspace = true, features = ["std"]}
 tracing-subscriber = { workspace = true, features = ["registry", "std"] }
 num-format = "0.4.4"
-sysinfo = { version = "0.30.12", optional = true }
+sysinfo = { version = "0.32.00", optional = true }
 
 [features]
 stats = ["sysinfo"]


### PR DESCRIPTION
Discussed originally in https://github.com/open-telemetry/opentelemetry-rust/pull/2267#discussion_r1828595967
and in https://github.com/open-telemetry/opentelemetry-rust/pull/2288#discussion_r1834460750

2 changes
1. HashMap for aggregations are created with enough capacity to hold cardinality. (Its currently hardcoded, but will be configurable later)
2. Delta - during collect, the hashmap is swapped with a secondary hashmap., and the original is drained.

These ensures HashMap never requires re-sizing in its lifetime.

Incremental changes only, as this is not quite the final state - we'll need to likely store the overflow outside of hashmap and also tackle https://github.com/open-telemetry/opentelemetry-rust/issues/2328