### PR TITLE
InstrumentationScope to include attributes in hash and eq check

### DIFF
--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -563,6 +563,25 @@ mod tests {
     }
 
     #[test]
+    fn same_meter_reused_same_scope_attributes() {
+        let meter_provider = super::SdkMeterProvider::builder().build();
+        let make_scope = |attributes| {
+            InstrumentationScope::builder("test.meter")
+                .with_version("v0.1.0")
+                .with_schema_url("http://example.com")
+                .with_attributes(attributes)
+                .build()
+        };
+
+        let _meter1 =
+            meter_provider.meter_with_scope(make_scope(vec![KeyValue::new("key", "value1")]));
+        let _meter2 =
+            meter_provider.meter_with_scope(make_scope(vec![KeyValue::new("key", "value1")]));
+
+        assert_eq!(meter_provider.inner.meters.lock().unwrap().len(), 1);
+    }
+
+    #[test]
     fn with_resource_multiple_calls_ensure_additive() {
         let builder = SdkMeterProvider::builder()
             .with_resource(Resource::new(vec![KeyValue::new("key1", "value1")]))

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -782,7 +782,7 @@ mod tests {
             .build();
 
         // Act
-        // Meters are identical except for scope attributes, but scope attributes are not an identifying property.
+        // Meters are identical.
         // Hence there should be a single metric stream output for this test.
         let make_scope = |attributes| {
             InstrumentationScope::builder("test.meter")
@@ -795,7 +795,7 @@ mod tests {
         let meter1 =
             meter_provider.meter_with_scope(make_scope(vec![KeyValue::new("key", "value1")]));
         let meter2 =
-            meter_provider.meter_with_scope(make_scope(vec![KeyValue::new("key", "value2")]));
+            meter_provider.meter_with_scope(make_scope(vec![KeyValue::new("key", "value1")]));
 
         let counter1 = meter1
             .u64_counter("my_counter")

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -6,6 +6,7 @@
 - *Breaking* Moved `TraceError` enum from `opentelemetry::trace::TraceError` to `opentelemetry_sdk::trace::TraceError`
 - *Breaking* Moved `TraceResult` type alias from `opentelemetry::trace::TraceResult` to `opentelemetry_sdk::trace::TraceResult`
 - {PLACEHOLDER} - Remove the above completely. // TODO fill this when changes are actually in.
+- Bug Fix: `InstrumentationScope` implementation for `PartialEq` and `Hash` fixed to include Attributes also.
 
 ## 0.28.0
 

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -1,13 +1,10 @@
 //! # OpenTelemetry Metrics API
 
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 mod instruments;
 mod meter;
 pub(crate) mod noop;
-
-use crate::{Array, KeyValue, Value};
 pub use instruments::{
     counter::{Counter, ObservableCounter},
     gauge::{Gauge, ObservableGauge},
@@ -17,42 +14,6 @@ pub use instruments::{
     SyncInstrument,
 };
 pub use meter::{Meter, MeterProvider};
-
-struct F64Hashable(f64);
-
-impl PartialEq for F64Hashable {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.to_bits() == other.0.to_bits()
-    }
-}
-
-impl Eq for F64Hashable {}
-
-impl Hash for F64Hashable {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.to_bits().hash(state);
-    }
-}
-
-impl Hash for KeyValue {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.key.hash(state);
-        match &self.value {
-            Value::F64(f) => F64Hashable(*f).hash(state),
-            Value::Array(a) => match a {
-                Array::Bool(b) => b.hash(state),
-                Array::I64(i) => i.hash(state),
-                Array::F64(f) => f.iter().for_each(|f| F64Hashable(*f).hash(state)),
-                Array::String(s) => s.hash(state),
-            },
-            Value::Bool(b) => b.hash(state),
-            Value::I64(i) => i.hash(state),
-            Value::String(s) => s.hash(state),
-        };
-    }
-}
-
-impl Eq for KeyValue {}
 
 /// SDK implemented trait for creating instruments
 pub trait InstrumentProvider {
@@ -161,82 +122,5 @@ pub trait InstrumentProvider {
     /// creates an instrument for recording a distribution of values.
     fn u64_histogram(&self, _builder: HistogramBuilder<'_, Histogram<u64>>) -> Histogram<u64> {
         Histogram::new(Arc::new(noop::NoopSyncInstrument::new()))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use rand::random;
-
-    use crate::KeyValue;
-    use std::collections::hash_map::DefaultHasher;
-    use std::f64;
-    use std::hash::{Hash, Hasher};
-
-    #[test]
-    fn kv_float_equality() {
-        let kv1 = KeyValue::new("key", 1.0);
-        let kv2 = KeyValue::new("key", 1.0);
-        assert_eq!(kv1, kv2);
-
-        let kv1 = KeyValue::new("key", 1.0);
-        let kv2 = KeyValue::new("key", 1.01);
-        assert_ne!(kv1, kv2);
-
-        let kv1 = KeyValue::new("key", f64::NAN);
-        let kv2 = KeyValue::new("key", f64::NAN);
-        assert_ne!(kv1, kv2, "NAN is not equal to itself");
-
-        for float_val in [
-            f64::INFINITY,
-            f64::NEG_INFINITY,
-            f64::MAX,
-            f64::MIN,
-            f64::MIN_POSITIVE,
-        ]
-        .iter()
-        {
-            let kv1 = KeyValue::new("key", *float_val);
-            let kv2 = KeyValue::new("key", *float_val);
-            assert_eq!(kv1, kv2);
-        }
-
-        for _ in 0..100 {
-            let random_value = random::<f64>();
-            let kv1 = KeyValue::new("key", random_value);
-            let kv2 = KeyValue::new("key", random_value);
-            assert_eq!(kv1, kv2);
-        }
-    }
-
-    #[test]
-    fn kv_float_hash() {
-        for float_val in [
-            f64::NAN,
-            f64::INFINITY,
-            f64::NEG_INFINITY,
-            f64::MAX,
-            f64::MIN,
-            f64::MIN_POSITIVE,
-        ]
-        .iter()
-        {
-            let kv1 = KeyValue::new("key", *float_val);
-            let kv2 = KeyValue::new("key", *float_val);
-            assert_eq!(hash_helper(&kv1), hash_helper(&kv2));
-        }
-
-        for _ in 0..100 {
-            let random_value = random::<f64>();
-            let kv1 = KeyValue::new("key", random_value);
-            let kv2 = KeyValue::new("key", random_value);
-            assert_eq!(hash_helper(&kv1), hash_helper(&kv2));
-        }
-    }
-
-    fn hash_helper<T: Hash>(item: &T) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        item.hash(&mut hasher);
-        hasher.finish()
     }
 }


### PR DESCRIPTION
Fixes #2225

For Metrics this affects aggregation (SDK), as now different Meter is returned for scope with different attributes.
Logs,Traces do not store Logger/Tracers, so this requires no change in SDKs.