### PR TITLE
fix: Change logger scope in log appender

### DIFF
--- a/opentelemetry-appender-log/CHANGELOG.md
+++ b/opentelemetry-appender-log/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+- Similar to the `opentelemetry-appender-tracing` fix [2658](https://github.com/open-telemetry/opentelemetry-rust/issues/2658)
+  InstrumentationScope(Logger) used by the appender now uses an empty ("") named Logger.
+  Previously, a Logger with name and version of the crate was used.
+  Receivers (processors, exporters) are expected to use `LogRecord.target()` as scope name.
+  This is already done in OTLP Exporters, so this change should be transparent to most users.
+
 ## 0.28.0
 
 Released 2025-Feb-10

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -173,7 +173,8 @@ where
 
         let mut log_record = self.logger.create_log_record();
 
-        log_record.set_target(target);
+        // TODO: Fix heap allocation
+        log_record.set_target(target.to_string());
         log_record.set_event_name(name);
         log_record.set_severity_number(severity);
         log_record.set_severity_text(metadata.level().as_str());

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -173,8 +173,7 @@ where
 
         let mut log_record = self.logger.create_log_record();
 
-        // TODO: Fix heap allocation
-        log_record.set_target(target.to_string());
+        log_record.set_target(target);
         log_record.set_event_name(name);
         log_record.set_severity_number(severity);
         log_record.set_severity_text(metadata.level().as_str());


### PR DESCRIPTION
Fixes #2747 

## Changes

- I was not sure what exactly is the desired state for
https://github.com/open-telemetry/opentelemetry-rust/blob/1ddecb04d9f19dafab682be42c5a2579a8c8182d/opentelemetry-proto/src/transform/common.rs#L57
set all the values to empty strings/vec, if target is `None`?

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
