### PR TITLE
chore: make opentelemetry-prometheus compatibility with opentelemetry 0.27

### DIFF
--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -3,10 +3,7 @@
 ## vNext
 
 - Bump MSRV to 1.70 [#2179](https://github.com/open-telemetry/opentelemetry-rust/pull/2179)
-- Update `opentelemetry` dependency version to 0.26
-- Update `opentelemetry_sdk` dependency version to 0.26
-- Update `opentelemetry-semantic-conventions` dependency version to 0.26
-
+- update `opentelemetry` and `opentelemetry_sdk` dependency version to 0.27 [#2385](https://github.com/open-telemetry/opentelemetry-rust/pull/2385)
 
 ## v0.17.0
 

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -21,13 +21,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 once_cell = { workspace = true }
-opentelemetry = { version = "0.26", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.26", default-features = false, features = ["metrics"] }
+opentelemetry = { version = "0.27", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.27", default-features = false, features = ["metrics"] }
 prometheus = "0.13"
 protobuf = "2.14"
 
 [dev-dependencies]
-opentelemetry-semantic-conventions = { version = "0.26" }
+opentelemetry-semantic-conventions = { version = "0.27" }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["full"] }

--- a/opentelemetry-prometheus/examples/hyper.rs
+++ b/opentelemetry-prometheus/examples/hyper.rs
@@ -85,17 +85,17 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         http_counter: meter
             .u64_counter("http_requests_total")
             .with_description("Total number of HTTP requests made.")
-            .init(),
+            .build(),
         http_body_gauge: meter
             .u64_histogram("example.http_response_size")
             .with_unit("By")
             .with_description("The metrics HTTP response sizes in bytes.")
-            .init(),
+            .build(),
         http_req_histogram: meter
             .f64_histogram("example.http_request_duration")
             .with_unit("ms")
             .with_description("The HTTP request latencies in milliseconds.")
-            .init(),
+            .build(),
     });
 
     let addr: SocketAddr = ([127, 0, 0, 1], 3000).into();

--- a/opentelemetry-prometheus/src/config.rs
+++ b/opentelemetry-prometheus/src/config.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 use once_cell::sync::OnceCell;
-use opentelemetry::metrics::{MetricsError, Result};
-use opentelemetry_sdk::metrics::ManualReaderBuilder;
+use opentelemetry_sdk::metrics::{ManualReaderBuilder, MetricError, MetricResult};
 use std::sync::{Arc, Mutex};
 
 use crate::{Collector, PrometheusExporter, ResourceSelector};
@@ -116,7 +115,7 @@ impl ExporterBuilder {
     }
 
     /// Creates a new [PrometheusExporter] from this configuration.
-    pub fn build(self) -> Result<PrometheusExporter> {
+    pub fn build(self) -> MetricResult<PrometheusExporter> {
         let reader = Arc::new(self.reader.build());
 
         let collector = Collector {
@@ -135,7 +134,7 @@ impl ExporterBuilder {
         let registry = self.registry.unwrap_or_default();
         registry
             .register(Box::new(collector))
-            .map_err(|e| MetricsError::Other(e.to_string()))?;
+            .map_err(|e| MetricError::Other(e.to_string()))?;
 
         Ok(PrometheusExporter { reader })
     }

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -7,13 +7,22 @@ use opentelemetry::metrics::{Meter, MeterProvider as _};
 use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use opentelemetry_prometheus::{ExporterBuilder, ResourceSelector};
-use opentelemetry_sdk::metrics::{new_view, Aggregation, Instrument, SdkMeterProvider, Stream};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::resource::{
     EnvResourceDetector, SdkProvidedResourceDetector, TelemetryResourceDetector,
 };
 use opentelemetry_sdk::Resource;
 use opentelemetry_semantic_conventions::resource::{SERVICE_NAME, TELEMETRY_SDK_VERSION};
 use prometheus::{Encoder, TextEncoder};
+
+const BOUNDARIES: &[f64] = &[
+    0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 1000.0,
+];
+
+const BYTES_BOUNDARIES: &[f64] = &[
+    0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0,
+    10000.0,
+];
 
 #[ignore = "https://github.com/open-telemetry/opentelemetry-rust/pull/2224"]
 #[test]
@@ -56,7 +65,7 @@ fn prometheus_exporter_integration() {
                     .f64_counter("foo")
                     .with_description("a simple counter")
                     .with_unit("ms")
-                    .init();
+                    .build();
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -85,7 +94,7 @@ fn prometheus_exporter_integration() {
                     .f64_counter("foo")
                     .with_description("a simple counter without a total suffix")
                     .with_unit("ms")
-                    .init();
+                    .build();
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -108,7 +117,7 @@ fn prometheus_exporter_integration() {
                     .f64_up_down_counter("bar")
                     .with_description("a fun little gauge")
                     .with_unit("1")
-                    .init();
+                    .build();
                 gauge.add(1.0, &attrs);
                 gauge.add(-0.25, &attrs);
             }),
@@ -123,7 +132,8 @@ fn prometheus_exporter_integration() {
                     .f64_histogram("histogram_baz")
                     .with_description("a very nice histogram")
                     .with_unit("By")
-                    .init();
+                    .with_boundaries(BOUNDARIES.to_vec())
+                    .build();
                 histogram.record(23.0, &attrs);
                 histogram.record(7.0, &attrs);
                 histogram.record(101.0, &attrs);
@@ -149,7 +159,7 @@ fn prometheus_exporter_integration() {
                     .with_description("a sanitary counter")
                     // This unit is not added to
                     .with_unit("By")
-                    .init();
+                    .build();
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -165,7 +175,7 @@ fn prometheus_exporter_integration() {
                 let mut gauge = meter
                     .f64_up_down_counter("bar")
                     .with_description("a fun little gauge")
-                    .init();
+                    .build();
                 gauge.add(100., &attrs);
                 gauge.add(-25.0, &attrs);
 
@@ -173,19 +183,20 @@ fn prometheus_exporter_integration() {
                 gauge = meter
                     .f64_up_down_counter("invalid.gauge.name")
                     .with_description("a gauge with an invalid name")
-                    .init();
+                    .build();
                 gauge.add(100.0, &attrs);
 
                 let counter = meter
                     .f64_counter("0invalid.counter.name")
                     .with_description("a counter with an invalid name")
-                    .init();
+                    .build();
                 counter.add(100.0, &attrs);
 
                 let histogram = meter
                     .f64_histogram("invalid.hist.name")
                     .with_description("a histogram with an invalid name")
-                    .init();
+                    .with_boundaries(BOUNDARIES.to_vec())
+                    .build();
                 histogram.record(23.0, &attrs);
             }),
             ..Default::default()
@@ -204,7 +215,7 @@ fn prometheus_exporter_integration() {
                 let counter = meter
                     .f64_counter("foo")
                     .with_description("a simple counter")
-                    .init();
+                    .build();
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -225,7 +236,7 @@ fn prometheus_exporter_integration() {
                 let counter = meter
                     .f64_counter("foo")
                     .with_description("a simple counter")
-                    .init();
+                    .build();
                 counter.add(5., &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -246,7 +257,7 @@ fn prometheus_exporter_integration() {
                 let counter = meter
                     .f64_counter("foo")
                     .with_description("a simple counter")
-                    .init();
+                    .build();
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
                 counter.add(9.0, &attrs);
@@ -263,7 +274,7 @@ fn prometheus_exporter_integration() {
                     .i64_up_down_counter("bar")
                     .with_description("a fun little gauge")
                     .with_unit("1")
-                    .init();
+                    .build();
                 gauge.add(2, &attrs);
                 gauge.add(-1, &attrs);
             }),
@@ -281,7 +292,7 @@ fn prometheus_exporter_integration() {
                     .u64_counter("bar")
                     .with_description("a fun little counter")
                     .with_unit("By")
-                    .init();
+                    .build();
                 counter.add(2, &attrs);
                 counter.add(1, &attrs);
             }),
@@ -301,7 +312,7 @@ fn prometheus_exporter_integration() {
                 let counter = meter
                     .f64_counter("foo")
                     .with_description("a simple counter")
-                    .init();
+                    .build();
 
                 counter.add(5.0, &attrs);
                 counter.add(10.3, &attrs);
@@ -319,7 +330,7 @@ fn prometheus_exporter_integration() {
                     .i64_up_down_counter("bar")
                     .with_description("a fun little gauge")
                     .with_unit("1")
-                    .init();
+                    .build();
                 gauge.add(2, &attrs);
                 gauge.add(-1, &attrs);
             }),
@@ -336,7 +347,7 @@ fn prometheus_exporter_integration() {
                     .i64_up_down_counter("bar")
                     .with_description("a fun little gauge")
                     .with_unit("1")
-                    .init();
+                    .build();
                 gauge.add(2, &attrs);
                 gauge.add(-1, &attrs);
             }),
@@ -374,24 +385,12 @@ fn prometheus_exporter_integration() {
         let provider = SdkMeterProvider::builder()
             .with_resource(res)
             .with_reader(exporter)
-            .with_view(
-                new_view(
-                    Instrument::new().name("histogram_*"),
-                    Stream::new().aggregation(Aggregation::ExplicitBucketHistogram {
-                        boundaries: vec![
-                            0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 1000.0,
-                        ],
-                        record_min_max: true,
-                    }),
-                )
-                .unwrap(),
-            )
             .build();
-        let meter = provider.versioned_meter(
-            "testmeter",
-            Some("v0.1.0"),
-            None::<&'static str>,
-            Some(vec![KeyValue::new("k", "v")]),
+        let meter = provider.meter_with_scope(
+            opentelemetry::InstrumentationScope::builder("testmeter")
+                .with_version("v0.1.0")
+                .with_attributes(vec![KeyValue::new("k", "v")])
+                .build(),
         );
         (tc.record_metrics)(meter);
 
@@ -450,29 +449,29 @@ fn multiple_scopes() {
         .build();
 
     let foo_counter = provider
-        .versioned_meter(
-            "meterfoo",
-            Some("v0.1.0"),
-            None::<&'static str>,
-            Some(vec![KeyValue::new("k", "v")]),
+        .meter_with_scope(
+            opentelemetry::InstrumentationScope::builder("meterfoo")
+                .with_version("v0.1.0")
+                .with_attributes(vec![KeyValue::new("k", "v")])
+                .build(),
         )
         .u64_counter("foo")
         .with_unit("ms")
         .with_description("meter foo counter")
-        .init();
+        .build();
     foo_counter.add(100, &[KeyValue::new("type", "foo")]);
 
     let bar_counter = provider
-        .versioned_meter(
-            "meterbar",
-            Some("v0.1.0"),
-            None::<&'static str>,
-            Some(vec![KeyValue::new("k", "v")]),
+        .meter_with_scope(
+            opentelemetry::InstrumentationScope::builder("meterbar")
+                .with_version("v0.1.0")
+                .with_attributes(vec![KeyValue::new("k", "v")])
+                .build(),
         )
         .u64_counter("bar")
         .with_unit("ms")
         .with_description("meter bar counter")
-        .init();
+        .build();
     bar_counter.add(200, &[KeyValue::new("type", "bar")]);
 
     let content = fs::read_to_string("./tests/data/multi_scopes.txt").unwrap();
@@ -510,7 +509,7 @@ fn duplicate_metrics() {
                     .u64_counter("foo")
                     .with_unit("By")
                     .with_description("meter counter foo")
-                    .init();
+                    .build();
 
                 foo_a.add(100, &[KeyValue::new("A", "B")]);
 
@@ -518,7 +517,7 @@ fn duplicate_metrics() {
                     .u64_counter("foo")
                     .with_unit("By")
                     .with_description("meter counter foo")
-                    .init();
+                    .build();
 
                 foo_b.add(100, &[KeyValue::new("A", "B")]);
             }),
@@ -532,7 +531,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("foo")
                     .with_unit("By")
                     .with_description("meter gauge foo")
-                    .init();
+                    .build();
 
                 foo_a.add(100, &[KeyValue::new("A", "B")]);
 
@@ -540,7 +539,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("foo")
                     .with_unit("By")
                     .with_description("meter gauge foo")
-                    .init();
+                    .build();
 
                 foo_b.add(100, &[KeyValue::new("A", "B")]);
             }),
@@ -554,7 +553,8 @@ fn duplicate_metrics() {
                     .u64_histogram("foo")
                     .with_unit("By")
                     .with_description("meter histogram foo")
-                    .init();
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
+                    .build();
 
                 foo_a.record(100, &[KeyValue::new("A", "B")]);
 
@@ -562,7 +562,8 @@ fn duplicate_metrics() {
                     .u64_histogram("foo")
                     .with_unit("By")
                     .with_description("meter histogram foo")
-                    .init();
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
+                    .build();
 
                 foo_b.record(100, &[KeyValue::new("A", "B")]);
             }),
@@ -576,7 +577,7 @@ fn duplicate_metrics() {
                     .u64_counter("bar")
                     .with_unit("By")
                     .with_description("meter a bar")
-                    .init();
+                    .build();
 
                 bar_a.add(100, &[KeyValue::new("type", "bar")]);
 
@@ -584,7 +585,7 @@ fn duplicate_metrics() {
                     .u64_counter("bar")
                     .with_unit("By")
                     .with_description("meter b bar")
-                    .init();
+                    .build();
 
                 bar_b.add(100, &[KeyValue::new("type", "bar")]);
             }),
@@ -601,7 +602,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("bar")
                     .with_unit("By")
                     .with_description("meter a bar")
-                    .init();
+                    .build();
 
                 bar_a.add(100, &[KeyValue::new("type", "bar")]);
 
@@ -609,7 +610,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("bar")
                     .with_unit("By")
                     .with_description("meter b bar")
-                    .init();
+                    .build();
 
                 bar_b.add(100, &[KeyValue::new("type", "bar")]);
             }),
@@ -626,7 +627,8 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("By")
                     .with_description("meter a bar")
-                    .init();
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
+                    .build();
 
                 bar_a.record(100, &[KeyValue::new("A", "B")]);
 
@@ -634,7 +636,8 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("By")
                     .with_description("meter b bar")
-                    .init();
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
+                    .build();
 
                 bar_b.record(100, &[KeyValue::new("A", "B")]);
             }),
@@ -651,7 +654,7 @@ fn duplicate_metrics() {
                     .u64_counter("bar")
                     .with_unit("By")
                     .with_description("meter bar")
-                    .init();
+                    .build();
 
                 baz_a.add(100, &[KeyValue::new("type", "bar")]);
 
@@ -659,7 +662,7 @@ fn duplicate_metrics() {
                     .u64_counter("bar")
                     .with_unit("ms")
                     .with_description("meter bar")
-                    .init();
+                    .build();
 
                 baz_b.add(100, &[KeyValue::new("type", "bar")]);
             }),
@@ -674,7 +677,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("bar")
                     .with_unit("By")
                     .with_description("meter gauge bar")
-                    .init();
+                    .build();
 
                 bar_a.add(100, &[KeyValue::new("type", "bar")]);
 
@@ -682,7 +685,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("bar")
                     .with_unit("ms")
                     .with_description("meter gauge bar")
-                    .init();
+                    .build();
 
                 bar_b.add(100, &[KeyValue::new("type", "bar")]);
             }),
@@ -697,7 +700,8 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("By")
                     .with_description("meter histogram bar")
-                    .init();
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
+                    .build();
 
                 bar_a.record(100, &[KeyValue::new("A", "B")]);
 
@@ -705,7 +709,8 @@ fn duplicate_metrics() {
                     .u64_histogram("bar")
                     .with_unit("ms")
                     .with_description("meter histogram bar")
-                    .init();
+                    .with_boundaries(BYTES_BOUNDARIES.to_vec())
+                    .build();
 
                 bar_b.record(100, &[KeyValue::new("A", "B")]);
             }),
@@ -720,7 +725,7 @@ fn duplicate_metrics() {
                     .u64_counter("foo")
                     .with_unit("By")
                     .with_description("meter foo")
-                    .init();
+                    .build();
 
                 counter.add(100, &[KeyValue::new("type", "foo")]);
 
@@ -728,7 +733,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("foo_total")
                     .with_unit("By")
                     .with_description("meter foo")
-                    .init();
+                    .build();
 
                 gauge.add(200, &[KeyValue::new("type", "foo")]);
             }),
@@ -746,7 +751,7 @@ fn duplicate_metrics() {
                     .i64_up_down_counter("foo")
                     .with_unit("By")
                     .with_description("meter gauge foo")
-                    .init();
+                    .build();
 
                 foo_a.add(100, &[KeyValue::new("A", "B")]);
 
@@ -754,7 +759,8 @@ fn duplicate_metrics() {
                     .u64_histogram("foo")
                     .with_unit("By")
                     .with_description("meter histogram foo")
-                    .init();
+                    .with_boundaries(BOUNDARIES.to_vec())
+                    .build();
 
                 foo_histogram_a.record(100, &[KeyValue::new("A", "B")]);
             }),
@@ -794,17 +800,17 @@ fn duplicate_metrics() {
             .with_reader(exporter)
             .build();
 
-        let meter_a = provider.versioned_meter(
-            "ma",
-            Some("v0.1.0"),
-            None::<&'static str>,
-            Some(vec![KeyValue::new("k", "v")]),
+        let meter_a = provider.meter_with_scope(
+            opentelemetry::InstrumentationScope::builder("ma")
+                .with_version("v0.1.0")
+                .with_attributes(vec![KeyValue::new("k", "v")])
+                .build(),
         );
-        let meter_b = provider.versioned_meter(
-            "mb",
-            Some("v0.1.0"),
-            None::<&'static str>,
-            Some(vec![KeyValue::new("k", "v")]),
+        let meter_b = provider.meter_with_scope(
+            opentelemetry::InstrumentationScope::builder("mb")
+                .with_version("v0.1.0")
+                .with_attributes(vec![KeyValue::new("k", "v")])
+                .build(),
         );
 
         (tc.record_metrics)(meter_a, meter_b);


### PR DESCRIPTION
## Changes

make opentelemetry-prometheus  compatible with opentelemetry 0.27

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
