### PR TITLE
Move time from DataPoint to Histogram/ExpoHistogram

### DIFF
--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -230,8 +230,8 @@ pub mod tonic {
                     .iter()
                     .map(|dp| TonicHistogramDataPoint {
                         attributes: dp.attributes.iter().map(Into::into).collect(),
-                        start_time_unix_nano: to_nanos(dp.start_time),
-                        time_unix_nano: to_nanos(dp.time),
+                        start_time_unix_nano: to_nanos(hist.start_time),
+                        time_unix_nano: to_nanos(hist.time),
                         count: dp.count,
                         sum: Some(dp.sum.into_f64()),
                         bucket_counts: dp.bucket_counts.clone(),
@@ -258,8 +258,8 @@ pub mod tonic {
                     .iter()
                     .map(|dp| TonicExponentialHistogramDataPoint {
                         attributes: dp.attributes.iter().map(Into::into).collect(),
-                        start_time_unix_nano: to_nanos(dp.start_time),
-                        time_unix_nano: to_nanos(dp.time),
+                        start_time_unix_nano: to_nanos(hist.start_time),
+                        time_unix_nano: to_nanos(hist.time),
                         count: dp.count as u64,
                         sum: Some(dp.sum.into_f64()),
                         scale: dp.scale.into(),

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -147,6 +147,10 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Sum<T> {
 pub struct Histogram<T> {
     /// Individual aggregated measurements with unique attributes.
     pub data_points: Vec<HistogramDataPoint<T>>,
+    /// The time when the time series was started.
+    pub start_time: SystemTime,
+    /// The time when the time series was recorded.
+    pub time: SystemTime,
     /// Describes if the aggregation is reported as the change from the last report
     /// time, or the cumulative changes since a fixed start time.
     pub temporality: Temporality,
@@ -166,11 +170,6 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Histogram<T> {
 pub struct HistogramDataPoint<T> {
     /// The set of key value pairs that uniquely identify the time series.
     pub attributes: Vec<KeyValue>,
-    /// The time when the time series was started.
-    pub start_time: SystemTime,
-    /// The time when the time series was recorded.
-    pub time: SystemTime,
-
     /// The number of updates this histogram has been calculated with.
     pub count: u64,
     /// The upper bounds of the buckets of the histogram.
@@ -195,8 +194,6 @@ impl<T: Copy> Clone for HistogramDataPoint<T> {
     fn clone(&self) -> Self {
         Self {
             attributes: self.attributes.clone(),
-            start_time: self.start_time,
-            time: self.time,
             count: self.count,
             bounds: self.bounds.clone(),
             bucket_counts: self.bucket_counts.clone(),
@@ -213,7 +210,10 @@ impl<T: Copy> Clone for HistogramDataPoint<T> {
 pub struct ExponentialHistogram<T> {
     /// The individual aggregated measurements with unique attributes.
     pub data_points: Vec<ExponentialHistogramDataPoint<T>>,
-
+    /// When the time series was started.
+    pub start_time: SystemTime,
+    /// The time when the time series was recorded.
+    pub time: SystemTime,
     /// Describes if the aggregation is reported as the change from the last report
     /// time, or the cumulative changes since a fixed start time.
     pub temporality: Temporality,
@@ -233,10 +233,6 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for ExponentialHistogram
 pub struct ExponentialHistogramDataPoint<T> {
     /// The set of key value pairs that uniquely identify the time series.
     pub attributes: Vec<KeyValue>,
-    /// When the time series was started.
-    pub start_time: SystemTime,
-    /// The time when the time series was recorded.
-    pub time: SystemTime,
 
     /// The number of updates this histogram has been calculated with.
     pub count: usize,
@@ -281,8 +277,6 @@ impl<T: Copy> Clone for ExponentialHistogramDataPoint<T> {
     fn clone(&self) -> Self {
         Self {
             attributes: self.attributes.clone(),
-            start_time: self.start_time,
-            time: self.time,
             count: self.count,
             min: self.min,
             max: self.max,
@@ -375,8 +369,6 @@ mod tests {
 
         let histogram_data_point = HistogramDataPoint {
             attributes: vec![KeyValue::new("key", "value")],
-            start_time: std::time::SystemTime::now(),
-            time: std::time::SystemTime::now(),
             count: 0,
             bounds: vec![],
             bucket_counts: vec![],
@@ -395,8 +387,6 @@ mod tests {
 
         let exponential_histogram_data_point = ExponentialHistogramDataPoint {
             attributes: vec![KeyValue::new("key", "value")],
-            start_time: std::time::SystemTime::now(),
-            time: std::time::SystemTime::now(),
             count: 0,
             min: None,
             max: None,

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -314,8 +314,6 @@ mod tests {
             let mut a = Histogram {
                 data_points: vec![HistogramDataPoint {
                     attributes: vec![KeyValue::new("a1", 1)],
-                    start_time: SystemTime::now(),
-                    time: SystemTime::now(),
                     count: 2,
                     bounds: vec![1.0, 2.0],
                     bucket_counts: vec![0, 1, 1],
@@ -324,6 +322,8 @@ mod tests {
                     sum: 3u64,
                     exemplars: vec![],
                 }],
+                start_time: SystemTime::now(),
+                time: SystemTime::now(),
                 temporality: if temporality == Temporality::Delta {
                     Temporality::Cumulative
                 } else {
@@ -357,8 +357,6 @@ mod tests {
             let mut a = ExponentialHistogram {
                 data_points: vec![ExponentialHistogramDataPoint {
                     attributes: vec![KeyValue::new("a1", 1)],
-                    start_time: SystemTime::now(),
-                    time: SystemTime::now(),
                     count: 2,
                     min: None,
                     max: None,
@@ -376,6 +374,8 @@ mod tests {
                     zero_threshold: 1.0,
                     exemplars: vec![],
                 }],
+                start_time: SystemTime::now(),
+                time: SystemTime::now(),
                 temporality: if temporality == Temporality::Delta {
                     Temporality::Cumulative
                 } else {

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -109,11 +109,18 @@ impl<T: Number> Histogram<T> {
         &self,
         dest: Option<&mut dyn Aggregation>,
     ) -> (usize, Option<Box<dyn Aggregation>>) {
-        let t = SystemTime::now();
+        let time = SystemTime::now();
+        let start_time = self
+            .start
+            .lock()
+            .map(|mut start| replace(start.deref_mut(), time))
+            .unwrap_or(time);
         let h = dest.and_then(|d| d.as_mut().downcast_mut::<data::Histogram<T>>());
         let mut new_agg = if h.is_none() {
             Some(data::Histogram {
                 data_points: vec![],
+                start_time,
+                time,
                 temporality: Temporality::Delta,
             })
         } else {
@@ -121,20 +128,14 @@ impl<T: Number> Histogram<T> {
         };
         let h = h.unwrap_or_else(|| new_agg.as_mut().expect("present if h is none"));
         h.temporality = Temporality::Delta;
-
-        let prev_start = self
-            .start
-            .lock()
-            .map(|mut start| replace(start.deref_mut(), t))
-            .unwrap_or(t);
+        h.start_time = start_time;
+        h.time = time;
 
         self.value_map
             .collect_and_reset(&mut h.data_points, |attributes, aggr| {
                 let b = aggr.into_inner().unwrap_or_else(|err| err.into_inner());
                 HistogramDataPoint {
                     attributes,
-                    start_time: prev_start,
-                    time: t,
                     count: b.count,
                     bounds: self.bounds.clone(),
                     bucket_counts: b.counts,
@@ -164,11 +165,19 @@ impl<T: Number> Histogram<T> {
         &self,
         dest: Option<&mut dyn Aggregation>,
     ) -> (usize, Option<Box<dyn Aggregation>>) {
-        let t = SystemTime::now();
+        let time = SystemTime::now();
+        let start_time = self
+            .start
+            .lock()
+            .map(|s| *s)
+            .unwrap_or_else(|_| SystemTime::now());
+
         let h = dest.and_then(|d| d.as_mut().downcast_mut::<data::Histogram<T>>());
         let mut new_agg = if h.is_none() {
             Some(data::Histogram {
                 data_points: vec![],
+                start_time,
+                time,
                 temporality: Temporality::Cumulative,
             })
         } else {
@@ -176,20 +185,14 @@ impl<T: Number> Histogram<T> {
         };
         let h = h.unwrap_or_else(|| new_agg.as_mut().expect("present if h is none"));
         h.temporality = Temporality::Cumulative;
-
-        let prev_start = self
-            .start
-            .lock()
-            .map(|s| *s)
-            .unwrap_or_else(|_| SystemTime::now());
+        h.start_time = start_time;
+        h.time = time;
 
         self.value_map
             .collect_readonly(&mut h.data_points, |attributes, aggr| {
                 let b = aggr.lock().unwrap_or_else(|err| err.into_inner());
                 HistogramDataPoint {
                     attributes,
-                    start_time: prev_start,
-                    time: t,
                     count: b.count,
                     bounds: self.bounds.clone(),
                     bucket_counts: b.counts.clone(),

--- a/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/testing/metrics/in_memory_exporter.rs
@@ -195,16 +195,22 @@ impl InMemoryMetricExporter {
         if let Some(hist) = data.as_any().downcast_ref::<Histogram<i64>>() {
             Some(Box::new(Histogram {
                 data_points: hist.data_points.clone(),
+                start_time: hist.start_time,
+                time: hist.time,
                 temporality: hist.temporality,
             }))
         } else if let Some(hist) = data.as_any().downcast_ref::<Histogram<f64>>() {
             Some(Box::new(Histogram {
                 data_points: hist.data_points.clone(),
+                start_time: hist.start_time,
+                time: hist.time,
                 temporality: hist.temporality,
             }))
         } else if let Some(hist) = data.as_any().downcast_ref::<Histogram<u64>>() {
             Some(Box::new(Histogram {
                 data_points: hist.data_points.clone(),
+                start_time: hist.start_time,
+                time: hist.time,
                 temporality: hist.temporality,
             }))
         } else if let Some(sum) = data.as_any().downcast_ref::<data::Sum<i64>>() {

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -160,13 +160,13 @@ fn print_gauge<T: Debug>(gauge: &data::Gauge<T>) {
     if let Some(start_time) = gauge.start_time {
         let datetime: DateTime<Utc> = start_time.into();
         println!(
-            "\t\t\tStartTime    : {}",
+            "\t\tStartTime    : {}",
             datetime.format("%Y-%m-%d %H:%M:%S%.6f")
         );
     }
     let datetime: DateTime<Utc> = gauge.time.into();
     println!(
-        "\t\t\tEndTime      : {}",
+        "\t\tEndTime      : {}",
         datetime.format("%Y-%m-%d %H:%M:%S%.6f")
     );
     print_gauge_data_points(&gauge.data_points);
@@ -178,6 +178,16 @@ fn print_histogram<T: Debug>(histogram: &data::Histogram<T>) {
     } else {
         println!("\t\tTemporality  : Delta");
     }
+    let datetime: DateTime<Utc> = histogram.start_time.into();
+    println!(
+        "\t\tStartTime    : {}",
+        datetime.format("%Y-%m-%d %H:%M:%S%.6f")
+    );
+    let datetime: DateTime<Utc> = histogram.time.into();
+    println!(
+        "\t\tEndTime      : {}",
+        datetime.format("%Y-%m-%d %H:%M:%S%.6f")
+    );
     println!("\t\tHistogram DataPoints");
     print_hist_data_points(&histogram.data_points);
 }
@@ -207,16 +217,6 @@ fn print_gauge_data_points<T: Debug>(data_points: &[data::GaugeDataPoint<T>]) {
 fn print_hist_data_points<T: Debug>(data_points: &[data::HistogramDataPoint<T>]) {
     for (i, data_point) in data_points.iter().enumerate() {
         println!("\t\tDataPoint #{}", i);
-        let datetime: DateTime<Utc> = data_point.start_time.into();
-        println!(
-            "\t\t\tStartTime    : {}",
-            datetime.format("%Y-%m-%d %H:%M:%S%.6f")
-        );
-        let datetime: DateTime<Utc> = data_point.time.into();
-        println!(
-            "\t\t\tEndTime      : {}",
-            datetime.format("%Y-%m-%d %H:%M:%S%.6f")
-        );
         println!("\t\t\tCount        : {}", data_point.count);
         println!("\t\t\tSum          : {:?}", data_point.sum);
         if let Some(min) = &data_point.min {


### PR DESCRIPTION
Fixes #1566.

## Changes

Move `time` and `start_time` fields from `DataPoint` to specific aggregations, - `Histogram` and `ExponentialHistogram`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
