### PR TITLE
Minor fixes to PeriodicReader and examples

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -15,7 +15,7 @@ experimental_metrics_periodicreader_with_async_runtime = ["opentelemetry_sdk/exp
 [dependencies]
 once_cell = { workspace = true }
 opentelemetry = { path = "../../../opentelemetry" }
-opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "metrics", "logs", "experimental_metrics_periodicreader_with_async_runtime"]}
+opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "experimental_metrics_periodicreader_with_async_runtime"]}
 opentelemetry-http = { path = "../../../opentelemetry-http", optional = true, default-features = false}
 opentelemetry-otlp = { path = "../..", features = ["http-proto", "http-json", "logs"] , default-features = false}
 opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -82,12 +82,6 @@ fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, Metric
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let tracer_provider = init_traces()?;
-    global::set_tracer_provider(tracer_provider.clone());
-
-    let meter_provider = init_metrics()?;
-    global::set_meter_provider(meter_provider.clone());
-
     let logger_provider = init_logs()?;
 
     // Create a new OpenTelemetryTracingBridge using the above LoggerProvider.
@@ -125,6 +119,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .with(otel_layer)
         .with(fmt_layer)
         .init();
+
+    let tracer_provider = init_traces()?;
+    global::set_tracer_provider(tracer_provider.clone());
+
+    let meter_provider = init_metrics()?;
+    global::set_meter_provider(meter_provider.clone());
 
     let common_scope_attributes = vec![KeyValue::new("scope-key", "scope-value")];
     let scope = InstrumentationScope::builder("basic")

--- a/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 once_cell = { workspace = true }
-opentelemetry = { path = "../../../opentelemetry", features = ["metrics", "logs"] }
-opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "logs"] }
-opentelemetry-otlp = { path = "../../../opentelemetry-otlp", features = ["tonic", "metrics", "logs"] }
+opentelemetry = { path = "../../../opentelemetry" }
+opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio"] }
+opentelemetry-otlp = { path = "../../../opentelemetry-otlp" }
 opentelemetry-semantic-conventions = { path = "../../../opentelemetry-semantic-conventions" }
 tokio = { version = "1.0", features = ["full"] }
 opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}

--- a/opentelemetry-otlp/examples/basic-otlp/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp/README.md
@@ -14,8 +14,16 @@ The example employs a `BatchExporter` for logs and traces, which is the
 recommended approach when using OTLP exporters. While it can be modified to use
 a `SimpleExporter`, this requires the main method to be a `tokio::main` function
 since the `tonic` client requires a Tokio runtime. If you prefer not to use
-`tokio::main`, then the `init_logs`, `init_traces`, and `init_metrics` functions
-must be executed within a Tokio runtime. Below is an example:
+`tokio::main`, then the `init_logs` and `init_traces` functions must be executed
+within a Tokio runtime. 
+
+This examples uses the default `PeriodicReader` for metrics, which uses own
+thread for background processing/exporting. Since the `tonic` client requires a
+Tokio runtime, the main method must be a `tokio::main` function. If you prefer not
+to use `tokio::main`, then the `init_metrics` function must be executed within a
+Tokio runtime.
+
+Below is an example on how to use non `tokio::main`:
 
 ```rust
 fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -56,12 +56,6 @@ fn init_logs() -> Result<opentelemetry_sdk::logs::LoggerProvider, LogError> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let tracer_provider = init_traces()?;
-    global::set_tracer_provider(tracer_provider.clone());
-
-    let meter_provider = init_metrics()?;
-    global::set_meter_provider(meter_provider.clone());
-
     let logger_provider = init_logs()?;
 
     // Create a new OpenTelemetryTracingBridge using the above LoggerProvider.
@@ -99,6 +93,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .with(otel_layer)
         .with(fmt_layer)
         .init();
+
+    let tracer_provider = init_traces()?;
+    global::set_tracer_provider(tracer_provider.clone());
+
+    let meter_provider = init_metrics()?;
+    global::set_meter_provider(meter_provider.clone());
 
     let common_scope_attributes = vec![KeyValue::new("scope-key", "scope-value")];
     let scope = InstrumentationScope::builder("basic")

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -344,7 +344,9 @@ impl PeriodicReaderInner {
             return Ok(());
         }
 
-        let metrics_count = rm.scope_metrics.iter().fold(0, | count, scope_metrics | count + scope_metrics.metrics.len());
+        let metrics_count = rm.scope_metrics.iter().fold(0, |count, scope_metrics| {
+            count + scope_metrics.metrics.len()
+        });
         otel_debug!(name: "PeriodicReaderMetricsCollected", count = metrics_count);
 
         // TODO: substract the time taken for collect from the timeout. collect

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -175,8 +175,8 @@ impl PeriodicReader {
                 let mut remaining_interval = interval;
                 otel_info!(
                     name: "PeriodReaderThreadStarted",
-                    interval_in_secs = interval.as_secs(),
-                    timeout_in_secs = timeout.as_secs()
+                    interval_in_millisecs = interval.as_millis(),
+                    timeout_in_millisecs = timeout.as_millis()
                 );
                 loop {
                     otel_debug!(
@@ -344,7 +344,8 @@ impl PeriodicReaderInner {
             return Ok(());
         }
 
-        otel_debug!(name: "PeriodicReaderMetricsCollected", count = rm.scope_metrics.len());
+        let metrics_count = rm.scope_metrics.iter().fold(0, | count, scope_metrics | count + scope_metrics.metrics.len());
+        otel_debug!(name: "PeriodicReaderMetricsCollected", count = metrics_count);
 
         // TODO: substract the time taken for collect from the timeout. collect
         // involves observable callbacks too, which are user defined and can


### PR DESCRIPTION
Cleanup unwanted duplicate attributes from internal logs
Example - re-order initialization to ensure Logs are initialized first, so we can see internal logs from metric/trace provider initialization.
Remove unwanted feature flags.