### PR TITLE
chore: Test sync exporters

### DIFF
--- a/examples/tracing-grpc/src/client.rs
+++ b/examples/tracing-grpc/src/client.rs
@@ -22,7 +22,7 @@ fn init_tracer() -> sdktrace::TracerProvider {
 
 struct MetadataMap<'a>(&'a mut tonic::metadata::MetadataMap);
 
-impl<'a> Injector for MetadataMap<'a> {
+impl Injector for MetadataMap<'_> {
     /// Set a key and value in the MetadataMap.  Does nothing if the key or value are not valid inputs
     fn set(&mut self, key: &str, value: String) {
         if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes()) {

--- a/examples/tracing-grpc/src/server.rs
+++ b/examples/tracing-grpc/src/server.rs
@@ -29,7 +29,7 @@ pub mod hello_world {
 
 struct MetadataMap<'a>(&'a tonic::metadata::MetadataMap);
 
-impl<'a> Extractor for MetadataMap<'a> {
+impl Extractor for MetadataMap<'_> {
     /// Get a value for a key from the MetadataMap.  If the value can't be converted to &str, returns None
     fn get(&self, key: &str) -> Option<&str> {
         self.0.get(key).and_then(|metadata| metadata.to_str().ok())

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -239,7 +239,7 @@ mod any_value {
     pub(crate) fn serialize(value: log::kv::Value) -> Option<AnyValue> {
         struct ValueVisitor(Option<AnyValue>);
 
-        impl<'kvs> log::kv::VisitValue<'kvs> for ValueVisitor {
+        impl log::kv::VisitValue<'_> for ValueVisitor {
             fn visit_any(&mut self, value: log::kv::Value) -> Result<(), log::kv::Error> {
                 self.0 = Some(AnyValue::String(StringValue::from(value.to_string())));
 

--- a/opentelemetry-otlp/tests/integration_test/src/logs_asserter.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/logs_asserter.rs
@@ -1,6 +1,6 @@
+use anyhow::Result;
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, LogsData, ResourceLogs};
 use std::fs::File;
-use anyhow::Result;
 
 // Given two ResourceLogs, assert that they are equal except for the timestamps
 pub struct LogsAsserter {

--- a/opentelemetry-otlp/tests/integration_test/src/logs_asserter.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/logs_asserter.rs
@@ -1,5 +1,6 @@
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, LogsData, ResourceLogs};
 use std::fs::File;
+use anyhow::Result;
 
 // Given two ResourceLogs, assert that they are equal except for the timestamps
 pub struct LogsAsserter {
@@ -96,9 +97,9 @@ impl std::fmt::Debug for LogRecordWrapper {
 }
 
 // read a file contains ResourceSpans in json format
-pub fn read_logs_from_json(file: File) -> Vec<ResourceLogs> {
+pub fn read_logs_from_json(file: File) -> Result<Vec<ResourceLogs>> {
     let reader = std::io::BufReader::new(file);
 
-    let log_data: LogsData = serde_json::from_reader(reader).unwrap();
-    log_data.resource_logs
+    let log_data: LogsData = serde_json::from_reader(reader)?;
+    Ok(log_data.resource_logs)
 }

--- a/opentelemetry-otlp/tests/integration_test/tests/logs.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs.rs
@@ -38,23 +38,25 @@ fn init_logs() -> Result<sdklogs::LoggerProvider> {
 mod logtests {
     use super::*;
     use integration_test_runner::logs_asserter::{read_logs_from_json, LogsAsserter};
+    use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
     use std::{fs::File, time::Duration};
     use tracing::info;
     use tracing_subscriber::layer::SubscriberExt;
-    use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 
     #[test]
     #[should_panic(expected = "assertion `left == right` failed: body does not match")]
     pub fn test_assert_logs_eq_failure() {
-        let left = read_logs_from_json(File::open("./expected/logs.json")
-            .expect("failed to open expected file"))
-            .expect("Failed to read logs from expected file");
+        let left = read_logs_from_json(
+            File::open("./expected/logs.json").expect("failed to open expected file"),
+        )
+        .expect("Failed to read logs from expected file");
 
-        let right = read_logs_from_json(File::open("./expected/failed_logs.json")
-            .expect("failed to open expected failed log file"))
-            .expect("Failed to read logs from expected failed log file");
+        let right = read_logs_from_json(
+            File::open("./expected/failed_logs.json")
+                .expect("failed to open expected failed log file"),
+        )
+        .expect("Failed to read logs from expected failed log file");
         LogsAsserter::new(right, left).assert();
-
     }
 
     #[test]
@@ -99,14 +101,13 @@ mod logtests {
 
     #[test]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
-    pub fn logs_batch_non_tokio_main()  -> Result<()>{
-
+    pub fn logs_batch_non_tokio_main() -> Result<()> {
         // Initialize the logger provider inside a tokio runtime
         // as this allows tonic client to capture the runtime,
         // but actual export occurs from the dedicated std::thread
         // created by BatchLogProcessor.
         let rt = tokio::runtime::Runtime::new()?;
-        let logger_provider = rt.block_on(async  {
+        let logger_provider = rt.block_on(async {
             // While we're here setup our collector container too, as this needs tokio to run
             test_utils::start_collector_container().await?;
             init_logs()
@@ -125,7 +126,6 @@ mod logtests {
 
         Ok(())
     }
-
 }
 
 pub fn assert_logs_results(result: &str, expected: &str) -> Result<()> {

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -54,6 +54,7 @@ pub struct ZipkinPipelineBuilder {
 impl Default for ZipkinPipelineBuilder {
     fn default() -> Self {
         let timeout = env::get_timeout();
+
         ZipkinPipelineBuilder {
             #[cfg(feature = "reqwest-blocking-client")]
             client: Some(Arc::new(

--- a/stress/src/throughput.rs
+++ b/stress/src/throughput.rs
@@ -140,8 +140,8 @@ struct UnsafeSlice<'a> {
     slice: &'a [UnsafeCell<WorkerStats>],
 }
 
-unsafe impl<'a> Send for UnsafeSlice<'a> {}
-unsafe impl<'a> Sync for UnsafeSlice<'a> {}
+unsafe impl Send for UnsafeSlice<'_> {}
+unsafe impl Sync for UnsafeSlice<'_> {}
 
 impl<'a> UnsafeSlice<'a> {
     fn new(slice: &'a mut [WorkerStats]) -> Self {
@@ -155,7 +155,7 @@ impl<'a> UnsafeSlice<'a> {
     #[inline(always)]
     unsafe fn increment(&self, i: usize) {
         let value = self.slice[i].get();
-        (*value).count = (*value).count + 1;
+        (*value).count += 1;
     }
 
     #[inline(always)]


### PR DESCRIPTION
More work for #2432. In this case we're adding coverage for using the batch log exporters from non-tokio main functions.


## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
