### PR TITLE
Track dropped spans and logs due to full buffer

### DIFF
--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -207,7 +207,7 @@ impl<R: RuntimeChannel> LogProcessor for BatchLogProcessor<R> {
                 name: "BatchLogProcessor.LogsDropped",
                 dropped_logs_count = dropped_logs,
                 max_queue_size = max_queue_size,
-                message = "Logs were dropped due to a queue being full or other error. The count represents the total count of lost dropped in the lifetime of this BatchLogProcessor. Consider increasing the queue size and/or decrease delay between intervals."
+                message = "Logs were dropped due to a queue being full or other error. The count represents the total count of log records dropped in the lifetime of this BatchLogProcessor. Consider increasing the queue size and/or decrease delay between intervals."
             );
         }
 

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -155,7 +155,7 @@ impl LogProcessor for SimpleLogProcessor {
 pub struct BatchLogProcessor<R: RuntimeChannel> {
     message_sender: R::Sender<BatchMessage>,
 
-    // Track dropped logs. We'll log this at shutdown and also emit
+    // Track dropped logs - we'll log this at shutdown
     dropped_logs_count: AtomicUsize,
 
     // Track the maximum queue size that was configured for this processor

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -286,7 +286,7 @@ impl<R: RuntimeChannel> SpanProcessor for BatchSpanProcessor<R> {
                 name: "BatchSpanProcessor.Shutdown",
                 dropped_spans = dropped_spans,
                 max_queue_size = max_queue_size,
-                message = "Spans were dropped due to a full or closed queue. The count represents the total count of lost logs in the lifetime of the BatchLogProcessor. Consider increasing the queue size and/or decrease delay between intervals."
+                message = "Spans were dropped due to a full or closed queue. The count represents the total count of span records dropped in the lifetime of the BatchLogProcessor. Consider increasing the queue size and/or decrease delay between intervals."
             );
         }
 

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -262,7 +262,7 @@ impl<R: RuntimeChannel> SpanProcessor for BatchSpanProcessor<R> {
             // emit a warning.
             if self.dropped_spans_count.fetch_add(1, Ordering::Relaxed) == 0 {
                 otel_warn!(name: "BatchSpanProcessor.SpanDroppingStarted",
-                    message = "Beginning to drop span messages due to full exporter queue.");
+                    message = "Beginning to drop span messages due to full/internal errors. No further log will be emitted for further drops until Shutdown. During Shutdown time, a log will be emitted with exact count of total spans dropped.");
             }
         }
     }


### PR DESCRIPTION
Fixes #2273

Design discussion issue (if applicable) #

## Changes

As suggested in #2273, this change adds a counter and a metric for dropped spans and logs; the counter is used to log total drop count at exporter shutdown, the metric is used to export this information.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
