### PR TITLE
Remove unsupported feature from BatchSpanProcessor

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -212,6 +212,9 @@ metadata, a feature introduced in version 0.1.40. [#2418](https://github.com/ope
         .build();
       ```
 
+      This implementation does not support multiple concurrent exports
+      (`with_max_concurrent_exports` is not supported).
+
     The new BatchLogProcessor can be used with OTLP Exporter, and supports
     following exporter features:
     - `grpc-tonic`: This requires `MeterProvider` to be created within a tokio

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -717,11 +717,12 @@ impl BatchConfigBuilder {
         self
     }
 
+    #[cfg(feature = "experimental_trace_batch_span_processor_with_async_runtime")]
     /// Set max_concurrent_exports for [`BatchConfigBuilder`].
     /// It's the maximum number of concurrent exports.
     /// Limits the number of spawned tasks for exports and thus memory consumed by an exporter.
     /// The default value is 1.
-    /// IF the max_concurrent_exports value is default value, it will cause exports to be performed
+    /// If the max_concurrent_exports value is default value, it will cause exports to be performed
     /// synchronously on the BatchSpanProcessor task.
     pub fn with_max_concurrent_exports(mut self, max_concurrent_exports: usize) -> Self {
         self.max_concurrent_exports = max_concurrent_exports;
@@ -960,9 +961,10 @@ mod tests {
             .with_max_export_batch_size(10)
             .with_scheduled_delay(Duration::from_millis(10))
             .with_max_export_timeout(Duration::from_millis(10))
-            .with_max_concurrent_exports(10)
-            .with_max_queue_size(10)
-            .build();
+            .with_max_queue_size(10);
+        #[cfg(feature = "experimental_trace_batch_span_processor_with_async_runtime")]
+        let batch = batch.with_max_concurrent_exports(10);
+        let batch = batch.build();
         assert_eq!(batch.max_export_batch_size, 10);
         assert_eq!(batch.scheduled_delay, Duration::from_millis(10));
         assert_eq!(batch.max_export_timeout, Duration::from_millis(10));


### PR DESCRIPTION
Conditional compilation for with_concurrent_export, as the implementation does not support this, so removing from API to avoid misleading.
Opened https://github.com/open-telemetry/opentelemetry-rust/issues/2555 to track adding this based on demand.