### PR TITLE
Fix OTel Appender for tracing from suppressing other layers

### DIFF
--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## vNext
 
+Fixes [1682](https://github.com/open-telemetry/opentelemetry-rust/issues/1682).
+"spec_unstable_logs_enabled" feature now do not suppress logs for other layers.
+
 ## 0.28.1
 
 Released 2025-Feb-12
 
-- Bump `tracing-opentelemetry` to 0.29
-- New experimental feature to use trace\_id & span\_id from spans created through the [tracing](https://crates.io/crates/tracing) crate (experimental_use_tracing_span_context) [#2438](https://github.com/open-telemetry/opentelemetry-rust/pull/2438)
-
+- New *experimental* feature to use trace_id & span_id from spans created through the [tracing](https://crates.io/crates/tracing) crate (experimental_use_tracing_span_context) [#2438](https://github.com/open-telemetry/opentelemetry-rust/pull/2438)
 
 ## 0.28.0
 
@@ -27,6 +28,7 @@ Released 2024-Nov-11
 - **Breaking** [2291](https://github.com/open-telemetry/opentelemetry-rust/pull/2291) Rename `logs_level_enabled flag` to `spec_unstable_logs_enabled`. Please enable this updated flag if the feature is needed. This flag will be removed once the feature is stabilized in the specifications.
 
 ## v0.26.0
+
 Released 2024-Sep-30
 
 - Update `opentelemetry` dependency version to 0.26
@@ -45,7 +47,7 @@ Released 2024-Sep-30
   Exporters might use the target to override the instrumentation scope, which previously contained "opentelemetry-appender-tracing".
 
 - **Breaking** [1928](https://github.com/open-telemetry/opentelemetry-rust/pull/1928) Insert tracing event name into LogRecord::event_name instead of attributes.
-   - If using a custom exporter, then they must serialize this field directly from LogRecord::event_name instead of iterating over the attributes. OTLP Exporter is modified to handle this.
+  - If using a custom exporter, then they must serialize this field directly from LogRecord::event_name instead of iterating over the attributes. OTLP Exporter is modified to handle this.
 - Update `opentelemetry` dependency version to 0.24
 
 ## v0.4.0

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -36,7 +36,6 @@ pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 default = []
 experimental_metadata_attributes = ["dep:tracing-log"]
 spec_unstable_logs_enabled = ["opentelemetry/spec_unstable_logs_enabled"]
-# TODO - Enable this in 0.28.1 (once tracing-opentelemetry v0.29 is released)
 experimental_use_tracing_span_context = ["tracing-opentelemetry"]
 
 

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -17,7 +17,6 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::InstrumentationScope;
 use opentelemetry_appender_tracing::layer as tracing_layer;
 use opentelemetry_sdk::error::OTelSdkResult;
-use opentelemetry_sdk::logs::{LogBatch, LogExporter};
 use opentelemetry_sdk::logs::{LogProcessor, SdkLogRecord, SdkLoggerProvider};
 use opentelemetry_sdk::Resource;
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
Fixes #1682 

No change in performance.
Also modified benchmarks to remove the need of a noop exporter, as noop processor is sufficient to test perf for enabled/disabled. (This change has no perf impact even without this cleanup.)