### PR TITLE
Add easier way to add periodicreader to meterprovider

### DIFF
--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -49,14 +49,12 @@ fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
         .with_temporality(Temporality::Delta)
         .build();
 
-    let reader = PeriodicReader::builder(exporter).build();
-
     let resource = Resource::builder()
         .with_service_name("metrics-advanced-example")
         .build();
 
     let provider = SdkMeterProvider::builder()
-        .with_reader(reader)
+        .with_periodic_exporter(exporter)
         .with_resource(resource)
         .with_view(my_view_rename_and_unit)
         .with_view(my_view_drop_attributes)

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -10,9 +10,8 @@ fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
         // Build exporter using Delta Temporality (Defaults to Temporality::Cumulative)
         // .with_temporality(opentelemetry_sdk::metrics::Temporality::Delta)
         .build();
-    let reader = PeriodicReader::builder(exporter).build();
     let provider = SdkMeterProvider::builder()
-        .with_reader(reader)
+        .with_periodic_exporter(exporter)
         .with_resource(
             Resource::builder()
                 .with_service_name("metrics-basic-example")

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -61,10 +61,8 @@ fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, Metric
         .with_endpoint("http://localhost:4318/v1/metrics")
         .build()?;
 
-    let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter).build();
-
     Ok(SdkMeterProvider::builder()
-        .with_reader(reader)
+        .with_periodic_exporter(exporter)
         .with_resource(RESOURCE.clone())
         .build())
 }

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -33,10 +33,9 @@ fn init_traces() -> Result<sdktrace::TracerProvider, TraceError> {
 
 fn init_metrics() -> Result<opentelemetry_sdk::metrics::SdkMeterProvider, MetricError> {
     let exporter = MetricExporter::builder().with_tonic().build()?;
-    let reader = PeriodicReader::builder(exporter).build();
 
     Ok(SdkMeterProvider::builder()
-        .with_reader(reader)
+        .with_periodic_exporter(exporter)
         .with_resource(RESOURCE.clone())
         .build())
 }

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -405,13 +405,32 @@ Released 2024-Nov-27
      Migration Guidance:
         - These methods are intended for log appenders. Keep the clone of the provider handle, instead of depending on above methods.
 
-
   - **Bug Fix:** Validates the `with_boundaries` bucket boundaries used in
     Histograms. The boundaries provided by the user must not contain `f64::NAN`,
     `f64::INFINITY` or `f64::NEG_INFINITY` and must be sorted in strictly
     increasing order, and contain no duplicates. Instruments will not record
     measurements if the boundaries are invalid.
     [#2351](https://github.com/open-telemetry/opentelemetry-rust/pull/2351)
+
+- Added `with_periodic_exporter` method to `MeterProviderBuilder`, allowing
+  users to easily attach an exporter with a PeriodicReader for automatic metric
+  export. Retained with_reader() for advanced use cases where a custom
+  MetricReader configuration is needed.
+  [2597](https://github.com/open-telemetry/opentelemetry-rust/pull/2597)
+  Example Usage:
+
+  ```rust
+  SdkMeterProvider::builder()
+      .with_periodic_exporter(exporter)
+      .build();
+  ```
+
+  Using a custom PeriodicReader (advanced use case):
+
+  let reader = PeriodicReader::builder(exporter).build();
+  SdkMeterProvider::builder()
+      .with_reader(reader)
+      .build();
 
 ## 0.27.0
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -337,25 +337,6 @@ let processor = BatchLogProcessor::builder(exporter)
     .build();
 ```
 
-- Added `with_periodic_exporter` method to `MeterProviderBuilder`, allowing
- users to easily attach an exporter with a PeriodicReader for automatic metric
- export. Retained with_reader() for advanced use cases where a custom
- MetricReader configuration is needed.
-Example Usage:
-
-```rust
-SdkMeterProvider::builder()
-    .with_periodic_exporter(exporter)
-    .build();
-```
-
-Using a custom PeriodicReader (advanced use case):
-
-let reader = PeriodicReader::builder(exporter).build();
-SdkMeterProvider::builder()
-    .with_reader(reader)
-    .build();
-
 ## 0.27.1
 
 Released 2024-Nov-27

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -337,6 +337,25 @@ let processor = BatchLogProcessor::builder(exporter)
     .build();
 ```
 
+- Added `with_periodic_exporter` method to `MeterProviderBuilder`, allowing
+ users to easily attach an exporter with a PeriodicReader for automatic metric
+ export. Retained with_reader() for advanced use cases where a custom
+ MetricReader configuration is needed.
+Example Usage:
+
+```rust
+SdkMeterProvider::builder()
+    .with_periodic_exporter(exporter)
+    .build();
+```
+
+Using a custom PeriodicReader (advanced use case):
+
+let reader = PeriodicReader::builder(exporter).build();
+SdkMeterProvider::builder()
+    .with_reader(reader)
+    .build();
+
 ## 0.27.1
 
 Released 2024-Nov-27

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -19,7 +19,8 @@ use crate::{
 };
 
 use super::{
-    meter::SdkMeter, noop::NoopMeter, pipeline::Pipelines, reader::MetricReader, view::View,
+    exporter::PushMetricExporter, meter::SdkMeter, noop::NoopMeter, pipeline::Pipelines,
+    reader::MetricReader, view::View, PeriodicReader,
 };
 
 /// Handles the creation and coordination of [Meter]s.
@@ -244,10 +245,33 @@ impl MeterProviderBuilder {
     }
 
     /// Associates a [MetricReader] with a [MeterProvider].
+    /// [`with_periodic_exporter`] can be used to add a PeriodicReader which is
+    /// the most common use case.
     ///
-    /// By default, if this option is not used, the [MeterProvider] will perform no
-    /// operations; no data will be exported without a [MetricReader].
+    /// A [MeterProvider] will perform no operations without [MetricReader]
+    /// added.
     pub fn with_reader<T: MetricReader>(mut self, reader: T) -> Self {
+        self.readers.push(Box::new(reader));
+        self
+    }
+
+    /// Adds a [`PushMetricExporter`] to the [`MeterProvider`] and configures it
+    /// to export metrics at **fixed** intervals (60 seconds) using a
+    /// [`PeriodicReader`].
+    ///
+    /// To customize the export interval, set the
+    /// **"OTEL_METRIC_EXPORT_INTERVAL"** environment variable (in
+    /// milliseconds).
+    ///
+    /// Most users should use this method to attach an exporter. Advanced users
+    /// who need finer control over the export process can use
+    /// [`PeriodicReaderBuilder`] to configure a custom reader and attach it
+    /// using [`with_reader`].
+    pub fn with_periodic_exporter<T>(mut self, exporter: T) -> Self
+    where
+        T: PushMetricExporter,
+    {
+        let reader = PeriodicReader::builder(exporter).build();
         self.readers.push(Box::new(reader));
         self
     }

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -248,7 +248,7 @@ impl MeterProviderBuilder {
     /// [`with_periodic_exporter`] can be used to add a PeriodicReader which is
     /// the most common use case.
     ///
-    /// A [MeterProvider] will perform no operations without [MetricReader]
+    /// A [MeterProvider] will export no metrics without [MetricReader]
     /// added.
     pub fn with_reader<T: MetricReader>(mut self, reader: T) -> Self {
         self.readers.push(Box::new(reader));

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -245,7 +245,7 @@ impl MeterProviderBuilder {
     }
 
     /// Associates a [MetricReader] with a [MeterProvider].
-    /// [`with_periodic_exporter`] can be used to add a PeriodicReader which is
+    /// [`MeterProviderBuilder::with_periodic_exporter()] can be used to add a PeriodicReader which is
     /// the most common use case.
     ///
     /// A [MeterProvider] will export no metrics without [MetricReader]
@@ -265,8 +265,8 @@ impl MeterProviderBuilder {
     ///
     /// Most users should use this method to attach an exporter. Advanced users
     /// who need finer control over the export process can use
-    /// [`PeriodicReaderBuilder`] to configure a custom reader and attach it
-    /// using [`with_reader`].
+    /// [`crate::metrics::PeriodicReaderBuilder`] to configure a custom reader and attach it
+    /// using [`MeterProviderBuilder::with_reader()`].
     pub fn with_periodic_exporter<T>(mut self, exporter: T) -> Self
     where
         T: PushMetricExporter,


### PR DESCRIPTION
Trying to avoid the term "reader" as much, which may not be easily relatable for most users.