### PR TITLE
chore: Add Bjorn as approver

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -26,11 +26,13 @@
     // workspace dictionary.
     "words": [
         "actix",
+        "Antonsson",
         "anyvalue",
         "appender",
         "appenders",
         "autobenches",
         "Bhasin",
+        "Björn",
         "BLRP",
         "Cijo",
         "clippy",

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ you're more than welcome to participate!
 ### Approvers
 
 * [Anton Grübel](https://github.com/gruebel), Baz
+* [Björn Antonsson](https://github.com/bantonsson), Datadog
 * [Shaun Cox](https://github.com/shaun-cox), Microsoft
 * [Scott Gerring](https://github.com/scottgerring), Datadog
 


### PR DESCRIPTION
Björn has been actively helping the repo for last few months, and is leading the exploration/development of tokio-tracing interop, among many other contributions/reviews.
He has agreed to volunteer time as an Approver for the repo.

In my view, https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#requirements-2 requirements have been met.