### PR TITLE
Fix CI

### DIFF
--- a/opentelemetry-jaeger-propagator/Cargo.toml
+++ b/opentelemetry-jaeger-propagator/Cargo.toml
@@ -23,9 +23,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 opentelemetry = { version = "0.27", default-features = false, features = [
     "trace",
 ], path = "../opentelemetry" }
+tracing = {workspace = true, optional = true} # optional for opentelemetry internal logging
 
 [dev-dependencies]
 opentelemetry = { features = ["testing"], path = "../opentelemetry" }
 
 [features]
-default = []
+default = ["internal-logs"]
+internal-logs = ["tracing"]


### PR DESCRIPTION
## Changes
- CI checks for [ubuntu-latest](https://github.com/open-telemetry/opentelemetry-rust/actions/runs/12114807724/job/33771974461) are failing with the following error:

![image](https://github.com/user-attachments/assets/c98858fe-bbf2-4812-875f-452799617321)

- Update `Cargo.toml` for Jaeger Propagator to fix this
