### PR TITLE
Remov deprecated LogData structure

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -18,6 +18,10 @@
      async fn export(&self, _batch: LogBatch<'_>) -> LogResult<()>
   Custom exporters will need to internally synchronize any mutable state, if applicable.
 
+- *Breaking* Removed the following deprecated methods:
+  - logs::LogData - Previously deprecated in version 0.27.1
+  Migration Guidance: This structure is no longer utilized within the SDK, and users should not have dependencies on it.
+  
 ## 0.27.1
 
 Released 2024-Nov-27

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -18,10 +18,10 @@
      async fn export(&self, _batch: LogBatch<'_>) -> LogResult<()>
   Custom exporters will need to internally synchronize any mutable state, if applicable.
 
-- *Breaking* Removed the following deprecated methods:
+- *Breaking* Removed the following deprecated struct:
   - logs::LogData - Previously deprecated in version 0.27.1
   Migration Guidance: This structure is no longer utilized within the SDK, and users should not have dependencies on it.
-  
+
 ## 0.27.1
 
 Released 2024-Nov-27

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -10,21 +10,7 @@ pub use log_processor::{
     BatchConfig, BatchConfigBuilder, BatchLogProcessor, BatchLogProcessorBuilder, LogProcessor,
     SimpleLogProcessor,
 };
-use opentelemetry::InstrumentationScope;
 pub use record::{LogRecord, TraceContext};
-
-#[deprecated(
-    since = "0.27.1",
-    note = "The struct is not used anywhere in the SDK and will be removed in the next major release."
-)]
-/// `LogData` represents a single log event without resource context.
-#[derive(Clone, Debug)]
-pub struct LogData {
-    /// Log record
-    pub record: LogRecord,
-    /// Instrumentation details for the emitter who produced this `LogEvent`.
-    pub instrumentation: InstrumentationScope,
-}
 
 #[cfg(all(test, feature = "testing"))]
 mod tests {
@@ -33,6 +19,7 @@ mod tests {
     use crate::Resource;
     use opentelemetry::logs::LogRecord;
     use opentelemetry::logs::{Logger, LoggerProvider as _, Severity};
+    use opentelemetry::InstrumentationScope;
     use opentelemetry::{logs::AnyValue, Key, KeyValue};
     use std::borrow::Borrow;
     use std::collections::HashMap;


### PR DESCRIPTION
## Changes

This struct was deprecated in 0.27.1 release with PR #2325 

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
