### PR TITLE
refactor: change `Protocol`'s `Serialize` and `Deserialize` to use standard values

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- **Breaking** `opentelemetry_otlp::Protocol` implementations of `Serialize` and `Deserialize` have been changed to [match standard otel values for protocol](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_protocol). [#2765](https://github.com/open-telemetry/opentelemetry-rust/pull/2765)
+
 ## 0.30.0
 
 Released 2025-May-23

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -442,10 +442,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Protocol {
     /// GRPC protocol
+    #[cfg_attr(feature = "serialize", serde(rename = "grpc"))]
     Grpc,
     /// HTTP protocol with binary protobuf
+    #[cfg_attr(feature = "serialize", serde(rename = "http/protobuf"))]
     HttpBinary,
     /// HTTP protocol with JSON payload
+    #[cfg_attr(feature = "serialize", serde(rename = "http/json"))]
     HttpJson,
 }
 
@@ -468,5 +471,27 @@ pub mod tonic_types {
     pub mod transport {
         #[doc(no_inline)]
         pub use tonic::transport::{Certificate, ClientTlsConfig, Identity};
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(feature = "serialize")]
+    #[test]
+    fn test_protocol_serialization() {
+        use super::Protocol;
+
+        for (protocol, expected) in [
+            (Protocol::Grpc, r#""grpc""#),
+            (Protocol::HttpBinary, r#""http/protobuf""#),
+            (Protocol::HttpJson, r#""http/json""#),
+        ] {
+            let serialized = serde_json::to_string(&protocol).unwrap();
+            assert_eq!(serialized, expected);
+
+            let deserialized: Protocol = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(deserialized, protocol);
+        }
     }
 }


### PR DESCRIPTION
Follow up from #2758

## Changes

As noted in the above PR, the current implementation of `Serialize` and `Deserialize` for protocol will emit the enum name as it is read in source code. I propose it would be better to match [the standard values in the spec](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_protocol), especially if #2758 is merged.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
