### PR TITLE
docs: Fix tracing grpc example

### DIFF
--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -19,7 +19,7 @@ opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["rt-tokio"] 
 opentelemetry-stdout = { workspace = true, features = ["trace"] }
 prost = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tonic = { workspace = true, features = ["server"] }
+tonic = { workspace = true, features = ["server", "codegen", "channel", "prost"] }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/examples/tracing-grpc/src/client.rs
+++ b/examples/tracing-grpc/src/client.rs
@@ -13,7 +13,7 @@ fn init_tracer() -> sdktrace::SdkTracerProvider {
     global::set_text_map_propagator(TraceContextPropagator::new());
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     let provider = sdktrace::SdkTracerProvider::builder()
-        .with_batch_exporter(SpanExporter::default())
+        .with_simple_exporter(SpanExporter::default())
         .build();
 
     global::set_tracer_provider(provider.clone());
@@ -43,10 +43,14 @@ async fn greet() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static
     let span = tracer
         .span_builder("Greeter/client")
         .with_kind(SpanKind::Client)
-        .with_attributes([KeyValue::new("component", "grpc")])
+        .with_attributes([
+            KeyValue::new("rpc.system", "grpc"),
+            KeyValue::new("server.port", 50052),
+            KeyValue::new("rpc.method", "say_hello"),
+        ])
         .start(&tracer);
     let cx = Context::current_with_span(span);
-    let mut client = GreeterClient::connect("http://[::1]:50051").await?;
+    let mut client = GreeterClient::connect("http://[::1]:50052").await?;
 
     let mut request = tonic::Request::new(HelloRequest {
         name: "Tonic".into(),
@@ -58,16 +62,23 @@ async fn greet() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static
 
     let response = client.say_hello(request).await;
 
+    let span = cx.span();
     let status = match response {
-        Ok(_res) => "OK".to_string(),
+        Ok(_res) => {
+            span.set_attribute(KeyValue::new("response", "OK"));
+            "OK".to_string()
+        }
         Err(status) => {
             // Access the status code
             let status_code = status.code();
+            span.set_attribute(KeyValue::new(
+                "response_code_desc",
+                status_code.description(),
+            ));
             status_code.to_string()
         }
     };
-    cx.span()
-        .add_event("Got response!", vec![KeyValue::new("status", status)]);
+    span.add_event("Got response!", vec![KeyValue::new("status", status)]);
 
     Ok(())
 }


### PR DESCRIPTION
This example was not building as required features were not enabled.
Also modified provider to use SimpleExporter, consistent with rest of examples to immediately see spans printed to console.
changed port from 50051 to 50052, as 50051 is what most tutorials showcase and hence likely to clash port.
Nit additions to span attributes. Eventually we need this to match the OTel conventions, but not this PR.