### PR TITLE
sdk: set correct span limit in builder

### DIFF
--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -336,7 +336,7 @@ impl Builder {
 
     /// Specify the number of events to be recorded per span.
     pub fn with_max_events_per_span(mut self, max_events: u32) -> Self {
-        self.config.span_limits.max_attributes_per_span = max_events;
+        self.config.span_limits.max_events_per_span = max_events;
         self
     }
 


### PR DESCRIPTION
#2303 refactored the `TracerProvider` builder to deprecate the `Config` API. I like the API changes this resulted in, but the `Builder::max_events_per_span()` method sets the incorrect `span_limits.max_attributes_per_span` field.
