### PR TITLE
Enable clippy for integration tests

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,7 +10,8 @@ cargo_feature() {
 }
 
 if rustup component add clippy; then
- crates=( "opentelemetry"
+ crates=(
+                "opentelemetry"
                 "opentelemetry-http"
                 "opentelemetry-jaeger-propagator"
                 "opentelemetry-appender-log"
@@ -21,12 +22,18 @@ if rustup component add clippy; then
                 "opentelemetry-sdk"
                 "opentelemetry-semantic-conventions"
                 "opentelemetry-stdout"
-                "opentelemetry-zipkin")
+                "opentelemetry-zipkin"
+         )
   for crate in "${crates[@]}"; do
       cargo clippy --manifest-path=$crate/Cargo.toml --all-targets --all-features -- \
           `# Exit with a nonzero code if there are clippy warnings` \
           -Dwarnings
   done
+
+  # Add integration test linting
+  echo "checking integration tests"
+  cargo clippy --manifest-path=opentelemetry-otlp/tests/integration_test/Cargo.toml --all-targets --all-features -- \
+      -Dwarnings
 
   cargo_feature opentelemetry "trace,metrics,logs,spec_unstable_logs_enabled,testing"
 


### PR DESCRIPTION
Fixes: https://github.com/open-telemetry/opentelemetry-rust/issues/2470

ToDo:
1) There are a couple of failure due to this lint check.
2) Enable linter wherever possible apart from the crates

Will open up the PR for review after addressing 1 and 2.