### PR TITLE
feat: Allow event name to be provided to IsEnabled check in Logger

### DIFF
--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -136,9 +136,11 @@ where
 {
     fn enabled(&self, _metadata: &Metadata) -> bool {
         #[cfg(feature = "spec_unstable_logs_enabled")]
-        return self
-            .logger
-            .event_enabled(severity_of_level(_metadata.level()), _metadata.target());
+        return self.logger.event_enabled(
+            severity_of_level(_metadata.level()),
+            _metadata.target(),
+            None,
+        );
         #[cfg(not(feature = "spec_unstable_logs_enabled"))]
         true
     }

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -38,6 +38,10 @@ Receivers (processors, exporters) are expected to use `LogRecord.target()` as
 scope name. This is already done in OTLP Exporters, so this change should be
 transparent to most users.
 
+- Passes event name  to the `event_enabled` method on the `Logger`. This allows
+  implementations (SDK, processor, exporters) to leverage this additional
+  information to determine if an event is enabled.
+
 ## 0.28.1
 
 Released 2025-Feb-12

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -52,7 +52,7 @@ impl LogProcessor for NoopProcessor {
         &self,
         _level: opentelemetry::logs::Severity,
         _target: &str,
-        _name: &str,
+        _name: Option<&str>,
     ) -> bool {
         self.enabled
     }

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -55,12 +55,11 @@
   when its `shutdown` is invoked.
 
 - Reduced some info level logs to debug
-- **Breaking** for custom LogProcessor/Exporter authors:
-  Added an additional `name: Option<&str>` parameter to the `event_enabled`
-  method on the `LogProcessor` and `LogExporter` traits. This allows
-  implementations to leverage this additional information to determine if an
-  event is enabled. `SdkLogger` no longer passes its `scope` name but instead
-  passes the incoming `name` when invoking `event_enabled` on processors.
+- **Breaking** for custom LogProcessor/Exporter authors: Changed `name`
+  parameter from `&str` to `Option<&str>` in `event_enabled` method on the
+  `LogProcessor` and `LogExporter` traits. `SdkLogger` no longer passes its
+  `scope` name but instead passes the incoming `name` when invoking
+  `event_enabled` on processors.
 
 ## 0.28.0
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -38,10 +38,13 @@
 
 - **Breaking** The SpanExporter::export() method no longer requires a mutable reference to self.
   Before:
+
   ```rust
     async fn export(&mut self, batch: Vec<SpanData>) -> OTelSdkResult
   ```
+
   After:
+  
   ```rust
     async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult
   ```
@@ -52,6 +55,12 @@
   when its `shutdown` is invoked.
 
 - Reduced some info level logs to debug
+- **Breaking** for custom LogProcessor/Exporter authors:
+  Added an additional `name: Option<&str>` parameter to the `event_enabled`
+  method on the `LogProcessor` and `LogExporter` traits. This allows
+  implementations to leverage this additional information to determine if an
+  event is enabled. `SdkLogger` no longer passes its `scope` name but instead
+  passes the incoming `name` when invoking `event_enabled` on processors.
 
 ## 0.28.0
 

--- a/opentelemetry-sdk/src/logs/export.rs
+++ b/opentelemetry-sdk/src/logs/export.rs
@@ -141,7 +141,7 @@ pub trait LogExporter: Send + Sync + Debug {
     }
     #[cfg(feature = "spec_unstable_logs_enabled")]
     /// Check if logs are enabled.
-    fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
+    fn event_enabled(&self, _level: Severity, _target: &str, _name: Option<&str>) -> bool {
         // By default, all logs are enabled
         true
     }

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -59,7 +59,7 @@ pub trait LogProcessor: Send + Sync + Debug {
     fn shutdown(&self) -> OTelSdkResult;
     #[cfg(feature = "spec_unstable_logs_enabled")]
     /// Check if logging is enabled
-    fn event_enabled(&self, _level: Severity, _target: &str, _name: &str) -> bool {
+    fn event_enabled(&self, _level: Severity, _target: &str, _name: Option<&str>) -> bool {
         // By default, all logs are enabled
         true
     }

--- a/opentelemetry-sdk/src/logs/logger.rs
+++ b/opentelemetry-sdk/src/logs/logger.rs
@@ -53,10 +53,10 @@ impl opentelemetry::logs::Logger for SdkLogger {
     }
 
     #[cfg(feature = "spec_unstable_logs_enabled")]
-    fn event_enabled(&self, level: Severity, target: &str) -> bool {
+    fn event_enabled(&self, level: Severity, target: &str, name: Option<&str>) -> bool {
         self.provider
             .log_processors()
             .iter()
-            .any(|processor| processor.event_enabled(level, target, self.scope.name().as_ref()))
+            .any(|processor| processor.event_enabled(level, target, name))
     }
 }

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Updated `Baggage` constants to reflect latest standard (`MAX_KEY_VALUE_PAIRS` - 180 -> 64, `MAX_BYTES_FOR_ONE_PAIR` - removed) and increased insert performance see #[2284](https://github.com/open-telemetry/opentelemetry-rust/pull/2284).
 - *Breaking* Align `Baggage.remove()` signature with `.get()` to take the key as a reference
 
+- Added additional `name: Option<&str>` parameter to the `event_enabled` method
+  on the `Logger` trait. This allows implementations (SDK, processor, exporters)
+  to leverage this additional information to determine if an event is enabled.
+
 ## 0.28.0
 
 Released 2025-Feb-10

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -21,7 +21,7 @@ pub trait Logger {
 
     #[cfg(feature = "spec_unstable_logs_enabled")]
     /// Check if the given log level is enabled.
-    fn event_enabled(&self, level: Severity, target: &str) -> bool;
+    fn event_enabled(&self, level: Severity, target: &str, name: Option<&str>) -> bool;
 }
 
 /// Interfaces that can create [`Logger`] instances.

--- a/opentelemetry/src/logs/noop.rs
+++ b/opentelemetry/src/logs/noop.rs
@@ -79,7 +79,7 @@ impl Logger for NoopLogger {
     }
     fn emit(&self, _record: Self::LogRecord) {}
     #[cfg(feature = "spec_unstable_logs_enabled")]
-    fn event_enabled(&self, _level: super::Severity, _target: &str) -> bool {
+    fn event_enabled(&self, _level: super::Severity, _target: &str, _name: Option<&str>) -> bool {
         false
     }
 }


### PR DESCRIPTION
Followup to https://github.com/open-telemetry/opentelemetry-rust/pull/2735, this PR adds an additional parameter (event name) to be passed to the `event_enabled` method, allowing consumer to leverage this additional information.
EventName is part of `tracing` metadata, so there is no extra cost to obtain it.

Modified SdkLogger to pass the name received to the processor, instead of passing scope.name. (Scope.name was empty due to 2735, so it no longer makes sense to pass it. Even without 2735, it was not useful, as scope-name was just the hardcoded crate name of the appender, not particularly useful!)

(Note: EventEnabled is still under experimental feature flag.)