### PR TITLE
Remove cardinality capping in Metrics

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -257,6 +257,12 @@ metadata, a feature introduced in version 0.1.40. [#2418](https://github.com/ope
   - If you're implementing a custom runtime, you must explicitly enable the   experimental_async_runtime` feature in your 
   Cargo.toml and implement the required `Runtime` traits.
 
+- Removed Metrics Cardinality Limit feature. This was originally introduced in
+[#1066](https://github.com/open-telemetry/opentelemetry-rust/pull/1066) with a
+hardcoded limit of 2000 and no ability to change it. This feature will be
+re-introduced in a future date, along with the ability to change the cardinality
+limit.
+
 ## 0.27.1
 
 Released 2024-Nov-27

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -18,8 +18,11 @@ use super::{
 pub(crate) const STREAM_CARDINALITY_LIMIT: usize = 2000;
 
 /// Checks whether aggregator has hit cardinality limit for metric streams
-pub(crate) fn is_under_cardinality_limit(size: usize) -> bool {
-    size < STREAM_CARDINALITY_LIMIT
+pub(crate) fn is_under_cardinality_limit(_size: usize) -> bool {
+    true
+
+    // TODO: Implement this feature, after allowing the ability to customize the cardinality limit.
+    // size < STREAM_CARDINALITY_LIMIT
 }
 
 /// Receives measurements to be aggregated.

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -259,11 +259,13 @@ mod tests {
         assert_eq!(data_point.value, 50, "Unexpected data point value");
     }
 
+    #[ignore = "https://github.com/open-telemetry/opentelemetry-rust/issues/1065"]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn counter_aggregation_overflow_delta() {
         counter_aggregation_overflow_helper(Temporality::Delta);
     }
 
+    #[ignore = "https://github.com/open-telemetry/opentelemetry-rust/issues/1065"]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn counter_aggregation_overflow_cumulative() {
         counter_aggregation_overflow_helper(Temporality::Cumulative);


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-rust/issues/1951#issuecomment-2605404259

To support customizing cardinality cap, we need to use Views, but Views are behind experimental feature flag. Though it is possible to offer a MetricReader level way to configure the limit, it is better to offer the per-metric capability via Views too. Until ability to customize the feature is available, it is better to remove the cardinality capping from the SDK.

(Note that the CardinalityCapping spec is relatively new to OTel and just stabilized few months ago, so this is not a mandatory feature to have for the stable release)