### PR TITLE
Make a common Error enum for export shutdown and flush operations

### DIFF
--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{global, KeyValue};
-use opentelemetry_sdk::error::ShutdownError;
+use opentelemetry_sdk::error::OTelSdkError;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::Resource;
 use std::error::Error;

--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use http::{header::CONTENT_TYPE, Method};
 use opentelemetry::otel_debug;
-use opentelemetry_sdk::error::{ShutdownError, ShutdownResult};
+use opentelemetry_sdk::error::{OTelSdkError, ShutdownResult};
 use opentelemetry_sdk::metrics::data::ResourceMetrics;
 use opentelemetry_sdk::metrics::{MetricError, MetricResult};
 
@@ -47,7 +47,7 @@ impl MetricsClient for OtlpHttpClient {
     fn shutdown(&self) -> ShutdownResult {
         self.client
             .lock()
-            .map_err(|e| ShutdownError::InternalFailure(format!("Failed to acquire lock: {}", e)))?
+            .map_err(|e| OTelSdkError::InternalFailure(format!("Failed to acquire lock: {}", e)))?
             .take();
 
         Ok(())

--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use http::{header::CONTENT_TYPE, Method};
 use opentelemetry::otel_debug;
-use opentelemetry_sdk::error::{OTelSdkError, ShutdownResult};
+use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::metrics::data::ResourceMetrics;
 use opentelemetry_sdk::metrics::{MetricError, MetricResult};
 
@@ -44,7 +44,7 @@ impl MetricsClient for OtlpHttpClient {
         Ok(())
     }
 
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         self.client
             .lock()
             .map_err(|e| OTelSdkError::InternalFailure(format!("Failed to acquire lock: {}", e)))?

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -6,7 +6,7 @@ use opentelemetry::otel_debug;
 use opentelemetry_proto::tonic::collector::metrics::v1::{
     metrics_service_client::MetricsServiceClient, ExportMetricsServiceRequest,
 };
-use opentelemetry_sdk::error::{ShutdownError, ShutdownResult};
+use opentelemetry_sdk::error::{OTelSdkError, ShutdownResult};
 use opentelemetry_sdk::metrics::data::ResourceMetrics;
 use opentelemetry_sdk::metrics::{MetricError, MetricResult};
 use tonic::{codegen::CompressionEncoding, service::Interceptor, transport::Channel, Request};
@@ -93,7 +93,7 @@ impl MetricsClient for TonicMetricsClient {
     fn shutdown(&self) -> ShutdownResult {
         self.inner
             .lock()
-            .map_err(|e| ShutdownError::InternalFailure(format!("Failed to acquire lock: {}", e)))?
+            .map_err(|e| OTelSdkError::InternalFailure(format!("Failed to acquire lock: {}", e)))?
             .take();
 
         Ok(())

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -6,7 +6,7 @@ use opentelemetry::otel_debug;
 use opentelemetry_proto::tonic::collector::metrics::v1::{
     metrics_service_client::MetricsServiceClient, ExportMetricsServiceRequest,
 };
-use opentelemetry_sdk::error::{OTelSdkError, ShutdownResult};
+use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::metrics::data::ResourceMetrics;
 use opentelemetry_sdk::metrics::{MetricError, MetricResult};
 use tonic::{codegen::CompressionEncoding, service::Interceptor, transport::Channel, Request};
@@ -90,7 +90,7 @@ impl MetricsClient for TonicMetricsClient {
         Ok(())
     }
 
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         self.inner
             .lock()
             .map_err(|e| OTelSdkError::InternalFailure(format!("Failed to acquire lock: {}", e)))?

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -16,7 +16,7 @@ use crate::NoExporterBuilderSet;
 
 use async_trait::async_trait;
 use core::fmt;
-use opentelemetry_sdk::error::ShutdownResult;
+use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::metrics::MetricResult;
 
 use opentelemetry_sdk::metrics::{
@@ -124,7 +124,7 @@ impl HasHttpConfig for MetricExporterBuilder<HttpExporterBuilderSet> {
 #[async_trait]
 pub(crate) trait MetricsClient: fmt::Debug + Send + Sync + 'static {
     async fn export(&self, metrics: &mut ResourceMetrics) -> MetricResult<()>;
-    fn shutdown(&self) -> ShutdownResult;
+    fn shutdown(&self) -> OTelSdkResult;
 }
 
 /// Export metrics in OTEL format.
@@ -150,7 +150,7 @@ impl PushMetricExporter for MetricExporter {
         Ok(())
     }
 
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         self.client.shutdown()
     }
 

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -7,7 +7,7 @@ use opentelemetry::{
     Key, KeyValue,
 };
 use opentelemetry_sdk::{
-    error::ShutdownResult,
+    error::OTelSdkResult,
     metrics::{
         data::ResourceMetrics, new_view, reader::MetricReader, Aggregation, Instrument,
         InstrumentKind, ManualReader, MetricResult, Pipeline, SdkMeterProvider, Stream,
@@ -32,7 +32,7 @@ impl MetricReader for SharedReader {
         self.0.force_flush()
     }
 
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         self.0.shutdown()
     }
 

--- a/opentelemetry-sdk/src/error.rs
+++ b/opentelemetry-sdk/src/error.rs
@@ -42,4 +42,4 @@ pub enum OTelSdkError {
 }
 
 /// A specialized `Result` type for Shutdown operations.
-pub type ShutdownResult = Result<(), OTelSdkError>;
+pub type OTelSdkResult = Result<(), OTelSdkError>;

--- a/opentelemetry-sdk/src/error.rs
+++ b/opentelemetry-sdk/src/error.rs
@@ -11,8 +11,8 @@ pub trait ExportError: std::error::Error + Send + Sync + 'static {
 }
 
 #[derive(Error, Debug)]
-/// Errors that can occur during shutdown.
-pub enum ShutdownError {
+/// Errors that can occur during SDK operations export(), force_flush() and shutdown().
+pub enum OTelSdkError {
     /// Shutdown has already been invoked.
     ///
     /// While shutdown is idempotent and calling it multiple times has no
@@ -42,4 +42,4 @@ pub enum ShutdownError {
 }
 
 /// A specialized `Result` type for Shutdown operations.
-pub type ShutdownResult = Result<(), ShutdownError>;
+pub type ShutdownResult = Result<(), OTelSdkError>;

--- a/opentelemetry-sdk/src/metrics/exporter.rs
+++ b/opentelemetry-sdk/src/metrics/exporter.rs
@@ -1,7 +1,7 @@
 //! Interfaces for exporting metrics
 use async_trait::async_trait;
 
-use crate::error::ShutdownResult;
+use crate::error::OTelSdkResult;
 use crate::metrics::MetricResult;
 
 use crate::metrics::data::ResourceMetrics;
@@ -28,7 +28,7 @@ pub trait PushMetricExporter: Send + Sync + 'static {
     ///
     /// After Shutdown is called, calls to Export will perform no operation and
     /// instead will return an error indicating the shutdown state.
-    fn shutdown(&self) -> ShutdownResult;
+    fn shutdown(&self) -> OTelSdkResult;
 
     /// Access the [Temporality] of the MetricExporter.
     fn temporality(&self) -> Temporality;

--- a/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
@@ -1,4 +1,4 @@
-use crate::error::ShutdownResult;
+use crate::error::OTelSdkResult;
 use crate::metrics::data::{self, Gauge, Sum};
 use crate::metrics::data::{Histogram, Metric, ResourceMetrics, ScopeMetrics};
 use crate::metrics::exporter::PushMetricExporter;
@@ -278,7 +278,7 @@ impl PushMetricExporter for InMemoryMetricExporter {
         Ok(()) // In this implementation, flush does nothing
     }
 
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         Ok(())
     }
 

--- a/opentelemetry-sdk/src/metrics/manual_reader.rs
+++ b/opentelemetry-sdk/src/metrics/manual_reader.rs
@@ -6,7 +6,7 @@ use std::{
 use opentelemetry::otel_debug;
 
 use crate::{
-    error::{OTelSdkError, ShutdownResult},
+    error::{OTelSdkError, OTelSdkResult},
     metrics::{MetricError, MetricResult, Temporality},
 };
 
@@ -110,7 +110,7 @@ impl MetricReader for ManualReader {
     }
 
     /// Closes any connections and frees any resources used by the reader.
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         let mut inner = self.inner.lock().map_err(|e| {
             OTelSdkError::InternalFailure(format!("Failed to acquire lock: {}", e))
         })?;

--- a/opentelemetry-sdk/src/metrics/manual_reader.rs
+++ b/opentelemetry-sdk/src/metrics/manual_reader.rs
@@ -111,9 +111,10 @@ impl MetricReader for ManualReader {
 
     /// Closes any connections and frees any resources used by the reader.
     fn shutdown(&self) -> OTelSdkResult {
-        let mut inner = self.inner.lock().map_err(|e| {
-            OTelSdkError::InternalFailure(format!("Failed to acquire lock: {}", e))
-        })?;
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|e| OTelSdkError::InternalFailure(format!("Failed to acquire lock: {}", e)))?;
 
         // Any future call to collect will now return an error.
         inner.sdk_producer = None;

--- a/opentelemetry-sdk/src/metrics/manual_reader.rs
+++ b/opentelemetry-sdk/src/metrics/manual_reader.rs
@@ -6,7 +6,7 @@ use std::{
 use opentelemetry::otel_debug;
 
 use crate::{
-    error::{ShutdownError, ShutdownResult},
+    error::{OTelSdkError, ShutdownResult},
     metrics::{MetricError, MetricResult, Temporality},
 };
 
@@ -112,7 +112,7 @@ impl MetricReader for ManualReader {
     /// Closes any connections and frees any resources used by the reader.
     fn shutdown(&self) -> ShutdownResult {
         let mut inner = self.inner.lock().map_err(|e| {
-            ShutdownError::InternalFailure(format!("Failed to acquire lock: {}", e))
+            OTelSdkError::InternalFailure(format!("Failed to acquire lock: {}", e))
         })?;
 
         // Any future call to collect will now return an error.

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -141,7 +141,7 @@ impl SdkMeterProviderInner {
             .swap(true, std::sync::atomic::Ordering::SeqCst)
         {
             // If the previous value was true, shutdown was already invoked.
-            Err(crate::error::ShutdownError::AlreadyShutdown)
+            Err(crate::error::OTelSdkError::AlreadyShutdown)
         } else {
             self.pipes.shutdown()
         }

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -14,7 +14,7 @@ use opentelemetry::{
 
 use crate::Resource;
 use crate::{
-    error::ShutdownResult,
+    error::OTelSdkResult,
     metrics::{MetricError, MetricResult},
 };
 
@@ -112,7 +112,7 @@ impl SdkMeterProvider {
     ///
     /// There is no guaranteed that all telemetry be flushed or all resources have
     /// been released on error.
-    pub fn shutdown(&self) -> ShutdownResult {
+    pub fn shutdown(&self) -> OTelSdkResult {
         otel_info!(
             name: "MeterProvider.Shutdown",
             message = "User initiated shutdown of MeterProvider."
@@ -135,7 +135,7 @@ impl SdkMeterProviderInner {
         }
     }
 
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         if self
             .shutdown_invoked
             .swap(true, std::sync::atomic::Ordering::SeqCst)

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -11,7 +11,7 @@ use std::{
 use opentelemetry::{otel_debug, otel_error, otel_info, otel_warn};
 
 use crate::{
-    error::{OTelSdkError, ShutdownResult},
+    error::{OTelSdkError, OTelSdkResult},
     metrics::{exporter::PushMetricExporter, reader::SdkProducer, MetricError, MetricResult},
     Resource,
 };
@@ -474,7 +474,7 @@ impl PeriodicReaderInner {
         }
     }
 
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         // TODO: See if this is better to be created upfront.
         let (response_tx, response_rx) = mpsc::channel();
         self.message_sender
@@ -523,7 +523,7 @@ impl MetricReader for PeriodicReader {
     // completion, and avoid blocking the thread. The default shutdown on drop
     // can still use blocking call. If user already explicitly called shutdown,
     // drop won't call shutdown again.
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         self.inner.shutdown()
     }
 
@@ -543,7 +543,7 @@ impl MetricReader for PeriodicReader {
 mod tests {
     use super::PeriodicReader;
     use crate::{
-        error::{OTelSdkError, ShutdownResult},
+        error::{OTelSdkError, OTelSdkResult},
         metrics::{
             data::ResourceMetrics, exporter::PushMetricExporter, reader::MetricReader,
             InMemoryMetricExporter, MetricError, MetricResult, SdkMeterProvider, Temporality,
@@ -596,7 +596,7 @@ mod tests {
             Ok(())
         }
 
-        fn shutdown(&self) -> ShutdownResult {
+        fn shutdown(&self) -> OTelSdkResult {
             Ok(())
         }
 
@@ -620,7 +620,7 @@ mod tests {
             Ok(())
         }
 
-        fn shutdown(&self) -> ShutdownResult {
+        fn shutdown(&self) -> OTelSdkResult {
             self.is_shutdown.store(true, Ordering::Relaxed);
             Ok(())
         }

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -11,7 +11,7 @@ use std::{
 use opentelemetry::{otel_debug, otel_error, otel_info, otel_warn};
 
 use crate::{
-    error::{ShutdownError, ShutdownResult},
+    error::{OTelSdkError, ShutdownResult},
     metrics::{exporter::PushMetricExporter, reader::SdkProducer, MetricError, MetricResult},
     Resource,
 };
@@ -479,7 +479,7 @@ impl PeriodicReaderInner {
         let (response_tx, response_rx) = mpsc::channel();
         self.message_sender
             .send(Message::Shutdown(response_tx))
-            .map_err(|e| ShutdownError::InternalFailure(e.to_string()))?;
+            .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
 
         // TODO: Make this timeout configurable.
         match response_rx.recv_timeout(Duration::from_secs(5)) {
@@ -487,14 +487,14 @@ impl PeriodicReaderInner {
                 if response {
                     Ok(())
                 } else {
-                    Err(ShutdownError::InternalFailure("Failed to shutdown".into()))
+                    Err(OTelSdkError::InternalFailure("Failed to shutdown".into()))
                 }
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                Err(ShutdownError::Timeout(Duration::from_secs(5)))
+                Err(OTelSdkError::Timeout(Duration::from_secs(5)))
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                Err(ShutdownError::InternalFailure("Failed to shutdown".into()))
+                Err(OTelSdkError::InternalFailure("Failed to shutdown".into()))
             }
         }
     }
@@ -543,7 +543,7 @@ impl MetricReader for PeriodicReader {
 mod tests {
     use super::PeriodicReader;
     use crate::{
-        error::{ShutdownError, ShutdownResult},
+        error::{OTelSdkError, ShutdownResult},
         metrics::{
             data::ResourceMetrics, exporter::PushMetricExporter, reader::MetricReader,
             InMemoryMetricExporter, MetricError, MetricResult, SdkMeterProvider, Temporality,
@@ -675,12 +675,12 @@ mod tests {
         // calling shutdown again should return Err
         let result = meter_provider.shutdown();
         assert!(result.is_err());
-        assert!(matches!(result, Err(ShutdownError::AlreadyShutdown)));
+        assert!(matches!(result, Err(OTelSdkError::AlreadyShutdown)));
 
         // calling shutdown again should return Err
         let result = meter_provider.shutdown();
         assert!(result.is_err());
-        assert!(matches!(result, Err(ShutdownError::AlreadyShutdown)));
+        assert!(matches!(result, Err(OTelSdkError::AlreadyShutdown)));
     }
 
     #[test]

--- a/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
@@ -15,7 +15,7 @@ use opentelemetry::{otel_debug, otel_error};
 
 use crate::runtime::Runtime;
 use crate::{
-    error::{OtelSdkError, OtelSdkResult},
+    error::{OTelSdkError, OTelSdkResult},
     metrics::{exporter::PushMetricExporter, reader::SdkProducer, MetricError, MetricResult},
     Resource,
 };
@@ -217,7 +217,7 @@ struct PeriodicReaderInner {
 enum Message {
     Export,
     Flush(oneshot::Sender<MetricResult<()>>),
-    Shutdown(oneshot::Sender<OtelSdkResult>),
+    Shutdown(oneshot::Sender<OTelSdkResult>),
 }
 
 enum ProducerOrWorker {
@@ -297,7 +297,7 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
                 let res = self.collect_and_export().await;
                 let _ = self.reader.exporter.shutdown();
                 if let Err(send_error) =
-                    ch.send(res.map_err(|e| OtelSdkError::InternalFailure(e.to_string())))
+                    ch.send(res.map_err(|e| OTelSdkError::InternalFailure(e.to_string())))
                 {
                     otel_debug!(
                         name: "PeriodicReader.Shutdown.SendResultError",
@@ -378,30 +378,30 @@ impl MetricReader for PeriodicReader {
             .and_then(|res| res)
     }
 
-    fn shutdown(&self) -> OtelSdkResult {
+    fn shutdown(&self) -> OTelSdkResult {
         let mut inner = self
             .inner
             .lock()
-            .map_err(|e| OtelSdkError::InternalFailure(e.to_string()))?;
+            .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
         if inner.is_shutdown {
-            return Err(OtelSdkError::AlreadyShutdown);
+            return Err(OTelSdkError::AlreadyShutdown);
         }
 
         let (sender, receiver) = oneshot::channel();
         inner
             .message_sender
             .try_send(Message::Shutdown(sender))
-            .map_err(|e| OtelSdkError::InternalFailure(e.to_string()))?;
+            .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
         drop(inner); // don't hold lock when blocking on future
 
         let shutdown_result = futures_executor::block_on(receiver)
-            .map_err(|err| OtelSdkError::InternalFailure(err.to_string()))?;
+            .map_err(|err| OTelSdkError::InternalFailure(err.to_string()))?;
 
         // Acquire the lock again to set the shutdown flag
         let mut inner = self
             .inner
             .lock()
-            .map_err(|e| OtelSdkError::InternalFailure(e.to_string()))?;
+            .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
         inner.is_shutdown = true;
 
         shutdown_result

--- a/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
@@ -15,7 +15,7 @@ use opentelemetry::{otel_debug, otel_error};
 
 use crate::runtime::Runtime;
 use crate::{
-    error::{ShutdownError, ShutdownResult},
+    error::{OtelSdkError, OtelSdkResult},
     metrics::{exporter::PushMetricExporter, reader::SdkProducer, MetricError, MetricResult},
     Resource,
 };
@@ -217,7 +217,7 @@ struct PeriodicReaderInner {
 enum Message {
     Export,
     Flush(oneshot::Sender<MetricResult<()>>),
-    Shutdown(oneshot::Sender<ShutdownResult>),
+    Shutdown(oneshot::Sender<OtelSdkResult>),
 }
 
 enum ProducerOrWorker {
@@ -297,7 +297,7 @@ impl<RT: Runtime> PeriodicReaderWorker<RT> {
                 let res = self.collect_and_export().await;
                 let _ = self.reader.exporter.shutdown();
                 if let Err(send_error) =
-                    ch.send(res.map_err(|e| ShutdownError::InternalFailure(e.to_string())))
+                    ch.send(res.map_err(|e| OtelSdkError::InternalFailure(e.to_string())))
                 {
                     otel_debug!(
                         name: "PeriodicReader.Shutdown.SendResultError",
@@ -378,30 +378,30 @@ impl MetricReader for PeriodicReader {
             .and_then(|res| res)
     }
 
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OtelSdkResult {
         let mut inner = self
             .inner
             .lock()
-            .map_err(|e| ShutdownError::InternalFailure(e.to_string()))?;
+            .map_err(|e| OtelSdkError::InternalFailure(e.to_string()))?;
         if inner.is_shutdown {
-            return Err(ShutdownError::AlreadyShutdown);
+            return Err(OtelSdkError::AlreadyShutdown);
         }
 
         let (sender, receiver) = oneshot::channel();
         inner
             .message_sender
             .try_send(Message::Shutdown(sender))
-            .map_err(|e| ShutdownError::InternalFailure(e.to_string()))?;
+            .map_err(|e| OtelSdkError::InternalFailure(e.to_string()))?;
         drop(inner); // don't hold lock when blocking on future
 
         let shutdown_result = futures_executor::block_on(receiver)
-            .map_err(|err| ShutdownError::InternalFailure(err.to_string()))?;
+            .map_err(|err| OtelSdkError::InternalFailure(err.to_string()))?;
 
         // Acquire the lock again to set the shutdown flag
         let mut inner = self
             .inner
             .lock()
-            .map_err(|e| ShutdownError::InternalFailure(e.to_string()))?;
+            .map_err(|e| OtelSdkError::InternalFailure(e.to_string()))?;
         inner.is_shutdown = true;
 
         shutdown_result

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -661,7 +661,7 @@ impl Pipelines {
         if errs.is_empty() {
             Ok(())
         } else {
-            Err(crate::error::ShutdownError::InternalFailure(format!(
+            Err(crate::error::OTelSdkError::InternalFailure(format!(
                 "{errs:?}"
             )))
         }

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -8,7 +8,7 @@ use std::{
 use opentelemetry::{otel_debug, InstrumentationScope, KeyValue};
 
 use crate::{
-    error::ShutdownResult,
+    error::OTelSdkResult,
     metrics::{
         aggregation,
         data::{Metric, ResourceMetrics, ScopeMetrics},
@@ -95,7 +95,7 @@ impl Pipeline {
     }
 
     /// Shut down pipeline
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         self.reader.shutdown()
     }
 }
@@ -650,7 +650,7 @@ impl Pipelines {
     }
 
     /// Shut down all pipelines
-    pub(crate) fn shutdown(&self) -> ShutdownResult {
+    pub(crate) fn shutdown(&self) -> OTelSdkResult {
         let mut errs = vec![];
         for pipeline in &self.0 {
             if let Err(err) = pipeline.shutdown() {

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -1,7 +1,7 @@
 //! Interfaces for reading and producing metrics
 use std::{fmt, sync::Weak};
 
-use crate::{error::ShutdownResult, metrics::MetricResult};
+use crate::{error::OTelSdkResult, metrics::MetricResult};
 
 use super::{data::ResourceMetrics, pipeline::Pipeline, InstrumentKind, Temporality};
 
@@ -46,7 +46,7 @@ pub trait MetricReader: fmt::Debug + Send + Sync + 'static {
     ///
     /// After `shutdown` is called, calls to `collect` will perform no operation and
     /// instead will return an error indicating the shutdown state.
-    fn shutdown(&self) -> ShutdownResult;
+    fn shutdown(&self) -> OTelSdkResult;
 
     /// The output temporality, a function of instrument kind.
     /// This SHOULD be obtained from the exporter.

--- a/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
+++ b/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex, Weak};
 
-use crate::error::{ShutdownError, ShutdownResult};
+use crate::error::{OTelSdkError, ShutdownResult};
 use crate::metrics::{
     data::ResourceMetrics, pipeline::Pipeline, reader::MetricReader, InstrumentKind,
 };
@@ -48,7 +48,7 @@ impl MetricReader for TestMetricReader {
             let mut is_shutdown = self.is_shutdown.lock().unwrap();
             *is_shutdown = true;
         }
-        result.map_err(|e| ShutdownError::InternalFailure(e.to_string()))
+        result.map_err(|e| OTelSdkError::InternalFailure(e.to_string()))
     }
 
     fn temporality(&self, _kind: InstrumentKind) -> Temporality {

--- a/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
+++ b/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex, Weak};
 
-use crate::error::{OTelSdkError, ShutdownResult};
+use crate::error::{OTelSdkError, OTelSdkResult};
 use crate::metrics::{
     data::ResourceMetrics, pipeline::Pipeline, reader::MetricReader, InstrumentKind,
 };
@@ -42,7 +42,7 @@ impl MetricReader for TestMetricReader {
         Ok(())
     }
 
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         let result = self.force_flush();
         {
             let mut is_shutdown = self.is_shutdown.lock().unwrap();

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use core::{f64, fmt};
 use opentelemetry_sdk::metrics::{MetricError, MetricResult, Temporality};
 use opentelemetry_sdk::{
-    error::ShutdownResult,
+    error::OTelSdkResult,
     metrics::{
         data::{
             ExponentialHistogram, Gauge, GaugeDataPoint, Histogram, HistogramDataPoint,
@@ -65,7 +65,7 @@ impl PushMetricExporter for MetricExporter {
         Ok(())
     }
 
-    fn shutdown(&self) -> ShutdownResult {
+    fn shutdown(&self) -> OTelSdkResult {
         self.is_shutdown.store(true, atomic::Ordering::SeqCst);
         Ok(())
     }


### PR DESCRIPTION
As discussed https://github.com/open-telemetry/opentelemetry-rust/pull/2600/files#r1941764809 this renames the ShutdownError to OTelSdkError
ShutdownResult to OTelSdkResult

In separate follow up PR, we can modify usages to move to the new one, and finally do the removal of existing Errors types
