### PR TITLE
refactor: make baggage::KeyValueMetadata private

### DIFF
--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Align `Baggage.remove()` signature with `.get()` to take the key as a reference
   - `Baggage` can't be retrieved from the `Context` directly anymore and needs to be accessed via `context.baggage()`
   - `with_baggage()` and `current_with_baggage()` override any existing `Baggage` in the `Context`
+  - `opentelemetry::baggage::KeyValueMetadata` is now private use instead `opentelemetry::KeyValue` with `opentelemetry::baggage::BaggageMetadata`
 - Changed `Context` to use a stack to properly handle out of order dropping of `ContextGuard`. This imposes a limit of `65535` nested contexts on a single thread. See #[2378](https://github.com/open-telemetry/opentelemetry-rust/pull/2284) and #[1887](https://github.com/open-telemetry/opentelemetry-rust/issues/1887).
 - Added additional `name: Option<&str>` parameter to the `event_enabled` method
   on the `Logger` trait. This allows implementations (SDK, processor, exporters)

--- a/opentelemetry/src/baggage.rs
+++ b/opentelemetry/src/baggage.rs
@@ -439,7 +439,7 @@ impl fmt::Display for BaggageMetadata {
 
 /// [`Baggage`] name/value pairs with their associated metadata.
 #[derive(Clone, Debug, PartialEq)]
-pub struct KeyValueMetadata {
+struct KeyValueMetadata {
     /// Dimension or event key
     pub key: Key,
     /// Dimension or event value
@@ -448,28 +448,32 @@ pub struct KeyValueMetadata {
     pub metadata: BaggageMetadata,
 }
 
-impl KeyValueMetadata {
-    /// Create a new `KeyValue` pair with metadata
-    pub fn new<K, V, S>(key: K, value: V, metadata: S) -> Self
-    where
-        K: Into<Key>,
-        V: Into<StringValue>,
-        S: Into<BaggageMetadata>,
-    {
-        KeyValueMetadata {
-            key: key.into(),
-            value: value.into(),
-            metadata: metadata.into(),
-        }
-    }
-}
-
 impl From<KeyValue> for KeyValueMetadata {
     fn from(kv: KeyValue) -> Self {
         KeyValueMetadata {
             key: kv.key,
             value: kv.value.into(),
             metadata: BaggageMetadata::default(),
+        }
+    }
+}
+
+impl From<(KeyValue, BaggageMetadata)> for KeyValueMetadata {
+    fn from((kv, metadata): (KeyValue, BaggageMetadata)) -> Self {
+        Self {
+            key: kv.key,
+            value: kv.value.into(),
+            metadata,
+        }
+    }
+}
+
+impl From<(Key, StringValue, BaggageMetadata)> for KeyValueMetadata {
+    fn from((key, value, metadata): (Key, StringValue, BaggageMetadata)) -> Self {
+        Self {
+            key,
+            value,
+            metadata,
         }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/open-telemetry/opentelemetry-rust/pull/2748#discussion_r1978292523

## Changes

@cijothomas let me know, if you had this in mind. if it is too inconvenient to use 2/3 value tuples, then we can also keep the current implementation

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
