### PR TITLE
chore: change webpki-roots exception license to CDLA

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,7 @@ allow = [
 ]
 
 exceptions = [
-    { allow = ["MPL-2.0"], crate = "webpki-roots" }, # This crate is a dependency of `reqwest`.
+    { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" }, # This crate is a dependency of `reqwest`.
     { allow = ["Unicode-3.0"], crate = "icu_collections" }, # This crate gets used transitively by `reqwest`.
     { allow = ["Unicode-3.0"], crate = "icu_locid" }, # This crate gets used transitively by `reqwest`.
     { allow = ["Unicode-3.0"], crate = "icu_locid_transform" }, # This crate gets used transitively by `reqwest`.


### PR DESCRIPTION
## Changes

- `webpki-roots` was updated and has now the CDLA license

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
