### PR TITLE
Add internal logging to HTTP libraries

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,5 +24,5 @@ jobs:
         with:
           components: rustfmt
       - uses: arduino/setup-protoc@v3
-      - name: Run integration tests using docker compose
+      - name: Run integration tests
         run: ./scripts/integration_tests.sh

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## vNext
 
 - Bump msrv to 1.75.0.
-
+- Add "internal-logs" feature flag (enabled by default), and emit internal logs.
 
 ## 0.27.0
 

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -10,9 +10,11 @@ edition = "2021"
 rust-version = "1.75.0"
 
 [features]
+default = ["internal-logs"]
 hyper = ["dep:http-body-util", "dep:hyper", "dep:hyper-util", "dep:tokio"]
 reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
 reqwest-rustls-webpki-roots = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
+internal-logs = ["tracing", "opentelemetry/internal-logs"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -24,3 +26,4 @@ hyper-util = { workspace = true, features = ["client-legacy", "http1", "http2"],
 opentelemetry = { version = "0.27", path = "../opentelemetry", features = ["trace"] }
 reqwest = { workspace = true, features = ["blocking"], optional = true }
 tokio = { workspace = true, features = ["time"], optional = true }
+tracing = {workspace = true, optional = true}

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -106,9 +106,8 @@ mod reqwest {
 
 #[cfg(feature = "hyper")]
 pub mod hyper {
-    use crate::ResponseExt;
-
     use super::{async_trait, Bytes, HttpClient, HttpError, Request, Response};
+    use crate::ResponseExt;
     use http::HeaderValue;
     use http_body_util::{BodyExt, Full};
     use hyper::body::{Body as HttpBody, Frame};
@@ -116,6 +115,7 @@ pub mod hyper {
         connect::{Connect, HttpConnector},
         Client,
     };
+    use opentelemetry::otel_debug;
     use std::fmt::Debug;
     use std::pin::Pin;
     use std::task::{self, Poll};

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -58,7 +58,7 @@ trace = ["opentelemetry/trace", "opentelemetry_sdk/trace", "opentelemetry-proto/
 metrics = ["opentelemetry/metrics", "opentelemetry_sdk/metrics", "opentelemetry-proto/metrics"]
 logs = ["opentelemetry/logs", "opentelemetry_sdk/logs", "opentelemetry-proto/logs"]
 populate-logs-event-name = ["opentelemetry-proto/populate-logs-event-name"]
-internal-logs = ["tracing"]
+internal-logs = ["tracing", "opentelemetry/internal-logs"]
 
 # add ons
 serialize = ["serde", "serde_json"]

--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -16,7 +16,7 @@ experimental_metrics_periodicreader_with_async_runtime = ["opentelemetry_sdk/exp
 once_cell = { workspace = true }
 opentelemetry = { path = "../../../opentelemetry" }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "experimental_metrics_periodicreader_with_async_runtime"]}
-opentelemetry-otlp = { path = "../..", features = ["http-proto", "http-json", "logs"] , default-features = false}
+opentelemetry-otlp = { path = "../..", features = ["http-proto", "http-json", "logs", "internal-logs"] , default-features = false}
 opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}
 
 tokio = { workspace = true, features = ["full"] }

--- a/opentelemetry-otlp/src/exporter/http/logs.rs
+++ b/opentelemetry-otlp/src/exporter/http/logs.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use http::{header::CONTENT_TYPE, Method};
+use opentelemetry::otel_debug;
 use opentelemetry_sdk::export::logs::{LogBatch, LogExporter};
 use opentelemetry_sdk::logs::{LogError, LogResult};
 
@@ -32,6 +33,7 @@ impl LogExporter for OtlpHttpClient {
         }
 
         let request_uri = request.uri().to_string();
+        otel_debug!(name: "HttpLogsClient.CallingExport");
         let response = client.send(request).await?;
 
         if !response.status().is_success() {

--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use http::{header::CONTENT_TYPE, Method};
+use opentelemetry::otel_debug;
 use opentelemetry_sdk::metrics::data::ResourceMetrics;
 use opentelemetry_sdk::metrics::{MetricError, MetricResult};
 
@@ -33,6 +34,7 @@ impl MetricsClient for OtlpHttpClient {
             request.headers_mut().insert(k.clone(), v.clone());
         }
 
+        otel_debug!(name: "HttpMetricsClient.CallingExport");
         client
             .send(request)
             .await

--- a/opentelemetry-otlp/src/exporter/http/trace.rs
+++ b/opentelemetry-otlp/src/exporter/http/trace.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use futures_core::future::BoxFuture;
 use http::{header::CONTENT_TYPE, Method};
-use opentelemetry::trace::TraceError;
+use opentelemetry::{otel_debug, trace::TraceError};
 use opentelemetry_sdk::export::trace::{ExportResult, SpanData, SpanExporter};
 
 use super::OtlpHttpClient;
@@ -47,6 +47,7 @@ impl SpanExporter for OtlpHttpClient {
 
         Box::pin(async move {
             let request_uri = request.uri().to_string();
+            otel_debug!(name: "HttpTracesClient.CallingExport");
             let response = client.send(request).await?;
 
             if !response.status().is_success() {


### PR DESCRIPTION
Fixes #2446 

It's now easy to debug, especially since `tracing::fmt` can also show the thread from which the calls are made!
```
2024-12-18T20:09:59.890413Z DEBUG tokio-runtime-worker opentelemetry_sdk:  name="PeriodicReaderWorker.InvokeExporter" Calling exporter's export method with collected metrics. count=1
2024-12-18T20:09:59.890457Z DEBUG tokio-runtime-worker opentelemetry-otlp:  name="HttpMetricsClient.CallingExport"
2024-12-18T20:09:59.890462Z DEBUG tokio-runtime-worker opentelemetry-http:  name="ReqwestClient.Send"
```

