### PR TITLE
chore: Add Anton Grübel as approver

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -42,6 +42,8 @@
         "Dwarnings",
         "EPYC",
         "flamegraph",
+        "Gerring",
+        "Grübel",
         "hasher",
         "Isobel",
         "jaegertracing",

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ you're more than welcome to participate!
 
 ### Approvers
 
+* [Anton Grübel](https://github.com/gruebel), Baz
 * [Shaun Cox](https://github.com/shaun-cox), Microsoft
 * [Scott Gerring](https://github.com/scottgerring), Datadog
 


### PR DESCRIPTION
Anton has been helping with both main repo and the contrib repo for a while, and has accepted to volunteer time as an Approver.

Requirements from Otel guide has been met:
https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#requirements-2

