### PR TITLE
Add Scott Gerring as an Approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ you're more than welcome to participate!
 ### Approvers
 
 * [Shaun Cox](https://github.com/shaun-cox)
+* [Scott Gerring](https://github.com/scottgerring)
 
 ### Emeritus
 


### PR DESCRIPTION
I'd like to nominate @scottgerring as an Approver for the project. He has been helping with reviews/contributions for the last 2-3 months, and has expressed willingness to continue to help drive the project forward.

https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#requirements-2
The "_at least 10 substantial PRs_" **is not met**, (?) largely due to others (including me) taking over implementing the PRs, after Scott helped drive design consensus. Happy to discuss more if there are concerns about not strictly meeting the "10 PR requirement.".