### PR TITLE
Version up sample code/Cargo.toml on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ Project versioning information and stability guarantees can be found
 ## Getting Started
 
 ```rust
-use opentelemetry::{
-    global,
-    trace::{Tracer, TracerProvider as _},
+use opentelemetry::trace::{
+    TraceContextExt,
+    Tracer,
+    TracerProvider as _,
 };
 use opentelemetry_sdk::trace::TracerProvider;
 
@@ -92,9 +93,9 @@ The example above requires the following packages:
 ```toml
 # Cargo.toml
 [dependencies]
-opentelemetry = "0.22"
-opentelemetry_sdk = "0.22"
-opentelemetry-stdout = { version = "0.3", features = ["trace"] }
+opentelemetry = "0.27"
+opentelemetry_sdk = "0.27"
+opentelemetry-stdout = { version = "0.27", features = ["trace"] }
 ```
 
 See the [examples](./examples) directory for different integration patterns.


### PR DESCRIPTION
## Changes
This PR modifies some problems in the sample code on README 😸 :
- TracerProvider in v0.22 doesn't have shutdown() method. We should use v0.27 (the latest version) instead
- opentelemetry::global is no longer used since https://github.com/open-telemetry/opentelemetry-rust/commit/6d1a765c41e9f21951aae19665ae569bc8978abc
- opentelemetry-stdout v0.3 is outdated. It's SpanExporter doesn't satisfy with_simple_exporter()'s requirement

## Merge requirement checklist
* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
