### PR TITLE
Add missing Windows exclusion for pprof crate in sdk/benches

### DIFF
--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -23,6 +23,7 @@ use opentelemetry_sdk::logs::LogBatch;
 use opentelemetry_sdk::logs::LogProcessor;
 use opentelemetry_sdk::logs::SdkLogRecord;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
+#[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
 use std::fmt::Debug;
 

--- a/opentelemetry-sdk/benches/metrics_counter.rs
+++ b/opentelemetry-sdk/benches/metrics_counter.rs
@@ -20,6 +20,7 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
+#[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
 use rand::{
     rngs::{self},


### PR DESCRIPTION
Fixes # (Not Applicable)
Design discussion issue (if applicable) # (Not Applicable)

## Changes

After cloning down the repository for the first time on Windows, noticed build failures in 2 places around import of `pprof` crate:

> failed to resolve: use of undeclared crate or module `pprof`
use of undeclared crate or module `pprof`

Looking at other references in the project, including [the cargo.toml](https://github.com/open-telemetry/opentelemetry-rust/blob/5236670f8d9c00adeacdd66f1ffd6e077aa1333d/opentelemetry-sdk/Cargo.toml#L41), it is clear they should have `[cfg` markers disabling them for Windows developers.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
