### PR TITLE
Minor Internal logs

### DIFF
--- a/examples/self-diagnostics/Cargo.toml
+++ b/examples/self-diagnostics/Cargo.toml
@@ -12,4 +12,4 @@ opentelemetry-stdout = { path = "../../opentelemetry-stdout"}
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true, features = ["std"]}
 tracing-core = { workspace = true }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter","registry", "std"]}
+tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"]}

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -59,11 +59,19 @@ impl opentelemetry::logs::LoggerProvider for LoggerProvider {
     fn logger_with_scope(&self, scope: InstrumentationScope) -> Self::Logger {
         // If the provider is shutdown, new logger will refer a no-op logger provider.
         if self.inner.is_shutdown.load(Ordering::Relaxed) {
+            otel_debug!(
+                name: "LoggerProvider.NoOpLoggerReturned",
+                logger_name = scope.name(),
+            );
             return Logger::new(scope, noop_logger_provider().clone());
         }
         if scope.name().is_empty() {
             otel_info!(name: "LoggerNameEmpty",  message = "Logger name is empty; consider providing a meaningful name. Logger will function normally and the provided name will be used as-is.");
         };
+        otel_debug!(
+            name: "LoggerProvider.NewLoggerReturned",
+            logger_name = scope.name(),
+        );
         Logger::new(scope, self.clone())
     }
 }
@@ -92,6 +100,9 @@ impl LoggerProvider {
 
     /// Shuts down this `LoggerProvider`
     pub fn shutdown(&self) -> LogResult<()> {
+        otel_debug!(
+            name: "LoggerProvider.ShutdownInvokedByUser",
+        );
         if self
             .inner
             .is_shutdown
@@ -224,6 +235,10 @@ impl Builder {
         for processor in logger_provider.log_processors() {
             processor.set_resource(logger_provider.resource());
         }
+
+        otel_debug!(
+            name: "LoggerProvider.Built",
+        );
         logger_provider
     }
 }


### PR DESCRIPTION
Its hard to see internal logs during initialization phase, as the fmt layer is not yet set. I set a separate one wrapping initialization code, just to see if the internal logs added in this PR are working!

```
let fmt_subscriber = fmt::Subscriber::builder()
    .with_env_filter(EnvFilter::new("debug"))
    .finish();
    let (logger_provider, layer) = tracing::subscriber::with_default(fmt_subscriber, || {
        let logger_provider = init_logs().unwrap();
        let layer = OpenTelemetryTracingBridge::new(&logger_provider);
        (logger_provider, layer)
    });
	
	// rest of code
```

```txt
2024-11-27T18:58:01.309390Z DEBUG opentelemetry_sdk:  name="LoggerProvider.Built"
2024-11-27T18:58:01.309445Z DEBUG opentelemetry_sdk:  name="LoggerProvider.NewLoggerReturned" logger_name="opentelemetry-appender-tracing"
```