### PR TITLE
BatchSpanProcessor optimizations  - Separate control signal queue, and wake up background thread only when required.

### DIFF
--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -293,6 +293,8 @@ impl BatchSpanProcessor {
                     match message_receiver.recv_timeout(remaining_time) {
                         Ok(message) => match message {
                             BatchMessage::ExportSpan(export_span_message_sent) => {
+                                // Reset the export span message sent flag now it has has been processed.
+                                export_span_message_sent.store(false, Ordering::Relaxed);
                                 otel_debug!(
                                     name: "BatchSpanProcessor.ExportingDueToBatchSize",
                                 );
@@ -304,8 +306,6 @@ impl BatchSpanProcessor {
                                     &current_batch_size,
                                     &config,
                                 );
-                                // Reset the export span message sent flag now it has has been processed.
-                                export_span_message_sent.store(false, Ordering::Relaxed);
                             }
                             BatchMessage::ForceFlush(sender) => {
                                 otel_debug!(name: "BatchSpanProcessor.ExportingDueToForceFlush");


### PR DESCRIPTION
Fixes: Towards #2493 

## Changes

Similar to the BatchLogProcessor in #2494 :
  - wake up the background thread ONLY when needed
  - Separate control signal queue  ( to ensure that the shutdown signal is not lost when message queue is full).

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
