### PR TITLE
Retain empty tracer name as is instead of using default name

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -211,6 +211,10 @@ metadata, a feature introduced in version 0.1.40. [#2418](https://github.com/ope
     - Continue enabling one of the async runtime feature flags: `rt-tokio`,
       `rt-tokio-current-thread`, or `rt-async-std`.
 
+- Bug fix: Empty Tracer names are retained as-is instead of replacing with
+  "rust.opentelemetry.io/sdk/tracer"
+  [#2486](https://github.com/open-telemetry/opentelemetry-rust/pull/2486)
+
 ## 0.27.1
 
 Released 2024-Nov-27

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -48,7 +48,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        testing::trace::InMemorySpanExporterBuilder,
+        testing::trace::{InMemorySpanExporter, InMemorySpanExporterBuilder},
         trace::span_limit::{DEFAULT_MAX_EVENT_PER_SPAN, DEFAULT_MAX_LINKS_PER_SPAN},
     };
     use opentelemetry::trace::{
@@ -341,5 +341,47 @@ mod tests {
         assert!(instrumentation_scope
             .attributes()
             .eq(&[KeyValue::new("test_k", "test_v")]));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn empty_tracer_name_retained() {
+        async fn tracer_name_retained_helper(
+            tracer: super::Tracer,
+            provider: TracerProvider,
+            exporter: InMemorySpanExporter,
+        ) {
+            // Act
+            tracer.start("my_span").end();
+
+            // Force flush to ensure spans are exported
+            provider.force_flush().into_iter().for_each(|result| {
+                result.expect("failed to flush spans");
+            });
+
+            // Assert
+            let finished_spans = exporter
+                .get_finished_spans()
+                .expect("spans are expected to be exported.");
+            assert_eq!(finished_spans.len(), 1, "There should be a single span");
+
+            let tracer_name = finished_spans[0].instrumentation_scope.name();
+            assert_eq!(tracer_name, "", "The tracer name should be an empty string");
+
+            exporter.reset();
+        }
+
+        let exporter = InMemorySpanExporter::default();
+        let span_processor = SimpleSpanProcessor::new(Box::new(exporter.clone()));
+        let tracer_provider = TracerProvider::builder()
+            .with_span_processor(span_processor)
+            .build();
+
+        // Test Tracer creation in 2 ways, both with empty string as tracer name
+        let tracer1 = tracer_provider.tracer("");
+        tracer_name_retained_helper(tracer1, tracer_provider.clone(), exporter.clone()).await;
+
+        let tracer_scope = InstrumentationScope::builder("").build();
+        let tracer2 = tracer_provider.tracer_with_scope(tracer_scope);
+        tracer_name_retained_helper(tracer2, tracer_provider, exporter).await;
     }
 }


### PR DESCRIPTION
Fixes #2372

## Changes

Ensures empty tracer names are retained, similar to #2334 and #2316.

After implementing this change, I realized [the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md) might not mention empty tracer names..
Advice on whether this change is necessary would be appreciated!

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
