### PR TITLE
feat: Refine runtime trait

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## vNext
 
-- *Breaking* Make `force_flush()` in `PushMetricExporter` synchronous
-- Breaking: The `Runtime` trait has been simplified and refined. See the [#2641](https://github.com/open-telemetry/opentelemetry-rust/pull/2641)
+- *Breaking*: Make `force_flush()` in `PushMetricExporter` synchronous
+- *Breaking*: The `Runtime` trait has been simplified and refined. See the [#2641](https://github.com/open-telemetry/opentelemetry-rust/pull/2641)
   for the changes.
 
 ## 0.28.0

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## vNext
 
 - *Breaking* Make `force_flush()` in `PushMetricExporter` synchronous
+- Breaking: The `Runtime` trait has been simplified and refined. See the [#2641](https://github.com/open-telemetry/opentelemetry-rust/pull/2641)
+  for the changes.
 
 ## 0.28.0
 

--- a/opentelemetry-sdk/src/logs/log_processor_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/logs/log_processor_with_async_runtime.rs
@@ -126,7 +126,7 @@ impl<R: RuntimeChannel> BatchLogProcessor<R> {
         let inner_runtime = runtime.clone();
 
         // Spawn worker process via user-defined spawn function.
-        runtime.spawn(Box::pin(async move {
+        runtime.spawn(async move {
             // Timer will take a reference to the current runtime, so its important we do this within the
             // runtime.spawn()
             let ticker = to_interval_stream(inner_runtime.clone(), config.scheduled_delay)
@@ -204,7 +204,7 @@ impl<R: RuntimeChannel> BatchLogProcessor<R> {
                     }
                 }
             }
-        }));
+        });
         // Return batch processor with link to worker
         BatchLogProcessor {
             message_sender,

--- a/opentelemetry-sdk/src/logs/log_processor_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/logs/log_processor_with_async_runtime.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 use super::{BatchConfig, LogProcessor};
-use crate::runtime::{RuntimeChannel, TrySend};
+use crate::runtime::{to_interval_stream, RuntimeChannel, TrySend};
 use futures_channel::oneshot;
 use futures_util::{
     future::{self, Either},
@@ -129,10 +129,10 @@ impl<R: RuntimeChannel> BatchLogProcessor<R> {
         runtime.spawn(Box::pin(async move {
             // Timer will take a reference to the current runtime, so its important we do this within the
             // runtime.spawn()
-            let ticker = inner_runtime
-                .interval(config.scheduled_delay)
+            let ticker = to_interval_stream(inner_runtime.clone(), config.scheduled_delay)
                 .skip(1) // The ticker is fired immediately, so we should skip the first one to align with the interval.
                 .map(|_| BatchMessage::Flush(None));
+
             let timeout_runtime = inner_runtime.clone();
             let mut logs = Vec::new();
             let mut messages = Box::pin(stream::select(message_receiver, ticker));

--- a/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
@@ -109,7 +109,7 @@ where
         let worker = move |reader: &PeriodicReader<E>| {
             let runtime = self.runtime.clone();
             let reader = reader.clone();
-            self.runtime.spawn(Box::pin(async move {
+            self.runtime.spawn(async move {
                 let ticker = to_interval_stream(runtime.clone(), self.interval)
                     .skip(1) // The ticker is fired immediately, so we should skip the first one to align with the interval.
                     .map(|_| Message::Export);
@@ -125,7 +125,7 @@ where
                 }
                 .run(messages)
                 .await
-            }));
+            });
         };
 
         otel_debug!(

--- a/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
@@ -13,7 +13,7 @@ use futures_util::{
 };
 use opentelemetry::{otel_debug, otel_error};
 
-use crate::runtime::Runtime;
+use crate::runtime::{to_interval_stream, Runtime};
 use crate::{
     error::{OTelSdkError, OTelSdkResult},
     metrics::{exporter::PushMetricExporter, reader::SdkProducer, MetricError, MetricResult},
@@ -110,8 +110,7 @@ where
             let runtime = self.runtime.clone();
             let reader = reader.clone();
             self.runtime.spawn(Box::pin(async move {
-                let ticker = runtime
-                    .interval(self.interval)
+                let ticker = to_interval_stream(runtime.clone(), self.interval)
                     .skip(1) // The ticker is fired immediately, so we should skip the first one to align with the interval.
                     .map(|_| Message::Export);
                 let messages = Box::pin(stream::select(message_receiver, ticker));

--- a/opentelemetry-sdk/src/runtime.rs
+++ b/opentelemetry-sdk/src/runtime.rs
@@ -44,6 +44,7 @@ pub trait Runtime: Clone + Send + Sync + 'static {
 
 /// Uses the given runtime to produce an interval stream.
 #[cfg(feature = "experimental_async_runtime")]
+#[allow(dead_code)]
 pub(crate) fn to_interval_stream<T: Runtime>(
     runtime: T,
     interval: Duration,

--- a/opentelemetry-sdk/src/runtime.rs
+++ b/opentelemetry-sdk/src/runtime.rs
@@ -6,8 +6,8 @@
 //! [Tokio]: https://crates.io/crates/tokio
 //! [async-std]: https://crates.io/crates/async-std
 
-use std::{fmt::Debug, future::Future, time::Duration};
 use futures_util::stream::{unfold, Stream};
+use std::{fmt::Debug, future::Future, time::Duration};
 use thiserror::Error;
 
 /// A runtime is an abstraction of an async runtime like [Tokio] or [async-std]. It allows
@@ -34,7 +34,9 @@ pub trait Runtime: Clone + Send + Sync + 'static {
     /// At the moment, the shutdown happens by blocking the
     /// current thread. This means runtime implementations need to make sure they can still execute
     /// the given future even if the main thread is blocked.
-    fn spawn<F>(&self, future: F) where F: Future<Output = ()> + Send + 'static;
+    fn spawn<F>(&self, future: F)
+    where
+        F: Future<Output = ()> + Send + 'static;
 
     /// Return a future that resolves after the specified [Duration].
     fn delay(&self, duration: Duration) -> impl Future<Output = ()> + Send + 'static;
@@ -42,7 +44,10 @@ pub trait Runtime: Clone + Send + Sync + 'static {
 
 /// Uses the given runtime to produce an interval stream.
 #[cfg(feature = "experimental_async_runtime")]
-pub(crate) fn to_interval_stream<T: Runtime>(runtime: T, interval: Duration) -> impl Stream<Item = ()> {
+pub(crate) fn to_interval_stream<T: Runtime>(
+    runtime: T,
+    interval: Duration,
+) -> impl Stream<Item = ()> {
     unfold((), move |_| {
         let runtime_cloned = runtime.clone();
 
@@ -70,7 +75,7 @@ pub struct Tokio;
 impl Runtime for Tokio {
     fn spawn<F>(&self, future: F)
     where
-        F: Future<Output = ()> + Send + 'static
+        F: Future<Output = ()> + Send + 'static,
     {
         #[allow(clippy::let_underscore_future)]
         // we don't have to await on the returned future to execute
@@ -111,7 +116,7 @@ pub struct TokioCurrentThread;
 impl Runtime for TokioCurrentThread {
     fn spawn<F>(&self, future: F)
     where
-        F: Future<Output = ()> + Send + 'static
+        F: Future<Output = ()> + Send + 'static,
     {
         // We cannot force push tracing in current thread tokio scheduler because we rely on
         // BatchSpanProcessor to export spans in a background task, meanwhile we need to block the
@@ -150,7 +155,7 @@ pub struct AsyncStd;
 impl Runtime for AsyncStd {
     fn spawn<F>(&self, future: F)
     where
-        F: Future<Output = ()> + Send + 'static
+        F: Future<Output = ()> + Send + 'static,
     {
         #[allow(clippy::let_underscore_future)]
         let _ = async_std::task::spawn(future);

--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
@@ -1,4 +1,4 @@
-use crate::runtime::RuntimeChannel;
+use crate::runtime::{to_interval_stream, RuntimeChannel};
 use crate::trace::sampler::jaeger_remote::remote::SamplingStrategyResponse;
 use crate::trace::sampler::jaeger_remote::sampling_strategy::Inner;
 use crate::trace::{Sampler, ShouldSample};
@@ -189,7 +189,8 @@ impl JaegerRemoteSampler {
         C: HttpClient + 'static,
     {
         // todo: review if we need 'static here
-        let interval = runtime.interval(update_timeout);
+        let interval = to_interval_stream(runtime.clone(), update_timeout);
+
         runtime.spawn(Box::pin(async move {
             // either update or shutdown
             let mut update = Box::pin(stream::select(

--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
@@ -191,7 +191,7 @@ impl JaegerRemoteSampler {
         // todo: review if we need 'static here
         let interval = to_interval_stream(runtime.clone(), update_timeout);
 
-        runtime.spawn(Box::pin(async move {
+        runtime.spawn(async move {
             // either update or shutdown
             let mut update = Box::pin(stream::select(
                 shutdown.map(|_| false),
@@ -217,7 +217,7 @@ impl JaegerRemoteSampler {
                     break;
                 }
             }
-        }));
+        });
     }
 
     async fn request_new_strategy<C>(

--- a/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
@@ -351,7 +351,7 @@ impl<R: RuntimeChannel> BatchSpanProcessor<R> {
 
         let inner_runtime = runtime.clone();
         // Spawn worker process via user-defined spawn function.
-        runtime.spawn(Box::pin(async move {
+        runtime.spawn(async move {
             // Timer will take a reference to the current runtime, so its important we do this within the
             // runtime.spawn()
             let ticker = to_interval_stream(inner_runtime.clone(), config.scheduled_delay)
@@ -369,7 +369,7 @@ impl<R: RuntimeChannel> BatchSpanProcessor<R> {
             };
 
             processor.run(messages).await
-        }));
+        });
 
         // Return batch processor with link to worker
         BatchSpanProcessor {

--- a/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
@@ -308,13 +308,13 @@ impl<R: RuntimeChannel> BatchSpanProcessorInternal<R> {
         }
 
         let export = self.exporter.export(self.spans.split_off(0));
-        let timeout = Box::pin(self.runtime.delay(self.config.max_export_timeout));
-        let time_out = self.config.max_export_timeout;
+        let timeout_future = Box::pin(self.runtime.delay(self.config.max_export_timeout));
+        let timeout = self.config.max_export_timeout;
 
         Box::pin(async move {
-            match future::select(export, timeout).await {
+            match future::select(export, timeout_future).await {
                 Either::Left((export_res, _)) => export_res,
-                Either::Right((_, _)) => Err(OTelSdkError::Timeout(time_out)),
+                Either::Right((_, _)) => Err(OTelSdkError::Timeout(timeout)),
             }
         })
     }


### PR DESCRIPTION
Contributes to #2643

## Changes

This PR cleans-up and simplifies the `Runtime` trait.


Before:

```rust
pub trait Runtime: Clone + Send + Sync + 'static {
    type Interval: Stream + Send;

    type Delay: Future + Send + Unpin;

    fn interval(&self, duration: Duration) -> Self::Interval;

    fn spawn(&self, future: BoxFuture<'static, ()>);

    fn delay(&self, duration: Duration) -> Self::Delay;
}
```

After:

```rust
pub trait Runtime: Clone + Send + Sync + 'static {
    fn spawn<F>(&self, future: F) where F: Future<Output = ()> + Send + 'static;

    fn delay(&self, duration: Duration) -> impl Future<Output = ()> + Send + 'static;
}
```

The main changes is the drop of the interval, which can be moved to an internal helper method. 

**Future Improvements:** 

This trait could even made to be agnostic to single-threaded and multi-threaded runtimes and be simplified to:

```rust
pub trait Runtime {
    fn spawn<F>(&self, future: F) where F: Future<Output = ()> + Send + 'static;

    async fn delay(&self, duration: Duration);
}
```

The trait requirements would have to be specified on the consuming side:

```rust
impl<E, RT> PeriodicReaderBuilder<E, RT>
where
    E: PushMetricExporter,
    RT: Runtime + Send + Sync + 'static,
    RT::delay(..): send + 'static
{
   fn new(exporter: E, runtime: RT) -> Self {
      ...
   }
}
```

However, this requires the [return type notation support](https://blog.rust-lang.org/inside-rust/2024/09/26/rtn-call-for-testing.html) which is not yet stable.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
