### PR TITLE
chore: Move 'main' benchmark to shared workers temporarily

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,10 @@ jobs:
     # If we're running on a PR, use ubuntu-latest - a shared runner. We can't use the self-hosted
     # runners on arbitrary PRs, and we don't want to unleash that load on the pool anyway.     
     # If we're running on main, use the OTEL self-hosted runner pool. 
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
+    
+    # TODO - temporarily move main to the shared workers, until we've resolved the instance setup issue
+    # runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: 'ubuntu-latest'
     if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'performance')) || github.event_name == 'push' }}
     env:
       # For PRs, compare against the base branch - e.g., 'main'. 


### PR DESCRIPTION
While we're blocked getting the dedicated workers pool going, let's move main's benchmark back to shared so that it stops failing in the meantime.

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
