### PR TITLE
fix: Avoid stringifying int values unless necessary

### DIFF
--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -42,6 +42,11 @@ transparent to most users.
   implementations (SDK, processor, exporters) to leverage this additional
   information to determine if an event is enabled.
 
+- `u64` and `usize` values are stored as `opentelemetry::logs::AnyValue::Int`
+when conversion is feasible. Otherwise stored as
+`opentelemetry::logs::AnyValue::String`. This avoids unnecessary string
+allocation when values can be represented in their original types.
+
 ## 0.28.1
 
 Released 2025-Feb-12

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -114,6 +114,8 @@ impl<LR: LogRecord> tracing::field::Visit for EventVisitor<'_, LR> {
             .add_attribute(Key::new(field.name()), AnyValue::from(value));
     }
 
+    // TODO: We might need to do similar for record_i128,record_u128 too
+    // to avoid stringification, unless needed.
     fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
         #[cfg(feature = "experimental_metadata_attributes")]
         if is_duplicated_metadata(field.name()) {

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -121,15 +121,12 @@ impl<LR: LogRecord> tracing::field::Visit for EventVisitor<'_, LR> {
         if is_duplicated_metadata(field.name()) {
             return;
         }
-        match i64::try_from(value) {
-            Ok(signed) => {
-                self.log_record
-                    .add_attribute(Key::new(field.name()), AnyValue::from(signed));
-            }
-            Err(_) => {
-                self.log_record
-                    .add_attribute(Key::new(field.name()), AnyValue::from(format!("{value:?}")));
-            }
+        if let Ok(signed) = i64::try_from(value) {
+            self.log_record
+            .add_attribute(Key::new(field.name()), AnyValue::from(signed));
+        } else {
+            self.log_record
+            .add_attribute(Key::new(field.name()), AnyValue::from(format!("{value:?}")));
         }
     }
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -123,10 +123,10 @@ impl<LR: LogRecord> tracing::field::Visit for EventVisitor<'_, LR> {
         }
         if let Ok(signed) = i64::try_from(value) {
             self.log_record
-            .add_attribute(Key::new(field.name()), AnyValue::from(signed));
+                .add_attribute(Key::new(field.name()), AnyValue::from(signed));
         } else {
             self.log_record
-            .add_attribute(Key::new(field.name()), AnyValue::from(format!("{value:?}")));
+                .add_attribute(Key::new(field.name()), AnyValue::from(format!("{value:?}")));
         }
     }
 


### PR DESCRIPTION
Though this works, I am wondering if AnyValue should contain variants to store u64 too?