### PR TITLE
0.28 migration guide and OTLP Example fixes

### DIFF
--- a/docs/migration_0.28.md
+++ b/docs/migration_0.28.md
@@ -1,0 +1,152 @@
+# Migration guide from 0.27 to 0.28
+
+OpenTelemetry Rust 0.28 introduces a large number of breaking changes that
+impact all signals (logs/metrics/traces). This guide is intended to help with a
+smooth migration for the common use cases of using `opentelemetry`,
+`opentelemetry_sdk` `opentelemetry-otlp`, `opentelemetry-appender-tracing`
+crates. The detailed changelog for each crate that you use can be consulted for
+the full set of changes. This doc covers only the common scenario.
+
+## Tracing Shutdown changes
+
+`opentelemetry::global::shutdown_tracer_provider()` is removed. Now, you should
+explicitly call shutdown() on the created tracer provider.
+
+Before (0.27):
+
+```rust
+opentelemetry::global::shutdown_tracer_provider();
+```
+
+ • After (0.28):
+
+```rust
+let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+    .build();
+
+// Clone and set the tracer provider globally. Retain the original to invoke shutdown later.
+opentelemetry::global::set_tracer_provider(tracer_provider.clone());
+
+// Shutdown the provider when application is exiting.
+tracer_provider.shutdown();
+```
+
+This now makes shutdown consistent across signals.
+
+## Rename SDK Structs
+
+`LoggerProvider`, `TracerProvider` are renamed to `SdkLoggerProvider` and
+`SdkTracerProvider` respectively. `MeterProvider` was already named
+`SdkMeterProvider` and this now ensures consistency across signals.
+
+### Async Runtime Requirements removed
+
+When using OTLP Exporter for Logs, Traces a "batching" exporter is recommended.
+Also, metrics always required a component named `PeriodicReader`. These
+components previously needed user to pass in an async runtime and enable
+appropriate feature flag depending on the runtime.
+
+These components have been re-written to no longer require an async runtime.
+Instead they operate by spawning dedicated background thread, and making
+blocking calls from the same.
+
+PeriodicReader, BatchSpanProcessor, BatchLogProcessor are the components
+affected.
+
+For Logs,Traces replace `.with_batch_exporter(exporter, runtime::Tokio)` with
+`.with_batch_exporter(exporter)`. For Metrics, replace `let reader =
+PeriodicReader::builder(exporter, runtime::Tokio).build();` with `let reader =
+PeriodicReader::builder(exporter).build();` or more conveniently,
+`.with_periodic_exporter(exporter)`.
+
+Please note the following:
+
+1. With the new approach, only the following grpc/http clients are supported in
+   `opentelemetry-otlp`. grpc-tonic, reqwest-blocking-client In other words,
+   `reqwest` and `hyper` are not supported. If using `grpc-tonic`, the OTLP
+   Exporter must be created from within a Tokio runtime.
+2. Timeout enforcement is now moved to Exporters. i.e
+BatchProcessor,PeriodicReader does not enforce timeouts. For logs and traces,
+`max_export_timeout` (on Processors) or `OTEL_BLRP_EXPORT_TIMEOUT` or
+`OTEL_BSP_EXPORT_TIMEOUT` is no longer supported. For metrics, `with_timeout` on
+PeriodicReader is no longer supported.
+
+`OTEL_EXPORTER_OTLP_TIMEOUT` can be used to setup timeout for OTLP Exporters via
+environment variables, or `.with_tonic().with_timeout()` or
+`.with_http().with_timeout()` programmatically.
+
+If you need the old behavior (your application cannot spawn a new thread, or
+need to use another networking client etc.) use appropriate feature flags from
+  below “experimental_metrics_periodicreader_with_async_runtime”
+  "experimental_logs_batch_log_processor_with_async_runtime"
+  "experimental_trace_batch_span_processor_with_async_runtime"
+
+ **and** adjust the namespace:
+
+ Example, when using Tokio runtime.
+
+ ```rust
+let reader = opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader::builder(exporter, runtime::Tokio).build();
+let tracer_provider = SdkTracerProvider::builder()
+        .with_span_processor(span_processor_with_async_runtime::BatchSpanProcessor::builder(exporter, runtime::Tokio).build())
+        .build();
+let logger_provider = SdkLoggerProvider::builder()
+.with_log_processor(log_processor_with_async_runtime::BatchLogProcessor::builder(exporter, runtime::Tokio).build())
+.build();
+```
+
+## OTLP Default change
+
+"grpc-tonic" feature flag is no longer enabled by default. "http-proto" and
+  "reqwest-blocking-client" features are added as default, to align with the
+  OTel specification.
+
+## Resource Changes
+
+`Resource` creation is moved to a builder pattern, and `Resource::{new, empty,
+from_detectors, new_with_defaults, from_schema_url, merge, default}` are
+replaced with `Resource::builder()`.
+
+Before:
+
+```rust
+Resource::default().with_attributes([
+    KeyValue::new("service.name", "test_service"),
+    KeyValue::new("key", "value"),
+]);
+```
+
+After:
+
+```rust
+Resource::builder()
+    .with_service_name("test_service")
+    .with_attribute(KeyValue::new("key", "value"))
+    .build();
+```
+
+## Improved internal logging
+
+OpenTelemetry internally used `tracing` to emit its internal logs. This is under
+feature-flag "internal-logs" that is enabled by default in all crates. When
+using OTel Logging, care must be taken to avoid OTel's own internal log being
+fed back to OTel, creating an infinite loop. This can be achieved via proper
+filtering. The OTLP Examples in the repo shows how to achieve this. It also
+shows how to send OTel's internal logs to stdtout using `tracing::Fmt`.
+
+
+## Full example
+
+A fully runnable example application using OTLP Exporter is provided in this
+repo. Comparing the 0.27 vs 0.28 of the example would give a good overview of
+the changes required to be made.
+
+[Basic OTLP Example
+(0.27)](https://github.com/open-telemetry/opentelemetry-rust/tree/opentelemetry-otlp-0.27.0/opentelemetry-otlp/examples)
+[Basic OTLP Example
+(0.28)](https://github.com/open-telemetry/opentelemetry-rust/tree/opentelemetry-otlp-0.28.0/opentelemetry-otlp/examples)
+
+This guide covers only the most common breaking changes. If you’re using custom
+exporters or processors (or authoring one), please consult the changelog for
+additional migration details.
+

--- a/docs/migration_0.28.md
+++ b/docs/migration_0.28.md
@@ -152,4 +152,3 @@ the changes required to be made.
 This guide covers only the most common breaking changes. If you’re using custom
 exporters or processors (or authoring one), please consult the changelog for
 additional migration details.
-

--- a/docs/migration_0.28.md
+++ b/docs/migration_0.28.md
@@ -65,6 +65,9 @@ Please note the following:
    `opentelemetry-otlp`. grpc-tonic, reqwest-blocking-client In other words,
    `reqwest` and `hyper` are not supported. If using `grpc-tonic`, the OTLP
    Exporter must be created from within a Tokio runtime.
+   If using exporters other than `opentelemetry-otlp`, consult the docs
+   for the same to know if there are any restrictions/requirements on async
+   runtime.
 2. Timeout enforcement is now moved to Exporters. i.e
 BatchProcessor,PeriodicReader does not enforce timeouts. For logs and traces,
 `max_export_timeout` (on Processors) or `OTEL_BLRP_EXPORT_TIMEOUT` or
@@ -134,7 +137,6 @@ fed back to OTel, creating an infinite loop. This can be achieved via proper
 filtering. The OTLP Examples in the repo shows how to achieve this. It also
 shows how to send OTel's internal logs to stdtout using `tracing::Fmt`.
 
-
 ## Full example
 
 A fully runnable example application using OTLP Exporter is provided in this
@@ -144,7 +146,8 @@ the changes required to be made.
 [Basic OTLP Example
 (0.27)](https://github.com/open-telemetry/opentelemetry-rust/tree/opentelemetry-otlp-0.27.0/opentelemetry-otlp/examples)
 [Basic OTLP Example
-(0.28)](https://github.com/open-telemetry/opentelemetry-rust/tree/opentelemetry-otlp-0.28.0/opentelemetry-otlp/examples)
+(0.28)](https://github.com/open-telemetry/opentelemetry-rust/tree/opentelemetry-otlp-0.27.0/opentelemetry-otlp/examples)
+// TODO: Update this link after github tag is created.
 
 This guide covers only the most common breaking changes. If you’re using custom
 exporters or processors (or authoring one), please consult the changelog for

--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -13,8 +13,8 @@ reqwest-blocking = ["opentelemetry-otlp/reqwest-blocking-client"]
 once_cell = { workspace = true }
 opentelemetry = { path = "../../../opentelemetry" }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk" }
-opentelemetry-otlp = { path = "../..", features = ["http-proto", "http-json", "logs", "internal-logs"], default-features = false}
-opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}
+opentelemetry-otlp = { path = "../.."}
+opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing"}
 
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true, features = ["std"]}

--- a/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
@@ -11,6 +11,6 @@ opentelemetry = { path = "../../../opentelemetry" }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk" }
 opentelemetry-otlp = { path = "../../../opentelemetry-otlp", features = ["grpc-tonic"] }
 tokio = { version = "1.0", features = ["full"] }
-opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}
+opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing"}
 tracing = { workspace = true, features = ["std"]}
 tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -112,7 +112,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // uses global::meter() or global::meter_with_version() to get a meter.
     // Cloning simply creates a new reference to the same meter provider. It is
     // important to hold on to the meter_provider here, so as to invoke
-    // shutdown on it when application ends.    
+    // shutdown on it when application ends.
     global::set_meter_provider(meter_provider.clone());
 
     let common_scope_attributes = vec![KeyValue::new("scope-key", "scope-value")];

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -15,7 +15,7 @@ use tracing_subscriber::EnvFilter;
 
 static RESOURCE: Lazy<Resource> = Lazy::new(|| {
     Resource::builder()
-        .with_service_name("basic-otlp-example")
+        .with_service_name("basic-otlp-example-grpc")
         .build()
 });
 
@@ -94,10 +94,25 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .with(fmt_layer)
         .init();
 
+    // At this point Logs (OTel Logs and Fmt Logs) are initialized, which will
+    // allow internal-logs from Tracing/Metrics initializer to be captured.
+
     let tracer_provider = init_traces();
+    // Set the global tracer provider using a clone of the tracer_provider.
+    // Setting global tracer provider is required if other parts of the application
+    // uses global::tracer() or global::tracer_with_version() to get a tracer.
+    // Cloning simply creates a new reference to the same tracer provider. It is
+    // important to hold on to the tracer_provider here, so as to invoke
+    // shutdown on it when application ends.
     global::set_tracer_provider(tracer_provider.clone());
 
     let meter_provider = init_metrics();
+    // Set the global meter provider using a clone of the meter_provider.
+    // Setting global meter provider is required if other parts of the application
+    // uses global::meter() or global::meter_with_version() to get a meter.
+    // Cloning simply creates a new reference to the same meter provider. It is
+    // important to hold on to the meter_provider here, so as to invoke
+    // shutdown on it when application ends.    
     global::set_meter_provider(meter_provider.clone());
 
     let common_scope_attributes = vec![KeyValue::new("scope-key", "scope-value")];

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -344,7 +344,7 @@ let processor = BatchLogProcessor::builder(exporter)
 ```
 
 - **Breaking**: The `BatchSpanProcessor` no longer supports configuration of `max_export_timeout` 
-   or the `OTEL_BLRP_EXPORT_TIMEOUT` environment variable. Timeout handling is now the 
+   or the `OTEL_BSP_EXPORT_TIMEOUT` environment variable. Timeout handling is now the 
    responsibility of the exporter.
    For example, in the OTLP Span exporter, the export timeout can be configured using:
    - The environment variables `OTEL_EXPORTER_OTLP_TIMEOUT` or `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`.


### PR DESCRIPTION
Fixes #2611 
Also fixed OTLP Examples a bit to panic when exporter creation fails. The exporter failures need to return proper Result, and until then its best to panic in the example application.