### PR TITLE
perf: LogEnabled inline more

### DIFF
--- a/opentelemetry-sdk/benches/log_enabled.rs
+++ b/opentelemetry-sdk/benches/log_enabled.rs
@@ -5,8 +5,8 @@
     Total Number of Cores:   14 (10 performance and 4 efficiency)
     | Test                                         | Average time|
     |---------------------------------------------|-------------|
-    | exporter_disabled_concurrent_processor      |  1.0 ns     |
-    | exporter_disabled_simple_processor          |  4.5 ns     |
+    | exporter_disabled_concurrent_processor      |  980 ps     |
+    | exporter_disabled_simple_processor          |  4.3 ns     |
 */
 
 // cargo bench --bench log_enabled --features="spec_unstable_logs_enabled,experimental_logs_concurrent_log_processor"
@@ -33,6 +33,7 @@ impl LogExporter for NoopExporter {
         Ok(())
     }
 
+    #[inline]
     fn event_enabled(
         &self,
         _level: opentelemetry::logs::Severity,

--- a/opentelemetry-sdk/src/logs/concurrent_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/concurrent_log_processor.rs
@@ -48,6 +48,7 @@ impl<T: LogExporter> LogProcessor for SimpleConcurrentLogProcessor<T> {
     }
 
     #[cfg(feature = "spec_unstable_logs_enabled")]
+    #[inline]
     fn event_enabled(
         &self,
         level: opentelemetry::logs::Severity,

--- a/opentelemetry-sdk/src/logs/simple_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/simple_log_processor.rs
@@ -134,6 +134,7 @@ impl<T: LogExporter> LogProcessor for SimpleLogProcessor<T> {
     }
 
     #[cfg(feature = "spec_unstable_logs_enabled")]
+    #[inline]
     fn event_enabled(
         &self,
         level: opentelemetry::logs::Severity,


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-rust/pull/2823/files#r2001429329
Slight improvement actually. But at such low level, it is hard to measure.
Time to switch to measuring the number of instructions for more reliable numbers!