### PR TITLE
Metric Export to return dedicated ExportResult

### DIFF
--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -1,35 +1,39 @@
 use std::sync::Arc;
 
+use crate::metric::MetricsClient;
 use async_trait::async_trait;
 use http::{header::CONTENT_TYPE, Method};
 use opentelemetry::otel_debug;
-use opentelemetry_sdk::error::{ShutdownError, ShutdownResult};
+use opentelemetry_sdk::error::{ExportErrorMetric, ExportResult, ShutdownError, ShutdownResult};
 use opentelemetry_sdk::metrics::data::ResourceMetrics;
-use opentelemetry_sdk::metrics::{MetricError, MetricResult};
-
-use crate::{metric::MetricsClient, Error};
 
 use super::OtlpHttpClient;
 
 #[async_trait]
 impl MetricsClient for OtlpHttpClient {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()> {
+    async fn export(&self, metrics: &mut ResourceMetrics) -> ExportResult {
         let client = self
             .client
             .lock()
-            .map_err(Into::into)
+            .map_err(|e| {
+                ExportErrorMetric::InternalFailure(format!("Failed to acquire lock: {e:?}"))
+            })
             .and_then(|g| match &*g {
                 Some(client) => Ok(Arc::clone(client)),
-                _ => Err(MetricError::Other("exporter is already shut down".into())),
+                _ => Err(ExportErrorMetric::InternalFailure(
+                    "exporter is already shut down".into(),
+                )),
             })?;
 
-        let (body, content_type) = self.build_metrics_export_body(metrics)?;
+        let (body, content_type) = self.build_metrics_export_body(metrics).map_err(|e| {
+            ExportErrorMetric::InternalFailure(format!("Failed to serialize metrics: {e:?}"))
+        })?;
         let mut request = http::Request::builder()
             .method(Method::POST)
             .uri(&self.collector_endpoint)
             .header(CONTENT_TYPE, content_type)
             .body(body.into())
-            .map_err(|e| crate::Error::RequestFailed(Box::new(e)))?;
+            .map_err(|e| ExportErrorMetric::InternalFailure(format!("{e:?}")))?;
 
         for (k, v) in &self.headers {
             request.headers_mut().insert(k.clone(), v.clone());
@@ -39,7 +43,7 @@ impl MetricsClient for OtlpHttpClient {
         client
             .send_bytes(request)
             .await
-            .map_err(|e| MetricError::ExportErr(Box::new(Error::RequestFailed(e))))?;
+            .map_err(|e| ExportErrorMetric::InternalFailure(format!("{e:?}")))?;
 
         Ok(())
     }

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -16,7 +16,7 @@ use crate::NoExporterBuilderSet;
 
 use async_trait::async_trait;
 use core::fmt;
-use opentelemetry_sdk::error::ShutdownResult;
+use opentelemetry_sdk::error::{ExportResult, ShutdownResult};
 use opentelemetry_sdk::metrics::MetricResult;
 
 use opentelemetry_sdk::metrics::{
@@ -123,7 +123,7 @@ impl HasHttpConfig for MetricExporterBuilder<HttpExporterBuilderSet> {
 /// An interface for OTLP metrics clients
 #[async_trait]
 pub(crate) trait MetricsClient: fmt::Debug + Send + Sync + 'static {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()>;
+    async fn export(&self, metrics: &mut ResourceMetrics) -> ExportResult;
     fn shutdown(&self) -> ShutdownResult;
 }
 
@@ -141,7 +141,7 @@ impl Debug for MetricExporter {
 
 #[async_trait]
 impl PushMetricExporter for MetricExporter {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()> {
+    async fn export(&self, metrics: &mut ResourceMetrics) -> ExportResult {
         self.client.export(metrics).await
     }
 

--- a/opentelemetry-sdk/src/error.rs
+++ b/opentelemetry-sdk/src/error.rs
@@ -41,5 +41,30 @@ pub enum ShutdownError {
     InternalFailure(String),
 }
 
+#[derive(Error, Debug)]
+/// Errors that can occur during export.
+/// TODO: This should be ExportError, but that can be done after rest of repo changes are done.
+pub enum ExportErrorMetric {
+    /// Export timed out before completing.
+    ///
+    /// This does not necessarily indicate a failure—export may still be
+    /// complete. If this occurs frequently, consider increasing the timeout
+    /// duration to allow more time for completion.
+    #[error("Export timed out after {0:?}")]
+    Timeout(Duration),
+
+    /// Export failed due to an internal error.
+    ///
+    /// The error message is intended for logging purposes only and should not
+    /// be used to make programmatic decisions. It is implementation-specific
+    /// and subject to change without notice. Consumers of this error should not
+    /// rely on its content beyond logging.
+    #[error("Export failed: {0}")]
+    InternalFailure(String),
+}
+
 /// A specialized `Result` type for Shutdown operations.
 pub type ShutdownResult = Result<(), ShutdownError>;
+
+/// A specialized `Result` type for Export operations.
+pub type ExportResult = Result<(), ExportErrorMetric>;

--- a/opentelemetry-sdk/src/metrics/exporter.rs
+++ b/opentelemetry-sdk/src/metrics/exporter.rs
@@ -1,7 +1,7 @@
 //! Interfaces for exporting metrics
 use async_trait::async_trait;
 
-use crate::error::ShutdownResult;
+use crate::error::{ExportResult, ShutdownResult};
 use crate::metrics::MetricResult;
 
 use crate::metrics::data::ResourceMetrics;
@@ -17,9 +17,8 @@ pub trait PushMetricExporter: Send + Sync + 'static {
     ///
     /// All retry logic must be contained in this function. The SDK does not
     /// implement any retry logic. All errors returned by this function are
-    /// considered unrecoverable and will be reported to a configured error
-    /// Handler.
-    async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()>;
+    /// considered unrecoverable and will be logged.
+    async fn export(&self, metrics: &mut ResourceMetrics) -> ExportResult;
 
     /// Flushes any metric data held by an exporter.
     async fn force_flush(&self) -> MetricResult<()>;

--- a/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
@@ -1,4 +1,4 @@
-use crate::error::ShutdownResult;
+use crate::error::{ExportErrorMetric, ExportResult, ShutdownResult};
 use crate::metrics::data::{self, Gauge, Sum};
 use crate::metrics::data::{Histogram, Metric, ResourceMetrics, ScopeMetrics};
 use crate::metrics::exporter::PushMetricExporter;
@@ -265,13 +265,13 @@ impl InMemoryMetricExporter {
 
 #[async_trait]
 impl PushMetricExporter for InMemoryMetricExporter {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()> {
+    async fn export(&self, metrics: &mut ResourceMetrics) -> ExportResult {
         self.metrics
             .lock()
             .map(|mut metrics_guard| {
                 metrics_guard.push_back(InMemoryMetricExporter::clone_metrics(metrics))
             })
-            .map_err(MetricError::from)
+            .map_err(|_| ExportErrorMetric::InternalFailure("Failed to lock metrics".to_string()))
     }
 
     async fn force_flush(&self) -> MetricResult<()> {

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -264,7 +264,7 @@ impl MetricExporterBuilder {
     /// Create a metrics exporter with the current configuration
     pub fn build(self) -> MetricExporter {
         MetricExporter {
-            temporality: self.temporality.unwrap_or_default()
+            temporality: self.temporality.unwrap_or_default(),
         }
     }
 }


### PR DESCRIPTION
Continuing this https://github.com/open-telemetry/opentelemetry-rust/pull/2573/files for ExportResult. Only touching Metrics, but this should be reused for all signals.