### PR TITLE
Sepatate Aggregate measure and collect functions

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -27,15 +27,6 @@ pub(crate) trait Measure<T>: Send + Sync + 'static {
     fn call(&self, measurement: T, attrs: &[KeyValue]);
 }
 
-impl<F, T> Measure<T> for F
-where
-    F: Fn(T, &[KeyValue]) + Send + Sync + 'static,
-{
-    fn call(&self, measurement: T, attrs: &[KeyValue]) {
-        self(measurement, attrs)
-    }
-}
-
 /// Stores the aggregate of measurements into the aggregation and returns the number
 /// of aggregate data-points output.
 pub(crate) trait ComputeAggregation: Send + Sync + 'static {
@@ -47,15 +38,23 @@ pub(crate) trait ComputeAggregation: Send + Sync + 'static {
     fn call(&self, dest: Option<&mut dyn Aggregation>) -> (usize, Option<Box<dyn Aggregation>>);
 }
 
-impl<T> ComputeAggregation for T
+/// Separate `measure` and `collect` functions for an aggregate.
+pub(crate) struct AggregateFns<T> {
+    pub(crate) measure: Arc<dyn Measure<T>>,
+    pub(crate) collect: Arc<dyn ComputeAggregation>,
+}
+
+/// Creates aggregate functions out of aggregate instance
+impl<A, T> From<A> for AggregateFns<T>
 where
-    T: Fn(Option<&mut dyn Aggregation>) -> (usize, Option<Box<dyn Aggregation>>)
-        + Send
-        + Sync
-        + 'static,
+    A: Measure<T> + ComputeAggregation,
 {
-    fn call(&self, dest: Option<&mut dyn Aggregation>) -> (usize, Option<Box<dyn Aggregation>>) {
-        self(dest)
+    fn from(value: A) -> Self {
+        let inst = Arc::new(value);
+        Self {
+            measure: inst.clone(),
+            collect: inst,
+        }
     }
 }
 
@@ -144,30 +143,18 @@ impl<T: Number> AggregateBuilder<T> {
     }
 
     /// Builds a last-value aggregate function input and output.
-    pub(crate) fn last_value(&self) -> (impl Measure<T>, impl ComputeAggregation) {
-        let lv = Arc::new(LastValue::new(self.temporality, self.filter.clone()));
-        (lv.clone(), lv)
+    pub(crate) fn last_value(&self) -> AggregateFns<T> {
+        LastValue::new(self.temporality, self.filter.clone()).into()
     }
 
     /// Builds a precomputed sum aggregate function input and output.
-    pub(crate) fn precomputed_sum(
-        &self,
-        monotonic: bool,
-    ) -> (impl Measure<T>, impl ComputeAggregation) {
-        let s = Arc::new(PrecomputedSum::new(
-            self.temporality,
-            self.filter.clone(),
-            monotonic,
-        ));
-
-        (s.clone(), s)
+    pub(crate) fn precomputed_sum(&self, monotonic: bool) -> AggregateFns<T> {
+        PrecomputedSum::new(self.temporality, self.filter.clone(), monotonic).into()
     }
 
     /// Builds a sum aggregate function input and output.
-    pub(crate) fn sum(&self, monotonic: bool) -> (impl Measure<T>, impl ComputeAggregation) {
-        let s = Arc::new(Sum::new(self.temporality, self.filter.clone(), monotonic));
-
-        (s.clone(), s)
+    pub(crate) fn sum(&self, monotonic: bool) -> AggregateFns<T> {
+        Sum::new(self.temporality, self.filter.clone(), monotonic).into()
     }
 
     /// Builds a histogram aggregate function input and output.
@@ -176,16 +163,15 @@ impl<T: Number> AggregateBuilder<T> {
         boundaries: Vec<f64>,
         record_min_max: bool,
         record_sum: bool,
-    ) -> (impl Measure<T>, impl ComputeAggregation) {
-        let h = Arc::new(Histogram::new(
+    ) -> AggregateFns<T> {
+        Histogram::new(
             self.temporality,
             self.filter.clone(),
             boundaries,
             record_min_max,
             record_sum,
-        ));
-
-        (h.clone(), h)
+        )
+        .into()
     }
 
     /// Builds an exponential histogram aggregate function input and output.
@@ -195,17 +181,16 @@ impl<T: Number> AggregateBuilder<T> {
         max_scale: i8,
         record_min_max: bool,
         record_sum: bool,
-    ) -> (impl Measure<T>, impl ComputeAggregation) {
-        let h = Arc::new(ExpoHistogram::new(
+    ) -> AggregateFns<T> {
+        ExpoHistogram::new(
             self.temporality,
             self.filter.clone(),
             max_size,
             max_scale,
             record_min_max,
             record_sum,
-        ));
-
-        (h.clone(), h)
+        )
+        .into()
     }
 }
 
@@ -221,7 +206,7 @@ mod tests {
 
     #[test]
     fn last_value_aggregation() {
-        let (measure, agg) =
+        let AggregateFns { measure, collect } =
             AggregateBuilder::<u64>::new(Temporality::Cumulative, None).last_value();
         let mut a = Gauge {
             data_points: vec![GaugeDataPoint {
@@ -235,7 +220,7 @@ mod tests {
         let new_attributes = [KeyValue::new("b", 2)];
         measure.call(2, &new_attributes[..]);
 
-        let (count, new_agg) = agg.call(Some(&mut a));
+        let (count, new_agg) = collect.call(Some(&mut a));
 
         assert_eq!(count, 1);
         assert!(new_agg.is_none());
@@ -247,7 +232,7 @@ mod tests {
     #[test]
     fn precomputed_sum_aggregation() {
         for temporality in [Temporality::Delta, Temporality::Cumulative] {
-            let (measure, agg) =
+            let AggregateFns { measure, collect } =
                 AggregateBuilder::<u64>::new(temporality, None).precomputed_sum(true);
             let mut a = Sum {
                 data_points: vec![
@@ -274,7 +259,7 @@ mod tests {
             let new_attributes = [KeyValue::new("b", 2)];
             measure.call(3, &new_attributes[..]);
 
-            let (count, new_agg) = agg.call(Some(&mut a));
+            let (count, new_agg) = collect.call(Some(&mut a));
 
             assert_eq!(count, 1);
             assert!(new_agg.is_none());
@@ -289,7 +274,8 @@ mod tests {
     #[test]
     fn sum_aggregation() {
         for temporality in [Temporality::Delta, Temporality::Cumulative] {
-            let (measure, agg) = AggregateBuilder::<u64>::new(temporality, None).sum(true);
+            let AggregateFns { measure, collect } =
+                AggregateBuilder::<u64>::new(temporality, None).sum(true);
             let mut a = Sum {
                 data_points: vec![
                     SumDataPoint {
@@ -315,7 +301,7 @@ mod tests {
             let new_attributes = [KeyValue::new("b", 2)];
             measure.call(3, &new_attributes[..]);
 
-            let (count, new_agg) = agg.call(Some(&mut a));
+            let (count, new_agg) = collect.call(Some(&mut a));
 
             assert_eq!(count, 1);
             assert!(new_agg.is_none());
@@ -330,7 +316,7 @@ mod tests {
     #[test]
     fn explicit_bucket_histogram_aggregation() {
         for temporality in [Temporality::Delta, Temporality::Cumulative] {
-            let (measure, agg) = AggregateBuilder::<u64>::new(temporality, None)
+            let AggregateFns { measure, collect } = AggregateBuilder::<u64>::new(temporality, None)
                 .explicit_bucket_histogram(vec![1.0], true, true);
             let mut a = Histogram {
                 data_points: vec![HistogramDataPoint {
@@ -354,7 +340,7 @@ mod tests {
             let new_attributes = [KeyValue::new("b", 2)];
             measure.call(3, &new_attributes[..]);
 
-            let (count, new_agg) = agg.call(Some(&mut a));
+            let (count, new_agg) = collect.call(Some(&mut a));
 
             assert_eq!(count, 1);
             assert!(new_agg.is_none());
@@ -373,7 +359,7 @@ mod tests {
     #[test]
     fn exponential_histogram_aggregation() {
         for temporality in [Temporality::Delta, Temporality::Cumulative] {
-            let (measure, agg) = AggregateBuilder::<u64>::new(temporality, None)
+            let AggregateFns { measure, collect } = AggregateBuilder::<u64>::new(temporality, None)
                 .exponential_bucket_histogram(4, 20, true, true);
             let mut a = ExponentialHistogram {
                 data_points: vec![ExponentialHistogramDataPoint {
@@ -406,7 +392,7 @@ mod tests {
             let new_attributes = [KeyValue::new("b", 2)];
             measure.call(3, &new_attributes[..]);
 
-            let (count, new_agg) = agg.call(Some(&mut a));
+            let (count, new_agg) = collect.call(Some(&mut a));
 
             assert_eq!(count, 1);
             assert!(new_agg.is_none());

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -1,6 +1,5 @@
 use std::mem::replace;
 use std::ops::DerefMut;
-use std::sync::Arc;
 use std::sync::Mutex;
 
 use crate::metrics::data::HistogramDataPoint;
@@ -209,7 +208,7 @@ impl<T: Number> Histogram<T> {
     }
 }
 
-impl<T> Measure<T> for Arc<Histogram<T>>
+impl<T> Measure<T> for Histogram<T>
 where
     T: Number,
 {
@@ -228,7 +227,7 @@ where
     }
 }
 
-impl<T> ComputeAggregation for Arc<Histogram<T>>
+impl<T> ComputeAggregation for Histogram<T>
 where
     T: Number,
 {
@@ -246,13 +245,13 @@ mod tests {
 
     #[test]
     fn check_buckets_are_selected_correctly() {
-        let hist = Arc::new(Histogram::<i64>::new(
+        let hist = Histogram::<i64>::new(
             Temporality::Cumulative,
             AttributeSetFilter::new(None),
             vec![1.0, 3.0, 6.0],
             false,
             false,
-        ));
+        );
         for v in 1..11 {
             Measure::call(&hist, v, &[]);
         }

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::metrics::{
     data::{self, Aggregation, GaugeDataPoint},
     Temporality,
@@ -128,7 +126,7 @@ impl<T: Number> LastValue<T> {
     }
 }
 
-impl<T> Measure<T> for Arc<LastValue<T>>
+impl<T> Measure<T> for LastValue<T>
 where
     T: Number,
 {
@@ -139,7 +137,7 @@ where
     }
 }
 
-impl<T> ComputeAggregation for Arc<LastValue<T>>
+impl<T> ComputeAggregation for LastValue<T>
 where
     T: Number,
 {

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering}
 use std::sync::{Arc, OnceLock, RwLock};
 
 use aggregate::{is_under_cardinality_limit, STREAM_CARDINALITY_LIMIT};
-pub(crate) use aggregate::{AggregateBuilder, ComputeAggregation, Measure};
+pub(crate) use aggregate::{AggregateBuilder, AggregateFns, ComputeAggregation, Measure};
 pub(crate) use exponential_histogram::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
 use opentelemetry::{otel_warn, KeyValue};
 

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -6,7 +6,6 @@ use crate::metrics::Temporality;
 use super::aggregate::{AggregateTimeInitiator, AttributeSetFilter};
 use super::{last_value::Assign, AtomicTracker, Number, ValueMap};
 use super::{ComputeAggregation, Measure};
-use std::sync::Arc;
 use std::{collections::HashMap, sync::Mutex};
 
 /// Summarizes a set of pre-computed sums as their arithmetic sum.
@@ -124,7 +123,7 @@ impl<T: Number> PrecomputedSum<T> {
     }
 }
 
-impl<T> Measure<T> for Arc<PrecomputedSum<T>>
+impl<T> Measure<T> for PrecomputedSum<T>
 where
     T: Number,
 {
@@ -135,7 +134,7 @@ where
     }
 }
 
-impl<T> ComputeAggregation for Arc<PrecomputedSum<T>>
+impl<T> ComputeAggregation for PrecomputedSum<T>
 where
     T: Number,
 {

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -1,6 +1,3 @@
-use std::sync::Arc;
-use std::vec;
-
 use crate::metrics::data::{self, Aggregation, SumDataPoint};
 use crate::metrics::Temporality;
 use opentelemetry::KeyValue;
@@ -143,7 +140,7 @@ impl<T: Number> Sum<T> {
     }
 }
 
-impl<T> Measure<T> for Arc<Sum<T>>
+impl<T> Measure<T> for Sum<T>
 where
     T: Number,
 {
@@ -154,7 +151,7 @@ where
     }
 }
 
-impl<T> ComputeAggregation for Arc<Sum<T>>
+impl<T> ComputeAggregation for Sum<T>
 where
     T: Number,
 {

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -22,6 +22,8 @@ use crate::{
     Resource,
 };
 
+use self::internal::AggregateFns;
+
 use super::Aggregation;
 
 /// Connects all of the instruments created by a meter provider to a [MetricReader].
@@ -176,7 +178,7 @@ struct InstrumentSync {
     name: Cow<'static, str>,
     description: Cow<'static, str>,
     unit: Cow<'static, str>,
-    comp_agg: Box<dyn internal::ComputeAggregation>,
+    comp_agg: Arc<dyn internal::ComputeAggregation>,
 }
 
 impl fmt::Debug for InstrumentSync {
@@ -385,9 +387,9 @@ where
                 .map(|allowed| Arc::new(move |kv: &KeyValue| allowed.contains(&kv.key)) as Arc<_>);
 
             let b = AggregateBuilder::new(self.pipeline.reader.temporality(kind), filter);
-            let (m, ca) = match aggregate_fn(b, &agg, kind) {
-                Ok(Some((m, ca))) => (m, ca),
-                other => return other.map(|fs| fs.map(|(m, _)| m)), // Drop aggregator or error
+            let AggregateFns { measure, collect } = match aggregate_fn(b, &agg, kind) {
+                Ok(Some(inst)) => inst,
+                other => return other.map(|fs| fs.map(|inst| inst.measure)), // Drop aggregator or error
             };
 
             self.pipeline.add_sync(
@@ -396,11 +398,11 @@ where
                     name: stream.name,
                     description: stream.description,
                     unit: stream.unit,
-                    comp_agg: ca,
+                    comp_agg: collect,
                 },
             );
 
-            Ok(Some(m))
+            Ok(Some(measure))
         });
 
         match cached {
@@ -476,11 +478,6 @@ fn default_aggregation_selector(kind: InstrumentKind) -> Aggregation {
     }
 }
 
-type AggregateFns<T> = (
-    Arc<dyn internal::Measure<T>>,
-    Box<dyn internal::ComputeAggregation>,
-);
-
 /// Returns new aggregate functions for the given params.
 ///
 /// If the aggregation is unknown or temporality is invalid, an error is returned.
@@ -489,25 +486,16 @@ fn aggregate_fn<T: Number>(
     agg: &aggregation::Aggregation,
     kind: InstrumentKind,
 ) -> MetricResult<Option<AggregateFns<T>>> {
-    fn box_val<T>(
-        (m, ca): (impl internal::Measure<T>, impl internal::ComputeAggregation),
-    ) -> (
-        Arc<dyn internal::Measure<T>>,
-        Box<dyn internal::ComputeAggregation>,
-    ) {
-        (Arc::new(m), Box::new(ca))
-    }
-
     match agg {
         Aggregation::Default => aggregate_fn(b, &default_aggregation_selector(kind), kind),
         Aggregation::Drop => Ok(None),
-        Aggregation::LastValue => Ok(Some(box_val(b.last_value()))),
+        Aggregation::LastValue => Ok(Some(b.last_value())),
         Aggregation::Sum => {
             let fns = match kind {
-                InstrumentKind::ObservableCounter => box_val(b.precomputed_sum(true)),
-                InstrumentKind::ObservableUpDownCounter => box_val(b.precomputed_sum(false)),
-                InstrumentKind::Counter | InstrumentKind::Histogram => box_val(b.sum(true)),
-                _ => box_val(b.sum(false)),
+                InstrumentKind::ObservableCounter => b.precomputed_sum(true),
+                InstrumentKind::ObservableUpDownCounter => b.precomputed_sum(false),
+                InstrumentKind::Counter | InstrumentKind::Histogram => b.sum(true),
+                _ => b.sum(false),
             };
             Ok(Some(fns))
         }
@@ -521,11 +509,11 @@ fn aggregate_fn<T: Number>(
                     | InstrumentKind::ObservableUpDownCounter
                     | InstrumentKind::ObservableGauge
             );
-            Ok(Some(box_val(b.explicit_bucket_histogram(
+            Ok(Some(b.explicit_bucket_histogram(
                 boundaries.to_vec(),
                 *record_min_max,
                 record_sum,
-            ))))
+            )))
         }
         Aggregation::Base2ExponentialHistogram {
             max_size,
@@ -538,12 +526,12 @@ fn aggregate_fn<T: Number>(
                     | InstrumentKind::ObservableUpDownCounter
                     | InstrumentKind::ObservableGauge
             );
-            Ok(Some(box_val(b.exponential_bucket_histogram(
+            Ok(Some(b.exponential_bucket_histogram(
                 *max_size,
                 *max_scale,
                 *record_min_max,
                 record_sum,
-            ))))
+            )))
         }
     }
 }


### PR DESCRIPTION
## Changes

Minor improvements in how aggregate functions for `measure` and `collect` is created.
* Makes it more convenient to create aggregate functions
```diff
-    pub(crate) fn last_value(&self) -> (impl Measure<T>, impl ComputeAggregation) {
-        let lv = Arc::new(LastValue::new(self.temporality, self.filter.clone()));
-        (lv.clone(), lv)
+    pub(crate) fn last_value(&self) -> AggregateFns<T> {
+        LastValue::new(self.temporality, self.filter.clone()).into()
``` 
This will be important for #2328, when we'll want to construct separate instances for different temporality
* Now there's only single `Arc` instance for measure and collect. Previously there was helper function that wrapped single `Arc` into another `Arc` for measure, and into `Box` for collect.
```diff
-    fn box_val<T>(
-        (m, ca): (impl internal::Measure<T>, impl internal::ComputeAggregation),
-    ) -> (
-        Arc<dyn internal::Measure<T>>,
-        Box<dyn internal::ComputeAggregation>,
-    ) {
-        (Arc::new(m), Box::new(ca))
-    }
-
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
