### PR TITLE
Add internal-logs feature to opentelemetry-proto

### DIFF
--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -30,7 +30,7 @@ path = "tests/json_serde.rs"
 
 [features]
 default = ["full"]
-full = ["gen-tonic", "trace", "logs", "metrics", "zpages", "with-serde"]
+full = ["gen-tonic", "trace", "logs", "metrics", "zpages", "with-serde", "internal-logs"]
 
 # crates used to generate rs files
 gen-tonic = ["gen-tonic-messages", "tonic/transport"]
@@ -44,6 +44,7 @@ zpages = ["trace"]
 testing = ["opentelemetry/testing"]
 
 # add ons
+internal-logs = ["tracing"]
 with-schemars = ["schemars"]
 with-serde = ["serde", "hex"]
 
@@ -55,6 +56,7 @@ opentelemetry_sdk = { version = "0.27", default-features = false, path = "../ope
 schemars = { version = "0.8", optional = true }
 serde = { workspace = true, optional = true, features = ["serde_derive"] }
 hex = { version = "0.4.3", optional = true }
+tracing = {workspace = true, optional = true} # optional for opentelemetry internal logging
 
 [dev-dependencies]
 opentelemetry = { features = ["testing"], path = "../opentelemetry" }


### PR DESCRIPTION
CI checks are failing due to `internal-logs` not being a feature defined for opentelemetry-proto: https://github.com/open-telemetry/opentelemetry-rust/actions/runs/12745545110/job/35519725802?pr=2494

## Changes
- Add internal-logs feature to opentelemetry-proto

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
