### PR TITLE
Fix cargo bench on Windows, where pprof is not a accessible crate

### DIFF
--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -24,6 +24,7 @@ use opentelemetry_sdk::export::logs::LogBatch;
 use opentelemetry_sdk::logs::LogProcessor;
 use opentelemetry_sdk::logs::LogRecord;
 use opentelemetry_sdk::logs::LoggerProvider;
+#[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
 use std::fmt::Debug;
 

--- a/opentelemetry-sdk/benches/metrics_counter.rs
+++ b/opentelemetry-sdk/benches/metrics_counter.rs
@@ -19,6 +19,7 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
+#[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
 use rand::{
     rngs::{self},


### PR DESCRIPTION
## Changes

Just synced the project, did `cargo bench` and found tests not compiling due to unavailable on Windows `pprof` crate.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
