### PR TITLE
Aggregate time initiator

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -1,9 +1,10 @@
-use std::{mem::replace, ops::DerefMut, sync::Mutex, time::SystemTime};
-
 use crate::metrics::data::{self, Aggregation, GaugeDataPoint};
 use opentelemetry::KeyValue;
 
-use super::{Aggregator, AtomicTracker, AtomicallyUpdate, Number, ValueMap};
+use super::{
+    aggregate::AggregateTimeInitiator, Aggregator, AtomicTracker, AtomicallyUpdate, Number,
+    ValueMap,
+};
 
 /// this is reused by PrecomputedSum
 pub(crate) struct Assign<T>
@@ -40,14 +41,14 @@ where
 /// Summarizes a set of measurements as the last one made.
 pub(crate) struct LastValue<T: Number> {
     value_map: ValueMap<Assign<T>>,
-    start: Mutex<SystemTime>,
+    init_time: AggregateTimeInitiator,
 }
 
 impl<T: Number> LastValue<T> {
     pub(crate) fn new() -> Self {
         LastValue {
             value_map: ValueMap::new(()),
-            start: Mutex::new(SystemTime::now()),
+            init_time: AggregateTimeInitiator::default(),
         }
     }
 
@@ -60,26 +61,21 @@ impl<T: Number> LastValue<T> {
         &self,
         dest: Option<&mut dyn Aggregation>,
     ) -> (usize, Option<Box<dyn Aggregation>>) {
-        let time = SystemTime::now();
-        let start_time = self
-            .start
-            .lock()
-            .map(|mut start| replace(start.deref_mut(), time))
-            .unwrap_or(time);
+        let time = self.init_time.delta();
 
         let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<data::Gauge<T>>());
         let mut new_agg = if s_data.is_none() {
             Some(data::Gauge {
                 data_points: vec![],
-                start_time: Some(start_time),
-                time,
+                start_time: Some(time.start),
+                time: time.current,
             })
         } else {
             None
         };
         let s_data = s_data.unwrap_or_else(|| new_agg.as_mut().expect("present if s_data is none"));
-        s_data.start_time = Some(start_time);
-        s_data.time = time;
+        s_data.start_time = Some(time.start);
+        s_data.time = time.current;
 
         self.value_map
             .collect_and_reset(&mut s_data.data_points, |attributes, aggr| GaugeDataPoint {
@@ -98,22 +94,21 @@ impl<T: Number> LastValue<T> {
         &self,
         dest: Option<&mut dyn Aggregation>,
     ) -> (usize, Option<Box<dyn Aggregation>>) {
-        let time = SystemTime::now();
-        let start_time = self.start.lock().map(|start| *start).unwrap_or(time);
+        let time = self.init_time.cumulative();
         let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<data::Gauge<T>>());
         let mut new_agg = if s_data.is_none() {
             Some(data::Gauge {
                 data_points: vec![],
-                start_time: Some(start_time),
-                time,
+                start_time: Some(time.start),
+                time: time.current,
             })
         } else {
             None
         };
         let s_data = s_data.unwrap_or_else(|| new_agg.as_mut().expect("present if s_data is none"));
 
-        s_data.start_time = Some(start_time);
-        s_data.time = time;
+        s_data.start_time = Some(time.start);
+        s_data.time = time.current;
 
         self.value_map
             .collect_readonly(&mut s_data.data_points, |attributes, aggr| GaugeDataPoint {

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -3,14 +3,15 @@ use opentelemetry::KeyValue;
 use crate::metrics::data::{self, Aggregation, SumDataPoint};
 use crate::metrics::Temporality;
 
+use super::aggregate::AggregateTimeInitiator;
 use super::{last_value::Assign, AtomicTracker, Number, ValueMap};
-use std::{collections::HashMap, mem::replace, ops::DerefMut, sync::Mutex, time::SystemTime};
+use std::{collections::HashMap, sync::Mutex};
 
 /// Summarizes a set of pre-computed sums as their arithmetic sum.
 pub(crate) struct PrecomputedSum<T: Number> {
     value_map: ValueMap<Assign<T>>,
     monotonic: bool,
-    start: Mutex<SystemTime>,
+    init_time: AggregateTimeInitiator,
     reported: Mutex<HashMap<Vec<KeyValue>, T>>,
 }
 
@@ -19,7 +20,7 @@ impl<T: Number> PrecomputedSum<T> {
         PrecomputedSum {
             value_map: ValueMap::new(()),
             monotonic,
-            start: Mutex::new(SystemTime::now()),
+            init_time: AggregateTimeInitiator::default(),
             reported: Mutex::new(Default::default()),
         }
     }
@@ -33,19 +34,14 @@ impl<T: Number> PrecomputedSum<T> {
         &self,
         dest: Option<&mut dyn Aggregation>,
     ) -> (usize, Option<Box<dyn Aggregation>>) {
-        let time = SystemTime::now();
-        let start_time = self
-            .start
-            .lock()
-            .map(|mut start| replace(start.deref_mut(), time))
-            .unwrap_or(time);
+        let time = self.init_time.delta();
 
         let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<data::Sum<T>>());
         let mut new_agg = if s_data.is_none() {
             Some(data::Sum {
                 data_points: vec![],
-                start_time,
-                time,
+                start_time: time.start,
+                time: time.current,
                 temporality: Temporality::Delta,
                 is_monotonic: self.monotonic,
             })
@@ -53,8 +49,8 @@ impl<T: Number> PrecomputedSum<T> {
             None
         };
         let s_data = s_data.unwrap_or_else(|| new_agg.as_mut().expect("present if s_data is none"));
-        s_data.start_time = start_time;
-        s_data.time = time;
+        s_data.start_time = time.start;
+        s_data.time = time.current;
         s_data.temporality = Temporality::Delta;
         s_data.is_monotonic = self.monotonic;
 
@@ -89,15 +85,14 @@ impl<T: Number> PrecomputedSum<T> {
         &self,
         dest: Option<&mut dyn Aggregation>,
     ) -> (usize, Option<Box<dyn Aggregation>>) {
-        let time = SystemTime::now();
-        let start_time = self.start.lock().map(|start| *start).unwrap_or(time);
+        let time = self.init_time.cumulative();
 
         let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<data::Sum<T>>());
         let mut new_agg = if s_data.is_none() {
             Some(data::Sum {
                 data_points: vec![],
-                start_time,
-                time,
+                start_time: time.start,
+                time: time.current,
                 temporality: Temporality::Cumulative,
                 is_monotonic: self.monotonic,
             })
@@ -105,8 +100,8 @@ impl<T: Number> PrecomputedSum<T> {
             None
         };
         let s_data = s_data.unwrap_or_else(|| new_agg.as_mut().expect("present if s_data is none"));
-        s_data.start_time = start_time;
-        s_data.time = time;
+        s_data.start_time = time.start;
+        s_data.time = time.current;
         s_data.temporality = Temporality::Cumulative;
         s_data.is_monotonic = self.monotonic;
 

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -1,12 +1,10 @@
-use std::mem::replace;
-use std::ops::DerefMut;
 use std::vec;
-use std::{sync::Mutex, time::SystemTime};
 
 use crate::metrics::data::{self, Aggregation, SumDataPoint};
 use crate::metrics::Temporality;
 use opentelemetry::KeyValue;
 
+use super::aggregate::AggregateTimeInitiator;
 use super::{Aggregator, AtomicTracker, Number};
 use super::{AtomicallyUpdate, ValueMap};
 
@@ -45,7 +43,7 @@ where
 pub(crate) struct Sum<T: Number> {
     value_map: ValueMap<Increment<T>>,
     monotonic: bool,
-    start: Mutex<SystemTime>,
+    init_time: AggregateTimeInitiator,
 }
 
 impl<T: Number> Sum<T> {
@@ -58,7 +56,7 @@ impl<T: Number> Sum<T> {
         Sum {
             value_map: ValueMap::new(()),
             monotonic,
-            start: Mutex::new(SystemTime::now()),
+            init_time: AggregateTimeInitiator::default(),
         }
     }
 
@@ -71,19 +69,13 @@ impl<T: Number> Sum<T> {
         &self,
         dest: Option<&mut dyn Aggregation>,
     ) -> (usize, Option<Box<dyn Aggregation>>) {
-        let time = SystemTime::now();
-        let start_time = self
-            .start
-            .lock()
-            .map(|mut start| replace(start.deref_mut(), time))
-            .unwrap_or(time);
-
+        let time = self.init_time.delta();
         let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<data::Sum<T>>());
         let mut new_agg = if s_data.is_none() {
             Some(data::Sum {
                 data_points: vec![],
-                start_time,
-                time,
+                start_time: time.start,
+                time: time.current,
                 temporality: Temporality::Delta,
                 is_monotonic: self.monotonic,
             })
@@ -91,8 +83,8 @@ impl<T: Number> Sum<T> {
             None
         };
         let s_data = s_data.unwrap_or_else(|| new_agg.as_mut().expect("present if s_data is none"));
-        s_data.start_time = start_time;
-        s_data.time = time;
+        s_data.start_time = time.start;
+        s_data.time = time.current;
         s_data.temporality = Temporality::Delta;
         s_data.is_monotonic = self.monotonic;
 
@@ -113,14 +105,13 @@ impl<T: Number> Sum<T> {
         &self,
         dest: Option<&mut dyn Aggregation>,
     ) -> (usize, Option<Box<dyn Aggregation>>) {
-        let time = SystemTime::now();
-        let start_time = self.start.lock().map(|start| *start).unwrap_or(time);
+        let time = self.init_time.cumulative();
         let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<data::Sum<T>>());
         let mut new_agg = if s_data.is_none() {
             Some(data::Sum {
                 data_points: vec![],
-                start_time,
-                time,
+                start_time: time.start,
+                time: time.current,
                 temporality: Temporality::Cumulative,
                 is_monotonic: self.monotonic,
             })
@@ -129,8 +120,8 @@ impl<T: Number> Sum<T> {
         };
         let s_data = s_data.unwrap_or_else(|| new_agg.as_mut().expect("present if s_data is none"));
 
-        s_data.start_time = start_time;
-        s_data.time = time;
+        s_data.start_time = time.start;
+        s_data.time = time.current;
         s_data.temporality = Temporality::Cumulative;
         s_data.is_monotonic = self.monotonic;
 


### PR DESCRIPTION
## Changes

Calculation of `start_time` and `time` on aggregation is copy/pasted for all aggregators (5 of them).
This PR provides time calculation in a single place.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
