### PR TITLE
Update appender-tracing pprof usage with Windows exclusion

### DIFF
--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -20,7 +20,8 @@ use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::logs::{LogBatch, LogExporter};
 use opentelemetry_sdk::logs::{LogProcessor, SdkLogRecord, SdkLoggerProvider};
 use opentelemetry_sdk::Resource;
-use pprof::criterion::{Output, PProfProfiler};
+#[cfg(not(target_os = "windows"))]
+use pprof::criterion::{Output, PProfProfiler}; 
 use tracing::error;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::Layer;

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -21,7 +21,7 @@ use opentelemetry_sdk::logs::{LogBatch, LogExporter};
 use opentelemetry_sdk::logs::{LogProcessor, SdkLogRecord, SdkLoggerProvider};
 use opentelemetry_sdk::Resource;
 #[cfg(not(target_os = "windows"))]
-use pprof::criterion::{Output, PProfProfiler}; 
+use pprof::criterion::{Output, PProfProfiler};
 use tracing::error;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::Layer;


### PR DESCRIPTION
Fixes # N/A
Design discussion issue (if applicable) # N/A

## Changes

Follow-up to #2648, found another instance of pprof usage that needs to be excluded on Windows.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
