### PR TITLE
otlp: spawn thread to create blocking reqwest client

### DIFF
--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -66,8 +66,11 @@ pub struct HttpConfig {
 impl Default for HttpConfig {
     fn default() -> Self {
         #[cfg(feature = "reqwest-blocking-client")]
-        let default_client =
-            Some(Arc::new(reqwest::blocking::Client::new()) as Arc<dyn HttpClient>);
+        let default_client = std::thread::spawn(|| {
+            Some(Arc::new(reqwest::blocking::Client::new()) as Arc<dyn HttpClient>)
+        })
+        .join()
+        .expect("creating reqwest::blocking::Client on a new thread not to fail");
         #[cfg(all(not(feature = "reqwest-blocking-client"), feature = "reqwest-client"))]
         let default_client = Some(Arc::new(reqwest::Client::new()) as Arc<dyn HttpClient>);
         #[cfg(all(


### PR DESCRIPTION
fixes #2400

## Changes
Using a new thread to create reqwest blocking client to avoid panics from async main

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
