### PR TITLE
docs: fix unit in metrics semantic conventions example

### DIFF
--- a/opentelemetry-semantic-conventions/scripts/templates/registry/rust/metric.rs.j2
+++ b/opentelemetry-semantic-conventions/scripts/templates/registry/rust/metric.rs.j2
@@ -24,7 +24,7 @@
 //! let meter = global::meter("mylibraryname");
 //! let histogram = meter
 //!     .u64_histogram(semconv::metric::HTTP_SERVER_REQUEST_DURATION)
-//!     .with_unit("By")
+//!     .with_unit("s")
 //!     .with_description("Duration of HTTP server requests.")
 //!     .build();
 //! ```

--- a/opentelemetry-semantic-conventions/src/metric.rs
+++ b/opentelemetry-semantic-conventions/src/metric.rs
@@ -23,7 +23,7 @@
 //! let meter = global::meter("mylibraryname");
 //! let histogram = meter
 //!     .u64_histogram(semconv::metric::HTTP_SERVER_REQUEST_DURATION)
-//!     .with_unit("By")
+//!     .with_unit("s")
 //!     .with_description("Duration of HTTP server requests.")
 //!     .build();
 //! ```


### PR DESCRIPTION
## Changes

Minor documentation update for a code example. Duration should be measured in seconds, not bytes.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [X] Unit tests added/updated (if applicable) _not applicable_
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes _trivial change_
* [X] Changes in public API reviewed (if applicable) _not applicable_
