### PR TITLE
Simplifiy OTLP Example Resource creation

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -10,7 +10,6 @@ default = ["reqwest-blocking"]
 reqwest-blocking = ["opentelemetry-otlp/reqwest-blocking-client"]
 
 [dependencies]
-once_cell = { workspace = true }
 opentelemetry = { path = "../../../opentelemetry" }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk" }
 opentelemetry-otlp = { path = "../.."}

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -1,4 +1,3 @@
-use once_cell::sync::Lazy;
 use opentelemetry::{
     global,
     trace::{TraceContextExt, Tracer},
@@ -16,11 +15,11 @@ use tracing::info;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
-static RESOURCE: Lazy<Resource> = Lazy::new(|| {
+fn get_resource() -> Resource {
     Resource::builder()
         .with_service_name("basic-otlp-example-http")
         .build()
-});
+}
 
 fn init_logs() -> SdkLoggerProvider {
     let exporter = LogExporter::builder()
@@ -31,7 +30,7 @@ fn init_logs() -> SdkLoggerProvider {
 
     SdkLoggerProvider::builder()
         .with_batch_exporter(exporter)
-        .with_resource(RESOURCE.clone())
+        .with_resource(get_resource())
         .build()
 }
 
@@ -44,7 +43,7 @@ fn init_traces() -> SdkTracerProvider {
 
     SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
-        .with_resource(RESOURCE.clone())
+        .with_resource(get_resource())
         .build()
 }
 
@@ -57,7 +56,7 @@ fn init_metrics() -> SdkMeterProvider {
 
     SdkMeterProvider::builder()
         .with_periodic_exporter(exporter)
-        .with_resource(RESOURCE.clone())
+        .with_resource(get_resource())
         .build()
 }
 

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -10,15 +10,20 @@ use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::{
     logs::SdkLoggerProvider, metrics::SdkMeterProvider, trace::SdkTracerProvider,
 };
-use std::error::Error;
+use std::{error::Error, sync::OnceLock};
 use tracing::info;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
 fn get_resource() -> Resource {
-    Resource::builder()
-        .with_service_name("basic-otlp-example-http")
-        .build()
+    static RESOURCE: OnceLock<Resource> = OnceLock::new();
+    RESOURCE
+        .get_or_init(|| {
+            Resource::builder()
+                .with_service_name("basic-otlp-example-grpc")
+                .build()
+        })
+        .clone()
 }
 
 fn init_logs() -> SdkLoggerProvider {

--- a/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
@@ -6,7 +6,6 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-once_cell = { workspace = true }
 opentelemetry = { path = "../../../opentelemetry" }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk" }
 opentelemetry-otlp = { path = "../../../opentelemetry-otlp", features = ["grpc-tonic"] }

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -1,4 +1,3 @@
-use once_cell::sync::Lazy;
 use opentelemetry::trace::{TraceContextExt, Tracer};
 use opentelemetry::KeyValue;
 use opentelemetry::{global, InstrumentationScope};
@@ -13,11 +12,11 @@ use tracing::info;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
-static RESOURCE: Lazy<Resource> = Lazy::new(|| {
+fn get_resource() -> Resource {
     Resource::builder()
         .with_service_name("basic-otlp-example-grpc")
         .build()
-});
+}
 
 fn init_traces() -> SdkTracerProvider {
     let exporter = SpanExporter::builder()
@@ -25,7 +24,7 @@ fn init_traces() -> SdkTracerProvider {
         .build()
         .expect("Failed to create span exporter");
     SdkTracerProvider::builder()
-        .with_resource(RESOURCE.clone())
+        .with_resource(get_resource())
         .with_batch_exporter(exporter)
         .build()
 }
@@ -38,7 +37,7 @@ fn init_metrics() -> SdkMeterProvider {
 
     SdkMeterProvider::builder()
         .with_periodic_exporter(exporter)
-        .with_resource(RESOURCE.clone())
+        .with_resource(get_resource())
         .build()
 }
 
@@ -49,7 +48,7 @@ fn init_logs() -> SdkLoggerProvider {
         .expect("Failed to create log exporter");
 
     SdkLoggerProvider::builder()
-        .with_resource(RESOURCE.clone())
+        .with_resource(get_resource())
         .with_batch_exporter(exporter)
         .build()
 }

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -8,14 +8,20 @@ use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_sdk::Resource;
 use std::error::Error;
+use std::sync::OnceLock;
 use tracing::info;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
 fn get_resource() -> Resource {
-    Resource::builder()
-        .with_service_name("basic-otlp-example-grpc")
-        .build()
+    static RESOURCE: OnceLock<Resource> = OnceLock::new();
+    RESOURCE
+        .get_or_init(|| {
+            Resource::builder()
+                .with_service_name("basic-otlp-example-grpc")
+                .build()
+        })
+        .clone()
 }
 
 fn init_traces() -> SdkTracerProvider {


### PR DESCRIPTION
Resource needs to be handed over to each provider, so it must be created or cloned anyway.