### PR TITLE
Deprecate logger::provider() and logger::instrumentation_scope()

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -29,8 +29,7 @@
   - `Logger::provider`: This method is deprecated as of version `0.27.1`. To be removed in `0.28.0`.
   - `Logger::instrumentation_scope`: This method is deprecated as of version `0.27.1`. To be removed in `0.28.0`
      Migration Guidance: 
-        - These methods are intended for log appenders. Keep the clone of the provider handle, instead of depending 
-        on above methods.
+        - These methods are intended for log appenders. Keep the clone of the provider handle, instead of depending on above methods.
 
 
 ## 0.27.0

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -25,6 +25,13 @@
   - Bug fix: Empty Logger names are retained as-is instead of replacing with
     "rust.opentelemetry.io/sdk/logger"
     [#2316](https://github.com/open-telemetry/opentelemetry-rust/pull/2316)
+  
+  - `Logger::provider`: This method is deprecated as of version `0.27.1`. To be removed in `0.28.0`.
+  - `Logger::instrumentation_scope`: This method is deprecated as of version `0.27.1`. To be removed in `0.28.0`
+     Migration Guidance: 
+        - These methods are intended for log appenders. Keep the clone of the provider handle, instead of depending 
+        on above methods.
+
 
 ## 0.27.0
 

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -240,7 +240,7 @@ impl Logger {
 
     #[deprecated(
         since = "0.27.1",
-        note = "This method is intended for appender developers, but has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
+        note = "This method was intended for appender developers, but has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
     )]
     /// LoggerProvider associated with this logger.
     pub fn provider(&self) -> &LoggerProvider {

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -240,7 +240,7 @@ impl Logger {
 
     #[deprecated(
         since = "0.27.1",
-        note = "This method is intended for appender developers and has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
+        note = "This method is intended for appender developers, but has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
     )]
     /// LoggerProvider associated with this logger.
     pub fn provider(&self) -> &LoggerProvider {
@@ -249,7 +249,7 @@ impl Logger {
 
     #[deprecated(
         since = "0.27.1",
-        note = "This method is intended for appender developers and has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
+        note = "This method is intended for appender developers, but has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
     )]
     /// Instrumentation scope of this logger.
     pub fn instrumentation_scope(&self) -> &InstrumentationScope {

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -238,11 +238,19 @@ impl Logger {
         Logger { scope, provider }
     }
 
+    #[deprecated(
+        since = "0.27.1",
+        note = "This method is intended for appender developers and has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
+    )]
     /// LoggerProvider associated with this logger.
     pub fn provider(&self) -> &LoggerProvider {
         &self.provider
     }
 
+    #[deprecated(
+        since = "0.27.1",
+        note = "This method is intended for appender developers and has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
+    )]
     /// Instrumentation scope of this logger.
     pub fn instrumentation_scope(&self) -> &InstrumentationScope {
         &self.scope

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -249,7 +249,7 @@ impl Logger {
 
     #[deprecated(
         since = "0.27.1",
-        note = "This method is intended for appender developers, but has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
+        note = "This method was intended for appender developers, but has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
     )]
     /// Instrumentation scope of this logger.
     pub fn instrumentation_scope(&self) -> &InstrumentationScope {

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -108,6 +108,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn logger_attributes() {
         let provider = LoggerProvider::builder().build();
         let scope = InstrumentationScope::builder("test_logger")


### PR DESCRIPTION
## Changes

Deprecating these methods. The methods were meant to be used by appenders, and they can always keep hold to the `provider` handle to get this data. We can anyway have additive changes even after stable release, so safe to remove it for now. Thanks for noticing them @utpilla :)

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
