### PR TITLE
Add the full log validation test in Integration test

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/Cargo.toml
+++ b/opentelemetry-otlp/tests/integration_test/Cargo.toml
@@ -17,6 +17,7 @@ ctor = "0.2.9"
 uuid = { version = "1.3", features = ["v4"] }
 tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }
 tracing = {workspace = true}
+serial_test = "3.2.0"
 
 [target.'cfg(unix)'.dependencies]
 opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}

--- a/opentelemetry-otlp/tests/integration_test/Cargo.toml
+++ b/opentelemetry-otlp/tests/integration_test/Cargo.toml
@@ -17,7 +17,6 @@ ctor = "0.2.9"
 uuid = { version = "1.3", features = ["v4"] }
 tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }
 tracing = {workspace = true}
-serial_test = "3.2.0"
 
 [target.'cfg(unix)'.dependencies]
 opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}

--- a/opentelemetry-otlp/tests/integration_test/src/test_utils.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/test_utils.rs
@@ -135,28 +135,6 @@ pub fn cleanup_file(file_path: &str) {
         .open(file_path); // ignore result, as file may not exist
 }
 
-pub fn print_file_content(file_path: &str) {
-    use std::io::BufRead;
-    use std::io::BufReader;
-    // Open the file for reading
-    let file_result = File::open(file_path);
-
-    match file_result {
-        Ok(file) => {
-            let reader = BufReader::new(file);
-            for line in reader.lines() {
-                match line {
-                    Ok(content) => println!("{}", content), // Print each line
-                    Err(e) => eprintln!("Error reading a line: {}", e),
-                }
-            }
-        }
-        Err(e) => {
-            eprintln!("Failed to open file: {}", e);
-        }
-    }
-}
-
 ///
 /// Shuts down our collector container. This should be run as part of each test
 /// suite shutting down!

--- a/opentelemetry-otlp/tests/integration_test/tests/logs.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs.rs
@@ -89,42 +89,18 @@ mod logtests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
-    #[serial_test::serial]
-    pub async fn test_logs() -> Result<()> {
-        // Make sure the container is running
-        use crate::{assert_logs_results, init_logs};
-        test_utils::start_collector_container().await?;
-        test_utils::cleanup_file("./actual/logs.json"); // Ensure logs.json is empty before the test
-        let logger_provider = init_logs(false).unwrap();
-        let layer = layer::OpenTelemetryTracingBridge::new(&logger_provider);
-        let subscriber = tracing_subscriber::registry().with(layer);
-        {
-            let _guard = tracing::subscriber::set_default(subscriber);
-            info!(target: "my-target", "hello from {}. My price is {}.", "banana", 2.99);
-        }
-        let _ = logger_provider.shutdown();
-        tokio::time::sleep(Duration::from_secs(5)).await;
-        assert_logs_results(test_utils::LOGS_FILE, "expected/logs.json")?;
-        Ok(())
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
-    #[serial_test::parallel]
     pub async fn logs_batch_tokio_multi_thread() -> Result<()> {
         logs_tokio_helper(false).await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
-    #[serial_test::parallel]
     pub async fn logs_batch_tokio_multi_with_one_worker() -> Result<()> {
         logs_tokio_helper(false).await
     }
 
     #[tokio::test(flavor = "current_thread")]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
-    #[serial_test::parallel]
     pub async fn logs_batch_tokio_current() -> Result<()> {
         logs_tokio_helper(false).await
     }
@@ -151,14 +127,12 @@ mod logtests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-client"))]
-    #[serial_test::parallel]
     pub async fn logs_simple_tokio_multi_thread() -> Result<()> {
         logs_tokio_helper(true).await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-client"))]
-    #[serial_test::parallel]
     pub async fn logs_simple_tokio_multi_with_one_worker() -> Result<()> {
         logs_tokio_helper(true).await
     }
@@ -167,14 +141,12 @@ mod logtests {
     #[ignore]
     #[tokio::test(flavor = "current_thread")]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-client"))]
-    #[serial_test::parallel]
     pub async fn logs_simple_tokio_current() -> Result<()> {
         logs_tokio_helper(true).await
     }
 
     #[test]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
-    #[serial_test::parallel]
     pub fn logs_batch_non_tokio_main() -> Result<()> {
         logs_non_tokio_helper(false)
     }
@@ -207,7 +179,6 @@ mod logtests {
 
     #[test]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
-    #[serial_test::parallel]
     pub fn logs_simple_non_tokio_main() -> Result<()> {
         logs_non_tokio_helper(true)
     }

--- a/opentelemetry-otlp/tests/integration_test/tests/logs.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs.rs
@@ -93,10 +93,6 @@ mod logtests {
     pub async fn test_logs() -> Result<()> {
         // Make sure the container is running
         use crate::{assert_logs_results, init_logs};
-        use integration_test_runner::test_utils;
-        use opentelemetry_appender_tracing::layer;
-        use tracing::info;
-        use tracing_subscriber::layer::SubscriberExt;
         test_utils::start_collector_container().await?;
         test_utils::cleanup_file("./actual/logs.json"); // Ensure logs.json is empty before the test
         let logger_provider = init_logs(false).unwrap();
@@ -106,10 +102,8 @@ mod logtests {
             let _guard = tracing::subscriber::set_default(subscriber);
             info!(target: "my-target", "hello from {}. My price is {}.", "banana", 2.99);
         }
-        // TODO: remove below wait before calling logger_provider.shutdown()
-        // tokio::time::sleep(Duration::from_secs(10)).await;
         let _ = logger_provider.shutdown();
-        tokio::time::sleep(Duration::from_secs(10)).await;
+        tokio::time::sleep(Duration::from_secs(5)).await;
         assert_logs_results(test_utils::LOGS_FILE, "expected/logs.json")?;
         Ok(())
     }

--- a/opentelemetry-otlp/tests/integration_test/tests/logs_serialize_deserialize.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs_serialize_deserialize.rs
@@ -1,0 +1,64 @@
+#![cfg(unix)]
+
+use anyhow::Result;
+use ctor::dtor;
+use integration_test_runner::logs_asserter::{read_logs_from_json, LogsAsserter};
+use integration_test_runner::test_utils;
+use opentelemetry_appender_tracing::layer;
+use opentelemetry_otlp::LogExporter;
+use opentelemetry_sdk::logs::LoggerProvider;
+use opentelemetry_sdk::Resource;
+use std::fs::File;
+use std::os::unix::fs::MetadataExt;
+use tracing::info;
+use tracing_subscriber::layer::SubscriberExt;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[cfg(feature = "tonic-client")]
+pub async fn test_logs() -> Result<()> {
+    test_utils::start_collector_container().await?;
+    test_utils::cleanup_file("./actual/logs.json"); // Ensure logs.json is empty before the test
+    let exporter_builder = LogExporter::builder().with_tonic();
+    let exporter = exporter_builder.build()?;
+    let mut logger_provider_builder = LoggerProvider::builder();
+    logger_provider_builder = logger_provider_builder.with_batch_exporter(exporter);
+    let logger_provider = logger_provider_builder
+        .with_resource(
+            Resource::builder_empty()
+                .with_service_name("logs-integration-test")
+                .build(),
+        )
+        .build();
+    let layer = layer::OpenTelemetryTracingBridge::new(&logger_provider);
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        info!(target: "my-target", "hello from {}. My price is {}.", "banana", 2.99);
+    }
+
+    let _ = logger_provider.shutdown();
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    assert_logs_results(test_utils::LOGS_FILE, "expected/logs.json")?;
+    Ok(())
+}
+
+fn assert_logs_results(result: &str, expected: &str) -> Result<()> {
+    let left = read_logs_from_json(File::open(expected)?)?;
+    let right = read_logs_from_json(File::open(result)?)?;
+
+    LogsAsserter::new(left, right).assert();
+
+    assert!(File::open(result).unwrap().metadata().unwrap().size() > 0);
+    Ok(())
+}
+
+///
+/// Make sure we stop the collector container, otherwise it will sit around hogging our
+/// ports and subsequent test runs will fail.
+///
+#[dtor]
+fn shutdown() {
+    println!("metrics::shutdown");
+    test_utils::stop_collector_container();
+}


### PR DESCRIPTION
## Changes

- The full log validation test runs sequentially, and the `logs.json` is cleaned-up before running
- Rest of the tests run in parallel.
- Some nit cleanup of method for reusability.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)


