### PR TITLE
chore: Move FutureExt into context

### DIFF
--- a/opentelemetry/src/context/context_store.rs
+++ b/opentelemetry/src/context/context_store.rs
@@ -1,3 +1,4 @@
+
 use crate::otel_warn;
 #[cfg(feature = "trace")]
 use crate::trace::context::SynchronizedSpan;
@@ -78,7 +79,7 @@ thread_local! {
 #[derive(Clone, Default)]
 pub struct Context {
     #[cfg(feature = "trace")]
-    pub(super) span: Option<Arc<SynchronizedSpan>>,
+    pub(crate) span: Option<Arc<SynchronizedSpan>>,
     entries: Option<Arc<EntryMap>>,
 }
 
@@ -314,7 +315,7 @@ impl Context {
     }
 
     #[cfg(feature = "trace")]
-    pub(super) fn current_with_synchronized_span(value: SynchronizedSpan) -> Self {
+    pub(crate) fn current_with_synchronized_span(value: SynchronizedSpan) -> Self {
         Context {
             span: Some(Arc::new(value)),
             entries: Context::map_current(|cx| cx.entries.clone()),
@@ -322,7 +323,7 @@ impl Context {
     }
 
     #[cfg(feature = "trace")]
-    pub(super) fn with_synchronized_span(&self, value: SynchronizedSpan) -> Self {
+    pub(crate) fn with_synchronized_span(&self, value: SynchronizedSpan) -> Self {
         Context {
             span: Some(Arc::new(value)),
             entries: self.entries.clone(),

--- a/opentelemetry/src/context/future_ext.rs
+++ b/opentelemetry/src/context/future_ext.rs
@@ -1,0 +1,31 @@
+use crate::Context;
+use crate::trace::WithContext;
+
+/// Extension trait allowing futures, streams, and sinks to be traced with a span.
+pub trait FutureExt: Sized {
+    /// Attaches the provided [`Context`] to this type, returning a `WithContext`
+    /// wrapper.
+    ///
+    /// When the wrapped type is a future, stream, or sink, the attached context
+    /// will be set as current while it is being polled.
+    ///
+    /// [`Context`]: Context
+    fn with_context(self, otel_cx: Context) -> WithContext<Self> {
+        WithContext {
+            inner: self,
+            otel_cx,
+        }
+    }
+
+    /// Attaches the current [`Context`] to this type, returning a `WithContext`
+    /// wrapper.
+    ///
+    /// When the wrapped type is a future, stream, or sink, the attached context
+    /// will be set as the default while it is being polled.
+    ///
+    /// [`Context`]: Context
+    fn with_current_context(self) -> WithContext<Self> {
+        let otel_cx = Context::current();
+        self.with_context(otel_cx)
+    }
+}

--- a/opentelemetry/src/context/mod.rs
+++ b/opentelemetry/src/context/mod.rs
@@ -1,0 +1,4 @@
+mod context_store;
+
+pub use context_store::Context;
+pub use context_store::ContextGuard;

--- a/opentelemetry/src/context/mod.rs
+++ b/opentelemetry/src/context/mod.rs
@@ -1,4 +1,6 @@
 mod context_store;
+mod future_ext;
 
 pub use context_store::Context;
 pub use context_store::ContextGuard;
+pub use future_ext::FutureExt;


### PR DESCRIPTION
Fixes #2754 

## Changes
* Switch `opentelemetry::context` from `context.rs` to `context/mod.rs` module style so that we can add `future_ext` without jamming everything together into the same file
* Move `FutureExt` from `opentelemetry::trace::context` into `opentelemetry::context::future_ext`
* Re-export `FutureExt` in trace to maintain backwards compatibility

I had to make a couple bits in `Context` `pub(crate)` to make this work. 

I'm not sure what to call the file containing `Context` - `opentelemetry/src/context/context_store.rs` - its contents are re-exported as `context::Context` as previously available, but double nesting the same module name is a bad practice, and so is putting anything in `mod.rs` itself. Open to suggestions! 

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
