### PR TITLE
Remove is_shutdown flag from processors. And fix logger::emit() to check for the flag before emit.

### DIFF
--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -271,7 +271,7 @@ impl opentelemetry::logs::Logger for Logger {
         if self.provider.inner.is_shutdown.load(Ordering::Relaxed) {
             // Optionally, log a debug message indicating logs are being discarded due to shutdown.
             otel_debug!(
-                name: "Logger.Emit.Discarded",
+                name: "Logger.Emit.ProviderShutdown",
                 message = "Log discarded because the LoggerProvider is shut down."
             );
             return;

--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -268,6 +268,14 @@ impl opentelemetry::logs::Logger for Logger {
 
     /// Emit a `LogRecord`.
     fn emit(&self, mut record: Self::LogRecord) {
+        if self.provider.inner.is_shutdown.load(Ordering::Relaxed) {
+            // Optionally, log a debug message indicating logs are being discarded due to shutdown.
+            otel_debug!(
+                name: "Logger.Emit.Discarded",
+                message = "Log discarded because the LoggerProvider is shut down."
+            );
+            return;
+        }
         let provider = &self.provider;
         let processors = provider.log_processors();
 


### PR DESCRIPTION
## Changes

To discuss the change suggested be @cijothomas  here - https://github.com/open-telemetry/opentelemetry-rust/pull/2381#discussion_r1894079938

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
