### PR TITLE
Better handling of shutdown in BatchLogProcessor

### DIFF
--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -345,7 +345,6 @@ impl LogProcessor for BatchLogProcessor {
                     otel_warn!(name: "BatchLogProcessor.LogDroppingStarted",
                         message = "BatchLogProcessor dropped a LogRecord due to queue full/internal errors. No further log will be emitted for further drops until Shutdown. During Shutdown time, a log will be emitted with exact count of total logs dropped.");
                 }
-                return;
             }
             Err(mpsc::TrySendError::Disconnected(_)) => {
                 // Given background thread is the only receiver, and it's
@@ -354,7 +353,6 @@ impl LogProcessor for BatchLogProcessor {
                     name: "BatchLogProcessor.Emit.AfterShutdown",
                     message = "Logs are being emitted even after Shutdown. This indicates incorrect lifecycle management of OTelLoggerProvider in application. Logs will not be exported."
                 );
-                return;
             }
         }
     }


### PR DESCRIPTION
Another attempt at https://github.com/open-telemetry/opentelemetry-rust/pull/2462
The key change/idea here is
1. Do not perform any unnecessary check in hot path that unnecessarily punishes normal users
2. Rely on alternative mechanisms to determine state.

Specifically, in this PR, BatchLogProcessor no longer keeps track of "is_shutdown" in the AtomicBool and check it in every *hot* path. (1 above).
Instead, it relies on the well known error from the Channel ("failed to send message to channel as no receiver exists") to determine that Shutdown is already performed (2 above).

No change in behavior, just avoid an unnecessary check in hot path. (the perf impact is [minimal (couple of ns)](https://github.com/open-telemetry/opentelemetry-rust/pull/2462#discussion_r1894582949) but every ns counts)

If this is generally agreed, we need to replicate this idea everywhere.

@scottgerring Unfortunately this touches Log::Shutdown area (these changes were sitting in me for quite a while!!). I hope the changes here will allow you to return better, targeted Result as we agreed. Currently it sticks with LogError for everything. If it turns out to be merge nightmare, I am happy to abandon this one, and re-attempt it after you fix Result handling. (This has no public API change, so can be done later too)