### PR TITLE
Use opentelemetry:time::now instead of systemtime (final part)

### DIFF
--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -223,11 +223,11 @@ mod tests {
     use opentelemetry::logs::LogRecord as _;
     use opentelemetry::logs::Logger as _;
     use opentelemetry::logs::LoggerProvider as _;
+    use opentelemetry::time::now;
     use opentelemetry::InstrumentationScope;
     use opentelemetry_sdk::logs::LogProcessor;
     use opentelemetry_sdk::logs::{LogResult, LoggerProvider};
     use opentelemetry_sdk::{logs::LogBatch, logs::LogRecord, Resource};
-    use std::time::SystemTime;
 
     #[derive(Debug)]
     struct MockProcessor;
@@ -254,8 +254,8 @@ mod tests {
             .build()
             .logger("test");
         let mut logrecord = logger.create_log_record();
-        logrecord.set_timestamp(SystemTime::now());
-        logrecord.set_observed_timestamp(SystemTime::now());
+        logrecord.set_timestamp(now());
+        logrecord.set_observed_timestamp(now());
         let instrumentation =
             InstrumentationScope::builder(instrumentation_name.to_string()).build();
         (logrecord, instrumentation)

--- a/opentelemetry-proto/src/transform/trace.rs
+++ b/opentelemetry-proto/src/transform/trace.rs
@@ -193,6 +193,7 @@ pub mod tonic {
 mod tests {
     use crate::tonic::common::v1::any_value::Value;
     use crate::transform::common::tonic::ResourceAttributesWithSchema;
+    use opentelemetry::time::now;
     use opentelemetry::trace::{
         SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
     };
@@ -202,7 +203,7 @@ mod tests {
     use opentelemetry_sdk::trace::SpanData;
     use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
     use std::borrow::Cow;
-    use std::time::{Duration, SystemTime};
+    use std::time::Duration;
 
     fn create_test_span_data(instrumentation_name: &'static str) -> SpanData {
         let span_context = SpanContext::new(
@@ -218,8 +219,8 @@ mod tests {
             parent_span_id: SpanId::from_u64(0),
             span_kind: SpanKind::Internal,
             name: Cow::Borrowed("test_span"),
-            start_time: SystemTime::now(),
-            end_time: SystemTime::now() + Duration::from_secs(1),
+            start_time: now(),
+            end_time: now() + Duration::from_secs(1),
             attributes: vec![KeyValue::new("key", "value")],
             dropped_attributes_count: 0,
             events: SpanEvents::default(),

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -230,8 +230,8 @@ impl From<&SpanContext> for TraceContext {
 mod tests {
     use super::*;
     use opentelemetry::logs::{AnyValue, LogRecord as _, Severity};
+    use opentelemetry::time::now;
     use std::borrow::Cow;
-    use std::time::SystemTime;
 
     #[test]
     fn test_set_eventname() {
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn test_set_timestamp() {
         let mut log_record = LogRecord::new();
-        let now = SystemTime::now();
+        let now = now();
         log_record.set_timestamp(now);
         assert_eq!(log_record.timestamp, Some(now));
     }
@@ -258,7 +258,7 @@ mod tests {
     #[test]
     fn test_set_observed_timestamp() {
         let mut log_record = LogRecord::new();
-        let now = SystemTime::now();
+        let now = now();
         log_record.set_observed_timestamp(now);
         assert_eq!(log_record.observed_timestamp, Some(now));
     }
@@ -331,8 +331,8 @@ mod tests {
         let mut log_record = LogRecord {
             event_name: Some("test_event"),
             target: Some(Cow::Borrowed("foo::bar")),
-            timestamp: Some(SystemTime::now()),
-            observed_timestamp: Some(SystemTime::now()),
+            timestamp: Some(now()),
+            observed_timestamp: Some(now()),
             severity_text: Some("ERROR"),
             severity_number: Some(Severity::Error),
             body: Some(AnyValue::String("Test body".into())),

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -350,6 +350,7 @@ mod tests {
 
     use super::{Exemplar, ExponentialHistogramDataPoint, HistogramDataPoint, SumDataPoint};
 
+    use opentelemetry::time::now;
     use opentelemetry::KeyValue;
 
     #[test]
@@ -359,7 +360,7 @@ mod tests {
             value: 0u32,
             exemplars: vec![Exemplar {
                 filtered_attributes: vec![],
-                time: std::time::SystemTime::now(),
+                time: now(),
                 value: 0u32,
                 span_id: [0; 8],
                 trace_id: [0; 16],
@@ -377,7 +378,7 @@ mod tests {
             sum: 0u32,
             exemplars: vec![Exemplar {
                 filtered_attributes: vec![],
-                time: std::time::SystemTime::now(),
+                time: now(),
                 value: 0u32,
                 span_id: [0; 8],
                 trace_id: [0; 16],
@@ -404,7 +405,7 @@ mod tests {
             zero_threshold: 0.0,
             exemplars: vec![Exemplar {
                 filtered_attributes: vec![],
-                time: std::time::SystemTime::now(),
+                time: now(),
                 value: 0u32,
                 span_id: [0; 8],
                 trace_id: [0; 16],

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -6,9 +6,9 @@ use std::{
     time::SystemTime,
 };
 
-use opentelemetry::KeyValue;
-
 use crate::metrics::{data::Aggregation, Temporality};
+use opentelemetry::time::now;
+use opentelemetry::KeyValue;
 
 use super::{
     exponential_histogram::ExpoHistogram, histogram::Histogram, last_value::LastValue,
@@ -71,7 +71,7 @@ pub(crate) struct AggregateTimeInitiator(Mutex<SystemTime>);
 
 impl AggregateTimeInitiator {
     pub(crate) fn delta(&self) -> AggregateTime {
-        let current_time = SystemTime::now();
+        let current_time = now();
         let start_time = self
             .0
             .lock()
@@ -84,7 +84,7 @@ impl AggregateTimeInitiator {
     }
 
     pub(crate) fn cumulative(&self) -> AggregateTime {
-        let current_time = SystemTime::now();
+        let current_time = now();
         let start_time = self.0.lock().map(|start| *start).unwrap_or(current_time);
         AggregateTime {
             start: start_time,
@@ -95,7 +95,7 @@ impl AggregateTimeInitiator {
 
 impl Default for AggregateTimeInitiator {
     fn default() -> Self {
-        Self(Mutex::new(SystemTime::now()))
+        Self(Mutex::new(now()))
     }
 }
 
@@ -203,7 +203,7 @@ mod tests {
         ExponentialBucket, ExponentialHistogram, ExponentialHistogramDataPoint, Gauge,
         GaugeDataPoint, Histogram, HistogramDataPoint, Sum, SumDataPoint,
     };
-    use std::{time::SystemTime, vec};
+    use std::vec;
 
     use super::*;
 
@@ -217,8 +217,8 @@ mod tests {
                 value: 1u64,
                 exemplars: vec![],
             }],
-            start_time: Some(SystemTime::now()),
-            time: SystemTime::now(),
+            start_time: Some(now()),
+            time: now(),
         };
         let new_attributes = [KeyValue::new("b", 2)];
         measure.call(2, &new_attributes[..]);
@@ -250,8 +250,8 @@ mod tests {
                         exemplars: vec![],
                     },
                 ],
-                start_time: SystemTime::now(),
-                time: SystemTime::now(),
+                start_time: now(),
+                time: now(),
                 temporality: if temporality == Temporality::Delta {
                     Temporality::Cumulative
                 } else {
@@ -292,8 +292,8 @@ mod tests {
                         exemplars: vec![],
                     },
                 ],
-                start_time: SystemTime::now(),
-                time: SystemTime::now(),
+                start_time: now(),
+                time: now(),
                 temporality: if temporality == Temporality::Delta {
                     Temporality::Cumulative
                 } else {
@@ -332,8 +332,8 @@ mod tests {
                     sum: 3u64,
                     exemplars: vec![],
                 }],
-                start_time: SystemTime::now(),
-                time: SystemTime::now(),
+                start_time: now(),
+                time: now(),
                 temporality: if temporality == Temporality::Delta {
                     Temporality::Cumulative
                 } else {
@@ -384,8 +384,8 @@ mod tests {
                     zero_threshold: 1.0,
                     exemplars: vec![],
                 }],
-                start_time: SystemTime::now(),
-                time: SystemTime::now(),
+                start_time: now(),
+                time: now(),
                 temporality: if temporality == Temporality::Delta {
                     Temporality::Cumulative
                 } else {

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -526,9 +526,9 @@ where
 }
 #[cfg(test)]
 mod tests {
-    use std::{ops::Neg, time::SystemTime};
-
     use data::{ExponentialHistogram, Gauge, Histogram, Sum};
+    use opentelemetry::time::now;
+    use std::ops::Neg;
     use tests::internal::AggregateFns;
 
     use crate::metrics::internal::{self, AggregateBuilder};
@@ -1299,8 +1299,8 @@ mod tests {
                         zero_threshold: 0.0,
                         zero_count: 0,
                     }],
-                    start_time: SystemTime::now(),
-                    time: SystemTime::now(),
+                    start_time: now(),
+                    time: now(),
                 },
                 want_count: 1,
             },
@@ -1340,8 +1340,8 @@ mod tests {
                         zero_threshold: 0.0,
                         zero_count: 0,
                     }],
-                    start_time: SystemTime::now(),
-                    time: SystemTime::now(),
+                    start_time: now(),
+                    time: now(),
                 },
                 want_count: 1,
             },
@@ -1384,8 +1384,8 @@ mod tests {
                         zero_threshold: 0.0,
                         zero_count: 0,
                     }],
-                    start_time: SystemTime::now(),
-                    time: SystemTime::now(),
+                    start_time: now(),
+                    time: now(),
                 },
                 want_count: 1,
             },
@@ -1428,8 +1428,8 @@ mod tests {
                         zero_threshold: 0.0,
                         zero_count: 0,
                     }],
-                    start_time: SystemTime::now(),
-                    time: SystemTime::now(),
+                    start_time: now(),
+                    time: now(),
                 },
                 want_count: 1,
             },
@@ -1440,8 +1440,8 @@ mod tests {
 
             let mut got: Box<dyn data::Aggregation> = Box::new(data::ExponentialHistogram::<T> {
                 data_points: vec![],
-                start_time: SystemTime::now(),
-                time: SystemTime::now(),
+                start_time: now(),
+                time: now(),
                 temporality: Temporality::Delta,
             });
             let mut count = 0;

--- a/opentelemetry-zipkin/src/exporter/model/span.rs
+++ b/opentelemetry-zipkin/src/exporter/model/span.rs
@@ -59,12 +59,12 @@ mod tests {
     use crate::exporter::model::endpoint::Endpoint;
     use crate::exporter::model::span::{Kind, Span};
     use crate::exporter::model::{into_zipkin_span, OTEL_ERROR_DESCRIPTION, OTEL_STATUS_CODE};
+    use opentelemetry::time::now;
     use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId};
     use opentelemetry_sdk::trace::SpanData;
     use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
     use std::collections::HashMap;
     use std::net::Ipv4Addr;
-    use std::time::SystemTime;
 
     #[test]
     fn test_empty() {
@@ -158,8 +158,8 @@ mod tests {
                 parent_span_id: SpanId::from_u64(1),
                 span_kind: SpanKind::Client,
                 name: "".into(),
-                start_time: SystemTime::now(),
-                end_time: SystemTime::now(),
+                start_time: now(),
+                end_time: now(),
                 attributes: Vec::new(),
                 dropped_attributes_count: 0,
                 events: SpanEvents::default(),


### PR DESCRIPTION
Fixes #2557 
Final 2 for https://github.com/open-telemetry/opentelemetry-rust/issues/2557