### PR TITLE
perf: Run all benchmarks for shorter time

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10  # Fetch current commit and its parent
+      - name: "Show change commit"
+        run: git log -1
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -42,11 +44,15 @@ jobs:
         with:
           cwd: opentelemetry
           branchName: ${{ env.BRANCH_NAME }}
+      - name: "Checkout change commit"
+        run: git checkout $GITHUB_SHA
       - uses: boa-dev/criterion-compare-action@v3
         with:
           cwd: opentelemetry-appender-tracing
           features: spec_unstable_logs_enabled
           branchName: ${{ env.BRANCH_NAME }}
+      - name: "Checkout change commit"
+        run: git checkout $GITHUB_SHA
       - uses: boa-dev/criterion-compare-action@v3
         with:
           cwd: opentelemetry-sdk

--- a/examples/logs-basic/Cargo.toml
+++ b/examples/logs-basic/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
+autobenches = false
+
+[[bin]]
+name = "logs-basic"
+path = "src/main.rs"
+bench = false
 
 [dependencies]
 opentelemetry_sdk = { path = "../../opentelemetry-sdk", features = ["logs"] }

--- a/examples/metrics-advanced/Cargo.toml
+++ b/examples/metrics-advanced/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
+autobenches = false
+
+[[bin]]
+name = "metrics-advanced"
+path = "src/main.rs"
+bench = false
 
 [dependencies]
 opentelemetry = { path = "../../opentelemetry", features = ["metrics"] }

--- a/examples/metrics-basic/Cargo.toml
+++ b/examples/metrics-basic/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
+autobenches = false
+
+[[bin]]
+name = "metrics-basic"
+path = "src/main.rs"
+bench = false
 
 [dependencies]
 opentelemetry = { path = "../../opentelemetry", features = ["metrics"] }

--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -4,14 +4,17 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
+autobenches = false
 
 [[bin]] # Bin to run the gRPC server
 name = "grpc-server"
 path = "src/server.rs"
+bench = false
 
 [[bin]] # Bin to run the gRPC client
 name = "grpc-client"
 path = "src/client.rs"
+bench = false
 
 [dependencies]
 opentelemetry = { path = "../../opentelemetry" }

--- a/examples/tracing-http-propagator/Cargo.toml
+++ b/examples/tracing-http-propagator/Cargo.toml
@@ -4,16 +4,19 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
+autobenches = false
 
 [[bin]] # Bin to run the http server
 name = "http-server"
 path = "src/server.rs"
 doc = false
+bench = false
 
 [[bin]] # Bin to run the client
 name = "http-client"
 path = "src/client.rs"
 doc = false
+bench = false
 
 [dependencies]
 http-body-util = { workspace = true }

--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -9,6 +9,10 @@ keywords = ["opentelemetry", "log", "logs"]
 license = "Apache-2.0"
 rust-version = "1.75.0"
 edition = "2021"
+autobenches = false
+
+[lib]
+bench = false
 
 [dependencies]
 opentelemetry = { version = "0.29", path = "../opentelemetry", features = [

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["opentelemetry", "log", "logs", "tracing"]
 license = "Apache-2.0"
 rust-version = "1.75.0"
+autobenches = false
 
 [dependencies]
 log = { workspace = true, optional = true }

--- a/opentelemetry-appender-tracing/benches/log-attributes.rs
+++ b/opentelemetry-appender-tracing/benches/log-attributes.rs
@@ -258,14 +258,19 @@ fn criterion_benchmark(c: &mut Criterion) {
 #[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2))
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
 
 #[cfg(target_os = "windows")]
 criterion_group! {
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
     targets = criterion_benchmark
 }
 

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -168,13 +168,18 @@ fn criterion_benchmark(c: &mut Criterion) {
 #[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2))
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
 #[cfg(target_os = "windows")]
 criterion_group! {
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["opentelemetry", "tracing", "context", "propagation"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
+autobenches = false
 
 [features]
 default = ["internal-logs"]
@@ -35,3 +36,6 @@ ignored = [
 
 [lints]
 workspace = true
+
+[lib]
+bench = false

--- a/opentelemetry-jaeger-propagator/Cargo.toml
+++ b/opentelemetry-jaeger-propagator/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["opentelemetry", "jaeger", "propagator"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
+autobenches = false
 
 [package.metadata.docs.rs]
 all-features = true
@@ -39,3 +40,6 @@ ignored = [
 
 [lints]
 workspace = true
+
+[lib]
+bench = false

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -15,6 +15,7 @@ license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
 autotests = false
+autobenches = false
 
 [[test]]
 name = "smoke"
@@ -85,3 +86,6 @@ integration-testing = ["tonic", "prost", "tokio/full", "trace", "logs"]
 
 [lints]
 workspace = true
+
+[lib]
+bench = false

--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
+autobenches = false
+
+[[bin]]
+name = "basic-otlp-http"
+path = "src/main.rs"
+bench = false
 
 [features]
 default = ["reqwest-blocking"]

--- a/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = false
+autobenches = false
+
+[[bin]]
+name = "basic-otlp"
+path = "src/main.rs"
+bench = false
 
 [dependencies]
 opentelemetry = { path = "../../../opentelemetry" }

--- a/opentelemetry-otlp/tests/integration_test/Cargo.toml
+++ b/opentelemetry-otlp/tests/integration_test/Cargo.toml
@@ -3,6 +3,7 @@ name = "integration_test_runner"
 version = "0.1.0"
 edition = "2021"
 publish = false
+autobenches = false
 
 [dependencies]
 opentelemetry = { path = "../../../opentelemetry", features = [] }
@@ -35,3 +36,6 @@ default = ["tonic-client", "internal-logs"]
 
 [lints]
 workspace = true
+
+[lib]
+bench = false

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -15,9 +15,11 @@ license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
 autotests = false
+autobenches = false
 
 [lib]
 doctest = false
+bench = false
 
 [[test]]
 name = "grpc_build"

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
+autobenches = false
 
 [dependencies]
 opentelemetry = { version = "0.29", path = "../opentelemetry/" }
@@ -112,7 +113,7 @@ required-features = ["rt-tokio", "testing"]
 [[bench]]
 name = "metric"
 harness = false
-required-features = ["metrics"]
+required-features = ["metrics", "spec_unstable_metrics_views"]
 
 [[bench]]
 name = "log"

--- a/opentelemetry-sdk/benches/batch_span_processor.rs
+++ b/opentelemetry-sdk/benches/batch_span_processor.rs
@@ -80,5 +80,11 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/context.rs
+++ b/opentelemetry-sdk/benches/context.rs
@@ -173,13 +173,18 @@ impl SpanExporter for NoopExporter {
 #[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2))
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
 #[cfg(target_os = "windows")]
 criterion_group! {
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -330,5 +330,11 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/log_enabled.rs
+++ b/opentelemetry-sdk/benches/log_enabled.rs
@@ -76,13 +76,18 @@ fn criterion_benchmark(c: &mut Criterion) {
 #[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2))
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
 #[cfg(target_os = "windows")]
 criterion_group! {
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -167,13 +167,18 @@ fn exporter_without_future(c: &mut Criterion) {
 #[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2))
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
 #[cfg(target_os = "windows")]
 criterion_group! {
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/log_processor.rs
+++ b/opentelemetry-sdk/benches/log_processor.rs
@@ -169,6 +169,12 @@ fn log_cloning_and_send_to_channel_processor(c: &mut Criterion) {
         });
     });
 }
-criterion_group!(benches, criterion_benchmark);
 
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -351,5 +351,12 @@ fn benchmark_collect_histogram(b: &mut Bencher, n: usize) {
     })
 }
 
-criterion_group!(benches, counters, histograms);
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = counters, histograms
+}
+
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/metrics_counter.rs
+++ b/opentelemetry-sdk/benches/metrics_counter.rs
@@ -242,13 +242,18 @@ fn random_generator(c: &mut Criterion) {
 #[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2))
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
 #[cfg(target_os = "windows")]
 criterion_group! {
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/metrics_gauge.rs
+++ b/opentelemetry-sdk/benches/metrics_gauge.rs
@@ -78,6 +78,11 @@ fn gauge_record(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
-
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/metrics_histogram.rs
+++ b/opentelemetry-sdk/benches/metrics_histogram.rs
@@ -146,13 +146,18 @@ fn histogram_record_with_non_static_values(c: &mut Criterion, attribute_values: 
 #[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2))
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
 #[cfg(target_os = "windows")]
 criterion_group! {
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/span_builder.rs
+++ b/opentelemetry-sdk/benches/span_builder.rs
@@ -83,13 +83,18 @@ const MAP_KEYS: [&str; 64] = [
 #[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2))
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
 #[cfg(target_os = "windows")]
 criterion_group! {
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -92,13 +92,18 @@ fn trace_benchmark_group<F: Fn(&sdktrace::SdkTracer)>(c: &mut Criterion, name: &
 #[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2))
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
 #[cfg(target_os = "windows")]
 criterion_group! {
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/tracer_creation.rs
+++ b/opentelemetry-sdk/benches/tracer_creation.rs
@@ -86,14 +86,17 @@ fn criterion_benchmark(c: &mut Criterion) {
 #[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)))
+                               .warm_up_time(std::time::Duration::from_secs(1))
+                               .measurement_time(std::time::Duration::from_secs(2));
     targets = criterion_benchmark
 }
 
 #[cfg(target_os = "windows")]
 criterion_group! {
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default().warm_up_time(std::time::Duration::from_secs(1))
+                               .measurement_time(std::time::Duration::from_secs(2));
     targets = criterion_benchmark
 }
 

--- a/opentelemetry-semantic-conventions/Cargo.toml
+++ b/opentelemetry-semantic-conventions/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["opentelemetry", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
+autobenches = false
 
 [package.metadata.docs.rs]
 all-features = true
@@ -29,3 +30,6 @@ opentelemetry_sdk = { features = ["trace"], path = "../opentelemetry-sdk" } # fo
 
 [lints]
 workspace = true
+
+[lib]
+bench = false

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["opentelemetry", "tracing", "metrics", "logs"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
+autobenches = false
 
 [package.metadata.docs.rs]
 all-features = true
@@ -41,3 +42,6 @@ once_cell = { workspace = true }
 
 [lints]
 workspace = true
+
+[lib]
+bench = false

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
+autobenches = false
 
 [package.metadata.docs.rs]
 all-features = true
@@ -48,3 +49,6 @@ temp-env = { workspace = true }
 
 [lints]
 workspace = true
+
+[lib]
+bench = false

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["opentelemetry", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.75.0"
+autobenches = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry/benches/anyvalue.rs
+++ b/opentelemetry/benches/anyvalue.rs
@@ -39,6 +39,12 @@ fn attributes_creation(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+      .warm_up_time(std::time::Duration::from_secs(1))
+      .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
 
 criterion_main!(benches);

--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -103,6 +103,11 @@ fn attributes_creation(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().warm_up_time(std::time::Duration::from_secs(1))
+                               .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
 
 criterion_main!(benches);

--- a/opentelemetry/benches/baggage.rs
+++ b/opentelemetry/benches/baggage.rs
@@ -94,6 +94,11 @@ fn set_baggage_dynamic_with_metadata(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
-
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/opentelemetry/benches/context_attach.rs
+++ b/opentelemetry/benches/context_attach.rs
@@ -105,6 +105,11 @@ fn group(c: &mut Criterion) -> BenchmarkGroup<WallTime> {
 #[derive(Debug, PartialEq)]
 struct Value(i32);
 
-criterion_group!(benches, criterion_benchmark);
-
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/opentelemetry/benches/context_suppression.rs
+++ b/opentelemetry/benches/context_suppression.rs
@@ -55,5 +55,11 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/opentelemetry/benches/metrics.rs
+++ b/opentelemetry/benches/metrics.rs
@@ -103,6 +103,11 @@ fn counter_add(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, criterion_benchmark);
-
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -3,41 +3,49 @@ name = "stress"
 version = "0.1.0"
 edition = "2021"
 publish = false
+autobenches = false
 
 [[bin]] # Bin to run the metrics stress tests for Counter
 name = "metrics"
 path = "src/metrics_counter.rs"
 doc = false
+bench = false
 
 [[bin]] # Bin to run the metrics stress tests for Gauge
 name = "metrics_gauge"
 path = "src/metrics_gauge.rs"
 doc = false
+bench = false
 
 [[bin]] # Bin to run the metrics stress tests for Histogram
 name = "metrics_histogram"
 path = "src/metrics_histogram.rs"
 doc = false
+bench = false
 
 [[bin]] # Bin to run the metrics overflow stress tests
 name = "metrics_overflow"
 path = "src/metrics_overflow.rs"
 doc = false
+bench = false
 
 [[bin]] # Bin to run the logs stress tests
 name = "logs"
 path = "src/logs.rs"
 doc = false
+bench = false
 
 [[bin]] # Bin to run the traces stress tests
 name = "traces"
 path = "src/traces.rs"
 doc = false
+bench = false
 
 [[bin]] # Bin to run the stress tests to show the cost of random number generation
 name = "random"
 path = "src/random.rs"
 doc = false
+bench = false
 
 [dependencies]
 ctrlc = { workspace = true }


### PR DESCRIPTION
## Changes

Shortens the warmup time to 1 second and measurement time to 2 seconds for all benchmarks, and prepares them to be run in one go from the workspace root. Most benchmarks have millions or billions of iterations with a 5 second measurement, which seems a bit excessive.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
