### PR TITLE
Remove `mut` self reference from LogExporter::export() method.

### DIFF
--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -34,7 +34,7 @@ struct NoopExporter {
 
 #[async_trait]
 impl LogExporter for NoopExporter {
-    async fn export(&mut self, _: LogBatch<'_>) -> LogResult<()> {
+    async fn export(&self, _: LogBatch<'_>) -> LogResult<()> {
         LogResult::Ok(())
     }
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -247,7 +247,7 @@ mod tests {
 
     #[async_trait]
     impl LogExporter for ReentrantLogExporter {
-        async fn export(&mut self, _batch: LogBatch<'_>) -> LogResult<()> {
+        async fn export(&self, _batch: LogBatch<'_>) -> LogResult<()> {
             // This will cause a deadlock as the export itself creates a log
             // while still within the lock of the SimpleLogProcessor.
             warn!(name: "my-event-name", target: "reentrant", event_id = 20, user_name = "otel", user_email = "otel@opentelemetry.io");

--- a/opentelemetry-otlp/src/exporter/http/logs.rs
+++ b/opentelemetry-otlp/src/exporter/http/logs.rs
@@ -9,7 +9,7 @@ use super::OtlpHttpClient;
 
 #[async_trait]
 impl LogExporter for OtlpHttpClient {
-    async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()> {
+    async fn export(&self, batch: LogBatch<'_>) -> LogResult<()> {
         let client = self
             .client
             .lock()

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -124,7 +124,7 @@ impl LogExporter {
 
 #[async_trait]
 impl opentelemetry_sdk::export::logs::LogExporter for LogExporter {
-    async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()> {
+    async fn export(&self, batch: LogBatch<'_>) -> LogResult<()> {
         self.client.export(batch).await
     }
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -8,12 +8,12 @@
   transparent change.
   [#2338](https://github.com/open-telemetry/opentelemetry-rust/pull/2338)
 
-- *Breaking* LogExporter::export() method doesn't take mutable reference to self:
+- *Breaking* The LogExporter::export() method no longer requires a mutable reference to self.:
   Before:
      async fn export(&mut self, _batch: LogBatch<'_>) -> LogResult<()>
   After:
      async fn export(&self, _batch: LogBatch<'_>) -> LogResult<()>
-  The custom exporters would need to internally synchronize their mutable states (if any)
+  Custom exporters will need to internally synchronize any mutable state, if applicable.
 
 ## 0.27.1
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -8,6 +8,13 @@
   transparent change.
   [#2338](https://github.com/open-telemetry/opentelemetry-rust/pull/2338)
 
+- *Breaking* LogExporter::export() method doesn't take mutable reference to self:
+  Before:
+     async fn export(&mut self, _batch: LogBatch<'_>) -> LogResult<()>
+  After:
+     async fn export(&self, _batch: LogBatch<'_>) -> LogResult<()>
+  The custom exporters would need to internally synchronize their mutable states (if any)
+
 ## 0.27.1
 
 Released 2024-Nov-27

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -81,7 +81,7 @@ pub trait LogExporter: Send + Sync + Debug {
     /// A `LogResult<()>`, which is a result type indicating either a successful export (with
     /// `Ok(())`) or an error (`Err(LogError)`) if the export operation failed.
     ///
-    async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()>;
+    async fn export(&self, batch: LogBatch<'_>) -> LogResult<()>;
     /// Shuts down the exporter.
     fn shutdown(&mut self) {}
     #[cfg(feature = "spec_unstable_logs_enabled")]

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -106,7 +106,7 @@ impl<T: LogExporter> LogProcessor for SimpleLogProcessor<T> {
             .exporter
             .lock()
             .map_err(|_| LogError::MutexPoisoned("SimpleLogProcessor".into()))
-            .and_then(|mut exporter| {
+            .and_then(|exporter| {
                 let log_tuple = &[(record as &LogRecord, instrumentation)];
                 futures_executor::block_on(exporter.export(LogBatch::new(log_tuple)))
             });
@@ -586,7 +586,7 @@ mod tests {
 
     #[async_trait]
     impl LogExporter for MockLogExporter {
-        async fn export(&mut self, _batch: LogBatch<'_>) -> LogResult<()> {
+        async fn export(&self, _batch: LogBatch<'_>) -> LogResult<()> {
             Ok(())
         }
 
@@ -1093,7 +1093,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LogExporter for LogExporterThatRequiresTokio {
-        async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()> {
+        async fn export(&self, batch: LogBatch<'_>) -> LogResult<()> {
             // Simulate minimal dependency on tokio by sleeping asynchronously for a short duration
             tokio::time::sleep(Duration::from_millis(50)).await;
 

--- a/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/logs/in_memory_exporter.rs
@@ -183,7 +183,7 @@ impl InMemoryLogExporter {
 
 #[async_trait]
 impl LogExporter for InMemoryLogExporter {
-    async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()> {
+    async fn export(&self, batch: LogBatch<'_>) -> LogResult<()> {
         let mut logs_guard = self.logs.lock().map_err(LogError::from)?;
         for (log_record, instrumentation) in batch.iter() {
             let owned_log = OwnedLogData {

--- a/opentelemetry-stdout/src/logs/exporter.rs
+++ b/opentelemetry-stdout/src/logs/exporter.rs
@@ -5,12 +5,13 @@ use opentelemetry_sdk::export::logs::LogBatch;
 use opentelemetry_sdk::logs::LogResult;
 use opentelemetry_sdk::Resource;
 use std::sync::atomic;
+use std::sync::atomic::Ordering;
 
 /// An OpenTelemetry exporter that writes Logs to stdout on export.
 pub struct LogExporter {
     resource: Resource,
     is_shutdown: atomic::AtomicBool,
-    resource_emitted: bool,
+    resource_emitted: atomic::AtomicBool,
 }
 
 impl Default for LogExporter {
@@ -18,7 +19,7 @@ impl Default for LogExporter {
         LogExporter {
             resource: Resource::default(),
             is_shutdown: atomic::AtomicBool::new(false),
-            resource_emitted: false,
+            resource_emitted: atomic::AtomicBool::new(false),
         }
     }
 }
@@ -32,15 +33,18 @@ impl fmt::Debug for LogExporter {
 #[async_trait]
 impl opentelemetry_sdk::export::logs::LogExporter for LogExporter {
     /// Export spans to stdout
-    async fn export(&mut self, batch: LogBatch<'_>) -> LogResult<()> {
+    async fn export(&self, batch: LogBatch<'_>) -> LogResult<()> {
         if self.is_shutdown.load(atomic::Ordering::SeqCst) {
             return Err("exporter is shut down".into());
         } else {
             println!("Logs");
-            if self.resource_emitted {
+            if self
+                .resource_emitted
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err()
+            {
                 print_logs(batch);
             } else {
-                self.resource_emitted = true;
                 println!("Resource");
                 if let Some(schema_url) = self.resource.schema_url() {
                     println!("\t Resource SchemaUrl: {:?}", schema_url);

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -53,5 +53,7 @@ num-format = "0.4.4"
 sysinfo = { version = "0.32", optional = true }
 libc = "=0.2.164" # https://github.com/GuillaumeGomez/sysinfo/issues/1392
 async-trait = "0.1.51"
+futures-executor = { workspace = true }
+
 [features]
 stats = ["sysinfo"]

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -52,6 +52,6 @@ tracing-subscriber = { workspace = true, features = ["registry", "std"] }
 num-format = "0.4.4"
 sysinfo = { version = "0.32", optional = true }
 libc = "=0.2.164" # https://github.com/GuillaumeGomez/sysinfo/issues/1392
-
+async-trait = "0.1.51"
 [features]
 stats = ["sysinfo"]

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -6,7 +6,7 @@
     ~31 M/sec
 
     Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
-    ~44 M /sec
+    ~40 M /sec
 */
 
 use opentelemetry::InstrumentationScope;
@@ -37,7 +37,7 @@ pub struct NoOpLogProcessor {
 impl LogProcessor for NoOpLogProcessor {
     fn emit(&self, record: &mut opentelemetry_sdk::logs::LogRecord, scope: &InstrumentationScope) {
         let log_tuple = &[(record as &LogRecord, scope)];
-        let _ = self.exporter.export(LogBatch::new(log_tuple));
+        let _ = futures_executor::block_on(self.exporter.export(LogBatch::new(log_tuple)));
     }
 
     fn force_flush(&self) -> opentelemetry_sdk::logs::LogResult<()> {

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -20,21 +20,21 @@ mod throughput;
 use async_trait::async_trait;
 
 #[derive(Debug, Clone)]
-struct NoopExporter;
+struct MockLogExporter;
 
 #[async_trait]
-impl LogExporter for NoopExporter {
+impl LogExporter for MockLogExporter {
     async fn export(&self, _: LogBatch<'_>) -> LogResult<()> {
         LogResult::Ok(())
     }
 }
 
 #[derive(Debug)]
-pub struct NoOpLogProcessor {
-    exporter: NoopExporter,
+pub struct MockLogProcessor {
+    exporter: MockLogExporter,
 }
 
-impl LogProcessor for NoOpLogProcessor {
+impl LogProcessor for MockLogProcessor {
     fn emit(&self, record: &mut opentelemetry_sdk::logs::LogRecord, scope: &InstrumentationScope) {
         let log_tuple = &[(record as &LogRecord, scope)];
         let _ = futures_executor::block_on(self.exporter.export(LogBatch::new(log_tuple)));
@@ -52,8 +52,8 @@ impl LogProcessor for NoOpLogProcessor {
 fn main() {
     // LoggerProvider with a no-op processor.
     let provider: LoggerProvider = LoggerProvider::builder()
-        .with_log_processor(NoOpLogProcessor {
-            exporter: NoopExporter {},
+        .with_log_processor(MockLogProcessor {
+            exporter: MockLogExporter {},
         })
         .build();
 


### PR DESCRIPTION
## Changes

As discussed here - https://github.com/open-telemetry/opentelemetry-rust/pull/2374#discussion_r1866729502
The changes are minimal, and the stress test for the logs now includes an exporter call over the future, causing a slight regression.

## Merge requirement checklist
* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
