### PR TITLE
perf: Run all benchmarks in one action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,8 +32,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10  # Fetch current commit and its parent
-      - name: "Show change commit"
-        run: git log -1
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -42,19 +40,4 @@ jobs:
           toolchain: stable
       - uses: boa-dev/criterion-compare-action@v3
         with:
-          cwd: opentelemetry
-          branchName: ${{ env.BRANCH_NAME }}
-      - name: "Checkout change commit"
-        run: git checkout $GITHUB_SHA
-      - uses: boa-dev/criterion-compare-action@v3
-        with:
-          cwd: opentelemetry-appender-tracing
-          features: spec_unstable_logs_enabled
-          branchName: ${{ env.BRANCH_NAME }}
-      - name: "Checkout change commit"
-        run: git checkout $GITHUB_SHA
-      - uses: boa-dev/criterion-compare-action@v3
-        with:
-          cwd: opentelemetry-sdk
-          features: testing,metrics,logs,spec_unstable_metrics_views,spec_unstable_logs_enabled,experimental_logs_concurrent_log_processor
           branchName: ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
## Changes

Runs all the benchmarks in one single action. It also removes all feature flags from the github action and relies on the features defined in the `Cargo.toml` files.  This ensure that no benchmarks are skipped accidentally.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
