### PR TITLE
test: fix otlp log integration tests failing with some set of features 

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/Cargo.toml
+++ b/opentelemetry-otlp/tests/integration_test/Cargo.toml
@@ -29,6 +29,7 @@ reqwest-client = ["opentelemetry-otlp/reqwest-client", "opentelemetry-otlp/http-
 reqwest-blocking-client = ["opentelemetry-otlp/reqwest-blocking-client", "opentelemetry-otlp/http-proto", "opentelemetry-otlp/trace","opentelemetry-otlp/logs", "opentelemetry-otlp/metrics", "internal-logs"]
 tonic-client = ["opentelemetry-otlp/grpc-tonic", "opentelemetry-otlp/trace", "opentelemetry-otlp/logs", "opentelemetry-otlp/metrics", "internal-logs"]
 internal-logs = ["opentelemetry-otlp/internal-logs"]
+experimental_metadata_attributes = ["opentelemetry-appender-tracing/experimental_metadata_attributes"]
 
 # Keep tonic as the default client
 default = ["tonic-client", "internal-logs"]

--- a/opentelemetry-otlp/tests/integration_test/tests/logs.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs.rs
@@ -255,6 +255,7 @@ mod logtests {
     // current thread
     #[test]
     #[cfg(feature = "reqwest-blocking-client")]
+    #[cfg(not(feature = "tonic-client"))]
     pub fn logs_batch_non_tokio_main_with_init_logs_outside_rt() -> Result<()> {
         logs_non_tokio_helper(false, false)
     }
@@ -295,7 +296,8 @@ mod logtests {
     // Client - Reqwest-blocking
     #[test]
     #[cfg(feature = "reqwest-blocking-client")]
-    pub fn logs_simple_non_tokio_main_with_init_logs_outsie_rt_blocking() -> Result<()> {
+    #[cfg(not(feature = "tonic-client"))]
+    pub fn logs_simple_non_tokio_main_with_init_logs_outside_rt_blocking() -> Result<()> {
         logs_non_tokio_helper(true, false)
     }
 
@@ -309,7 +311,7 @@ mod logtests {
         feature = "tonic-client",
         feature = "reqwest-client"
     ))]
-    pub fn logs_simple_non_tokio_main_with_init_logs_outsie_rt() -> Result<()> {
+    pub fn logs_simple_non_tokio_main_with_init_logs_outside_rt() -> Result<()> {
         logs_non_tokio_helper(true, false)
     }
 

--- a/opentelemetry-otlp/tests/integration_test/tests/logs_serialize_deserialize.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs_serialize_deserialize.rs
@@ -37,7 +37,7 @@ pub async fn test_logs() -> Result<()> {
         info!(target: "my-target", "hello from {}. My price is {}.", "banana", 2.99);
     }
 
-    let _ = logger_provider.shutdown();
+    logger_provider.shutdown().unwrap();
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     assert_logs_results(test_utils::LOGS_FILE, "expected/logs.json")?;
     Ok(())


### PR DESCRIPTION
I like to run `cargo test --workspace --all-features` to run all tests in a workspace. This is currently failing:

* Running otlp logger integration tests with `reqwest-blocking-client` and the default features in the `integration_test_runner` package are failing two of the tests are not compatible with having both  `reqwest-blocking-client` and `tonic-client` enabled at the same time.
* Running otlp logger integration tests with `experimental_metadata_attributes` fails because of the extra attributes added to logs do not match the snapshot.

## Changes

* Skip tests on incompatible features
* Remove extra attributes before doing the snapshot comparison if the `experimental_metadata_attributes` flag is set

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
