### PR TITLE
feat: Add experimental concurrent processor for logs

### DIFF
--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -56,6 +56,7 @@ internal-logs = ["tracing"]
 experimental_metrics_periodicreader_with_async_runtime = ["metrics"]
 spec_unstable_metrics_views = ["metrics"]
 experimental_logs_batch_log_processor_with_async_runtime = ["logs"]
+experimental_logs_concurrent_log_processor = ["logs"]
 experimental_trace_batch_span_processor_with_async_runtime = ["trace"]
 experimental_metrics_disable_name_validation = ["metrics"]
 
@@ -87,6 +88,11 @@ harness = false
 [[bench]]
 name = "log_processor"
 harness = false
+
+[[bench]]
+name = "log_enabled"
+harness = false
+required-features = ["spec_unstable_logs_enabled", "experimental_logs_concurrent_log_processor"]
 
 [[bench]]
 name = "tracer_creation"

--- a/opentelemetry-sdk/benches/log_enabled.rs
+++ b/opentelemetry-sdk/benches/log_enabled.rs
@@ -12,7 +12,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::logs::{Logger, LoggerProvider};
 use opentelemetry_sdk::error::OTelSdkResult;
-use opentelemetry_sdk::logs::concurrent_log_processor::ConcurrentExportProcessor;
+use opentelemetry_sdk::logs::concurrent_log_processor::SimpleConcurrentProcessor;
 use opentelemetry_sdk::logs::{
     LogBatch, LogExporter, LogProcessor, SdkLoggerProvider, SimpleLogProcessor,
 };
@@ -60,7 +60,7 @@ where
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let processor = ConcurrentExportProcessor::new(NoopExporter);
+    let processor = SimpleConcurrentProcessor::new(NoopExporter);
     benchmark_exporter_enabled_false(c, "exporter_disabled_concurrent_processor", processor);
     let simple = SimpleLogProcessor::new(NoopExporter);
     benchmark_exporter_enabled_false(c, "exporter_disabled_simple_processor", simple);

--- a/opentelemetry-sdk/benches/log_enabled.rs
+++ b/opentelemetry-sdk/benches/log_enabled.rs
@@ -12,7 +12,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::logs::{Logger, LoggerProvider};
 use opentelemetry_sdk::error::OTelSdkResult;
-use opentelemetry_sdk::logs::concurrent_log_processor::SimpleConcurrentProcessor;
+use opentelemetry_sdk::logs::concurrent_log_processor::SimpleConcurrentLogProcessor;
 use opentelemetry_sdk::logs::{
     LogBatch, LogExporter, LogProcessor, SdkLoggerProvider, SimpleLogProcessor,
 };
@@ -60,7 +60,7 @@ where
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let processor = SimpleConcurrentProcessor::new(NoopExporter);
+    let processor = SimpleConcurrentLogProcessor::new(NoopExporter);
     benchmark_exporter_enabled_false(c, "exporter_disabled_concurrent_processor", processor);
     let simple = SimpleLogProcessor::new(NoopExporter);
     benchmark_exporter_enabled_false(c, "exporter_disabled_simple_processor", simple);

--- a/opentelemetry-sdk/benches/log_enabled.rs
+++ b/opentelemetry-sdk/benches/log_enabled.rs
@@ -1,0 +1,81 @@
+/*
+    The benchmark results:
+    criterion = "0.5.1"
+    Hardware: Apple M4 Pro
+    Total Number of Cores:   14 (10 performance and 4 efficiency)
+    | Test                                         | Average time|
+    |---------------------------------------------|-------------|
+    | exporter_disabled_concurrent_processor      |  1.9 ns     |
+    | exporter_disabled_simple_processor          |  5.0 ns     |
+*/
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use opentelemetry::logs::{Logger, LoggerProvider};
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::logs::concurrent_log_processor::ConcurrentExportProcessor;
+use opentelemetry_sdk::logs::{
+    LogBatch, LogExporter, LogProcessor, SdkLoggerProvider, SimpleLogProcessor,
+};
+use opentelemetry_sdk::Resource;
+#[cfg(not(target_os = "windows"))]
+use pprof::criterion::{Output, PProfProfiler};
+
+#[derive(Debug)]
+struct NoopExporter;
+impl LogExporter for NoopExporter {
+    async fn export(&self, _: LogBatch<'_>) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn event_enabled(
+        &self,
+        _level: opentelemetry::logs::Severity,
+        _target: &str,
+        _name: Option<&str>,
+    ) -> bool {
+        false
+    }
+
+    fn set_resource(&mut self, _: &Resource) {}
+}
+
+fn benchmark_exporter_enabled_false<T>(c: &mut Criterion, name: &str, processor: T)
+where
+    T: LogProcessor + Send + Sync + 'static,
+{
+    let provider = SdkLoggerProvider::builder()
+        .with_log_processor(processor)
+        .build();
+    let logger = provider.logger("test_logger");
+
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            logger.event_enabled(opentelemetry::logs::Severity::Debug, "target", Some("name"));
+        });
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let processor = ConcurrentExportProcessor::new(NoopExporter);
+    benchmark_exporter_enabled_false(c, "exporter_disabled_concurrent_processor", processor);
+    let simple = SimpleLogProcessor::new(NoopExporter);
+    benchmark_exporter_enabled_false(c, "exporter_disabled_simple_processor", simple);
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/opentelemetry-sdk/src/logs/concurrent_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/concurrent_log_processor.rs
@@ -1,4 +1,4 @@
-use opentelemetry::InstrumentationScope;
+use opentelemetry::{otel_info, InstrumentationScope};
 
 use crate::error::OTelSdkResult;
 
@@ -13,21 +13,27 @@ use super::{LogBatch, LogExporter, LogProcessor, SdkLogRecord};
 /// This is intended to be used when exporting to operating system
 /// tracing facilities like Windows ETW, Linux TracePoints etc.
 #[derive(Debug)]
-pub struct SimpleConcurrentProcessor<T: LogExporter> {
+pub struct SimpleConcurrentLogProcessor<T: LogExporter> {
     exporter: T,
 }
 
-impl<T: LogExporter> SimpleConcurrentProcessor<T> {
+impl<T: LogExporter> SimpleConcurrentLogProcessor<T> {
     /// Creates a new `ConcurrentExportProcessor` with the given exporter.
     pub fn new(exporter: T) -> Self {
         Self { exporter }
     }
 }
 
-impl<T: LogExporter> LogProcessor for SimpleConcurrentProcessor<T> {
+impl<T: LogExporter> LogProcessor for SimpleConcurrentLogProcessor<T> {
     fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
         let log_tuple = &[(record as &SdkLogRecord, instrumentation)];
-        let _ = futures_executor::block_on(self.exporter.export(LogBatch::new(log_tuple)));
+        let result = futures_executor::block_on(self.exporter.export(LogBatch::new(log_tuple)));
+        if let Err(err) = result {
+            otel_info!(
+                name: "SimpleConcurrentLogProcessor.Emit.ExportError",
+                error = format!("{}",err)
+            );
+        }
     }
 
     fn force_flush(&self) -> OTelSdkResult {

--- a/opentelemetry-sdk/src/logs/concurrent_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/concurrent_log_processor.rs
@@ -13,18 +13,18 @@ use super::{LogBatch, LogExporter, LogProcessor, SdkLogRecord};
 /// This is intended to be used when exporting to operating system
 /// tracing facilities like Windows ETW, Linux TracePoints etc.
 #[derive(Debug)]
-pub struct ConcurrentExportProcessor<T: LogExporter> {
+pub struct SimpleConcurrentProcessor<T: LogExporter> {
     exporter: T,
 }
 
-impl<T: LogExporter> ConcurrentExportProcessor<T> {
+impl<T: LogExporter> SimpleConcurrentProcessor<T> {
     /// Creates a new `ConcurrentExportProcessor` with the given exporter.
     pub fn new(exporter: T) -> Self {
         Self { exporter }
     }
 }
 
-impl<T: LogExporter> LogProcessor for ConcurrentExportProcessor<T> {
+impl<T: LogExporter> LogProcessor for SimpleConcurrentProcessor<T> {
     fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
         let log_tuple = &[(record as &SdkLogRecord, instrumentation)];
         let _ = futures_executor::block_on(self.exporter.export(LogBatch::new(log_tuple)));

--- a/opentelemetry-sdk/src/logs/concurrent_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/concurrent_log_processor.rs
@@ -1,0 +1,53 @@
+use opentelemetry::InstrumentationScope;
+
+use crate::error::OTelSdkResult;
+
+use super::{LogBatch, LogExporter, LogProcessor, SdkLogRecord};
+
+/// A concurrent log processor calls exporter's export method on each emit. This
+/// processor does not buffer logs. Note: This invokes exporter's export method
+/// on the current thread without synchronization. i.e multiple export() calls
+/// can happen simultaneously from different threads. This is not a problem if
+/// the exporter is designed to handle that. As of now, exporters in the
+/// opentelemetry-rust project (stdout/otlp) are not thread-safe.
+/// This is intended to be used when exporting to operating system
+/// tracing facilities like Windows ETW, Linux TracePoints etc.
+#[derive(Debug)]
+pub struct ConcurrentExportProcessor<T: LogExporter> {
+    exporter: T,
+}
+
+impl<T: LogExporter> ConcurrentExportProcessor<T> {
+    /// Creates a new `ConcurrentExportProcessor` with the given exporter.
+    pub fn new(exporter: T) -> Self {
+        Self { exporter }
+    }
+}
+
+impl<T: LogExporter> LogProcessor for ConcurrentExportProcessor<T> {
+    fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+        let log_tuple = &[(record as &SdkLogRecord, instrumentation)];
+        let _ = futures_executor::block_on(self.exporter.export(LogBatch::new(log_tuple)));
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        // TODO: invoke flush on exporter
+        // once https://github.com/open-telemetry/opentelemetry-rust/issues/2261
+        // is resolved
+        Ok(())
+    }
+
+    fn shutdown(&self) -> OTelSdkResult {
+        self.exporter.shutdown()
+    }
+
+    #[cfg(feature = "spec_unstable_logs_enabled")]
+    fn event_enabled(
+        &self,
+        level: opentelemetry::logs::Severity,
+        target: &str,
+        name: Option<&str>,
+    ) -> bool {
+        self.exporter.event_enabled(level, target, name)
+    }
+}

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -27,6 +27,10 @@ pub use logger_provider::{LoggerProviderBuilder, SdkLoggerProvider};
 pub use record::{SdkLogRecord, TraceContext};
 pub use simple_log_processor::SimpleLogProcessor;
 
+#[cfg(feature = "experimental_logs_concurrent_log_processor")]
+/// Module for ConcurrentLogProcessor.
+pub mod concurrent_log_processor;
+
 #[cfg(feature = "experimental_logs_batch_log_processor_with_async_runtime")]
 /// Module for BatchLogProcessor with async runtime.
 pub mod log_processor_with_async_runtime;

--- a/opentelemetry-sdk/src/logs/simple_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/simple_log_processor.rs
@@ -65,7 +65,8 @@ pub struct SimpleLogProcessor<T: LogExporter> {
 }
 
 impl<T: LogExporter> SimpleLogProcessor<T> {
-    pub(crate) fn new(exporter: T) -> Self {
+    /// Creates a new instance of `SimpleLogProcessor`.
+    pub fn new(exporter: T) -> Self {
         SimpleLogProcessor {
             exporter: Mutex::new(exporter),
             is_shutdown: AtomicBool::new(false),
@@ -129,6 +130,20 @@ impl<T: LogExporter> LogProcessor for SimpleLogProcessor<T> {
     fn set_resource(&self, resource: &Resource) {
         if let Ok(mut exporter) = self.exporter.lock() {
             exporter.set_resource(resource);
+        }
+    }
+
+    #[cfg(feature = "spec_unstable_logs_enabled")]
+    fn event_enabled(
+        &self,
+        level: opentelemetry::logs::Severity,
+        target: &str,
+        name: Option<&str>,
+    ) -> bool {
+        if let Ok(exporter) = self.exporter.lock() {
+            exporter.event_enabled(level, target, name)
+        } else {
+            true
         }
     }
 }

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -44,7 +44,7 @@ ctrlc = { workspace = true }
 lazy_static = { workspace = true }
 num_cpus = { workspace = true }
 opentelemetry = { path = "../opentelemetry", features = ["metrics", "logs", "trace", "spec_unstable_logs_enabled"] }
-opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics", "logs", "trace", "spec_unstable_logs_enabled"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics", "logs", "trace", "spec_unstable_logs_enabled", "experimental_logs_concurrent_log_processor"] }
 opentelemetry-appender-tracing = { workspace = true, features = ["spec_unstable_logs_enabled"] }
 rand = { workspace = true, features = ["small_rng", "os_rng"] }
 tracing = { workspace = true, features = ["std"]}

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -19,7 +19,7 @@
 */
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::error::OTelSdkResult;
-use opentelemetry_sdk::logs::concurrent_log_processor::ConcurrentExportProcessor;
+use opentelemetry_sdk::logs::concurrent_log_processor::SimpleConcurrentProcessor;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
 use opentelemetry_sdk::logs::{LogBatch, LogExporter};
 
@@ -65,7 +65,7 @@ fn main() {
 
     // LoggerProvider with a no-op processor.
     let provider: SdkLoggerProvider = SdkLoggerProvider::builder()
-        .with_log_processor(ConcurrentExportProcessor::new(NoopExporter::new(enabled)))
+        .with_log_processor(SimpleConcurrentProcessor::new(NoopExporter::new(enabled)))
         .build();
 
     // Use the OpenTelemetryTracingBridge to test the throughput of the appender-tracing.

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -12,6 +12,10 @@
     Total Number of Cores:	14 (10 performance and 4 efficiency)
     ~50 M/sec
     ~1.1 B/sec (when disabled)
+
+    With existing SimpleLogProcessor:
+     3 M/sec (when enabled)  (.with_log_processor(SimpleLogProcessor::new(NoopExporter::new(true))))
+    26 M/sec (when disabled) (.with_log_processor(SimpleLogProcessor::new(NoopExporter::new(false)))
 */
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::error::OTelSdkResult;
@@ -57,7 +61,7 @@ impl LogExporter for NoopExporter {
 
 fn main() {
     // change this to false to test the throughput when enabled is false.
-    let enabled = false;
+    let enabled = true;
 
     // LoggerProvider with a no-op processor.
     let provider: SdkLoggerProvider = SdkLoggerProvider::builder()

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -19,7 +19,7 @@
 */
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::error::OTelSdkResult;
-use opentelemetry_sdk::logs::concurrent_log_processor::SimpleConcurrentProcessor;
+use opentelemetry_sdk::logs::concurrent_log_processor::SimpleConcurrentLogProcessor;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
 use opentelemetry_sdk::logs::{LogBatch, LogExporter};
 
@@ -65,7 +65,9 @@ fn main() {
 
     // LoggerProvider with a no-op processor.
     let provider: SdkLoggerProvider = SdkLoggerProvider::builder()
-        .with_log_processor(SimpleConcurrentProcessor::new(NoopExporter::new(enabled)))
+        .with_log_processor(SimpleConcurrentLogProcessor::new(NoopExporter::new(
+            enabled,
+        )))
         .build();
 
     // Use the OpenTelemetryTracingBridge to test the throughput of the appender-tracing.


### PR DESCRIPTION
1. Add a new processor under experimental feature flag. 
2. This is to facilitate discussions in OTel spec about adding such a component to the official spec itself.
3. This is *NOT* useful as-is with any existing exporters in this repo (like OTLP Log Exporter
4. This is an initial version. Next, I'll introduce ways to ensure that only those exporters that can support concurrent exporting will be paired with ConcurrentExporter. This is one possible way spec could evolve. Alternatively, existing processors can be modified to export concurrently if the exporter advertises that they are okay with that!. BatchLogProcessor also need to evolve to support [concurrent exporting in the future](https://github.com/open-telemetry/opentelemetry-rust/issues/2555).
5. Also modified Stress test to use the new experimental processor to compare the perf numbers with Concurrent vs Existing  SimpleProcessor.
6. SimpleProcessor did not have a public new method and it did not implement `event_enabled`. This addresses that also, as it was required to run stress test comparison. Can do this in a separate PR it helps review easier.

Spec discussion:
https://github.com/open-telemetry/opentelemetry-specification/issues/4231