### PR TITLE
test: fix span_processor test failing with default features

### DIFF
--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -971,15 +971,20 @@ mod tests {
             .with_scheduled_delay(Duration::from_millis(10))
             .with_max_queue_size(10);
         #[cfg(feature = "experimental_trace_batch_span_processor_with_async_runtime")]
-        let batch = batch.with_max_concurrent_exports(10);
-        #[cfg(feature = "experimental_trace_batch_span_processor_with_async_runtime")]
-        let batch = batch.with_max_export_timeout(Duration::from_millis(10));
+        let batch = {
+            batch
+                .with_max_concurrent_exports(10)
+                .with_max_export_timeout(Duration::from_millis(10))
+        };
         let batch = batch.build();
         assert_eq!(batch.max_export_batch_size, 10);
         assert_eq!(batch.scheduled_delay, Duration::from_millis(10));
-        assert_eq!(batch.max_export_timeout, Duration::from_millis(10));
-        assert_eq!(batch.max_concurrent_exports, 10);
         assert_eq!(batch.max_queue_size, 10);
+        #[cfg(feature = "experimental_trace_batch_span_processor_with_async_runtime")]
+        {
+            assert_eq!(batch.max_concurrent_exports, 10);
+            assert_eq!(batch.max_export_timeout, Duration::from_millis(10));
+        }
     }
 
     // Helper function to create a default test span


### PR DESCRIPTION
Some of the assertions are only passing if `experimental_trace_batch_span_processor_with_async_runtime` is enabled, which is not in the default features set, so running `cargo test --workspace` without specifying features is failing.

## Changes

* Add a feature gate around failing assertions

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
