### PR TITLE
chore: Remove lint exceptions for 2024 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,6 @@ opentelemetry-stdout = { path = "opentelemetry-stdout" }
 rust_2024_compatibility = { level = "warn", priority = -1 }
 # No need to enable those, because it either not needed or results in ugly syntax
 edition_2024_expr_fragment_specifier = "allow"
-if_let_rescope = "allow"
 tail_expr_drop_order = "allow"
 
 [workspace.lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,6 @@ opentelemetry-stdout = { path = "opentelemetry-stdout" }
 [workspace.lints.rust]
 rust_2024_compatibility = { level = "warn", priority = -1 }
 # No need to enable those, because it either not needed or results in ugly syntax
-edition_2024_expr_fragment_specifier = "allow"
 tail_expr_drop_order = "allow"
 
 [workspace.lints.clippy]

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -244,15 +244,15 @@ impl TonicExporterBuilder {
         &self,
         env_override: &str,
     ) -> Result<Option<CompressionEncoding>, crate::Error> {
-        if let Some(compression) = self.tonic_config.compression {
+        match self.tonic_config.compression { Some(compression) => {
             Ok(Some(compression.try_into()?))
-        } else if let Ok(compression) = env::var(env_override) {
+        } _ => if let Ok(compression) = env::var(env_override) {
             Ok(Some(compression.parse::<Compression>()?.try_into()?))
         } else if let Ok(compression) = env::var(OTEL_EXPORTER_OTLP_COMPRESSION) {
             Ok(Some(compression.parse::<Compression>()?.try_into()?))
         } else {
             Ok(None)
-        }
+        }}
     }
 
     /// Build a new tonic log exporter

--- a/opentelemetry-sdk/src/growable_array.rs
+++ b/opentelemetry-sdk/src/growable_array.rs
@@ -73,11 +73,11 @@ impl<
     pub(crate) fn get(&self, index: usize) -> Option<&T> {
         if index < self.count {
             Some(&self.inline[index])
-        } else if let Some(ref overflow) = self.overflow {
+        } else { match self.overflow { Some(ref overflow) => {
             overflow.get(index - MAX_INLINE_CAPACITY)
-        } else {
+        } _ => {
             None
-        }
+        }}}
     }
 
     /// Returns the number of elements in the `GrowableArray`.

--- a/opentelemetry-sdk/src/logs/simple_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/simple_log_processor.rs
@@ -117,13 +117,13 @@ impl<T: LogExporter> LogProcessor for SimpleLogProcessor<T> {
     fn shutdown(&self) -> OTelSdkResult {
         self.is_shutdown
             .store(true, std::sync::atomic::Ordering::Relaxed);
-        if let Ok(mut exporter) = self.exporter.lock() {
+        match self.exporter.lock() { Ok(mut exporter) => {
             exporter.shutdown()
-        } else {
+        } _ => {
             Err(OTelSdkError::InternalFailure(
                 "SimpleLogProcessor mutex poison at shutdown".into(),
             ))
-        }
+        }}
     }
 
     fn set_resource(&self, resource: &Resource) {

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -114,13 +114,13 @@ impl AttributeSetFilter {
     }
 
     pub(crate) fn apply(&self, attrs: &[KeyValue], run: impl FnOnce(&[KeyValue])) {
-        if let Some(filter) = &self.filter {
+        match &self.filter { Some(filter) => {
             let filtered_attrs: Vec<KeyValue> =
                 attrs.iter().filter(|kv| filter(kv)).cloned().collect();
             run(&filtered_attrs);
-        } else {
+        } _ => {
             run(attrs);
-        };
+        }};
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -1469,7 +1469,7 @@ mod tests {
             test_name
         );
 
-        if let Some(a) = a.as_any().downcast_ref::<Gauge<T>>() {
+        match a.as_any().downcast_ref::<Gauge<T>>() { Some(a) => {
             let b = b.as_any().downcast_ref::<Gauge<T>>().unwrap();
             assert_eq!(
                 a.data_points.len(),
@@ -1480,7 +1480,7 @@ mod tests {
             for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
                 assert_gauge_data_points_eq(a, b, "mismatching gauge data points", test_name);
             }
-        } else if let Some(a) = a.as_any().downcast_ref::<Sum<T>>() {
+        } _ => { match a.as_any().downcast_ref::<Sum<T>>() { Some(a) => {
             let b = b.as_any().downcast_ref::<Sum<T>>().unwrap();
             assert_eq!(
                 a.temporality, b.temporality,
@@ -1501,7 +1501,7 @@ mod tests {
             for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
                 assert_sum_data_points_eq(a, b, "mismatching sum data points", test_name);
             }
-        } else if let Some(a) = a.as_any().downcast_ref::<Histogram<T>>() {
+        } _ => { match a.as_any().downcast_ref::<Histogram<T>>() { Some(a) => {
             let b = b.as_any().downcast_ref::<Histogram<T>>().unwrap();
             assert_eq!(
                 a.temporality, b.temporality,
@@ -1517,7 +1517,7 @@ mod tests {
             for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
                 assert_hist_data_points_eq(a, b, "mismatching hist data points", test_name);
             }
-        } else if let Some(a) = a.as_any().downcast_ref::<ExponentialHistogram<T>>() {
+        } _ => { match a.as_any().downcast_ref::<ExponentialHistogram<T>>() { Some(a) => {
             let b = b
                 .as_any()
                 .downcast_ref::<ExponentialHistogram<T>>()
@@ -1541,9 +1541,9 @@ mod tests {
                     test_name,
                 );
             }
-        } else {
+        } _ => {
             panic!("Aggregation of unknown types")
-        }
+        }}}}}}}}
     }
 
     fn assert_sum_data_points_eq<T: Number>(

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -191,14 +191,14 @@ impl MeterProvider for SdkMeterProvider {
             otel_info!(name: "MeterNameEmpty", message = "Meter name is empty; consider providing a meaningful name. Meter will function normally and the provided name will be used as-is.");
         };
 
-        if let Ok(mut meters) = self.inner.meters.lock() {
-            if let Some(existing_meter) = meters.get(&scope) {
+        match self.inner.meters.lock() { Ok(mut meters) => {
+            match meters.get(&scope) { Some(existing_meter) => {
                 otel_debug!(
                     name: "MeterProvider.ExistingMeterReturned",
                     meter_name = scope.name(),
                 );
                 Meter::new(existing_meter.clone())
-            } else {
+            } _ => {
                 let new_meter = Arc::new(SdkMeter::new(scope.clone(), self.inner.pipes.clone()));
                 meters.insert(scope.clone(), new_meter.clone());
                 otel_debug!(
@@ -206,14 +206,14 @@ impl MeterProvider for SdkMeterProvider {
                     meter_name = scope.name(),
                 );
                 Meter::new(new_meter)
-            }
-        } else {
+            }}
+        } _ => {
             otel_debug!(
                 name: "MeterProvider.NoOpMeterReturned",
                 meter_name = scope.name(),
             );
             Meter::new(Arc::new(NoopMeter::new()))
-        }
+        }}
     }
 }
 

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -155,13 +155,13 @@ impl<T: SpanExporter> SpanProcessor for SimpleSpanProcessor<T> {
     }
 
     fn shutdown(&self) -> OTelSdkResult {
-        if let Ok(mut exporter) = self.exporter.lock() {
+        match self.exporter.lock() { Ok(mut exporter) => {
             exporter.shutdown()
-        } else {
+        } _ => {
             Err(OTelSdkError::InternalFailure(
                 "SimpleSpanProcessor mutex poison at shutdown".into(),
             ))
-        }
+        }}
     }
 
     fn set_resource(&mut self, resource: &Resource) {

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -78,7 +78,7 @@ impl ZipkinExporterBuilder {
     pub fn build(self) -> Result<ZipkinExporter, TraceError> {
         let endpoint = Endpoint::new(self.service_addr);
 
-        if let Some(client) = self.client {
+        match self.client { Some(client) => {
             let exporter = ZipkinExporter::new(
                 endpoint,
                 client,
@@ -87,9 +87,9 @@ impl ZipkinExporterBuilder {
                     .map_err::<Error, _>(Into::into)?,
             );
             Ok(exporter)
-        } else {
+        } _ => {
             Err(Error::NoHttpClient.into())
-        }
+        }}
     }
 
     /// Assign client implementation

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -197,7 +197,7 @@ fn display_array_str<T: fmt::Display>(slice: &[T], fmt: &mut fmt::Formatter<'_>)
 }
 
 macro_rules! into_array {
-    ($(($t:ty, $val:expr),)+) => {
+    ($(($t:ty, $val:expr_2021),)+) => {
         $(
             impl From<$t> for Array {
                 fn from(t: $t) -> Self {
@@ -332,7 +332,7 @@ impl Value {
 macro_rules! from_values {
    (
         $(
-            ($t:ty, $val:expr);
+            ($t:ty, $val:expr_2021);
         )+
     ) => {
         $(

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -214,15 +214,15 @@ impl Context {
     /// assert_eq!(cx_with_a_and_b.get::<ValueB>(), Some(&ValueB(42)));
     /// ```
     pub fn with_value<T: 'static + Send + Sync>(&self, value: T) -> Self {
-        let entries = if let Some(current_entries) = &self.entries {
+        let entries = match &self.entries { Some(current_entries) => {
             let mut inner_entries = (**current_entries).clone();
             inner_entries.insert(TypeId::of::<T>(), Arc::new(value));
             Some(Arc::new(inner_entries))
-        } else {
+        } _ => {
             let mut entries = EntryMap::default();
             entries.insert(TypeId::of::<T>(), Arc::new(value));
             Some(Arc::new(entries))
-        };
+        }};
         Context {
             entries,
             #[cfg(feature = "trace")]
@@ -336,12 +336,12 @@ impl fmt::Debug for Context {
         let mut entries = self.entries.as_ref().map_or(0, |e| e.len());
         #[cfg(feature = "trace")]
         {
-            if let Some(span) = &self.span {
+            match &self.span { Some(span) => {
                 dbg.field("span", &span.span_context());
                 entries += 1;
-            } else {
+            } _ => {
                 dbg.field("span", &"None");
-            }
+            }}
         }
 
         dbg.field("entries count", &entries).finish()

--- a/opentelemetry/src/global/internal_logging.rs
+++ b/opentelemetry/src/global/internal_logging.rs
@@ -20,7 +20,7 @@
 // See issue: https://github.com/tokio-rs/tracing/issues/2774
 #[macro_export]
 macro_rules! otel_info {
-    (name: $name:expr $(,)?) => {
+    (name: $name:expr_2021 $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             tracing::info!( name: $name, target: env!("CARGO_PKG_NAME"), name = $name, "");
@@ -30,7 +30,7 @@ macro_rules! otel_info {
             let _ = $name; // Compiler will optimize this out as it's unused.
         }
     };
-    (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
+    (name: $name:expr_2021, $($key:ident = $value:expr_2021),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             tracing::info!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, $($key = $value),+, "");
@@ -55,7 +55,7 @@ macro_rules! otel_info {
 /// ```
 #[macro_export]
 macro_rules! otel_warn {
-    (name: $name:expr $(,)?) => {
+    (name: $name:expr_2021 $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             tracing::warn!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, "");
@@ -65,7 +65,7 @@ macro_rules! otel_warn {
             let _ = $name; // Compiler will optimize this out as it's unused.
         }
     };
-    (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
+    (name: $name:expr_2021, $($key:ident = $value:expr_2021),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             tracing::warn!(name: $name,
@@ -97,7 +97,7 @@ macro_rules! otel_warn {
 /// ```
 #[macro_export]
 macro_rules! otel_debug {
-    (name: $name:expr $(,)?) => {
+    (name: $name:expr_2021 $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             tracing::debug!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, "");
@@ -107,7 +107,7 @@ macro_rules! otel_debug {
             let _ = $name; // Compiler will optimize this out as it's unused.
         }
     };
-    (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
+    (name: $name:expr_2021, $($key:ident = $value:expr_2021),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             tracing::debug!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, $($key = $value),+, "");
@@ -132,7 +132,7 @@ macro_rules! otel_debug {
 /// ```
 #[macro_export]
 macro_rules! otel_error {
-    (name: $name:expr $(,)?) => {
+    (name: $name:expr_2021 $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             tracing::error!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, "");
@@ -142,7 +142,7 @@ macro_rules! otel_error {
             let _ = $name; // Compiler will optimize this out as it's unused.
         }
     };
-    (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
+    (name: $name:expr_2021, $($key:ident = $value:expr_2021),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             tracing::error!(name: $name,

--- a/opentelemetry/src/global/metrics.rs
+++ b/opentelemetry/src/global/metrics.rs
@@ -24,24 +24,24 @@ where
 {
     // Try to set the global meter provider. If the RwLock is poisoned, we'll log an error.
     let mut global_provider = global_meter_provider().write();
-    if let Ok(ref mut provider) = global_provider {
+    match global_provider { Ok(ref mut provider) => {
         **provider = Arc::new(new_provider);
         otel_info!(name: "MeterProvider.GlobalSet", message = "Global meter provider is set. Meters can now be created using global::meter() or global::meter_with_scope().");
-    } else {
+    } _ => {
         otel_error!(name: "MeterProvider.GlobalSetFailed", message = "Setting global meter provider failed. Meters created using global::meter() or global::meter_with_scope() will not function. Report this issue in OpenTelemetry repo.");
-    }
+    }}
 }
 
 /// Returns an instance of the currently configured global [`MeterProvider`].
 pub fn meter_provider() -> GlobalMeterProvider {
     // Try to get the global meter provider. If the RwLock is poisoned, we'll log an error and return a NoopMeterProvider.
     let global_provider = global_meter_provider().read();
-    if let Ok(provider) = global_provider {
+    match global_provider { Ok(provider) => {
         provider.clone()
-    } else {
+    } _ => {
         otel_error!(name: "MeterProvider.GlobalGetFailed", message = "Getting global meter provider failed. Meters created using global::meter() or global::meter_with_scope() will not function. Report this issue in OpenTelemetry repo.");
         Arc::new(crate::metrics::noop::NoopMeterProvider::new())
-    }
+    }}
 }
 
 /// Creates a named [`Meter`] via the currently configured global [`MeterProvider`].

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -290,11 +290,11 @@ impl TraceContextExt for Context {
     }
 
     fn span(&self) -> SpanRef<'_> {
-        if let Some(span) = self.span.as_ref() {
+        match self.span.as_ref() { Some(span) => {
             SpanRef(span)
-        } else {
+        } _ => {
             SpanRef(&NOOP_SPAN)
-        }
+        }}
     }
 
     fn has_active_span(&self) -> bool {


### PR DESCRIPTION
Remove the exceptions added to the new 2024 lint rules by applying fixes to the code. Most of this is done auto-magically by `cargo clippy --fix`. 

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
