### PR TITLE
Upgrade opentelemetry-prometheus to 0.28

### DIFF
--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -2,15 +2,18 @@
 
 ## vNext
 
-- Bump msrv to 1.75.0.
+## v0.28.0
 
+- Update `opentelemetry` dependency version to 0.28
+- Update `opentelemetry_sdk` dependency version to 0.28
+- Update `opentelemetry-semantic-conventions` dependency version to 0.28
+- Bump msrv to 1.75.0.
 
 ## v0.27.0
 
 - Update `opentelemetry` dependency version to 0.27
 - Update `opentelemetry_sdk` dependency version to 0.27
 - Update `opentelemetry-semantic-conventions` dependency version to 0.27
-
 
 ## v0.17.0
 
@@ -66,6 +69,7 @@
 ## v0.12.0
 
 ### Changed
+
 - [Breaking] Add `_total` suffix for all counters [#952](https://github.com/open-telemetry/opentelemetry-rust/pull/952).
 - Update to `opentelemetry` v0.19.
 - Bump MSRV to 1.57 [#953](https://github.com/open-telemetry/opentelemetry-rust/pull/953).

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-prometheus"
-version = "0.27.0"
+version = "0.28.0"
 description = "Prometheus exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust"
 repository = "https://github.com/open-telemetry/opentelemetry-rust"
@@ -21,14 +21,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 once_cell = { version = "1.13" }
-opentelemetry = { version = "0.27", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.27", default-features = false, features = ["metrics"] }
+opentelemetry = { version = "0.28", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.28", default-features = false, features = ["metrics"] }
 prometheus = "0.13"
 protobuf = "2.14"
 tracing = {version = ">=0.1.40", default-features = false, optional = true} # optional for opentelemetry internal logging
 
 [dev-dependencies]
-opentelemetry-semantic-conventions = { version = "0.27" }
+opentelemetry-semantic-conventions = { version = "0.28" }
 http-body-util = { version = "0.1" }
 hyper = { version = "1.3", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -99,6 +99,7 @@
 use once_cell::sync::{Lazy, OnceCell};
 use opentelemetry::{otel_error, otel_warn, InstrumentationScope, Key, Value};
 use opentelemetry_sdk::{
+    error::OTelSdkResult,
     metrics::{
         data::{self, ResourceMetrics},
         reader::MetricReader,
@@ -157,11 +158,11 @@ impl MetricReader for PrometheusExporter {
         self.reader.collect(rm)
     }
 
-    fn force_flush(&self) -> MetricResult<()> {
+    fn force_flush(&self) -> OTelSdkResult {
         self.reader.force_flush()
     }
 
-    fn shutdown(&self) -> MetricResult<()> {
+    fn shutdown(&self) -> OTelSdkResult {
         self.reader.shutdown()
     }
 
@@ -284,7 +285,7 @@ impl prometheus::core::Collector for Collector {
         };
 
         let mut metrics = ResourceMetrics {
-            resource: Resource::empty(),
+            resource: Resource::builder_empty().build(),
             scope_metrics: vec![],
         };
         if let Err(err) = self.reader.collect(&mut metrics) {


### PR DESCRIPTION
## Changes

Upgrade the dependencies to the latest 0.28 version and fix breaking changes.

I noticed this issue regarding discontinuing the prometheus crate: https://github.com/open-telemetry/opentelemetry-rust/issues/2451

If that is the plan, you may want to disregard this PR. Although, I am not sure what the proper way to transition from using the opentelemetry-prometheus crate to just simply using otlp natively would involve. Any pointers there would be much appreciated.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
