### PR TITLE
docs: Include context, baggage etc to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ documentation.
 
 | Signal/Component      | Overall Status     |
 | --------------------  | ------------------ |
+| Context               | Beta               |
+| Baggage               | Beta               |
+| Propagators           | Beta               |
 | Logs-API              | Stable*            |
 | Logs-SDK              | RC                 |
 | Logs-OTLP Exporter    | RC                 |


### PR DESCRIPTION
As discussed in community call today, explicitly listing the status for the key components that are missing in readme today.
I put Beta as the status, but hopefully, we should be moving it to RC with the next release (0.29)