### PR TITLE
feat: Add and enabled Metric cardinality capping by default

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -12,6 +12,15 @@ the suppression flag in their dedicated thread, so that telemetry generated from
 those threads will not be fed back into OTel. Similarly, `SimpleLogProcessor`
 also modified to suppress telemetry before invoking exporters.
 
+- **Feature**: Implemented and enabled cardinality capping for Metrics by
+  default.  
+  - The default cardinality limit is 2000 and can be customized using Views.  
+  - This feature was previously removed in version 0.28 due to the lack of
+    configurability but has now been reintroduced with the ability to configure
+    the limit.  
+  - TODO/Placeholder: Add ability to configure cardinality limits via Instrument
+    advisory.
+
 ## 0.29.0
 
 Released 2025-Mar-21

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -203,6 +203,9 @@ pub struct Stream {
     /// dropped. If the set is empty, all attributes will be dropped, if `None` all
     /// attributes will be kept.
     pub allowed_attribute_keys: Option<Arc<HashSet<Key>>>,
+
+    /// Cardinality limit for the stream.
+    pub cardinality_limit: Option<usize>,
 }
 
 #[cfg(feature = "spec_unstable_metrics_views")]
@@ -243,6 +246,12 @@ impl Stream {
     pub fn allowed_attribute_keys(mut self, attribute_keys: impl IntoIterator<Item = Key>) -> Self {
         self.allowed_attribute_keys = Some(Arc::new(attribute_keys.into_iter().collect()));
 
+        self
+    }
+
+    /// Set the stream cardinality limit.
+    pub fn cardinality_limit(mut self, limit: usize) -> Self {
+        self.cardinality_limit = Some(limit);
         self
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -369,12 +369,16 @@ impl<T: Number> ExpoHistogram<T> {
         max_scale: i8,
         record_min_max: bool,
         record_sum: bool,
+        cardinality_limit: usize,
     ) -> Self {
         ExpoHistogram {
-            value_map: ValueMap::new(BucketConfig {
-                max_size: max_size as i32,
-                max_scale,
-            }),
+            value_map: ValueMap::new(
+                BucketConfig {
+                    max_size: max_size as i32,
+                    max_scale,
+                },
+                cardinality_limit,
+            ),
             init_time: AggregateTimeInitiator::default(),
             temporality,
             filter,
@@ -546,6 +550,8 @@ mod tests {
 
     use super::*;
 
+    const CARDINALITY_LIMIT_DEFAULT: usize = 2000;
+
     #[test]
     fn test_expo_histogram_data_point_record() {
         run_data_point_record::<f64>();
@@ -710,6 +716,7 @@ mod tests {
                 20,
                 true,
                 true,
+                CARDINALITY_LIMIT_DEFAULT,
             );
             for v in test.values {
                 Measure::call(&h, v, &[]);
@@ -766,6 +773,7 @@ mod tests {
                 20,
                 true,
                 true,
+                CARDINALITY_LIMIT_DEFAULT,
             );
             for v in test.values {
                 Measure::call(&h, v, &[]);
@@ -1278,12 +1286,13 @@ mod tests {
             TestCase {
                 name: "Delta Single",
                 build: Box::new(move || {
-                    AggregateBuilder::new(Temporality::Delta, None).exponential_bucket_histogram(
-                        max_size,
-                        max_scale,
-                        record_min_max,
-                        record_sum,
-                    )
+                    AggregateBuilder::new(Temporality::Delta, None, CARDINALITY_LIMIT_DEFAULT)
+                        .exponential_bucket_histogram(
+                            max_size,
+                            max_scale,
+                            record_min_max,
+                            record_sum,
+                        )
                 }),
                 input: vec![vec![4, 4, 4, 2, 16, 1]
                     .into_iter()
@@ -1318,13 +1327,17 @@ mod tests {
             TestCase {
                 name: "Cumulative Single",
                 build: Box::new(move || {
-                    internal::AggregateBuilder::new(Temporality::Cumulative, None)
-                        .exponential_bucket_histogram(
-                            max_size,
-                            max_scale,
-                            record_min_max,
-                            record_sum,
-                        )
+                    internal::AggregateBuilder::new(
+                        Temporality::Cumulative,
+                        None,
+                        CARDINALITY_LIMIT_DEFAULT,
+                    )
+                    .exponential_bucket_histogram(
+                        max_size,
+                        max_scale,
+                        record_min_max,
+                        record_sum,
+                    )
                 }),
                 input: vec![vec![4, 4, 4, 2, 16, 1]
                     .into_iter()
@@ -1359,13 +1372,17 @@ mod tests {
             TestCase {
                 name: "Delta Multiple",
                 build: Box::new(move || {
-                    internal::AggregateBuilder::new(Temporality::Delta, None)
-                        .exponential_bucket_histogram(
-                            max_size,
-                            max_scale,
-                            record_min_max,
-                            record_sum,
-                        )
+                    internal::AggregateBuilder::new(
+                        Temporality::Delta,
+                        None,
+                        CARDINALITY_LIMIT_DEFAULT,
+                    )
+                    .exponential_bucket_histogram(
+                        max_size,
+                        max_scale,
+                        record_min_max,
+                        record_sum,
+                    )
                 }),
                 input: vec![
                     vec![2, 3, 8].into_iter().map(Into::into).collect(),
@@ -1403,13 +1420,17 @@ mod tests {
             TestCase {
                 name: "Cumulative Multiple ",
                 build: Box::new(move || {
-                    internal::AggregateBuilder::new(Temporality::Cumulative, None)
-                        .exponential_bucket_histogram(
-                            max_size,
-                            max_scale,
-                            record_min_max,
-                            record_sum,
-                        )
+                    internal::AggregateBuilder::new(
+                        Temporality::Cumulative,
+                        None,
+                        CARDINALITY_LIMIT_DEFAULT,
+                    )
+                    .exponential_bucket_histogram(
+                        max_size,
+                        max_scale,
+                        record_min_max,
+                        record_sum,
+                    )
                 }),
                 input: vec![
                     vec![2, 3, 8].into_iter().map(Into::into).collect(),

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -87,6 +87,7 @@ impl<T: Number> Histogram<T> {
         mut bounds: Vec<f64>,
         record_min_max: bool,
         record_sum: bool,
+        cardinality_limit: usize,
     ) -> Self {
         #[cfg(feature = "spec_unstable_metrics_views")]
         {
@@ -97,7 +98,7 @@ impl<T: Number> Histogram<T> {
 
         let buckets_count = bounds.len() + 1;
         Histogram {
-            value_map: ValueMap::new(buckets_count),
+            value_map: ValueMap::new(buckets_count, cardinality_limit),
             init_time: AggregateTimeInitiator::default(),
             temporality,
             filter,
@@ -262,6 +263,7 @@ mod tests {
             vec![1.0, 3.0, 6.0],
             false,
             false,
+            2000,
         );
         for v in 1..11 {
             Measure::call(&hist, v, &[]);

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -50,9 +50,13 @@ pub(crate) struct LastValue<T: Number> {
 }
 
 impl<T: Number> LastValue<T> {
-    pub(crate) fn new(temporality: Temporality, filter: AttributeSetFilter) -> Self {
+    pub(crate) fn new(
+        temporality: Temporality,
+        filter: AttributeSetFilter,
+        cardinality_limit: usize,
+    ) -> Self {
         LastValue {
-            value_map: ValueMap::new(()),
+            value_map: ValueMap::new((), cardinality_limit),
             init_time: AggregateTimeInitiator::default(),
             temporality,
             filter,

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -23,9 +23,10 @@ impl<T: Number> PrecomputedSum<T> {
         temporality: Temporality,
         filter: AttributeSetFilter,
         monotonic: bool,
+        cardinality_limit: usize,
     ) -> Self {
         PrecomputedSum {
-            value_map: ValueMap::new(()),
+            value_map: ValueMap::new((), cardinality_limit),
             init_time: AggregateTimeInitiator::default(),
             temporality,
             filter,

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -56,9 +56,10 @@ impl<T: Number> Sum<T> {
         temporality: Temporality,
         filter: AttributeSetFilter,
         monotonic: bool,
+        cardinality_limit: usize,
     ) -> Self {
         Sum {
-            value_map: ValueMap::new(()),
+            value_map: ValueMap::new((), cardinality_limit),
             init_time: AggregateTimeInitiator::default(),
             temporality,
             filter,

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -374,8 +374,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn counter_aggregation_overflow_cumulative() {
-        counter_aggregation_overflow_helper(Temporality::Delta);
-        counter_aggregation_overflow_helper_custom_limit(Temporality::Delta);
+        counter_aggregation_overflow_helper(Temporality::Cumulative);
+        counter_aggregation_overflow_helper_custom_limit(Temporality::Cumulative);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -2550,7 +2550,7 @@ mod tests {
             assert_eq!(data_point.value, 100);
         } else {
             // For cumulative, overflow should still be there, and new points should not be added.
-            assert_eq!(sum.data_points.len(), 2002);
+            assert_eq!(sum.data_points.len(), cardinality_limit + 1 + 1);
             let data_point =
                 find_sum_datapoint_with_key_value(&sum.data_points, "otel.metric.overflow", "true")
                     .expect("overflow point expected");

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -374,7 +374,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn counter_aggregation_overflow_cumulative() {
-        counter_aggregation_overflow_helper(Temporality::Cumulative);
+        counter_aggregation_overflow_helper(Temporality::Delta);
         counter_aggregation_overflow_helper_custom_limit(Temporality::Delta);
     }
 

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -50,6 +50,8 @@ impl fmt::Debug for Pipeline {
 /// Single or multi-instrument callbacks
 type GenericCallback = Arc<dyn Fn() + Send + Sync>;
 
+const DEFAULT_CARDINALITY_LIMIT: usize = 2000;
+
 #[derive(Default)]
 struct PipelineInner {
     aggregations: HashMap<InstrumentationScope, Vec<InstrumentSync>>,
@@ -389,7 +391,9 @@ where
             let b = AggregateBuilder::new(
                 self.pipeline.reader.temporality(kind),
                 filter,
-                stream.cardinality_limit.unwrap_or(2000),
+                stream
+                    .cardinality_limit
+                    .unwrap_or(DEFAULT_CARDINALITY_LIMIT),
             );
             let AggregateFns { measure, collect } = match aggregate_fn(b, &agg, kind) {
                 Ok(Some(inst)) => inst,

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -303,6 +303,7 @@ where
             unit: inst.unit,
             aggregation: None,
             allowed_attribute_keys: None,
+            cardinality_limit: None,
         };
 
         // Override default histogram boundaries if provided.
@@ -385,7 +386,11 @@ where
                 .clone()
                 .map(|allowed| Arc::new(move |kv: &KeyValue| allowed.contains(&kv.key)) as Arc<_>);
 
-            let b = AggregateBuilder::new(self.pipeline.reader.temporality(kind), filter);
+            let b = AggregateBuilder::new(
+                self.pipeline.reader.temporality(kind),
+                filter,
+                stream.cardinality_limit.unwrap_or(2000),
+            );
             let AggregateFns { measure, collect } = match aggregate_fn(b, &agg, kind) {
                 Ok(Some(inst)) => inst,
                 other => return other.map(|fs| fs.map(|inst| inst.measure)), // Drop aggregator or error

--- a/opentelemetry-sdk/src/metrics/view.rs
+++ b/opentelemetry-sdk/src/metrics/view.rs
@@ -161,6 +161,7 @@ pub fn new_view(criteria: Instrument, mask: Stream) -> MetricResult<Box<dyn View
                 },
                 aggregation: agg.clone(),
                 allowed_attribute_keys: mask.allowed_attribute_keys.clone(),
+                cardinality_limit: mask.cardinality_limit,
             })
         } else {
             None


### PR DESCRIPTION
Fixes #1065

Re-introduce Metric cardinality capping, but this time, with the ability to configure the limit using Views.
The default is 2000, following OTel spec. 
There is no ability to change the limit globally (at reader level) - this is not a MUST from the spec, and based on my experience, this is rarely used/needed.
Existing tests are re-enabled, and also enhanced to test customization ability and to test that limits are per cycle.

TODO (in next PR): is to add coverage for all instruments, as only Counters are currently covered.
TODO : doc additions. Depending on the next PR where I plan to introduce customization ability via Advisory, we can decide how best to document this.
TODO(next PR): Fix https://github.com/open-telemetry/opentelemetry-rust/issues/2878 too

I expect to send another PR which will enhance the Instrument Advisory parameters to accept cardinality limits via that option. This is not a thing from the spec (but spec does not prohibit offering additional capabilities either), but planned to be added to Rust as using Views is generally non-trivial and my own experience tells it is somewhat confusing.
(Also planning to make a spec enhancement proposal in parallel, but I don't think it is a blocker)
