### PR TITLE
test: Modify perf tests to pass event name correctly to avoid string allocation

### DIFF
--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -10,7 +10,7 @@
     | noop_layer_disabled         | 12 ns       |
     | noop_layer_enabled          | 25 ns       |
     | ot_layer_disabled           | 19 ns       |
-    | ot_layer_enabled            | 196 ns      |
+    | ot_layer_enabled            | 167 ns      |
 */
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -94,7 +94,7 @@ fn benchmark_no_subscriber(c: &mut Criterion) {
     c.bench_function("log_no_subscriber", |b| {
         b.iter(|| {
             error!(
-                name = "CheckoutFailed",
+                name : "CheckoutFailed",
                 book_id = "12345",
                 book_title = "Rust Programming Adventures",
                 message = "Unable to process checkout."
@@ -120,7 +120,7 @@ fn benchmark_with_ot_layer(c: &mut Criterion, enabled: bool, bench_name: &str) {
         c.bench_function(bench_name, |b| {
             b.iter(|| {
                 error!(
-                    name = "CheckoutFailed",
+                    name : "CheckoutFailed",
                     book_id = "12345",
                     book_title = "Rust Programming Adventures",
                     message = "Unable to process checkout."
@@ -137,7 +137,7 @@ fn benchmark_with_noop_layer(c: &mut Criterion, enabled: bool, bench_name: &str)
         c.bench_function(bench_name, |b| {
             b.iter(|| {
                 error!(
-                    name = "CheckoutFailed",
+                    name : "CheckoutFailed",
                     book_id = "12345",
                     book_title = "Rust Programming Adventures",
                     "Unable to process checkout."

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -11,6 +11,16 @@
     | noop_layer_enabled          | 25 ns       |
     | ot_layer_disabled           | 19 ns       |
     | ot_layer_enabled            | 167 ns      |
+
+    Hardware: Apple M4 Pro
+    Total Number of Cores:	14 (10 performance and 4 efficiency)
+    | Test                        | Average time|
+    |-----------------------------|-------------|
+    | log_no_subscriber           | 285 ps      |
+    | noop_layer_disabled         | 8 ns       |
+    | noop_layer_enabled          | 14 ns       |
+    | ot_layer_disabled           | 12 ns       |
+    | ot_layer_enabled            | 186 ns      |
 */
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -140,7 +150,7 @@ fn benchmark_with_noop_layer(c: &mut Criterion, enabled: bool, bench_name: &str)
                     name : "CheckoutFailed",
                     book_id = "12345",
                     book_title = "Rust Programming Adventures",
-                    "Unable to process checkout."
+                    message = "Unable to process checkout."
                 );
             });
         });

--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -147,7 +147,7 @@ fn exporter_without_future(c: &mut Criterion) {
     let logger = provider.logger("benchmark");
 
     c.bench_function("LogExporterWithoutFuture", |b| {
-        b.iter(|| { 
+        b.iter(|| {
             let mut log_record = logger.create_log_record();
             let now = now();
             log_record.set_observed_timestamp(now);

--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -147,7 +147,7 @@ fn exporter_without_future(c: &mut Criterion) {
     let logger = provider.logger("benchmark");
 
     c.bench_function("LogExporterWithoutFuture", |b| {
-        b.iter(|| {
+        b.iter(|| { 
             let mut log_record = logger.create_log_record();
             let now = now();
             log_record.set_observed_timestamp(now);

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -6,7 +6,7 @@
     ~31 M/sec
 
     Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
-    ~40 M /sec
+    ~44 M /sec
 
     Hardware: Apple M4 Pro
     Total Number of Cores:	14 (10 performance and 4 efficiency)

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -10,7 +10,7 @@
 
     Hardware: Apple M4 Pro
     Total Number of Cores:	14 (10 performance and 4 efficiency)
-    ~40 M/sec
+    ~50 M/sec
     ~1.1 B/sec (when disabled)
 */
 
@@ -88,7 +88,7 @@ fn main() {
 
 fn test_log() {
     error!(
-        name = "CheckoutFailed",
+        name : "CheckoutFailed",
         book_id = "12345",
         book_title = "Rust Programming Adventures",
         message = "Unable to process checkout."


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-rust/pull/2760