### PR TITLE
leverage native async trait in MetricsClient

### DIFF
--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -26,7 +26,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-async-trait = { workspace = true }
 futures-core = { workspace = true }
 opentelemetry = { version = "0.28", default-features = false, path = "../opentelemetry" }
 opentelemetry_sdk = { version = "0.28", default-features = false, path = "../opentelemetry-sdk" }

--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use crate::metric::MetricsClient;
-use async_trait::async_trait;
 use http::{header::CONTENT_TYPE, Method};
 use opentelemetry::otel_debug;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
@@ -9,7 +8,6 @@ use opentelemetry_sdk::metrics::data::ResourceMetrics;
 
 use super::OtlpHttpClient;
 
-#[async_trait]
 impl MetricsClient for OtlpHttpClient {
     async fn export(&self, metrics: &mut ResourceMetrics) -> OTelSdkResult {
         let client = self

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -262,7 +262,7 @@ impl HttpExporterBuilder {
             OTEL_EXPORTER_OTLP_METRICS_HEADERS,
         )?;
 
-        Ok(crate::MetricExporter::new(client, temporality))
+        Ok(crate::MetricExporter::from_http(client, temporality))
     }
 }
 

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 use std::sync::Mutex;
 
-use async_trait::async_trait;
 use opentelemetry::otel_debug;
 use opentelemetry_proto::tonic::collector::metrics::v1::{
     metrics_service_client::MetricsServiceClient, ExportMetricsServiceRequest,
@@ -52,7 +51,6 @@ impl TonicMetricsClient {
     }
 }
 
-#[async_trait]
 impl MetricsClient for TonicMetricsClient {
     async fn export(&self, metrics: &mut ResourceMetrics) -> OTelSdkResult {
         let (mut client, metadata, extensions) = self

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 pub(crate) mod logs;
 
 #[cfg(feature = "metrics")]
-mod metrics;
+pub(crate) mod metrics;
 
 #[cfg(feature = "trace")]
 pub(crate) mod trace;
@@ -296,7 +296,7 @@ impl TonicExporterBuilder {
 
         let client = TonicMetricsClient::new(channel, interceptor, compression);
 
-        Ok(MetricExporter::new(client, temporality))
+        Ok(MetricExporter::from_tonic(client, temporality))
     }
 
     /// Build a new tonic span exporter

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -14,7 +14,6 @@ use crate::{exporter::tonic::TonicExporterBuilder, HasTonicConfig, TonicExporter
 
 use crate::NoExporterBuilderSet;
 
-use async_trait::async_trait;
 use core::fmt;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::metrics::MetricResult;
@@ -121,16 +120,26 @@ impl HasHttpConfig for MetricExporterBuilder<HttpExporterBuilderSet> {
 }
 
 /// An interface for OTLP metrics clients
-#[async_trait]
 pub(crate) trait MetricsClient: fmt::Debug + Send + Sync + 'static {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> OTelSdkResult;
+    fn export(
+        &self,
+        metrics: &mut ResourceMetrics,
+    ) -> impl std::future::Future<Output = OTelSdkResult> + Send;
     fn shutdown(&self) -> OTelSdkResult;
 }
 
 /// Export metrics in OTEL format.
 pub struct MetricExporter {
-    client: Box<dyn MetricsClient>,
+    client: SupportedTransportClient,
     temporality: Temporality,
+}
+
+#[derive(Debug)]
+enum SupportedTransportClient {
+    #[cfg(feature = "grpc-tonic")]
+    Tonic(crate::exporter::tonic::metrics::TonicMetricsClient),
+    #[cfg(any(feature = "http-proto", feature = "http-json"))]
+    Http(crate::exporter::http::OtlpHttpClient),
 }
 
 impl Debug for MetricExporter {
@@ -141,7 +150,12 @@ impl Debug for MetricExporter {
 
 impl PushMetricExporter for MetricExporter {
     async fn export(&self, metrics: &mut ResourceMetrics) -> OTelSdkResult {
-        self.client.export(metrics).await
+        match &self.client {
+            #[cfg(feature = "grpc-tonic")]
+            SupportedTransportClient::Tonic(client) => client.export(metrics).await,
+            #[cfg(any(feature = "http-proto", feature = "http-json"))]
+            SupportedTransportClient::Http(client) => client.export(metrics).await,
+        }
     }
 
     fn force_flush(&self) -> OTelSdkResult {
@@ -150,7 +164,12 @@ impl PushMetricExporter for MetricExporter {
     }
 
     fn shutdown(&self) -> OTelSdkResult {
-        self.client.shutdown()
+        match &self.client {
+            #[cfg(feature = "grpc-tonic")]
+            SupportedTransportClient::Tonic(client) => client.shutdown(),
+            #[cfg(any(feature = "http-proto", feature = "http-json"))]
+            SupportedTransportClient::Http(client) => client.shutdown(),
+        }
     }
 
     fn temporality(&self) -> Temporality {
@@ -164,10 +183,24 @@ impl MetricExporter {
         MetricExporterBuilder::default()
     }
 
-    /// Create a new metrics exporter
-    pub(crate) fn new(client: impl MetricsClient, temporality: Temporality) -> MetricExporter {
-        MetricExporter {
-            client: Box::new(client),
+    #[cfg(feature = "grpc-tonic")]
+    pub(crate) fn from_tonic(
+        client: crate::exporter::tonic::metrics::TonicMetricsClient,
+        temporality: Temporality,
+    ) -> Self {
+        Self {
+            client: SupportedTransportClient::Tonic(client),
+            temporality,
+        }
+    }
+
+    #[cfg(any(feature = "http-proto", feature = "http-json"))]
+    pub(crate) fn from_http(
+        client: crate::exporter::http::OtlpHttpClient,
+        temporality: Temporality,
+    ) -> Self {
+        Self {
+            client: SupportedTransportClient::Http(client),
             temporality,
         }
     }


### PR DESCRIPTION
Relates #2517 

## Changes

- I think this is the last `asyn_trait` we can remove. there is still some usage around `HttpClient` trait, but this one is used quite often with dynamic dispatch and this can't be handled by the native async capabilities.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
