### PR TITLE
refactor: AggregatedMetrics as enum instead of dyn Aggregation

### DIFF
--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -9,7 +9,7 @@ use crate::Resource;
 use super::Temporality;
 
 /// A collection of [ScopeMetrics] and the associated [Resource] that created them.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ResourceMetrics {
     /// The entity that collected the metrics.
     pub resource: Resource,
@@ -18,7 +18,7 @@ pub struct ResourceMetrics {
 }
 
 /// A collection of metrics produced by a meter.
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Debug)]
 pub struct ScopeMetrics {
     /// The [InstrumentationScope] that the meter was created with.
     pub scope: InstrumentationScope,
@@ -29,7 +29,7 @@ pub struct ScopeMetrics {
 /// A collection of one or more aggregated time series from an [Instrument].
 ///
 /// [Instrument]: crate::metrics::Instrument
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Metric {
     /// The name of the instrument that created this data.
     pub name: Cow<'static, str>,
@@ -42,7 +42,7 @@ pub struct Metric {
 }
 
 /// Aggregated metrics data from an instrument
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum AggregatedMetrics {
     /// All metric data with `f64` value type
     F64(MetricData<f64>),
@@ -53,7 +53,7 @@ pub enum AggregatedMetrics {
 }
 
 /// Metric data for all types
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum MetricData<T> {
     /// Metric data for Gauge
     Gauge(Gauge<T>),

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -1,6 +1,6 @@
 //! Types for delivery of pre-aggregated metric time series data.
 
-use std::{any, borrow::Cow, fmt, time::SystemTime};
+use std::{borrow::Cow, time::SystemTime};
 
 use opentelemetry::{InstrumentationScope, KeyValue};
 
@@ -9,7 +9,7 @@ use crate::Resource;
 use super::Temporality;
 
 /// A collection of [ScopeMetrics] and the associated [Resource] that created them.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ResourceMetrics {
     /// The entity that collected the metrics.
     pub resource: Resource,
@@ -18,7 +18,7 @@ pub struct ResourceMetrics {
 }
 
 /// A collection of metrics produced by a meter.
-#[derive(Default, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct ScopeMetrics {
     /// The [InstrumentationScope] that the meter was created with.
     pub scope: InstrumentationScope,
@@ -29,7 +29,7 @@ pub struct ScopeMetrics {
 /// A collection of one or more aggregated time series from an [Instrument].
 ///
 /// [Instrument]: crate::metrics::Instrument
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Metric {
     /// The name of the instrument that created this data.
     pub name: Cow<'static, str>,
@@ -38,23 +38,77 @@ pub struct Metric {
     /// The unit in which the instrument reports.
     pub unit: Cow<'static, str>,
     /// The aggregated data from an instrument.
-    pub data: Box<dyn Aggregation>,
+    pub data: AggregatedMetrics,
 }
 
-/// The store of data reported by an [Instrument].
-///
-/// It will be one of: [Gauge], [Sum], or [Histogram].
-///
-/// [Instrument]: crate::metrics::Instrument
-pub trait Aggregation: fmt::Debug + any::Any + Send + Sync {
-    /// Support downcasting
-    fn as_any(&self) -> &dyn any::Any;
-    /// Support downcasting during aggregation
-    fn as_mut(&mut self) -> &mut dyn any::Any;
+/// Aggregated metrics data from an instrument
+#[derive(Debug, Clone)]
+pub enum AggregatedMetrics {
+    /// All metric data with `f64` value type
+    F64(MetricData<f64>),
+    /// All metric data with `u64` value type
+    U64(MetricData<u64>),
+    /// All metric data with `i64` value type
+    I64(MetricData<i64>),
+}
+
+/// Metric data for all types
+#[derive(Debug, Clone)]
+pub enum MetricData<T> {
+    /// Metric data for Gauge
+    Gauge(Gauge<T>),
+    /// Metric data for Sum
+    Sum(Sum<T>),
+    /// Metric data for Histogram
+    Histogram(Histogram<T>),
+    /// Metric data for ExponentialHistogram
+    ExponentialHistogram(ExponentialHistogram<T>),
+}
+
+impl From<MetricData<f64>> for AggregatedMetrics {
+    fn from(value: MetricData<f64>) -> Self {
+        AggregatedMetrics::F64(value)
+    }
+}
+
+impl From<MetricData<i64>> for AggregatedMetrics {
+    fn from(value: MetricData<i64>) -> Self {
+        AggregatedMetrics::I64(value)
+    }
+}
+
+impl From<MetricData<u64>> for AggregatedMetrics {
+    fn from(value: MetricData<u64>) -> Self {
+        AggregatedMetrics::U64(value)
+    }
+}
+
+impl<T> From<Gauge<T>> for MetricData<T> {
+    fn from(value: Gauge<T>) -> Self {
+        MetricData::Gauge(value)
+    }
+}
+
+impl<T> From<Sum<T>> for MetricData<T> {
+    fn from(value: Sum<T>) -> Self {
+        MetricData::Sum(value)
+    }
+}
+
+impl<T> From<Histogram<T>> for MetricData<T> {
+    fn from(value: Histogram<T>) -> Self {
+        MetricData::Histogram(value)
+    }
+}
+
+impl<T> From<ExponentialHistogram<T>> for MetricData<T> {
+    fn from(value: ExponentialHistogram<T>) -> Self {
+        MetricData::ExponentialHistogram(value)
+    }
 }
 
 /// DataPoint is a single data point in a time series.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GaugeDataPoint<T> {
     /// Attributes is the set of key value pairs that uniquely identify the
     /// time series.
@@ -65,18 +119,8 @@ pub struct GaugeDataPoint<T> {
     pub exemplars: Vec<Exemplar<T>>,
 }
 
-impl<T: Copy> Clone for GaugeDataPoint<T> {
-    fn clone(&self) -> Self {
-        Self {
-            attributes: self.attributes.clone(),
-            value: self.value,
-            exemplars: self.exemplars.clone(),
-        }
-    }
-}
-
 /// A measurement of the current value of an instrument.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Gauge<T> {
     /// Represents individual aggregated measurements with unique attributes.
     pub data_points: Vec<GaugeDataPoint<T>>,
@@ -86,17 +130,8 @@ pub struct Gauge<T> {
     pub time: SystemTime,
 }
 
-impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Gauge<T> {
-    fn as_any(&self) -> &dyn any::Any {
-        self
-    }
-    fn as_mut(&mut self) -> &mut dyn any::Any {
-        self
-    }
-}
-
 /// DataPoint is a single data point in a time series.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SumDataPoint<T> {
     /// Attributes is the set of key value pairs that uniquely identify the
     /// time series.
@@ -107,18 +142,8 @@ pub struct SumDataPoint<T> {
     pub exemplars: Vec<Exemplar<T>>,
 }
 
-impl<T: Copy> Clone for SumDataPoint<T> {
-    fn clone(&self) -> Self {
-        Self {
-            attributes: self.attributes.clone(),
-            value: self.value,
-            exemplars: self.exemplars.clone(),
-        }
-    }
-}
-
 /// Represents the sum of all measurements of values from an instrument.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Sum<T> {
     /// Represents individual aggregated measurements with unique attributes.
     pub data_points: Vec<SumDataPoint<T>>,
@@ -133,17 +158,8 @@ pub struct Sum<T> {
     pub is_monotonic: bool,
 }
 
-impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Sum<T> {
-    fn as_any(&self) -> &dyn any::Any {
-        self
-    }
-    fn as_mut(&mut self) -> &mut dyn any::Any {
-        self
-    }
-}
-
 /// Represents the histogram of all measurements of values from an instrument.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Histogram<T> {
     /// Individual aggregated measurements with unique attributes.
     pub data_points: Vec<HistogramDataPoint<T>>,
@@ -156,17 +172,8 @@ pub struct Histogram<T> {
     pub temporality: Temporality,
 }
 
-impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for Histogram<T> {
-    fn as_any(&self) -> &dyn any::Any {
-        self
-    }
-    fn as_mut(&mut self) -> &mut dyn any::Any {
-        self
-    }
-}
-
 /// A single histogram data point in a time series.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct HistogramDataPoint<T> {
     /// The set of key value pairs that uniquely identify the time series.
     pub attributes: Vec<KeyValue>,
@@ -190,23 +197,8 @@ pub struct HistogramDataPoint<T> {
     pub exemplars: Vec<Exemplar<T>>,
 }
 
-impl<T: Copy> Clone for HistogramDataPoint<T> {
-    fn clone(&self) -> Self {
-        Self {
-            attributes: self.attributes.clone(),
-            count: self.count,
-            bounds: self.bounds.clone(),
-            bucket_counts: self.bucket_counts.clone(),
-            min: self.min,
-            max: self.max,
-            sum: self.sum,
-            exemplars: self.exemplars.clone(),
-        }
-    }
-}
-
 /// The histogram of all measurements of values from an instrument.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ExponentialHistogram<T> {
     /// The individual aggregated measurements with unique attributes.
     pub data_points: Vec<ExponentialHistogramDataPoint<T>>,
@@ -219,17 +211,8 @@ pub struct ExponentialHistogram<T> {
     pub temporality: Temporality,
 }
 
-impl<T: fmt::Debug + Send + Sync + 'static> Aggregation for ExponentialHistogram<T> {
-    fn as_any(&self) -> &dyn any::Any {
-        self
-    }
-    fn as_mut(&mut self) -> &mut dyn any::Any {
-        self
-    }
-}
-
 /// A single exponential histogram data point in a time series.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ExponentialHistogramDataPoint<T> {
     /// The set of key value pairs that uniquely identify the time series.
     pub attributes: Vec<KeyValue>,
@@ -273,26 +256,8 @@ pub struct ExponentialHistogramDataPoint<T> {
     pub exemplars: Vec<Exemplar<T>>,
 }
 
-impl<T: Copy> Clone for ExponentialHistogramDataPoint<T> {
-    fn clone(&self) -> Self {
-        Self {
-            attributes: self.attributes.clone(),
-            count: self.count,
-            min: self.min,
-            max: self.max,
-            sum: self.sum,
-            scale: self.scale,
-            zero_count: self.zero_count,
-            positive_bucket: self.positive_bucket.clone(),
-            negative_bucket: self.negative_bucket.clone(),
-            zero_threshold: self.zero_threshold,
-            exemplars: self.exemplars.clone(),
-        }
-    }
-}
-
 /// A set of bucket counts, encoded in a contiguous array of counts.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ExponentialBucket {
     /// The bucket index of the first entry in the `counts` vec.
     pub offset: i32,
@@ -304,17 +269,8 @@ pub struct ExponentialBucket {
     pub counts: Vec<u64>,
 }
 
-impl Clone for ExponentialBucket {
-    fn clone(&self) -> Self {
-        Self {
-            offset: self.offset,
-            counts: self.counts.clone(),
-        }
-    }
-}
-
 /// A measurement sampled from a time series providing a typical example.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Exemplar<T> {
     /// The attributes recorded with the measurement but filtered out of the
     /// time series' aggregated data.
@@ -331,18 +287,6 @@ pub struct Exemplar<T> {
     ///
     /// If no span was active or the span was not sampled this will be empty.
     pub trace_id: [u8; 16],
-}
-
-impl<T: Copy> Clone for Exemplar<T> {
-    fn clone(&self) -> Self {
-        Self {
-            filtered_attributes: self.filtered_attributes.clone(),
-            time: self.time,
-            value: self.value,
-            span_id: self.span_id,
-            trace_id: self.trace_id,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -4,7 +4,7 @@ use opentelemetry::{otel_debug, KeyValue};
 use std::sync::OnceLock;
 
 use crate::metrics::{
-    data::{self, Aggregation, ExponentialHistogram},
+    data::{self, AggregatedMetrics, MetricData},
     Temporality,
 };
 
@@ -383,10 +383,16 @@ impl<T: Number> ExpoHistogram<T> {
         }
     }
 
-    fn delta(&self, dest: Option<&mut dyn Aggregation>) -> (usize, Option<Box<dyn Aggregation>>) {
+    fn delta(&self, dest: Option<&mut MetricData<T>>) -> (usize, Option<MetricData<T>>) {
         let time = self.init_time.delta();
 
-        let h = dest.and_then(|d| d.as_mut().downcast_mut::<ExponentialHistogram<T>>());
+        let h = dest.and_then(|d| {
+            if let MetricData::ExponentialHistogram(hist) = d {
+                Some(hist)
+            } else {
+                None
+            }
+        });
         let mut new_agg = if h.is_none() {
             Some(data::ExponentialHistogram {
                 data_points: vec![],
@@ -434,16 +440,19 @@ impl<T: Number> ExpoHistogram<T> {
                 }
             });
 
-        (h.data_points.len(), new_agg.map(|a| Box::new(a) as Box<_>))
+        (h.data_points.len(), new_agg.map(Into::into))
     }
 
-    fn cumulative(
-        &self,
-        dest: Option<&mut dyn Aggregation>,
-    ) -> (usize, Option<Box<dyn Aggregation>>) {
+    fn cumulative(&self, dest: Option<&mut MetricData<T>>) -> (usize, Option<MetricData<T>>) {
         let time = self.init_time.cumulative();
 
-        let h = dest.and_then(|d| d.as_mut().downcast_mut::<ExponentialHistogram<T>>());
+        let h = dest.and_then(|d| {
+            if let MetricData::ExponentialHistogram(hist) = d {
+                Some(hist)
+            } else {
+                None
+            }
+        });
         let mut new_agg = if h.is_none() {
             Some(data::ExponentialHistogram {
                 data_points: vec![],
@@ -491,7 +500,7 @@ impl<T: Number> ExpoHistogram<T> {
                 }
             });
 
-        (h.data_points.len(), new_agg.map(|a| Box::new(a) as Box<_>))
+        (h.data_points.len(), new_agg.map(Into::into))
     }
 }
 
@@ -517,18 +526,20 @@ impl<T> ComputeAggregation for ExpoHistogram<T>
 where
     T: Number,
 {
-    fn call(&self, dest: Option<&mut dyn Aggregation>) -> (usize, Option<Box<dyn Aggregation>>) {
-        match self.temporality {
-            Temporality::Delta => self.delta(dest),
-            _ => self.cumulative(dest),
-        }
+    fn call(&self, dest: Option<&mut AggregatedMetrics>) -> (usize, Option<AggregatedMetrics>) {
+        let data = dest.and_then(|d| T::extract_metrics_data_mut(d));
+        let (len, new) = match self.temporality {
+            Temporality::Delta => self.delta(data),
+            _ => self.cumulative(data),
+        };
+        (len, new.map(T::make_aggregated_metrics))
     }
 }
+
 #[cfg(test)]
 mod tests {
-    use data::{ExponentialHistogram, Gauge, Histogram, Sum};
     use opentelemetry::time::now;
-    use std::ops::Neg;
+    use std::{any::Any, ops::Neg};
     use tests::internal::AggregateFns;
 
     use crate::metrics::internal::{self, AggregateBuilder};
@@ -1438,111 +1449,114 @@ mod tests {
         for test in test_cases {
             let AggregateFns { measure, collect } = (test.build)();
 
-            let mut got: Box<dyn data::Aggregation> = Box::new(data::ExponentialHistogram::<T> {
-                data_points: vec![],
-                start_time: now(),
-                time: now(),
-                temporality: Temporality::Delta,
-            });
+            let mut got = T::make_aggregated_metrics(MetricData::ExponentialHistogram(
+                data::ExponentialHistogram::<T> {
+                    data_points: vec![],
+                    start_time: now(),
+                    time: now(),
+                    temporality: Temporality::Delta,
+                },
+            ));
             let mut count = 0;
             for n in test.input {
                 for v in n {
                     measure.call(v, &[])
                 }
-                count = collect.call(Some(got.as_mut())).0
+                count = collect.call(Some(&mut got)).0
             }
 
-            assert_aggregation_eq::<T>(Box::new(test.want), got, test.name);
+            assert_aggregation_eq(
+                &MetricData::ExponentialHistogram(test.want),
+                T::extract_metrics_data_ref(&got).unwrap(),
+                test.name,
+            );
             assert_eq!(test.want_count, count, "{}", test.name);
         }
     }
 
     fn assert_aggregation_eq<T: Number + PartialEq>(
-        a: Box<dyn Aggregation>,
-        b: Box<dyn Aggregation>,
+        a: &MetricData<T>,
+        b: &MetricData<T>,
         test_name: &'static str,
     ) {
-        assert_eq!(
-            a.as_any().type_id(),
-            b.as_any().type_id(),
-            "{} Aggregation types not equal",
-            test_name
-        );
-
-        if let Some(a) = a.as_any().downcast_ref::<Gauge<T>>() {
-            let b = b.as_any().downcast_ref::<Gauge<T>>().unwrap();
-            assert_eq!(
-                a.data_points.len(),
-                b.data_points.len(),
-                "{} gauge counts",
-                test_name
-            );
-            for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
-                assert_gauge_data_points_eq(a, b, "mismatching gauge data points", test_name);
+        match (a, b) {
+            (MetricData::Gauge(a), MetricData::Gauge(b)) => {
+                assert_eq!(
+                    a.data_points.len(),
+                    b.data_points.len(),
+                    "{} gauge counts",
+                    test_name
+                );
+                for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
+                    assert_gauge_data_points_eq(a, b, "mismatching gauge data points", test_name);
+                }
             }
-        } else if let Some(a) = a.as_any().downcast_ref::<Sum<T>>() {
-            let b = b.as_any().downcast_ref::<Sum<T>>().unwrap();
-            assert_eq!(
-                a.temporality, b.temporality,
-                "{} mismatching sum temporality",
-                test_name
-            );
-            assert_eq!(
-                a.is_monotonic, b.is_monotonic,
-                "{} mismatching sum monotonicity",
-                test_name,
-            );
-            assert_eq!(
-                a.data_points.len(),
-                b.data_points.len(),
-                "{} sum counts",
-                test_name
-            );
-            for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
-                assert_sum_data_points_eq(a, b, "mismatching sum data points", test_name);
-            }
-        } else if let Some(a) = a.as_any().downcast_ref::<Histogram<T>>() {
-            let b = b.as_any().downcast_ref::<Histogram<T>>().unwrap();
-            assert_eq!(
-                a.temporality, b.temporality,
-                "{}: mismatching hist temporality",
-                test_name
-            );
-            assert_eq!(
-                a.data_points.len(),
-                b.data_points.len(),
-                "{} hist counts",
-                test_name
-            );
-            for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
-                assert_hist_data_points_eq(a, b, "mismatching hist data points", test_name);
-            }
-        } else if let Some(a) = a.as_any().downcast_ref::<ExponentialHistogram<T>>() {
-            let b = b
-                .as_any()
-                .downcast_ref::<ExponentialHistogram<T>>()
-                .unwrap();
-            assert_eq!(
-                a.temporality, b.temporality,
-                "{} mismatching hist temporality",
-                test_name
-            );
-            assert_eq!(
-                a.data_points.len(),
-                b.data_points.len(),
-                "{} hist counts",
-                test_name
-            );
-            for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
-                assert_exponential_hist_data_points_eq(
-                    a,
-                    b,
-                    "mismatching hist data points",
+            (MetricData::Sum(a), MetricData::Sum(b)) => {
+                assert_eq!(
+                    a.temporality, b.temporality,
+                    "{} mismatching sum temporality",
+                    test_name
+                );
+                assert_eq!(
+                    a.is_monotonic, b.is_monotonic,
+                    "{} mismatching sum monotonicity",
                     test_name,
                 );
+                assert_eq!(
+                    a.data_points.len(),
+                    b.data_points.len(),
+                    "{} sum counts",
+                    test_name
+                );
+                for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
+                    assert_sum_data_points_eq(a, b, "mismatching sum data points", test_name);
+                }
             }
-        } else {
-            panic!("Aggregation of unknown types")
+            (MetricData::Histogram(a), MetricData::Histogram(b)) => {
+                assert_eq!(
+                    a.temporality, b.temporality,
+                    "{}: mismatching hist temporality",
+                    test_name
+                );
+                assert_eq!(
+                    a.data_points.len(),
+                    b.data_points.len(),
+                    "{} hist counts",
+                    test_name
+                );
+                for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
+                    assert_hist_data_points_eq(a, b, "mismatching hist data points", test_name);
+                }
+            }
+            (MetricData::ExponentialHistogram(a), MetricData::ExponentialHistogram(b)) => {
+                assert_eq!(
+                    a.temporality, b.temporality,
+                    "{} mismatching hist temporality",
+                    test_name
+                );
+                assert_eq!(
+                    a.data_points.len(),
+                    b.data_points.len(),
+                    "{} hist counts",
+                    test_name
+                );
+                for (a, b) in a.data_points.iter().zip(b.data_points.iter()) {
+                    assert_exponential_hist_data_points_eq(
+                        a,
+                        b,
+                        "mismatching hist data points",
+                        test_name,
+                    );
+                }
+            }
+            _ => {
+                assert_eq!(
+                    a.type_id(),
+                    b.type_id(),
+                    "{} Aggregation types not equal",
+                    test_name
+                );
+            }
         }
     }
 

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -1,6 +1,6 @@
 use opentelemetry::KeyValue;
 
-use crate::metrics::data::{self, Aggregation, Sum, SumDataPoint};
+use crate::metrics::data::{self, AggregatedMetrics, MetricData, SumDataPoint};
 use crate::metrics::Temporality;
 
 use super::aggregate::{AggregateTimeInitiator, AttributeSetFilter};
@@ -34,13 +34,16 @@ impl<T: Number> PrecomputedSum<T> {
         }
     }
 
-    pub(crate) fn delta(
-        &self,
-        dest: Option<&mut dyn Aggregation>,
-    ) -> (usize, Option<Box<dyn Aggregation>>) {
+    pub(crate) fn delta(&self, dest: Option<&mut MetricData<T>>) -> (usize, Option<MetricData<T>>) {
         let time = self.init_time.delta();
 
-        let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<Sum<T>>());
+        let s_data = dest.and_then(|d| {
+            if let MetricData::Sum(sum) = d {
+                Some(sum)
+            } else {
+                None
+            }
+        });
         let mut new_agg = if s_data.is_none() {
             Some(data::Sum {
                 data_points: vec![],
@@ -79,19 +82,22 @@ impl<T: Number> PrecomputedSum<T> {
         *reported = new_reported;
         drop(reported); // drop before values guard is dropped
 
-        (
-            s_data.data_points.len(),
-            new_agg.map(|a| Box::new(a) as Box<_>),
-        )
+        (s_data.data_points.len(), new_agg.map(Into::into))
     }
 
     pub(crate) fn cumulative(
         &self,
-        dest: Option<&mut dyn Aggregation>,
-    ) -> (usize, Option<Box<dyn Aggregation>>) {
+        dest: Option<&mut MetricData<T>>,
+    ) -> (usize, Option<MetricData<T>>) {
         let time = self.init_time.cumulative();
 
-        let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<Sum<T>>());
+        let s_data = dest.and_then(|d| {
+            if let MetricData::Sum(sum) = d {
+                Some(sum)
+            } else {
+                None
+            }
+        });
         let mut new_agg = if s_data.is_none() {
             Some(data::Sum {
                 data_points: vec![],
@@ -116,10 +122,7 @@ impl<T: Number> PrecomputedSum<T> {
                 exemplars: vec![],
             });
 
-        (
-            s_data.data_points.len(),
-            new_agg.map(|a| Box::new(a) as Box<_>),
-        )
+        (s_data.data_points.len(), new_agg.map(Into::into))
     }
 }
 
@@ -138,10 +141,12 @@ impl<T> ComputeAggregation for PrecomputedSum<T>
 where
     T: Number,
 {
-    fn call(&self, dest: Option<&mut dyn Aggregation>) -> (usize, Option<Box<dyn Aggregation>>) {
-        match self.temporality {
-            Temporality::Delta => self.delta(dest),
-            _ => self.cumulative(dest),
-        }
+    fn call(&self, dest: Option<&mut AggregatedMetrics>) -> (usize, Option<AggregatedMetrics>) {
+        let data = dest.and_then(|d| T::extract_metrics_data_mut(d));
+        let (len, new) = match self.temporality {
+            Temporality::Delta => self.delta(data),
+            _ => self.cumulative(data),
+        };
+        (len, new.map(T::make_aggregated_metrics))
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -1,4 +1,4 @@
-use crate::metrics::data::{self, Aggregation, SumDataPoint};
+use crate::metrics::data::{self, AggregatedMetrics, MetricData, SumDataPoint};
 use crate::metrics::Temporality;
 use opentelemetry::KeyValue;
 
@@ -66,12 +66,15 @@ impl<T: Number> Sum<T> {
         }
     }
 
-    pub(crate) fn delta(
-        &self,
-        dest: Option<&mut dyn Aggregation>,
-    ) -> (usize, Option<Box<dyn Aggregation>>) {
+    pub(crate) fn delta(&self, dest: Option<&mut MetricData<T>>) -> (usize, Option<MetricData<T>>) {
         let time = self.init_time.delta();
-        let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<data::Sum<T>>());
+        let s_data = dest.and_then(|d| {
+            if let MetricData::Sum(sum) = d {
+                Some(sum)
+            } else {
+                None
+            }
+        });
         let mut new_agg = if s_data.is_none() {
             Some(data::Sum {
                 data_points: vec![],
@@ -96,18 +99,21 @@ impl<T: Number> Sum<T> {
                 exemplars: vec![],
             });
 
-        (
-            s_data.data_points.len(),
-            new_agg.map(|a| Box::new(a) as Box<_>),
-        )
+        (s_data.data_points.len(), new_agg.map(Into::into))
     }
 
     pub(crate) fn cumulative(
         &self,
-        dest: Option<&mut dyn Aggregation>,
-    ) -> (usize, Option<Box<dyn Aggregation>>) {
+        dest: Option<&mut MetricData<T>>,
+    ) -> (usize, Option<MetricData<T>>) {
         let time = self.init_time.cumulative();
-        let s_data = dest.and_then(|d| d.as_mut().downcast_mut::<data::Sum<T>>());
+        let s_data = dest.and_then(|d| {
+            if let MetricData::Sum(sum) = d {
+                Some(sum)
+            } else {
+                None
+            }
+        });
         let mut new_agg = if s_data.is_none() {
             Some(data::Sum {
                 data_points: vec![],
@@ -133,10 +139,7 @@ impl<T: Number> Sum<T> {
                 exemplars: vec![],
             });
 
-        (
-            s_data.data_points.len(),
-            new_agg.map(|a| Box::new(a) as Box<_>),
-        )
+        (s_data.data_points.len(), new_agg.map(Into::into))
     }
 }
 
@@ -155,10 +158,12 @@ impl<T> ComputeAggregation for Sum<T>
 where
     T: Number,
 {
-    fn call(&self, dest: Option<&mut dyn Aggregation>) -> (usize, Option<Box<dyn Aggregation>>) {
-        match self.temporality {
-            Temporality::Delta => self.delta(dest),
-            _ => self.cumulative(dest),
-        }
+    fn call(&self, dest: Option<&mut AggregatedMetrics>) -> (usize, Option<AggregatedMetrics>) {
+        let data = dest.and_then(|d| T::extract_metrics_data_mut(d));
+        let (len, new) = match self.temporality {
+            Temporality::Delta => self.delta(data),
+            _ => self.cumulative(data),
+        };
+        (len, new.map(T::make_aggregated_metrics))
     }
 }

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -135,7 +135,7 @@ impl SdkProducer for Pipeline {
             let mut j = 0;
             for inst in instruments {
                 let mut m = sm.metrics.get_mut(j);
-                match (inst.comp_agg.call(m.as_mut().map(|m| m.data.as_mut())), m) {
+                match (inst.comp_agg.call(m.as_mut().map(|m| &mut m.data)), m) {
                     // No metric to re-use, expect agg to create new metric data
                     ((len, Some(initial_agg)), None) if len > 0 => sm.metrics.push(Metric {
                         name: inst.name.clone(),

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -1,12 +1,13 @@
 use chrono::{DateTime, Utc};
 use core::{f64, fmt};
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
 use opentelemetry_sdk::metrics::Temporality;
 use opentelemetry_sdk::{
     error::OTelSdkResult,
     metrics::{
         data::{
-            ExponentialHistogram, Gauge, GaugeDataPoint, Histogram, HistogramDataPoint,
-            ResourceMetrics, ScopeMetrics, Sum, SumDataPoint,
+            Gauge, GaugeDataPoint, Histogram, HistogramDataPoint, ResourceMetrics, ScopeMetrics,
+            Sum, SumDataPoint,
         },
         exporter::PushMetricExporter,
     },
@@ -100,39 +101,32 @@ fn print_metrics(metrics: &[ScopeMetrics]) {
             println!("\t\tDescription  : {}", &metric.description);
             println!("\t\tUnit         : {}", &metric.unit);
 
-            let data = metric.data.as_any();
-            if let Some(hist) = data.downcast_ref::<Histogram<u64>>() {
-                println!("\t\tType         : Histogram");
-                print_histogram(hist);
-            } else if let Some(hist) = data.downcast_ref::<Histogram<f64>>() {
-                println!("\t\tType         : Histogram");
-                print_histogram(hist);
-            } else if let Some(_hist) = data.downcast_ref::<ExponentialHistogram<u64>>() {
-                println!("\t\tType         : Exponential Histogram");
-                // TODO
-            } else if let Some(_hist) = data.downcast_ref::<ExponentialHistogram<f64>>() {
-                println!("\t\tType         : Exponential Histogram");
-                // TODO
-            } else if let Some(sum) = data.downcast_ref::<Sum<u64>>() {
-                println!("\t\tType         : Sum");
-                print_sum(sum);
-            } else if let Some(sum) = data.downcast_ref::<Sum<i64>>() {
-                println!("\t\tType         : Sum");
-                print_sum(sum);
-            } else if let Some(sum) = data.downcast_ref::<Sum<f64>>() {
-                println!("\t\tType         : Sum");
-                print_sum(sum);
-            } else if let Some(gauge) = data.downcast_ref::<Gauge<u64>>() {
-                println!("\t\tType         : Gauge");
-                print_gauge(gauge);
-            } else if let Some(gauge) = data.downcast_ref::<Gauge<i64>>() {
-                println!("\t\tType         : Gauge");
-                print_gauge(gauge);
-            } else if let Some(gauge) = data.downcast_ref::<Gauge<f64>>() {
-                println!("\t\tType         : Gauge");
-                print_gauge(gauge);
-            } else {
-                println!("Unsupported data type");
+            fn print_info<T>(data: &MetricData<T>)
+            where
+                T: Debug,
+            {
+                match data {
+                    MetricData::Gauge(gauge) => {
+                        println!("\t\tType         : Gauge");
+                        print_gauge(gauge);
+                    }
+                    MetricData::Sum(sum) => {
+                        println!("\t\tType         : Sum");
+                        print_sum(sum);
+                    }
+                    MetricData::Histogram(hist) => {
+                        println!("\t\tType         : Histogram");
+                        print_histogram(hist);
+                    }
+                    MetricData::ExponentialHistogram(_) => {
+                        println!("\t\tType         : Exponential Histogram");
+                    }
+                }
+            }
+            match &metric.data {
+                AggregatedMetrics::F64(data) => print_info(data),
+                AggregatedMetrics::U64(data) => print_info(data),
+                AggregatedMetrics::I64(data) => print_info(data),
             }
         });
     }


### PR DESCRIPTION
## Changes

* Introduced a new `AggregatedMetrics` enum, which store data reported by Instruments.
* Change `Metric::data` field from `Box<dyn Aggregation>` to `AggregatedMetrics`.
* `ResourceMetrics` is now `Clone`, because `AggregatedMetrics` is a simple enum that can be easily `cloned`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
