### PR TITLE
json: ser/de bytes as base64 strings not an array of bytes

### DIFF
--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -46,7 +46,7 @@ testing = ["opentelemetry/testing"]
 # add ons
 internal-logs = ["tracing"]
 with-schemars = ["schemars"]
-with-serde = ["serde", "hex"]
+with-serde = ["serde", "hex", "base64"]
 
 [dependencies]
 tonic = { workspace = true, optional = true, features = ["codegen", "prost"] }
@@ -57,6 +57,7 @@ schemars = { version = "0.8", optional = true }
 serde = { workspace = true, optional = true, features = ["serde_derive"] }
 hex = { version = "0.4.3", optional = true }
 tracing = {workspace = true, optional = true} # optional for opentelemetry internal logging
+base64 = { version = "0.22.1", optional = true }
 
 [dev-dependencies]
 opentelemetry = { features = ["testing"], path = "../opentelemetry" }

--- a/opentelemetry-proto/tests/json_serde.rs
+++ b/opentelemetry-proto/tests/json_serde.rs
@@ -275,18 +275,20 @@ mod json_serde {
                                 start_time_unix_nano: 1544712660000000000,
                                 end_time_unix_nano: 1544712661000000000,
                                 attributes: vec![
-                                  KeyValue {
-                                    key: String::from("my.span.attr"),
-                                    value: Some(AnyValue {
-                                        value: Some(Value::StringValue(String::from("some value"))),
-                                    }),
-                                  },
-                                  KeyValue {
-                                    key: String::from("my.span.bytes.attr"),
-                                    value: Some(AnyValue {
-                                        value: Some(Value::BytesValue(vec![0x80, 0x80, 0x80])),
-                                    }),
-                                  },
+                                    KeyValue {
+                                        key: String::from("my.span.attr"),
+                                        value: Some(AnyValue {
+                                            value: Some(Value::StringValue(String::from(
+                                                "some value",
+                                            ))),
+                                        }),
+                                    },
+                                    KeyValue {
+                                        key: String::from("my.span.bytes.attr"),
+                                        value: Some(AnyValue {
+                                            value: Some(Value::BytesValue(vec![0x80, 0x80, 0x80])),
+                                        }),
+                                    },
                                 ],
                                 dropped_attributes_count: 1,
                                 events: vec![Event {

--- a/opentelemetry-proto/tests/json_serde.rs
+++ b/opentelemetry-proto/tests/json_serde.rs
@@ -274,12 +274,20 @@ mod json_serde {
                                 kind: 2,
                                 start_time_unix_nano: 1544712660000000000,
                                 end_time_unix_nano: 1544712661000000000,
-                                attributes: vec![KeyValue {
+                                attributes: vec![
+                                  KeyValue {
                                     key: String::from("my.span.attr"),
                                     value: Some(AnyValue {
                                         value: Some(Value::StringValue(String::from("some value"))),
                                     }),
-                                }],
+                                  },
+                                  KeyValue {
+                                    key: String::from("my.span.bytes.attr"),
+                                    value: Some(AnyValue {
+                                        value: Some(Value::BytesValue(vec![0x80, 0x80, 0x80])),
+                                    }),
+                                  },
+                                ],
                                 dropped_attributes_count: 1,
                                 events: vec![Event {
                                     time_unix_nano: 1544712660500000000,
@@ -368,6 +376,12 @@ mod json_serde {
                   "key": "my.span.attr",
                   "value": {
                     "stringValue": "some value"
+                  }
+                },
+                {
+                  "key": "my.span.bytes.attr",
+                  "value": {
+                    "bytesValue": "gICA"
                   }
                 }
               ],


### PR DESCRIPTION
I believe this is how the proto <-> json spec defines that binary data should be handled: https://protobuf.dev/programming-guides/json/

I confirmed by exporting data from Python:

```python
from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
from opentelemetry.proto.resource.v1.resource_pb2 import Resource
from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans
from google.protobuf.json_format import MessageToJson


export = ExportTraceServiceRequest(
    resource_spans=[
        ResourceSpans(
            resource=Resource(
                attributes=[
                    KeyValue(key="key", value=AnyValue(bytes_value=b"value"))
                ]
            )
        )
    ]
)

json = MessageToJson(export, use_integers_for_enums=True)

print(json)

with open("export.json", "w") as f:
    f.write(json)
```

```json
{
  "resourceSpans": [
    {
      "resource": {
        "attributes": [
          {
            "key": "key",
            "value": {
              "bytesValue": "dmFsdWU="
            }
          }
        ]
      }
    }
  ]
}
```