### PR TITLE
Remove unused Error enum

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -268,7 +268,7 @@ hardcoded limit of 2000 and no ability to change it. This feature will be
 re-introduced in a future date, along with the ability to change the cardinality
 limit.
 
-
+- *Breaking* Removed unused `opentelemetry_sdk::Error` enum.
 - *Breaking* (Affects custom Exporter authors only) Moved `ExportError` trait from `opentelemetry::export::ExportError` to `opentelemetry_sdk::ExportError`
 - *Breaking (Affects custom SpanExporter, SpanProcessor authors only)*: Rename namespaces for Span exporter structs/traits
   before:

--- a/opentelemetry-sdk/src/error.rs
+++ b/opentelemetry-sdk/src/error.rs
@@ -1,49 +1,4 @@
 //! Wrapper for error from trace, logs and metrics part of open telemetry.
-use std::sync::PoisonError;
-
-#[cfg(feature = "logs")]
-use crate::logs::LogError;
-#[cfg(feature = "metrics")]
-use crate::metrics::MetricError;
-use opentelemetry::propagation::PropagationError;
-#[cfg(feature = "trace")]
-use opentelemetry::trace::TraceError;
-
-/// Wrapper for error from both tracing and metrics part of open telemetry.
-#[derive(thiserror::Error, Debug)]
-#[non_exhaustive]
-pub enum Error {
-    #[cfg(feature = "trace")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "trace")))]
-    #[error(transparent)]
-    /// Failed to export traces.
-    Trace(#[from] TraceError),
-    #[cfg(feature = "metrics")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-    #[error(transparent)]
-    /// An issue raised by the metrics module.
-    Metric(#[from] MetricError),
-
-    #[cfg(feature = "logs")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "logs")))]
-    #[error(transparent)]
-    /// Failed to export logs.
-    Log(#[from] LogError),
-
-    #[error(transparent)]
-    /// Error happens when injecting and extracting information using propagators.
-    Propagation(#[from] PropagationError),
-
-    #[error("{0}")]
-    /// Other types of failures not covered by the variants above.
-    Other(String),
-}
-
-impl<T> From<PoisonError<T>> for Error {
-    fn from(err: PoisonError<T>) -> Self {
-        Error::Other(err.to_string())
-    }
-}
 
 /// Trait for errors returned by exporters
 pub trait ExportError: std::error::Error + Send + Sync + 'static {


### PR DESCRIPTION
While reviewing https://github.com/open-telemetry/opentelemetry-rust/pull/2381 I noted that there is a pub enum Error declared, that is not used anywhere in the codebase. I can't think of any reason why it exists, so removing it!

@scottgerring @lalitb Please see if you agree with this.