### PR TITLE
Move shutdown checks to MeterProvider

### DIFF
--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -119,7 +119,10 @@ impl SdkMeterProvider {
 
 impl SdkMeterProviderInner {
     fn force_flush(&self) -> MetricResult<()> {
-        if self.shutdown_invoked.load(std::sync::atomic::Ordering::Relaxed) {
+        if self
+            .shutdown_invoked
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
             Err(MetricError::Other(
                 "Cannot perform flush as MeterProvider shutdown already invoked.".into(),
             ))


### PR DESCRIPTION
Unsure why we need to duplicate this in PeriodicReader if the MeterProvider can take care of this.
PeriodicReader will still return Error when shutdown is invoked again, but won't be as descriptive. But not something to worry, as users should only be calling flush/shutdown on the Providers, not on reader/exporter directly.

