### PR TITLE
[Metrics][POC] Use Weak instead of Arc in Counter to respect MeterProvider shutdown

### DIFF
--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -278,8 +278,18 @@ impl InstrumentId {
     }
 }
 
+pub(crate) trait SyncInstrumentUpdate: Send + Sync {}
+
+impl<T> SyncInstrumentUpdate for ResolvedMeasures<T> {}
+
 pub(crate) struct ResolvedMeasures<T> {
     pub(crate) measures: Vec<Arc<dyn Measure<T>>>,
+}
+
+impl<T: 'static> ResolvedMeasures<T> {
+    pub(crate) fn as_sync_instrument_update(self: Arc<Self>) -> Arc<dyn SyncInstrumentUpdate> {
+        self
+    }
 }
 
 impl<T: Copy + 'static> SyncInstrument<T> for ResolvedMeasures<T> {

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -141,6 +141,10 @@ impl SdkMeterProviderInner {
                 "MeterProvider shutdown already invoked.".into(),
             ))
         } else {
+            let mut meters = self.meters.lock().unwrap();
+            for (_, meter) in meters.drain() {
+                meter.sync_instruments.lock().unwrap().clear(); // Clear all `SyncInstrument` trait objects to avoid any further updates from instruments.
+            }
             self.pipes.shutdown()
         }
     }


### PR DESCRIPTION
Towards #2442 

## Changes
- Use `Weak` instead of `Arc` in instruments to respect `MeterProvider` shutdown

Note: This also requires `MeterProvider` instance to be valid for metrics to be emitted.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
