### PR TITLE
chore: remove the global::shutdown_tracer_provider function

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ fn main() {
     });
 
     // Shutdown trace pipeline
-    global::shutdown_tracer_provider();
+    provider.shutdown().expect("TracerProvider should shutdown successfully")
 }
 ```
 

--- a/examples/tracing-jaeger/src/main.rs
+++ b/examples/tracing-jaeger/src/main.rs
@@ -1,4 +1,3 @@
-use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::{
     global,
     trace::{TraceContextExt, TraceError, Tracer},
@@ -43,6 +42,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         });
     });
 
-    shutdown_tracer_provider();
+    tracer_provider.shutdown()?;
+
     Ok(())
 }

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -156,7 +156,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     info!(target: "my-target", "hello from {}. My price is {}", "apple", 1.99);
 
-    global::shutdown_tracer_provider();
+    tracer_provider.shutdown()?;
     logger_provider.shutdown()?;
     meter_provider.shutdown()?;
 

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -139,8 +139,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     });
 
     info!(name: "my-event", target: "my-target", "hello from {}. My price is {}", "apple", 1.99);
-
-    global::shutdown_tracer_provider();
+    tracer_provider.shutdown()?;
     meter_provider.shutdown()?;
     logger_provider.shutdown()?;
 

--- a/opentelemetry-otlp/tests/integration_test/tests/traces.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/traces.rs
@@ -2,7 +2,6 @@
 
 use integration_test_runner::trace_asserter::{read_spans_from_json, TraceAsserter};
 use opentelemetry::global;
-use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::trace::TraceError;
 use opentelemetry::{
     trace::{TraceContextExt, Tracer},
@@ -65,7 +64,7 @@ pub async fn traces() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         });
     });
 
-    shutdown_tracer_provider();
+    tracer_provider.shutdown()?;
 
     Ok(())
 }

--- a/opentelemetry-otlp/tests/smoke.rs
+++ b/opentelemetry-otlp/tests/smoke.rs
@@ -1,6 +1,5 @@
 use futures_util::StreamExt;
 use opentelemetry::global;
-use opentelemetry::global::shutdown_tracer_provider;
 use opentelemetry::trace::{Span, SpanKind, Tracer};
 use opentelemetry_otlp::{WithExportConfig, WithTonicConfig};
 use opentelemetry_proto::tonic::collector::trace::v1::{
@@ -105,7 +104,7 @@ async fn smoke_tracer() {
             )
             .build();
 
-        global::set_tracer_provider(tracer_provider);
+        global::set_tracer_provider(tracer_provider.clone());
 
         let tracer = global::tracer("smoke");
 
@@ -117,7 +116,9 @@ async fn smoke_tracer() {
         span.add_event("my-test-event", vec![]);
         span.end();
 
-        shutdown_tracer_provider();
+        tracer_provider
+            .shutdown()
+            .expect("tracer_provider should shutdown successfully");
     }
 
     println!("Waiting for request...");

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -9,6 +9,7 @@
     transparent change.
     [#2338](https://github.com/open-telemetry/opentelemetry-rust/pull/2338)
   - `ResourceDetector.detect()` no longer supports timeout option.
+  - `opentelemetry::global::shutdown_tracer_provider()` Removed from the API, should now use `tracer_provider.shutdown()` see [#2369](https://github.com/open-telemetry/opentelemetry-rust/pull/2369) for a migration example. "Tracer provider" is cheaply cloneable, so users are encouraged to set a clone of it as the global (ex: `global::set_tracer_provider(provider.clone()))`, so that instrumentations and other components can obtain tracers from `global::tracer()`. The tracer_provider must be kept around to call shutdown on it at the end of application (ex: `tracer_provider.shutdown()`)
 
 ## 0.27.1
 

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -30,7 +30,7 @@
 //!     });
 //!
 //!     // Shutdown trace pipeline
-//!     global::shutdown_tracer_provider();
+//!     provider.shutdown().expect("TracerProvider should shutdown successfully")
 //!     # }
 //! }
 //! # }

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -219,10 +219,8 @@ impl TracerProvider {
     ///
     ///     // create more spans..
     ///
-    ///     // dropping provider and shutting down global provider ensure all
-    ///     // remaining spans are exported
+    ///     // dropping provider ensures all remaining spans are exported
     ///     drop(provider);
-    ///     global::shutdown_tracer_provider();
     /// }
     /// ```
     pub fn force_flush(&self) -> Vec<TraceResult<()>> {

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         // Traced app logic here...
     });
 
-    global::shutdown_tracer_provider();
+    provider.shutdown().expect("TracerProvider should shutdown successfully");
 
     Ok(())
 }

--- a/opentelemetry-zipkin/examples/zipkin.rs
+++ b/opentelemetry-zipkin/examples/zipkin.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{
-    global::{self, shutdown_tracer_provider},
+    global::{self},
     trace::{Span, Tracer},
 };
 use std::thread;
@@ -13,7 +13,7 @@ fn bar() {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-    let tracer = opentelemetry_zipkin::new_pipeline()
+    let (tracer, provider) = opentelemetry_zipkin::new_pipeline()
         .with_service_name("trace-demo")
         .install_simple()?;
 
@@ -23,6 +23,6 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         thread::sleep(Duration::from_millis(6));
     });
 
-    shutdown_tracer_provider();
+    provider.shutdown()?;
     Ok(())
 }

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -140,7 +140,9 @@ impl ZipkinPipelineBuilder {
 
     /// Install the Zipkin trace exporter pipeline with a simple span processor.
     #[allow(deprecated)]
-    pub fn install_simple(mut self) -> Result<Tracer, TraceError> {
+    pub fn install_simple(
+        mut self,
+    ) -> Result<(Tracer, opentelemetry_sdk::trace::TracerProvider), TraceError> {
         let (config, endpoint) = self.init_config_and_endpoint();
         let exporter = self.init_exporter_with_endpoint(endpoint)?;
         let mut provider_builder = TracerProvider::builder().with_simple_exporter(exporter);
@@ -151,14 +153,17 @@ impl ZipkinPipelineBuilder {
             .with_schema_url(semcov::SCHEMA_URL)
             .build();
         let tracer = opentelemetry::trace::TracerProvider::tracer_with_scope(&provider, scope);
-        let _ = global::set_tracer_provider(provider);
-        Ok(tracer)
+        let _ = global::set_tracer_provider(provider.clone());
+        Ok((tracer, provider))
     }
 
     /// Install the Zipkin trace exporter pipeline with a batch span processor using the specified
     /// runtime.
     #[allow(deprecated)]
-    pub fn install_batch<R: RuntimeChannel>(mut self, runtime: R) -> Result<Tracer, TraceError> {
+    pub fn install_batch<R: RuntimeChannel>(
+        mut self,
+        runtime: R,
+    ) -> Result<(Tracer, opentelemetry_sdk::trace::TracerProvider), TraceError> {
         let (config, endpoint) = self.init_config_and_endpoint();
         let exporter = self.init_exporter_with_endpoint(endpoint)?;
         let mut provider_builder = TracerProvider::builder().with_batch_exporter(exporter, runtime);
@@ -169,8 +174,8 @@ impl ZipkinPipelineBuilder {
             .with_schema_url(semcov::SCHEMA_URL)
             .build();
         let tracer = opentelemetry::trace::TracerProvider::tracer_with_scope(&provider, scope);
-        let _ = global::set_tracer_provider(provider);
-        Ok(tracer)
+        let _ = global::set_tracer_provider(provider.clone());
+        Ok((tracer, provider))
     }
 
     /// Assign the service name under which to group traces.

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -26,13 +26,13 @@
 //!
 //! fn main() -> Result<(), TraceError> {
 //!     global::set_text_map_propagator(opentelemetry_zipkin::Propagator::new());
-//!     let tracer = opentelemetry_zipkin::new_pipeline().install_simple()?;
+//!     let (tracer, provider) = opentelemetry_zipkin::new_pipeline().install_simple()?;
 //!
 //!     tracer.in_span("doing_work", |cx| {
 //!         // Traced app logic here...
 //!     });
 //!
-//!     global::shutdown_tracer_provider(); // sending remaining spans
+//!     provider.shutdown().expect("TracerProvider should shutdown successfully"); // sending remaining spans
 //!
 //!     Ok(())
 //! }
@@ -131,7 +131,7 @@
 //!
 //! fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 //!     global::set_text_map_propagator(opentelemetry_zipkin::Propagator::new());
-//!     let tracer = opentelemetry_zipkin::new_pipeline()
+//!     let (tracer, provider) = opentelemetry_zipkin::new_pipeline()
 //!         .with_http_client(
 //!             HyperClient(
 //!                 Client::builder(TokioExecutor::new())
@@ -156,7 +156,7 @@
 //!         // Traced app logic here...
 //!     });
 //!
-//!     global::shutdown_tracer_provider(); // sending remaining spans
+//!     provider.shutdown()?; // sending remaining spans
 //!
 //!     Ok(())
 //! }

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -437,16 +437,3 @@ where
         GlobalTracerProvider::new(new_provider),
     )
 }
-
-/// Shut down the current tracer provider. This will invoke the shutdown method on all span processors.
-/// span processors should export remaining spans before return
-pub fn shutdown_tracer_provider() {
-    let mut tracer_provider = global_tracer_provider()
-        .write()
-        .expect("GLOBAL_TRACER_PROVIDER RwLock poisoned");
-
-    let _ = mem::replace(
-        &mut *tracer_provider,
-        GlobalTracerProvider::new(NoopTracerProvider::new()),
-    );
-}


### PR DESCRIPTION
related to: https://github.com/open-telemetry/opentelemetry-rust/issues/1961

## Changes
Removing the `opentelemetry::global::shutdown_tracer_provider()`. This should no longer be in the API, making tracing consistent with logs and metrics.

## Migration Guide
the `opentelemetry::global::shutdown_tracer_provider()` is no longer available, to shutdown the `TracerProvider` properly you will need to have access to the provider and call the `shutdown()` function.

example:
```diff
    let provider = init_tracer();
-   opentelemetry::global::shutdown_tracer_provider();
+   provider.shutdown()?;
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
