### PR TITLE
fix: Remove logging for cardinality overflow

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -152,9 +152,6 @@ where
             let new_tracker = A::create(&self.config);
             new_tracker.update(value);
             trackers.insert(stream_overflow_attributes().clone(), Arc::new(new_tracker));
-            otel_warn!( name: "ValueMap.measure",
-                message = "Maximum data points for metric stream exceeded. Entry added to overflow. Subsequent overflows to same metric until next collect will not be logged."
-            );
         }
     }
 


### PR DESCRIPTION
This log was pure noise, especially for Delta, as this will be emitted each cycle (if facing overflow). Spec does not suggest to do this logging either.
When overflow occurs, it is reflected in the attribute anyway, so no need of emitting another signal to indicate this situation has occurred.