### PR TITLE
Enable Feature in otlp http example

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 publish = false
 
 [features]
-default = ["reqwest"]
+default = ["reqwest", "experimental_metrics_periodicreader_with_async_runtime"]
 reqwest = ["opentelemetry-otlp/reqwest-client"]
 hyper = ["opentelemetry-otlp/hyper-client"]
 experimental_metrics_periodicreader_with_async_runtime = ["opentelemetry_sdk/experimental_metrics_periodicreader_with_async_runtime"]


### PR DESCRIPTION
As of now, HTTP Exporter does not work without the experimental feature flag, so enabling it by default until this is fixed.