### PR TITLE
Remove `mut` self reference from SpanExporter::export() method.

### DIFF
--- a/opentelemetry-otlp/src/exporter/http/trace.rs
+++ b/opentelemetry-otlp/src/exporter/http/trace.rs
@@ -9,7 +9,7 @@ use opentelemetry_sdk::{
 };
 
 impl SpanExporter for OtlpHttpClient {
-    async fn export(&mut self, batch: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
         let client = match self
             .client
             .lock()

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -141,8 +141,8 @@ impl SpanExporter {
 }
 
 impl opentelemetry_sdk::trace::SpanExporter for SpanExporter {
-    async fn export(&mut self, batch: Vec<SpanData>) -> OTelSdkResult {
-        match &mut self.client {
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        match &self.client {
             #[cfg(feature = "grpc-tonic")]
             SupportedTransportClient::Tonic(client) => client.export(batch).await,
             #[cfg(any(feature = "http-proto", feature = "http-json"))]

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -11,13 +11,11 @@
 - **Breaking** The SpanExporter::export() method no longer requires a mutable reference to self.
   Before: 
   ```rust
-    async fn export(&mut self, _batch: LogBatch<'_>)
-     -> LogResult<()>` 
+    async fn export(&mut self, batch: Vec<SpanData>) -> OTelSdkResult 
   ```
   After: 
   ```rust 
-  async fn export(&self, _batch: LogBatch<'_>) ->
-  LogResult<()>` 
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult  
   ```
   Custom exporters will need to internally synchronize any mutable state, if applicable.
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -8,6 +8,18 @@
 - Moved `ExportError` trait from `opentelemetry::trace::ExportError` to `opentelemetry_sdk::export::ExportError`
 - Moved `TraceError` enum from `opentelemetry::trace::TraceError` to `opentelemetry_sdk::trace::TraceError`
 - Moved `TraceResult` type alias from `opentelemetry::trace::TraceResult` to `opentelemetry_sdk::trace::TraceResult`
+- **Breaking** The SpanExporter::export() method no longer requires a mutable reference to self.
+  Before: 
+  ```rust
+    async fn export(&mut self, _batch: LogBatch<'_>)
+     -> LogResult<()>` 
+  ```
+  After: 
+  ```rust 
+  async fn export(&self, _batch: LogBatch<'_>) ->
+  LogResult<()>` 
+  ```
+  Custom exporters will need to internally synchronize any mutable state, if applicable.
 
 ## 0.28.0
 

--- a/opentelemetry-sdk/benches/context.rs
+++ b/opentelemetry-sdk/benches/context.rs
@@ -136,7 +136,7 @@ fn parent_sampled_tracer(inner_sampler: Sampler) -> (SdkTracerProvider, BoxedTra
 struct NoopExporter;
 
 impl SpanExporter for NoopExporter {
-    async fn export(&mut self, _spans: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, _spans: Vec<SpanData>) -> OTelSdkResult {
         Ok(())
     }
 }

--- a/opentelemetry-sdk/benches/span_builder.rs
+++ b/opentelemetry-sdk/benches/span_builder.rs
@@ -65,7 +65,7 @@ fn not_sampled_provider() -> (sdktrace::SdkTracerProvider, sdktrace::SdkTracer) 
 struct NoopExporter;
 
 impl SpanExporter for NoopExporter {
-    async fn export(&mut self, _spans: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, _spans: Vec<SpanData>) -> OTelSdkResult {
         Ok(())
     }
 }

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -59,7 +59,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 struct VoidExporter;
 
 impl SpanExporter for VoidExporter {
-    async fn export(&mut self, _spans: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, _spans: Vec<SpanData>) -> OTelSdkResult {
         Ok(())
     }
 }

--- a/opentelemetry-sdk/src/testing/trace/span_exporters.rs
+++ b/opentelemetry-sdk/src/testing/trace/span_exporters.rs
@@ -41,7 +41,7 @@ pub struct TokioSpanExporter {
 }
 
 impl SpanExporter for TokioSpanExporter {
-    async fn export(&mut self, batch: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
         batch.into_iter().try_for_each(|span_data| {
             self.tx_export
                 .send(span_data)
@@ -110,7 +110,7 @@ impl NoopSpanExporter {
 }
 
 impl SpanExporter for NoopSpanExporter {
-    async fn export(&mut self, _: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, _: Vec<SpanData>) -> OTelSdkResult {
         Ok(())
     }
 }

--- a/opentelemetry-sdk/src/trace/export.rs
+++ b/opentelemetry-sdk/src/trace/export.rs
@@ -28,7 +28,7 @@ pub trait SpanExporter: Send + Sync + Debug {
     /// Any retry logic that is required by the exporter is the responsibility
     /// of the exporter.
     fn export(
-        &mut self,
+        &self,
         batch: Vec<SpanData>,
     ) -> impl std::future::Future<Output = OTelSdkResult> + Send;
 

--- a/opentelemetry-sdk/src/trace/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/trace/in_memory_exporter.rs
@@ -130,7 +130,7 @@ impl InMemorySpanExporter {
 }
 
 impl SpanExporter for InMemorySpanExporter {
-    async fn export(&mut self, batch: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
         let result = self
             .spans
             .lock()

--- a/opentelemetry-sdk/src/trace/runtime_tests.rs
+++ b/opentelemetry-sdk/src/trace/runtime_tests.rs
@@ -25,7 +25,7 @@ struct SpanCountExporter {
 
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
 impl SpanExporter for SpanCountExporter {
-    async fn export(&mut self, batch: Vec<crate::trace::SpanData>) -> OTelSdkResult {
+    async fn export(&self, batch: Vec<crate::trace::SpanData>) -> OTelSdkResult {
         self.span_count.fetch_add(batch.len(), Ordering::SeqCst);
         Ok(())
     }

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -139,7 +139,7 @@ impl<T: SpanExporter> SpanProcessor for SimpleSpanProcessor<T> {
             .exporter
             .lock()
             .map_err(|_| OTelSdkError::InternalFailure("SimpleSpanProcessor mutex poison".into()))
-            .and_then(|mut exporter| futures_executor::block_on(exporter.export(vec![span])));
+            .and_then(|exporter| futures_executor::block_on(exporter.export(vec![span])));
 
         if let Err(err) = result {
             // TODO: check error type, and log `error` only if the error is user-actionable, else log `debug`
@@ -1034,7 +1034,7 @@ mod tests {
     }
 
     impl SpanExporter for MockSpanExporter {
-        async fn export(&mut self, batch: Vec<SpanData>) -> OTelSdkResult {
+        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
             let exported_spans = self.exported_spans.clone();
             exported_spans.lock().unwrap().extend(batch);
             Ok(())

--- a/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
@@ -457,7 +457,7 @@ mod tests {
         D: Fn(Duration) -> DS + 'static + Send + Sync,
         DS: Future<Output = ()> + Send + Sync + 'static,
     {
-        async fn export(&mut self, _batch: Vec<SpanData>) -> OTelSdkResult {
+        async fn export(&self, _batch: Vec<SpanData>) -> OTelSdkResult {
             (self.delay_fn)(self.delay_for).await;
             Ok(())
         }

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -126,7 +126,7 @@ async fn zipkin_export(
 
 impl trace::SpanExporter for ZipkinExporter {
     /// Export spans to Zipkin collector.
-    async fn export(&mut self, batch: Vec<trace::SpanData>) -> OTelSdkResult {
+    async fn export(&self, batch: Vec<trace::SpanData>) -> OTelSdkResult {
         zipkin_export(batch, self.uploader.clone(), self.local_endpoint.clone()).await
     }
 }


### PR DESCRIPTION
## Changes

To make it consistent with `LogExporter` as done in #2380. This doesn't affect OTLP exporters, as their export are stateless.  If exporter need to modify its internal state during export process (e.g. batching etc.), it should rely on the interior mutability.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
