### PR TITLE
Fix `.with_headers` to support multiple k/v pairs

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - The `OTEL_EXPORTER_OTLP_TIMEOUT`, `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`, `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` and `OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` are changed from seconds to miliseconds.
+- Fixed `.with_headers()` in `HttpExporterBuilder` to correctly support multiple key/value pairs. [#2699](https://github.com/open-telemetry/opentelemetry-rust/pull/2699)
 
 ## 0.28.0
 
@@ -41,7 +42,7 @@ Released 2024-Nov-11
 - Update `opentelemetry-http` dependency version to 0.27
 - Update `opentelemetry-proto` dependency version to 0.27
 
-- **BREAKING**: 
+- **BREAKING**:
   - ([#2217](https://github.com/open-telemetry/opentelemetry-rust/pull/2217)) **Replaced**: The `MetricsExporterBuilder` interface is modified from `with_temporality_selector` to `with_temporality` example can be seen below:
     Previous Signature:
     ```rust
@@ -88,9 +89,9 @@ Released 2024-Nov-11
       - `MetricsExporterBuilder` -> `MetricExporterBuilder`
 
   - [#2263](https://github.com/open-telemetry/opentelemetry-rust/pull/2263)
-  Support `hyper` client for opentelemetry-otlp. This can be enabled using flag `hyper-client`. 
+  Support `hyper` client for opentelemetry-otlp. This can be enabled using flag `hyper-client`.
   Refer example: https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp/examples/basic-otlp-http
-  
+
 ## v0.26.0
 Released 2024-Sep-30
 

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -675,7 +675,10 @@ mod tests {
         use std::collections::HashMap;
         // Arrange
         let initial_headers = HashMap::from([("k1".to_string(), "v1".to_string())]);
-        let extra_headers = HashMap::from([("k2".to_string(), "v2".to_string())]);
+        let extra_headers = HashMap::from([
+            ("k2".to_string(), "v2".to_string()),
+            ("k3".to_string(), "v3".to_string()),
+        ]);
         let expected_headers = initial_headers.iter().chain(extra_headers.iter()).fold(
             HashMap::new(),
             |mut acc, (k, v)| {

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -449,13 +449,13 @@ impl<B: HasHttpConfig> WithHttpConfig for B {
 
     fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         // headers will be wrapped, so we must do some logic to unwrap first.
-        self.http_client_config()
+        let http_client_headers = self
+            .http_client_config()
             .headers
-            .iter_mut()
-            .zip(headers)
-            .for_each(|(http_client_headers, (key, value))| {
-                http_client_headers.insert(key, super::url_decode(&value).unwrap_or(value));
-            });
+            .get_or_insert(HashMap::new());
+        headers.into_iter().for_each(|(key, value)| {
+            http_client_headers.insert(key, super::url_decode(&value).unwrap_or(value));
+        });
         self
     }
 }

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -671,7 +671,7 @@ mod tests {
     }
 
     #[test]
-    fn test_http_exporter_builder_with_header() {
+    fn test_http_exporter_builder_with_headers() {
         use std::collections::HashMap;
         // Arrange
         let initial_headers = HashMap::from([("k1".to_string(), "v1".to_string())]);


### PR DESCRIPTION
## Changes

Currently, `.with_headers` doesn't work consistently when passing in multiple k/v pairs. For instance, something like this only adds one of the headers:

```rust
HttpExporterBuilder::default()
    .with_headers(HashMap::from([
        ("k1".to_string(), "v1".to_string()),
        ("k2".to_string(), "v2".to_string()),
    ]))
```

This is quite surprising -- only one header is actually accepted, and it's a random choice. The others are lost. To work around this with the existing code, add one k/v at a time like this:

```rust
HttpExporterBuilder::default()
    .with_headers(HashMap::from([("k1".to_string(), "v1".to_string())]))
    .with_headers(HashMap::from([("k2".to_string(), "v2".to_string())]));
```

I've updated the tests to cover the surprising scenario, and adjusted the logic to support multiple k/v pairs.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
