### PR TITLE
chore: Prevent libtest being added to bench builds

### DIFF
--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -44,5 +44,8 @@ name = "logs"
 harness = false
 required-features = ["spec_unstable_logs_enabled"]
 
+[lib]
+bench = false
+
 [lints]
 workspace = true

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -108,5 +108,8 @@ name = "log"
 harness = false
 required-features = ["logs"]
 
+[lib]
+bench = false
+
 [lints]
 workspace = true

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -57,5 +57,8 @@ harness = false
 name = "anyvalue"
 harness = false
 
+[lib]
+bench = false
+
 [lints]
 workspace = true


### PR DESCRIPTION
## Changes

This change sets us up to be able to run criterion performance regressions as part of the CI suite, annotating the PR with the results. As we've invested time into doing the performance tests, it would be great to be able to use them to monitor performance changes, and this is a relatively simple job. 

I reckon this will also be helpful in the context of #2378 , where @bantonsson has spent some time demonstrating this his new Context impl is faster than the previous. 

The change is split into two:

* #2705 - support running criterion with baseline across the crates that contain benches
* #2706 - introduce the criterion github workflow

You can see what this looks like in action over in the faked up PR => https://github.com/scotts-test-organization/opentelemetry-rust/pull/1

Without the first PR, the second PRs workflow will not succeed.

## Details 

To run criterion with additional CLI arguments across an entire crate at once - not just `--bench my_bench` - we need to stop `libtest` being added to the targets of the crates that contain benches. This is discussed in the [criterion FAQ](https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options).

This change allows you to run the following for each of the crates we publish with 

```bash
# From opentelemetry
 cargo bench -- --save-baseline abc

# From opentelemetry-appender-tracing
cargo bench --features spec_unstable_logs_enabled -- --save-baseline abc

# From opentelemetry-sdk
 cargo bench --features rt-tokio,testing,metrics,logs,spec_unstable_metrics_views -- --save-baseline abc
```


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
