### PR TITLE
feat(trace): impl ShouldSample for Box<dyn ShouldSample>

### DIFF
--- a/opentelemetry-sdk/src/trace/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler.rs
@@ -102,6 +102,21 @@ impl Clone for Box<dyn ShouldSample> {
     }
 }
 
+impl ShouldSample for Box<dyn ShouldSample> {
+    fn should_sample(
+        &self,
+        parent_context: Option<&Context>,
+        trace_id: TraceId,
+        name: &str,
+        span_kind: &SpanKind,
+        attributes: &[KeyValue],
+        links: &[Link],
+    ) -> SamplingResult {
+        self.as_ref()
+            .should_sample(parent_context, trace_id, name, span_kind, attributes, links)
+    }
+}
+
 /// Default Sampling options
 ///
 /// The [built-in samplers] allow for simple decisions. For more complex scenarios consider


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Implement `ShouldSample` for `Box<dyn ShouldSample>` because: 
- users of this crate cannot do it themselves (because of the Rust orphan rule)
- while working on a small wrapper around `opentelemetry-sdk` but `tracer_provider_builder.with_sampler(...)` currently only accepts a `T: crate::trace::ShouldSample + 'static` generic parameter... but I can't introduce generic types in my wrapper (for some reasons) and therefore I would like to use a `dyn ShouldSample` instead... and I currently can't do that 

I'll update this PR to fix the "Merge requirement checklist" below, only if you are OK with it in the first place.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
