### PR TITLE
Avoid vec allocation during each export for BatchLogProcessor - Part 2

### DIFF
--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -23,12 +23,12 @@ pub struct LogBatch<'a> {
 
 /// The `LogBatchData` enum represents the data field of a `LogBatch`.
 /// It can either be:
-/// - A mutable reference to a vector of tuples, where each tuple consists of a `LogRecord` and an `InstrumentationScope`.
+/// - A shared reference to a vector of tuples, where each tuple consists of a `LogRecord` and an `InstrumentationScope`.
 /// - Or it can be a slice of tuples, where each tuple consists of a reference to a `LogRecord` and a reference to an `InstrumentationScope`.
 #[derive(Debug)]
 #[allow(clippy::vec_box)] // TODO: Revisit this. Clippy complains about using Box in a Vec, but it's done here for performant moves of the data between channel and the vec.
 enum LogBatchData<'a> {
-    BorrowedVec(&'a mut Vec<Box<(LogRecord, InstrumentationScope)>>), // Used by BatchProcessor which clones the LogRecords for its own use.
+    BorrowedVec(&'a Vec<Box<(LogRecord, InstrumentationScope)>>), // Used by BatchProcessor which clones the LogRecords for its own use.
     BorrowedSlice(&'a [(&'a LogRecord, &'a InstrumentationScope)]),
 }
 
@@ -53,9 +53,9 @@ impl<'a> LogBatch<'a> {
         }
     }
 
-    #[allow(clippy::vec_box)] // TODO: Revisit this. Clippy complains about using Box in a Vec, but it's done here for performant moves of the data between channel and the vec.
+    #[allow(clippy::vec_box)] // Clippy complains about using Box in a Vec, but it's done here for performant moves of the data between channel and the vec.
     pub(crate) fn new_with_owned_data(
-        data: &'a mut Vec<Box<(LogRecord, InstrumentationScope)>>,
+        data: &'a Vec<Box<(LogRecord, InstrumentationScope)>>,
     ) -> LogBatch<'a> {
         LogBatch {
             data: LogBatchData::BorrowedVec(data),

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -23,7 +23,7 @@ pub struct LogBatch<'a> {
 
 /// The `LogBatchData` enum represents the data field of a `LogBatch`.
 /// It can either be:
-/// - A shared reference to a slice of tuples, where each tuple consists of an owned `LogRecord` and an owned `InstrumentationScope`.
+/// - A shared reference to a slice of boxed tuples, where each tuple consists of an owned `LogRecord` and an owned `InstrumentationScope`.
 /// - Or it can be a shared reference to a slice of tuples, where each tuple consists of a reference to a `LogRecord` and a reference to an `InstrumentationScope`.
 #[derive(Debug)]
 enum LogBatchData<'a> {

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -26,7 +26,7 @@ pub struct LogBatch<'a> {
 /// - A shared reference to a vector of tuples, where each tuple consists of a `LogRecord` and an `InstrumentationScope`.
 /// - Or it can be a slice of tuples, where each tuple consists of a reference to a `LogRecord` and a reference to an `InstrumentationScope`.
 #[derive(Debug)]
-#[allow(clippy::vec_box)] // TODO: Revisit this. Clippy complains about using Box in a Vec, but it's done here for performant moves of the data between channel and the vec.
+#[allow(clippy::vec_box)] // Clippy complains about using Box in a Vec, but it's done here for performant moves of the data between channel and the vec.
 enum LogBatchData<'a> {
     BorrowedVec(&'a Vec<Box<(LogRecord, InstrumentationScope)>>), // Used by BatchProcessor which clones the LogRecords for its own use.
     BorrowedSlice(&'a [(&'a LogRecord, &'a InstrumentationScope)]),

--- a/opentelemetry-sdk/src/export/logs/mod.rs
+++ b/opentelemetry-sdk/src/export/logs/mod.rs
@@ -23,12 +23,11 @@ pub struct LogBatch<'a> {
 
 /// The `LogBatchData` enum represents the data field of a `LogBatch`.
 /// It can either be:
-/// - A shared reference to a vector of tuples, where each tuple consists of a `LogRecord` and an `InstrumentationScope`.
-/// - Or it can be a slice of tuples, where each tuple consists of a reference to a `LogRecord` and a reference to an `InstrumentationScope`.
+/// - A shared reference to a slice of tuples, where each tuple consists of an owned `LogRecord` and an owned `InstrumentationScope`.
+/// - Or it can be a shared reference to a slice of tuples, where each tuple consists of a reference to a `LogRecord` and a reference to an `InstrumentationScope`.
 #[derive(Debug)]
-#[allow(clippy::vec_box)] // Clippy complains about using Box in a Vec, but it's done here for performant moves of the data between channel and the vec.
 enum LogBatchData<'a> {
-    BorrowedVec(&'a Vec<Box<(LogRecord, InstrumentationScope)>>), // Used by BatchProcessor which clones the LogRecords for its own use.
+    BorrowedVec(&'a [Box<(LogRecord, InstrumentationScope)>]), // Used by BatchProcessor which clones the LogRecords for its own use.
     BorrowedSlice(&'a [(&'a LogRecord, &'a InstrumentationScope)]),
 }
 
@@ -53,9 +52,8 @@ impl<'a> LogBatch<'a> {
         }
     }
 
-    #[allow(clippy::vec_box)] // Clippy complains about using Box in a Vec, but it's done here for performant moves of the data between channel and the vec.
     pub(crate) fn new_with_owned_data(
-        data: &'a Vec<Box<(LogRecord, InstrumentationScope)>>,
+        data: &'a [Box<(LogRecord, InstrumentationScope)>],
     ) -> LogBatch<'a> {
         LogBatch {
             data: LogBatchData::BorrowedVec(data),

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -524,12 +524,7 @@ where
         return LogResult::Ok(());
     }
 
-    let log_vec: Vec<(&LogRecord, &InstrumentationScope)> = batch
-        .iter()
-        .map(|log_data| (&log_data.0, &log_data.1))
-        .collect();
-
-    let export = exporter.export(LogBatch::new(log_vec.as_slice()));
+    let export = exporter.export(LogBatch::new_with_owned_data(batch));
     let export_result = futures_executor::block_on(export);
 
     // Clear the batch vec after exporting

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -524,7 +524,7 @@ where
         return LogResult::Ok(());
     }
 
-    let export = exporter.export(LogBatch::new_with_owned_data(batch));
+    let export = exporter.export(LogBatch::new_with_owned_data(batch.as_slice()));
     let export_result = futures_executor::block_on(export);
 
     // Clear the batch vec after exporting


### PR DESCRIPTION
For batch export, we create an additional vec just to hold the references to `LogRecord` and `InstrumentationScope`. This is needed because the constructor for `LogBatch` only accepts a slice of tuples that are references to `LogRecord` and `InstrumentationScope`. `BatchLogProcessor` already has a vec of owned `LogRecord` and `InstrumentationScope`. This PR is an attempt to reuse that vec.

## Changes
- Add a new constructor for `LogBatch` which accepts a shared reference of a vec of owned `LogRecord` and `InstrumentationScope`.
- No changes to the public API

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
