### PR TITLE
test : Add test to confirm Context expected behavior

### DIFF
--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -386,6 +386,43 @@ mod tests {
     use super::*;
 
     #[test]
+    fn context_immutable() {
+        #[derive(Debug, PartialEq)]
+        struct ValueA(u64);
+        #[derive(Debug, PartialEq)]
+        struct ValueB(u64);
+
+        // start with Current, which should be an empty context
+        let cx = Context::current();
+        assert_eq!(cx.get::<ValueA>(), None);
+        assert_eq!(cx.get::<ValueB>(), None);
+
+        // with_value should return a new context,
+        // leaving the original context unchanged
+        let cx_new = cx.with_value(ValueA(1));
+
+        // cx should be unchanged
+        assert_eq!(cx.get::<ValueA>(), None);
+        assert_eq!(cx.get::<ValueB>(), None);
+
+        // cx_new should contain the new value
+        assert_eq!(cx_new.get::<ValueA>(), Some(&ValueA(1)));
+
+        // cx_new should be unchanged
+        let cx_newer = cx_new.with_value(ValueB(1));
+
+        // Cx and cx_new are unchanged
+        assert_eq!(cx.get::<ValueA>(), None);
+        assert_eq!(cx.get::<ValueB>(), None);
+        assert_eq!(cx_new.get::<ValueA>(), Some(&ValueA(1)));
+        assert_eq!(cx_new.get::<ValueB>(), None);
+
+        // cx_newer should contain both values
+        assert_eq!(cx_newer.get::<ValueA>(), Some(&ValueA(1)));
+        assert_eq!(cx_newer.get::<ValueB>(), Some(&ValueB(1)));
+    }
+
+    #[test]
     fn nested_contexts() {
         #[derive(Debug, PartialEq)]
         struct ValueA(&'static str);


### PR DESCRIPTION
To assist reviewing https://github.com/open-telemetry/opentelemetry-rust/pull/2378/files I wrote some tests, which left me wondering with a unresolved question.

Context MUST be immutable, so adding value to context (with_value), should result in a *new* Context, leaving original untouched. A test for this is added and works as expected.
Then I tried this with Spans - Created an empty context, and added a Span to the Context. When I add another random value to that Context, it is cloning the random value, but the Span is stored via Arc, so clone is just pointing to the original span. Updates made to span from the new context updates the original span.
Not sure if this is the intended behavior, opening to discuss.

Edit: The expectation is Context itself is immutable, but the Span inside is mutable. Tests modified to assert this.