### PR TITLE
Remove non-default feature from doc test

### DIFF
--- a/opentelemetry-semantic-conventions/scripts/templates/registry/rust/metric.rs.j2
+++ b/opentelemetry-semantic-conventions/scripts/templates/registry/rust/metric.rs.j2
@@ -26,7 +26,7 @@
 //!     .u64_histogram(semconv::metric::HTTP_SERVER_REQUEST_DURATION)
 //!     .with_unit("By")
 //!     .with_description("Duration of HTTP server requests.")
-//!     .init();
+//!     .build();
 //! ```
 
 {% for root_ns in ctx %}

--- a/opentelemetry-semantic-conventions/scripts/templates/registry/rust/resource.rs.j2
+++ b/opentelemetry-semantic-conventions/scripts/templates/registry/rust/resource.rs.j2
@@ -22,7 +22,6 @@
 //! let _tracer = TracerProvider::builder()
 //!     .with_config(config().with_resource(Resource::new(vec![
 //!         KeyValue::new(semconv::resource::SERVICE_NAME, "my-service"),
-//!         KeyValue::new(semconv::resource::SERVICE_NAMESPACE, "my-namespace"),
 //!     ])))
 //!     .build();
 //! ```

--- a/opentelemetry-semantic-conventions/src/resource.rs
+++ b/opentelemetry-semantic-conventions/src/resource.rs
@@ -21,7 +21,6 @@
 //! let _tracer = TracerProvider::builder()
 //!     .with_config(config().with_resource(Resource::new(vec![
 //!         KeyValue::new(semconv::resource::SERVICE_NAME, "my-service"),
-//!         KeyValue::new(semconv::resource::SERVICE_NAMESPACE, "my-namespace"),
 //!     ])))
 //!     .build();
 //! ```


### PR DESCRIPTION
## Changes

Running `cargo test --all` locally fails in the doc tests with:

```
---- opentelemetry-semantic-conventions/src/resource.rs - resource (line 16) stdout ----
error[E0425]: cannot find value `SERVICE_NAMESPACE` in module `semconv::resource`
    --> opentelemetry-semantic-conventions/src/resource.rs:25:42
     |
12   |         KeyValue::new(semconv::resource::SERVICE_NAMESPACE, "my-namespace"),
     |                                          ^^^^^^^^^^^^^^^^^ help: a constant with a similar name exists: `SERVICE_NAME`
     |
```

This removes the `SERVICE_NAMESPACE` resource from the doc test, since it is now behind the non default feature `semconv_experimental`, making the doc test fail. It also updates the `metrics` template to use the `build()` method instead of the renamed `init()`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
