### PR TITLE
Time is not optional in DataPoints

### DIFF
--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -295,8 +295,8 @@ pub mod tonic {
                     .iter()
                     .map(|dp| TonicNumberDataPoint {
                         attributes: dp.attributes.iter().map(Into::into).collect(),
-                        start_time_unix_nano: dp.start_time.map(to_nanos).unwrap_or_default(),
-                        time_unix_nano: dp.time.map(to_nanos).unwrap_or_default(),
+                        start_time_unix_nano: to_nanos(dp.start_time),
+                        time_unix_nano: to_nanos(dp.time),
                         exemplars: dp.exemplars.iter().map(Into::into).collect(),
                         flags: TonicDataPointFlags::default() as u32,
                         value: Some(dp.value.into()),
@@ -319,8 +319,8 @@ pub mod tonic {
                     .iter()
                     .map(|dp| TonicNumberDataPoint {
                         attributes: dp.attributes.iter().map(Into::into).collect(),
-                        start_time_unix_nano: dp.start_time.map(to_nanos).unwrap_or_default(),
-                        time_unix_nano: dp.time.map(to_nanos).unwrap_or_default(),
+                        start_time_unix_nano: to_nanos(dp.start_time),
+                        time_unix_nano: to_nanos(dp.time),
                         exemplars: dp.exemplars.iter().map(Into::into).collect(),
                         flags: TonicDataPointFlags::default() as u32,
                         value: Some(dp.value.into()),

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -97,9 +97,9 @@ pub struct DataPoint<T> {
     /// time series.
     pub attributes: Vec<KeyValue>,
     /// The time when the time series was started.
-    pub start_time: Option<SystemTime>,
+    pub start_time: SystemTime,
     /// The time when the time series was recorded.
-    pub time: Option<SystemTime>,
+    pub time: SystemTime,
     /// The value of this data point.
     pub value: T,
     /// The sampled [Exemplar]s collected during the time series.
@@ -338,8 +338,8 @@ mod tests {
     fn validate_cloning_data_points() {
         let data_type = DataPoint {
             attributes: vec![KeyValue::new("key", "value")],
-            start_time: Some(std::time::SystemTime::now()),
-            time: Some(std::time::SystemTime::now()),
+            start_time: std::time::SystemTime::now(),
+            time: std::time::SystemTime::now(),
             value: 0u32,
             exemplars: vec![Exemplar {
                 filtered_attributes: vec![],

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -224,8 +224,8 @@ mod tests {
         let mut a = Gauge {
             data_points: vec![DataPoint {
                 attributes: vec![KeyValue::new("a", 1)],
-                start_time: Some(SystemTime::now()),
-                time: Some(SystemTime::now()),
+                start_time: SystemTime::now(),
+                time: SystemTime::now(),
                 value: 1u64,
                 exemplars: vec![],
             }],
@@ -251,15 +251,15 @@ mod tests {
                 data_points: vec![
                     DataPoint {
                         attributes: vec![KeyValue::new("a1", 1)],
-                        start_time: Some(SystemTime::now()),
-                        time: Some(SystemTime::now()),
+                        start_time: SystemTime::now(),
+                        time: SystemTime::now(),
                         value: 1u64,
                         exemplars: vec![],
                     },
                     DataPoint {
                         attributes: vec![KeyValue::new("a2", 1)],
-                        start_time: Some(SystemTime::now()),
-                        time: Some(SystemTime::now()),
+                        start_time: SystemTime::now(),
+                        time: SystemTime::now(),
                         value: 2u64,
                         exemplars: vec![],
                     },
@@ -294,15 +294,15 @@ mod tests {
                 data_points: vec![
                     DataPoint {
                         attributes: vec![KeyValue::new("a1", 1)],
-                        start_time: Some(SystemTime::now()),
-                        time: Some(SystemTime::now()),
+                        start_time: SystemTime::now(),
+                        time: SystemTime::now(),
                         value: 1u64,
                         exemplars: vec![],
                     },
                     DataPoint {
                         attributes: vec![KeyValue::new("a2", 1)],
-                        start_time: Some(SystemTime::now()),
-                        time: Some(SystemTime::now()),
+                        start_time: SystemTime::now(),
+                        time: SystemTime::now(),
                         value: 2u64,
                         exemplars: vec![],
                     },

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -66,8 +66,8 @@ impl<T: Number> LastValue<T> {
         self.value_map
             .collect_and_reset(dest, |attributes, aggr| DataPoint {
                 attributes,
-                start_time: Some(prev_start),
-                time: Some(t),
+                start_time: prev_start,
+                time: t,
                 value: aggr.value.get_value(),
                 exemplars: vec![],
             });
@@ -79,8 +79,8 @@ impl<T: Number> LastValue<T> {
         self.value_map
             .collect_readonly(dest, |attributes, aggr| DataPoint {
                 attributes,
-                start_time: Some(prev_start),
-                time: Some(t),
+                start_time: prev_start,
+                time: t,
                 value: aggr.value.get_value(),
                 exemplars: vec![],
             });

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -68,8 +68,8 @@ impl<T: Number> PrecomputedSum<T> {
                 let delta = value - *reported.get(&attributes).unwrap_or(&T::default());
                 DataPoint {
                     attributes,
-                    start_time: Some(prev_start),
-                    time: Some(t),
+                    start_time: prev_start,
+                    time: t,
                     value: delta,
                     exemplars: vec![],
                 }
@@ -109,8 +109,8 @@ impl<T: Number> PrecomputedSum<T> {
         self.value_map
             .collect_readonly(&mut s_data.data_points, |attributes, aggr| DataPoint {
                 attributes,
-                start_time: Some(prev_start),
-                time: Some(t),
+                start_time: prev_start,
+                time: t,
                 value: aggr.value.get_value(),
                 exemplars: vec![],
             });

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -95,8 +95,8 @@ impl<T: Number> Sum<T> {
         self.value_map
             .collect_and_reset(&mut s_data.data_points, |attributes, aggr| DataPoint {
                 attributes,
-                start_time: Some(prev_start),
-                time: Some(t),
+                start_time: prev_start,
+                time: t,
                 value: aggr.value.get_value(),
                 exemplars: vec![],
             });
@@ -132,8 +132,8 @@ impl<T: Number> Sum<T> {
         self.value_map
             .collect_readonly(&mut s_data.data_points, |attributes, aggr| DataPoint {
                 attributes,
-                start_time: Some(prev_start),
-                time: Some(t),
+                start_time: prev_start,
+                time: t,
                 value: aggr.value.get_value(),
                 exemplars: vec![],
             });

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -163,20 +163,16 @@ fn print_histogram<T: Debug>(histogram: &data::Histogram<T>) {
 fn print_data_points<T: Debug>(data_points: &[data::DataPoint<T>]) {
     for (i, data_point) in data_points.iter().enumerate() {
         println!("\t\tDataPoint #{}", i);
-        if let Some(start_time) = data_point.start_time {
-            let datetime: DateTime<Utc> = start_time.into();
-            println!(
-                "\t\t\tStartTime    : {}",
-                datetime.format("%Y-%m-%d %H:%M:%S%.6f")
-            );
-        }
-        if let Some(end_time) = data_point.time {
-            let datetime: DateTime<Utc> = end_time.into();
-            println!(
-                "\t\t\tEndTime      : {}",
-                datetime.format("%Y-%m-%d %H:%M:%S%.6f")
-            );
-        }
+        let datetime: DateTime<Utc> = data_point.start_time.into();
+        println!(
+            "\t\t\tStartTime    : {}",
+            datetime.format("%Y-%m-%d %H:%M:%S%.6f")
+        );
+        let datetime: DateTime<Utc> = data_point.time.into();
+        println!(
+            "\t\t\tEndTime      : {}",
+            datetime.format("%Y-%m-%d %H:%M:%S%.6f")
+        );
         println!("\t\t\tValue        : {:#?}", data_point.value);
         println!("\t\t\tAttributes   :");
         for kv in data_point.attributes.iter() {


### PR DESCRIPTION
## Changes

Make `start_time` and `time` non optional in `DataPoint<T>` (used for `Sum` and `Gauge`).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
