### PR TITLE
OTLP Example fixes

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -27,4 +27,4 @@ http-body-util = { workspace = true, optional = true  }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true, features = ["std"]}
 tracing-core = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std"] }
+tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }

--- a/opentelemetry-otlp/examples/basic-otlp-http/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp-http/README.md
@@ -18,6 +18,7 @@ making the `main()` a normal main and *not* `tokio::main`
 
 // TODO: Metrics does not work with non tokio main when using `reqwest-blocking-client` today, fix that when switching 
 // default to use own thread.
+// TODO: Document `hyper` feature flag when using SimpleProcessor.
 
 ## Usage
 

--- a/opentelemetry-otlp/examples/basic-otlp-http/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp-http/README.md
@@ -1,10 +1,23 @@
-# Basic OTLP exporter Example
+# Basic OTLP Exporter Example
 
-This example shows how to setup OpenTelemetry OTLP exporter for logs, metrics
-and traces to export them to the [OpenTelemetry
+This example demonstrates how to set up an OpenTelemetry OTLP exporter for logs,
+metrics, and traces to send data to the [OpenTelemetry
 Collector](https://github.com/open-telemetry/opentelemetry-collector) via OTLP
-over selected protocol such as HTTP/protobuf or HTTP/json. The Collector then sends the data to the appropriate
-backend, in this case, the logging Exporter, which displays data to console.
+over HTTP (using `protobuf` encoding by default but can be changed to use
+`json`). The Collector then forwards the data to the configured backend, which
+in this case is the logging exporter, displaying data on the console.
+Additionally, the example configures a `tracing::fmt` layer to output logs
+emitted via `tracing` to `stdout`. For demonstration, this layer uses a filter
+to display `DEBUG` level logs from various OpenTelemetry components. In real
+applications, these filters should be adjusted appropriately.
+
+The example employs a `BatchExporter` for logs and traces, which is the
+recommended approach when using OTLP exporters. While it can be modified to use
+a `SimpleExporter`, this requires enabling feature flag `reqwest-blocking-client` and
+making the `main()` a normal main and *not* `tokio::main`
+
+// TODO: Metrics does not work with non tokio main when using `reqwest-blocking-client` today, fix that when switching 
+// default to use own thread.
 
 ## Usage
 

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -43,7 +43,7 @@ fn init_logs() -> Result<sdklogs::LoggerProvider, opentelemetry_sdk::logs::LogEr
         .build())
 }
 
-fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
+fn init_traces() -> Result<sdktrace::TracerProvider, TraceError> {
     let exporter = SpanExporter::builder()
         .with_http()
         .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
@@ -71,7 +71,7 @@ fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, Metric
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let tracer_provider = init_tracer_provider()?;
+    let tracer_provider = init_traces()?;
     global::set_tracer_provider(tracer_provider.clone());
 
     let meter_provider = init_metrics()?;

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -71,51 +71,48 @@ fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, Metric
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let result = init_tracer_provider();
-    assert!(
-        result.is_ok(),
-        "Init tracer failed with error: {:?}",
-        result.err()
-    );
-
-    let tracer_provider = result.unwrap();
+    let tracer_provider = init_tracer_provider()?;
     global::set_tracer_provider(tracer_provider.clone());
 
-    let result = init_metrics();
-    assert!(
-        result.is_ok(),
-        "Init metrics failed with error: {:?}",
-        result.err()
-    );
-
-    let meter_provider = result.unwrap();
+    let meter_provider = init_metrics()?;
     global::set_meter_provider(meter_provider.clone());
 
-    // Opentelemetry will not provide a global API to manage the logger
-    // provider. Application users must manage the lifecycle of the logger
-    // provider on their own. Dropping logger providers will disable log
-    // emitting.
-    let logger_provider = init_logs().unwrap();
+    let logger_provider = init_logs()?;
 
     // Create a new OpenTelemetryTracingBridge using the above LoggerProvider.
-    let layer = OpenTelemetryTracingBridge::new(&logger_provider);
+    let otel_layer = OpenTelemetryTracingBridge::new(&logger_provider);
 
-    // Add a tracing filter to filter events from crates used by opentelemetry-otlp.
-    // The filter levels are set as follows:
+    // For the OpenTelemetry layer, add a tracing filter to filter events from
+    // OpenTelemetry and its dependent crates (opentelemetry-otlp uses crates
+    // like reqwest/tonic etc.) from being sent back to OTel itself, thus
+    // preventing infinite telemetry generation. The filter levels are set as
+    // follows:
     // - Allow `info` level and above by default.
-    // - Restrict `hyper`, `tonic`, and `reqwest` to `error` level logs only.
-    // This ensures events generated from these crates within the OTLP Exporter are not looped back,
-    // thus preventing infinite event generation.
-    // Note: This will also drop events from these crates used outside the OTLP Exporter.
-    // For more details, see: https://github.com/open-telemetry/opentelemetry-rust/issues/761
-    let filter = EnvFilter::new("info")
-        .add_directive("hyper=error".parse().unwrap())
-        .add_directive("tonic=error".parse().unwrap())
-        .add_directive("reqwest=error".parse().unwrap());
+    // - Restrict `opentelemetry`, `hyper`, `tonic`, and `reqwest` completely.
+    // Note: This will also drop events from crates like `tonic` etc. even when
+    // they are used outside the OTLP Exporter. For more details, see:
+    // https://github.com/open-telemetry/opentelemetry-rust/issues/761
+    let filter_otel = EnvFilter::new("info")
+        .add_directive("hyper=off".parse().unwrap())
+        .add_directive("opentelemetry=off".parse().unwrap())
+        .add_directive("tonic=off".parse().unwrap())
+        .add_directive("h2=off".parse().unwrap())
+        .add_directive("reqwest=off".parse().unwrap());
+    let otel_layer = otel_layer.with_filter(filter_otel);
 
+    // Create a new tracing::Fmt layer to print the logs to stdout. It has a
+    // default filter of `info` level and above, and `debug` and above for logs
+    // from OpenTelemtry crates. The filter levels can be customized as needed.
+    let filter_fmt = EnvFilter::new("info").add_directive("opentelemetry=debug".parse().unwrap());
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_thread_names(true)
+        .with_filter(filter_fmt);
+
+    // Initialize the tracing subscriber with the OpenTelemetry layer and the
+    // Fmt layer.
     tracing_subscriber::registry()
-        .with(filter)
-        .with(layer)
+        .with(otel_layer)
+        .with(fmt_layer)
         .init();
 
     let common_scope_attributes = vec![KeyValue::new("scope-key", "scope-value")];
@@ -158,7 +155,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     tracer_provider.shutdown()?;
     logger_provider.shutdown()?;
-    meter_provider.shutdown()?;
+    // meter_provider.shutdown()?;
 
     Ok(())
 }

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -155,7 +155,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     tracer_provider.shutdown()?;
     logger_provider.shutdown()?;
-    // meter_provider.shutdown()?;
+    meter_provider.shutdown()?;
 
     Ok(())
 }

--- a/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
@@ -15,4 +15,4 @@ tokio = { version = "1.0", features = ["full"] }
 opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}
 tracing = { workspace = true, features = ["std"]}
 tracing-core = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std"] }
+tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }

--- a/opentelemetry-otlp/examples/basic-otlp/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp/README.md
@@ -21,7 +21,7 @@ must be executed within a Tokio runtime. Below is an example:
 fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
      let rt = tokio::runtime::Runtime::new()?;
      let tracer_provider = rt.block_on(async {
-          init_tracer_provider()
+          init_traces()
      })?;
      global::set_tracer_provider(tracer_provider.clone());
 

--- a/opentelemetry-otlp/examples/basic-otlp/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp/README.md
@@ -14,8 +14,8 @@ The example employs a `BatchExporter` for logs and traces, which is the
 recommended approach when using OTLP exporters. While it can be modified to use
 a `SimpleExporter`, this requires the main method to be a `tokio::main` function
 since the `tonic` client requires a Tokio runtime. If you prefer not to use
-`tokio::main`, the `init_logs`, `init_traces`, and `init_metrics` functions
-should be executed within a Tokio runtime. Below is an example:
+`tokio::main`, then the `init_logs`, `init_traces`, and `init_metrics` functions
+must be executed within a Tokio runtime. Below is an example:
 
 ```rust
 fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {

--- a/opentelemetry-otlp/examples/basic-otlp/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp/README.md
@@ -1,10 +1,43 @@
-# Basic OTLP exporter Example
+# Basic OTLP Exporter Example
 
-This example shows how to setup OpenTelemetry OTLP exporter for logs, metrics
-and traces to exports them to the [OpenTelemetry
-Collector](https://github.com/open-telemetry/opentelemetry-collector) via OTLP over gRPC.
-The Collector then sends the data to the appropriate backend, in this case,
-the logging Exporter, which displays data to console.
+This example demonstrates how to set up an OpenTelemetry OTLP exporter for logs,
+metrics, and traces to send data to the [OpenTelemetry
+Collector](https://github.com/open-telemetry/opentelemetry-collector) via OTLP
+over gRPC. The Collector then forwards the data to the configured backend, which
+in this case is the logging exporter, displaying data on the console.
+Additionally, the example configures a `tracing::fmt` layer to output logs
+emitted via `tracing` to `stdout`. For demonstration, this layer uses a filter
+to display `DEBUG` level logs from various OpenTelemetry components. In real
+applications, these filters should be adjusted appropriately.
+
+The example employs a `BatchExporter` for logs and traces, which is the
+recommended approach when using OTLP exporters. While it can be modified to use
+a `SimpleExporter`, this requires the main method to be a `tokio::main` function
+since the `tonic` client requires a Tokio runtime. If you prefer not to use
+`tokio::main`, the `init_logs`, `init_traces`, and `init_metrics` functions
+should be executed within a Tokio runtime. Below is an example:
+
+```rust
+fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+     let rt = tokio::runtime::Runtime::new()?;
+     let tracer_provider = rt.block_on(async {
+          init_tracer_provider()
+     })?;
+     global::set_tracer_provider(tracer_provider.clone());
+
+     let meter_provider = rt.block_on(async {
+          init_metrics()
+     })?;
+     global::set_meter_provider(meter_provider.clone());
+
+     let logger_provider = rt.block_on(async {
+          init_logs()
+     })?;
+
+     // Ensure the runtime (`rt`) remains active until the program ends
+     // Additional code goes here...
+}
+```
 
 ## Usage
 

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -57,50 +57,48 @@ fn init_logs() -> Result<opentelemetry_sdk::logs::LoggerProvider, LogError> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    // By binding the result to an unused variable, the lifetime of the variable
-    // matches the containing block, reporting traces and metrics during the whole
-    // execution.
-
-    let result = init_tracer_provider();
-    assert!(
-        result.is_ok(),
-        "Init tracer failed with error: {:?}",
-        result.err()
-    );
-    let tracer_provider = result.unwrap();
+    let tracer_provider = init_tracer_provider()?;
     global::set_tracer_provider(tracer_provider.clone());
 
-    let result = init_metrics();
-    assert!(
-        result.is_ok(),
-        "Init metrics failed with error: {:?}",
-        result.err()
-    );
-    let meter_provider = result.unwrap();
+    let meter_provider = init_metrics()?;
     global::set_meter_provider(meter_provider.clone());
 
-    // Initialize logs and save the logger_provider.
-    let logger_provider = init_logs().unwrap();
+    let logger_provider = init_logs()?;
 
     // Create a new OpenTelemetryTracingBridge using the above LoggerProvider.
-    let layer = OpenTelemetryTracingBridge::new(&logger_provider);
+    let otel_layer = OpenTelemetryTracingBridge::new(&logger_provider);
 
-    // Add a tracing filter to filter events from crates used by opentelemetry-otlp.
-    // The filter levels are set as follows:
+    // For the OpenTelemetry layer, add a tracing filter to filter events from
+    // OpenTelemetry and its dependent crates (opentelemetry-otlp uses crates
+    // like reqwest/tonic etc.) from being sent back to OTel itself, thus
+    // preventing infinite telemetry generation. The filter levels are set as
+    // follows:
     // - Allow `info` level and above by default.
-    // - Restrict `hyper`, `tonic`, and `reqwest` to `error` level logs only.
-    // This ensures events generated from these crates within the OTLP Exporter are not looped back,
-    // thus preventing infinite event generation.
-    // Note: This will also drop events from these crates used outside the OTLP Exporter.
-    // For more details, see: https://github.com/open-telemetry/opentelemetry-rust/issues/761
-    let filter = EnvFilter::new("info")
-        .add_directive("hyper=error".parse().unwrap())
-        .add_directive("tonic=error".parse().unwrap())
-        .add_directive("reqwest=error".parse().unwrap());
+    // - Restrict `opentelemetry`, `hyper`, `tonic`, and `reqwest` completely.
+    // Note: This will also drop events from crates like `tonic` etc. even when
+    // they are used outside the OTLP Exporter. For more details, see:
+    // https://github.com/open-telemetry/opentelemetry-rust/issues/761
+    let filter_otel = EnvFilter::new("info")
+        .add_directive("hyper=off".parse().unwrap())
+        .add_directive("opentelemetry=off".parse().unwrap())
+        .add_directive("tonic=off".parse().unwrap())
+        .add_directive("h2=off".parse().unwrap())
+        .add_directive("reqwest=off".parse().unwrap());
+    let otel_layer = otel_layer.with_filter(filter_otel);
 
+    // Create a new tracing::Fmt layer to print the logs to stdout. It has a
+    // default filter of `info` level and above, and `debug` and above for logs
+    // from OpenTelemtry crates. The filter levels can be customized as needed.
+    let filter_fmt = EnvFilter::new("info").add_directive("opentelemetry=debug".parse().unwrap());
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_thread_names(true)
+        .with_filter(filter_fmt);
+
+    // Initialize the tracing subscriber with the OpenTelemetry layer and the
+    // Fmt layer.
     tracing_subscriber::registry()
-        .with(filter)
-        .with(layer)
+        .with(otel_layer)
+        .with(fmt_layer)
         .init();
 
     let common_scope_attributes = vec![KeyValue::new("scope-key", "scope-value")];

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -21,7 +21,7 @@ static RESOURCE: Lazy<Resource> = Lazy::new(|| {
     )])
 });
 
-fn init_tracer_provider() -> Result<sdktrace::TracerProvider, TraceError> {
+fn init_traces() -> Result<sdktrace::TracerProvider, TraceError> {
     let exporter = SpanExporter::builder()
         .with_tonic()
         .with_endpoint("http://localhost:4317")
@@ -57,7 +57,7 @@ fn init_logs() -> Result<opentelemetry_sdk::logs::LoggerProvider, LogError> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let tracer_provider = init_tracer_provider()?;
+    let tracer_provider = init_traces()?;
     global::set_tracer_provider(tracer_provider.clone());
 
     let meter_provider = init_metrics()?;


### PR DESCRIPTION
Fixes a few small, but important things
1. Modifies both OTLP Examples to filter out (completely) logs from OTel/known dependencies, from being routed to OTel itself. This prevents infinite logging and also deadlocks when using SimpleProcessors.
2. Both examples modified to show how to use the `tracing::fmt` layer along with above. This demonstrates how one can view OTel's own internal logs in stdout using `tracing::fmt`. We intend to eliminate the self-diagnostics example, as that is now redundant. (The actual removal is in a future PR, after making sure we have everything covered.)
3. Adds doc on how to use SimpleExportProcessor for logs, traces, closing https://github.com/open-telemetry/opentelemetry-rust/issues/2188

(Some of these are in prep to land https://github.com/open-telemetry/opentelemetry-rust/issues/2386 )