### PR TITLE
leverage tracer provider to set service name for Zipkin exporter

### DIFF
--- a/opentelemetry-sdk/src/testing/trace/span_exporters.rs
+++ b/opentelemetry-sdk/src/testing/trace/span_exporters.rs
@@ -111,7 +111,6 @@ impl NoopSpanExporter {
     }
 }
 
-#[async_trait::async_trait]
 impl SpanExporter for NoopSpanExporter {
     fn export(&mut self, _: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         Box::pin(std::future::ready(Ok(())))

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -305,10 +305,8 @@ impl TracerProviderBuilder {
     ///
     /// Processors are invoked in the order they are added.
     pub fn with_simple_exporter<T: SpanExporter + 'static>(self, exporter: T) -> Self {
-        let mut processors = self.processors;
-        processors.push(Box::new(SimpleSpanProcessor::new(Box::new(exporter))));
-
-        TracerProviderBuilder { processors, ..self }
+        let simple = SimpleSpanProcessor::new(Box::new(exporter));
+        self.with_span_processor(simple)
     }
 
     /// Adds a [BatchSpanProcessor] with the configured exporter to the pipeline.

--- a/opentelemetry-zipkin/CHANGELOG.md
+++ b/opentelemetry-zipkin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump msrv to 1.75.0.
 - **Breaking** The `opentelemetry_zipkin::new_pipeline()` interface is now replaced with `opentelemetry_zipkin::ZipkinExporter::builder()`.
+  Additionally, the service name needs to be set on the tracer provider.
   
   Previous Signature:
   ```rust
@@ -14,10 +15,10 @@
   Updated Signature:
   ```rust
   let exporter = ZipkinExporter::builder()
-      .with_service_name("trace-demo")
       .build()?;
   let provider = TracerProvider::builder()
       .with_simple_exporter(exporter)
+      .with_service_name("trace-demo")
       .build();
   global::set_tracer_provider(provider.clone());
 

--- a/opentelemetry-zipkin/CHANGELOG.md
+++ b/opentelemetry-zipkin/CHANGELOG.md
@@ -16,7 +16,7 @@
   ```rust
   let exporter = ZipkinExporter::builder()
       .build()?;
-  let provider = TracerProvider::builder()
+  let provider = SdkTracerProvider::builder()
       .with_simple_exporter(exporter)
       .with_service_name("trace-demo")
       .build();

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -30,7 +30,6 @@ once_cell = { workspace = true }
 opentelemetry = { version = "0.27", path = "../opentelemetry" }
 opentelemetry_sdk = { version = "0.27", path = "../opentelemetry-sdk", features = ["trace"] }
 opentelemetry-http = { version = "0.27", path = "../opentelemetry-http" }
-opentelemetry-semantic-conventions = { version = "0.27", path = "../opentelemetry-semantic-conventions" }
 serde_json = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 typed-builder = "0.18"

--- a/opentelemetry-zipkin/examples/zipkin.rs
+++ b/opentelemetry-zipkin/examples/zipkin.rs
@@ -3,7 +3,7 @@ use opentelemetry::{
     trace::{Span, TraceError, Tracer},
     InstrumentationScope, KeyValue,
 };
-use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::{trace::SdkTracerProvider, Resource};
 use opentelemetry_zipkin::ZipkinExporter;
 use std::thread;
 use std::time::Duration;
@@ -16,12 +16,15 @@ fn bar() {
 }
 
 fn init_traces() -> Result<SdkTracerProvider, TraceError> {
-    let exporter = ZipkinExporter::builder()
-        .with_service_name("trace-demo")
-        .build()?;
+    let exporter = ZipkinExporter::builder().build()?;
 
     Ok(SdkTracerProvider::builder()
         .with_simple_exporter(exporter)
+        .with_resource(
+            Resource::builder_empty()
+                .with_service_name("trace-demo")
+                .build(),
+        )
         .build())
 }
 

--- a/opentelemetry-zipkin/src/exporter/model/endpoint.rs
+++ b/opentelemetry-zipkin/src/exporter/model/endpoint.rs
@@ -6,9 +6,6 @@ use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 pub(crate) struct Endpoint {
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    service_name: Option<String>,
-    #[builder(setter(strip_option), default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     ipv4: Option<Ipv4Addr>,
     #[builder(setter(strip_option), default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -19,19 +16,11 @@ pub(crate) struct Endpoint {
 }
 
 impl Endpoint {
-    pub(crate) fn new(service_name: String, socket_addr: Option<SocketAddr>) -> Self {
+    pub(crate) fn new(socket_addr: Option<SocketAddr>) -> Self {
         match socket_addr {
-            Some(SocketAddr::V4(v4)) => Endpoint::builder()
-                .service_name(service_name)
-                .ipv4(*v4.ip())
-                .port(v4.port())
-                .build(),
-            Some(SocketAddr::V6(v6)) => Endpoint::builder()
-                .service_name(service_name)
-                .ipv6(*v6.ip())
-                .port(v6.port())
-                .build(),
-            None => Endpoint::builder().service_name(service_name).build(),
+            Some(SocketAddr::V4(v4)) => Endpoint::builder().ipv4(*v4.ip()).port(v4.port()).build(),
+            Some(SocketAddr::V6(v6)) => Endpoint::builder().ipv6(*v6.ip()).port(v6.port()).build(),
+            None => Endpoint::builder().build(),
         }
     }
 }
@@ -50,11 +39,10 @@ mod tests {
     fn test_ipv4_empty() {
         test_json_serialization(
             Endpoint::builder()
-                .service_name("open-telemetry".to_owned())
                 .ipv4(Ipv4Addr::new(127, 0, 0, 1))
                 .port(8080)
                 .build(),
-            "{\"serviceName\":\"open-telemetry\",\"ipv4\":\"127.0.0.1\",\"port\":8080}",
+            "{\"ipv4\":\"127.0.0.1\",\"port\":8080}",
         );
     }
 

--- a/opentelemetry-zipkin/src/exporter/model/span.rs
+++ b/opentelemetry-zipkin/src/exporter/model/span.rs
@@ -89,14 +89,12 @@ mod tests {
                 .duration(150_000)
                 .local_endpoint(
                     Endpoint::builder()
-                        .service_name("remote-service".to_owned())
                         .ipv4(Ipv4Addr::new(192, 168, 0, 1))
                         .port(8080)
                         .build()
                 )
                 .remote_endpoint(
                     Endpoint::builder()
-                        .service_name("open-telemetry".to_owned())
                         .ipv4(Ipv4Addr::new(127, 0, 0, 1))
                         .port(8080)
                         .build()
@@ -109,7 +107,7 @@ mod tests {
                 ])
                 .tags(tags)
                 .build(),
-            "{\"traceId\":\"4e441824ec2b6a44ffdc9bb9a6453df3\",\"parentId\":\"ffdc9bb9a6453df3\",\"id\":\"efdc9cd9a1849df3\",\"kind\":\"SERVER\",\"name\":\"main\",\"timestamp\":1502787600000000,\"duration\":150000,\"localEndpoint\":{\"serviceName\":\"remote-service\",\"ipv4\":\"192.168.0.1\",\"port\":8080},\"remoteEndpoint\":{\"serviceName\":\"open-telemetry\",\"ipv4\":\"127.0.0.1\",\"port\":8080},\"annotations\":[{\"timestamp\":1502780000000000,\"value\":\"interesting event\"}],\"tags\":{\"a\":\"b\"},\"debug\":false,\"shared\":false}",
+            "{\"traceId\":\"4e441824ec2b6a44ffdc9bb9a6453df3\",\"parentId\":\"ffdc9bb9a6453df3\",\"id\":\"efdc9cd9a1849df3\",\"kind\":\"SERVER\",\"name\":\"main\",\"timestamp\":1502787600000000,\"duration\":150000,\"localEndpoint\":{\"ipv4\":\"192.168.0.1\",\"port\":8080},\"remoteEndpoint\":{\"ipv4\":\"127.0.0.1\",\"port\":8080},\"annotations\":[{\"timestamp\":1502780000000000,\"value\":\"interesting event\"}],\"tags\":{\"a\":\"b\"},\"debug\":false,\"shared\":false}",
         );
     }
 
@@ -167,7 +165,7 @@ mod tests {
                 status,
                 instrumentation_scope: Default::default(),
             };
-            let local_endpoint = Endpoint::new("test".into(), None);
+            let local_endpoint = Endpoint::new(None);
             let span = into_zipkin_span(local_endpoint, span_data);
             if let Some(tags) = span.tags.as_ref() {
                 assert_tag_contains(tags, OTEL_STATUS_CODE, status_tag_val);

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -23,17 +23,21 @@
 //! ```no_run
 //! use opentelemetry::global;
 //! use opentelemetry::trace::{Tracer, TraceError};
-//! use opentelemetry_sdk::trace::SdkTracerProvider;
+//! use opentelemetry_sdk::{trace::SdkTracerProvider, Resource};
 //! use opentelemetry_zipkin::ZipkinExporter;
 //!
 //! fn main() -> Result<(), TraceError> {
 //!     global::set_text_map_propagator(opentelemetry_zipkin::Propagator::new());
 //!
 //!     let exporter = ZipkinExporter::builder()
-//!         .with_service_name("trace-demo")
 //!         .build()?;
-//!     let provider = TracerProvider::builder()
+//!     let provider = SdkTracerProvider::builder()
 //!         .with_simple_exporter(exporter)
+//!         .with_resource(
+//!             Resource::builder_empty()
+//!                 .with_service_name("trace-demo")
+//!                 .build(),
+//!         )
 //!         .build();
 //!     global::set_tracer_provider(provider.clone());
 //!
@@ -60,22 +64,27 @@
 //!     trace::{
 //!         BatchSpanProcessor,
 //!         BatchConfigBuilder,
-//!         TracerProvider,
-//!     }
+//!         SdkTracerProvider,
+//!     },
+//!     Resource,
 //! };
 //! use opentelemetry_zipkin::ZipkinExporter;
 //!
 //! fn main() -> Result<(), opentelemetry::trace::TraceError> {
 //!     let exporter = ZipkinExporter::builder()
-//!         .with_service_name("runtime-demo")
 //!         .build()?;
 //!
 //!     let batch = BatchSpanProcessor::builder(exporter)
 //!         .with_batch_config(BatchConfigBuilder::default().with_max_queue_size(4096).build())
 //!         .build();
 //!
-//!     let provider = TracerProvider::builder()
+//!     let provider = SdkTracerProvider::builder()
 //!         .with_span_processor(batch)
+//!         .with_resource(
+//!             Resource::builder_empty()
+//!                 .with_service_name("runtime-demo")
+//!                 .build(),
+//!         )
 //!         .build();
 //!
 //!     Ok(())
@@ -105,7 +114,7 @@
 //!
 //! ```no_run
 //! use opentelemetry::{global, InstrumentationScope, KeyValue, trace::{Tracer, TraceError}};
-//! use opentelemetry_sdk::{trace::{self, ExportResult, RandomIdGenerator, Sampler}, Resource};
+//! use opentelemetry_sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
 //! use opentelemetry_http::{HttpClient, HttpError};
 //! use opentelemetry_zipkin::{Error as ZipkinError, ZipkinExporter};
 //! use async_trait::async_trait;
@@ -148,7 +157,7 @@
 //!     }
 //! }
 //!
-//! fn init_traces() -> Result<trace::TracerProvider, TraceError> {
+//! fn init_traces() -> Result<trace::SdkTracerProvider, TraceError> {
 //!     let exporter = ZipkinExporter::builder()
 //!         .with_http_client(
 //!             HyperClient(
@@ -156,7 +165,6 @@
 //!                     .build_http()
 //!             )
 //!         )
-//!         .with_service_name("my_app")
 //!         .with_service_address(
 //!             "127.0.0.1:8080"
 //!                 .parse()
@@ -165,7 +173,7 @@
 //!         .with_collector_endpoint("http://localhost:9411/api/v2/spans")
 //!         .build()?;
 //!
-//!     Ok(trace::TracerProvider::builder()
+//!     Ok(trace::SdkTracerProvider::builder()
 //!         .with_sampler(Sampler::AlwaysOn)
 //!         .with_batch_exporter(exporter)
 //!         .with_id_generator(RandomIdGenerator::default())
@@ -174,6 +182,7 @@
 //!         .with_max_events_per_span(16)
 //!         .with_resource(
 //!             Resource::builder_empty()
+//!                 .with_service_name("my_app")
 //!                 .with_attribute(KeyValue::new("key", "value"))
 //!                 .build()
 //!         )


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

- continuation of https://github.com/open-telemetry/opentelemetry-rust/pull/2565#discussion_r1930930407
  Removed the possibility to set `service_name` via the Zipkin exporter in favour of leveraging tracer provider
- also removed an unused `async_trait` in `NoopSpanExporter`
- slightly simplified `with_simple_exporter()`
- some of the doc tests were not completely updated after changing the `TracerProvider` name

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
