### PR TITLE
Move inmemory exporter for spans to diff namespace

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -285,8 +285,10 @@ limit.
 - *Breaking*: Rename namespaces for InMemoryExporters. (The module is still under "testing" feature flag)
   before:
   `opentelemetry_sdk::testing::logs::{InMemoryLogExporter, InMemoryLogExporterBuilder};`
+  `opentelemetry_sdk::testing::trace::{InMemorySpanExporter, InMemorySpanExporterBuilder};`
   now:
   `opentelemetry_sdk::logs::{InMemoryLogExporter, InMemoryLogExporterBuilder};`
+  `opentelemetry_sdk::trace::{InMemorySpanExporter, InMemorySpanExporterBuilder};`
 
 ## 0.27.1
 

--- a/opentelemetry-sdk/src/testing/mod.rs
+++ b/opentelemetry-sdk/src/testing/mod.rs
@@ -1,5 +1,6 @@
 //! In-Memory exporters for testing purpose.
 
+/// Structs used for testing
 #[cfg(all(feature = "testing", feature = "trace"))]
 pub mod trace;
 

--- a/opentelemetry-sdk/src/testing/trace/mod.rs
+++ b/opentelemetry-sdk/src/testing/trace/mod.rs
@@ -1,10 +1,3 @@
-//! In-Memory trace exporter for testing purpose.
-
-/// The `in_memory_exporter` module provides in-memory trace exporter.
-/// For detailed usage and examples, see `in_memory_exporter`.
-pub mod in_memory_exporter;
-pub use in_memory_exporter::{InMemorySpanExporter, InMemorySpanExporterBuilder};
-
 #[doc(hidden)]
 mod span_exporters;
 pub use span_exporters::*;

--- a/opentelemetry-sdk/src/trace/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/trace/in_memory_exporter.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 ///# use opentelemetry::{global, trace::Tracer, Context};
 ///# use opentelemetry_sdk::propagation::TraceContextPropagator;
 ///# use opentelemetry_sdk::runtime;
-///# use opentelemetry_sdk::testing::trace::InMemorySpanExporterBuilder;
+///# use opentelemetry_sdk::trace::InMemorySpanExporterBuilder;
 ///# use opentelemetry_sdk::trace::{BatchSpanProcessor, TracerProvider};
 ///
 ///# #[tokio::main]
@@ -64,7 +64,7 @@ impl Default for InMemorySpanExporter {
 /// Builder for [`InMemorySpanExporter`].
 /// # Example
 /// ```
-///# use opentelemetry_sdk::testing::trace::InMemorySpanExporterBuilder;
+///# use opentelemetry_sdk::trace::InMemorySpanExporterBuilder;
 ///
 /// let exporter = InMemorySpanExporterBuilder::new().build();
 /// ```
@@ -102,7 +102,7 @@ impl InMemorySpanExporter {
     /// # Example
     ///
     /// ```
-    /// # use opentelemetry_sdk::testing::trace::InMemorySpanExporter;
+    /// # use opentelemetry_sdk::trace::InMemorySpanExporter;
     ///
     /// let exporter = InMemorySpanExporter::default();
     /// let finished_spans = exporter.get_finished_spans().unwrap();
@@ -119,7 +119,7 @@ impl InMemorySpanExporter {
     /// # Example
     ///
     /// ```
-    /// # use opentelemetry_sdk::testing::trace::InMemorySpanExporter;
+    /// # use opentelemetry_sdk::trace::InMemorySpanExporter;
     ///
     /// let exporter = InMemorySpanExporter::default();
     /// exporter.reset();

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -25,6 +25,14 @@ pub use config::{config, Config};
 pub use events::SpanEvents;
 pub use export::{ExportResult, SpanData, SpanExporter};
 
+/// In-Memory span exporter for testing purpose.
+#[cfg(any(feature = "testing", test))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "testing", test))))]
+pub mod in_memory_exporter;
+#[cfg(any(feature = "testing", test))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "testing", test))))]
+pub use in_memory_exporter::{InMemorySpanExporter, InMemorySpanExporterBuilder};
+
 pub use id_generator::{IdGenerator, RandomIdGenerator};
 pub use links::SpanLinks;
 pub use provider::{Builder, TracerProvider};
@@ -50,8 +58,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        testing::trace::{InMemorySpanExporter, InMemorySpanExporterBuilder},
         trace::span_limit::{DEFAULT_MAX_EVENT_PER_SPAN, DEFAULT_MAX_LINKS_PER_SPAN},
+        trace::{InMemorySpanExporter, InMemorySpanExporterBuilder},
     };
     use opentelemetry::trace::{
         SamplingDecision, SamplingResult, SpanKind, Status, TraceContextExt, TraceState,

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -814,11 +814,12 @@ mod tests {
         OTEL_BSP_MAX_EXPORT_BATCH_SIZE, OTEL_BSP_MAX_QUEUE_SIZE, OTEL_BSP_MAX_QUEUE_SIZE_DEFAULT,
         OTEL_BSP_SCHEDULE_DELAY, OTEL_BSP_SCHEDULE_DELAY_DEFAULT,
     };
-    use crate::testing::trace::{new_test_export_span_data, InMemorySpanExporterBuilder};
+    use crate::testing::trace::new_test_export_span_data;
     use crate::trace::span_processor::{
         OTEL_BSP_EXPORT_TIMEOUT_DEFAULT, OTEL_BSP_MAX_CONCURRENT_EXPORTS,
         OTEL_BSP_MAX_CONCURRENT_EXPORTS_DEFAULT, OTEL_BSP_MAX_EXPORT_BATCH_SIZE_DEFAULT,
     };
+    use crate::trace::InMemorySpanExporterBuilder;
     use crate::trace::{BatchConfig, BatchConfigBuilder, SpanEvents, SpanLinks};
     use crate::trace::{ExportResult, SpanData, SpanExporter};
     use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status};

--- a/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
@@ -421,14 +421,12 @@ mod tests {
     // cargo test trace::span_processor::tests:: --features=testing
     use super::{BatchSpanProcessor, SpanProcessor};
     use crate::runtime;
-    use crate::testing::trace::{
-        new_test_export_span_data, new_tokio_test_exporter, InMemorySpanExporterBuilder,
-    };
+    use crate::testing::trace::{new_test_export_span_data, new_tokio_test_exporter};
     use crate::trace::span_processor::{
         OTEL_BSP_EXPORT_TIMEOUT, OTEL_BSP_MAX_EXPORT_BATCH_SIZE, OTEL_BSP_MAX_QUEUE_SIZE,
         OTEL_BSP_MAX_QUEUE_SIZE_DEFAULT, OTEL_BSP_SCHEDULE_DELAY, OTEL_BSP_SCHEDULE_DELAY_DEFAULT,
     };
-    use crate::trace::{BatchConfig, BatchConfigBuilder};
+    use crate::trace::{BatchConfig, BatchConfigBuilder, InMemorySpanExporterBuilder};
     use crate::trace::{ExportResult, SpanData, SpanExporter};
     use futures_util::Future;
     use std::fmt::Debug;


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-rust/pull/2538 for traces.