### PR TITLE
chore: fix clippy lint errors for rust 1.86.0

### DIFF
--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -130,10 +130,10 @@ impl Instrument {
 
     /// empty returns if all fields of i are their default-value.
     pub(crate) fn is_empty(&self) -> bool {
-        self.name == ""
-            && self.description == ""
+        self.name.is_empty()
+            && self.description.is_empty()
             && self.kind.is_none()
-            && self.unit == ""
+            && self.unit.is_empty()
             && self.scope == InstrumentationScope::default()
     }
 

--- a/opentelemetry-sdk/src/metrics/view.rs
+++ b/opentelemetry-sdk/src/metrics/view.rs
@@ -110,7 +110,7 @@ pub fn new_view(criteria: Instrument, mask: Stream) -> MetricResult<Box<dyn View
     let contains_wildcard = criteria.name.contains(['*', '?']);
 
     let match_fn: Box<dyn Fn(&Instrument) -> bool + Send + Sync> = if contains_wildcard {
-        if mask.name != "" {
+        if !mask.name.is_empty() {
             // TODO - The error is getting lost here. Need to return or log.
             return Ok(Box::new(empty_view));
         }


### PR DESCRIPTION
## Changes

Fixes clippy lint errors, since rust stable is now `1.86.0`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
