### PR TITLE
ci: fix filter for benchmark pushes on branch 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
     # runners on arbitrary PRs, and we don't want to unleash that load on the pool anyway.     
     # If we're running on main, use the OTEL self-hosted runner pool. 
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'performance') }}
     env:
       # For PRs, compare against the base branch - e.g., 'main'. 
       # For pushes to main, compare against the previous commit

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,8 +25,7 @@ jobs:
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     if: |
       ${{ 
-        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'performance')) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'performance'))
       }}
     env:
       # For PRs, compare against the base branch - e.g., 'main'. 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
     # runners on arbitrary PRs, and we don't want to unleash that load on the pool anyway.     
     # If we're running on main, use the OTEL self-hosted runner pool. 
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
-    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'performance') }}
+    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'performance')) }}
     env:
       # For PRs, compare against the base branch - e.g., 'main'. 
       # For pushes to main, compare against the previous commit

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,10 +23,7 @@ jobs:
     # runners on arbitrary PRs, and we don't want to unleash that load on the pool anyway.     
     # If we're running on main, use the OTEL self-hosted runner pool. 
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
-    if: |
-      ${{ 
-        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'performance'))
-      }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'performance') }}
     env:
       # For PRs, compare against the base branch - e.g., 'main'. 
       # For pushes to main, compare against the previous commit

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
     if: |
       ${{ 
-        github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'performance') ||
-        github.event_name == 'push'
+        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'performance')) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/main')
       }}
     env:
       # For PRs, compare against the base branch - e.g., 'main'. 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
     # runners on arbitrary PRs, and we don't want to unleash that load on the pool anyway.     
     # If we're running on main, use the OTEL self-hosted runner pool. 
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
-    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'performance')) }}
+    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'performance')) || github.event_name == 'push' }}
     env:
       # For PRs, compare against the base branch - e.g., 'main'. 
       # For pushes to main, compare against the previous commit


### PR DESCRIPTION
## Changes
Something wasn't quite write with the filter for the branch runs; simplifying it into a single line seems to do the trick.
Have tested with and without label and validated it fires and doesn't fire accordingly. 

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
