### PR TITLE
Use opentelemetry:time::now instead of systemtime in LogEmitter

### DIFF
--- a/opentelemetry-sdk/src/logs/log_emitter.rs
+++ b/opentelemetry-sdk/src/logs/log_emitter.rs
@@ -6,7 +6,7 @@ use opentelemetry::{otel_debug, otel_info, trace::TraceContextExt, Context, Inst
 #[cfg(feature = "spec_unstable_logs_enabled")]
 use opentelemetry::logs::Severity;
 
-use std::time::SystemTime;
+use opentelemetry::time::now;
 use std::{
     borrow::Cow,
     sync::{
@@ -313,7 +313,7 @@ impl opentelemetry::logs::Logger for Logger {
             }
         }
         if record.observed_timestamp.is_none() {
-            record.observed_timestamp = Some(SystemTime::now());
+            record.observed_timestamp = Some(now());
         }
 
         for p in processors {

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -277,7 +277,7 @@ pub mod trace;
 pub mod logs;
 
 #[doc(hidden)]
-#[cfg(any(feature = "metrics", feature = "trace"))]
+#[cfg(any(feature = "metrics", feature = "trace", feature = "logs"))]
 pub mod time {
     use std::time::SystemTime;
 


### PR DESCRIPTION
Part 1 for https://github.com/open-telemetry/opentelemetry-rust/issues/2557 
This will help log emitter work in browser environments, though there could be other issues preventing it from functioning, that is to be tackled separately.