### PR TITLE
Fix CI lint error from new stable toolchain v1.83

### DIFF
--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -69,7 +69,7 @@ impl<'a, LR: LogRecord> EventVisitor<'a, LR> {
     }
 }
 
-impl<'a, LR: LogRecord> tracing::field::Visit for EventVisitor<'a, LR> {
+impl<LR: LogRecord> tracing::field::Visit for EventVisitor<'_, LR> {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         #[cfg(feature = "experimental_metadata_attributes")]
         if is_duplicated_metadata(field.name()) {

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -13,7 +13,7 @@ use opentelemetry::propagation::{Extractor, Injector};
 /// for example usage.
 pub struct HeaderInjector<'a>(pub &'a mut http::HeaderMap);
 
-impl<'a> Injector for HeaderInjector<'a> {
+impl Injector for HeaderInjector<'_> {
     /// Set a key and value in the HeaderMap.  Does nothing if the key or value are not valid inputs.
     fn set(&mut self, key: &str, value: String) {
         if let Ok(name) = http::header::HeaderName::from_bytes(key.as_bytes()) {
@@ -30,7 +30,7 @@ impl<'a> Injector for HeaderInjector<'a> {
 /// for example usage.
 pub struct HeaderExtractor<'a>(pub &'a http::HeaderMap);
 
-impl<'a> Extractor for HeaderExtractor<'a> {
+impl Extractor for HeaderExtractor<'_> {
     /// Get a value for a key from the HeaderMap.  If the value is not valid ASCII, returns None.
     fn get(&self, key: &str) -> Option<&str> {
         self.0.get(key).and_then(|value| value.to_str().ok())

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -39,7 +39,6 @@ impl<'a> LogBatch<'a> {
     ///
     /// Note - this is not a public function, and should not be used directly. This would be
     /// made private in the future.
-
     pub fn new(data: &'a [(&'a LogRecord, &'a InstrumentationScope)]) -> LogBatch<'a> {
         LogBatch { data }
     }

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -256,7 +256,6 @@ impl MeterProviderBuilder {
     }
 
     /// Construct a new [MeterProvider] with this configuration.
-
     pub fn build(self) -> SdkMeterProvider {
         otel_debug!(
             name: "MeterProvider.Building",

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -29,7 +29,6 @@ use std::sync::{Arc, Mutex};
 ///        .build();
 ///    // Setup Log Appenders and emit logs. (Not shown here)
 ///    logger_provider.force_flush();
-
 ///    let emitted_logs = exporter.get_emitted_logs().unwrap();
 ///    for log in emitted_logs {
 ///        println!("{:?}", log);

--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/remote.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/remote.rs
@@ -1,5 +1,4 @@
 /// Generate types based on proto
-
 /// ProbabilisticSamplingStrategy samples traces with a fixed probability.
 #[derive(serde::Serialize, serde::Deserialize, PartialOrd, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/opentelemetry-sdk/src/trace/span_limit.rs
+++ b/opentelemetry-sdk/src/trace/span_limit.rs
@@ -12,7 +12,6 @@
 ///
 /// If the limit has been breached. The attributes, events or links will be dropped based on their
 /// index in the collection. The one added to collections later will be dropped first.
-
 pub(crate) const DEFAULT_MAX_EVENT_PER_SPAN: u32 = 128;
 pub(crate) const DEFAULT_MAX_ATTRIBUTES_PER_SPAN: u32 = 128;
 pub(crate) const DEFAULT_MAX_LINKS_PER_SPAN: u32 = 128;

--- a/opentelemetry-semantic-conventions/scripts/templates/registry/rust/metric.rs.j2
+++ b/opentelemetry-semantic-conventions/scripts/templates/registry/rust/metric.rs.j2
@@ -57,7 +57,7 @@
                 {% set req_level = "Unspecified" %}
                 {% set req_message = '' %}
             {% endif %}
-/// | [`crate::attribute::{{ attribute.name | screaming_snake_case }}`] | `{{ req_level }}`{{ (': ' + req_message if req_message else '') }}
+/// | [`crate::attribute::{{ attribute.name | screaming_snake_case }}`] | `{{ req_level }}`{{ (': ' + req_message.replace('\n', ' ') if req_message else '') }}
         {% endfor %}
         {% if metric.examples %}
 ///

--- a/opentelemetry-semantic-conventions/src/lib.rs
+++ b/opentelemetry-semantic-conventions/src/lib.rs
@@ -14,6 +14,8 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]
+//TODO - remove once there are no empty lines after doc comments in the templates.
+#![allow(clippy::empty_line_after_doc_comments)]
 
 pub mod attribute;
 pub mod metric;

--- a/opentelemetry-semantic-conventions/src/metric.rs
+++ b/opentelemetry-semantic-conventions/src/metric.rs
@@ -626,10 +626,8 @@ pub const DB_CLIENT_CONNECTIONS_WAIT_TIME: &str = "db.client.connections.wait_ti
 /// | Name | Requirement |
 /// |:-|:- |
 /// | [`crate::attribute::DB_COLLECTION_NAME`] | `Conditionally_required`: If readily available. The collection name MAY be parsed from the query text, in which case it SHOULD be the first collection name in the query.
-
 /// | [`crate::attribute::DB_NAMESPACE`] | `Conditionally_required`: If available.
 /// | [`crate::attribute::DB_OPERATION_NAME`] | `Conditionally_required`: If readily available. The operation name MAY be parsed from the query text, in which case it SHOULD be the first operation name found in the query.
-
 /// | [`crate::attribute::DB_RESPONSE_STATUS_CODE`] | `Conditionally_required`: If the operation failed and status code is available.
 /// | [`crate::attribute::DB_SYSTEM`] | `Required`
 /// | [`crate::attribute::ERROR_TYPE`] | `Conditionally_required`: If and only if the operation failed.

--- a/opentelemetry/src/global/internal_logging.rs
+++ b/opentelemetry/src/global/internal_logging.rs
@@ -4,7 +4,6 @@
 /// **internally within OpenTelemetry code** or for **custom exporters and processors**. They are not designed
 /// for general application logging and should not be used for that purpose.
 ///
-
 /// Macro for logging informational messages in OpenTelemetry.
 ///
 /// # Fields:
@@ -17,10 +16,8 @@
 /// otel_info!(name: "sdk_start", version = "1.0.0", schema_url = "http://example.com");
 /// ```
 ///
-
 // TODO: Remove `name` attribute duplication in logging macros below once `tracing::Fmt` supports displaying `name`.
 // See issue: https://github.com/tokio-rs/tracing/issues/2774
-
 #[macro_export]
 macro_rules! otel_info {
     (name: $name:expr $(,)?) => {

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -6,7 +6,6 @@ use crate::{logs::LogRecord, InstrumentationScope};
 use super::Severity;
 
 /// The interface for emitting [`LogRecord`]s.
-
 pub trait Logger {
     /// Specifies the `LogRecord` type associated with this logger.
     type LogRecord: LogRecord;

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -113,7 +113,7 @@ impl<'a, T> HistogramBuilder<'a, T> {
     }
 }
 
-impl<'a> HistogramBuilder<'a, Histogram<f64>> {
+impl HistogramBuilder<'_, Histogram<f64>> {
     /// Creates a new instrument.
     ///
     /// Validates the instrument configuration and creates a new instrument. In
@@ -124,7 +124,7 @@ impl<'a> HistogramBuilder<'a, Histogram<f64>> {
     }
 }
 
-impl<'a> HistogramBuilder<'a, Histogram<u64>> {
+impl HistogramBuilder<'_, Histogram<u64>> {
     /// Creates a new instrument.
     ///
     /// Validates the instrument configuration and creates a new instrument. In


### PR DESCRIPTION
## Changes

Errors - https://github.com/open-telemetry/opentelemetry-rust/actions/runs/12108882297/job/33757381774?pr=2369

It seems we should have a lint check for beta toolchain, else CI may fail for new stable release as this time.

Summary of changes required for rust toolchain v1.83 (released on 29th Nov)

 - Remove explicit lifetime annotation if not required, to fix errors like:
 ```rust
error: the following explicit lifetimes could be elided: 'a
   --> opentelemetry/src/metrics/instruments/mod.rs:116:6
    |
116 | impl<'a> HistogramBuilder<'a, Histogram<f64>> {
```

- empty lines after doc-comments, to fix errors like:
```rust
error: empty lines after doc comment
  --> opentelemetry/src/global/internal_logging.rs:6:1
   |
6  | / ///
7  | |
8  | | /// Macro for logging informational messages in OpenTelemetry.
9  | | ///
```
Also this requires fixing the sem-conv jina file, to remove empty line during doc-generation.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
