### PR TITLE
fix: Byte arrays represented as Anyvalue::Byte instead of string

### DIFF
--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -46,7 +46,8 @@ transparent to most users.
 when conversion is feasible. Otherwise stored as
 `opentelemetry::logs::AnyValue::String`. This avoids unnecessary string
 allocation when values can be represented in their original types.
-
+- Byte arrays are stored as `opentelemetry::logs::AnyValue::Bytes` instead
+of string.
 - perf - small perf improvement by avoiding string allocation of `target`
 
 ## 0.28.1

--- a/opentelemetry/src/logs/record.rs
+++ b/opentelemetry/src/logs/record.rs
@@ -115,6 +115,12 @@ impl_trivial_from!(StringValue, AnyValue::String);
 
 impl_trivial_from!(bool, AnyValue::Boolean);
 
+impl From<&[u8]> for AnyValue {
+    fn from(val: &[u8]) -> AnyValue {
+        AnyValue::Bytes(Box::new(val.to_vec()))
+    }
+}
+
 impl<T: Into<AnyValue>> FromIterator<T> for AnyValue {
     /// Creates an [`AnyValue::ListAny`] value from a sequence of `Into<AnyValue>` values.
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {


### PR DESCRIPTION
Not very performant due to the need to vec! allocate and box, but this is the best we can do right now.