### PR TITLE
test: Add test to confirm programmatic config wins over env in BatchConfig

### DIFF
--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -614,6 +614,8 @@ impl Default for BatchConfigBuilder {
     /// * `OTEL_BLRP_SCHEDULE_DELAY`
     /// * `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE`
     /// * `OTEL_BLRP_EXPORT_TIMEOUT`
+    ///
+    /// Note: Programmatic configuration overrides any value set via the environment variable.
     fn default() -> Self {
         BatchConfigBuilder {
             max_queue_size: OTEL_BLRP_MAX_QUEUE_SIZE_DEFAULT,
@@ -630,7 +632,11 @@ impl BatchConfigBuilder {
     /// Set max_queue_size for [`BatchConfigBuilder`].
     /// It's the maximum queue size to buffer logs for delayed processing.
     /// If the queue gets full it will drop the logs.
-    /// The default value of is 2048.
+    /// The default value is 2048.
+    ///
+    /// Corresponding environment variable: `OTEL_BLRP_MAX_QUEUE_SIZE`.
+    ///
+    /// Note: Programmatically setting this will override any value set via the environment variable.
     pub fn with_max_queue_size(mut self, max_queue_size: usize) -> Self {
         self.max_queue_size = max_queue_size;
         self
@@ -639,6 +645,10 @@ impl BatchConfigBuilder {
     /// Set scheduled_delay for [`BatchConfigBuilder`].
     /// It's the delay interval in milliseconds between two consecutive processing of batches.
     /// The default value is 1000 milliseconds.
+    ///
+    /// Corresponding environment variable: `OTEL_BLRP_SCHEDULE_DELAY`.
+    ///
+    /// Note: Programmatically setting this will override any value set via the environment variable.
     pub fn with_scheduled_delay(mut self, scheduled_delay: Duration) -> Self {
         self.scheduled_delay = scheduled_delay;
         self
@@ -647,6 +657,10 @@ impl BatchConfigBuilder {
     /// Set max_export_timeout for [`BatchConfigBuilder`].
     /// It's the maximum duration to export a batch of data.
     /// The default value is 30000 milliseconds.
+    ///
+    /// Corresponding environment variable: `OTEL_BLRP_EXPORT_TIMEOUT`.
+    ///
+    /// Note: Programmatically setting this will override any value set via the environment variable.
     #[cfg(feature = "experimental_logs_batch_log_processor_with_async_runtime")]
     pub fn with_max_export_timeout(mut self, max_export_timeout: Duration) -> Self {
         self.max_export_timeout = max_export_timeout;
@@ -658,6 +672,10 @@ impl BatchConfigBuilder {
     /// more than one batch worth of logs then it processes multiple batches
     /// of logs one batch after the other without any delay.
     /// The default value is 512.
+    ///
+    /// Corresponding environment variable: `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE`.
+    ///
+    /// Note: Programmatically setting this will override any value set via the environment variable.
     pub fn with_max_export_batch_size(mut self, max_export_batch_size: usize) -> Self {
         self.max_export_batch_size = max_export_batch_size;
         self
@@ -772,6 +790,27 @@ mod tests {
             config.max_export_batch_size,
             OTEL_BLRP_MAX_EXPORT_BATCH_SIZE_DEFAULT
         );
+    }
+
+    #[test]
+    fn test_code_based_config_overrides_env_vars() {
+        let env_vars = vec![
+            (OTEL_BLRP_SCHEDULE_DELAY, Some("2000")),
+            (OTEL_BLRP_MAX_QUEUE_SIZE, Some("4096")),
+            (OTEL_BLRP_MAX_EXPORT_BATCH_SIZE, Some("1024")),
+        ];
+
+        temp_env::with_vars(env_vars, || {
+            let config = BatchConfigBuilder::default()
+                .with_max_queue_size(2048)
+                .with_scheduled_delay(Duration::from_millis(1000))
+                .with_max_export_batch_size(512)
+                .build();
+
+            assert_eq!(config.scheduled_delay, Duration::from_millis(1000));
+            assert_eq!(config.max_queue_size, 2048);
+            assert_eq!(config.max_export_batch_size, 512);
+        });
     }
 
     #[test]

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -200,15 +200,22 @@ impl LoggerProviderBuilder {
         LoggerProviderBuilder { processors, ..self }
     }
 
-    /// Adds a [BatchLogProcessor] with the configured exporter to the pipeline.
+    /// Adds a [BatchLogProcessor] with the configured exporter to the pipeline,
+    /// using the default [super::BatchConfig].
+    ///
+    /// The following environment variables can be used to configure the batching configuration:
+    ///
+    /// * `OTEL_BSP_SCHEDULE_DELAY` - Corresponds to `with_scheduled_delay`.
+    /// * `OTEL_BSP_MAX_QUEUE_SIZE` - Corresponds to `with_max_queue_size`.
+    /// * `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` - Corresponds to `with_max_export_batch_size`.
     ///
     /// # Arguments
     ///
-    /// * `exporter` - The exporter to be used by the BatchLogProcessor.
+    /// * `exporter` - The exporter to be used by the `BatchLogProcessor`.
     ///
     /// # Returns
     ///
-    /// A new `Builder` instance with the BatchLogProcessor added to the pipeline.
+    /// A new `LoggerProviderBuilder` instance with the `BatchLogProcessor` added to the pipeline.
     ///
     /// Processors are invoked in the order they are added.
     pub fn with_batch_exporter<T: LogExporter + 'static>(self, exporter: T) -> Self {

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -205,9 +205,9 @@ impl LoggerProviderBuilder {
     ///
     /// The following environment variables can be used to configure the batching configuration:
     ///
-    /// * `OTEL_BSP_SCHEDULE_DELAY` - Corresponds to `with_scheduled_delay`.
-    /// * `OTEL_BSP_MAX_QUEUE_SIZE` - Corresponds to `with_max_queue_size`.
-    /// * `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` - Corresponds to `with_max_export_batch_size`.
+    /// * `OTEL_BLRP_SCHEDULE_DELAY` - Corresponds to `with_scheduled_delay`.
+    /// * `OTEL_BLRP_MAX_QUEUE_SIZE` - Corresponds to `with_max_queue_size`.
+    /// * `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE` - Corresponds to `with_max_export_batch_size`.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-rust/issues/1225
For BatchLogProcessor, we were already preferring code over env_variables, so there is no change required. I added tests to confirm the behavior, and included this information in the docs too.

This is just the start, we need to audit entire ENV variables in the repo, and make changes.