### PR TITLE
Removed unnecessary public methods from OTLP Exporter

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -10,6 +10,9 @@
   "reqwest-blocking-client" features as default, to align with the
   specification.
   [2516](https://github.com/open-telemetry/opentelemetry-rust/pull/2516)
+- Remove unnecessarily public trait `opentelemetry_otlp::metrics::MetricsClient`
+  and `MetricExporter::new(..)` method. Use
+  `MetricExporter::builder()...build()` to obtain `MetricExporter`.
 
 ## 0.27.0
 

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -121,7 +121,7 @@ impl HasHttpConfig for MetricExporterBuilder<HttpExporterBuilderSet> {
 
 /// An interface for OTLP metrics clients
 #[async_trait]
-pub trait MetricsClient: fmt::Debug + Send + Sync + 'static {
+pub(crate) trait MetricsClient: fmt::Debug + Send + Sync + 'static {
     async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()>;
     fn shutdown(&self) -> MetricResult<()>;
 }
@@ -165,7 +165,7 @@ impl MetricExporter {
     }
 
     /// Create a new metrics exporter
-    pub fn new(client: impl MetricsClient, temporality: Temporality) -> MetricExporter {
+    pub(crate) fn new(client: impl MetricsClient, temporality: Temporality) -> MetricExporter {
         MetricExporter {
             client: Box::new(client),
             temporality,


### PR DESCRIPTION
In a future PR, based on the outcome of #2571 the exporter_builder::build() method would be returning a different Result than what it does today. 
