### PR TITLE
chore: Upgrade opentelemetry-prometheus to 0.29

### DIFF
--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+## v0.29.0
+
+- Update `opentelemetry` dependency version to 0.29
+- Update `opentelemetry_sdk` dependency version to 0.29
+- Update `opentelemetry-semantic-conventions` dependency version to 0.29
+
 ## v0.28.0
 
 - Update `opentelemetry` dependency version to 0.28

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-prometheus"
-version = "0.28.0"
+version = "0.29.0"
 description = "Prometheus exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-prometheus"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-prometheus"
@@ -21,14 +21,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 once_cell = { version = "1.13" }
-opentelemetry = { version = "0.28", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.28", default-features = false, features = ["metrics"] }
+opentelemetry = { version = "0.29", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.29", default-features = false, features = ["metrics"] }
 prometheus = "0.13"
 protobuf = "2.14"
-tracing = {version = ">=0.1.40", default-features = false, optional = true} # optional for opentelemetry internal logging
+tracing = { version = ">=0.1.40", default-features = false, optional = true } # optional for opentelemetry internal logging
 
 [dev-dependencies]
-opentelemetry-semantic-conventions = { version = "0.28" }
+opentelemetry-semantic-conventions = { version = "0.29" }
 http-body-util = { version = "0.1" }
 hyper = { version = "1.3", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }


### PR DESCRIPTION
## Changes

Upgrade the dependencies to the latest 0.29 version.

Not sure if you're still supporting this crate, but I figured this update is still simple enough.
 
## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
