### PR TITLE
Update the link to Meeting Notes doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ for specific dates and for Zoom meeting links. "OTel Rust SIG" is the name of
 meeting for this group.
 
 Meeting notes are available as a public [Google
-doc](https://docs.google.com/document/d/1tGKuCsSnyT2McDncVJrMgg74_z8V06riWZa0Sr79I_4/edit).
+doc](https://docs.google.com/document/d/12upOzNk8c3SFTjsL6IRohCWMgzLKoknSCOOdMakbWo4/edit).
 If you have trouble accessing the doc, please get in touch on
 [Slack](https://cloud-native.slack.com/archives/C03GDP0H023).
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/community/issues/2501, https://github.com/open-telemetry/community/pull/2502
- The meeting notes doc was not under OpenTelemetry account
- A copy of the existing doc has been moved under the OpenTelemetry account now
- We will be using this new doc going forward

## Changes
- Update the link to Meeting Notes doc

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
