### PR TITLE
Directly implement Measure trait for metric aggregates

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -13,7 +13,10 @@ use crate::metrics::{
     Temporality,
 };
 
-use super::{aggregate::AggregateTimeInitiator, Aggregator, ComputeAggregation, Number, ValueMap};
+use super::{
+    aggregate::{AggregateTimeInitiator, AttributeSetFilter},
+    Aggregator, ComputeAggregation, Measure, Number, ValueMap,
+};
 
 pub(crate) const EXPO_MAX_SCALE: i8 = 20;
 pub(crate) const EXPO_MIN_SCALE: i8 = -10;
@@ -357,6 +360,7 @@ pub(crate) struct ExpoHistogram<T: Number> {
     value_map: ValueMap<Mutex<ExpoHistogramDataPoint<T>>>,
     init_time: AggregateTimeInitiator,
     temporality: Temporality,
+    filter: AttributeSetFilter,
     record_sum: bool,
     record_min_max: bool,
 }
@@ -365,6 +369,7 @@ impl<T: Number> ExpoHistogram<T> {
     /// Create a new exponential histogram.
     pub(crate) fn new(
         temporality: Temporality,
+        filter: AttributeSetFilter,
         max_size: u32,
         max_scale: i8,
         record_min_max: bool,
@@ -377,20 +382,10 @@ impl<T: Number> ExpoHistogram<T> {
             }),
             init_time: AggregateTimeInitiator::default(),
             temporality,
+            filter,
             record_sum,
             record_min_max,
         }
-    }
-
-    pub(crate) fn measure(&self, value: T, attrs: &[KeyValue]) {
-        let f_value = value.into_float();
-        // Ignore NaN and infinity.
-        // Only makes sense if T is f64, maybe this could be no-op for other cases?
-        if !f_value.is_finite() {
-            return;
-        }
-
-        self.value_map.measure(value, attrs);
     }
 
     fn delta(&self, dest: Option<&mut dyn Aggregation>) -> (usize, Option<Box<dyn Aggregation>>) {
@@ -502,6 +497,24 @@ impl<T: Number> ExpoHistogram<T> {
             });
 
         (h.data_points.len(), new_agg.map(|a| Box::new(a) as Box<_>))
+    }
+}
+
+impl<T> Measure<T> for Arc<ExpoHistogram<T>>
+where
+    T: Number,
+{
+    fn call(&self, measurement: T, attrs: &[KeyValue]) {
+        let f_value = measurement.into_float();
+        // Ignore NaN and infinity.
+        // Only makes sense if T is f64, maybe this could be no-op for other cases?
+        if !f_value.is_finite() {
+            return;
+        }
+
+        self.filter.apply(attrs, |filtered| {
+            self.value_map.measure(measurement, filtered);
+        })
     }
 }
 
@@ -682,9 +695,16 @@ mod tests {
         ];
 
         for test in test_cases {
-            let h = ExpoHistogram::new(Temporality::Cumulative, 4, 20, true, true);
+            let h = Arc::new(ExpoHistogram::new(
+                Temporality::Cumulative,
+                AttributeSetFilter::new(None),
+                4,
+                20,
+                true,
+                true,
+            ));
             for v in test.values {
-                h.measure(v, &[]);
+                Measure::call(&h, v, &[]);
             }
             let dp = h.value_map.no_attribute_tracker.lock().unwrap();
 
@@ -731,9 +751,16 @@ mod tests {
         ];
 
         for test in test_cases {
-            let h = ExpoHistogram::new(Temporality::Cumulative, 4, 20, true, true);
+            let h = Arc::new(ExpoHistogram::new(
+                Temporality::Cumulative,
+                AttributeSetFilter::new(None),
+                4,
+                20,
+                true,
+                true,
+            ));
             for v in test.values {
-                h.measure(v, &[]);
+                Measure::call(&h, v, &[]);
             }
             let dp = h.value_map.no_attribute_tracker.lock().unwrap();
 

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -9,7 +9,9 @@ use crate::metrics::Temporality;
 use opentelemetry::KeyValue;
 
 use super::aggregate::AggregateTimeInitiator;
+use super::aggregate::AttributeSetFilter;
 use super::ComputeAggregation;
+use super::Measure;
 use super::ValueMap;
 use super::{Aggregator, Number};
 
@@ -72,6 +74,7 @@ pub(crate) struct Histogram<T: Number> {
     value_map: ValueMap<Mutex<Buckets<T>>>,
     init_time: AggregateTimeInitiator,
     temporality: Temporality,
+    filter: AttributeSetFilter,
     bounds: Vec<f64>,
     record_min_max: bool,
     record_sum: bool,
@@ -81,6 +84,7 @@ impl<T: Number> Histogram<T> {
     #[allow(unused_mut)]
     pub(crate) fn new(
         temporality: Temporality,
+        filter: AttributeSetFilter,
         mut bounds: Vec<f64>,
         record_min_max: bool,
         record_sum: bool,
@@ -97,22 +101,11 @@ impl<T: Number> Histogram<T> {
             value_map: ValueMap::new(buckets_count),
             init_time: AggregateTimeInitiator::default(),
             temporality,
+            filter,
             bounds,
             record_min_max,
             record_sum,
         }
-    }
-
-    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
-        let f = measurement.into_float();
-        // This search will return an index in the range `[0, bounds.len()]`, where
-        // it will return `bounds.len()` if value is greater than the last element
-        // of `bounds`. This aligns with the buckets in that the length of buckets
-        // is `bounds.len()+1`, with the last bucket representing:
-        // `(bounds[bounds.len()-1], +∞)`.
-        let index = self.bounds.partition_point(|&x| x < f);
-
-        self.value_map.measure((measurement, index), attrs);
     }
 
     fn delta(&self, dest: Option<&mut dyn Aggregation>) -> (usize, Option<Box<dyn Aggregation>>) {
@@ -216,6 +209,25 @@ impl<T: Number> Histogram<T> {
     }
 }
 
+impl<T> Measure<T> for Arc<Histogram<T>>
+where
+    T: Number,
+{
+    fn call(&self, measurement: T, attrs: &[KeyValue]) {
+        let f = measurement.into_float();
+        // This search will return an index in the range `[0, bounds.len()]`, where
+        // it will return `bounds.len()` if value is greater than the last element
+        // of `bounds`. This aligns with the buckets in that the length of buckets
+        // is `bounds.len()+1`, with the last bucket representing:
+        // `(bounds[bounds.len()-1], +∞)`.
+        let index = self.bounds.partition_point(|&x| x < f);
+
+        self.filter.apply(attrs, |filtered| {
+            self.value_map.measure((measurement, index), filtered);
+        })
+    }
+}
+
 impl<T> ComputeAggregation for Arc<Histogram<T>>
 where
     T: Number,
@@ -236,12 +248,13 @@ mod tests {
     fn check_buckets_are_selected_correctly() {
         let hist = Arc::new(Histogram::<i64>::new(
             Temporality::Cumulative,
+            AttributeSetFilter::new(None),
             vec![1.0, 3.0, 6.0],
             false,
             false,
         ));
         for v in 1..11 {
-            hist.measure(v, &[]);
+            Measure::call(&hist, v, &[]);
         }
         let (count, dp) = ComputeAggregation::call(&hist, None);
         let dp = dp.unwrap();

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -7,8 +7,8 @@ use crate::metrics::{
 use opentelemetry::KeyValue;
 
 use super::{
-    aggregate::AggregateTimeInitiator, Aggregator, AtomicTracker, AtomicallyUpdate,
-    ComputeAggregation, Number, ValueMap,
+    aggregate::{AggregateTimeInitiator, AttributeSetFilter},
+    Aggregator, AtomicTracker, AtomicallyUpdate, ComputeAggregation, Measure, Number, ValueMap,
 };
 
 /// this is reused by PrecomputedSum
@@ -48,20 +48,17 @@ pub(crate) struct LastValue<T: Number> {
     value_map: ValueMap<Assign<T>>,
     init_time: AggregateTimeInitiator,
     temporality: Temporality,
+    filter: AttributeSetFilter,
 }
 
 impl<T: Number> LastValue<T> {
-    pub(crate) fn new(temporality: Temporality) -> Self {
+    pub(crate) fn new(temporality: Temporality, filter: AttributeSetFilter) -> Self {
         LastValue {
             value_map: ValueMap::new(()),
             init_time: AggregateTimeInitiator::default(),
             temporality,
+            filter,
         }
-    }
-
-    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
-        // The argument index is not applicable to LastValue.
-        self.value_map.measure(measurement, attrs);
     }
 
     pub(crate) fn delta(
@@ -128,6 +125,17 @@ impl<T: Number> LastValue<T> {
             s_data.data_points.len(),
             new_agg.map(|a| Box::new(a) as Box<_>),
         )
+    }
+}
+
+impl<T> Measure<T> for Arc<LastValue<T>>
+where
+    T: Number,
+{
+    fn call(&self, measurement: T, attrs: &[KeyValue]) {
+        self.filter.apply(attrs, |filtered| {
+            self.value_map.measure(measurement, filtered);
+        })
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -5,8 +5,8 @@ use crate::metrics::data::{self, Aggregation, SumDataPoint};
 use crate::metrics::Temporality;
 use opentelemetry::KeyValue;
 
-use super::aggregate::AggregateTimeInitiator;
-use super::{Aggregator, AtomicTracker, ComputeAggregation, Number};
+use super::aggregate::{AggregateTimeInitiator, AttributeSetFilter};
+use super::{Aggregator, AtomicTracker, ComputeAggregation, Measure, Number};
 use super::{AtomicallyUpdate, ValueMap};
 
 struct Increment<T>
@@ -45,6 +45,7 @@ pub(crate) struct Sum<T: Number> {
     value_map: ValueMap<Increment<T>>,
     init_time: AggregateTimeInitiator,
     temporality: Temporality,
+    filter: AttributeSetFilter,
     monotonic: bool,
 }
 
@@ -54,18 +55,18 @@ impl<T: Number> Sum<T> {
     ///
     /// Each sum is scoped by attributes and the aggregation cycle the measurements
     /// were made in.
-    pub(crate) fn new(temporality: Temporality, monotonic: bool) -> Self {
+    pub(crate) fn new(
+        temporality: Temporality,
+        filter: AttributeSetFilter,
+        monotonic: bool,
+    ) -> Self {
         Sum {
             value_map: ValueMap::new(()),
-            temporality,
             init_time: AggregateTimeInitiator::default(),
+            temporality,
+            filter,
             monotonic,
         }
-    }
-
-    pub(crate) fn measure(&self, measurement: T, attrs: &[KeyValue]) {
-        // The argument index is not applicable to Sum.
-        self.value_map.measure(measurement, attrs);
     }
 
     pub(crate) fn delta(
@@ -139,6 +140,17 @@ impl<T: Number> Sum<T> {
             s_data.data_points.len(),
             new_agg.map(|a| Box::new(a) as Box<_>),
         )
+    }
+}
+
+impl<T> Measure<T> for Arc<Sum<T>>
+where
+    T: Number,
+{
+    fn call(&self, measurement: T, attrs: &[KeyValue]) {
+        self.filter.apply(attrs, |filtered| {
+            self.value_map.measure(measurement, filtered);
+        })
     }
 }
 


### PR DESCRIPTION
Prerequisite for #2328
This PR is similar to #2425, but it's for measurement instead of collection.

## Changes

* created `AttributeSetFilter` utility that (depending on provided filtering function) applies filter to attribute-sets before measurement. Similar logic as in `AggregateBuilder::filter`
* store `AttributeSetFilter` as part of aggregate 
* aggregates directly implement `Measure` trait.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
