### PR TITLE
Minor update to stdout exporter example to show log correlation

### DIFF
--- a/opentelemetry-stdout/src/logs/exporter.rs
+++ b/opentelemetry-stdout/src/logs/exporter.rs
@@ -82,6 +82,9 @@ fn print_logs(batch: LogBatch<'_>) {
         if let Some(trace_context) = record.trace_context() {
             println!("\t TraceId: {:?}", trace_context.trace_id);
             println!("\t SpanId: {:?}", trace_context.span_id);
+            if let Some(trace_flags) = trace_context.trace_flags {
+                println!("\t TraceFlags: {:?}", trace_flags);
+            }
         }
         if let Some(timestamp) = record.timestamp() {
             let datetime: DateTime<Utc> = timestamp.into();

--- a/opentelemetry-stdout/src/trace/exporter.rs
+++ b/opentelemetry-stdout/src/trace/exporter.rs
@@ -96,6 +96,7 @@ fn print_spans(batch: Vec<export::trace::SpanData>) {
         println!("\tName        : {}", &span.name);
         println!("\tTraceId     : {}", &span.span_context.trace_id());
         println!("\tSpanId      : {}", &span.span_context.span_id());
+        println!("\tTraceFlags  : {:?}", &span.span_context.trace_flags());
         println!("\tParentSpanId: {}", &span.parent_span_id);
         println!("\tKind        : {:?}", &span.span_kind);
 


### PR DESCRIPTION
Stdout example modified to emit a log within span context to show how correlation works.
Fix stdout to print TraceFlags.