### PR TITLE
Trace subsystem - use OTelSdkResult/OTelSdkError

### DIFF
--- a/opentelemetry-otlp/src/exporter/http/trace.rs
+++ b/opentelemetry-otlp/src/exporter/http/trace.rs
@@ -65,7 +65,7 @@ impl SpanExporter for OtlpHttpClient {
                     request_uri,
                     response.body()
                 );
-                return Err(OTelSdkError::InternalFailure(error.into()));
+                return Err(OTelSdkError::InternalFailure(error));
             }
 
             Ok(())

--- a/opentelemetry-otlp/src/exporter/http/trace.rs
+++ b/opentelemetry-otlp/src/exporter/http/trace.rs
@@ -1,21 +1,23 @@
 use std::sync::Arc;
 
+use super::OtlpHttpClient;
 use futures_core::future::BoxFuture;
 use http::{header::CONTENT_TYPE, Method};
-use opentelemetry::{otel_debug, trace::TraceError};
-use opentelemetry_sdk::trace::{ExportResult, SpanData, SpanExporter};
-
-use super::OtlpHttpClient;
+use opentelemetry::otel_debug;
+use opentelemetry_sdk::{
+    error::{OTelSdkError, OTelSdkResult},
+    trace::{SpanData, SpanExporter},
+};
 
 impl SpanExporter for OtlpHttpClient {
-    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         let client = match self
             .client
             .lock()
-            .map_err(|e| TraceError::Other(e.to_string().into()))
+            .map_err(|e| OTelSdkError::InternalFailure(format!("Mutex lock failed: {}", e)))
             .and_then(|g| match &*g {
                 Some(client) => Ok(Arc::clone(client)),
-                _ => Err(TraceError::Other("exporter is already shut down".into())),
+                _ => Err(OTelSdkError::AlreadyShutdown),
             }) {
             Ok(client) => client,
             Err(err) => return Box::pin(std::future::ready(Err(err))),
@@ -23,7 +25,11 @@ impl SpanExporter for OtlpHttpClient {
 
         let (body, content_type) = match self.build_trace_export_body(batch) {
             Ok(body) => body,
-            Err(e) => return Box::pin(std::future::ready(Err(e))),
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(OTelSdkError::InternalFailure(
+                    e.to_string(),
+                ))))
+            }
         };
 
         let mut request = match http::Request::builder()
@@ -34,10 +40,9 @@ impl SpanExporter for OtlpHttpClient {
         {
             Ok(req) => req,
             Err(e) => {
-                return Box::pin(std::future::ready(Err(crate::Error::RequestFailed(
-                    Box::new(e),
-                )
-                .into())))
+                return Box::pin(std::future::ready(Err(OTelSdkError::InternalFailure(
+                    e.to_string(),
+                ))))
             }
         };
 
@@ -48,7 +53,10 @@ impl SpanExporter for OtlpHttpClient {
         Box::pin(async move {
             let request_uri = request.uri().to_string();
             otel_debug!(name: "HttpTracesClient.CallingExport");
-            let response = client.send_bytes(request).await?;
+            let response = client
+                .send_bytes(request)
+                .await
+                .map_err(|e| OTelSdkError::InternalFailure(format!("{e:?}")))?;
 
             if !response.status().is_success() {
                 let error = format!(
@@ -57,15 +65,23 @@ impl SpanExporter for OtlpHttpClient {
                     request_uri,
                     response.body()
                 );
-                return Err(TraceError::Other(error.into()));
+                return Err(OTelSdkError::InternalFailure(error.into()));
             }
 
             Ok(())
         })
     }
 
-    fn shutdown(&mut self) {
-        let _ = self.client.lock().map(|mut c| c.take());
+    fn shutdown(&mut self) -> OTelSdkResult {
+        let mut client_guard = self.client.lock().map_err(|e| {
+            OTelSdkError::InternalFailure(format!("Failed to acquire client lock: {}", e))
+        })?;
+
+        if client_guard.take().is_none() {
+            return Err(OTelSdkError::AlreadyShutdown);
+        }
+
+        Ok(())
     }
 
     fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -5,7 +5,8 @@
 use std::fmt::Debug;
 
 use futures_core::future::BoxFuture;
-use opentelemetry_sdk::trace::{ExportResult, SpanData};
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::trace::SpanData;
 
 #[cfg(feature = "grpc-tonic")]
 use crate::{
@@ -122,7 +123,7 @@ impl SpanExporter {
 }
 
 impl opentelemetry_sdk::trace::SpanExporter for SpanExporter {
-    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         self.0.export(batch)
     }
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -370,6 +370,25 @@ let processor = BatchSpanProcessor::builder(exporter)
     .build();
 ```
 
+- **Breaking**
+ - The public API changes in the Tracing:
+   - Before:
+      ```rust
+        fn SpanExporter::export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult>;
+        fn SpanExporter::shutdown(&mut self);
+        fn SpanExporter::force_flush(&mut self) -> BoxFuture<'static, ExportResult>
+        fn TraerProvider::shutdown(&self) -> TraceResult<()>
+        fn TracerProvider::force_flush(&self) -> Vec<TraceResult<()>>
+      ```
+    - After:
+      ```rust
+        fn SpanExporter::export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult>;
+        fn SpanExporter::shutdown(&mut self) -> OTelSdkResult;
+        fn SpanExporter::force_flush(&mut self) -> BoxFuture<'static, OTelSdkResult>
+        fn TraerProvider::shutdown(&self) -> OTelSdkResult;
+        fn TracerProvider::force_flush(&self) -> OTelSdkResult;
+      ```
+
 ## 0.27.1
 
 Released 2024-Nov-27

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -42,7 +42,7 @@ temp-env = { workspace = true }
 pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 
 [features]
-default = ["trace", "metrics", "logs", "internal-logs"]
+default = ["trace", "metrics", "logs", "internal-logs", "experimental_trace_batch_span_processor_with_async_runtime"]
 trace = ["opentelemetry/trace", "rand", "percent-encoding"]
 jaeger_remote_sampler = ["trace", "opentelemetry-http", "http", "serde", "serde_json", "url"]
 logs = ["opentelemetry/logs", "serde_json"]

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -42,7 +42,7 @@ temp-env = { workspace = true }
 pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 
 [features]
-default = ["trace", "metrics", "logs", "internal-logs", "experimental_trace_batch_span_processor_with_async_runtime"]
+default = ["trace", "metrics", "logs", "internal-logs"]
 trace = ["opentelemetry/trace", "rand", "percent-encoding"]
 jaeger_remote_sampler = ["trace", "opentelemetry-http", "http", "serde", "serde_json", "url"]
 logs = ["opentelemetry/logs", "serde_json"]

--- a/opentelemetry-sdk/benches/context.rs
+++ b/opentelemetry-sdk/benches/context.rs
@@ -9,8 +9,8 @@ use opentelemetry::{
     Context, ContextGuard,
 };
 use opentelemetry_sdk::{
-    trace::{ExportResult, SpanData, SpanExporter},
-    trace::{Sampler, TracerProvider},
+    error::OTelSdkResult,
+    trace::{ExportResult, Sampler, SpanData, SpanExporter, TracerProvider},
 };
 #[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
@@ -137,7 +137,7 @@ fn parent_sampled_tracer(inner_sampler: Sampler) -> (TracerProvider, BoxedTracer
 struct NoopExporter;
 
 impl SpanExporter for NoopExporter {
-    fn export(&mut self, _spans: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, _spans: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         Box::pin(futures_util::future::ready(Ok(())))
     }
 }

--- a/opentelemetry-sdk/benches/context.rs
+++ b/opentelemetry-sdk/benches/context.rs
@@ -10,7 +10,7 @@ use opentelemetry::{
 };
 use opentelemetry_sdk::{
     error::OTelSdkResult,
-    trace::{ExportResult, Sampler, SpanData, SpanExporter, TracerProvider},
+    trace::{Sampler, SpanData, SpanExporter, TracerProvider},
 };
 #[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};

--- a/opentelemetry-sdk/benches/span_builder.rs
+++ b/opentelemetry-sdk/benches/span_builder.rs
@@ -4,9 +4,10 @@ use opentelemetry::{
     trace::{Span, Tracer, TracerProvider},
     KeyValue,
 };
+use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::{
     trace as sdktrace,
-    trace::{ExportResult, SpanData, SpanExporter},
+    trace::{SpanData, SpanExporter},
 };
 #[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
@@ -65,7 +66,7 @@ fn not_sampled_provider() -> (sdktrace::TracerProvider, sdktrace::Tracer) {
 struct NoopExporter;
 
 impl SpanExporter for NoopExporter {
-    fn export(&mut self, _spans: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, _spans: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         Box::pin(futures_util::future::ready(Ok(())))
     }
 }

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -5,8 +5,8 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_sdk::{
-    trace as sdktrace,
-    trace::{ExportResult, SpanData, SpanExporter},
+    error::OTelSdkResult,
+    trace::{self as sdktrace, SpanData, SpanExporter},
 };
 #[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
@@ -60,7 +60,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 struct VoidExporter;
 
 impl SpanExporter for VoidExporter {
-    fn export(&mut self, _spans: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, _spans: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         Box::pin(futures_util::future::ready(Ok(())))
     }
 }

--- a/opentelemetry-sdk/src/trace/export.rs
+++ b/opentelemetry-sdk/src/trace/export.rs
@@ -63,8 +63,8 @@ pub trait SpanExporter: Send + Sync + Debug {
     /// implemented as a blocking API or an asynchronous API which notifies the caller via
     /// a callback or an event. OpenTelemetry client authors can decide if they want to
     /// make the flush timeout configurable.
-    fn force_flush(&mut self) -> BoxFuture<'static, OTelSdkResult> {
-        Box::pin(async { Ok(()) })
+    fn force_flush(&mut self) -> OTelSdkResult {
+        Ok(())
     }
 
     /// Set the resource for the exporter.

--- a/opentelemetry-sdk/src/trace/export.rs
+++ b/opentelemetry-sdk/src/trace/export.rs
@@ -1,4 +1,5 @@
 //! Trace exporters
+use crate::error::OTelSdkResult;
 use crate::Resource;
 use futures_util::future::BoxFuture;
 use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status, TraceError};
@@ -30,7 +31,7 @@ pub trait SpanExporter: Send + Sync + Debug {
     ///
     /// Any retry logic that is required by the exporter is the responsibility
     /// of the exporter.
-    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult>;
+    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult>;
 
     /// Shuts down the exporter. Called when SDK is shut down. This is an
     /// opportunity for exporter to do any cleanup required.
@@ -43,7 +44,9 @@ pub trait SpanExporter: Send + Sync + Debug {
     /// flush the data and the destination is unavailable). SDK authors
     /// can decide if they want to make the shutdown timeout
     /// configurable.
-    fn shutdown(&mut self) {}
+    fn shutdown(&mut self) -> OTelSdkResult {
+        Ok(())
+    }
 
     /// This is a hint to ensure that the export of any Spans the exporter
     /// has received prior to the call to this function SHOULD be completed
@@ -60,7 +63,7 @@ pub trait SpanExporter: Send + Sync + Debug {
     /// implemented as a blocking API or an asynchronous API which notifies the caller via
     /// a callback or an event. OpenTelemetry client authors can decide if they want to
     /// make the flush timeout configurable.
-    fn force_flush(&mut self) -> BoxFuture<'static, ExportResult> {
+    fn force_flush(&mut self) -> BoxFuture<'static, OTelSdkResult> {
         Box::pin(async { Ok(()) })
     }
 

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -364,9 +364,7 @@ mod tests {
             tracer.start("my_span").end();
 
             // Force flush to ensure spans are exported
-            provider.force_flush().into_iter().for_each(|result| {
-                result.expect("failed to flush spans");
-            });
+            assert_eq!(provider.force_flush().is_err(), false);
 
             // Assert
             let finished_spans = exporter

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -364,7 +364,7 @@ mod tests {
             tracer.start("my_span").end();
 
             // Force flush to ensure spans are exported
-            assert_eq!(provider.force_flush().is_err(), false);
+            assert!(provider.force_flush().is_ok());
 
             // Assert
             let finished_spans = exporter

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -821,7 +821,6 @@ mod tests {
 
             // Explicitly shut down the tracer provider
             let shutdown_result = tracer_provider1.shutdown();
-            println!("----->>> Shutdown result: {:?}", shutdown_result);
             assert!(shutdown_result.is_ok());
 
             // Verify that shutdown was called exactly once

--- a/opentelemetry-sdk/src/trace/runtime_tests.rs
+++ b/opentelemetry-sdk/src/trace/runtime_tests.rs
@@ -2,11 +2,11 @@
 // need to run those tests one by one as the GlobalTracerProvider is a shared object between
 // threads Use cargo test -- --ignored --test-threads=1 to run those tests.
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
-use crate::runtime;
-#[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
 use crate::runtime::RuntimeChannel;
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
-use crate::trace::{ExportResult, SpanExporter};
+use crate::trace::SpanExporter;
+#[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
+use crate::{error::OTelSdkResult, runtime};
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
 use futures_util::future::BoxFuture;
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
@@ -28,7 +28,7 @@ struct SpanCountExporter {
 
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
 impl SpanExporter for SpanCountExporter {
-    fn export(&mut self, batch: Vec<crate::trace::SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, batch: Vec<crate::trace::SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         self.span_count.fetch_add(batch.len(), Ordering::SeqCst);
         Box::pin(async { Ok(()) })
     }

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -718,8 +718,9 @@ mod tests {
 
         let exported_data = span.exported_data();
         assert!(exported_data.is_some());
-
-        provider.shutdown().expect("shutdown panicked");
+        let res = provider.shutdown();
+        println!("{:?}", res);
+        assert!(res.is_ok());
         let dropped_span = tracer.start("span_with_dropped_provider");
         // return none if the provider has already been dropped
         assert!(dropped_span.exported_data().is_none());

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -34,15 +34,13 @@
 //! [`is_recording`]: opentelemetry::trace::Span::is_recording()
 //! [`TracerProvider`]: opentelemetry::trace::TracerProvider
 
+use crate::error::{OTelSdkError, OTelSdkResult};
 use crate::resource::Resource;
 use crate::trace::Span;
 use crate::trace::{SpanData, SpanExporter};
+use opentelemetry::Context;
 use opentelemetry::{otel_debug, otel_warn};
 use opentelemetry::{otel_error, otel_info};
-use opentelemetry::{
-    trace::{TraceError, TraceResult},
-    Context,
-};
 use std::cmp::min;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -88,12 +86,12 @@ pub trait SpanProcessor: Send + Sync + std::fmt::Debug {
     /// TODO - This method should take reference to `SpanData`
     fn on_end(&self, span: SpanData);
     /// Force the spans lying in the cache to be exported.
-    fn force_flush(&self) -> TraceResult<()>;
+    fn force_flush(&self) -> OTelSdkResult;
     /// Shuts down the processor. Called when SDK is shut down. This is an
     /// opportunity for processors to do any cleanup required.
     ///
     /// Implementation should make sure shutdown can be called multiple times.
-    fn shutdown(&self) -> TraceResult<()>;
+    fn shutdown(&self) -> OTelSdkResult;
     /// Set the resource for the span processor.
     fn set_resource(&mut self, _resource: &Resource) {}
 }
@@ -140,7 +138,7 @@ impl SpanProcessor for SimpleSpanProcessor {
         let result = self
             .exporter
             .lock()
-            .map_err(|_| TraceError::Other("SimpleSpanProcessor mutex poison".into()))
+            .map_err(|_| OTelSdkError::InternalFailure("SimpleSpanProcessor mutex poison".into()))
             .and_then(|mut exporter| futures_executor::block_on(exporter.export(vec![span])));
 
         if let Err(err) = result {
@@ -152,17 +150,16 @@ impl SpanProcessor for SimpleSpanProcessor {
         }
     }
 
-    fn force_flush(&self) -> TraceResult<()> {
+    fn force_flush(&self) -> OTelSdkResult {
         // Nothing to flush for simple span processor.
         Ok(())
     }
 
-    fn shutdown(&self) -> TraceResult<()> {
+    fn shutdown(&self) -> OTelSdkResult {
         if let Ok(mut exporter) = self.exporter.lock() {
-            exporter.shutdown();
-            Ok(())
+            exporter.shutdown()
         } else {
-            Err(TraceError::Other(
+            Err(OTelSdkError::InternalFailure(
                 "SimpleSpanProcessor mutex poison at shutdown".into(),
             ))
         }
@@ -175,7 +172,6 @@ impl SpanProcessor for SimpleSpanProcessor {
     }
 }
 
-use crate::trace::ExportResult;
 /// The `BatchSpanProcessor` collects finished spans in a buffer and exports them
 /// in batches to the configured `SpanExporter`. This processor is ideal for
 /// high-throughput environments, as it minimizes the overhead of exporting spans
@@ -247,8 +243,8 @@ use std::sync::mpsc::SyncSender;
 enum BatchMessage {
     //ExportSpan(SpanData),
     ExportSpan(Arc<AtomicBool>),
-    ForceFlush(SyncSender<TraceResult<()>>),
-    Shutdown(SyncSender<TraceResult<()>>),
+    ForceFlush(SyncSender<OTelSdkResult>),
+    Shutdown(SyncSender<OTelSdkResult>),
     SetResource(Arc<Resource>),
 }
 
@@ -460,7 +456,7 @@ impl BatchSpanProcessor {
         last_export_time: &mut Instant,
         current_batch_size: &AtomicUsize,
         config: &BatchConfig,
-    ) -> ExportResult
+    ) -> OTelSdkResult
     where
         E: SpanExporter + Send + Sync + 'static,
     {
@@ -484,27 +480,27 @@ impl BatchSpanProcessor {
         exporter: &mut E,
         batch: &mut Vec<SpanData>,
         last_export_time: &mut Instant,
-    ) -> ExportResult
+    ) -> OTelSdkResult
     where
         E: SpanExporter + Send + Sync + 'static,
     {
         *last_export_time = Instant::now();
 
         if batch.is_empty() {
-            return TraceResult::Ok(());
+            return OTelSdkResult::Ok(());
         }
 
         let export = exporter.export(batch.split_off(0));
         let export_result = futures_executor::block_on(export);
 
         match export_result {
-            Ok(_) => TraceResult::Ok(()),
+            Ok(_) => OTelSdkResult::Ok(()),
             Err(err) => {
                 otel_error!(
                     name: "BatchSpanProcessor.ExportError",
                     error = format!("{}", err)
                 );
-                TraceResult::Err(err)
+                Err(OTelSdkError::InternalFailure(err.to_string()))
             }
         }
     }
@@ -569,24 +565,24 @@ impl SpanProcessor for BatchSpanProcessor {
     }
 
     /// Flushes all pending spans.
-    fn force_flush(&self) -> TraceResult<()> {
+    fn force_flush(&self) -> OTelSdkResult {
         if self.is_shutdown.load(Ordering::Relaxed) {
-            return Err(TraceError::Other("Processor already shutdown".into()));
+            return Err(OTelSdkError::AlreadyShutdown);
         }
         let (sender, receiver) = sync_channel(1);
         self.message_sender
             .try_send(BatchMessage::ForceFlush(sender))
-            .map_err(|_| TraceError::Other("Failed to send ForceFlush message".into()))?;
+            .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
 
         receiver
             .recv_timeout(self.forceflush_timeout)
-            .map_err(|_| TraceError::ExportTimedOut(self.forceflush_timeout))?
+            .map_err(|_| OTelSdkError::Timeout(self.forceflush_timeout))?
     }
 
     /// Shuts down the processor.
-    fn shutdown(&self) -> TraceResult<()> {
+    fn shutdown(&self) -> OTelSdkResult {
         if self.is_shutdown.swap(true, Ordering::Relaxed) {
-            return Err(TraceError::Other("Processor already shutdown".into()));
+            return Err(OTelSdkError::AlreadyShutdown);
         }
         let dropped_spans = self.dropped_span_count.load(Ordering::Relaxed);
         let max_queue_size = self.max_queue_size;
@@ -602,14 +598,14 @@ impl SpanProcessor for BatchSpanProcessor {
         let (sender, receiver) = sync_channel(1);
         self.message_sender
             .try_send(BatchMessage::Shutdown(sender))
-            .map_err(|_| TraceError::Other("Failed to send Shutdown message".into()))?;
+            .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
 
         let result = receiver
             .recv_timeout(self.shutdown_timeout)
-            .map_err(|_| TraceError::ExportTimedOut(self.shutdown_timeout))?;
+            .map_err(|_| OTelSdkError::Timeout(self.shutdown_timeout))?;
         if let Some(handle) = self.handle.lock().unwrap().take() {
             if let Err(err) = handle.join() {
-                return Err(TraceError::Other(format!(
+                return Err(OTelSdkError::InternalFailure(format!(
                     "Background thread failed to join during shutdown. This may indicate a panic or unexpected termination: {:?}",
                     err
                 ).into()));
@@ -840,6 +836,7 @@ mod tests {
         OTEL_BSP_MAX_EXPORT_BATCH_SIZE, OTEL_BSP_MAX_QUEUE_SIZE, OTEL_BSP_MAX_QUEUE_SIZE_DEFAULT,
         OTEL_BSP_SCHEDULE_DELAY, OTEL_BSP_SCHEDULE_DELAY_DEFAULT,
     };
+    use crate::error::OTelSdkResult;
     use crate::testing::trace::new_test_export_span_data;
     use crate::trace::span_processor::{
         OTEL_BSP_EXPORT_TIMEOUT_DEFAULT, OTEL_BSP_MAX_CONCURRENT_EXPORTS,
@@ -847,7 +844,7 @@ mod tests {
     };
     use crate::trace::InMemorySpanExporterBuilder;
     use crate::trace::{BatchConfig, BatchConfigBuilder, SpanEvents, SpanLinks};
-    use crate::trace::{ExportResult, SpanData, SpanExporter};
+    use crate::trace::{SpanData, SpanExporter};
     use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status};
     use std::fmt::Debug;
     use std::time::Duration;
@@ -1039,7 +1036,7 @@ mod tests {
     }
 
     impl SpanExporter for MockSpanExporter {
-        fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+        fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
             let exported_spans = self.exported_spans.clone();
             async move {
                 exported_spans.lock().unwrap().extend(batch);
@@ -1048,7 +1045,9 @@ mod tests {
             .boxed()
         }
 
-        fn shutdown(&mut self) {}
+        fn shutdown(&mut self) -> OTelSdkResult {
+            Ok(())
+        }
         fn set_resource(&mut self, resource: &Resource) {
             let mut exported_resource = self.exported_resource.lock().unwrap();
             *exported_resource = Some(resource.clone());

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -608,7 +608,7 @@ impl SpanProcessor for BatchSpanProcessor {
                 return Err(OTelSdkError::InternalFailure(format!(
                     "Background thread failed to join during shutdown. This may indicate a panic or unexpected termination: {:?}",
                     err
-                ).into()));
+                )));
             }
         }
         result

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -7,6 +7,7 @@ use http::Uri;
 use model::endpoint::Endpoint;
 use opentelemetry::trace::TraceError;
 use opentelemetry_http::HttpClient;
+use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::{
     resource::{ResourceDetector, SdkProvidedResourceDetector},
     trace, ExportError,
@@ -23,7 +24,7 @@ pub struct ZipkinExporter {
 }
 
 impl ZipkinExporter {
-    /// Get a builder to configure a [ZipkinExporter].
+    /// Get a builder to configure a [ZipkinExporter]
     pub fn builder() -> ZipkinExporterBuilder {
         ZipkinExporterBuilder::default()
     }
@@ -137,7 +138,7 @@ async fn zipkin_export(
     batch: Vec<trace::SpanData>,
     uploader: uploader::Uploader,
     local_endpoint: Endpoint,
-) -> trace::ExportResult {
+) -> OTelSdkResult {
     let zipkin_spans = batch
         .into_iter()
         .map(|span| model::into_zipkin_span(local_endpoint.clone(), span))
@@ -148,7 +149,7 @@ async fn zipkin_export(
 
 impl trace::SpanExporter for ZipkinExporter {
     /// Export spans to Zipkin collector.
-    fn export(&mut self, batch: Vec<trace::SpanData>) -> BoxFuture<'static, trace::ExportResult> {
+    fn export(&mut self, batch: Vec<trace::SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         Box::pin(zipkin_export(
             batch,
             self.uploader.clone(),

--- a/opentelemetry-zipkin/src/exporter/uploader.rs
+++ b/opentelemetry-zipkin/src/exporter/uploader.rs
@@ -1,9 +1,9 @@
 //! # Zipkin Span Exporter
 use crate::exporter::model::span::Span;
-use crate::exporter::Error;
 use http::{header::CONTENT_TYPE, Method, Request, Uri};
 use opentelemetry_http::{HttpClient, ResponseExt};
-use opentelemetry_sdk::trace::ExportResult;
+use opentelemetry_sdk::error::OTelSdkError;
+use opentelemetry_sdk::error::OTelSdkResult;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -22,7 +22,7 @@ impl Uploader {
     }
 
     /// Upload spans to Zipkin
-    pub(crate) async fn upload(&self, spans: Vec<Span>) -> ExportResult {
+    pub(crate) async fn upload(&self, spans: Vec<Span>) -> OTelSdkResult {
         match self {
             Uploader::Http(client) => client.upload(spans).await,
         }
@@ -36,14 +36,27 @@ pub(crate) struct JsonV2Client {
 }
 
 impl JsonV2Client {
-    async fn upload(&self, spans: Vec<Span>) -> ExportResult {
+    async fn upload(&self, spans: Vec<Span>) -> OTelSdkResult {
+        let body = serde_json::to_vec(&spans).map_err(|e| {
+            OTelSdkError::InternalFailure(format!("JSON serialization failed: {}", e))
+        })?;
         let req = Request::builder()
             .method(Method::POST)
             .uri(self.collector_endpoint.clone())
             .header(CONTENT_TYPE, "application/json")
-            .body(serde_json::to_vec(&spans).unwrap_or_default().into())
-            .map_err::<Error, _>(Into::into)?;
-        let _ = self.client.send_bytes(req).await?.error_for_status()?;
+            .body(body.into())
+            .map_err(|e| {
+                OTelSdkError::InternalFailure(format!("Failed to create request: {}", e))
+            })?;
+
+        let response =
+            self.client.send_bytes(req).await.map_err(|e| {
+                OTelSdkError::InternalFailure(format!("HTTP request failed: {}", e))
+            })?;
+
+        response
+            .error_for_status()
+            .map_err(|e| OTelSdkError::InternalFailure(format!("HTTP response error: {}", e)))?;
         Ok(())
     }
 }

--- a/stress/src/traces.rs
+++ b/stress/src/traces.rs
@@ -15,8 +15,8 @@ use opentelemetry::{
     Context, KeyValue,
 };
 use opentelemetry_sdk::{
-    trace::SpanData,
-    trace::{self as sdktrace, SpanProcessor},
+    error::OTelSdkResult,
+    trace::{self as sdktrace, SpanData, SpanProcessor},
 };
 
 mod throughput;
@@ -41,11 +41,11 @@ impl SpanProcessor for NoOpSpanProcessor {
         // No-op
     }
 
-    fn force_flush(&self) -> TraceResult<()> {
+    fn force_flush(&self) -> OTelSdkResult {
         Ok(())
     }
 
-    fn shutdown(&self) -> TraceResult<()> {
+    fn shutdown(&self) -> OTelSdkResult {
         Ok(())
     }
 }


### PR DESCRIPTION
## Changes
The public API changes in Tracing:
 - Before:
 
      ```rust
        fn SpanExporter::export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult>;
        fn SpanExporter::shutdown(&mut self);
        fn SpanExporter::force_flush(&mut self) -> BoxFuture<'static, ExportResult>
        fn TraerProvider::shutdown(&self) -> TraceResult<()>
        fn TracerProvider::force_flush(&self) -> Vec<TraceResult<()>>
      ```

    - After:
    
      ```rust
        fn SpanExporter::export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult>;
        fn SpanExporter::shutdown(&mut self) -> OTelSdkResult;
        fn SpanExporter::force_flush(&mut self) -> BoxFuture<'static, OTelSdkResult>
        fn TraerProvider::shutdown(&self) -> OTelSdkResult;
        fn TracerProvider::force_flush(&self) -> OTelSdkResult;
      ```
Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
