### PR TITLE
docs: Modify example to use logs, baggage

### DIFF
--- a/examples/tracing-http-propagator/Cargo.toml
+++ b/examples/tracing-http-propagator/Cargo.toml
@@ -23,5 +23,8 @@ tokio = { workspace = true, features = ["full"] }
 opentelemetry = { path = "../../opentelemetry" }
 opentelemetry_sdk = { path = "../../opentelemetry-sdk" }
 opentelemetry-http = { path = "../../opentelemetry-http" }
-opentelemetry-stdout = { workspace = true, features = ["trace"] }
+opentelemetry-stdout = { workspace = true, features = ["trace", "logs"] }
 opentelemetry-semantic-conventions = { path = "../../opentelemetry-semantic-conventions" }
+opentelemetry-appender-tracing = { workspace = true }
+tracing = { workspace = true, features = ["std"]}
+tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }

--- a/examples/tracing-http-propagator/src/server.rs
+++ b/examples/tracing-http-propagator/src/server.rs
@@ -41,7 +41,7 @@ async fn handle_health_check(
     _req: Request<Incoming>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Infallible> {
     let tracer = get_tracer();
-    let _span = tracer
+    let _ = tracer
         .span_builder("health_check")
         .with_kind(SpanKind::Internal)
         .start(tracer);
@@ -61,7 +61,7 @@ async fn handle_echo(
     req: Request<Incoming>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Infallible> {
     let tracer = get_tracer();
-    let _span = tracer
+    let _ = tracer
         .span_builder("echo")
         .with_kind(SpanKind::Internal)
         .start(tracer);
@@ -77,9 +77,6 @@ async fn router(
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Infallible> {
     // Extract the context from the incoming request headers
     let parent_cx = extract_context_from_request(&req);
-    for bag in parent_cx.baggage() {
-        println!("Baggage: {:?} = {:?}", bag.0, bag.1);
-    }
     let response = {
         // Create a span parenting the remote client span.
         let tracer = get_tracer();
@@ -107,6 +104,8 @@ async fn router(
     response
 }
 
+/// A custom log processor that enriches LogRecords with baggage attributes.
+/// Baggage information is not added automatically without this processor.
 #[derive(Debug)]
 struct EnrichWithBaggageLogProcessor;
 impl LogProcessor for EnrichWithBaggageLogProcessor {
@@ -127,6 +126,8 @@ impl LogProcessor for EnrichWithBaggageLogProcessor {
     }
 }
 
+/// A custom span processor that enriches spans with baggage attributes. Baggage
+/// information is not added automatically without this processor.
 #[derive(Debug)]
 struct EnrichWithBaggageSpanProcessor;
 impl SpanProcessor for EnrichWithBaggageSpanProcessor {

--- a/examples/tracing-http-propagator/src/server.rs
+++ b/examples/tracing-http-propagator/src/server.rs
@@ -41,7 +41,7 @@ async fn handle_health_check(
     _req: Request<Incoming>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Infallible> {
     let tracer = get_tracer();
-    let _ = tracer
+    let _span = tracer
         .span_builder("health_check")
         .with_kind(SpanKind::Internal)
         .start(tracer);
@@ -61,7 +61,7 @@ async fn handle_echo(
     req: Request<Incoming>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Infallible> {
     let tracer = get_tracer();
-    let _ = tracer
+    let _span = tracer
         .span_builder("echo")
         .with_kind(SpanKind::Internal)
         .start(tracer);


### PR DESCRIPTION
Eventually, I expect that we should just need one example (or two - one for console apps, and one web app) that'd showcase each signals. This PR enhances the existing web examples to also use logs. It also showcases Baggage and composite propagators.
Only a small step - expecting many more changes to this examples next