### PR TITLE
ci: Update permissions for workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,8 @@ on:
     branches:
       - main
 name: benchmark pull requests
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   runBenchmark:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 env:
   CI: true
-permissions: read-all
+permissions:
+  contents: read
 on:
   pull_request:
   push:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,14 +3,13 @@ name: "CodeQL Analysis"
 env:    
     CODEQL_ENABLE_EXPERIMENTAL_FEATURES : true # CodeQL support for Rust is experimental
 
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request:
   push:
     branches: [main]
-  schedule:
-    - cron: '0 0 * * *' # once in a day at 00:00
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - main
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   fossa:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,7 +5,8 @@ on:
   pull_request:
     types: [ labeled, synchronize, opened, reopened ]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   integration_tests:

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -8,7 +8,8 @@ on:
     paths:
       - '**/*.md'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -8,7 +8,8 @@ on:
     - cron: "50 3 * * 0" # once a week
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/pr_naming.yml
+++ b/.github/workflows/pr_naming.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   validate-pr-title:

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,7 +1,8 @@
 name: Semver compliance
 env:
   CI: true
-permissions: read-all
+permissions:
+  contents: read
 on:
   pull_request:
     types: [ labeled, synchronize, opened, reopened ]


### PR DESCRIPTION
## Changes
- Restrict workflow permissions even further by limiting the read only access to `contents`. Check the [documentation](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions) for reference.
- Remove `cron` based trigger for CodeQL workflow since we are running the workflow for each commit.
