### PR TITLE
fix: cleanup MetricError

### DIFF
--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -20,7 +20,7 @@ impl MetricsClient for OtlpHttpClient {
             })?;
 
         let (body, content_type) = self.build_metrics_export_body(metrics).ok_or_else(|| {
-            OTelSdkError::InternalFailure("Failed to serialize metrics: None returned".to_string())
+            OTelSdkError::InternalFailure("Failed to serialize metrics".to_string())
         })?;
         let mut request = http::Request::builder()
             .method(Method::POST)

--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -19,8 +19,8 @@ impl MetricsClient for OtlpHttpClient {
                 _ => Err(OTelSdkError::AlreadyShutdown),
             })?;
 
-        let (body, content_type) = self.build_metrics_export_body(metrics).map_err(|e| {
-            OTelSdkError::InternalFailure(format!("Failed to serialize metrics: {e:?}"))
+        let (body, content_type) = self.build_metrics_export_body(metrics).ok_or_else(|| {
+            OTelSdkError::InternalFailure("Failed to serialize metrics: None returned".to_string())
         })?;
         let mut request = http::Request::builder()
             .method(Method::POST)

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -22,8 +22,8 @@ also modified to suppress telemetry before invoking exporters.
     advisory.
 
 - *Breaking* change for custom `MetricReader` authors.
-  The `shutdown_with_timeout` method is added to `MetricReader` trait. `collect`
-  method on `MetricReader` modified to return `OTelSdkResult`.
+  The `shutdown_with_timeout` method is added to `MetricReader` trait.
+  `collect` method on `MetricReader` modified to return `OTelSdkResult`.
   [#2905](https://github.com/open-telemetry/opentelemetry-rust/pull/2905)
 - *Breaking* `MetricError`, `MetricResult` no longer public (except when
   `spec_unstable_metrics_views` feature flag is enabled). `OTelSdkResult` should

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -22,8 +22,13 @@ also modified to suppress telemetry before invoking exporters.
     advisory.
 
 - *Breaking* change for custom `MetricReader` authors.
-  The `shutdown_with_timeout` method is added to `MetricReader` trait.
-  `collect` method on `MetricReader` modified to return `OTelSdkResult`.
+  The `shutdown_with_timeout` method is added to `MetricReader` trait. `collect`
+  method on `MetricReader` modified to return `OTelSdkResult`.
+  [#2905](https://github.com/open-telemetry/opentelemetry-rust/pull/2905)
+- *Breaking* `MetricError`, `MetricResult` no longer public (except when
+  `spec_unstable_metrics_views` feature flag is enabled). `OTelSdkResult` should
+  be used instead, wherever applicable.
+  [#2905](https://github.com/open-telemetry/opentelemetry-rust/pull/2905)
 
 ## 0.29.0
 


### PR DESCRIPTION
Continuing from https://github.com/open-telemetry/opentelemetry-rust/pull/2905

There will be further cleanups for `MetricError` to the point it'll be completely removed. All places where it is required has been modified to use the `OTelSdkResult`. The remaining usages are only required for "Views", which is experimental features, so the `MetricError` can remain public only when that feature is enabled, otherwise non-public.
This helps cleanup unnecessary public API from the Metrics Sdk, and gets one more step closer to declaring Metrics Sdk as stable.