### PR TITLE
Enable metric integration test for req-blocking

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -61,6 +61,7 @@
         "shoppingcart",
         "struct",
         "Tescher",
+        "testresults",
         "tracerprovider",
         "updown",
         "Zhongyang",

--- a/opentelemetry-otlp/tests/integration_test/Cargo.toml
+++ b/opentelemetry-otlp/tests/integration_test/Cargo.toml
@@ -28,7 +28,7 @@ hyper-client = ["opentelemetry-otlp/hyper-client", "opentelemetry-otlp/http-prot
 reqwest-client = ["opentelemetry-otlp/reqwest-client", "opentelemetry-otlp/http-proto", "opentelemetry-otlp/trace","opentelemetry-otlp/logs", "opentelemetry-otlp/metrics", "internal-logs"]
 reqwest-blocking-client = ["opentelemetry-otlp/reqwest-blocking-client", "opentelemetry-otlp/http-proto", "opentelemetry-otlp/trace","opentelemetry-otlp/logs", "opentelemetry-otlp/metrics", "internal-logs"]
 tonic-client = ["opentelemetry-otlp/grpc-tonic", "opentelemetry-otlp/trace", "opentelemetry-otlp/logs", "opentelemetry-otlp/metrics", "internal-logs"]
-internal-logs = []
+internal-logs = ["opentelemetry-otlp/internal-logs"]
 
 # Keep tonic as the default client
 default = ["tonic-client", "internal-logs"]

--- a/opentelemetry-otlp/tests/integration_test/Cargo.toml
+++ b/opentelemetry-otlp/tests/integration_test/Cargo.toml
@@ -15,7 +15,7 @@ testcontainers = { version = "0.23.1", features = ["http_wait"]}
 once_cell.workspace = true
 anyhow = "1.0.94"
 ctor = "0.2.9"
-tracing-subscriber = "0.3.19"
+tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }
 tracing = "0.1.41"
 
 [target.'cfg(unix)'.dependencies]

--- a/opentelemetry-otlp/tests/integration_test/README.md
+++ b/opentelemetry-otlp/tests/integration_test/README.md
@@ -1,10 +1,17 @@
 # OTLP - Integration Tests
-This directory contains integration tests for `opentelemetry-otlp`. It uses 
-[testcontainers](https://testcontainers.com/) to start an instance of the OTEL collector using [otel-collector-config.yaml](otel-collector-config.yaml), which then uses a file exporter per signal to write the output it receives back to the host machine.
 
-The tests connect directly to the collector on `localhost:4317` and `localhost:4318`, push data through, and then check that what they expect 
-has popped back out into the files output by the collector.
+This directory contains integration tests for `opentelemetry-otlp`. It uses
+[testcontainers](https://testcontainers.com/) to start an instance of the OTEL
+collector using [otel-collector-config.yaml](otel-collector-config.yaml), which
+then uses a file exporter per signal to write the output it receives back to the
+host machine.
 
-For this to work, you need a couple of things:
+The tests connect directly to the collector on `localhost:4317` and
+`localhost:4318`, push data through, and then check that what they expect has
+popped back out into the files output by the collector.
+
+## Pre-requisites
+
 * Docker, for the test container
-* TCP/4317 and TCP/4318 free on your local machine. If you are running another collector, you'll need to stop it for the tests to run
+* TCP/4317 and TCP/4318 free on your local machine. If you are running another
+  collector, you'll need to stop it for the tests to run.

--- a/opentelemetry-otlp/tests/integration_test/tests/metrics.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/metrics.rs
@@ -30,7 +30,7 @@ async fn init_metrics() -> SdkMeterProvider {
     let exporter = create_exporter();
 
     let reader = PeriodicReader::builder(exporter)
-        .with_interval(Duration::from_millis(100))
+        .with_interval(Duration::from_millis(500))
         .with_timeout(Duration::from_secs(1))
         .build();
 
@@ -146,7 +146,7 @@ async fn setup_metrics_test() -> Result<()> {
         println!("Running setup before any tests...");
         *done = true; // Mark setup as done
 
-        // Initialise the metrics subsystem
+        // Initialize the metrics subsystem
         _ = init_metrics().await;
     }
 
@@ -184,13 +184,13 @@ pub fn validate_metrics_against_results(scope_name: &str) -> Result<()> {
 }
 
 ///
-/// TODO - the HTTP metrics exporters do not seem to flush at the moment.
+/// TODO - the HTTP metrics exporters except reqwest-blocking-client do not seem
+/// to work at the moment.
 /// TODO - fix this asynchronously.
 ///
 #[cfg(test)]
 #[cfg(not(feature = "hyper-client"))]
 #[cfg(not(feature = "reqwest-client"))]
-#[cfg(not(feature = "reqwest-blocking-client"))]
 mod tests {
 
     use super::*;
@@ -293,7 +293,7 @@ mod tests {
         // Set up the exporter
         let exporter = create_exporter();
         let reader = PeriodicReader::builder(exporter)
-            .with_interval(Duration::from_millis(100))
+            .with_interval(Duration::from_secs(30))
             .with_timeout(Duration::from_secs(1))
             .build();
         let resource = Resource::builder_empty()


### PR DESCRIPTION
Reqwest-blocking-client should work for Metrics, so that is enabled.
Also changed the verbosity of internal logs to avoid overwhelming amount of debug logs. We still get debug level logs from OpenTelemetry.
Also enabled internal-logs from OTLP exporter itself.