### PR TITLE
chore: enable Rust 2024 edition lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,5 +85,12 @@ opentelemetry = { path = "opentelemetry" }
 opentelemetry_sdk = { path = "opentelemetry-sdk" }
 opentelemetry-stdout = { path = "opentelemetry-stdout" }
 
+[workspace.lints.rust]
+rust_2024_compatibility = { level = "warn", priority = -1 }
+# No need to enable those, because it either not needed or results in ugly syntax
+edition_2024_expr_fragment_specifier = "allow"
+if_let_rescope = "allow"
+tail_expr_drop_order = "allow"
+
 [workspace.lints.clippy]
 all = { level = "warn", priority = 1 }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -245,6 +245,7 @@ mod tests {
             .any(|(k, v)| k == key && v == value)
     }
 
+    #[allow(impl_trait_overcaptures)] // can only be fixed with Rust 1.82+
     fn create_tracing_subscriber(
         _exporter: InMemoryLogExporter,
         logger_provider: &SdkLoggerProvider,

--- a/opentelemetry-sdk/src/trace/id_generator/mod.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/mod.rs
@@ -22,11 +22,11 @@ pub struct RandomIdGenerator {
 
 impl IdGenerator for RandomIdGenerator {
     fn new_trace_id(&self) -> TraceId {
-        CURRENT_RNG.with(|rng| TraceId::from(rng.borrow_mut().gen::<u128>()))
+        CURRENT_RNG.with(|rng| TraceId::from(rng.borrow_mut().random::<u128>()))
     }
 
     fn new_span_id(&self) -> SpanId {
-        CURRENT_RNG.with(|rng| SpanId::from(rng.borrow_mut().gen::<u64>()))
+        CURRENT_RNG.with(|rng| SpanId::from(rng.borrow_mut().random::<u64>()))
     }
 }
 

--- a/stress/src/throughput.rs
+++ b/stress/src/throughput.rs
@@ -155,7 +155,7 @@ impl<'a> UnsafeSlice<'a> {
     #[inline(always)]
     unsafe fn increment(&self, i: usize) {
         let value = self.slice[i].get();
-        (*value).count += 1;
+        unsafe { (*value).count += 1 };
     }
 
     #[inline(always)]


### PR DESCRIPTION
## Changes

- I believe there is no need to enable the 3 lints, I tested out the code and it worked well with edition 2024

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
