### PR TITLE
feat: Hide MetricReader and friends

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -80,10 +80,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Note: This filtering will also drop logs from these components even when
     // they are used outside of the OTLP Exporter.
     let filter_otel = EnvFilter::new("info")
-        .add_directive("tokio=off".parse().unwrap())
+        .add_directive("hyper=off".parse().unwrap())
         .add_directive("tonic=off".parse().unwrap())
         .add_directive("h2=off".parse().unwrap())
-        .add_directive("oxidizer=warn".parse().unwrap())
         .add_directive("reqwest=off".parse().unwrap());
     let otel_layer = otel_layer.with_filter(filter_otel);
 

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -80,9 +80,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Note: This filtering will also drop logs from these components even when
     // they are used outside of the OTLP Exporter.
     let filter_otel = EnvFilter::new("info")
-        .add_directive("hyper=off".parse().unwrap())
+        .add_directive("tokio=off".parse().unwrap())
         .add_directive("tonic=off".parse().unwrap())
         .add_directive("h2=off".parse().unwrap())
+        .add_directive("oxidizer=warn".parse().unwrap())
         .add_directive("reqwest=off".parse().unwrap());
     let otel_layer = otel_layer.with_filter(filter_otel);
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -23,15 +23,22 @@ also modified to suppress telemetry before invoking exporters.
   - Fixed the overflow attribute to correctly use the boolean value `true`
     instead of the string `"true"`.
     [#2878](https://github.com/open-telemetry/opentelemetry-rust/issues/2878)
-
-- *Breaking* change for custom `MetricReader` authors.
-  The `shutdown_with_timeout` method is added to `MetricReader` trait.
-  `collect` method on `MetricReader` modified to return `OTelSdkResult`.
-  [#2905](https://github.com/open-telemetry/opentelemetry-rust/pull/2905)
 - *Breaking* `MetricError`, `MetricResult` no longer public (except when
   `spec_unstable_metrics_views` feature flag is enabled). `OTelSdkResult` should
   be used instead, wherever applicable.
+- *Breaking* change, affecting custom MetricReader authors:   The
+  `shutdown_with_timeout` method is added to `MetricReader` trait. `collect`
+  method on `MetricReader` modified to return `OTelSdkResult`.
   [#2905](https://github.com/open-telemetry/opentelemetry-rust/pull/2905)
+  [#2905](https://github.com/open-telemetry/opentelemetry-rust/pull/2905)
+- *Breaking* change, affecting custom MetricReader authors: `MetricReader`
+  trait, `ManualReader` struct, `Pipeline` struct, `InstrumentKind` enum moved
+  behind feature flag "experimental_metrics_custom_reader". These were only
+  required for writing custom readers.
+  [2928](https://github.com/open-telemetry/opentelemetry-rust/pull/2928)
+- *Breaking* `Aggregation` enum moved behind feature flag
+  "spec_unstable_metrics_views". This was only required when using Views.
+  [2928](https://github.com/open-telemetry/opentelemetry-rust/pull/2928)
 
 ## 0.29.0
 

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -53,7 +53,7 @@ rt-tokio-current-thread = ["tokio", "tokio-stream", "experimental_async_runtime"
 internal-logs = ["opentelemetry/internal-logs"]
 experimental_metrics_periodicreader_with_async_runtime = ["metrics", "experimental_async_runtime"]
 spec_unstable_metrics_views = ["metrics"]
-experimental_custom_metric_reader = ["metrics"]
+experimental_metrics_custom_reader = ["metrics"]
 experimental_logs_batch_log_processor_with_async_runtime = ["logs", "experimental_async_runtime"]
 experimental_logs_concurrent_log_processor = ["logs"]
 experimental_trace_batch_span_processor_with_async_runtime = ["trace", "experimental_async_runtime"]
@@ -108,7 +108,7 @@ required-features = ["testing"]
 [[bench]]
 name = "metric"
 harness = false
-required-features = ["metrics", "spec_unstable_metrics_views", "experimental_custom_metric_reader"]
+required-features = ["metrics", "spec_unstable_metrics_views", "experimental_metrics_custom_reader"]
 
 [[bench]]
 name = "log"

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -53,6 +53,7 @@ rt-tokio-current-thread = ["tokio", "tokio-stream", "experimental_async_runtime"
 internal-logs = ["opentelemetry/internal-logs"]
 experimental_metrics_periodicreader_with_async_runtime = ["metrics", "experimental_async_runtime"]
 spec_unstable_metrics_views = ["metrics"]
+experimental_custom_metric_reader = ["metrics"]
 experimental_logs_batch_log_processor_with_async_runtime = ["logs", "experimental_async_runtime"]
 experimental_logs_concurrent_log_processor = ["logs"]
 experimental_trace_batch_span_processor_with_async_runtime = ["trace", "experimental_async_runtime"]

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -108,7 +108,7 @@ required-features = ["testing"]
 [[bench]]
 name = "metric"
 harness = false
-required-features = ["metrics", "spec_unstable_metrics_views"]
+required-features = ["metrics", "spec_unstable_metrics_views", "experimental_custom_metric_reader"]
 
 [[bench]]
 name = "log"

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -696,7 +696,7 @@ where
 mod tests {
     use std::borrow::Cow;
 
-    use crate::metrics::MetricError;
+    use crate::metrics::error::MetricError;
 
     use super::{
         validate_instrument_name, validate_instrument_unit, INSTRUMENT_NAME_EMPTY,

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -16,8 +16,8 @@ use crate::error::OTelSdkResult;
 use crate::Resource;
 
 use super::{
-    exporter::PushMetricExporter, meter::SdkMeter, noop::NoopMeter, pipeline::Pipelines,
-    reader::MetricReader, view::View, PeriodicReader,
+    exporter::PushMetricExporter, meter::SdkMeter, noop::NoopMeter,
+    periodic_reader::PeriodicReader, pipeline::Pipelines, reader::MetricReader, view::View,
 };
 
 /// Handles the creation and coordination of [Meter]s.

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -45,16 +45,21 @@ mod error;
 pub mod exporter;
 pub(crate) mod instrument;
 pub(crate) mod internal;
+#[cfg(feature = "experimental_custom_metric_reader")]
 pub(crate) mod manual_reader;
 pub(crate) mod meter;
 mod meter_provider;
 pub(crate) mod noop;
+#[allow(unreachable_pub)]
 pub(crate) mod periodic_reader;
 #[cfg(feature = "experimental_metrics_periodicreader_with_async_runtime")]
 /// Module for periodic reader with async runtime.
 pub mod periodic_reader_with_async_runtime;
 pub(crate) mod pipeline;
+#[cfg(feature = "experimental_custom_metric_reader")]
 pub mod reader;
+#[cfg(not(feature = "experimental_custom_metric_reader"))]
+pub(crate) mod reader;
 pub(crate) mod view;
 
 /// In-Memory metric exporter for testing purpose.
@@ -68,9 +73,12 @@ pub use in_memory_exporter::{InMemoryMetricExporter, InMemoryMetricExporterBuild
 pub use aggregation::*;
 #[cfg(feature = "spec_unstable_metrics_views")]
 pub use error::{MetricError, MetricResult};
+#[cfg(feature = "experimental_custom_metric_reader")]
 pub use manual_reader::*;
 pub use meter_provider::*;
+#[cfg(feature = "experimental_custom_metric_reader")]
 pub use periodic_reader::*;
+#[cfg(feature = "experimental_custom_metric_reader")]
 pub use pipeline::Pipeline;
 
 pub use instrument::InstrumentKind;

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -76,7 +76,6 @@ pub use error::{MetricError, MetricResult};
 #[cfg(feature = "experimental_custom_metric_reader")]
 pub use manual_reader::*;
 pub use meter_provider::*;
-#[cfg(feature = "experimental_custom_metric_reader")]
 pub use periodic_reader::*;
 #[cfg(feature = "experimental_custom_metric_reader")]
 pub use pipeline::Pipeline;

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -39,26 +39,27 @@
 //!
 //! [Resource]: crate::Resource
 
+#[allow(unreachable_pub)]
+#[allow(unused)]
 pub(crate) mod aggregation;
 pub mod data;
 mod error;
 pub mod exporter;
 pub(crate) mod instrument;
 pub(crate) mod internal;
-#[cfg(feature = "experimental_custom_metric_reader")]
+#[cfg(feature = "experimental_metrics_custom_reader")]
 pub(crate) mod manual_reader;
 pub(crate) mod meter;
 mod meter_provider;
 pub(crate) mod noop;
-#[allow(unreachable_pub)]
 pub(crate) mod periodic_reader;
 #[cfg(feature = "experimental_metrics_periodicreader_with_async_runtime")]
 /// Module for periodic reader with async runtime.
 pub mod periodic_reader_with_async_runtime;
 pub(crate) mod pipeline;
-#[cfg(feature = "experimental_custom_metric_reader")]
+#[cfg(feature = "experimental_metrics_custom_reader")]
 pub mod reader;
-#[cfg(not(feature = "experimental_custom_metric_reader"))]
+#[cfg(not(feature = "experimental_metrics_custom_reader"))]
 pub(crate) mod reader;
 pub(crate) mod view;
 
@@ -70,16 +71,18 @@ pub mod in_memory_exporter;
 #[cfg_attr(docsrs, doc(cfg(any(feature = "testing", test))))]
 pub use in_memory_exporter::{InMemoryMetricExporter, InMemoryMetricExporterBuilder};
 
+#[cfg(feature = "spec_unstable_metrics_views")]
 pub use aggregation::*;
 #[cfg(feature = "spec_unstable_metrics_views")]
 pub use error::{MetricError, MetricResult};
-#[cfg(feature = "experimental_custom_metric_reader")]
+#[cfg(feature = "experimental_metrics_custom_reader")]
 pub use manual_reader::*;
 pub use meter_provider::*;
 pub use periodic_reader::*;
-#[cfg(feature = "experimental_custom_metric_reader")]
+#[cfg(feature = "experimental_metrics_custom_reader")]
 pub use pipeline::Pipeline;
 
+#[cfg(feature = "experimental_metrics_custom_reader")]
 pub use instrument::InstrumentKind;
 
 #[cfg(feature = "spec_unstable_metrics_views")]

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -52,7 +52,6 @@ where
     ///
     /// If this option is not used or `interval` is equal to zero, 60 seconds is
     /// used as the default.
-    #[allow(unused)]
     pub fn with_interval(mut self, interval: Duration) -> Self {
         if !interval.is_zero() {
             self.interval = interval;

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 use super::{
-    data::ResourceMetrics, instrument::InstrumentKind, reader::MetricReader, Pipeline, Temporality,
+    data::ResourceMetrics, instrument::InstrumentKind, reader::MetricReader, pipeline::Pipeline, Temporality,
 };
 
 const DEFAULT_INTERVAL: Duration = Duration::from_secs(60);
@@ -51,6 +51,7 @@ where
     ///
     /// If this option is not used or `interval` is equal to zero, 60 seconds is
     /// used as the default.
+    #[allow(unused)]
     pub fn with_interval(mut self, interval: Duration) -> Self {
         if !interval.is_zero() {
             self.interval = interval;

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -17,7 +17,8 @@ use crate::{
 };
 
 use super::{
-    data::ResourceMetrics, instrument::InstrumentKind, reader::MetricReader, pipeline::Pipeline, Temporality,
+    data::ResourceMetrics, instrument::InstrumentKind, pipeline::Pipeline, reader::MetricReader,
+    Temporality,
 };
 
 const DEFAULT_INTERVAL: Duration = Duration::from_secs(60);

--- a/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
@@ -20,7 +20,7 @@ use crate::{
     Resource,
 };
 
-use super::{data::ResourceMetrics, pipeline::Pipeline, reader::MetricReader, InstrumentKind};
+use super::{data::ResourceMetrics, pipeline::Pipeline, reader::MetricReader, instrument::InstrumentKind};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_INTERVAL: Duration = Duration::from_secs(60);

--- a/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
@@ -20,7 +20,9 @@ use crate::{
     Resource,
 };
 
-use super::{data::ResourceMetrics, pipeline::Pipeline, reader::MetricReader, instrument::InstrumentKind};
+use super::{
+    data::ResourceMetrics, instrument::InstrumentKind, pipeline::Pipeline, reader::MetricReader,
+};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_INTERVAL: Duration = Duration::from_secs(60);

--- a/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
@@ -20,7 +20,7 @@ use crate::{
     Resource,
 };
 
-use super::{data::ResourceMetrics, reader::MetricReader, InstrumentKind, Pipeline};
+use super::{data::ResourceMetrics, pipeline::Pipeline, reader::MetricReader, InstrumentKind};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_INTERVAL: Duration = Duration::from_secs(60);

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use self::internal::AggregateFns;
 
-use super::{Aggregation, Temporality};
+use super::{aggregation::Aggregation, Temporality};
 
 /// Connects all of the instruments created by a meter provider to a [MetricReader].
 ///

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -3,7 +3,7 @@ use crate::error::OTelSdkResult;
 use std::time::Duration;
 use std::{fmt, sync::Weak};
 
-use super::{data::ResourceMetrics, pipeline::Pipeline, instrument::InstrumentKind, Temporality};
+use super::{data::ResourceMetrics, instrument::InstrumentKind, pipeline::Pipeline, Temporality};
 
 /// The interface used between the SDK and an exporter.
 ///

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -3,7 +3,7 @@ use crate::error::OTelSdkResult;
 use std::time::Duration;
 use std::{fmt, sync::Weak};
 
-use super::{data::ResourceMetrics, pipeline::Pipeline, InstrumentKind, Temporality};
+use super::{data::ResourceMetrics, pipeline::Pipeline, instrument::InstrumentKind, Temporality};
 
 /// The interface used between the SDK and an exporter.
 ///

--- a/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
+++ b/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
@@ -1,7 +1,7 @@
 use crate::error::{OTelSdkError, OTelSdkResult};
 use crate::metrics::Temporality;
 use crate::metrics::{
-    data::ResourceMetrics, pipeline::Pipeline, reader::MetricReader, InstrumentKind,
+    data::ResourceMetrics, instrument::InstrumentKind, pipeline::Pipeline, reader::MetricReader,
 };
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -52,7 +52,7 @@ ctrlc = { workspace = true }
 lazy_static = { workspace = true }
 num_cpus = { workspace = true }
 opentelemetry = { path = "../opentelemetry", features = ["metrics", "logs", "trace", "spec_unstable_logs_enabled"] }
-opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics", "logs", "trace", "spec_unstable_logs_enabled", "experimental_logs_concurrent_log_processor"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics", "logs", "trace", "spec_unstable_logs_enabled", "experimental_logs_concurrent_log_processor", "experimental_custom_metric_reader"] }
 opentelemetry-appender-tracing = { workspace = true, features = ["spec_unstable_logs_enabled"] }
 rand = { workspace = true, features = ["small_rng", "os_rng"] }
 tracing = { workspace = true, features = ["std"]}

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -52,7 +52,7 @@ ctrlc = { workspace = true }
 lazy_static = { workspace = true }
 num_cpus = { workspace = true }
 opentelemetry = { path = "../opentelemetry", features = ["metrics", "logs", "trace", "spec_unstable_logs_enabled"] }
-opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics", "logs", "trace", "spec_unstable_logs_enabled", "experimental_logs_concurrent_log_processor", "experimental_custom_metric_reader"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics", "logs", "trace", "spec_unstable_logs_enabled", "experimental_logs_concurrent_log_processor", "experimental_metrics_custom_reader"] }
 opentelemetry-appender-tracing = { workspace = true, features = ["spec_unstable_logs_enabled"] }
 rand = { workspace = true, features = ["small_rng", "os_rng"] }
 tracing = { workspace = true, features = ["std"]}


### PR DESCRIPTION
Option2 from https://github.com/open-telemetry/opentelemetry-rust/issues/2917

Trimming public API, by hiding MetricReader+friends under feature flag. This won't affect normal usage of Metrics, but only custom MetricReader authors. It is unclear what scenario requires custom MetricReaders.....
Ability to write custom Exporter is still maintained.
Also removed `Aggregation` enum to existing View feature, as that was the only use for Aggregation.

Hoping to trim the questionable public API before declaring Metrics SDK as stable.