### PR TITLE
Bump version of sdk release 0.27.1

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.27.1
+
+Released 2024-Nov-27
+
 - **DEPRECATED**:
   - `trace::Config` methods are moving onto `TracerProvider` Builder to be consistent with other signals. See https://github.com/open-telemetry/opentelemetry-rust/pull/2303 for migration guide.
     `trace::Config` is scheduled to be removed from public API in `v0.28.0`.

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry_sdk"
-version = "0.27.0"
+version = "0.27.1"
 description = "The SDK for the OpenTelemetry metrics collection and distributed tracing framework"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.27.1
+
+Released 2024-Nov-27
+
 ## 0.27.0
 
 Released 2024-Nov-11

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry"
-version = "0.27.0"
+version = "0.27.1"
 description = "OpenTelemetry API for Rust"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"


### PR DESCRIPTION
I think only SDK crates need to be released to avoid doing empty-releases for other crates.
This has a lot of internal logs improvements.