### PR TITLE
make force_flush() in PushMetricExporter synchronous

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Make `force_flush()` in `PushMetricExporter` synchronous
+
 ## 0.28.0
 
 Released 2025-Feb-10

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## vNext
 
-- Make `force_flush()` in `PushMetricExporter` synchronous
-
 ## 0.28.0
 
 Released 2025-Feb-10

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -144,7 +144,7 @@ impl PushMetricExporter for MetricExporter {
         self.client.export(metrics).await
     }
 
-    async fn force_flush(&self) -> OTelSdkResult {
+    fn force_flush(&self) -> OTelSdkResult {
         // this component is stateless
         Ok(())
     }

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- *Breaking* Make `force_flush()` in `PushMetricExporter` synchronous
+
 ## 0.28.0
 
 Released 2025-Feb-10

--- a/opentelemetry-sdk/src/metrics/exporter.rs
+++ b/opentelemetry-sdk/src/metrics/exporter.rs
@@ -20,7 +20,7 @@ pub trait PushMetricExporter: Send + Sync + 'static {
     ) -> impl std::future::Future<Output = OTelSdkResult> + Send;
 
     /// Flushes any metric data held by an exporter.
-    fn force_flush(&self) -> impl std::future::Future<Output = OTelSdkResult> + Send;
+    fn force_flush(&self) -> OTelSdkResult;
 
     /// Releases any held computational resources.
     ///

--- a/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
@@ -272,7 +272,7 @@ impl PushMetricExporter for InMemoryMetricExporter {
             .map_err(|_| OTelSdkError::InternalFailure("Failed to lock metrics".to_string()))
     }
 
-    async fn force_flush(&self) -> OTelSdkResult {
+    fn force_flush(&self) -> OTelSdkResult {
         Ok(()) // In this implementation, flush does nothing
     }
 

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -557,7 +557,7 @@ mod tests {
             }
         }
 
-        async fn force_flush(&self) -> OTelSdkResult {
+        fn force_flush(&self) -> OTelSdkResult {
             Ok(())
         }
 
@@ -580,7 +580,7 @@ mod tests {
             Ok(())
         }
 
-        async fn force_flush(&self) -> OTelSdkResult {
+        fn force_flush(&self) -> OTelSdkResult {
             Ok(())
         }
 

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -58,7 +58,7 @@ impl PushMetricExporter for MetricExporter {
         }
     }
 
-    async fn force_flush(&self) -> OTelSdkResult {
+    fn force_flush(&self) -> OTelSdkResult {
         // exporter holds no state, nothing to flush
         Ok(())
     }


### PR DESCRIPTION
## Changes

- follow-up to https://github.com/open-telemetry/opentelemetry-rust/pull/2662#discussion_r1955357273

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
