### PR TITLE
Gauge start-time is optional

### DIFF
--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -319,7 +319,7 @@ pub mod tonic {
                     .iter()
                     .map(|dp| TonicNumberDataPoint {
                         attributes: dp.attributes.iter().map(Into::into).collect(),
-                        start_time_unix_nano: to_nanos(dp.start_time),
+                        start_time_unix_nano: dp.start_time.map(to_nanos).unwrap_or_default(),
                         time_unix_nano: to_nanos(dp.time),
                         exemplars: dp.exemplars.iter().map(Into::into).collect(),
                         flags: TonicDataPointFlags::default() as u32,

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -53,11 +53,39 @@ pub trait Aggregation: fmt::Debug + any::Any + Send + Sync {
     fn as_mut(&mut self) -> &mut dyn any::Any;
 }
 
+/// DataPoint is a single data point in a time series.
+#[derive(Debug, PartialEq)]
+pub struct GaugeDataPoint<T> {
+    /// Attributes is the set of key value pairs that uniquely identify the
+    /// time series.
+    pub attributes: Vec<KeyValue>,
+    /// The time when the time series was started.
+    pub start_time: Option<SystemTime>,
+    /// The time when the time series was recorded.
+    pub time: SystemTime,
+    /// The value of this data point.
+    pub value: T,
+    /// The sampled [Exemplar]s collected during the time series.
+    pub exemplars: Vec<Exemplar<T>>,
+}
+
+impl<T: Copy> Clone for GaugeDataPoint<T> {
+    fn clone(&self) -> Self {
+        Self {
+            attributes: self.attributes.clone(),
+            start_time: self.start_time,
+            time: self.time,
+            value: self.value,
+            exemplars: self.exemplars.clone(),
+        }
+    }
+}
+
 /// A measurement of the current value of an instrument.
 #[derive(Debug)]
 pub struct Gauge<T> {
     /// Represents individual aggregated measurements with unique attributes.
-    pub data_points: Vec<DataPoint<T>>,
+    pub data_points: Vec<GaugeDataPoint<T>>,
 }
 
 impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Gauge<T> {
@@ -69,30 +97,9 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Gauge<T> {
     }
 }
 
-/// Represents the sum of all measurements of values from an instrument.
-#[derive(Debug)]
-pub struct Sum<T> {
-    /// Represents individual aggregated measurements with unique attributes.
-    pub data_points: Vec<DataPoint<T>>,
-    /// Describes if the aggregation is reported as the change from the last report
-    /// time, or the cumulative changes since a fixed start time.
-    pub temporality: Temporality,
-    /// Whether this aggregation only increases or decreases.
-    pub is_monotonic: bool,
-}
-
-impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Sum<T> {
-    fn as_any(&self) -> &dyn any::Any {
-        self
-    }
-    fn as_mut(&mut self) -> &mut dyn any::Any {
-        self
-    }
-}
-
 /// DataPoint is a single data point in a time series.
 #[derive(Debug, PartialEq)]
-pub struct DataPoint<T> {
+pub struct SumDataPoint<T> {
     /// Attributes is the set of key value pairs that uniquely identify the
     /// time series.
     pub attributes: Vec<KeyValue>,
@@ -106,7 +113,7 @@ pub struct DataPoint<T> {
     pub exemplars: Vec<Exemplar<T>>,
 }
 
-impl<T: Copy> Clone for DataPoint<T> {
+impl<T: Copy> Clone for SumDataPoint<T> {
     fn clone(&self) -> Self {
         Self {
             attributes: self.attributes.clone(),
@@ -115,6 +122,27 @@ impl<T: Copy> Clone for DataPoint<T> {
             value: self.value,
             exemplars: self.exemplars.clone(),
         }
+    }
+}
+
+/// Represents the sum of all measurements of values from an instrument.
+#[derive(Debug)]
+pub struct Sum<T> {
+    /// Represents individual aggregated measurements with unique attributes.
+    pub data_points: Vec<SumDataPoint<T>>,
+    /// Describes if the aggregation is reported as the change from the last report
+    /// time, or the cumulative changes since a fixed start time.
+    pub temporality: Temporality,
+    /// Whether this aggregation only increases or decreases.
+    pub is_monotonic: bool,
+}
+
+impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Sum<T> {
+    fn as_any(&self) -> &dyn any::Any {
+        self
+    }
+    fn as_mut(&mut self) -> &mut dyn any::Any {
+        self
     }
 }
 
@@ -330,13 +358,13 @@ impl<T: Copy> Clone for Exemplar<T> {
 #[cfg(test)]
 mod tests {
 
-    use super::{DataPoint, Exemplar, ExponentialHistogramDataPoint, HistogramDataPoint};
+    use super::{Exemplar, ExponentialHistogramDataPoint, HistogramDataPoint, SumDataPoint};
 
     use opentelemetry::KeyValue;
 
     #[test]
     fn validate_cloning_data_points() {
-        let data_type = DataPoint {
+        let data_type = SumDataPoint {
             attributes: vec![KeyValue::new("key", "value")],
             start_time: std::time::SystemTime::now(),
             time: std::time::SystemTime::now(),

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -211,8 +211,8 @@ impl<T: Number> AggregateBuilder<T> {
 #[cfg(test)]
 mod tests {
     use crate::metrics::data::{
-        DataPoint, ExponentialBucket, ExponentialHistogram, ExponentialHistogramDataPoint,
-        Histogram, HistogramDataPoint, Sum,
+        ExponentialBucket, ExponentialHistogram, ExponentialHistogramDataPoint, GaugeDataPoint,
+        Histogram, HistogramDataPoint, Sum, SumDataPoint,
     };
     use std::{time::SystemTime, vec};
 
@@ -222,9 +222,9 @@ mod tests {
     fn last_value_aggregation() {
         let (measure, agg) = AggregateBuilder::<u64>::new(None, None).last_value();
         let mut a = Gauge {
-            data_points: vec![DataPoint {
+            data_points: vec![GaugeDataPoint {
                 attributes: vec![KeyValue::new("a", 1)],
-                start_time: SystemTime::now(),
+                start_time: Some(SystemTime::now()),
                 time: SystemTime::now(),
                 value: 1u64,
                 exemplars: vec![],
@@ -249,14 +249,14 @@ mod tests {
                 AggregateBuilder::<u64>::new(Some(temporality), None).precomputed_sum(true);
             let mut a = Sum {
                 data_points: vec![
-                    DataPoint {
+                    SumDataPoint {
                         attributes: vec![KeyValue::new("a1", 1)],
                         start_time: SystemTime::now(),
                         time: SystemTime::now(),
                         value: 1u64,
                         exemplars: vec![],
                     },
-                    DataPoint {
+                    SumDataPoint {
                         attributes: vec![KeyValue::new("a2", 1)],
                         start_time: SystemTime::now(),
                         time: SystemTime::now(),
@@ -292,14 +292,14 @@ mod tests {
             let (measure, agg) = AggregateBuilder::<u64>::new(Some(temporality), None).sum(true);
             let mut a = Sum {
                 data_points: vec![
-                    DataPoint {
+                    SumDataPoint {
                         attributes: vec![KeyValue::new("a1", 1)],
                         start_time: SystemTime::now(),
                         time: SystemTime::now(),
                         value: 1u64,
                         exemplars: vec![],
                     },
-                    DataPoint {
+                    SumDataPoint {
                         attributes: vec![KeyValue::new("a2", 1)],
                         start_time: SystemTime::now(),
                         time: SystemTime::now(),

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -1467,7 +1467,7 @@ mod tests {
                 test_name
             );
             for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
-                assert_data_points_eq(
+                assert_gauge_data_points_eq(
                     a,
                     b,
                     ignore_timestamp,
@@ -1494,7 +1494,7 @@ mod tests {
                 test_name
             );
             for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
-                assert_data_points_eq(
+                assert_sum_data_points_eq(
                     a,
                     b,
                     ignore_timestamp,
@@ -1554,9 +1554,33 @@ mod tests {
         }
     }
 
-    fn assert_data_points_eq<T: Number>(
-        a: &data::DataPoint<T>,
-        b: &data::DataPoint<T>,
+    fn assert_sum_data_points_eq<T: Number>(
+        a: &data::SumDataPoint<T>,
+        b: &data::SumDataPoint<T>,
+        ignore_timestamp: bool,
+        message: &'static str,
+        test_name: &'static str,
+    ) {
+        assert_eq!(
+            a.attributes, b.attributes,
+            "{}: {} attributes",
+            test_name, message
+        );
+        assert_eq!(a.value, b.value, "{}: {} value", test_name, message);
+
+        if !ignore_timestamp {
+            assert_eq!(
+                a.start_time, b.start_time,
+                "{}: {} start time",
+                test_name, message
+            );
+            assert_eq!(a.time, b.time, "{}: {} time", test_name, message);
+        }
+    }
+
+    fn assert_gauge_data_points_eq<T: Number>(
+        a: &data::GaugeDataPoint<T>,
+        b: &data::GaugeDataPoint<T>,
         ignore_timestamp: bool,
         message: &'static str,
         test_name: &'static str,

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -1,6 +1,6 @@
 use opentelemetry::KeyValue;
 
-use crate::metrics::data::{self, Aggregation, DataPoint};
+use crate::metrics::data::{self, Aggregation, SumDataPoint};
 use crate::metrics::Temporality;
 
 use super::{last_value::Assign, AtomicTracker, Number, ValueMap};
@@ -66,7 +66,7 @@ impl<T: Number> PrecomputedSum<T> {
                 let value = aggr.value.get_value();
                 new_reported.insert(attributes.clone(), value);
                 let delta = value - *reported.get(&attributes).unwrap_or(&T::default());
-                DataPoint {
+                SumDataPoint {
                     attributes,
                     start_time: prev_start,
                     time: t,
@@ -107,7 +107,7 @@ impl<T: Number> PrecomputedSum<T> {
         let prev_start = self.start.lock().map(|start| *start).unwrap_or(t);
 
         self.value_map
-            .collect_readonly(&mut s_data.data_points, |attributes, aggr| DataPoint {
+            .collect_readonly(&mut s_data.data_points, |attributes, aggr| SumDataPoint {
                 attributes,
                 start_time: prev_start,
                 time: t,

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -3,7 +3,7 @@ use std::ops::DerefMut;
 use std::vec;
 use std::{sync::Mutex, time::SystemTime};
 
-use crate::metrics::data::{self, Aggregation, DataPoint};
+use crate::metrics::data::{self, Aggregation, SumDataPoint};
 use crate::metrics::Temporality;
 use opentelemetry::KeyValue;
 
@@ -93,7 +93,7 @@ impl<T: Number> Sum<T> {
             .map(|mut start| replace(start.deref_mut(), t))
             .unwrap_or(t);
         self.value_map
-            .collect_and_reset(&mut s_data.data_points, |attributes, aggr| DataPoint {
+            .collect_and_reset(&mut s_data.data_points, |attributes, aggr| SumDataPoint {
                 attributes,
                 start_time: prev_start,
                 time: t,
@@ -130,7 +130,7 @@ impl<T: Number> Sum<T> {
         let prev_start = self.start.lock().map(|start| *start).unwrap_or(t);
 
         self.value_map
-            .collect_readonly(&mut s_data.data_points, |attributes, aggr| DataPoint {
+            .collect_readonly(&mut s_data.data_points, |attributes, aggr| SumDataPoint {
                 attributes,
                 start_time: prev_start,
                 time: t,

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -104,11 +104,12 @@ pub enum Temporality {
 
 #[cfg(all(test, feature = "testing"))]
 mod tests {
-    use self::data::{DataPoint, HistogramDataPoint, ScopeMetrics};
+    use self::data::{HistogramDataPoint, ScopeMetrics, SumDataPoint};
     use super::*;
     use crate::metrics::data::ResourceMetrics;
     use crate::testing::metrics::InMemoryMetricExporterBuilder;
     use crate::{runtime, testing::metrics::InMemoryMetricExporter};
+    use data::GaugeDataPoint;
     use opentelemetry::metrics::{Counter, Meter, UpDownCounter};
     use opentelemetry::InstrumentationScope;
     use opentelemetry::{metrics::MeterProvider as _, KeyValue};
@@ -465,7 +466,7 @@ mod tests {
             let data_point = if is_empty_attributes {
                 &sum.data_points[0]
             } else {
-                find_datapoint_with_key_value(&sum.data_points, "key1", "value1")
+                find_sum_datapoint_with_key_value(&sum.data_points, "key1", "value1")
                     .expect("datapoint with key1=value1 expected")
             };
 
@@ -1096,12 +1097,12 @@ mod tests {
         assert_eq!(sum.data_points.len(), 2);
 
         // find and validate key1=value1 datapoint
-        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "key1", "value1")
+        let data_point1 = find_sum_datapoint_with_key_value(&sum.data_points, "key1", "value1")
             .expect("datapoint with key1=value1 expected");
         assert_eq!(data_point1.value, 5);
 
         // find and validate key1=value2 datapoint
-        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "key1", "value2")
+        let data_point1 = find_sum_datapoint_with_key_value(&sum.data_points, "key1", "value2")
             .expect("datapoint with key1=value2 expected");
         assert_eq!(data_point1.value, 3);
 
@@ -1218,12 +1219,15 @@ mod tests {
                         test_context.get_aggregation::<data::Sum<u64>>("test_counter", None);
                     assert_eq!(counter_data.data_points.len(), 2);
                     let zero_attribute_datapoint =
-                        find_datapoint_with_no_attributes(&counter_data.data_points)
+                        find_sum_datapoint_with_no_attributes(&counter_data.data_points)
                             .expect("datapoint with no attributes expected");
                     assert_eq!(zero_attribute_datapoint.value, 5);
-                    let data_point1 =
-                        find_datapoint_with_key_value(&counter_data.data_points, "key1", "value1")
-                            .expect("datapoint with key1=value1 expected");
+                    let data_point1 = find_sum_datapoint_with_key_value(
+                        &counter_data.data_points,
+                        "key1",
+                        "value1",
+                    )
+                    .expect("datapoint with key1=value1 expected");
                     assert_eq!(data_point1.value, 10);
                 }
                 "updown_counter" => {
@@ -1231,10 +1235,10 @@ mod tests {
                         test_context.get_aggregation::<data::Sum<i64>>("test_updowncounter", None);
                     assert_eq!(updown_counter_data.data_points.len(), 2);
                     let zero_attribute_datapoint =
-                        find_datapoint_with_no_attributes(&updown_counter_data.data_points)
+                        find_sum_datapoint_with_no_attributes(&updown_counter_data.data_points)
                             .expect("datapoint with no attributes expected");
                     assert_eq!(zero_attribute_datapoint.value, 15);
-                    let data_point1 = find_datapoint_with_key_value(
+                    let data_point1 = find_sum_datapoint_with_key_value(
                         &updown_counter_data.data_points,
                         "key1",
                         "value1",
@@ -1269,12 +1273,15 @@ mod tests {
                         test_context.get_aggregation::<data::Gauge<u64>>("test_gauge", None);
                     assert_eq!(gauge_data.data_points.len(), 2);
                     let zero_attribute_datapoint =
-                        find_datapoint_with_no_attributes(&gauge_data.data_points)
+                        find_gauge_datapoint_with_no_attributes(&gauge_data.data_points)
                             .expect("datapoint with no attributes expected");
                     assert_eq!(zero_attribute_datapoint.value, 35);
-                    let data_point1 =
-                        find_datapoint_with_key_value(&gauge_data.data_points, "key1", "value1")
-                            .expect("datapoint with key1=value1 expected");
+                    let data_point1 = find_gauge_datapoint_with_key_value(
+                        &gauge_data.data_points,
+                        "key1",
+                        "value1",
+                    )
+                    .expect("datapoint with key1=value1 expected");
                     assert_eq!(data_point1.value, 40);
                 }
                 _ => panic!("Incorrect instrument kind provided"),
@@ -1366,12 +1373,15 @@ mod tests {
                     assert_eq!(counter_data.data_points.len(), 2);
                     assert!(counter_data.is_monotonic);
                     let zero_attribute_datapoint =
-                        find_datapoint_with_no_attributes(&counter_data.data_points)
+                        find_sum_datapoint_with_no_attributes(&counter_data.data_points)
                             .expect("datapoint with no attributes expected");
                     assert_eq!(zero_attribute_datapoint.value, 5);
-                    let data_point1 =
-                        find_datapoint_with_key_value(&counter_data.data_points, "key1", "value1")
-                            .expect("datapoint with key1=value1 expected");
+                    let data_point1 = find_sum_datapoint_with_key_value(
+                        &counter_data.data_points,
+                        "key1",
+                        "value1",
+                    )
+                    .expect("datapoint with key1=value1 expected");
                     assert_eq!(data_point1.value, 10);
                 }
                 "updown_counter" => {
@@ -1380,10 +1390,10 @@ mod tests {
                     assert_eq!(updown_counter_data.data_points.len(), 2);
                     assert!(!updown_counter_data.is_monotonic);
                     let zero_attribute_datapoint =
-                        find_datapoint_with_no_attributes(&updown_counter_data.data_points)
+                        find_sum_datapoint_with_no_attributes(&updown_counter_data.data_points)
                             .expect("datapoint with no attributes expected");
                     assert_eq!(zero_attribute_datapoint.value, 15);
-                    let data_point1 = find_datapoint_with_key_value(
+                    let data_point1 = find_sum_datapoint_with_key_value(
                         &updown_counter_data.data_points,
                         "key1",
                         "value1",
@@ -1396,12 +1406,15 @@ mod tests {
                         test_context.get_aggregation::<data::Gauge<u64>>("test_gauge", None);
                     assert_eq!(gauge_data.data_points.len(), 2);
                     let zero_attribute_datapoint =
-                        find_datapoint_with_no_attributes(&gauge_data.data_points)
+                        find_gauge_datapoint_with_no_attributes(&gauge_data.data_points)
                             .expect("datapoint with no attributes expected");
                     assert_eq!(zero_attribute_datapoint.value, 25);
-                    let data_point1 =
-                        find_datapoint_with_key_value(&gauge_data.data_points, "key1", "value1")
-                            .expect("datapoint with key1=value1 expected");
+                    let data_point1 = find_gauge_datapoint_with_key_value(
+                        &gauge_data.data_points,
+                        "key1",
+                        "value1",
+                    )
+                    .expect("datapoint with key1=value1 expected");
                     assert_eq!(data_point1.value, 30);
                 }
                 _ => panic!("Incorrect instrument kind provided"),
@@ -1970,12 +1983,12 @@ mod tests {
 
         // find and validate key1=value2 datapoint
         let data_point1 =
-            find_datapoint_with_key_value(&gauge_data_point.data_points, "key1", "value1")
+            find_gauge_datapoint_with_key_value(&gauge_data_point.data_points, "key1", "value1")
                 .expect("datapoint with key1=value1 expected");
         assert_eq!(data_point1.value, 4);
 
         let data_point1 =
-            find_datapoint_with_key_value(&gauge_data_point.data_points, "key1", "value2")
+            find_gauge_datapoint_with_key_value(&gauge_data_point.data_points, "key1", "value2")
                 .expect("datapoint with key1=value2 expected");
         assert_eq!(data_point1.value, 6);
 
@@ -1995,11 +2008,11 @@ mod tests {
 
         let gauge = test_context.get_aggregation::<data::Gauge<i64>>("my_gauge", None);
         assert_eq!(gauge.data_points.len(), 2);
-        let data_point1 = find_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
+        let data_point1 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
             .expect("datapoint with key1=value1 expected");
         assert_eq!(data_point1.value, 41);
 
-        let data_point1 = find_datapoint_with_key_value(&gauge.data_points, "key1", "value2")
+        let data_point1 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value2")
             .expect("datapoint with key1=value2 expected");
         assert_eq!(data_point1.value, 54);
     }
@@ -2029,18 +2042,19 @@ mod tests {
 
         if use_empty_attributes {
             // find and validate zero attribute datapoint
-            let zero_attribute_datapoint = find_datapoint_with_no_attributes(&gauge.data_points)
-                .expect("datapoint with no attributes expected");
+            let zero_attribute_datapoint =
+                find_gauge_datapoint_with_no_attributes(&gauge.data_points)
+                    .expect("datapoint with no attributes expected");
             assert_eq!(zero_attribute_datapoint.value, 1);
         }
 
         // find and validate key1=value1 datapoint
-        let data_point1 = find_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
+        let data_point1 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
             .expect("datapoint with key1=value1 expected");
         assert_eq!(data_point1.value, 4);
 
         // find and validate key2=value2 datapoint
-        let data_point2 = find_datapoint_with_key_value(&gauge.data_points, "key2", "value2")
+        let data_point2 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key2", "value2")
             .expect("datapoint with key2=value2 expected");
         assert_eq!(data_point2.value, 5);
 
@@ -2053,16 +2067,17 @@ mod tests {
         assert_eq!(gauge.data_points.len(), expected_time_series_count);
 
         if use_empty_attributes {
-            let zero_attribute_datapoint = find_datapoint_with_no_attributes(&gauge.data_points)
-                .expect("datapoint with no attributes expected");
+            let zero_attribute_datapoint =
+                find_gauge_datapoint_with_no_attributes(&gauge.data_points)
+                    .expect("datapoint with no attributes expected");
             assert_eq!(zero_attribute_datapoint.value, 1);
         }
 
-        let data_point1 = find_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
+        let data_point1 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
             .expect("datapoint with key1=value1 expected");
         assert_eq!(data_point1.value, 4);
 
-        let data_point2 = find_datapoint_with_key_value(&gauge.data_points, "key2", "value2")
+        let data_point2 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key2", "value2")
             .expect("datapoint with key2=value2 expected");
         assert_eq!(data_point2.value, 5);
     }
@@ -2101,11 +2116,11 @@ mod tests {
         }
 
         // find and validate key1=value2 datapoint
-        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "key1", "value1")
+        let data_point1 = find_sum_datapoint_with_key_value(&sum.data_points, "key1", "value1")
             .expect("datapoint with key1=value1 expected");
         assert_eq!(data_point1.value, 5);
 
-        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "key1", "value2")
+        let data_point1 = find_sum_datapoint_with_key_value(&sum.data_points, "key1", "value2")
             .expect("datapoint with key1=value2 expected");
         assert_eq!(data_point1.value, 3);
 
@@ -2125,7 +2140,7 @@ mod tests {
 
         let sum = test_context.get_aggregation::<data::Sum<u64>>("my_counter", None);
         assert_eq!(sum.data_points.len(), 2);
-        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "key1", "value1")
+        let data_point1 = find_sum_datapoint_with_key_value(&sum.data_points, "key1", "value1")
             .expect("datapoint with key1=value1 expected");
         if temporality == Temporality::Cumulative {
             assert_eq!(data_point1.value, 10);
@@ -2133,7 +2148,7 @@ mod tests {
             assert_eq!(data_point1.value, 5);
         }
 
-        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "key1", "value2")
+        let data_point1 = find_sum_datapoint_with_key_value(&sum.data_points, "key1", "value2")
             .expect("datapoint with key1=value2 expected");
         if temporality == Temporality::Cumulative {
             assert_eq!(data_point1.value, 6);
@@ -2169,12 +2184,12 @@ mod tests {
         assert_eq!(sum.data_points.len(), 2002);
 
         let data_point =
-            find_datapoint_with_key_value(&sum.data_points, "otel.metric.overflow", "true")
+            find_sum_datapoint_with_key_value(&sum.data_points, "otel.metric.overflow", "true")
                 .expect("overflow point expected");
         assert_eq!(data_point.value, 300);
 
         // let empty_attrs_data_point = &sum.data_points[0];
-        let empty_attrs_data_point = find_datapoint_with_no_attributes(&sum.data_points)
+        let empty_attrs_data_point = find_sum_datapoint_with_no_attributes(&sum.data_points)
             .expect("Empty attributes point expected");
         assert!(
             empty_attrs_data_point.attributes.is_empty(),
@@ -2300,11 +2315,11 @@ mod tests {
         );
 
         // find and validate key1=value2 datapoint
-        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "key1", "value1")
+        let data_point1 = find_sum_datapoint_with_key_value(&sum.data_points, "key1", "value1")
             .expect("datapoint with key1=value1 expected");
         assert_eq!(data_point1.value, 5);
 
-        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "key1", "value2")
+        let data_point1 = find_sum_datapoint_with_key_value(&sum.data_points, "key1", "value2")
             .expect("datapoint with key1=value2 expected");
         assert_eq!(data_point1.value, 7);
 
@@ -2324,20 +2339,20 @@ mod tests {
 
         let sum = test_context.get_aggregation::<data::Sum<i64>>("my_updown_counter", None);
         assert_eq!(sum.data_points.len(), 2);
-        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "key1", "value1")
+        let data_point1 = find_sum_datapoint_with_key_value(&sum.data_points, "key1", "value1")
             .expect("datapoint with key1=value1 expected");
         assert_eq!(data_point1.value, 10);
 
-        let data_point1 = find_datapoint_with_key_value(&sum.data_points, "key1", "value2")
+        let data_point1 = find_sum_datapoint_with_key_value(&sum.data_points, "key1", "value2")
             .expect("datapoint with key1=value2 expected");
         assert_eq!(data_point1.value, 14);
     }
 
-    fn find_datapoint_with_key_value<'a, T>(
-        data_points: &'a [DataPoint<T>],
+    fn find_sum_datapoint_with_key_value<'a, T>(
+        data_points: &'a [SumDataPoint<T>],
         key: &str,
         value: &str,
-    ) -> Option<&'a DataPoint<T>> {
+    ) -> Option<&'a SumDataPoint<T>> {
         data_points.iter().find(|&datapoint| {
             datapoint
                 .attributes
@@ -2346,7 +2361,30 @@ mod tests {
         })
     }
 
-    fn find_datapoint_with_no_attributes<T>(data_points: &[DataPoint<T>]) -> Option<&DataPoint<T>> {
+    fn find_gauge_datapoint_with_key_value<'a, T>(
+        data_points: &'a [GaugeDataPoint<T>],
+        key: &str,
+        value: &str,
+    ) -> Option<&'a GaugeDataPoint<T>> {
+        data_points.iter().find(|&datapoint| {
+            datapoint
+                .attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == key && kv.value.as_str() == value)
+        })
+    }
+
+    fn find_sum_datapoint_with_no_attributes<T>(
+        data_points: &[SumDataPoint<T>],
+    ) -> Option<&SumDataPoint<T>> {
+        data_points
+            .iter()
+            .find(|&datapoint| datapoint.attributes.is_empty())
+    }
+
+    fn find_gauge_datapoint_with_no_attributes<T>(
+        data_points: &[GaugeDataPoint<T>],
+    ) -> Option<&GaugeDataPoint<T>> {
         data_points
             .iter()
             .find(|&datapoint| datapoint.attributes.is_empty())

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -142,12 +142,12 @@ fn print_sum<T: Debug>(sum: &data::Sum<T>) {
     } else {
         println!("\t\tTemporality  : Delta");
     }
-    print_data_points(&sum.data_points);
+    print_sum_data_points(&sum.data_points);
 }
 
 fn print_gauge<T: Debug>(gauge: &data::Gauge<T>) {
     println!("\t\tGauge DataPoints");
-    print_data_points(&gauge.data_points);
+    print_gauge_data_points(&gauge.data_points);
 }
 
 fn print_histogram<T: Debug>(histogram: &data::Histogram<T>) {
@@ -160,7 +160,7 @@ fn print_histogram<T: Debug>(histogram: &data::Histogram<T>) {
     print_hist_data_points(&histogram.data_points);
 }
 
-fn print_data_points<T: Debug>(data_points: &[data::DataPoint<T>]) {
+fn print_sum_data_points<T: Debug>(data_points: &[data::SumDataPoint<T>]) {
     for (i, data_point) in data_points.iter().enumerate() {
         println!("\t\tDataPoint #{}", i);
         let datetime: DateTime<Utc> = data_point.start_time.into();
@@ -168,6 +168,29 @@ fn print_data_points<T: Debug>(data_points: &[data::DataPoint<T>]) {
             "\t\t\tStartTime    : {}",
             datetime.format("%Y-%m-%d %H:%M:%S%.6f")
         );
+        let datetime: DateTime<Utc> = data_point.time.into();
+        println!(
+            "\t\t\tEndTime      : {}",
+            datetime.format("%Y-%m-%d %H:%M:%S%.6f")
+        );
+        println!("\t\t\tValue        : {:#?}", data_point.value);
+        println!("\t\t\tAttributes   :");
+        for kv in data_point.attributes.iter() {
+            println!("\t\t\t\t ->  {}: {}", kv.key, kv.value.as_str());
+        }
+    }
+}
+
+fn print_gauge_data_points<T: Debug>(data_points: &[data::GaugeDataPoint<T>]) {
+    for (i, data_point) in data_points.iter().enumerate() {
+        println!("\t\tDataPoint #{}", i);
+        if let Some(start_time) = data_point.start_time {
+            let datetime: DateTime<Utc> = start_time.into();
+            println!(
+                "\t\t\tStartTime    : {}",
+                datetime.format("%Y-%m-%d %H:%M:%S%.6f")
+            );
+        }
         let datetime: DateTime<Utc> = data_point.time.into();
         println!(
             "\t\t\tEndTime      : {}",


### PR DESCRIPTION
Fixes #2387

## Changes

* cloned `DataPoint<T>` into two separate structs: `SumDataPoint<T>` and `GaugeDataPoint<T>`
* made `start_time` in `GaugeDataPoint<T>` optional

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
