### PR TITLE
Version pinning for tracing and tracing-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,10 @@ tonic = { version = "0.12.3", default-features = false }
 tonic-build = "0.12"
 tokio = { version = "1", default-features = false }
 tokio-stream = "0.1"
-# Using `tracing 0.1.39` because it introduces the ability to set event names in macros, 
-# required for OpenTelemetry's internal logging macros. Falling back to 0.1.40 or later if unavailable.
-tracing = { version = ">=0.1.39", default-features = false }
-tracing-core = { version = ">=0.1.33", default-features = false } # tracing 0.1.40 needs tracing-core 0.1.33 and above
+# Using `tracing 0.1.40` because 0.1.39 (which is yanked) introduces the ability to set event names in macros, 
+# required for OpenTelemetry's internal logging macros.
+tracing = { version = ">=0.1.40", default-features = false }
+# `tracing-core >=0.1.33` is required for compatibility with `tracing >=0.1.40`.
+tracing-core = { version = ">=0.1.33", default-features = false } 
 tracing-subscriber = { version = "0.3", default-features = false }
 url = { version = "2.5.2", default-features = false } #https://github.com/servo/rust-url/issues/992

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,9 @@ tonic = { version = "0.12.3", default-features = false }
 tonic-build = "0.12"
 tokio = { version = "1", default-features = false }
 tokio-stream = "0.1"
-tracing = { version = "0.1", default-features = false }
-tracing-core = { version = "0.1", default-features = false }
+# Using `tracing 0.1.39` because it introduces the ability to set event names in macros, 
+# required for OpenTelemetry's internal logging macros. Falling back to 0.1.40 or later if unavailable.
+tracing = { version = ">=0.1.39", default-features = false }
+tracing-core = { version = ">=0.1.33", default-features = false } # tracing 0.1.40 needs tracing-core 0.1.33 and above
 tracing-subscriber = { version = "0.3", default-features = false }
 url = { version = "2.5.2", default-features = false } #https://github.com/servo/rust-url/issues/992

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -102,6 +102,9 @@
     - Getter methods have been introduced to access field values.
     This change impacts custom exporter and processor developers by requiring updates to code that directly accessed LogRecord fields. They must now use the provided getter methods (e.g., `log_record.event_name()` instead of `log_record.event_name`).
 
+- Upgrade the tracing crate used for internal logging to version 0.1.40 or later. This is necessary because the internal logging macros utilize the name field as       
+metadata, a feature introduced in version 0.1.40. [#2418](https://github.com/open-telemetry/opentelemetry-rust/pull/2418)
+
 ## 0.27.1
 
 Released 2024-Nov-27


### PR DESCRIPTION
Fixes: #2373 
## Changes

Pinning versions of tracing and tracing-core that are compatible with the version required to support name metadata in macros.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
