### PR TITLE
fix: align baggage.remove() implementation

### DIFF
--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -8,6 +8,7 @@
 - {PLACEHOLDER} - Remove the above completely. // TODO fill this when changes are actually in.
 - Bug Fix: `InstrumentationScope` implementation for `PartialEq` and `Hash` fixed to include Attributes also.
 - *Breaking* Changed value type of `Baggage` from `Value` to `StringValue`
+- *Breaking* Align `Baggage.remove()` signature with `.get()` to take the key as a reference
 
 ## 0.28.0
 

--- a/opentelemetry/src/baggage.rs
+++ b/opentelemetry/src/baggage.rs
@@ -622,11 +622,11 @@ mod tests {
         assert_eq!(baggage.len(), 1);
 
         // get
-        assert_eq!(baggage.get("foo"), Some(&Value::from("1")));
+        assert_eq!(baggage.get("foo"), Some(&StringValue::from("1")));
 
         // update
         baggage.insert("foo", "2");
-        assert_eq!(baggage.get("foo"), Some(&Value::from("2")));
+        assert_eq!(baggage.get("foo"), Some(&StringValue::from("2")));
 
         // delete
         baggage.remove("foo");

--- a/opentelemetry/src/baggage.rs
+++ b/opentelemetry/src/baggage.rs
@@ -161,8 +161,8 @@ impl Baggage {
 
     /// Removes a name from the baggage, returning the value
     /// corresponding to the name if the pair was previously in the map.
-    pub fn remove<K: Into<Key>>(&mut self, key: K) -> Option<(Value, BaggageMetadata)> {
-        self.inner.remove(&key.into())
+    pub fn remove<K: AsRef<str>>(&mut self, key: K) -> Option<(Value, BaggageMetadata)> {
+        self.inner.remove(key.as_ref())
     }
 
     /// Returns the number of attributes for this baggage
@@ -607,5 +607,26 @@ mod tests {
         b.insert_with_metadata("bar", StringValue::from("2"), "yellow");
         assert!(b.to_string().contains("bar=2;yellow"));
         assert!(b.to_string().contains("foo=1;red;state=on"));
+    }
+
+    #[test]
+    fn test_crud_operations() {
+        let mut baggage = Baggage::default();
+        assert!(baggage.is_empty());
+
+        // create
+        baggage.insert("foo", "1");
+        assert_eq!(baggage.len(), 1);
+
+        // get
+        assert_eq!(baggage.get("foo"), Some(&Value::from("1")));
+
+        // update
+        baggage.insert("foo", "2");
+        assert_eq!(baggage.get("foo"), Some(&Value::from("2")));
+
+        // delete
+        baggage.remove("foo");
+        assert!(baggage.is_empty());
     }
 }


### PR DESCRIPTION
Relates to #2717 point 6

## Changes

- also added a simple CRUD test to make sure, all the operations work as intended (also the conflict override)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
