### PR TITLE
chore: publish otel-proto v1.6.0

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/expected/serialized_traces.json
+++ b/opentelemetry-otlp/tests/integration_test/expected/serialized_traces.json
@@ -10,7 +10,8 @@
             }
           }
         ],
-        "droppedAttributesCount": 0
+        "droppedAttributesCount": 0,
+        "entityRefs": []
       },
       "scopeSpans": [
         {

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Update `tonic` dependency version to 0.13
+- - Update proto definitions to v1.6.0.
 
 ## 0.29.0
 

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
@@ -153,8 +153,6 @@ pub mod logs_service_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
-        /// For performance reasons, it is recommended to keep this RPC
-        /// alive for the entire life of the application.
         pub async fn export(
             &mut self,
             request: impl tonic::IntoRequest<super::ExportLogsServiceRequest>,
@@ -200,8 +198,6 @@ pub mod logs_service_server {
     /// Generated trait containing gRPC methods that should be implemented for use with LogsServiceServer.
     #[async_trait]
     pub trait LogsService: std::marker::Send + std::marker::Sync + 'static {
-        /// For performance reasons, it is recommended to keep this RPC
-        /// alive for the entire life of the application.
         async fn export(
             &self,
             request: tonic::Request<super::ExportLogsServiceRequest>,

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
@@ -153,8 +153,6 @@ pub mod metrics_service_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
-        /// For performance reasons, it is recommended to keep this RPC
-        /// alive for the entire life of the application.
         pub async fn export(
             &mut self,
             request: impl tonic::IntoRequest<super::ExportMetricsServiceRequest>,
@@ -200,8 +198,6 @@ pub mod metrics_service_server {
     /// Generated trait containing gRPC methods that should be implemented for use with MetricsServiceServer.
     #[async_trait]
     pub trait MetricsService: std::marker::Send + std::marker::Sync + 'static {
-        /// For performance reasons, it is recommended to keep this RPC
-        /// alive for the entire life of the application.
         async fn export(
             &self,
             request: tonic::Request<super::ExportMetricsServiceRequest>,

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
@@ -153,8 +153,6 @@ pub mod trace_service_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
-        /// For performance reasons, it is recommended to keep this RPC
-        /// alive for the entire life of the application.
         pub async fn export(
             &mut self,
             request: impl tonic::IntoRequest<super::ExportTraceServiceRequest>,
@@ -200,8 +198,6 @@ pub mod trace_service_server {
     /// Generated trait containing gRPC methods that should be implemented for use with TraceServiceServer.
     #[async_trait]
     pub trait TraceService: std::marker::Send + std::marker::Sync + 'static {
-        /// For performance reasons, it is recommended to keep this RPC
-        /// alive for the entire life of the application.
         async fn export(
             &self,
             request: tonic::Request<super::ExportTraceServiceRequest>,

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.common.v1.rs
@@ -106,3 +106,41 @@ pub struct InstrumentationScope {
     #[prost(uint32, tag = "4")]
     pub dropped_attributes_count: u32,
 }
+/// A reference to an Entity.
+/// Entity represents an object of interest associated with produced telemetry: e.g spans, metrics, profiles, or logs.
+///
+/// Status: \[Development\]
+#[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EntityRef {
+    /// The Schema URL, if known. This is the identifier of the Schema that the entity data
+    /// is recorded in. To learn more about Schema URL see
+    /// <https://opentelemetry.io/docs/specs/otel/schemas/#schema-url>
+    ///
+    /// This schema_url applies to the data in this message and to the Resource attributes
+    /// referenced by id_keys and description_keys.
+    /// TODO: discuss if we are happy with this somewhat complicated definition of what
+    /// the schema_url applies to.
+    ///
+    /// This field obsoletes the schema_url field in ResourceMetrics/ResourceSpans/ResourceLogs.
+    #[prost(string, tag = "1")]
+    pub schema_url: ::prost::alloc::string::String,
+    /// Defines the type of the entity. MUST not change during the lifetime of the entity.
+    /// For example: "service" or "host". This field is required and MUST not be empty
+    /// for valid entities.
+    #[prost(string, tag = "2")]
+    pub r#type: ::prost::alloc::string::String,
+    /// Attribute Keys that identify the entity.
+    /// MUST not change during the lifetime of the entity. The Id must contain at least one attribute.
+    /// These keys MUST exist in the containing {message}.attributes.
+    #[prost(string, repeated, tag = "3")]
+    pub id_keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Descriptive (non-identifying) attribute keys of the entity.
+    /// MAY change over the lifetime of the entity. MAY be empty.
+    /// These attribute keys are not part of entity's identity.
+    /// These keys MUST exist in the containing {message}.attributes.
+    #[prost(string, repeated, tag = "4")]
+    pub description_keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.logs.v1.rs
@@ -190,8 +190,6 @@ pub struct LogRecord {
     /// as an event.
     ///
     /// \[Optional\].
-    ///
-    /// Status: \[Development\]
     #[prost(string, tag = "12")]
     pub event_name: ::prost::alloc::string::String,
 }

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.resource.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.resource.v1.rs
@@ -15,4 +15,11 @@ pub struct Resource {
     /// no attributes were dropped.
     #[prost(uint32, tag = "2")]
     pub dropped_attributes_count: u32,
+    /// Set of entities that participate in this Resource.
+    ///
+    /// Note: keys in the references MUST exist in attributes of this message.
+    ///
+    /// Status: \[Development\]
+    #[prost(message, repeated, tag = "3")]
+    pub entity_refs: ::prost::alloc::vec::Vec<super::super::common::v1::EntityRef>,
 }

--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -150,6 +150,7 @@ pub mod tonic {
                 resource: Some(Resource {
                     attributes: resource.attributes.0.clone(),
                     dropped_attributes_count: 0,
+                    entity_refs: vec![],
                 }),
                 schema_url: resource.schema_url.clone().unwrap_or_default(),
                 scope_logs: vec![ScopeLogs {
@@ -210,6 +211,7 @@ pub mod tonic {
             resource: Some(Resource {
                 attributes: resource.attributes.0.clone(),
                 dropped_attributes_count: 0,
+                entity_refs: vec![],
             }),
             scope_logs,
             schema_url: resource.schema_url.clone().unwrap_or_default(),

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -127,6 +127,7 @@ pub mod tonic {
             TonicResource {
                 attributes: resource.iter().map(Into::into).collect(),
                 dropped_attributes_count: 0,
+                entity_refs: vec![], // internal and currently unused
             }
         }
     }

--- a/opentelemetry-proto/src/transform/trace.rs
+++ b/opentelemetry-proto/src/transform/trace.rs
@@ -97,6 +97,7 @@ pub mod tonic {
                 resource: Some(Resource {
                     attributes: resource.attributes.0.clone(),
                     dropped_attributes_count: 0,
+                    entity_refs: vec![],
                 }),
                 schema_url: resource.schema_url.clone().unwrap_or_default(),
                 scope_spans: vec![ScopeSpans {
@@ -182,6 +183,7 @@ pub mod tonic {
             resource: Some(Resource {
                 attributes: resource.attributes.0.clone(),
                 dropped_attributes_count: 0,
+                entity_refs: vec![],
             }),
             scope_spans,
             schema_url: resource.schema_url.clone().unwrap_or_default(),

--- a/opentelemetry-proto/tests/json_serde.rs
+++ b/opentelemetry-proto/tests/json_serde.rs
@@ -44,6 +44,7 @@ mod json_serde {
                                 }),
                             }],
                             dropped_attributes_count: 0,
+                            entity_refs: vec![],
                         }),
                         scope_spans: vec![ScopeSpans {
                             scope: Some(InstrumentationScope {
@@ -249,6 +250,7 @@ mod json_serde {
                                 }),
                             }],
                             dropped_attributes_count: 1,
+                            entity_refs: vec![],
                         }),
                         scope_spans: vec![ScopeSpans {
                             scope: Some(InstrumentationScope {
@@ -792,6 +794,7 @@ mod json_serde {
                                 }),
                             }],
                             dropped_attributes_count: 0,
+                            entity_refs: vec![],
                         }),
                         scope_metrics: vec![ScopeMetrics {
                             scope: Some(InstrumentationScope {
@@ -1178,6 +1181,7 @@ mod json_serde {
                                 }),
                             }],
                             dropped_attributes_count: 0,
+                            entity_refs: vec![],
                         }),
                         scope_logs: vec![ScopeLogs {
                             scope: Some(InstrumentationScope {


### PR DESCRIPTION
## Changes

Update otel-proto v1.6.0:
https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.6.0

Important changes:
  - Entities are proposed to be first-class concept in OpenTelemetry and are modeled as part of the Resource object in OTLP.
     - [Entities Data Model, Part 1](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/entities/0256-entities-data-model.md)
     - [Resource and Entities - Data Model Part 2](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/entities/0264-resource-and-entities.md)
     - [Add EntityRef and use it in Resource](https://github.com/open-telemetry/opentelemetry-proto/pull/635)

- logs: [Stabilize event_name field in LogRecord message.](https://github.com/open-telemetry/opentelemetry-proto/pull/643)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
