### PR TITLE
use workspace lint configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ url = { version = "2.5", default-features = false }
 opentelemetry = { path = "opentelemetry" }
 opentelemetry_sdk = { path = "opentelemetry-sdk" }
 opentelemetry-stdout = { path = "opentelemetry-stdout" }
+
+[workspace.lints.clippy]
+all = { level = "warn", priority = 1 }

--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -1,9 +1,7 @@
 use opentelemetry::global;
 use opentelemetry::Key;
 use opentelemetry::KeyValue;
-use opentelemetry_sdk::metrics::{
-    Aggregation, Instrument, SdkMeterProvider, Stream, Temporality,
-};
+use opentelemetry_sdk::metrics::{Aggregation, Instrument, SdkMeterProvider, Stream, Temporality};
 use opentelemetry_sdk::Resource;
 use std::error::Error;
 

--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -2,7 +2,7 @@ use opentelemetry::global;
 use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::metrics::{
-    Aggregation, Instrument, PeriodicReader, SdkMeterProvider, Stream, Temporality,
+    Aggregation, Instrument, SdkMeterProvider, Stream, Temporality,
 };
 use opentelemetry_sdk::Resource;
 use std::error::Error;

--- a/examples/metrics-basic/src/main.rs
+++ b/examples/metrics-basic/src/main.rs
@@ -1,6 +1,5 @@
 use opentelemetry::{global, KeyValue};
-use opentelemetry_sdk::error::OTelSdkError;
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::Resource;
 use std::error::Error;
 use std::vec;

--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -34,3 +34,6 @@ opentelemetry-stdout = { path = "../opentelemetry-stdout", features = ["logs"] }
 log = { workspace = true, features = ["kv_serde"] }
 tokio = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
+
+[lints]
+workspace = true

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -43,3 +43,6 @@ experimental_use_tracing_span_context = ["tracing-opentelemetry"]
 name = "logs"
 harness = false
 required-features = ["spec_unstable_logs_enabled"]
+
+[lints]
+workspace = true

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -27,3 +27,6 @@ opentelemetry = { version = "0.28", path = "../opentelemetry", features = ["trac
 reqwest = { workspace = true, features = ["blocking"], optional = true }
 tokio = { workspace = true, features = ["time"], optional = true }
 tracing = {workspace = true, optional = true}
+
+[lints]
+workspace = true

--- a/opentelemetry-jaeger-propagator/Cargo.toml
+++ b/opentelemetry-jaeger-propagator/Cargo.toml
@@ -31,3 +31,6 @@ opentelemetry = { features = ["testing"], path = "../opentelemetry" }
 [features]
 default = ["internal-logs"]
 internal-logs = ["tracing"]
+
+[lints]
+workspace = true

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -83,3 +83,6 @@ hyper-client = ["opentelemetry-http/hyper"]
 
 # test
 integration-testing = ["tonic", "prost", "tokio/full", "trace", "logs"]
+
+[lints]
+workspace = true

--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -18,3 +18,6 @@ opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-traci
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true, features = ["std"]}
 tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }
+
+[lints]
+workspace = true

--- a/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
@@ -13,3 +13,6 @@ tokio = { version = "1.0", features = ["full"] }
 opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing"}
 tracing = { workspace = true, features = ["std"]}
 tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }
+
+[lints]
+workspace = true

--- a/opentelemetry-otlp/tests/integration_test/Cargo.toml
+++ b/opentelemetry-otlp/tests/integration_test/Cargo.toml
@@ -33,3 +33,5 @@ internal-logs = ["opentelemetry-otlp/internal-logs"]
 # Keep tonic as the default client
 default = ["tonic-client", "internal-logs"]
 
+[lints]
+workspace = true

--- a/opentelemetry-otlp/tests/integration_test/src/metric_helpers.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/metric_helpers.rs
@@ -142,7 +142,8 @@ pub fn fetch_latest_metrics_for_scope(scope_name: &str) -> Result<Value> {
                                     scope
                                         .get("scope")
                                         .and_then(|s| s.get("name"))
-                                        .and_then(|name| name.as_str()) == Some(scope_name)
+                                        .and_then(|name| name.as_str())
+                                        == Some(scope_name)
                                 });
 
                                 // Keep the resource only if it has any matching `ScopeMetrics`

--- a/opentelemetry-otlp/tests/integration_test/src/metric_helpers.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/metric_helpers.rs
@@ -142,8 +142,7 @@ pub fn fetch_latest_metrics_for_scope(scope_name: &str) -> Result<Value> {
                                     scope
                                         .get("scope")
                                         .and_then(|s| s.get("name"))
-                                        .and_then(|name| name.as_str())
-                                        .map_or(false, |n| n == scope_name)
+                                        .and_then(|name| name.as_str()) == Some(scope_name)
                                 });
 
                                 // Keep the resource only if it has any matching `ScopeMetrics`

--- a/opentelemetry-otlp/tests/integration_test/src/test_utils.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/test_utils.rs
@@ -55,6 +55,7 @@ fn init_tracing() {
     });
 }
 
+#[allow(clippy::await_holding_lock)]
 pub async fn start_collector_container() -> Result<()> {
     init_tracing();
 

--- a/opentelemetry-otlp/tests/integration_test/tests/logs.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs.rs
@@ -276,7 +276,7 @@ mod logtests {
     // Client - Tonic, Reqwest-blocking
     #[test]
     #[cfg(any(feature = "tonic-client", feature = "reqwest-blocking-client"))]
-    pub fn logs_simple_non_tokio_main_with_init_logs_inside_rt() -> Result<()> {
+    pub fn logs_simple_non_tokio_main_with_init_logs_inside_rt_blocking() -> Result<()> {
         logs_non_tokio_helper(true, true)
     }
 
@@ -295,7 +295,7 @@ mod logtests {
     // Client - Reqwest-blocking
     #[test]
     #[cfg(feature = "reqwest-blocking-client")]
-    pub fn logs_simple_non_tokio_main_with_init_logs_outsie_rt() -> Result<()> {
+    pub fn logs_simple_non_tokio_main_with_init_logs_outsie_rt_blocking() -> Result<()> {
         logs_non_tokio_helper(true, false)
     }
 
@@ -320,7 +320,7 @@ mod logtests {
     #[ignore] // request-blocking client does not work with tokio
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[cfg(feature = "reqwest-blocking-client")]
-    pub async fn logs_simple_tokio_multi_thread() -> Result<()> {
+    pub async fn logs_simple_tokio_multi_thread_blocking() -> Result<()> {
         logs_tokio_helper(true, false, false).await
     }
 

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -65,3 +65,6 @@ tonic-build = { workspace = true }
 prost-build = { workspace = true }
 tempfile = "3.3.0"
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -107,3 +107,6 @@ required-features = ["metrics"]
 name = "log"
 harness = false
 required-features = ["logs"]
+
+[lints]
+workspace = true

--- a/opentelemetry-semantic-conventions/Cargo.toml
+++ b/opentelemetry-semantic-conventions/Cargo.toml
@@ -26,3 +26,6 @@ semconv_experimental = []
 [dev-dependencies]
 opentelemetry = { default-features = false, path = "../opentelemetry" } # for doctests
 opentelemetry_sdk = { features = ["trace"], path = "../opentelemetry-sdk" } # for doctests
+
+[lints]
+workspace = true

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -39,3 +39,6 @@ tracing = { workspace = true, features = ["std"]}
 tracing-subscriber = { workspace = true, features = ["registry", "std"] }
 tokio = { workspace = true, features = ["full"] }
 once_cell = { workspace = true }
+
+[lints]
+workspace = true

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -46,3 +46,6 @@ http-body-util = { workspace = true }
 hyper-util = { workspace = true, features = ["client-legacy", "http1", "tokio"] }
 opentelemetry_sdk = { default-features = false, features = ["trace", "testing"], path = "../opentelemetry-sdk" }
 temp-env = { workspace = true }
+
+[lints]
+workspace = true

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -56,3 +56,6 @@ harness = false
 [[bench]]
 name = "anyvalue"
 harness = false
+
+[lints]
+workspace = true

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,23 +10,12 @@ cargo_feature() {
 }
 
 if rustup component add clippy; then
- crates=( "opentelemetry"
-                "opentelemetry-http"
-                "opentelemetry-jaeger-propagator"
-                "opentelemetry-appender-log"
-                "opentelemetry-appender-tracing"
-                "opentelemetry-otlp"
-                "opentelemetry-prometheus"
-                "opentelemetry-proto"
-                "opentelemetry-sdk"
-                "opentelemetry-semantic-conventions"
-                "opentelemetry-stdout"
-                "opentelemetry-zipkin")
-  for crate in "${crates[@]}"; do
-      cargo clippy --manifest-path=$crate/Cargo.toml --all-targets --all-features -- \
-          `# Exit with a nonzero code if there are clippy warnings` \
-          -Dwarnings
-  done
+  # Exit with a nonzero code if there are clippy warnings
+  cargo clippy --workspace --all-targets --all-features -- -Dwarnings
+
+  # `opentelemetry-prometheus` doesn't belong to the workspace
+  cargo clippy --manifest-path=opentelemetry-prometheus/Cargo.toml --all-targets --all-features -- \
+    -Dwarnings
 
   cargo_feature opentelemetry "trace,metrics,logs,spec_unstable_logs_enabled,testing"
 

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -55,3 +55,6 @@ futures-executor = { workspace = true }
 
 [features]
 stats = ["sysinfo"]
+
+[lints]
+workspace = true

--- a/stress/src/metrics_histogram.rs
+++ b/stress/src/metrics_histogram.rs
@@ -57,7 +57,7 @@ fn test_histogram_shared() {
 }
 
 fn test_histogram_per_thread() {
-    HISTOGRAM_PER_THREAD.with(|h| test_histogram(h));
+    HISTOGRAM_PER_THREAD.with(test_histogram);
 }
 
 fn test_histogram(histogram: &Histogram<u64>) {


### PR DESCRIPTION
## Changes

- Rust added in 1.74 (I think 😅) the possibility to configure the lints for a whole workspace in the `Cargo.toml`. Since `prometheus` doesn't belong to the workspace it is handled separately. Now you can easily configure lints for all workspace crates 🍻 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
