### PR TITLE
Modify OTLP Http example to use reqwest blocking

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -6,11 +6,9 @@ license = "Apache-2.0"
 publish = false
 
 [features]
-default = ["reqwest", "experimental_metrics_periodicreader_with_async_runtime"]
-reqwest = ["opentelemetry-otlp/reqwest-client"]
+default = ["reqwest-blocking"]
+reqwest-blocking = ["opentelemetry-otlp/reqwest-blocking-client"]
 hyper = ["opentelemetry-otlp/hyper-client"]
-experimental_metrics_periodicreader_with_async_runtime = ["opentelemetry_sdk/experimental_metrics_periodicreader_with_async_runtime"]
-
 
 [dependencies]
 once_cell = { workspace = true }

--- a/opentelemetry-otlp/examples/basic-otlp-http/README.md
+++ b/opentelemetry-otlp/examples/basic-otlp-http/README.md
@@ -13,11 +13,9 @@ applications, these filters should be adjusted appropriately.
 
 The example employs a `BatchExporter` for logs and traces, which is the
 recommended approach when using OTLP exporters. While it can be modified to use
-a `SimpleExporter`, this requires enabling feature flag `reqwest-blocking-client` and
-making the `main()` a normal main and *not* `tokio::main`
+a `SimpleExporter`, this requires making the main function a regular main and
+*not* tokio main.
 
-// TODO: Metrics does not work with non tokio main when using `reqwest-blocking-client` today, fix that when switching
-// default to use own thread.
 // TODO: Document `hyper` feature flag when using SimpleProcessor.
 
 ## Usage

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -11,7 +11,6 @@ use opentelemetry_otlp::{LogExporter, MetricExporter, Protocol, SpanExporter};
 use opentelemetry_sdk::{
     logs::LoggerProvider,
     metrics::{MetricError, SdkMeterProvider},
-    runtime,
     trace::{self as sdktrace, TracerProvider},
 };
 use opentelemetry_sdk::{
@@ -50,7 +49,9 @@ fn init_traces() -> Result<sdktrace::TracerProvider, TraceError> {
         .build()?;
 
     Ok(TracerProvider::builder()
-        .with_batch_exporter(exporter, runtime::Tokio)
+        // TODO: Enable BatchExporter after
+        // https://github.com/open-telemetry/opentelemetry-rust/pull/2456
+        .with_simple_exporter(exporter)
         .with_resource(RESOURCE.clone())
         .build())
 }
@@ -62,15 +63,6 @@ fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, Metric
         .with_endpoint("http://localhost:4318/v1/metrics")
         .build()?;
 
-    #[cfg(feature = "experimental_metrics_periodicreader_with_async_runtime")]
-    let reader =
-        opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader::builder(
-            exporter,
-            runtime::Tokio,
-        )
-        .build();
-    // TODO: This does not work today. See https://github.com/open-telemetry/opentelemetry-rust/issues/2400
-    #[cfg(not(feature = "experimental_metrics_periodicreader_with_async_runtime"))]
     let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter).build();
 
     Ok(SdkMeterProvider::builder()
@@ -79,8 +71,10 @@ fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, Metric
         .build())
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+// #[tokio::main]
+// TODO: Re-enable tokio::main, if needed, after
+// https://github.com/open-telemetry/opentelemetry-rust/pull/2456
+fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     let logger_provider = init_logs()?;
 
     // Create a new OpenTelemetryTracingBridge using the above LoggerProvider.


### PR DESCRIPTION
We expect to make reqwest::blocking as the default. This PR modifies the examples to use it.
Had to switch to normal main, so as to use simple exporter for Spans, as SpanBatchProcessor is WIP.