### PR TITLE
Remove Deprecated Logger Method

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -18,6 +18,12 @@
      async fn export(&self, _batch: LogBatch<'_>) -> LogResult<()>
   Custom exporters will need to internally synchronize any mutable state, if applicable.
 
+- *Breaking* Removed the following deprecated methods:
+  - `Logger::provider()` : Previously deprecated in version 0.27.1
+  - `Logger::instrumentation_scope()` : Previously deprecated in version 0.27.1.
+     Migration Guidance: 
+        - These methods were intended for log appenders. Keep the clone of the provider handle, instead of depending on above methods.
+
 ## 0.27.1
 
 Released 2024-Nov-27

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -257,21 +257,8 @@ impl Logger {
         Logger { scope, provider }
     }
 
-    #[deprecated(
-        since = "0.27.1",
-        note = "This method was intended for appender developers, but has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
-    )]
-    /// LoggerProvider associated with this logger.
-    pub fn provider(&self) -> &LoggerProvider {
-        &self.provider
-    }
-
-    #[deprecated(
-        since = "0.27.1",
-        note = "This method was intended for appender developers, but has no defined use-case in typical workflows. It is deprecated and will be removed in the next major release."
-    )]
-    /// Instrumentation scope of this logger.
-    pub fn instrumentation_scope(&self) -> &InstrumentationScope {
+    #[cfg(test)]
+    pub(crate) fn instrumentation_scope(&self) -> &InstrumentationScope {
         &self.scope
     }
 }


### PR DESCRIPTION
## Changes

These methods were deprecated in 0.27.1 release with PR #2349 

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
