### PR TITLE
fix: KeyValueMetadata to not expose its fields public

### DIFF
--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -14,6 +14,7 @@
   - `Baggage` can't be retrieved from the `Context` directly anymore and needs to be accessed via `context.baggage()`
   - `with_baggage()` and `current_with_baggage()` override any existing `Baggage` in the `Context`
   - `Baggage` keys can't be empty and only allow ASCII visual chars, except `"(),/:;<=>?@[\]{}` (see [RFC7230, Section 3.2.6](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6))
+  - `KeyValueMetadata` does not publicly expose its fields. This should be transparent change to the users.
 - Changed `Context` to use a stack to properly handle out of order dropping of `ContextGuard`. This imposes a limit of `65535` nested contexts on a single thread. See #[2378](https://github.com/open-telemetry/opentelemetry-rust/pull/2284) and #[1887](https://github.com/open-telemetry/opentelemetry-rust/issues/1887).
 - Added additional `name: Option<&str>` parameter to the `event_enabled` method
   on the `Logger` trait. This allows implementations (SDK, processor, exporters)

--- a/opentelemetry/src/baggage.rs
+++ b/opentelemetry/src/baggage.rs
@@ -458,11 +458,11 @@ impl fmt::Display for BaggageMetadata {
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeyValueMetadata {
     /// Dimension or event key
-    pub key: Key,
+    pub(crate) key: Key,
     /// Dimension or event value
-    pub value: StringValue,
+    pub(crate) value: StringValue,
     /// Metadata associate with this key value pair
-    pub metadata: BaggageMetadata,
+    pub(crate) metadata: BaggageMetadata,
 }
 
 impl KeyValueMetadata {


### PR DESCRIPTION
Don't think public was required, and this should be transparent to users anyway...
https://github.com/open-telemetry/opentelemetry-rust/pull/2837/files#r2008002156