### PR TITLE
Upgrade to thiserror 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ reqwest = { version = "0.12", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0"
 temp-env = "0.3.6"
-thiserror = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false }
 tonic = { version = "0.12.3", default-features = false }
 tonic-build = "0.12"
 tokio = { version = "1", default-features = false }

--- a/opentelemetry-sdk/src/logs/error.rs
+++ b/opentelemetry-sdk/src/logs/error.rs
@@ -11,7 +11,7 @@ pub type LogResult<T> = Result<T, LogError>;
 /// Errors returned by the log SDK.
 pub enum LogError {
     /// Export failed with the error returned by the exporter.
-    #[error("Exporter {} encountered the following errors: {0}", .0.exporter_name())]
+    #[error("Exporter {0} encountered the following errors: {name}", name = .0.exporter_name())]
     ExportFailed(Box<dyn ExportError>),
 
     /// Export failed to finish after certain period and processor stopped the export.

--- a/opentelemetry-sdk/src/metrics/error.rs
+++ b/opentelemetry-sdk/src/metrics/error.rs
@@ -18,7 +18,7 @@ pub enum MetricError {
     #[error("Config error {0}")]
     Config(String),
     /// Fail to export metrics
-    #[error("Metrics exporter {} failed with {0}", .0.exporter_name())]
+    #[error("Metrics exporter {0} failed with {name}", name = .0.exporter_name())]
     ExportErr(Box<dyn ExportError>),
     /// Invalid instrument configuration such invalid instrument name, invalid instrument description, invalid instrument unit, etc.
     /// See [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#general-characteristics)

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -205,7 +205,7 @@ pub type TraceResult<T> = Result<T, TraceError>;
 #[non_exhaustive]
 pub enum TraceError {
     /// Export failed with the error returned by the exporter
-    #[error("Exporter {} encountered the following error(s): {0}", .0.exporter_name())]
+    #[error("Exporter {0} encountered the following error(s): {name}", name = .0.exporter_name())]
     ExportFailed(Box<dyn ExportError>),
 
     /// Export failed to finish after certain period and processor stopped the export.


### PR DESCRIPTION
The minimal version for thiserror (`1`) was too low, resulting in build failures with `-Z minimal-versions`. Upgrade to thiserror 2 instead of trying to pinpoint a better minimal version.