### PR TITLE
fix: LogProcessor.SetResource to require mutable self

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -64,6 +64,9 @@
  `LogExporter` trait no longer requires a mutable ref to `self`. If the exporter
  needs to mutate state, it should rely on interior mutability.
  [2764](https://github.com/open-telemetry/opentelemetry-rust/pull/2764)
+- **Breaking** for custom LogProcessor/Exporter authors: Changed `set_resource`
+  to require mutable ref.
+  `fn set_resource(&mut self, _resource: &Resource) {}`
 
 ## 0.28.0
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -64,7 +64,7 @@
  `LogExporter` trait no longer requires a mutable ref to `self`. If the exporter
  needs to mutate state, it should rely on interior mutability.
  [2764](https://github.com/open-telemetry/opentelemetry-rust/pull/2764)
-- **Breaking** for custom LogProcessor/Exporter authors: Changed `set_resource`
+- **Breaking** for custom `LogProcessor` authors: Changed `set_resource`
   to require mutable ref.
   `fn set_resource(&mut self, _resource: &Resource) {}`
 

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -319,7 +319,7 @@ impl LogProcessor for BatchLogProcessor {
         }
     }
 
-    fn set_resource(&self, resource: &Resource) {
+    fn set_resource(&mut self, resource: &Resource) {
         let resource = Arc::new(resource.clone());
         let _ = self
             .message_sender

--- a/opentelemetry-sdk/src/logs/concurrent_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/concurrent_log_processor.rs
@@ -1,6 +1,6 @@
 use opentelemetry::{otel_info, InstrumentationScope};
 
-use crate::error::OTelSdkResult;
+use crate::{error::OTelSdkResult, Resource};
 
 use super::{LogBatch, LogExporter, LogProcessor, SdkLogRecord};
 
@@ -55,5 +55,9 @@ impl<T: LogExporter> LogProcessor for SimpleConcurrentLogProcessor<T> {
         name: Option<&str>,
     ) -> bool {
         self.exporter.event_enabled(level, target, name)
+    }
+
+    fn set_resource(&mut self, resource: &Resource) {
+        self.exporter.set_resource(resource);
     }
 }

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -65,7 +65,7 @@ pub trait LogProcessor: Send + Sync + Debug {
     }
 
     /// Set the resource for the log processor.
-    fn set_resource(&self, _resource: &Resource) {}
+    fn set_resource(&mut self, _resource: &Resource) {}
 }
 
 #[cfg(all(test, feature = "testing", feature = "logs"))]

--- a/opentelemetry-sdk/src/logs/log_processor_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/logs/log_processor_with_async_runtime.rs
@@ -108,7 +108,7 @@ impl<R: RuntimeChannel> LogProcessor for BatchLogProcessor<R> {
             .and_then(std::convert::identity)
     }
 
-    fn set_resource(&self, resource: &Resource) {
+    fn set_resource(&mut self, resource: &Resource) {
         let resource = Arc::new(resource.clone());
         let _ = self
             .message_sender

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -258,7 +258,7 @@ impl LoggerProviderBuilder {
 
         let logger_provider = SdkLoggerProvider {
             inner: Arc::new(LoggerProviderInner {
-                processors: processors,
+                processors
                 is_shutdown: AtomicBool::new(false),
             }),
         };

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -20,7 +20,6 @@ fn noop_logger_provider() -> &'static SdkLoggerProvider {
     NOOP_LOGGER_PROVIDER.get_or_init(|| SdkLoggerProvider {
         inner: Arc::new(LoggerProviderInner {
             processors: Vec::new(),
-            resource: Resource::empty(),
             is_shutdown: AtomicBool::new(true),
         }),
     })
@@ -82,10 +81,6 @@ impl SdkLoggerProvider {
         &self.inner.processors
     }
 
-    pub(crate) fn resource(&self) -> &Resource {
-        &self.inner.resource
-    }
-
     /// Force flush all remaining logs in log processors and return results.
     pub fn force_flush(&self) -> OTelSdkResult {
         let result: Vec<_> = self
@@ -133,7 +128,6 @@ impl SdkLoggerProvider {
 #[derive(Debug)]
 struct LoggerProviderInner {
     processors: Vec<Box<dyn LogProcessor>>,
-    resource: Resource,
     is_shutdown: AtomicBool,
 }
 
@@ -257,19 +251,17 @@ impl LoggerProviderBuilder {
     /// Create a new provider from this configuration.
     pub fn build(self) -> SdkLoggerProvider {
         let resource = self.resource.unwrap_or(Resource::builder().build());
+        let mut processors = self.processors;
+        for processor in &mut processors {
+            processor.set_resource(&resource);
+        }
 
         let logger_provider = SdkLoggerProvider {
             inner: Arc::new(LoggerProviderInner {
-                processors: self.processors,
-                resource,
+                processors: processors,
                 is_shutdown: AtomicBool::new(false),
             }),
         };
-
-        // invoke set_resource on all the processors
-        for processor in logger_provider.log_processors() {
-            processor.set_resource(logger_provider.resource());
-        }
 
         otel_debug!(
             name: "LoggerProvider.Built",
@@ -346,9 +338,43 @@ mod tests {
             Ok(())
         }
     }
+
+    #[derive(Debug, Clone)]
+    struct TestProcessorForResource {
+        resource: Arc<Mutex<Resource>>,
+    }
+    impl LogProcessor for TestProcessorForResource {
+        fn emit(&self, _data: &mut SdkLogRecord, _scope: &InstrumentationScope) {
+            // nothing to do.
+        }
+
+        fn force_flush(&self) -> OTelSdkResult {
+            Ok(())
+        }
+
+        fn shutdown(&self) -> OTelSdkResult {
+            Ok(())
+        }
+
+        fn set_resource(&mut self, resource: &Resource) {
+            let mut res = self.resource.lock().unwrap();
+            *res = resource.clone();
+        }
+    }
+    impl TestProcessorForResource {
+        fn new() -> Self {
+            TestProcessorForResource {
+                resource: Arc::new(Mutex::new(Resource::empty())),
+            }
+        }
+        fn resource(&self) -> Resource {
+            self.resource.lock().unwrap().clone()
+        }
+    }
+
     #[test]
     fn test_logger_provider_default_resource() {
-        let assert_resource = |provider: &super::SdkLoggerProvider,
+        let assert_resource = |provider: &TestProcessorForResource,
                                resource_key: &'static str,
                                expect: Option<&'static str>| {
             assert_eq!(
@@ -359,7 +385,7 @@ mod tests {
                 expect.map(|s| s.to_string())
             );
         };
-        let assert_telemetry_resource = |provider: &super::SdkLoggerProvider| {
+        let assert_telemetry_resource = |provider: &TestProcessorForResource| {
             assert_eq!(
                 provider.resource().get(&TELEMETRY_SDK_LANGUAGE.into()),
                 Some(Value::from("rust"))
@@ -376,41 +402,49 @@ mod tests {
 
         // If users didn't provide a resource and there isn't a env var set. Use default one.
         temp_env::with_var_unset("OTEL_RESOURCE_ATTRIBUTES", || {
-            let default_config_provider = super::SdkLoggerProvider::builder().build();
+            let processor_with_resource = TestProcessorForResource::new();
+            let _ = super::SdkLoggerProvider::builder()
+                .with_log_processor(processor_with_resource.clone())
+                .build();
             assert_resource(
-                &default_config_provider,
+                &processor_with_resource,
                 SERVICE_NAME,
                 Some("unknown_service"),
             );
-            assert_telemetry_resource(&default_config_provider);
+            assert_telemetry_resource(&processor_with_resource);
         });
 
         // If user provided a resource, use that.
-        let custom_config_provider = super::SdkLoggerProvider::builder()
+        let processor_with_resource = TestProcessorForResource::new();
+        let _ = super::SdkLoggerProvider::builder()
             .with_resource(
                 Resource::builder_empty()
                     .with_service_name("test_service")
                     .build(),
             )
+            .with_log_processor(processor_with_resource.clone())
             .build();
-        assert_resource(&custom_config_provider, SERVICE_NAME, Some("test_service"));
-        assert_eq!(custom_config_provider.resource().len(), 1);
+        assert_resource(&processor_with_resource, SERVICE_NAME, Some("test_service"));
+        assert_eq!(processor_with_resource.resource().len(), 1);
 
         // If `OTEL_RESOURCE_ATTRIBUTES` is set, read them automatically
         temp_env::with_var(
             "OTEL_RESOURCE_ATTRIBUTES",
             Some("key1=value1, k2, k3=value2"),
             || {
-                let env_resource_provider = super::SdkLoggerProvider::builder().build();
+                let processor_with_resource = TestProcessorForResource::new();
+                let _ = super::SdkLoggerProvider::builder()
+                    .with_log_processor(processor_with_resource.clone())
+                    .build();
                 assert_resource(
-                    &env_resource_provider,
+                    &processor_with_resource,
                     SERVICE_NAME,
                     Some("unknown_service"),
                 );
-                assert_resource(&env_resource_provider, "key1", Some("value1"));
-                assert_resource(&env_resource_provider, "k3", Some("value2"));
-                assert_telemetry_resource(&env_resource_provider);
-                assert_eq!(env_resource_provider.resource().len(), 6);
+                assert_resource(&processor_with_resource, "key1", Some("value1"));
+                assert_resource(&processor_with_resource, "k3", Some("value2"));
+                assert_telemetry_resource(&processor_with_resource);
+                assert_eq!(processor_with_resource.resource().len(), 6);
             },
         );
 
@@ -419,7 +453,8 @@ mod tests {
             "OTEL_RESOURCE_ATTRIBUTES",
             Some("my-custom-key=env-val,k2=value2"),
             || {
-                let user_provided_resource_config_provider = super::SdkLoggerProvider::builder()
+                let processor_with_resource = TestProcessorForResource::new();
+                let _ = super::SdkLoggerProvider::builder()
                     .with_resource(
                         Resource::builder()
                             .with_attributes([
@@ -428,37 +463,36 @@ mod tests {
                             ])
                             .build(),
                     )
+                    .with_log_processor(processor_with_resource.clone())
                     .build();
                 assert_resource(
-                    &user_provided_resource_config_provider,
+                    &processor_with_resource,
                     SERVICE_NAME,
                     Some("unknown_service"),
                 );
                 assert_resource(
-                    &user_provided_resource_config_provider,
+                    &processor_with_resource,
                     "my-custom-key",
                     Some("my-custom-value"),
                 );
                 assert_resource(
-                    &user_provided_resource_config_provider,
+                    &processor_with_resource,
                     "my-custom-key2",
                     Some("my-custom-value2"),
                 );
-                assert_resource(
-                    &user_provided_resource_config_provider,
-                    "k2",
-                    Some("value2"),
-                );
-                assert_telemetry_resource(&user_provided_resource_config_provider);
-                assert_eq!(user_provided_resource_config_provider.resource().len(), 7);
+                assert_resource(&processor_with_resource, "k2", Some("value2"));
+                assert_telemetry_resource(&processor_with_resource);
+                assert_eq!(processor_with_resource.resource().len(), 7);
             },
         );
 
         // If user provided a resource, it takes priority during collision.
-        let no_service_name = super::SdkLoggerProvider::builder()
+        let processor_with_resource = TestProcessorForResource::new();
+        let _ = super::SdkLoggerProvider::builder()
             .with_resource(Resource::empty())
+            .with_log_processor(processor_with_resource.clone())
             .build();
-        assert_eq!(no_service_name.resource().len(), 0);
+        assert_eq!(processor_with_resource.resource().len(), 0);
     }
 
     #[test]
@@ -615,7 +649,6 @@ mod tests {
                     shutdown_called.clone(),
                     flush_called.clone(),
                 ))],
-                resource: Resource::empty(),
                 is_shutdown: AtomicBool::new(false),
             });
 
@@ -656,7 +689,6 @@ mod tests {
                 shutdown_called.clone(),
                 flush_called.clone(),
             ))],
-            resource: Resource::empty(),
             is_shutdown: AtomicBool::new(false),
         });
 

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -258,7 +258,7 @@ impl LoggerProviderBuilder {
 
         let logger_provider = SdkLoggerProvider {
             inner: Arc::new(LoggerProviderInner {
-                processors
+                processors,
                 is_shutdown: AtomicBool::new(false),
             }),
         };

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -273,7 +273,7 @@ impl LoggerProviderBuilder {
 #[cfg(test)]
 mod tests {
     use crate::{
-        logs::{InMemoryLogExporter, SdkLogRecord, TraceContext},
+        logs::{InMemoryLogExporter, LogBatch, SdkLogRecord, TraceContext},
         resource::{
             SERVICE_NAME, TELEMETRY_SDK_LANGUAGE, TELEMETRY_SDK_NAME, TELEMETRY_SDK_VERSION,
         },
@@ -340,8 +340,39 @@ mod tests {
     }
 
     #[derive(Debug, Clone)]
+    struct TestExporterForResource {
+        resource: Arc<Mutex<Resource>>,
+    }
+    impl TestExporterForResource {
+        fn new() -> Self {
+            TestExporterForResource {
+                resource: Arc::new(Mutex::new(Resource::empty())),
+            }
+        }
+
+        fn resource(&self) -> Resource {
+            self.resource.lock().unwrap().clone()
+        }
+    }
+    impl LogExporter for TestExporterForResource {
+        async fn export(&self, _: LogBatch<'_>) -> OTelSdkResult {
+            Ok(())
+        }
+
+        fn set_resource(&mut self, resource: &Resource) {
+            let mut res = self.resource.lock().unwrap();
+            *res = resource.clone();
+        }
+
+        fn shutdown(&self) -> OTelSdkResult {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Clone)]
     struct TestProcessorForResource {
         resource: Arc<Mutex<Resource>>,
+        exporter: TestExporterForResource,
     }
     impl LogProcessor for TestProcessorForResource {
         fn emit(&self, _data: &mut SdkLogRecord, _scope: &InstrumentationScope) {
@@ -359,12 +390,14 @@ mod tests {
         fn set_resource(&mut self, resource: &Resource) {
             let mut res = self.resource.lock().unwrap();
             *res = resource.clone();
+            self.exporter.set_resource(resource);
         }
     }
     impl TestProcessorForResource {
-        fn new() -> Self {
+        fn new(exporter: TestExporterForResource) -> Self {
             TestProcessorForResource {
                 resource: Arc::new(Mutex::new(Resource::empty())),
+                exporter,
             }
         }
         fn resource(&self) -> Resource {
@@ -373,49 +406,75 @@ mod tests {
     }
 
     #[test]
-    fn test_logger_provider_default_resource() {
-        let assert_resource = |provider: &TestProcessorForResource,
+    fn test_resource_handling_provider_processor_exporter() {
+        let assert_resource = |processor: &TestProcessorForResource,
+                               exporter: &TestExporterForResource,
                                resource_key: &'static str,
                                expect: Option<&'static str>| {
             assert_eq!(
-                provider
+                processor
+                    .resource()
+                    .get(&Key::from_static_str(resource_key))
+                    .map(|v| v.to_string()),
+                expect.map(|s| s.to_string())
+            );
+
+            assert_eq!(
+                exporter
                     .resource()
                     .get(&Key::from_static_str(resource_key))
                     .map(|v| v.to_string()),
                 expect.map(|s| s.to_string())
             );
         };
-        let assert_telemetry_resource = |provider: &TestProcessorForResource| {
-            assert_eq!(
-                provider.resource().get(&TELEMETRY_SDK_LANGUAGE.into()),
-                Some(Value::from("rust"))
-            );
-            assert_eq!(
-                provider.resource().get(&TELEMETRY_SDK_NAME.into()),
-                Some(Value::from("opentelemetry"))
-            );
-            assert_eq!(
-                provider.resource().get(&TELEMETRY_SDK_VERSION.into()),
-                Some(Value::from(env!("CARGO_PKG_VERSION")))
-            );
-        };
+        let assert_telemetry_resource =
+            |processor: &TestProcessorForResource, exporter: &TestExporterForResource| {
+                assert_eq!(
+                    processor.resource().get(&TELEMETRY_SDK_LANGUAGE.into()),
+                    Some(Value::from("rust"))
+                );
+                assert_eq!(
+                    processor.resource().get(&TELEMETRY_SDK_NAME.into()),
+                    Some(Value::from("opentelemetry"))
+                );
+                assert_eq!(
+                    processor.resource().get(&TELEMETRY_SDK_VERSION.into()),
+                    Some(Value::from(env!("CARGO_PKG_VERSION")))
+                );
+                assert_eq!(
+                    exporter.resource().get(&TELEMETRY_SDK_LANGUAGE.into()),
+                    Some(Value::from("rust"))
+                );
+                assert_eq!(
+                    exporter.resource().get(&TELEMETRY_SDK_NAME.into()),
+                    Some(Value::from("opentelemetry"))
+                );
+                assert_eq!(
+                    exporter.resource().get(&TELEMETRY_SDK_VERSION.into()),
+                    Some(Value::from(env!("CARGO_PKG_VERSION")))
+                );
+            };
 
         // If users didn't provide a resource and there isn't a env var set. Use default one.
         temp_env::with_var_unset("OTEL_RESOURCE_ATTRIBUTES", || {
-            let processor_with_resource = TestProcessorForResource::new();
+            let exporter_with_resource = TestExporterForResource::new();
+            let processor_with_resource =
+                TestProcessorForResource::new(exporter_with_resource.clone());
             let _ = super::SdkLoggerProvider::builder()
                 .with_log_processor(processor_with_resource.clone())
                 .build();
             assert_resource(
                 &processor_with_resource,
+                &exporter_with_resource,
                 SERVICE_NAME,
                 Some("unknown_service"),
             );
-            assert_telemetry_resource(&processor_with_resource);
+            assert_telemetry_resource(&processor_with_resource, &exporter_with_resource);
         });
 
         // If user provided a resource, use that.
-        let processor_with_resource = TestProcessorForResource::new();
+        let exporter_with_resource = TestExporterForResource::new();
+        let processor_with_resource = TestProcessorForResource::new(exporter_with_resource.clone());
         let _ = super::SdkLoggerProvider::builder()
             .with_resource(
                 Resource::builder_empty()
@@ -424,7 +483,12 @@ mod tests {
             )
             .with_log_processor(processor_with_resource.clone())
             .build();
-        assert_resource(&processor_with_resource, SERVICE_NAME, Some("test_service"));
+        assert_resource(
+            &processor_with_resource,
+            &exporter_with_resource,
+            SERVICE_NAME,
+            Some("test_service"),
+        );
         assert_eq!(processor_with_resource.resource().len(), 1);
 
         // If `OTEL_RESOURCE_ATTRIBUTES` is set, read them automatically
@@ -432,18 +496,31 @@ mod tests {
             "OTEL_RESOURCE_ATTRIBUTES",
             Some("key1=value1, k2, k3=value2"),
             || {
-                let processor_with_resource = TestProcessorForResource::new();
+                let exporter_with_resource = TestExporterForResource::new();
+                let processor_with_resource =
+                    TestProcessorForResource::new(exporter_with_resource.clone());
                 let _ = super::SdkLoggerProvider::builder()
                     .with_log_processor(processor_with_resource.clone())
                     .build();
                 assert_resource(
                     &processor_with_resource,
+                    &exporter_with_resource,
                     SERVICE_NAME,
                     Some("unknown_service"),
                 );
-                assert_resource(&processor_with_resource, "key1", Some("value1"));
-                assert_resource(&processor_with_resource, "k3", Some("value2"));
-                assert_telemetry_resource(&processor_with_resource);
+                assert_resource(
+                    &processor_with_resource,
+                    &exporter_with_resource,
+                    "key1",
+                    Some("value1"),
+                );
+                assert_resource(
+                    &processor_with_resource,
+                    &exporter_with_resource,
+                    "k3",
+                    Some("value2"),
+                );
+                assert_telemetry_resource(&processor_with_resource, &exporter_with_resource);
                 assert_eq!(processor_with_resource.resource().len(), 6);
             },
         );
@@ -453,7 +530,9 @@ mod tests {
             "OTEL_RESOURCE_ATTRIBUTES",
             Some("my-custom-key=env-val,k2=value2"),
             || {
-                let processor_with_resource = TestProcessorForResource::new();
+                let exporter_with_resource = TestExporterForResource::new();
+                let processor_with_resource =
+                    TestProcessorForResource::new(exporter_with_resource.clone());
                 let _ = super::SdkLoggerProvider::builder()
                     .with_resource(
                         Resource::builder()
@@ -467,27 +546,36 @@ mod tests {
                     .build();
                 assert_resource(
                     &processor_with_resource,
+                    &exporter_with_resource,
                     SERVICE_NAME,
                     Some("unknown_service"),
                 );
                 assert_resource(
                     &processor_with_resource,
+                    &exporter_with_resource,
                     "my-custom-key",
                     Some("my-custom-value"),
                 );
                 assert_resource(
                     &processor_with_resource,
+                    &exporter_with_resource,
                     "my-custom-key2",
                     Some("my-custom-value2"),
                 );
-                assert_resource(&processor_with_resource, "k2", Some("value2"));
-                assert_telemetry_resource(&processor_with_resource);
+                assert_resource(
+                    &processor_with_resource,
+                    &exporter_with_resource,
+                    "k2",
+                    Some("value2"),
+                );
+                assert_telemetry_resource(&processor_with_resource, &exporter_with_resource);
                 assert_eq!(processor_with_resource.resource().len(), 7);
             },
         );
 
         // If user provided a resource, it takes priority during collision.
-        let processor_with_resource = TestProcessorForResource::new();
+        let exporter_with_resource = TestExporterForResource::new();
+        let processor_with_resource = TestProcessorForResource::new(exporter_with_resource);
         let _ = super::SdkLoggerProvider::builder()
             .with_resource(Resource::empty())
             .with_log_processor(processor_with_resource.clone())

--- a/opentelemetry-sdk/src/logs/simple_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/simple_log_processor.rs
@@ -127,7 +127,7 @@ impl<T: LogExporter> LogProcessor for SimpleLogProcessor<T> {
         }
     }
 
-    fn set_resource(&self, resource: &Resource) {
+    fn set_resource(&mut self, resource: &Resource) {
         if let Ok(mut exporter) = self.exporter.lock() {
             exporter.set_resource(resource);
         }

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -17,12 +17,12 @@
      3 M/sec (when enabled)  (.with_log_processor(SimpleLogProcessor::new(NoopExporter::new(true))))
     26 M/sec (when disabled) (.with_log_processor(SimpleLogProcessor::new(NoopExporter::new(false)))
 */
+use opentelemetry::Key;
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::logs::concurrent_log_processor::SimpleConcurrentLogProcessor;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
 use opentelemetry_sdk::logs::{LogBatch, LogExporter};
-use opentelemetry::Key;
 use opentelemetry_sdk::Resource;
 use tracing::error;
 use tracing_subscriber::prelude::*;


### PR DESCRIPTION
While attempting to measure throughput for `SimpleConcurrentLogProcessor`, I realized that it cannot pass the resource to exporter, as exporter's set_resource required `mut self` but processor only needed `self`. This PR addresses the issue, so that processor can now pass resource to the exporter.
(The stress test is modified to show that processor can pass resource to exporter without sacrificing performance. Without this PR, processor had to rely on interior mutability (i.e store exporter in a Mutex), affecting throughput.

This also opens up making Simple/BatchProcessor a lot more simpler. That'll be in a follow up PR.