### PR TITLE
Enable per-thread instances for histogram stress test

### DIFF
--- a/stress/src/metrics_histogram.rs
+++ b/stress/src/metrics_histogram.rs
@@ -37,13 +37,30 @@ lazy_static! {
 thread_local! {
     /// Store random number generator for each thread
     static CURRENT_RNG: RefCell<rngs::SmallRng> = RefCell::new(rngs::SmallRng::from_entropy());
+
+    static PROVIDER_PER_THREAD: SdkMeterProvider = SdkMeterProvider::builder()
+        .with_reader(ManualReader::builder().build())
+        .build();
+
+    static HISTOGRAM_PER_THREAD: Histogram<u64> = PROVIDER_PER_THREAD.with(|h|h.meter("test").u64_histogram("hello").build());
 }
 
 fn main() {
-    throughput::test_throughput(test_histogram);
+    match std::env::args().find(|arg| arg == "--per-thread") {
+        None => throughput::test_throughput(test_histogram_shared),
+        Some(_) => throughput::test_throughput(test_histogram_per_thread)
+    }
 }
 
-fn test_histogram() {
+fn test_histogram_shared() {
+    test_histogram(&HISTOGRAM);
+}
+
+fn test_histogram_per_thread() {
+    HISTOGRAM_PER_THREAD.with(|h|test_histogram(h));
+}
+
+fn test_histogram(histogram: &Histogram<u64>) {
     let len = ATTRIBUTE_VALUES.len();
     let rands = CURRENT_RNG.with(|rng| {
         let mut rng = rng.borrow_mut();
@@ -58,7 +75,7 @@ fn test_histogram() {
     let index_third_attribute = rands[2];
 
     // each attribute has 10 possible values, so there are 1000 possible combinations (time-series)
-    HISTOGRAM.record(
+    histogram.record(
         1,
         &[
             KeyValue::new("attribute1", ATTRIBUTE_VALUES[index_first_attribute]),

--- a/stress/src/metrics_histogram.rs
+++ b/stress/src/metrics_histogram.rs
@@ -48,7 +48,7 @@ thread_local! {
 fn main() {
     match std::env::args().find(|arg| arg == "--per-thread") {
         None => throughput::test_throughput(test_histogram_shared),
-        Some(_) => throughput::test_throughput(test_histogram_per_thread)
+        Some(_) => throughput::test_throughput(test_histogram_per_thread),
     }
 }
 
@@ -57,7 +57,7 @@ fn test_histogram_shared() {
 }
 
 fn test_histogram_per_thread() {
-    HISTOGRAM_PER_THREAD.with(|h|test_histogram(h));
+    HISTOGRAM_PER_THREAD.with(|h| test_histogram(h));
 }
 
 fn test_histogram(histogram: &Histogram<u64>) {


### PR DESCRIPTION
Contributes to #1386

## Changes

This PR enables the secondary mode for the `metrics_histogram` stress test where each thread gets it's own instance of meter provider:


**Shared**

``` 
Number of threads: 32
Throughput: 7,980,759 iterations/sec
Throughput: 7,766,680 iterations/sec
Throughput: 7,592,290 iterations/sec
Throughput: 7,229,872 iterations/sec
```

**Per-thread**

```
Number of threads: 32
Throughput: 92,490,062 iterations/sec
Throughput: 90,558,222 iterations/sec
Throughput: 91,087,973 iterations/sec
Throughput: 89,307,343 iterations/sec
```

To run the per-thread scenario run the following command:

```bash
cargo run --release --bin metrics_histogram -- 32 --per-thread
```

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
