### PR TITLE
Refactor BatchLogProcessor

### DIFF
--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -310,7 +310,7 @@ impl LogProcessor for BatchLogProcessor {
                 // This is a cost-efficient check as atomic load operations do not require exclusive access to cache line.
                 // Perform atomic swap to `export_log_message_sent` ONLY when the atomic load operation above returns false.
                 // Atomic swap/compare_exchange operations require exclusive access to cache line on most processor architectures.
-                // We could have used compare_exchange as well here, but it's more verbose than swap. Also, swap uses compare_exchange internally anyway.
+                // We could have used compare_exchange as well here, but it's more verbose than swap.
                 if !self.export_log_message_sent.swap(true, Ordering::Relaxed) {
                     match self.message_sender.try_send(BatchMessage::ExportLog(
                         self.export_log_message_sent.clone(),

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -308,7 +308,7 @@ impl LogProcessor for BatchLogProcessor {
 
             if !self.export_log_message_sent.load(Ordering::Relaxed) {
                 // This is a cost-efficient check as atomic load operations do not require exclusive access to cache line.
-                // Perform atomic swap to `export_log_message_sent` ONLY when the atomic load operation abbove returns false.
+                // Perform atomic swap to `export_log_message_sent` ONLY when the atomic load operation above returns false.
                 // Atomic swap/compare_exchange operations require exclusive access to cache line on most processor architectures.
                 // We could have used compare_exchange as well here, but it's more verbose than swap. Also, swap uses compare_exchange internally anyway.
                 if !self.export_log_message_sent.swap(true, Ordering::Relaxed) {


### PR DESCRIPTION
Towards #2478 

## Changes
- Refactor `BatchLogProcessor` to wake up the background thread ONLY when needed https://github.com/open-telemetry/opentelemetry-rust/issues/2478#issuecomment-2568633280
- Address the shutdown issue

## Performance
There is a significant performance improvement mainly because of `mpsc:Receiver` not being excessively active (unlike how it is on main branch). It looks like there is a significant amount of synchronization overhead with senders and receivers actively working on the channel all the time. With this PR, the channel receivers are only woken up when needed so the logging threads incur a lesser synchronization overhead cost.

I updated the [`Logging_Comparable_To_Appender`](https://github.com/open-telemetry/opentelemetry-rust/blob/37d2e51c23afea4d318a31294f3229963c6e88dc/opentelemetry-sdk/benches/log.rs#L103-L127) benchmark and [logs stress test](https://github.com/open-telemetry/opentelemetry-rust/blob/main/stress/src/logs.rs) to use a `BatchProcessor` with a no-op exporter and ran the tests. Here are the results:

- **25% improvement in throughput** with stress test results going up from 12M (main) to 15 M
- **~46% improvement in benchmarks** with the latency measurement going down from 420ns (main) to 227 ns.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
