### PR TITLE
chore: Add company affiliation to maintainers and approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,16 +179,16 @@ you're more than welcome to participate!
 
 ### Maintainers
 
-* [Cijo Thomas](https://github.com/cijothomas)
+* [Cijo Thomas](https://github.com/cijothomas), Microsoft
 * [Harold Dost](https://github.com/hdost)
-* [Lalit Kumar Bhasin](https://github.com/lalitb)
-* [Utkarsh Umesan Pillai](https://github.com/utpilla)
+* [Lalit Kumar Bhasin](https://github.com/lalitb), Microsoft
+* [Utkarsh Umesan Pillai](https://github.com/utpilla), Microsoft
 * [Zhongyang Wu](https://github.com/TommyCpp)
 
 ### Approvers
 
-* [Shaun Cox](https://github.com/shaun-cox)
-* [Scott Gerring](https://github.com/scottgerring)
+* [Shaun Cox](https://github.com/shaun-cox), Microsoft
+* [Scott Gerring](https://github.com/scottgerring), Datadog
 
 ### Emeritus
 


### PR DESCRIPTION
Following other Otel repos.