### PR TITLE
ci: Run perf tests on demand

### DIFF
--- a/.github/workflows/pr_criterion.yaml
+++ b/.github/workflows/pr_criterion.yaml
@@ -6,6 +6,7 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
     steps:
       - uses: actions/checkout@v3
       - uses: arduino/setup-protoc@v3


### PR DESCRIPTION
It's taking a lot of time (60 mins of near full CPU usage!) and burning unnecessary resources (paid by CNCF) to run performance tests on every commit. So making it run on demand only.