### PR TITLE
Remove unnecessary featureflag for eventname

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## vNext
 
 - Bump msrv to 1.75.0.
+- Feature flag "populate-logs-event-name" is removed as no longer relevant.
+  LogRecord's `event_name()` is now automatically populated on the newly added
+  "event_name" field in LogRecord proto definition.
 
 
 ## 0.27.0

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -57,7 +57,6 @@ temp-env = { workspace = true }
 trace = ["opentelemetry/trace", "opentelemetry_sdk/trace", "opentelemetry-proto/trace"]
 metrics = ["opentelemetry/metrics", "opentelemetry_sdk/metrics", "opentelemetry-proto/metrics"]
 logs = ["opentelemetry/logs", "opentelemetry_sdk/logs", "opentelemetry-proto/logs"]
-populate-logs-event-name = ["opentelemetry-proto/populate-logs-event-name"]
 internal-logs = ["tracing", "opentelemetry/internal-logs"]
 
 # add ons

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -98,8 +98,6 @@
 //!
 //! The following feature flags generate additional code and types:
 //! * `serialize`: Enables serialization support for type defined in this create via `serde`.
-//! * `populate-logs-event-name`: Enables sending `LogRecord::event_name` as an attribute
-//!    with the key `name`
 //!
 //! The following feature flags offer additional configurations on gRPC:
 //!

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -5,7 +5,9 @@
 - Update proto definitions to v1.4.0 [#2315](https://github.com/open-telemetry/opentelemetry-rust/pull/2315)
 - Bump msrv to 1.75.0.
 - Update proto definitions to v1.5.0 [#2439](https://github.com/open-telemetry/opentelemetry-rust/pull/2439)
-
+- Feature flag "populate-logs-event-name" is removed as no longer relevant.
+  LogRecord's `event_name()` is now automatically populated on the newly added
+  "event_name" field in LogRecord proto definition.
 
 ## 0.27.0
 

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -46,7 +46,6 @@ testing = ["opentelemetry/testing"]
 # add ons
 with-schemars = ["schemars"]
 with-serde = ["serde", "hex"]
-populate-logs-event-name = []
 
 [dependencies]
 tonic = { workspace = true, optional = true, features = ["codegen", "prost"] }

--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -91,7 +91,7 @@ pub mod tonic {
                 time_unix_nano: log_record.timestamp().map(to_nanos).unwrap_or_default(),
                 observed_time_unix_nano: to_nanos(log_record.observed_timestamp().unwrap()),
                 attributes: {
-                    let attributes: Vec<KeyValue> = log_record
+                    log_record
                         .attributes_iter()
                         .map(|kv| KeyValue {
                             key: kv.0.to_string(),
@@ -99,24 +99,7 @@ pub mod tonic {
                                 value: Some(kv.1.clone().into()),
                             }),
                         })
-                        .collect();
-                    #[cfg(feature = "populate-logs-event-name")]
-                    {
-                        if let Some(event_name) = &log_record.event_name() {
-                            let mut attributes_with_name = attributes;
-                            attributes_with_name.push(KeyValue {
-                                key: "event.name".into(),
-                                value: Some(AnyValue {
-                                    value: Some(Value::StringValue(event_name.to_string())),
-                                }),
-                            });
-                            attributes_with_name
-                        } else {
-                            attributes
-                        }
-                    }
-                    #[cfg(not(feature = "populate-logs-event-name"))]
-                    attributes
+                        .collect()
                 },
                 event_name: log_record.event_name().unwrap_or_default().into(),
                 severity_number: severity_number.into(),


### PR DESCRIPTION
Fully fixes https://github.com/open-telemetry/opentelemetry-rust/issues/2410 by removing feature flags that are no longer relevant.