### PR TITLE
chore: disable failing integration tests

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/tests/logs.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs.rs
@@ -99,7 +99,7 @@ mod logtests {
         Ok(())
     }
 
-    #[ignore = "TODO: [Fix Me] Ignored due to concurrent test failures. Needs resolution."]
+    #[ignore = "TODO: [Fix Me] Failing on CI. Needs to be investigated and resolved."]
     #[test]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
     pub fn logs_batch_non_tokio_main() -> Result<()> {

--- a/opentelemetry-otlp/tests/integration_test/tests/logs.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs.rs
@@ -99,6 +99,7 @@ mod logtests {
         Ok(())
     }
 
+    #[ignore = "TODO: [Fix Me] Ignored due to concurrent test failures. Needs resolution."]
     #[test]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
     pub fn logs_batch_non_tokio_main() -> Result<()> {

--- a/opentelemetry-otlp/tests/integration_test/tests/traces.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/traces.rs
@@ -141,6 +141,7 @@ pub fn test_serde() -> Result<()> {
     Ok(())
 }
 
+#[ignore = "TODO: [Fix Me] Ignored due to concurrent test failures. Needs resolution."]
 #[test]
 #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
 pub fn span_batch_non_tokio_main() -> Result<()> {

--- a/opentelemetry-otlp/tests/integration_test/tests/traces.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/traces.rs
@@ -141,7 +141,7 @@ pub fn test_serde() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "TODO: [Fix Me] Ignored due to concurrent test failures. Needs resolution."]
+#[ignore = "TODO: [Fix Me] Failing on CI. Needs to be investigated and resolved."]
 #[test]
 #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
 pub fn span_batch_non_tokio_main() -> Result<()> {


### PR DESCRIPTION
## Changes

As of now, multiple integration tests are [unstable](https://github.com/open-telemetry/opentelemetry-rust/actions/runs/12577873922/job/35055861465?pr=2491) in the CI. These tests are as such fine, but being running concurrently with existing test, the collector generated output file get's used in both the tests and validation fails. Running these tests in single thread using `--test-thread=1` doesn't seem to help. Disabling _temporarily_ to unblock PRs. Raised #2496 to track this.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
