### PR TITLE
Add reqwest client to integration test

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/tests/logs.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs.rs
@@ -124,13 +124,13 @@ mod logtests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    #[cfg(any(feature = "tonic-client"))]
+    #[cfg(any(feature = "tonic-client", feature = "reqwest-client"))]
     pub async fn logs_simple_tokio_multi_thread() -> Result<()> {
         logs_simple_tokio_helper().await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[cfg(any(feature = "tonic-client"))]
+    #[cfg(any(feature = "tonic-client", feature = "reqwest-client"))]
     pub async fn logs_simple_tokio_multi_with_one_worker() -> Result<()> {
         logs_simple_tokio_helper().await
     }
@@ -138,7 +138,7 @@ mod logtests {
     // Ignored, to be investigated
     #[ignore]
     #[tokio::test(flavor = "current_thread")]
-    #[cfg(any(feature = "tonic-client"))]
+    #[cfg(any(feature = "tonic-client", feature = "reqwest-client"))]
     pub async fn logs_simple_tokio_current() -> Result<()> {
         logs_simple_tokio_helper().await
     }
@@ -155,9 +155,7 @@ mod logtests {
         let expected_uuid = Uuid::new_v4().to_string();
         {
             let _guard = tracing::subscriber::set_default(subscriber);
-            info!("Tracing subscriber initialized");
             info!(target: "my-target",  uuid = expected_uuid, "hello from {}. My price is {}.", "banana", 2.99);
-            info!("Log emitted");
         }
 
         let _ = logger_provider.shutdown();

--- a/opentelemetry-otlp/tests/integration_test/tests/metrics.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/metrics.rs
@@ -189,8 +189,7 @@ pub fn validate_metrics_against_results(scope_name: &str) -> Result<()> {
 /// TODO - fix this asynchronously.
 ///
 #[cfg(test)]
-#[cfg(not(feature = "hyper-client"))]
-#[cfg(not(feature = "reqwest-client"))]
+#[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
 mod metrictests {
 
     use super::*;

--- a/opentelemetry-otlp/tests/integration_test/tests/traces.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/traces.rs
@@ -48,6 +48,7 @@ const LEMONS_KEY: Key = Key::from_static_str("lemons");
 const ANOTHER_KEY: Key = Key::from_static_str("ex.com/another");
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
 pub async fn traces() -> Result<()> {
     test_utils::start_collector_container().await?;
 

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -16,11 +16,10 @@ if [ -d "$TEST_DIR" ]; then
     # Run tests with the reqwest-client feature
     echo
     echo ####
-    echo "Integration Tests: Reqwest Client (Disabled now)"
+    echo "Integration Tests: Reqwest Client"
     echo ####
     echo
-    # TODO: reqwest client is not supported with thread based processor and reader. Enable this test once it is supported.
-    #cargo test --no-default-features --features "reqwest-client","internal-logs"
+    cargo test --no-default-features --features "reqwest-client","internal-logs"
 
     # Run tests with the reqwest-blocking-client feature
     echo


### PR DESCRIPTION
script will not run integration test with request-client feature. But metric tests are not compiled for this target.
Log tests are compiled when using simple processor.

Almost done with tests, next step is to create an .md file or a doc, which show the matrix of all combinations of runtime, simple/batch, and networkclient.