### PR TITLE
docs: fix the HTTP and gRPC transports quickstart guides

### DIFF
--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -39,9 +39,12 @@
 //!         .build()?;
 //!
 //!     // Create a tracer provider with the exporter
-//!     let _ = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+//!     let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
 //!         .with_simple_exporter(otlp_exporter)
 //!         .build();
+//!
+//!     // Set it as the global provider
+//!     global::set_tracer_provider(tracer_provider);
 //!
 //!     // Get a tracer and create spans
 //!     let tracer = global::tracer("my_tracer");

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -62,14 +62,16 @@
 //! $ docker run -p 4317:4317 otel/opentelemetry-collector:latest
 //! ```
 //!
-//! Configure your application to export traces via gRPC:
+//! Configure your application to export traces via gRPC (the tonic client requires a Tokio runtime):
+//!
+//! - With `[tokio::main]`
 //!
 //! ```no_run
 //! # #[cfg(all(feature = "trace", feature = "grpc-tonic"))]
 //! # {
-//! use opentelemetry::global;
-//! use opentelemetry::trace::Tracer;
+//! use opentelemetry::{global, trace::Tracer};
 //!
+//! #[tokio::main]
 //! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //!     // Initialize OTLP exporter using gRPC (Tonic)
 //!     let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
@@ -77,9 +79,12 @@
 //!         .build()?;
 //!
 //!     // Create a tracer provider with the exporter
-//!     let _ = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+//!     let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
 //!         .with_simple_exporter(otlp_exporter)
 //!         .build();
+//!
+//!     // Set it as the global provider
+//!     global::set_tracer_provider(tracer_provider);
 //!
 //!     // Get a tracer and create spans
 //!     let tracer = global::tracer("my_tracer");
@@ -87,6 +92,41 @@
 //!         // Your application logic here...
 //!     });
 //!
+//!     Ok(())
+//! # }
+//! }
+//! ```
+//!
+//! - Without `[tokio::main]`
+//!
+//!  ```no_run
+//! # #[cfg(all(feature = "trace", feature = "grpc-tonic"))]
+//! # {
+//! use opentelemetry::{global, trace::Tracer};
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//!     // Initialize OTLP exporter using gRPC (Tonic)
+//!     let rt = tokio::runtime::Runtime::new()?;
+//!     let tracer_provider = rt.block_on(async {
+//!         let exporter = opentelemetry_otlp::SpanExporter::builder()
+//!             .with_tonic()
+//!             .build()
+//!             .expect("Failed to create span exporter");
+//!         opentelemetry_sdk::trace::SdkTracerProvider::builder()
+//!             .with_simple_exporter(exporter)
+//!             .build()
+//!     });
+//!
+//!     // Set it as the global provider
+//!     global::set_tracer_provider(tracer_provider);
+//!
+//!     // Get a tracer and create spans
+//!     let tracer = global::tracer("my_tracer");
+//!     tracer.in_span("doing_work", |_cx| {
+//!         // Your application logic here...
+//!     });
+//!
+//!     // Ensure the runtime (`rt`) remains active until the program ends
 //!     Ok(())
 //! # }
 //! }

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -72,7 +72,7 @@
 //! use opentelemetry::{global, trace::Tracer};
 //!
 //! #[tokio::main]
-//! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //!     // Initialize OTLP exporter using gRPC (Tonic)
 //!     let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
 //!         .with_tonic()


### PR DESCRIPTION
## Changes

Fixed the `opentelemtry-otlp` quickstart guides for HTTP & gRPC

HTTP:
- Added missing call to `global::set_tracer_provider`

gRPC:
- Fixed the main sample to use `[tokio:main]` and to call `global::set_tracer_provider`
- Added a small sample using gRPC without `[tokio:main]` (based on opentelemtry-otlp/examples/basic-otlp)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (NA)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes (NA)
* [ ] Changes in public API reviewed (NA)

## Tests

`cargo test --all` fails on `test build_tonic` but this is also the case on `main`