### PR TITLE
Metrics aggregate collector generic over temporality

### DIFF
--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -53,6 +53,14 @@ pub trait Aggregation: fmt::Debug + any::Any + Send + Sync {
     fn as_mut(&mut self) -> &mut dyn any::Any;
 }
 
+/// Allow to access data points of an [Aggregation].
+pub trait AggregationDataPoints {
+    /// The type of data point in the aggregation.
+    type Point;
+    /// The data points of the aggregation.
+    fn points(&mut self) -> &mut Vec<Self::Point>;
+}
+
 /// DataPoint is a single data point in a time series.
 #[derive(Debug, PartialEq)]
 pub struct GaugeDataPoint<T> {
@@ -225,6 +233,14 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for ExponentialHistogram
     }
     fn as_mut(&mut self) -> &mut dyn any::Any {
         self
+    }
+}
+
+impl<T> AggregationDataPoints for ExponentialHistogram<T> {
+    type Point = ExponentialHistogramDataPoint<T>;
+
+    fn points(&mut self) -> &mut Vec<Self::Point> {
+        &mut self.data_points
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -54,11 +54,11 @@ pub trait Aggregation: fmt::Debug + any::Any + Send + Sync {
 }
 
 /// Allow to access data points of an [Aggregation].
-pub trait AggregationDataPoints {
+pub(crate) trait AggregationDataPoints {
     /// The type of data point in the aggregation.
-    type Point;
+    type DataPoint;
     /// The data points of the aggregation.
-    fn points(&mut self) -> &mut Vec<Self::Point>;
+    fn points(&mut self) -> &mut Vec<Self::DataPoint>;
 }
 
 /// DataPoint is a single data point in a time series.
@@ -237,9 +237,9 @@ impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for ExponentialHistogram
 }
 
 impl<T> AggregationDataPoints for ExponentialHistogram<T> {
-    type Point = ExponentialHistogramDataPoint<T>;
+    type DataPoint = ExponentialHistogramDataPoint<T>;
 
-    fn points(&mut self) -> &mut Vec<Self::Point> {
+    fn points(&mut self) -> &mut Vec<Self::DataPoint> {
         &mut self.data_points
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -198,29 +198,29 @@ impl<T: Number> AggregateBuilder<T> {
         record_sum: bool,
     ) -> AggregateFns<T> {
         match self.temporality {
-            Temporality::Delta => ExpoHistogram {
-                aggregate_collector: Collector::new(
+            Temporality::Delta => ExpoHistogram::new(
+                Collector::new(
                     self.filter.clone(),
                     DeltaValueMap::new(ExpoHistogramBucketConfig {
                         max_size: max_size as i32,
                         max_scale,
                     }),
                 ),
-                record_min_max,
                 record_sum,
-            }
+                record_min_max,
+            )
             .into(),
-            _ => ExpoHistogram {
-                aggregate_collector: Collector::new(
+            _ => ExpoHistogram::new(
+                Collector::new(
                     self.filter.clone(),
                     CumulativeValueMap::new(ExpoHistogramBucketConfig {
                         max_size: max_size as i32,
                         max_scale,
                     }),
                 ),
-                record_min_max,
                 record_sum,
-            }
+                record_min_max,
+            )
             .into(),
         }
     }

--- a/opentelemetry-sdk/src/metrics/internal/collector.rs
+++ b/opentelemetry-sdk/src/metrics/internal/collector.rs
@@ -1,0 +1,195 @@
+use opentelemetry::KeyValue;
+
+use crate::metrics::{
+    data::{Aggregation, AggregationDataPoints},
+    Temporality,
+};
+
+use super::{
+    aggregate::{AggregateTime, AttributeSetFilter},
+    AggregateTimeInitiator, Aggregator, InitAggregationData, ValueMap,
+};
+
+/// Aggregate measurements for attribute sets and collect these aggregates into data points for specific temporality
+pub(crate) trait AggregateMap: Send + Sync + 'static {
+    const TEMPORALITY: Temporality;
+    type Aggr: Aggregator;
+
+    fn measure(&self, value: <Self::Aggr as Aggregator>::PreComputedValue, attributes: &[KeyValue]);
+
+    fn collect_data_points<DP, MapFn>(&self, dest: &mut Vec<DP>, map_fn: MapFn)
+    where
+        MapFn: FnMut(Vec<KeyValue>, &Self::Aggr) -> DP;
+}
+
+/// Higher level abstraction (compared to [`AggregateMap`]) that also does the filtering and collection into aggregation data
+pub(crate) trait AggregateCollector: Send + Sync + 'static {
+    const TEMPORALITY: Temporality;
+    type Aggr: Aggregator;
+
+    fn measure(&self, value: <Self::Aggr as Aggregator>::PreComputedValue, attributes: &[KeyValue]);
+
+    fn collect<InitAggregate, F>(
+        &self,
+        aggregate: &InitAggregate,
+        dest: Option<&mut dyn Aggregation>,
+        create_point: F,
+    ) -> (usize, Option<Box<dyn Aggregation>>)
+    where
+        InitAggregate: InitAggregationData,
+        F: FnMut(
+            Vec<KeyValue>,
+            &Self::Aggr,
+        ) -> <InitAggregate::Aggr as AggregationDataPoints>::Point;
+}
+
+pub(crate) struct Collector<AM> {
+    filter: AttributeSetFilter,
+    aggregate_map: AM,
+    time: AggregateTimeInitiator,
+}
+
+impl<AM> Collector<AM>
+where
+    AM: AggregateMap,
+{
+    pub(crate) fn new(filter: AttributeSetFilter, aggregate_map: AM) -> Self {
+        Self {
+            filter,
+            aggregate_map,
+            time: AggregateTimeInitiator::default(),
+        }
+    }
+
+    fn init_time(&self) -> AggregateTime {
+        if let Temporality::Delta = AM::TEMPORALITY {
+            self.time.delta()
+        } else {
+            self.time.cumulative()
+        }
+    }
+}
+
+impl<AM> AggregateCollector for Collector<AM>
+where
+    AM: AggregateMap,
+{
+    const TEMPORALITY: Temporality = AM::TEMPORALITY;
+
+    type Aggr = AM::Aggr;
+
+    fn measure(&self, value: <AM::Aggr as Aggregator>::PreComputedValue, attributes: &[KeyValue]) {
+        self.filter.apply(attributes, |filtered_attrs| {
+            self.aggregate_map.measure(value, filtered_attrs);
+        });
+    }
+
+    fn collect<InitAggregate, F>(
+        &self,
+        aggregate: &InitAggregate,
+        dest: Option<&mut dyn Aggregation>,
+        create_point: F,
+    ) -> (usize, Option<Box<dyn Aggregation>>)
+    where
+        InitAggregate: InitAggregationData,
+        F: FnMut(Vec<KeyValue>, &AM::Aggr) -> <InitAggregate::Aggr as AggregationDataPoints>::Point,
+    {
+        let time = self.init_time();
+        let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<InitAggregate::Aggr>());
+        let mut new_agg = if s_data.is_none() {
+            Some(aggregate.create_new(time))
+        } else {
+            None
+        };
+        let s_data = s_data.unwrap_or_else(|| new_agg.as_mut().expect("present if s_data is none"));
+        aggregate.reset_existing(s_data, time);
+        self.aggregate_map
+            .collect_data_points(s_data.points(), create_point);
+
+        (
+            s_data.points().len(),
+            new_agg.map(|a| Box::new(a) as Box<_>),
+        )
+    }
+}
+
+/// At the moment use [`ValueMap`] under the hood (which support both Delta and Cumulative), to implement `AggregateMap` for Delta temporality
+/// Later this could be improved to support only Delta temporality
+pub(crate) struct DeltaValueMap<A>(ValueMap<A>)
+where
+    A: Aggregator;
+
+impl<A> DeltaValueMap<A>
+where
+    A: Aggregator,
+{
+    pub(crate) fn new(config: A::InitConfig) -> Self {
+        Self(ValueMap::new(config))
+    }
+}
+
+impl<A> AggregateMap for DeltaValueMap<A>
+where
+    A: Aggregator,
+    <A as Aggregator>::InitConfig: Send + Sync,
+{
+    const TEMPORALITY: Temporality = Temporality::Delta;
+
+    type Aggr = A;
+
+    fn measure(
+        &self,
+        value: <Self::Aggr as Aggregator>::PreComputedValue,
+        attributes: &[KeyValue],
+    ) {
+        self.0.measure(value, attributes);
+    }
+
+    fn collect_data_points<DP, MapFn>(&self, dest: &mut Vec<DP>, mut map_fn: MapFn)
+    where
+        MapFn: FnMut(Vec<KeyValue>, &Self::Aggr) -> DP,
+    {
+        self.0
+            .collect_and_reset(dest, |attributes, aggr| map_fn(attributes, &aggr));
+    }
+}
+
+/// At the moment use [`ValueMap`] under the hood (which support both Delta and Cumulative), to implement `AggregateMap` for Cumulative temporality
+/// Later this could be improved to support only Cumulative temporality
+pub(crate) struct CumulativeValueMap<A>(ValueMap<A>)
+where
+    A: Aggregator;
+
+impl<A> CumulativeValueMap<A>
+where
+    A: Aggregator,
+{
+    pub(crate) fn new(config: A::InitConfig) -> Self {
+        Self(ValueMap::new(config))
+    }
+}
+
+impl<A> AggregateMap for CumulativeValueMap<A>
+where
+    A: Aggregator,
+    <A as Aggregator>::InitConfig: Send + Sync,
+{
+    const TEMPORALITY: Temporality = Temporality::Cumulative;
+
+    type Aggr = A;
+
+    fn measure(
+        &self,
+        value: <Self::Aggr as Aggregator>::PreComputedValue,
+        attributes: &[KeyValue],
+    ) {
+        self.0.measure(value, attributes);
+    }
+
+    fn collect_data_points<DP, MapFn>(&self, dest: &mut Vec<DP>, map_fn: MapFn)
+    where
+        MapFn: FnMut(Vec<KeyValue>, &Self::Aggr) -> DP,
+    {
+        self.0.collect_readonly(dest, map_fn);
+    }
+}

--- a/opentelemetry-sdk/src/metrics/internal/collector.rs
+++ b/opentelemetry-sdk/src/metrics/internal/collector.rs
@@ -40,7 +40,7 @@ pub(crate) trait AggregateCollector: Send + Sync + 'static {
         F: FnMut(
             Vec<KeyValue>,
             &Self::Aggr,
-        ) -> <InitAggregate::Aggr as AggregationDataPoints>::Point;
+        ) -> <InitAggregate::Aggr as AggregationDataPoints>::DataPoint;
 }
 
 pub(crate) struct Collector<AM> {
@@ -92,7 +92,10 @@ where
     ) -> (usize, Option<Box<dyn Aggregation>>)
     where
         InitAggregate: InitAggregationData,
-        F: FnMut(Vec<KeyValue>, &AM::Aggr) -> <InitAggregate::Aggr as AggregationDataPoints>::Point,
+        F: FnMut(
+            Vec<KeyValue>,
+            &AM::Aggr,
+        ) -> <InitAggregate::Aggr as AggregationDataPoints>::DataPoint,
     {
         let time = self.init_time();
         let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<InitAggregate::Aggr>());

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -349,9 +349,19 @@ pub(crate) struct ExpoHistogramBucketConfig {
 /// Each histogram is scoped by attributes and the aggregation cycle the
 /// measurements were made in.
 pub(crate) struct ExpoHistogram<AC> {
-    pub(crate) aggregate_collector: AC,
-    pub(crate) record_sum: bool,
-    pub(crate) record_min_max: bool,
+    aggregate_collector: AC,
+    record_sum: bool,
+    record_min_max: bool,
+}
+
+impl<AC> ExpoHistogram<AC> {
+    pub(crate) fn new(aggregate_collector: AC, record_sum: bool, record_min_max: bool) -> Self {
+        Self {
+            aggregate_collector,
+            record_sum,
+            record_min_max,
+        }
+    }
 }
 
 impl<AC, T> Measure<T> for ExpoHistogram<AC>

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -1,4 +1,5 @@
 mod aggregate;
+mod collector;
 mod exponential_histogram;
 mod histogram;
 mod last_value;
@@ -12,7 +13,10 @@ use std::ops::{Add, AddAssign, DerefMut, Sub};
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
 
-use aggregate::{is_under_cardinality_limit, STREAM_CARDINALITY_LIMIT};
+use aggregate::{
+    is_under_cardinality_limit, AggregateTimeInitiator, InitAggregationData,
+    STREAM_CARDINALITY_LIMIT,
+};
 pub(crate) use aggregate::{AggregateBuilder, AggregateFns, ComputeAggregation, Measure};
 pub(crate) use exponential_histogram::{EXPO_MAX_SCALE, EXPO_MIN_SCALE};
 use opentelemetry::{otel_warn, KeyValue};
@@ -25,7 +29,7 @@ fn stream_overflow_attributes() -> &'static Vec<KeyValue> {
     STREAM_OVERFLOW_ATTRIBUTES.get_or_init(|| vec![KeyValue::new("otel.metric.overflow", "true")])
 }
 
-pub(crate) trait Aggregator {
+pub(crate) trait Aggregator: Send + Sync + 'static {
     /// A static configuration that is needed in order to initialize aggregator.
     /// E.g. bucket_size at creation time .
     type InitConfig;


### PR DESCRIPTION
Prerequisite for #2328

## Changes

Provided several interfaces that allow to provide "ValueMap" implementation for specific temporality.
The key element is `Collector` (which implements `AggregateCollector`). It provides common functionality for all aggregations (Sum, LastValue, Histogram, etc...):
* provide attribute-set filtering functionality (for measurement).
* for specific temporality:
  * time initialization
  * aggregate data creation/initialization
  * collection of aggregation data
This allow to have very clean concrete implementations. I have refactored `ExponentialHistogram` to use these new interfaces as an example.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
