### PR TITLE
ci: use GHCR otel-collector image

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/src/test_utils.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/test_utils.rs
@@ -72,32 +72,35 @@ pub async fn start_collector_container() -> Result<()> {
         upsert_empty_file(LOGS_FILE);
 
         // Start a new container
-        let container_instance = GenericImage::new("otel/opentelemetry-collector", "latest")
-            .with_wait_for(WaitFor::http(
-                HttpWaitStrategy::new("/")
-                    .with_expected_status_code(404u16)
-                    .with_port(ContainerPort::Tcp(4318)),
-            ))
-            .with_mapped_port(4317, ContainerPort::Tcp(4317))
-            .with_mapped_port(4318, ContainerPort::Tcp(4318))
-            .with_mount(Mount::bind_mount(
-                fs::canonicalize("./otel-collector-config.yaml")?.to_string_lossy(),
-                "/etc/otelcol/config.yaml",
-            ))
-            .with_mount(Mount::bind_mount(
-                fs::canonicalize("./actual/logs.json")?.to_string_lossy(),
-                "/testresults/logs.json",
-            ))
-            .with_mount(Mount::bind_mount(
-                fs::canonicalize("./actual/metrics.json")?.to_string_lossy(),
-                "/testresults/metrics.json",
-            ))
-            .with_mount(Mount::bind_mount(
-                fs::canonicalize("./actual/traces.json")?.to_string_lossy(),
-                "/testresults/traces.json",
-            ))
-            .start()
-            .await?;
+        let container_instance = GenericImage::new(
+            "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector",
+            "latest",
+        )
+        .with_wait_for(WaitFor::http(
+            HttpWaitStrategy::new("/")
+                .with_expected_status_code(404u16)
+                .with_port(ContainerPort::Tcp(4318)),
+        ))
+        .with_mapped_port(4317, ContainerPort::Tcp(4317))
+        .with_mapped_port(4318, ContainerPort::Tcp(4318))
+        .with_mount(Mount::bind_mount(
+            fs::canonicalize("./otel-collector-config.yaml")?.to_string_lossy(),
+            "/etc/otelcol/config.yaml",
+        ))
+        .with_mount(Mount::bind_mount(
+            fs::canonicalize("./actual/logs.json")?.to_string_lossy(),
+            "/testresults/logs.json",
+        ))
+        .with_mount(Mount::bind_mount(
+            fs::canonicalize("./actual/metrics.json")?.to_string_lossy(),
+            "/testresults/metrics.json",
+        ))
+        .with_mount(Mount::bind_mount(
+            fs::canonicalize("./actual/traces.json")?.to_string_lossy(),
+            "/testresults/traces.json",
+        ))
+        .start()
+        .await?;
 
         let container = Arc::new(container_instance);
         otel_info!(


### PR DESCRIPTION
## Changes

- from time to time the integration tests are failing because of the Docker rate limit shared by everyone on the public runners, so I switched the collector image to the official GHCR variant

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
