### PR TITLE
test: add benchmark tests for baggage

### DIFF
--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -62,6 +62,10 @@ name = "context_attach"
 harness = false
 required-features = ["tracing"]
 
+[[bench]]
+name = "baggage"
+harness = false
+
 [lib]
 bench = false
 

--- a/opentelemetry/benches/baggage.rs
+++ b/opentelemetry/benches/baggage.rs
@@ -1,0 +1,66 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use opentelemetry::baggage::Baggage;
+use rand::distr::{Alphanumeric, SampleString};
+use rand::Rng;
+
+const MAX_KEY_VALUE_PAIRS: usize = 64;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    set_baggage_value(c);
+    set_baggage_value_with_metadata(c);
+}
+
+fn set_baggage_value(c: &mut Criterion) {
+    let mut baggage = Baggage::new();
+
+    let mut rng = rand::rng();
+    let key_value = (0..MAX_KEY_VALUE_PAIRS)
+        .map(|_| {
+            (
+                Alphanumeric.sample_string(&mut rng, 4),
+                Alphanumeric.sample_string(&mut rng, 4),
+            )
+        })
+        .collect::<Vec<(String, String)>>();
+
+    c.bench_function("set_baggage_value", move |b| {
+        b.iter_batched(
+            || rng.random_range(0..MAX_KEY_VALUE_PAIRS),
+            |idx| {
+                let (key, value) = key_value[idx].clone();
+                baggage.insert(key, value);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn set_baggage_value_with_metadata(c: &mut Criterion) {
+    let mut baggage = Baggage::new();
+
+    let mut rng = rand::rng();
+    let key_value_metadata = (0..MAX_KEY_VALUE_PAIRS)
+        .map(|_| {
+            (
+                Alphanumeric.sample_string(&mut rng, 4),
+                Alphanumeric.sample_string(&mut rng, 4),
+                Alphanumeric.sample_string(&mut rng, 4),
+            )
+        })
+        .collect::<Vec<(String, String, String)>>();
+
+    c.bench_function("set_baggage_value_with_metadata", move |b| {
+        b.iter_batched(
+            || rng.random_range(0..MAX_KEY_VALUE_PAIRS),
+            |idx| {
+                let (key, value, metadata) = key_value_metadata[idx].clone();
+                baggage.insert_with_metadata(key, value, metadata);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+
+criterion_main!(benches);


### PR DESCRIPTION
Relates to #2717 point 2

## Changes

- I was not sure about the `MAX_KEY_VALUE_PAIRS` const, it is currently private so I just duplicated it for the benchmark test. let me know, if you want to make it public or not.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
