### PR TITLE
Rename provider builders

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -288,8 +288,11 @@ limit.
   `opentelemetry_sdk::logs::{ExportResult, LogBatch, LogExporter};`
 
 - *Breaking* `opentelemetry_sdk::LogRecord::default()` method is removed.
-  The only way to create log record outside opentelemetry_sdk crate is using 
+  The only way to create log record outside opentelemetry_sdk crate is using
   `Logger::create_log_record()` method.
+
+- Rename `opentelemetry_sdk::logs::Builder` to `opentelemetry_sdk::logs::LoggerProviderBuilder`.
+- Rename `opentelemetry_sdk::trace::Builder` to  `opentelemetry_sdk::trace::TracerProviderBuilder`.
 
 - *Breaking*: Rename namespaces for InMemoryExporters. (The module is still under "testing" feature flag)
   before:

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -78,8 +78,8 @@ impl opentelemetry::logs::LoggerProvider for LoggerProvider {
 
 impl LoggerProvider {
     /// Create a new `LoggerProvider` builder.
-    pub fn builder() -> Builder {
-        Builder::default()
+    pub fn builder() -> LoggerProviderBuilder {
+        LoggerProviderBuilder::default()
     }
 
     pub(crate) fn log_processors(&self) -> &[Box<dyn LogProcessor>] {
@@ -179,12 +179,12 @@ impl Drop for LoggerProviderInner {
 
 #[derive(Debug, Default)]
 /// Builder for provider attributes.
-pub struct Builder {
+pub struct LoggerProviderBuilder {
     processors: Vec<Box<dyn LogProcessor>>,
     resource: Option<Resource>,
 }
 
-impl Builder {
+impl LoggerProviderBuilder {
     /// Adds a [SimpleLogProcessor] with the configured exporter to the pipeline.
     ///
     /// # Arguments
@@ -200,7 +200,7 @@ impl Builder {
         let mut processors = self.processors;
         processors.push(Box::new(SimpleLogProcessor::new(exporter)));
 
-        Builder { processors, ..self }
+        LoggerProviderBuilder { processors, ..self }
     }
 
     /// Adds a [BatchLogProcessor] with the configured exporter to the pipeline.
@@ -234,12 +234,12 @@ impl Builder {
         let mut processors = self.processors;
         processors.push(Box::new(processor));
 
-        Builder { processors, ..self }
+        LoggerProviderBuilder { processors, ..self }
     }
 
     /// The `Resource` to be associated with this Provider.
     pub fn with_resource(self, resource: Resource) -> Self {
-        Builder {
+        LoggerProviderBuilder {
             resource: Some(resource),
             ..self
         }

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -19,7 +19,7 @@ pub use log_processor::{
     BatchConfig, BatchConfigBuilder, BatchLogProcessor, BatchLogProcessorBuilder, LogProcessor,
     SimpleLogProcessor,
 };
-pub use logger_provider::{Builder, Logger, LoggerProvider};
+pub use logger_provider::{Logger, LoggerProvider, LoggerProviderBuilder};
 pub use record::{LogRecord, TraceContext};
 
 #[cfg(feature = "experimental_logs_batch_log_processor_with_async_runtime")]

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -35,7 +35,7 @@ pub use in_memory_exporter::{InMemorySpanExporter, InMemorySpanExporterBuilder};
 
 pub use id_generator::{IdGenerator, RandomIdGenerator};
 pub use links::SpanLinks;
-pub use provider::{Builder, TracerProvider};
+pub use provider::{TracerProvider, TracerProviderBuilder};
 pub use sampler::{Sampler, ShouldSample};
 pub use span::Span;
 pub use span_limit::SpanLimits;

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -167,8 +167,8 @@ impl TracerProvider {
     }
 
     /// Create a new [`TracerProvider`] builder.
-    pub fn builder() -> Builder {
-        Builder::default()
+    pub fn builder() -> TracerProviderBuilder {
+        TracerProviderBuilder::default()
     }
 
     /// Span processors associated with this provider
@@ -274,12 +274,12 @@ impl opentelemetry::trace::TracerProvider for TracerProvider {
 
 /// Builder for provider attributes.
 #[derive(Debug, Default)]
-pub struct Builder {
+pub struct TracerProviderBuilder {
     processors: Vec<Box<dyn SpanProcessor>>,
     config: crate::trace::Config,
 }
 
-impl Builder {
+impl TracerProviderBuilder {
     /// Adds a [SimpleSpanProcessor] with the configured exporter to the pipeline.
     ///
     /// # Arguments
@@ -295,7 +295,7 @@ impl Builder {
         let mut processors = self.processors;
         processors.push(Box::new(SimpleSpanProcessor::new(Box::new(exporter))));
 
-        Builder { processors, ..self }
+        TracerProviderBuilder { processors, ..self }
     }
 
     /// Adds a [BatchSpanProcessor] with the configured exporter to the pipeline.
@@ -329,7 +329,7 @@ impl Builder {
         let mut processors = self.processors;
         processors.push(Box::new(processor));
 
-        Builder { processors, ..self }
+        TracerProviderBuilder { processors, ..self }
     }
 
     /// The sdk [`crate::trace::Config`] that this provider will use.
@@ -338,7 +338,7 @@ impl Builder {
         note = "Config is becoming a private type. Use Builder::with_{config_name}(resource) instead. ex: Builder::with_resource(resource)"
     )]
     pub fn with_config(self, config: crate::trace::Config) -> Self {
-        Builder { config, ..self }
+        TracerProviderBuilder { config, ..self }
     }
 
     /// Specify the sampler to be used.
@@ -398,7 +398,7 @@ impl Builder {
     ///
     /// [Tracer]: opentelemetry::trace::Tracer
     pub fn with_resource(self, resource: Resource) -> Self {
-        Builder {
+        TracerProviderBuilder {
             config: self.config.with_resource(resource),
             ..self
         }


### PR DESCRIPTION
Fixes #2560 
Technically breaking, but practically no impact for most. All examples/usages continue to work as-is.