### PR TITLE
docs: OTLP Examples to shutdown all signals

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -164,9 +164,27 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     info!(target: "my-target", "hello from {}. My price is {}", "apple", 1.99);
 
-    tracer_provider.shutdown()?;
-    meter_provider.shutdown()?;
-    logger_provider.shutdown()?;
+    // Collect all shutdown errors
+    let mut shutdown_errors = Vec::new();
+    if let Err(e) = tracer_provider.shutdown() {
+        shutdown_errors.push(format!("tracer provider: {}", e));
+    }
 
+    if let Err(e) = meter_provider.shutdown() {
+        shutdown_errors.push(format!("meter provider: {}", e));
+    }
+
+    if let Err(e) = logger_provider.shutdown() {
+        shutdown_errors.push(format!("logger provider: {}", e));
+    }
+
+    // Return an error if any shutdown failed
+    if !shutdown_errors.is_empty() {
+        return Err(format!(
+            "Failed to shutdown providers:{}",
+            shutdown_errors.join("\n")
+        )
+        .into());
+    }
     Ok(())
 }

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -156,9 +156,29 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     });
 
     info!(name: "my-event", target: "my-target", "hello from {}. My price is {}", "apple", 1.99);
-    tracer_provider.shutdown()?;
-    meter_provider.shutdown()?;
-    logger_provider.shutdown()?;
+
+    // Collect all shutdown errors
+    let mut shutdown_errors = Vec::new();
+    if let Err(e) = tracer_provider.shutdown() {
+        shutdown_errors.push(format!("tracer provider: {}", e));
+    }
+
+    if let Err(e) = meter_provider.shutdown() {
+        shutdown_errors.push(format!("meter provider: {}", e));
+    }
+
+    if let Err(e) = logger_provider.shutdown() {
+        shutdown_errors.push(format!("logger provider: {}", e));
+    }
+
+    // Return an error if any shutdown failed
+    if !shutdown_errors.is_empty() {
+        return Err(format!(
+            "Failed to shutdown providers:{}",
+            shutdown_errors.join("\n")
+        )
+        .into());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Current code will not invoke shutdown on the rest, if any provider fails.

Addressing https://github.com/open-telemetry/opentelemetry-rust/issues/2723#issuecomment-2715101190