### PR TITLE
Add few internal logs for Metrics sdks

### DIFF
--- a/examples/self-diagnostics/src/main.rs
+++ b/examples/self-diagnostics/src/main.rs
@@ -1,6 +1,7 @@
 use opentelemetry::global;
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::metrics::PeriodicReader;
+use opentelemetry_sdk::Resource;
 use std::error::Error;
 use tracing::info;
 use tracing_subscriber::fmt;
@@ -13,9 +14,10 @@ fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
     let reader = PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::Tokio).build();
 
     let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
-        .with_resource(opentelemetry_sdk::resource::Resource::new(vec![
-            KeyValue::new("service.name", "self-diagnostics"),
-        ]))
+        .with_resource(Resource::new([KeyValue::new(
+            "service.name",
+            "self-diagnostics-example",
+        )]))
         .with_reader(reader)
         .build();
 

--- a/examples/self-diagnostics/src/main.rs
+++ b/examples/self-diagnostics/src/main.rs
@@ -13,6 +13,9 @@ fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
     let reader = PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::Tokio).build();
 
     let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+        .with_resource(opentelemetry_sdk::resource::Resource::new(vec![
+            KeyValue::new("service.name", "self-diagnostics"),
+        ]))
         .with_reader(reader)
         .build();
 
@@ -26,7 +29,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // OpenTelemetry uses `tracing` crate for its internal logging. Unless a
     // tracing subscriber is set, the logs will be discarded. In this example,
     // we configure a `tracing` subscriber to:
-    // 1. Print logs of level INFO or higher to stdout using tracing's fmt layer.
+    // 1. Print logs of level DEBUG or higher to stdout using tracing's fmt layer.
     // 2. Filter logs from OpenTelemetry's dependencies (like tonic, hyper,
     // reqwest etc. which are commonly used by the OTLP exporter) to only print
     // ERROR-level logs. This filtering helps reduce repetitive log messages
@@ -39,7 +42,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Hence, one may use "add_directive("opentelemetry=off".parse().unwrap())"
     // to turn off all logs from OpenTelemetry.
 
-    let filter = EnvFilter::new("info")
+    let filter = EnvFilter::new("debug")
         .add_directive("hyper=error".parse().unwrap())
         .add_directive("tonic=error".parse().unwrap())
         .add_directive("h2=error".parse().unwrap())
@@ -54,10 +57,13 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     info!("Starting self-diagnostics example");
 
     let meter = global::meter("example");
-    // Create a counter using an invalid name to trigger
-    // internal log about the same.
-    let counter = meter.u64_counter("my_counter with_space").build();
+    let counter = meter.u64_counter("my_counter").build();
     counter.add(10, &[KeyValue::new("key", "value")]);
+
+    let _observable_counter = meter
+        .u64_observable_counter("my_observable_counter")
+        .with_callback(|observer| observer.observe(10, &[KeyValue::new("key", "value")]))
+        .build();
 
     meter_provider.shutdown()?;
     info!("Shutdown complete. Bye!");

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -132,6 +132,7 @@ where
             name: "PeriodicReader.BuildCompleted",
             message = "Periodic reader built.",
             interval_in_secs = self.interval.as_secs(),
+            temporality = format!("{:?}", self.exporter.temporality()),
         );
 
         PeriodicReader {

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -72,6 +72,10 @@ impl Pipeline {
     /// unique values.
     fn add_sync(&self, scope: InstrumentationScope, i_sync: InstrumentSync) {
         let _ = self.inner.lock().map(|mut inner| {
+            otel_debug!(
+                name : "InstrumentCreated",
+                instrument_name = i_sync.name.as_ref(),
+            );
             inner.aggregations.entry(scope).or_default().push(i_sync);
         });
     }
@@ -99,6 +103,10 @@ impl SdkProducer for Pipeline {
     /// Returns aggregated metrics from a single collection.
     fn produce(&self, rm: &mut ResourceMetrics) -> MetricResult<()> {
         let inner = self.inner.lock()?;
+        otel_debug!(
+            name: "MeterProviderInvokingObservableCallbacks",
+            count =  inner.callbacks.len(),
+        );
         for cb in &inner.callbacks {
             // TODO consider parallel callbacks.
             cb();


### PR DESCRIPTION
Modified self-diag example to not do anything invalid to trigger logs, as we have sufficient logs otherwise to demonstrate!
Also few logs inside Metric sdk.