### PR TITLE
fix: missing `thiserror` crate when building with `--no-default-features`

### DIFF
--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -24,7 +24,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 futures-core = { workspace = true, optional = true }
 futures-sink = { version = "0.3", optional = true }
 pin-project-lite = { workspace = true, optional = true }
-thiserror = { workspace = true, optional = true}
+thiserror = { workspace = true }
 tracing = {workspace = true, optional = true} # optional for opentelemetry internal logging
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
@@ -32,7 +32,7 @@ js-sys = "0.3.63"
 
 [features]
 default = ["trace", "metrics", "logs", "internal-logs"]
-trace = ["pin-project-lite", "futures-sink", "futures-core", "thiserror"]
+trace = ["pin-project-lite", "futures-sink", "futures-core"]
 metrics = []
 testing = ["trace", "metrics"]
 logs = []


### PR DESCRIPTION
Building with `cargo check -p opentelemetry --no-default-features` fails since `thiserror` is optional.


## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
