### PR TITLE
perf: Nit fix to benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,5 +56,5 @@ jobs:
       - uses: boa-dev/criterion-compare-action@v3
         with:
           cwd: opentelemetry-sdk
-          features: rt-tokio,testing,metrics,logs,spec_unstable_metrics_views
+          features: testing,metrics,logs,spec_unstable_metrics_views,spec_unstable_logs_enabled,experimental_logs_concurrent_log_processor
           branchName: ${{ env.BRANCH_NAME }}

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -108,7 +108,7 @@ harness = false
 [[bench]]
 name = "batch_span_processor"
 harness = false
-required-features = ["rt-tokio", "testing"]
+required-features = ["testing"]
 
 [[bench]]
 name = "metric"


### PR DESCRIPTION
Some test were not run in benchmarks-CI due to missing feature flag.
Also did a nit cleanup - benchmarks didn't need `rt-tokio` so its cleaned up.