### PR TITLE
test: validate code-based config is preferred over env vars in ZipkinExporterBuilder

### DIFF
--- a/opentelemetry-zipkin/src/exporter/env.rs
+++ b/opentelemetry-zipkin/src/exporter/env.rs
@@ -6,7 +6,7 @@ const DEFAULT_COLLECTOR_ENDPOINT: &str = "http://127.0.0.1:9411/api/v2/spans";
 
 /// HTTP endpoint for Zipkin collector.
 /// e.g. "http://localhost:9411/api/v2/spans"
-const ENV_ENDPOINT: &str = "OTEL_EXPORTER_ZIPKIN_ENDPOINT";
+pub(crate) const ENV_ENDPOINT: &str = "OTEL_EXPORTER_ZIPKIN_ENDPOINT";
 
 /// Maximum time the Zipkin exporter will wait for each batch export
 const ENV_TIMEOUT: &str = "OTEL_EXPORTER_ZIPKIN_TIMEOUT";


### PR DESCRIPTION
Relates to #1225 

## Changes

- I couldn't find a way to validate the timeout env var prioritization

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
