### PR TITLE
feat(opentelemetry-sdk): add a constructor for SpanEvents and SpanLinks

### DIFF
--- a/opentelemetry-sdk/src/trace/events.rs
+++ b/opentelemetry-sdk/src/trace/events.rs
@@ -31,6 +31,14 @@ impl IntoIterator for SpanEvents {
 }
 
 impl SpanEvents {
+    /// Create a new `SpanEvents` from a list of events and a dropped count
+    pub fn new(events: Vec<Event>, dropped_count: u32) -> Self {
+        Self {
+            events,
+            dropped_count,
+        }
+    }
+
     pub(crate) fn add_event(&mut self, event: Event) {
         self.events.push(event);
     }

--- a/opentelemetry-sdk/src/trace/links.rs
+++ b/opentelemetry-sdk/src/trace/links.rs
@@ -31,6 +31,14 @@ impl IntoIterator for SpanLinks {
 }
 
 impl SpanLinks {
+    /// Create a new `SpanLinks` from a list of events and a dropped count
+    pub fn new(links: Vec<Link>, dropped_count: u32) -> Self {
+        Self {
+            links,
+            dropped_count,
+        }
+    }
+
     pub(crate) fn add_link(&mut self, link: Link) {
         self.links.push(link);
     }


### PR DESCRIPTION
Even though all fields are public, because of the `#[non_exhaustive]` annotation on `SpanEvents`and `SpanLinks`, it's not possible to construct instances of these outside of the `opentelemetry-sdk` crate.

Since they are used in `export::SpanData`, it is problematic because it means there is no way to create span data containing any events or span links. So there is no way to write tests on how to these fields are processed in external crate that implement the SpanExporter or SpanProcessor traits.

## Changes

Add public constructors on SpanEvents and SpanLinks structs.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
