### PR TITLE
refactor: PushMetricExporter interface

### DIFF
--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -4,12 +4,12 @@ use crate::metric::MetricsClient;
 use http::{header::CONTENT_TYPE, Method};
 use opentelemetry::otel_debug;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
-use opentelemetry_sdk::metrics::exporter::ResourceMetricsRef;
+use opentelemetry_sdk::metrics::exporter::ResourceMetrics;
 
 use super::OtlpHttpClient;
 
 impl MetricsClient for OtlpHttpClient {
-    async fn export(&self, metrics: ResourceMetricsRef<'_>) -> OTelSdkResult {
+    async fn export(&self, metrics: ResourceMetrics<'_>) -> OTelSdkResult {
         let client = self
             .client
             .lock()

--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -4,12 +4,12 @@ use crate::metric::MetricsClient;
 use http::{header::CONTENT_TYPE, Method};
 use opentelemetry::otel_debug;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
-use opentelemetry_sdk::metrics::data::ResourceMetrics;
+use opentelemetry_sdk::metrics::exporter::ResourceMetricsRef;
 
 use super::OtlpHttpClient;
 
 impl MetricsClient for OtlpHttpClient {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> OTelSdkResult {
+    async fn export(&self, metrics: ResourceMetricsRef<'_>) -> OTelSdkResult {
         let client = self
             .client
             .lock()

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 mod metrics;
 
 #[cfg(feature = "metrics")]
-use opentelemetry_sdk::metrics::exporter::ResourceMetricsRef;
+use opentelemetry_sdk::metrics::exporter::ResourceMetrics;
 
 #[cfg(feature = "logs")]
 pub(crate) mod logs;
@@ -326,7 +326,7 @@ impl OtlpHttpClient {
     #[cfg(feature = "metrics")]
     fn build_metrics_export_body(
         &self,
-        metrics: ResourceMetricsRef<'_>,
+        metrics: ResourceMetrics<'_>,
     ) -> Option<(Vec<u8>, &'static str)> {
         use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 mod metrics;
 
 #[cfg(feature = "metrics")]
-use opentelemetry_sdk::metrics::data::ResourceMetrics;
+use opentelemetry_sdk::metrics::exporter::ResourceMetricsRef;
 
 #[cfg(feature = "logs")]
 pub(crate) mod logs;
@@ -326,11 +326,11 @@ impl OtlpHttpClient {
     #[cfg(feature = "metrics")]
     fn build_metrics_export_body(
         &self,
-        metrics: &mut ResourceMetrics,
+        metrics: ResourceMetricsRef<'_>,
     ) -> Option<(Vec<u8>, &'static str)> {
         use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 
-        let req: ExportMetricsServiceRequest = (&*metrics).into();
+        let req: ExportMetricsServiceRequest = metrics.into();
 
         match self.protocol {
             #[cfg(feature = "http-json")]

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -6,7 +6,7 @@ use opentelemetry_proto::tonic::collector::metrics::v1::{
     metrics_service_client::MetricsServiceClient, ExportMetricsServiceRequest,
 };
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
-use opentelemetry_sdk::metrics::data::ResourceMetrics;
+use opentelemetry_sdk::metrics::exporter::ResourceMetricsRef;
 use tonic::{codegen::CompressionEncoding, service::Interceptor, transport::Channel, Request};
 
 use super::BoxInterceptor;
@@ -52,7 +52,7 @@ impl TonicMetricsClient {
 }
 
 impl MetricsClient for TonicMetricsClient {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> OTelSdkResult {
+    async fn export(&self, metrics: ResourceMetricsRef<'_>) -> OTelSdkResult {
         let (mut client, metadata, extensions) = self
             .inner
             .lock()
@@ -81,7 +81,7 @@ impl MetricsClient for TonicMetricsClient {
             .export(Request::from_parts(
                 metadata,
                 extensions,
-                ExportMetricsServiceRequest::from(&*metrics),
+                ExportMetricsServiceRequest::from(metrics),
             ))
             .await
             .map_err(|e| OTelSdkError::InternalFailure(format!("{e:?}")))?;

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -6,7 +6,7 @@ use opentelemetry_proto::tonic::collector::metrics::v1::{
     metrics_service_client::MetricsServiceClient, ExportMetricsServiceRequest,
 };
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
-use opentelemetry_sdk::metrics::exporter::ResourceMetricsRef;
+use opentelemetry_sdk::metrics::exporter::ResourceMetrics;
 use tonic::{codegen::CompressionEncoding, service::Interceptor, transport::Channel, Request};
 
 use super::BoxInterceptor;
@@ -52,7 +52,7 @@ impl TonicMetricsClient {
 }
 
 impl MetricsClient for TonicMetricsClient {
-    async fn export(&self, metrics: ResourceMetricsRef<'_>) -> OTelSdkResult {
+    async fn export(&self, metrics: ResourceMetrics<'_>) -> OTelSdkResult {
         let (mut client, metadata, extensions) = self
             .inner
             .lock()

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -17,9 +17,8 @@ use crate::{ExporterBuildError, NoExporterBuilderSet};
 use core::fmt;
 use opentelemetry_sdk::error::OTelSdkResult;
 
-use opentelemetry_sdk::metrics::{
-    data::ResourceMetrics, exporter::PushMetricExporter, Temporality,
-};
+use opentelemetry_sdk::metrics::exporter::ResourceMetricsRef;
+use opentelemetry_sdk::metrics::{exporter::PushMetricExporter, Temporality};
 use std::fmt::{Debug, Formatter};
 use std::time::Duration;
 
@@ -123,7 +122,7 @@ impl HasHttpConfig for MetricExporterBuilder<HttpExporterBuilderSet> {
 pub(crate) trait MetricsClient: fmt::Debug + Send + Sync + 'static {
     fn export(
         &self,
-        metrics: &mut ResourceMetrics,
+        metrics: ResourceMetricsRef<'_>,
     ) -> impl std::future::Future<Output = OTelSdkResult> + Send;
     fn shutdown(&self) -> OTelSdkResult;
 }
@@ -149,7 +148,7 @@ impl Debug for MetricExporter {
 }
 
 impl PushMetricExporter for MetricExporter {
-    async fn export(&self, metrics: &mut ResourceMetrics) -> OTelSdkResult {
+    async fn export(&self, metrics: ResourceMetricsRef<'_>) -> OTelSdkResult {
         match &self.client {
             #[cfg(feature = "grpc-tonic")]
             SupportedTransportClient::Tonic(client) => client.export(metrics).await,

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -17,7 +17,7 @@ use crate::{ExporterBuildError, NoExporterBuilderSet};
 use core::fmt;
 use opentelemetry_sdk::error::OTelSdkResult;
 
-use opentelemetry_sdk::metrics::exporter::ResourceMetricsRef;
+use opentelemetry_sdk::metrics::exporter::ResourceMetrics;
 use opentelemetry_sdk::metrics::{exporter::PushMetricExporter, Temporality};
 use std::fmt::{Debug, Formatter};
 use std::time::Duration;
@@ -122,7 +122,7 @@ impl HasHttpConfig for MetricExporterBuilder<HttpExporterBuilderSet> {
 pub(crate) trait MetricsClient: fmt::Debug + Send + Sync + 'static {
     fn export(
         &self,
-        metrics: ResourceMetricsRef<'_>,
+        metrics: ResourceMetrics<'_>,
     ) -> impl std::future::Future<Output = OTelSdkResult> + Send;
     fn shutdown(&self) -> OTelSdkResult;
 }
@@ -148,7 +148,7 @@ impl Debug for MetricExporter {
 }
 
 impl PushMetricExporter for MetricExporter {
-    async fn export(&self, metrics: ResourceMetricsRef<'_>) -> OTelSdkResult {
+    async fn export(&self, metrics: ResourceMetrics<'_>) -> OTelSdkResult {
         match &self.client {
             #[cfg(feature = "grpc-tonic")]
             SupportedTransportClient::Tonic(client) => client.export(metrics).await,

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -113,7 +113,7 @@ pub mod tonic {
     impl From<ResourceMetrics<'_>> for ExportMetricsServiceRequest {
         fn from(mut rm: ResourceMetrics<'_>) -> Self {
             let mut scope_metrics = Vec::new();
-            while let Some(scope_metric) = rm.scope_metrics.next() {
+            while let Some(scope_metric) = rm.scope_metrics.next_scope_metric() {
                 scope_metrics.push(scope_metric.into());
             }
             ExportMetricsServiceRequest {
@@ -138,7 +138,7 @@ pub mod tonic {
     impl From<ScopeMetrics<'_>> for TonicScopeMetrics {
         fn from(mut sm: ScopeMetrics<'_>) -> Self {
             let mut metrics = Vec::new();
-            while let Some(metric) = sm.metrics.next() {
+            while let Some(metric) = sm.metrics.next_metric() {
                 metrics.push(metric.into());
             }
             TonicScopeMetrics {

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -11,9 +11,9 @@ pub mod tonic {
     use opentelemetry_sdk::metrics::data::{
         AggregatedMetrics, Exemplar as SdkExemplar,
         ExponentialHistogram as SdkExponentialHistogram, Gauge as SdkGauge,
-        Histogram as SdkHistogram, Metric as SdkMetric, MetricData, Sum as SdkSum,
+        Histogram as SdkHistogram, MetricData, Sum as SdkSum,
     };
-    use opentelemetry_sdk::metrics::exporter::{ResourceMetrics, ScopeMetrics};
+    use opentelemetry_sdk::metrics::exporter::{Metric, ResourceMetrics, ScopeMetrics};
     use opentelemetry_sdk::metrics::Temporality;
     use opentelemetry_sdk::Resource as SdkResource;
 
@@ -153,12 +153,12 @@ pub mod tonic {
         }
     }
 
-    impl From<&SdkMetric> for TonicMetric {
-        fn from(metric: &SdkMetric) -> Self {
+    impl From<Metric<'_>> for TonicMetric {
+        fn from(metric: Metric<'_>) -> Self {
             TonicMetric {
-                name: metric.name.to_string(),
-                description: metric.description.to_string(),
-                unit: metric.unit.to_string(),
+                name: metric.instrument.name.to_string(),
+                description: metric.instrument.description.to_string(),
+                unit: metric.instrument.unit.to_string(),
                 metadata: vec![], // internal and currently unused
                 data: Some(match &metric.data {
                     AggregatedMetrics::F64(data) => data.into(),

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## vNext
 
+- *Breaking* change for `PushMetricExporter::export` from accepting 
+  `metrics: &mut ResourceMetrics`, to accepting `metrics: ResourceMetrics<'_>`.
+  In addition, `ResourceMetrics` was also changed to allow improving underlying 
+  metric collection without any allocations in the future.
+  [#2921](https://github.com/open-telemetry/opentelemetry-rust/pull/2921)
+- *Breaking* change for `Metric::data` field: From dynamic `Box<dyn Aggregation>` 
+  to new enum `AggregatedMetrics`.
+  [#2857](https://github.com/open-telemetry/opentelemetry-rust/pull/2857)
+
 [#2868](https://github.com/open-telemetry/opentelemetry-rust/pull/2868)
 `SdkLogger`, `SdkTracer` modified to respect telemetry suppression based on
 `Context`. In other words, if the current context has telemetry suppression
@@ -39,6 +48,7 @@ also modified to suppress telemetry before invoking exporters.
 - *Breaking* `Aggregation` enum moved behind feature flag
   "spec_unstable_metrics_views". This was only required when using Views.
   [2928](https://github.com/open-telemetry/opentelemetry-rust/pull/2928)
+
 
 ## 0.29.0
 

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -6,8 +6,10 @@ use opentelemetry::{
 use opentelemetry_sdk::{
     error::OTelSdkResult,
     metrics::{
-        data::ResourceMetricsData, new_view, reader::MetricReader, Aggregation, Instrument,
-        InstrumentKind, ManualReader, Pipeline, SdkMeterProvider, Stream, Temporality, View,
+        new_view,
+        reader::{MetricReader, ResourceMetricsData},
+        Aggregation, Instrument, InstrumentKind, ManualReader, Pipeline, SdkMeterProvider, Stream,
+        Temporality, View,
     },
     Resource,
 };

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -6,7 +6,7 @@ use opentelemetry::{
 use opentelemetry_sdk::{
     error::OTelSdkResult,
     metrics::{
-        data::ResourceMetrics, new_view, reader::MetricReader, Aggregation, Instrument,
+        data::ResourceMetricsData, new_view, reader::MetricReader, Aggregation, Instrument,
         InstrumentKind, ManualReader, Pipeline, SdkMeterProvider, Stream, Temporality, View,
     },
     Resource,
@@ -23,7 +23,7 @@ impl MetricReader for SharedReader {
         self.0.register_pipeline(pipeline)
     }
 
-    fn collect(&self, rm: &mut ResourceMetrics) -> OTelSdkResult {
+    fn collect(&self, rm: &mut ResourceMetricsData) -> OTelSdkResult {
         self.0.collect(rm)
     }
 
@@ -240,7 +240,7 @@ fn counters(c: &mut Criterion) {
     });
 
     let (rdr, cntr) = bench_counter(None, "cumulative");
-    let mut rm = ResourceMetrics {
+    let mut rm = ResourceMetricsData {
         resource: Resource::builder_empty().build(),
         scope_metrics: Vec::new(),
     };
@@ -337,7 +337,7 @@ fn benchmark_collect_histogram(b: &mut Bencher, n: usize) {
         h.record(1, &[]);
     }
 
-    let mut rm = ResourceMetrics {
+    let mut rm = ResourceMetricsData {
         resource: Resource::builder_empty().build(),
         scope_metrics: Vec::new(),
     };

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -2,29 +2,9 @@
 
 use std::{borrow::Cow, time::SystemTime};
 
-use opentelemetry::{InstrumentationScope, KeyValue};
-
-use crate::Resource;
+use opentelemetry::KeyValue;
 
 use super::Temporality;
-
-/// A collection of [ScopeMetrics] and the associated [Resource] that created them.
-#[derive(Debug)]
-pub struct ResourceMetrics {
-    /// The entity that collected the metrics.
-    pub resource: Resource,
-    /// The collection of metrics with unique [InstrumentationScope]s.
-    pub scope_metrics: Vec<ScopeMetrics>,
-}
-
-/// A collection of metrics produced by a meter.
-#[derive(Debug, Default)]
-pub struct ScopeMetrics {
-    /// The [InstrumentationScope] that the meter was created with.
-    pub scope: InstrumentationScope,
-    /// The list of aggregations created by the meter.
-    pub metrics: Vec<Metric>,
-}
 
 /// A collection of one or more aggregated time series from an [Instrument].
 ///

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -18,7 +18,7 @@ pub struct ResourceMetrics {
 }
 
 /// A collection of metrics produced by a meter.
-#[derive(Default, Debug)]
+#[derive(Debug, Default)]
 pub struct ScopeMetrics {
     /// The [InstrumentationScope] that the meter was created with.
     pub scope: InstrumentationScope,

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -1,25 +1,10 @@
 //! Types for delivery of pre-aggregated metric time series data.
 
-use std::{borrow::Cow, time::SystemTime};
+use std::time::SystemTime;
 
 use opentelemetry::KeyValue;
 
 use super::Temporality;
-
-/// A collection of one or more aggregated time series from an [Instrument].
-///
-/// [Instrument]: crate::metrics::Instrument
-#[derive(Debug)]
-pub struct Metric {
-    /// The name of the instrument that created this data.
-    pub name: Cow<'static, str>,
-    /// The description of the instrument, which can be used in documentation.
-    pub description: Cow<'static, str>,
-    /// The unit in which the instrument reports.
-    pub unit: Cow<'static, str>,
-    /// The aggregated data from an instrument.
-    pub data: AggregatedMetrics,
-}
 
 /// Aggregated metrics data from an instrument
 #[derive(Debug)]

--- a/opentelemetry-sdk/src/metrics/exporter.rs
+++ b/opentelemetry-sdk/src/metrics/exporter.rs
@@ -1,11 +1,92 @@
 //! Interfaces for exporting metrics
 
-use crate::error::OTelSdkResult;
-use std::time::Duration;
+use opentelemetry::InstrumentationScope;
 
-use crate::metrics::data::ResourceMetrics;
+use crate::{error::OTelSdkResult, Resource};
+use std::{fmt::Debug, slice::Iter, time::Duration};
 
-use super::Temporality;
+use super::{
+    data::{Metric, ResourceMetrics, ScopeMetrics},
+    Temporality,
+};
+
+/// A collection of [`BatchScopeMetrics`] and the associated [Resource] that created them.
+#[derive(Debug)]
+pub struct ResourceMetricsRef<'a> {
+    /// The entity that collected the metrics.
+    pub resource: &'a Resource,
+    /// The collection of metrics with unique [InstrumentationScope]s.
+    pub scope_metrics: BatchScopeMetrics<'a>,
+}
+
+/// Iterator over libraries instrumentation scopes ([`InstrumentationScope`]) together with metrics.
+pub struct BatchScopeMetrics<'a> {
+    iter: Iter<'a, ScopeMetrics>,
+}
+
+/// A collection of metrics produced by a [`InstrumentationScope`] meter.
+#[derive(Debug)]
+pub struct ScopeMetricsRef<'a> {
+    /// The [InstrumentationScope] that the meter was created with.
+    pub scope: &'a InstrumentationScope,
+    /// The list of aggregations created by the meter.
+    pub metrics: BatchMetrics<'a>,
+}
+
+/// Iterator over aggregations created by the meter.
+pub struct BatchMetrics<'a> {
+    iter: Iter<'a, Metric>,
+}
+
+impl<'a> ResourceMetricsRef<'a> {
+    pub(crate) fn new(rm: &'a ResourceMetrics) -> Self {
+        Self {
+            resource: &rm.resource,
+            scope_metrics: BatchScopeMetrics {
+                iter: rm.scope_metrics.iter(),
+            },
+        }
+    }
+}
+
+impl<'a> ScopeMetricsRef<'a> {
+    fn new(sm: &'a ScopeMetrics) -> Self {
+        Self {
+            scope: &sm.scope,
+            metrics: BatchMetrics {
+                iter: sm.metrics.iter(),
+            },
+        }
+    }
+}
+
+impl Debug for BatchScopeMetrics<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BatchScopeMetrics").finish()
+    }
+}
+
+impl<'a> Iterator for BatchScopeMetrics<'a> {
+    type Item = ScopeMetricsRef<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(ScopeMetricsRef::new)
+    }
+}
+
+impl<'a> Iterator for BatchMetrics<'a> {
+    type Item = &'a Metric;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+impl Debug for BatchMetrics<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BatchMetrics").finish()
+    }
+}
 
 /// Exporter handles the delivery of metric data to external receivers.
 ///
@@ -18,7 +99,7 @@ pub trait PushMetricExporter: Send + Sync + 'static {
     /// considered unrecoverable and will be logged.
     fn export(
         &self,
-        metrics: &mut ResourceMetrics,
+        metrics: ResourceMetricsRef<'_>,
     ) -> impl std::future::Future<Output = OTelSdkResult> + Send;
 
     /// Flushes any metric data held by an exporter.

--- a/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
@@ -8,9 +8,9 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use super::data::{AggregatedMetrics, Metric};
+use super::data::AggregatedMetrics;
 use super::exporter::ResourceMetrics;
-use super::reader::{ResourceMetricsData, ScopeMetricsData};
+use super::reader::{MetricsData, ResourceMetricsData, ScopeMetricsData};
 
 /// An in-memory metrics exporter that stores metrics data in memory.
 ///
@@ -163,10 +163,8 @@ impl InMemoryMetricExporter {
                                 metrics: data
                                     .metrics
                                     .iter()
-                                    .map(|data| Metric {
-                                        name: data.name.clone(),
-                                        description: data.description.clone(),
-                                        unit: data.unit.clone(),
+                                    .map(|data| MetricsData {
+                                        instrument: data.instrument.clone(),
                                         data: Self::clone_data(&data.data),
                                     })
                                     .collect(),
@@ -201,10 +199,8 @@ impl InMemoryMetricExporter {
         while let Some(mut scope_metric) = metric.scope_metrics.next() {
             let mut metrics = Vec::new();
             while let Some(metric) = scope_metric.metrics.next() {
-                metrics.push(Metric {
-                    name: metric.name.clone(),
-                    description: metric.description.clone(),
-                    unit: metric.unit.clone(),
+                metrics.push(MetricsData {
+                    instrument: metric.instrument.clone(),
                     data: Self::clone_data(&metric.data),
                 });
             }

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -65,6 +65,19 @@ impl InstrumentKind {
     }
 }
 
+/// Describes properties an instrument is created with
+#[derive(Debug, Clone)]
+pub struct InstrumentInfo {
+    /// The human-readable identifier of the instrument.
+    pub name: Cow<'static, str>,
+    /// describes the purpose of the instrument.
+    pub description: Cow<'static, str>,
+    /// The functional group of the instrument.
+    pub kind: InstrumentKind,
+    /// Unit is the unit of measurement recorded by the instrument.
+    pub unit: Cow<'static, str>,
+}
+
 /// Describes properties an instrument is created with, also used for filtering
 /// in [View](crate::metrics::View)s.
 ///

--- a/opentelemetry-sdk/src/metrics/manual_reader.rs
+++ b/opentelemetry-sdk/src/metrics/manual_reader.rs
@@ -10,8 +10,8 @@ use crate::{
     metrics::Temporality,
 };
 
+use super::reader::ResourceMetricsData;
 use super::{
-    data::ResourceMetrics,
     pipeline::Pipeline,
     reader::{MetricReader, SdkProducer},
 };
@@ -90,7 +90,7 @@ impl MetricReader for ManualReader {
     /// callbacks necessary and returning the results.
     ///
     /// Returns an error if called after shutdown.
-    fn collect(&self, rm: &mut ResourceMetrics) -> OTelSdkResult {
+    fn collect(&self, rm: &mut ResourceMetricsData) -> OTelSdkResult {
         let inner = self
             .inner
             .lock()

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -122,11 +122,12 @@ pub enum Temporality {
 
 #[cfg(all(test, feature = "testing"))]
 mod tests {
-    use self::data::{HistogramDataPoint, ScopeMetrics, SumDataPoint};
+    use self::data::{HistogramDataPoint, SumDataPoint};
     use super::data::MetricData;
+    use super::data::ResourceMetrics;
+    use super::data::ScopeMetrics;
     use super::internal::Number;
     use super::*;
-    use crate::metrics::data::ResourceMetrics;
     use crate::metrics::internal::AggregatedMetricsAccess;
     use crate::metrics::InMemoryMetricExporter;
     use crate::metrics::InMemoryMetricExporterBuilder;

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -690,8 +690,8 @@ mod tests {
             "There should be single metric merging duplicate instruments"
         );
         let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
-        assert_eq!(metric.name, "my_counter");
-        assert_eq!(metric.unit, "my_unit");
+        assert_eq!(metric.instrument.name, "my_counter");
+        assert_eq!(metric.instrument.unit, "my_unit");
         let MetricData::Sum(sum) = u64::extract_metrics_data_ref(&metric.data)
             .expect("Sum aggregation expected for Counter instruments by default")
         else {
@@ -756,9 +756,9 @@ mod tests {
 
         if let Some(scope1) = scope1 {
             let metric1 = &scope1.metrics[0];
-            assert_eq!(metric1.name, "my_counter");
-            assert_eq!(metric1.unit, "my_unit");
-            assert_eq!(metric1.description, "my_description");
+            assert_eq!(metric1.instrument.name, "my_counter");
+            assert_eq!(metric1.instrument.unit, "my_unit");
+            assert_eq!(metric1.instrument.description, "my_description");
             let MetricData::Sum(sum1) = u64::extract_metrics_data_ref(&metric1.data)
                 .expect("Sum aggregation expected for Counter instruments by default")
             else {
@@ -776,9 +776,9 @@ mod tests {
 
         if let Some(scope2) = scope2 {
             let metric2 = &scope2.metrics[0];
-            assert_eq!(metric2.name, "my_counter");
-            assert_eq!(metric2.unit, "my_unit");
-            assert_eq!(metric2.description, "my_description");
+            assert_eq!(metric2.instrument.name, "my_counter");
+            assert_eq!(metric2.instrument.unit, "my_unit");
+            assert_eq!(metric2.instrument.description, "my_description");
 
             let MetricData::Sum(sum2) = u64::extract_metrics_data_ref(&metric2.data)
                 .expect("Sum aggregation expected for Counter instruments by default")
@@ -862,9 +862,9 @@ mod tests {
         assert!(scope.attributes().eq(&[KeyValue::new("key", "value1")]));
 
         let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
-        assert_eq!(metric.name, "my_counter");
-        assert_eq!(metric.unit, "my_unit");
-        assert_eq!(metric.description, "my_description");
+        assert_eq!(metric.instrument.name, "my_counter");
+        assert_eq!(metric.instrument.unit, "my_unit");
+        assert_eq!(metric.instrument.description, "my_description");
 
         let MetricData::Sum(sum) = u64::extract_metrics_data_ref(&metric.data)
             .expect("Sum aggregation expected for Counter instruments by default")
@@ -919,11 +919,11 @@ mod tests {
         assert!(!resource_metrics.is_empty());
         let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
         assert_eq!(
-            metric.name, "test_histogram",
+            metric.instrument.name, "test_histogram",
             "View rename should be ignored and original name retained."
         );
         assert_eq!(
-            metric.unit, "test_unit",
+            metric.instrument.unit, "test_unit",
             "View rename of unit should be ignored and original unit retained."
         );
     }
@@ -985,7 +985,7 @@ mod tests {
             .expect("metrics are expected to be exported.");
         assert!(!resource_metrics.is_empty());
         let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
-        assert_eq!(metric.name, "my_observable_counter",);
+        assert_eq!(metric.instrument.name, "my_observable_counter",);
 
         let MetricData::Sum(sum) = u64::extract_metrics_data_ref(&metric.data)
             .expect("Sum aggregation expected for ObservableCounter instruments by default")
@@ -1061,7 +1061,7 @@ mod tests {
             .expect("metrics are expected to be exported.");
         assert!(!resource_metrics.is_empty());
         let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
-        assert_eq!(metric.name, "my_counter",);
+        assert_eq!(metric.instrument.name, "my_counter",);
 
         let MetricData::Sum(sum) = u64::extract_metrics_data_ref(&metric.data)
             .expect("Sum aggregation expected for Counter instruments by default")
@@ -3029,9 +3029,9 @@ mod tests {
             assert!(!resource_metric.scope_metrics[0].metrics.is_empty());
 
             let metric = &resource_metric.scope_metrics[0].metrics[0];
-            assert_eq!(metric.name, counter_name);
+            assert_eq!(metric.instrument.name, counter_name);
             if let Some(expected_unit) = unit_name {
-                assert_eq!(metric.unit, expected_unit);
+                assert_eq!(metric.instrument.unit, expected_unit);
             }
 
             T::extract_metrics_data_ref(&metric.data)
@@ -3073,10 +3073,10 @@ mod tests {
                     assert!(!resource_metric.scope_metrics[0].metrics.is_empty());
 
                     let metric = &resource_metric.scope_metrics[0].metrics[0];
-                    assert_eq!(metric.name, counter_name);
+                    assert_eq!(metric.instrument.name, counter_name);
 
                     if let Some(expected_unit) = unit_name {
-                        assert_eq!(metric.unit, expected_unit);
+                        assert_eq!(metric.instrument.unit, expected_unit);
                     }
 
                     let aggregation = T::extract_metrics_data_ref(&metric.data)

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -82,8 +82,7 @@ pub use periodic_reader::*;
 #[cfg(feature = "experimental_metrics_custom_reader")]
 pub use pipeline::Pipeline;
 
-#[cfg(feature = "experimental_metrics_custom_reader")]
-pub use instrument::InstrumentKind;
+pub use instrument::{InstrumentInfo, InstrumentKind};
 
 #[cfg(feature = "spec_unstable_metrics_views")]
 pub use instrument::*;

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -124,9 +124,9 @@ pub enum Temporality {
 mod tests {
     use self::data::{HistogramDataPoint, SumDataPoint};
     use super::data::MetricData;
-    use super::data::ResourceMetrics;
-    use super::data::ScopeMetrics;
     use super::internal::Number;
+    use super::reader::ResourceMetricsData;
+    use super::reader::ScopeMetricsData;
     use super::*;
     use crate::metrics::internal::AggregatedMetricsAccess;
     use crate::metrics::InMemoryMetricExporter;
@@ -2903,9 +2903,9 @@ mod tests {
     }
 
     fn find_scope_metric<'a>(
-        metrics: &'a [ScopeMetrics],
+        metrics: &'a [ScopeMetricsData],
         name: &'a str,
-    ) -> Option<&'a ScopeMetrics> {
+    ) -> Option<&'a ScopeMetricsData> {
         metrics
             .iter()
             .find(|&scope_metric| scope_metric.scope.name() == name)
@@ -2916,7 +2916,7 @@ mod tests {
         meter_provider: SdkMeterProvider,
 
         // Saving this on the test context for lifetime simplicity
-        resource_metrics: Vec<ResourceMetrics>,
+        resource_metrics: Vec<ResourceMetricsData>,
     }
 
     impl TestContext {

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -13,14 +13,16 @@ use opentelemetry::{otel_debug, otel_error, otel_info, otel_warn, Context};
 use crate::{
     error::{OTelSdkError, OTelSdkResult},
     metrics::{
-        exporter::{PushMetricExporter, ResourceMetricsRef},
+        exporter::{PushMetricExporter, ResourceMetrics},
         reader::SdkProducer,
     },
     Resource,
 };
 
 use super::{
-    data::ResourceMetrics, instrument::InstrumentKind, pipeline::Pipeline, reader::MetricReader,
+    instrument::InstrumentKind,
+    pipeline::Pipeline,
+    reader::{MetricReader, ResourceMetricsData},
     Temporality,
 };
 
@@ -361,7 +363,7 @@ impl<E: PushMetricExporter> PeriodicReaderInner<E> {
         self.exporter.temporality()
     }
 
-    fn collect(&self, rm: &mut ResourceMetrics) -> OTelSdkResult {
+    fn collect(&self, rm: &mut ResourceMetricsData) -> OTelSdkResult {
         let producer = self.producer.lock().expect("lock poisoned");
         if let Some(p) = producer.as_ref() {
             p.upgrade()
@@ -384,7 +386,7 @@ impl<E: PushMetricExporter> PeriodicReaderInner<E> {
     fn collect_and_export(&self) -> OTelSdkResult {
         // TODO: Reuse the internal vectors. Or refactor to avoid needing any
         // owned data structures to be passed to exporters.
-        let mut rm = ResourceMetrics {
+        let mut rm = ResourceMetricsData {
             resource: Resource::empty(),
             scope_metrics: Vec::new(),
         };
@@ -414,7 +416,7 @@ impl<E: PushMetricExporter> PeriodicReaderInner<E> {
 
         // Relying on futures executor to execute async call.
         // TODO: Pass timeout to exporter
-        futures_executor::block_on(self.exporter.export(ResourceMetricsRef::new(&rm)))
+        futures_executor::block_on(self.exporter.export(ResourceMetrics::new(&rm)))
     }
 
     fn force_flush(&self) -> OTelSdkResult {
@@ -485,7 +487,7 @@ impl<E: PushMetricExporter> MetricReader for PeriodicReader<E> {
         self.inner.register_pipeline(pipeline);
     }
 
-    fn collect(&self, rm: &mut ResourceMetrics) -> OTelSdkResult {
+    fn collect(&self, rm: &mut ResourceMetricsData) -> OTelSdkResult {
         self.inner.collect(rm)
     }
 
@@ -519,9 +521,8 @@ mod tests {
     use crate::{
         error::{OTelSdkError, OTelSdkResult},
         metrics::{
-            data::ResourceMetrics,
-            exporter::{PushMetricExporter, ResourceMetricsRef},
-            reader::MetricReader,
+            exporter::{PushMetricExporter, ResourceMetrics},
+            reader::{MetricReader, ResourceMetricsData},
             InMemoryMetricExporter, SdkMeterProvider, Temporality,
         },
         Resource,
@@ -558,7 +559,7 @@ mod tests {
     }
 
     impl PushMetricExporter for MetricExporterThatFailsOnlyOnFirst {
-        async fn export(&self, _metrics: ResourceMetricsRef<'_>) -> OTelSdkResult {
+        async fn export(&self, _metrics: ResourceMetrics<'_>) -> OTelSdkResult {
             if self.count.fetch_add(1, Ordering::Relaxed) == 0 {
                 Err(OTelSdkError::InternalFailure("export failed".into()))
             } else {
@@ -589,7 +590,7 @@ mod tests {
     }
 
     impl PushMetricExporter for MockMetricExporter {
-        async fn export(&self, _metrics: ResourceMetricsRef<'_>) -> OTelSdkResult {
+        async fn export(&self, _metrics: ResourceMetrics<'_>) -> OTelSdkResult {
             Ok(())
         }
 
@@ -703,7 +704,7 @@ mod tests {
         let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone()).build();
 
-        let rm = &mut ResourceMetrics {
+        let rm = &mut ResourceMetricsData {
             resource: Resource::empty(),
             scope_metrics: Vec::new(),
         };

--- a/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
@@ -13,6 +13,7 @@ use futures_util::{
 };
 use opentelemetry::{otel_debug, otel_error};
 
+use crate::metrics::exporter::ResourceMetricsRef;
 use crate::runtime::{to_interval_stream, Runtime};
 use crate::{
     error::{OTelSdkError, OTelSdkResult},
@@ -259,7 +260,10 @@ impl<E: PushMetricExporter, RT: Runtime> PeriodicReaderWorker<E, RT> {
             message = "Calling exporter's export method with collected metrics.",
             count = self.rm.scope_metrics.len(),
         );
-        let export = self.reader.exporter.export(&mut self.rm);
+        let export = self
+            .reader
+            .exporter
+            .export(ResourceMetricsRef::new(&self.rm));
         let timeout = self.runtime.delay(self.timeout);
         pin_mut!(export);
         pin_mut!(timeout);

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -11,11 +11,11 @@ use crate::{
     error::{OTelSdkError, OTelSdkResult},
     metrics::{
         aggregation,
-        data::{Metric, ResourceMetrics, ScopeMetrics},
+        data::Metric,
         error::{MetricError, MetricResult},
         instrument::{Instrument, InstrumentId, InstrumentKind, Stream},
         internal::{self, AggregateBuilder, Number},
-        reader::{MetricReader, SdkProducer},
+        reader::{MetricReader, ScopeMetricsData, SdkProducer},
         view::View,
     },
     Resource,
@@ -23,7 +23,7 @@ use crate::{
 
 use self::internal::AggregateFns;
 
-use super::{aggregation::Aggregation, Temporality};
+use super::{aggregation::Aggregation, reader::ResourceMetricsData, Temporality};
 
 /// Connects all of the instruments created by a meter provider to a [MetricReader].
 ///
@@ -100,7 +100,7 @@ impl Pipeline {
 
 impl SdkProducer for Pipeline {
     /// Returns aggregated metrics from a single collection.
-    fn produce(&self, rm: &mut ResourceMetrics) -> OTelSdkResult {
+    fn produce(&self, rm: &mut ResourceMetricsData) -> OTelSdkResult {
         let inner = self
             .inner
             .lock()
@@ -125,7 +125,7 @@ impl SdkProducer for Pipeline {
             let sm = match rm.scope_metrics.get_mut(i) {
                 Some(sm) => sm,
                 None => {
-                    rm.scope_metrics.push(ScopeMetrics::default());
+                    rm.scope_metrics.push(ScopeMetricsData::default());
                     rm.scope_metrics.last_mut().unwrap()
                 }
             };

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -15,7 +15,8 @@ use crate::{
         instrument::{Instrument, InstrumentId, InstrumentKind, Stream},
         internal::{self, AggregateBuilder, Number},
         reader::{MetricReader, MetricsData, ScopeMetricsData, SdkProducer},
-        view::View, InstrumentInfo,
+        view::View,
+        InstrumentInfo,
     },
     Resource,
 };
@@ -37,7 +38,7 @@ pub struct Pipeline {
     pub(crate) resource: Resource,
     reader: Box<dyn MetricReader>,
     views: Vec<Arc<dyn View>>,
-    inner: Mutex<PipelineInner>,
+    pub(crate) inner: Mutex<PipelineInner>,
 }
 
 impl fmt::Debug for Pipeline {
@@ -52,9 +53,9 @@ type GenericCallback = Arc<dyn Fn() + Send + Sync>;
 const DEFAULT_CARDINALITY_LIMIT: usize = 2000;
 
 #[derive(Default)]
-struct PipelineInner {
-    aggregations: HashMap<InstrumentationScope, Vec<InstrumentSync>>,
-    callbacks: Vec<GenericCallback>,
+pub(crate) struct PipelineInner {
+    pub(crate) aggregations: HashMap<InstrumentationScope, Vec<InstrumentSync>>,
+    pub(crate) callbacks: Vec<GenericCallback>,
 }
 
 impl fmt::Debug for PipelineInner {
@@ -169,9 +170,9 @@ impl SdkProducer for Pipeline {
 }
 
 /// A synchronization point between a [Pipeline] and an instrument's aggregate function.
-struct InstrumentSync {
-    info: InstrumentInfo,
-    comp_agg: Arc<dyn internal::ComputeAggregation>,
+pub(crate) struct InstrumentSync {
+    pub(crate) info: InstrumentInfo,
+    pub(crate) comp_agg: Arc<dyn internal::ComputeAggregation>,
 }
 
 impl fmt::Debug for InstrumentSync {

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -6,7 +6,8 @@ use crate::Resource;
 use std::time::Duration;
 use std::{fmt, sync::Weak};
 
-use super::data::Metric;
+use super::data::AggregatedMetrics;
+use super::InstrumentInfo;
 use super::{pipeline::Pipeline, InstrumentKind, Temporality};
 
 /// A collection of [ScopeMetricsData] and the associated [Resource] that created them.
@@ -24,7 +25,18 @@ pub struct ScopeMetricsData {
     /// The [InstrumentationScope] that the meter was created with.
     pub scope: InstrumentationScope,
     /// The list of aggregations created by the meter.
-    pub metrics: Vec<Metric>,
+    pub metrics: Vec<MetricsData>,
+}
+
+/// A collection of one or more aggregated time series from an [Instrument].
+///
+/// [Instrument]: crate::metrics::Instrument
+#[derive(Debug)]
+pub struct MetricsData {
+    /// The name of the instrument that created this data.
+    pub instrument: InstrumentInfo,
+    /// The aggregated data from an instrument.
+    pub data: AggregatedMetrics,
 }
 
 /// The interface used between the SDK and an exporter.

--- a/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
+++ b/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
@@ -1,8 +1,7 @@
 use crate::error::{OTelSdkError, OTelSdkResult};
+use crate::metrics::reader::ResourceMetricsData;
 use crate::metrics::Temporality;
-use crate::metrics::{
-    data::ResourceMetrics, instrument::InstrumentKind, pipeline::Pipeline, reader::MetricReader,
-};
+use crate::metrics::{instrument::InstrumentKind, pipeline::Pipeline, reader::MetricReader};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
@@ -34,7 +33,7 @@ impl Default for TestMetricReader {
 impl MetricReader for TestMetricReader {
     fn register_pipeline(&self, _pipeline: Weak<Pipeline>) {}
 
-    fn collect(&self, _rm: &mut ResourceMetrics) -> OTelSdkResult {
+    fn collect(&self, _rm: &mut ResourceMetricsData) -> OTelSdkResult {
         Ok(())
     }
 

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -111,9 +111,9 @@ fn print_metrics(mut metrics: MetricsLendingIter<'_>) {
         iter += 1;
 
         println!("Metric #{}", iter);
-        println!("\t\tName         : {}", &metric.name);
-        println!("\t\tDescription  : {}", &metric.description);
-        println!("\t\tUnit         : {}", &metric.unit);
+        println!("\t\tName         : {}", &metric.instrument.name);
+        println!("\t\tDescription  : {}", &metric.instrument.description);
+        println!("\t\tUnit         : {}", &metric.instrument.unit);
 
         fn print_info<T>(data: &MetricData<T>)
         where

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -81,7 +81,7 @@ impl PushMetricExporter for MetricExporter {
 
 fn print_scope_metrics(mut metrics: ScopeMetricsLendingIter<'_>) {
     let mut iter = 0;
-    while let Some(scope_metric) = metrics.next() {
+    while let Some(scope_metric) = metrics.next_scope_metric() {
         iter += 1;
         println!("\tInstrumentation Scope #{}", iter);
         println!("\t\tName         : {}", &scope_metric.scope.name());
@@ -107,7 +107,7 @@ fn print_scope_metrics(mut metrics: ScopeMetricsLendingIter<'_>) {
 
 fn print_metrics(mut metrics: MetricsLendingIter<'_>) {
     let mut iter = 0;
-    while let Some(metric) = metrics.next() {
+    while let Some(metric) = metrics.next_metric() {
         iter += 1;
 
         println!("Metric #{}", iter);


### PR DESCRIPTION
## Changes

Changed `PushMetricExporer::export` signature. `fn export(&self, metrics: ResourceMetricsRef<'_>) -> ...`. It is very similar to `LogExporter::export`, with one key difference: I do not expose `iter()` method on items (metrics) (to create iterator), but directly provide Iterator over data. This means, that it's only possible to iterate everything once.
However, since I implement standard `Iterator` trait we still need to have all the items stored somewhere, so I'm not sure how much we can optimize internal implementation...

If I would change `Iterator` to [LendingIterator](https://blog.rust-lang.org/2022/10/28/gats-stabilization.html#what-are-gats), it would be possible to collect/export all metrics without any memory allocation at all!

So I have few questions for this PR:
* Do we want to be able to implement collect/export without memory allocation (e.g. have one `Metric` instance on the stack (iterator itself) ?)
* Regarding naming... if we optimize internal implementation it might be that `ResourceMetrics` and `ScopeMetrics` will not be present anymore, so I could use these names here (it sounds better than `ResourceMetricRef`...). In general, any suggestion for better naming is welcome :)

P.S. I wasn't able to provide `set_resource(&mut self, resource: &Resource)` on the `PushMetricExporter` (without making `PeriodicReader` very inefficient, and disabling async version of it) before MetricReader is refactored/improved #2917.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
