### PR TITLE
feat(otlp): Re-export tonic crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           cargo install cargo-check-external-types@0.1.13
           cd ${{ matrix.example }}
-          cargo check-external-types --config allowed-external-types.toml
+          cargo check-external-types --all-features --config allowed-external-types.toml
   msrv:
     strategy:
       matrix:

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## vNext
 
 - Update `tonic` dependency version to 0.13
+- Re-export `tonic` types under `tonic_types`
+  [2898](https://github.com/open-telemetry/opentelemetry-rust/pull/2898)
 
 ## 0.29.0
 

--- a/opentelemetry-otlp/allowed-external-types.toml
+++ b/opentelemetry-otlp/allowed-external-types.toml
@@ -13,6 +13,7 @@ allowed_external_types = [
     # prost is a pre 1.0 crate
     "prost::error::EncodeError",
     # tonic is a pre 1.0 crate
+    "tonic",
     "tonic::status::Code",
     "tonic::status::Status",
     "tonic::metadata::map::MetadataMap",

--- a/opentelemetry-otlp/allowed-external-types.toml
+++ b/opentelemetry-otlp/allowed-external-types.toml
@@ -3,23 +3,16 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "opentelemetry::*",
     "opentelemetry_http::*",
     "opentelemetry_sdk::*",
-    # http is a pre 1.0 crate
-    "http::uri::InvalidUri",
-    "http::header::name::InvalidHeaderName",
-    "http::header::value::InvalidHeaderValue",
-    # prost is a pre 1.0 crate
-    "prost::error::EncodeError",
+    # serde
+    "serde::de::Deserialize",
+    "serde::ser::Serialize",
     # tonic is a pre 1.0 crate
-    "tonic::status::Code",
-    "tonic::status::Status",
     "tonic::metadata::map::MetadataMap",
     "tonic::transport::channel::tls::ClientTlsConfig",
     "tonic::transport::tls::Certificate",
     "tonic::transport::tls::Identity",
     "tonic::transport::channel::Channel",
-    "tonic::transport::error::Error",
     "tonic::service::interceptor::Interceptor",
 ]

--- a/opentelemetry-otlp/allowed-external-types.toml
+++ b/opentelemetry-otlp/allowed-external-types.toml
@@ -13,10 +13,12 @@ allowed_external_types = [
     # prost is a pre 1.0 crate
     "prost::error::EncodeError",
     # tonic is a pre 1.0 crate
-    "tonic",
     "tonic::status::Code",
     "tonic::status::Status",
     "tonic::metadata::map::MetadataMap",
+    "tonic::transport::channel::tls::ClientTlsConfig",
+    "tonic::transport::tls::Certificate",
+    "tonic::transport::tls::Identity",
     "tonic::transport::channel::Channel",
     "tonic::transport::error::Error",
     "tonic::service::interceptor::Interceptor",

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -451,13 +451,16 @@ pub enum Protocol {
 /// Placeholder type when no exporter pipeline has been configured in telemetry pipeline.
 pub struct NoExporterConfig(());
 
+/// Re-exported types from the `tonic` crate.
 #[cfg(feature = "grpc-tonic")]
 pub mod tonic_types {
+    /// Re-exported types from `tonic::metadata`.
     pub mod metadata {
         #[doc(no_inline)]
         pub use tonic::metadata::MetadataMap;
     }
 
+    /// Re-exported types from `tonic::transport`.
     #[cfg(feature = "tls")]
     pub mod transport {
         #[doc(no_inline)]

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -407,3 +407,7 @@ pub enum Protocol {
 #[doc(hidden)]
 /// Placeholder type when no exporter pipeline has been configured in telemetry pipeline.
 pub struct NoExporterConfig(());
+
+#[cfg(feature = "grpc-tonic")]
+#[doc(no_inline)]
+pub use tonic;

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -452,5 +452,15 @@ pub enum Protocol {
 pub struct NoExporterConfig(());
 
 #[cfg(feature = "grpc-tonic")]
-#[doc(no_inline)]
-pub use tonic;
+pub mod tonic_types {
+    pub mod metadata {
+        #[doc(no_inline)]
+        pub use tonic::metadata::MetadataMap;
+    }
+
+    #[cfg(feature = "tls")]
+    pub mod transport {
+        #[doc(no_inline)]
+        pub use tonic::transport::{Certificate, ClientTlsConfig, Identity};
+    }
+}


### PR DESCRIPTION
Fixes #882

## Design discussion issue

I chose to re-export the entire `tonic` crate instead of cherry-picking types to avoid maintenance overhead. The re-export is gated behind the `grpc-tonic` feature.

Let me know your thoughts if re-exporting the whole `tonic` crate is too much and how we should tackle this in this situation.

## Changes

Re-exports the entire `tonic` crate from the `opentelemetry-otlp` crate, to allows downstream crates to use `tonic` types (such as `MetadataMap`) compatible with `opentelemetry-otlp` without needing to manually match the internal `tonic` version.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
