### PR TITLE
Calls to `with_resource` for signal builders (Metrics, Logs, Traces) are now additive

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## vNext
 
-- *Breaking* Make `force_flush()` in `PushMetricExporter` synchronous
+- *Breaking*: Calls to `MeterProviderBuilder::with_resource` are now additive ([#2324](https://github.com/open-telemetry/opentelemetry-rust/issues/2324)).
+- *Breaking*: Make `force_flush()` in `PushMetricExporter` synchronous
 
 ## 0.28.0
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- *Breaking*: Calls to `MeterProviderBuilder::with_resource`, `TracerProviderBuilder::with_resource`, 
+- Calls to `MeterProviderBuilder::with_resource`, `TracerProviderBuilder::with_resource`, 
   `LoggerProviderBuilder::with_resource` are now additive ([#2677](https://github.com/open-telemetry/opentelemetry-rust/pull/2677)).
 - *Breaking*: Make `force_flush()` in `PushMetricExporter` synchronous
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## vNext
 
-- *Breaking*: Calls to `MeterProviderBuilder::with_resource` are now additive ([#2324](https://github.com/open-telemetry/opentelemetry-rust/issues/2324)).
+- *Breaking*: Calls to `MeterProviderBuilder::with_resource`, `TracerProviderBuilder::with_resource`, 
+  `LoggerProviderBuilder::with_resource` are now additive ([#2677](https://github.com/open-telemetry/opentelemetry-rust/pull/2677)).
 - *Breaking*: Make `force_flush()` in `PushMetricExporter` synchronous
 
 ## 0.28.0

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -232,10 +232,16 @@ impl MeterProviderBuilder {
     /// with all [Meter]s the [MeterProvider] will create.
     ///
     /// By default, if this option is not used, the default [Resource] will be used.
+    /// Note that the calls to this method are additive, each call merges the provided
+    /// resource with the previous one.
     ///
     /// [Meter]: opentelemetry::metrics::Meter
     pub fn with_resource(mut self, resource: Resource) -> Self {
-        self.resource = Some(resource);
+        self.resource = match self.resource {
+            Some(existing) => Some(existing.merge(&resource)),
+            None => Some(resource),
+        };
+
         self
     }
 
@@ -331,6 +337,7 @@ mod tests {
     use opentelemetry::{global, InstrumentationScope};
     use opentelemetry::{Key, KeyValue, Value};
     use std::env;
+    use crate::metrics::SdkMeterProvider;
 
     #[test]
     fn test_meter_provider_resource() {
@@ -552,5 +559,21 @@ mod tests {
         let _meter8 = provider.meter_with_scope(make_scope("abc"));
 
         assert_eq!(provider.inner.meters.lock().unwrap().len(), 5);
+    }
+
+    #[test]
+    fn with_resource_multiple_calls_ensure_additive() {
+        let builder = SdkMeterProvider::builder()
+            .with_resource(Resource::new(vec![KeyValue::new("key1", "value1")]))
+            .with_resource(Resource::new(vec![KeyValue::new("key2", "value2")]))
+            .with_resource(Resource::builder_empty().with_schema_url(vec![], "http://example.com").build())
+            .with_resource(Resource::new(vec![KeyValue::new("key3", "value3")]));
+
+        let resource = builder.resource.unwrap();
+
+        assert_eq!(resource.get(&Key::from_static_str("key1")), Some(Value::from("value1")));
+        assert_eq!(resource.get(&Key::from_static_str("key2")), Some(Value::from("value2")));
+        assert_eq!(resource.get(&Key::from_static_str("key3")), Some(Value::from("value3")));
+        assert_eq!(resource.schema_url(), Some("http://example.com"));
     }
 }

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -328,6 +328,7 @@ impl fmt::Debug for MeterProviderBuilder {
 #[cfg(all(test, feature = "testing"))]
 mod tests {
     use crate::error::OTelSdkError;
+    use crate::metrics::SdkMeterProvider;
     use crate::resource::{
         SERVICE_NAME, TELEMETRY_SDK_LANGUAGE, TELEMETRY_SDK_NAME, TELEMETRY_SDK_VERSION,
     };
@@ -337,7 +338,6 @@ mod tests {
     use opentelemetry::{global, InstrumentationScope};
     use opentelemetry::{Key, KeyValue, Value};
     use std::env;
-    use crate::metrics::SdkMeterProvider;
 
     #[test]
     fn test_meter_provider_resource() {
@@ -566,14 +566,27 @@ mod tests {
         let builder = SdkMeterProvider::builder()
             .with_resource(Resource::new(vec![KeyValue::new("key1", "value1")]))
             .with_resource(Resource::new(vec![KeyValue::new("key2", "value2")]))
-            .with_resource(Resource::builder_empty().with_schema_url(vec![], "http://example.com").build())
+            .with_resource(
+                Resource::builder_empty()
+                    .with_schema_url(vec![], "http://example.com")
+                    .build(),
+            )
             .with_resource(Resource::new(vec![KeyValue::new("key3", "value3")]));
 
         let resource = builder.resource.unwrap();
 
-        assert_eq!(resource.get(&Key::from_static_str("key1")), Some(Value::from("value1")));
-        assert_eq!(resource.get(&Key::from_static_str("key2")), Some(Value::from("value2")));
-        assert_eq!(resource.get(&Key::from_static_str("key3")), Some(Value::from("value3")));
+        assert_eq!(
+            resource.get(&Key::from_static_str("key1")),
+            Some(Value::from("value1"))
+        );
+        assert_eq!(
+            resource.get(&Key::from_static_str("key2")),
+            Some(Value::from("value2"))
+        );
+        assert_eq!(
+            resource.get(&Key::from_static_str("key3")),
+            Some(Value::from("value3"))
+        );
         assert_eq!(resource.schema_url(), Some("http://example.com"));
     }
 }

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -232,7 +232,8 @@ impl MeterProviderBuilder {
     /// with all [Meter]s the [MeterProvider] will create.
     ///
     /// By default, if this option is not used, the default [Resource] will be used.
-    /// Note that the calls to this method are additive, each call merges the provided
+    ///
+    /// *Note*: Calls to this method are additive, each call merges the provided
     /// resource with the previous one.
     ///
     /// [Meter]: opentelemetry::metrics::Meter

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -754,9 +754,9 @@ mod tests {
             .with_resource(Resource::new(vec![KeyValue::new("key3", "value3")]))
             .build()
             .inner
-            .config
-            .resource
-            .to_owned();
+            .config.resource
+            .clone()
+            .into_owned();
 
         assert_eq!(
             resource.get(&Key::from_static_str("key1")),

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -754,7 +754,8 @@ mod tests {
             .with_resource(Resource::new(vec![KeyValue::new("key3", "value3")]))
             .build()
             .inner
-            .config.resource
+            .config
+            .resource
             .clone()
             .into_owned();
 

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -293,6 +293,7 @@ impl opentelemetry::trace::TracerProvider for SdkTracerProvider {
 pub struct TracerProviderBuilder {
     processors: Vec<Box<dyn SpanProcessor>>,
     config: crate::trace::Config,
+    resource: Option<Resource>,
 }
 
 impl TracerProviderBuilder {
@@ -410,17 +411,27 @@ impl TracerProviderBuilder {
     ///
     /// By default, if this option is not used, the default [Resource] will be used.
     ///
+    /// *Note*: Calls to this method are additive, each call merges the provided
+    /// resource with the previous one.
+    ///
     /// [Tracer]: opentelemetry::trace::Tracer
     pub fn with_resource(self, resource: Resource) -> Self {
-        TracerProviderBuilder {
-            config: self.config.with_resource(resource),
-            ..self
-        }
+        let resource = match self.resource {
+            Some(existing) => Some(existing.merge(&resource)),
+            None => Some(resource),
+        };
+
+        TracerProviderBuilder { resource, ..self }
     }
 
     /// Create a new provider from this configuration.
     pub fn build(self) -> SdkTracerProvider {
         let mut config = self.config;
+
+        // Now, we can update the config with the resource.
+        if let Some(resource) = self.resource {
+            config = config.with_resource(resource);
+        };
 
         // Standard config will contain an owned [`Resource`] (either sdk default or use supplied)
         // we can optimize the common case with a static ref to avoid cloning the underlying
@@ -462,8 +473,8 @@ mod tests {
         SERVICE_NAME, TELEMETRY_SDK_LANGUAGE, TELEMETRY_SDK_NAME, TELEMETRY_SDK_VERSION,
     };
     use crate::trace::provider::TracerProviderInner;
-    use crate::trace::SpanData;
     use crate::trace::{Config, Span, SpanProcessor};
+    use crate::trace::{SdkTracerProvider, SpanData};
     use crate::Resource;
     use opentelemetry::trace::{Tracer, TracerProvider};
     use opentelemetry::{Context, Key, KeyValue, Value};
@@ -728,6 +739,38 @@ mod tests {
 
         // also existing tracer's tracer provider are in shutdown state
         assert!(test_tracer_1.provider().is_shutdown());
+    }
+
+    #[test]
+    fn with_resource_multiple_calls_ensure_additive() {
+        let resource = SdkTracerProvider::builder()
+            .with_resource(Resource::new(vec![KeyValue::new("key1", "value1")]))
+            .with_resource(Resource::new(vec![KeyValue::new("key2", "value2")]))
+            .with_resource(
+                Resource::builder_empty()
+                    .with_schema_url(vec![], "http://example.com")
+                    .build(),
+            )
+            .with_resource(Resource::new(vec![KeyValue::new("key3", "value3")]))
+            .build()
+            .inner
+            .config
+            .resource
+            .to_owned();
+
+        assert_eq!(
+            resource.get(&Key::from_static_str("key1")),
+            Some(Value::from("value1"))
+        );
+        assert_eq!(
+            resource.get(&Key::from_static_str("key2")),
+            Some(Value::from("value2"))
+        );
+        assert_eq!(
+            resource.get(&Key::from_static_str("key3")),
+            Some(Value::from("value3"))
+        );
+        assert_eq!(resource.schema_url(), Some("http://example.com"));
     }
 
     #[derive(Debug)]


### PR DESCRIPTION
Fixes #2324

## Changes

The calls to:

- `MeterProviderBuilder::with_resource`
- `TracerProviderBuilder::with_resource`
- `LoggerProviderBuilder::with_resource`

Are now additive and the previous resource is not discarded anymore. Additionally, I fixed a bug where setting the `schema_url` was discarded due to a bug how merging of resources was handled.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
