### PR TITLE
refactor: PushMetricExporter hide implementation for ResourceMetrics

### DIFF
--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -4,12 +4,12 @@ use crate::metric::MetricsClient;
 use http::{header::CONTENT_TYPE, Method};
 use opentelemetry::otel_debug;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
-use opentelemetry_sdk::metrics::data::ResourceMetrics;
+use opentelemetry_sdk::metrics::exporter::ResourceMetrics;
 
 use super::OtlpHttpClient;
 
 impl MetricsClient for OtlpHttpClient {
-    async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
+    async fn export(&self, metrics: ResourceMetrics<'_>) -> OTelSdkResult {
         let client = self
             .client
             .lock()

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 mod metrics;
 
 #[cfg(feature = "metrics")]
-use opentelemetry_sdk::metrics::data::ResourceMetrics;
+use opentelemetry_sdk::metrics::exporter::ResourceMetrics;
 
 #[cfg(feature = "logs")]
 pub(crate) mod logs;
@@ -326,7 +326,7 @@ impl OtlpHttpClient {
     #[cfg(feature = "metrics")]
     fn build_metrics_export_body(
         &self,
-        metrics: &ResourceMetrics,
+        metrics: ResourceMetrics<'_>,
     ) -> Option<(Vec<u8>, &'static str)> {
         use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -6,7 +6,7 @@ use opentelemetry_proto::tonic::collector::metrics::v1::{
     metrics_service_client::MetricsServiceClient, ExportMetricsServiceRequest,
 };
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
-use opentelemetry_sdk::metrics::data::ResourceMetrics;
+use opentelemetry_sdk::metrics::exporter::ResourceMetrics;
 use tonic::{codegen::CompressionEncoding, service::Interceptor, transport::Channel, Request};
 
 use super::BoxInterceptor;
@@ -52,7 +52,7 @@ impl TonicMetricsClient {
 }
 
 impl MetricsClient for TonicMetricsClient {
-    async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
+    async fn export(&self, metrics: ResourceMetrics<'_>) -> OTelSdkResult {
         let (mut client, metadata, extensions) = self
             .inner
             .lock()

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -17,9 +17,8 @@ use crate::{ExporterBuildError, NoExporterBuilderSet};
 use core::fmt;
 use opentelemetry_sdk::error::OTelSdkResult;
 
-use opentelemetry_sdk::metrics::{
-    data::ResourceMetrics, exporter::PushMetricExporter, Temporality,
-};
+use opentelemetry_sdk::metrics::exporter::ResourceMetrics;
+use opentelemetry_sdk::metrics::{exporter::PushMetricExporter, Temporality};
 use std::fmt::{Debug, Formatter};
 use std::time::Duration;
 
@@ -123,7 +122,7 @@ impl HasHttpConfig for MetricExporterBuilder<HttpExporterBuilderSet> {
 pub(crate) trait MetricsClient: fmt::Debug + Send + Sync + 'static {
     fn export(
         &self,
-        metrics: &ResourceMetrics,
+        metrics: ResourceMetrics<'_>,
     ) -> impl std::future::Future<Output = OTelSdkResult> + Send;
     fn shutdown(&self) -> OTelSdkResult;
 }
@@ -149,7 +148,7 @@ impl Debug for MetricExporter {
 }
 
 impl PushMetricExporter for MetricExporter {
-    async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
+    async fn export(&self, metrics: ResourceMetrics<'_>) -> OTelSdkResult {
         match &self.client {
             #[cfg(feature = "grpc-tonic")]
             SupportedTransportClient::Tonic(client) => client.export(metrics).await,

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -11,9 +11,9 @@ pub mod tonic {
     use opentelemetry_sdk::metrics::data::{
         AggregatedMetrics, Exemplar as SdkExemplar,
         ExponentialHistogram as SdkExponentialHistogram, Gauge as SdkGauge,
-        Histogram as SdkHistogram, Metric as SdkMetric, MetricData, ResourceMetrics,
-        ScopeMetrics as SdkScopeMetrics, Sum as SdkSum,
+        Histogram as SdkHistogram, MetricData, Sum as SdkSum,
     };
+    use opentelemetry_sdk::metrics::exporter::{Metric, ResourceMetrics, ScopeMetrics};
     use opentelemetry_sdk::metrics::Temporality;
     use opentelemetry_sdk::Resource as SdkResource;
 
@@ -110,12 +110,18 @@ pub mod tonic {
         }
     }
 
-    impl From<&ResourceMetrics> for ExportMetricsServiceRequest {
-        fn from(rm: &ResourceMetrics) -> Self {
+    impl From<ResourceMetrics<'_>> for ExportMetricsServiceRequest {
+        fn from(rm: ResourceMetrics<'_>) -> Self {
+            let mut scope_metrics = Vec::new();
+            rm.scope_metrics.collect(|mut iter| {
+                while let Some(scope_metric) = iter.next_scope_metrics() {
+                    scope_metrics.push(scope_metric.into());
+                }
+            });
             ExportMetricsServiceRequest {
                 resource_metrics: vec![TonicResourceMetrics {
-                    resource: Some((&rm.resource).into()),
-                    scope_metrics: rm.scope_metrics.iter().map(Into::into).collect(),
+                    resource: Some(rm.resource.into()),
+                    scope_metrics,
                     schema_url: rm.resource.schema_url().map(Into::into).unwrap_or_default(),
                 }],
             }
@@ -131,11 +137,15 @@ pub mod tonic {
         }
     }
 
-    impl From<&SdkScopeMetrics> for TonicScopeMetrics {
-        fn from(sm: &SdkScopeMetrics) -> Self {
+    impl From<ScopeMetrics<'_>> for TonicScopeMetrics {
+        fn from(mut sm: ScopeMetrics<'_>) -> Self {
+            let mut metrics = Vec::new();
+            while let Some(metric) = sm.metrics.next_metric() {
+                metrics.push(metric.into());
+            }
             TonicScopeMetrics {
-                scope: Some((&sm.scope, None).into()),
-                metrics: sm.metrics.iter().map(Into::into).collect(),
+                scope: Some((sm.scope, None).into()),
+                metrics,
                 schema_url: sm
                     .scope
                     .schema_url()
@@ -145,12 +155,12 @@ pub mod tonic {
         }
     }
 
-    impl From<&SdkMetric> for TonicMetric {
-        fn from(metric: &SdkMetric) -> Self {
+    impl From<Metric<'_>> for TonicMetric {
+        fn from(metric: Metric<'_>) -> Self {
             TonicMetric {
-                name: metric.name.to_string(),
-                description: metric.description.to_string(),
-                unit: metric.unit.to_string(),
+                name: metric.instrument.name.to_string(),
+                description: metric.instrument.description.to_string(),
+                unit: metric.instrument.unit.to_string(),
                 metadata: vec![], // internal and currently unused
                 data: Some(match &metric.data {
                     AggregatedMetrics::F64(data) => data.into(),

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## vNext
 
+- *Breaking* change for `PushMetricExporter::export` from accepting
+  `metrics: &ResourceMetrics`, to accepting `metrics: ResourceMetrics<'_>`.
+  In addition, `ResourceMetrics` was also changed to allow improving underlying
+  metric collection without any allocations in the future.
+  [#2957](https://github.com/open-telemetry/opentelemetry-rust/pull/2957)
+- *Breaking* change for `Metric::data` field: From dynamic `Box<dyn Aggregation>`
+  to new enum `AggregatedMetrics`.
+  [#2857](https://github.com/open-telemetry/opentelemetry-rust/pull/2857)
+
 - **Feature**: Added context based telemetry suppression. [#2868](https://github.com/open-telemetry/opentelemetry-rust/pull/2868)
   - `SdkLogger`, `SdkTracer` modified to respect telemetry suppression based on
 `Context`. In other words, if the current context has telemetry suppression
@@ -47,6 +56,7 @@ also modified to suppress telemetry before invoking exporters.
 - *Breaking* change, affecting custom `PushMetricExporter` authors:
   - The `export` method on `PushMetricExporter` now accepts `&ResourceMetrics`
     instead of `&mut ResourceMetrics`.
+
 
 ## 0.29.0
 

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -6,8 +6,10 @@ use opentelemetry::{
 use opentelemetry_sdk::{
     error::OTelSdkResult,
     metrics::{
-        data::ResourceMetrics, new_view, reader::MetricReader, Aggregation, Instrument,
-        InstrumentKind, ManualReader, Pipeline, SdkMeterProvider, Stream, Temporality, View,
+        new_view,
+        reader::{MetricReader, ResourceMetricsData},
+        Aggregation, Instrument, InstrumentKind, ManualReader, Pipeline, SdkMeterProvider, Stream,
+        Temporality, View,
     },
     Resource,
 };
@@ -23,7 +25,7 @@ impl MetricReader for SharedReader {
         self.0.register_pipeline(pipeline)
     }
 
-    fn collect(&self, rm: &mut ResourceMetrics) -> OTelSdkResult {
+    fn collect(&self, rm: &mut ResourceMetricsData) -> OTelSdkResult {
         self.0.collect(rm)
     }
 
@@ -240,7 +242,7 @@ fn counters(c: &mut Criterion) {
     });
 
     let (rdr, cntr) = bench_counter(None, "cumulative");
-    let mut rm = ResourceMetrics {
+    let mut rm = ResourceMetricsData {
         resource: Resource::builder_empty().build(),
         scope_metrics: Vec::new(),
     };
@@ -337,7 +339,7 @@ fn benchmark_collect_histogram(b: &mut Bencher, n: usize) {
         h.record(1, &[]);
     }
 
-    let mut rm = ResourceMetrics {
+    let mut rm = ResourceMetricsData {
         resource: Resource::builder_empty().build(),
         scope_metrics: Vec::new(),
     };

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -1,45 +1,10 @@
 //! Types for delivery of pre-aggregated metric time series data.
 
-use std::{borrow::Cow, time::SystemTime};
+use std::time::SystemTime;
 
-use opentelemetry::{InstrumentationScope, KeyValue};
-
-use crate::Resource;
+use opentelemetry::KeyValue;
 
 use super::Temporality;
-
-/// A collection of [ScopeMetrics] and the associated [Resource] that created them.
-#[derive(Debug)]
-pub struct ResourceMetrics {
-    /// The entity that collected the metrics.
-    pub resource: Resource,
-    /// The collection of metrics with unique [InstrumentationScope]s.
-    pub scope_metrics: Vec<ScopeMetrics>,
-}
-
-/// A collection of metrics produced by a meter.
-#[derive(Default, Debug)]
-pub struct ScopeMetrics {
-    /// The [InstrumentationScope] that the meter was created with.
-    pub scope: InstrumentationScope,
-    /// The list of aggregations created by the meter.
-    pub metrics: Vec<Metric>,
-}
-
-/// A collection of one or more aggregated time series from an [Instrument].
-///
-/// [Instrument]: crate::metrics::Instrument
-#[derive(Debug)]
-pub struct Metric {
-    /// The name of the instrument that created this data.
-    pub name: Cow<'static, str>,
-    /// The description of the instrument, which can be used in documentation.
-    pub description: Cow<'static, str>,
-    /// The unit in which the instrument reports.
-    pub unit: Cow<'static, str>,
-    /// The aggregated data from an instrument.
-    pub data: AggregatedMetrics,
-}
 
 /// Aggregated metrics data from an instrument
 #[derive(Debug)]

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -65,6 +65,19 @@ impl InstrumentKind {
     }
 }
 
+/// Describes properties an instrument is created with
+#[derive(Debug, Clone)]
+pub struct InstrumentInfo {
+    /// The human-readable identifier of the instrument.
+    pub name: Cow<'static, str>,
+    /// describes the purpose of the instrument.
+    pub description: Cow<'static, str>,
+    /// The functional group of the instrument.
+    pub kind: InstrumentKind,
+    /// Unit is the unit of measurement recorded by the instrument.
+    pub unit: Cow<'static, str>,
+}
+
 /// Describes properties an instrument is created with, also used for filtering
 /// in [View](crate::metrics::View)s.
 ///

--- a/opentelemetry-sdk/src/metrics/manual_reader.rs
+++ b/opentelemetry-sdk/src/metrics/manual_reader.rs
@@ -10,8 +10,8 @@ use crate::{
     metrics::Temporality,
 };
 
+use super::reader::ResourceMetricsData;
 use super::{
-    data::ResourceMetrics,
     pipeline::Pipeline,
     reader::{MetricReader, SdkProducer},
 };
@@ -90,7 +90,7 @@ impl MetricReader for ManualReader {
     /// callbacks necessary and returning the results.
     ///
     /// Returns an error if called after shutdown.
-    fn collect(&self, rm: &mut ResourceMetrics) -> OTelSdkResult {
+    fn collect(&self, rm: &mut ResourceMetricsData) -> OTelSdkResult {
         let inner = self
             .inner
             .lock()

--- a/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
@@ -13,16 +13,17 @@ use futures_util::{
 };
 use opentelemetry::{otel_debug, otel_error};
 
-use crate::runtime::{to_interval_stream, Runtime};
 use crate::{
     error::{OTelSdkError, OTelSdkResult},
     metrics::{exporter::PushMetricExporter, reader::SdkProducer},
     Resource,
 };
-
-use super::{
-    data::ResourceMetrics, instrument::InstrumentKind, pipeline::Pipeline, reader::MetricReader,
+use crate::{
+    metrics::{exporter::ResourceMetrics, reader::ResourceMetricsData},
+    runtime::{to_interval_stream, Runtime},
 };
+
+use super::{instrument::InstrumentKind, pipeline::Pipeline, reader::MetricReader};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_INTERVAL: Duration = Duration::from_secs(60);
@@ -120,7 +121,7 @@ where
                     reader,
                     timeout: self.timeout,
                     runtime,
-                    rm: ResourceMetrics {
+                    rm: ResourceMetricsData {
                         resource: Resource::empty(),
                         scope_metrics: Vec::new(),
                     },
@@ -238,7 +239,7 @@ struct PeriodicReaderWorker<E: PushMetricExporter, RT: Runtime> {
     reader: PeriodicReader<E>,
     timeout: Duration,
     runtime: RT,
-    rm: ResourceMetrics,
+    rm: ResourceMetricsData,
 }
 
 impl<E: PushMetricExporter, RT: Runtime> PeriodicReaderWorker<E, RT> {
@@ -259,7 +260,7 @@ impl<E: PushMetricExporter, RT: Runtime> PeriodicReaderWorker<E, RT> {
             message = "Calling exporter's export method with collected metrics.",
             count = self.rm.scope_metrics.len(),
         );
-        let export = self.reader.exporter.export(&self.rm);
+        let export = self.reader.exporter.export(ResourceMetrics::new(&self.rm));
         let timeout = self.runtime.delay(self.timeout);
         pin_mut!(export);
         pin_mut!(timeout);
@@ -353,7 +354,7 @@ impl<E: PushMetricExporter> MetricReader for PeriodicReader<E> {
         worker(self);
     }
 
-    fn collect(&self, rm: &mut ResourceMetrics) -> OTelSdkResult {
+    fn collect(&self, rm: &mut ResourceMetricsData) -> OTelSdkResult {
         let inner = self
             .inner
             .lock()
@@ -443,11 +444,8 @@ impl<E: PushMetricExporter> MetricReader for PeriodicReader<E> {
 mod tests {
     use super::PeriodicReader;
     use crate::error::OTelSdkError;
-    use crate::metrics::reader::MetricReader;
-    use crate::{
-        metrics::data::ResourceMetrics, metrics::InMemoryMetricExporter, metrics::SdkMeterProvider,
-        runtime, Resource,
-    };
+    use crate::metrics::reader::{MetricReader, ResourceMetricsData};
+    use crate::{metrics::InMemoryMetricExporter, metrics::SdkMeterProvider, runtime, Resource};
     use opentelemetry::metrics::MeterProvider;
     use std::sync::mpsc;
 
@@ -494,7 +492,7 @@ mod tests {
         // Arrange
         let exporter = InMemoryMetricExporter::default();
         let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
-        let mut rm = ResourceMetrics {
+        let mut rm = ResourceMetricsData {
             resource: Resource::empty(),
             scope_metrics: Vec::new(),
         };

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -1,9 +1,43 @@
 //! Interfaces for reading and producing metrics
+use opentelemetry::InstrumentationScope;
+
 use crate::error::OTelSdkResult;
+use crate::Resource;
 use std::time::Duration;
 use std::{fmt, sync::Weak};
 
-use super::{data::ResourceMetrics, instrument::InstrumentKind, pipeline::Pipeline, Temporality};
+use super::data::AggregatedMetrics;
+use super::InstrumentInfo;
+use super::{pipeline::Pipeline, InstrumentKind, Temporality};
+
+/// A collection of [ScopeMetricsData] and the associated [Resource] that created them.
+#[derive(Debug)]
+pub struct ResourceMetricsData {
+    /// The entity that collected the metrics.
+    pub resource: Resource,
+    /// The collection of metrics with unique [InstrumentationScope]s.
+    pub scope_metrics: Vec<ScopeMetricsData>,
+}
+
+/// A collection of metrics produced by a meter.
+#[derive(Debug, Default)]
+pub struct ScopeMetricsData {
+    /// The [InstrumentationScope] that the meter was created with.
+    pub scope: InstrumentationScope,
+    /// The list of aggregations created by the meter.
+    pub metrics: Vec<MetricsData>,
+}
+
+/// A collection of one or more aggregated time series from an [Instrument].
+///
+/// [Instrument]: crate::metrics::Instrument
+#[derive(Debug)]
+pub struct MetricsData {
+    /// The name of the instrument that created this data.
+    pub instrument: InstrumentInfo,
+    /// The aggregated data from an instrument.
+    pub data: AggregatedMetrics,
+}
 
 /// The interface used between the SDK and an exporter.
 ///
@@ -27,10 +61,10 @@ pub trait MetricReader: fmt::Debug + Send + Sync + 'static {
     fn register_pipeline(&self, pipeline: Weak<Pipeline>);
 
     /// Gathers and returns all metric data related to the [MetricReader] from the
-    /// SDK and stores it in the provided [ResourceMetrics] reference.
+    /// SDK and stores it in the provided [ResourceMetricsData] reference.
     ///
     /// An error is returned if this is called after shutdown.
-    fn collect(&self, rm: &mut ResourceMetrics) -> OTelSdkResult;
+    fn collect(&self, rm: &mut ResourceMetricsData) -> OTelSdkResult;
 
     /// Flushes all metric measurements held in an export pipeline.
     ///
@@ -63,5 +97,5 @@ pub trait MetricReader: fmt::Debug + Send + Sync + 'static {
 /// Produces metrics for a [MetricReader].
 pub(crate) trait SdkProducer: fmt::Debug + Send + Sync {
     /// Returns aggregated metrics from a single collection.
-    fn produce(&self, rm: &mut ResourceMetrics) -> OTelSdkResult;
+    fn produce(&self, rm: &mut ResourceMetricsData) -> OTelSdkResult;
 }

--- a/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
+++ b/opentelemetry-sdk/src/testing/metrics/metric_reader.rs
@@ -1,8 +1,7 @@
 use crate::error::{OTelSdkError, OTelSdkResult};
+use crate::metrics::reader::ResourceMetricsData;
 use crate::metrics::Temporality;
-use crate::metrics::{
-    data::ResourceMetrics, instrument::InstrumentKind, pipeline::Pipeline, reader::MetricReader,
-};
+use crate::metrics::{instrument::InstrumentKind, pipeline::Pipeline, reader::MetricReader};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
@@ -34,7 +33,7 @@ impl Default for TestMetricReader {
 impl MetricReader for TestMetricReader {
     fn register_pipeline(&self, _pipeline: Weak<Pipeline>) {}
 
-    fn collect(&self, _rm: &mut ResourceMetrics) -> OTelSdkResult {
+    fn collect(&self, _rm: &mut ResourceMetricsData) -> OTelSdkResult {
         Ok(())
     }
 

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -1,14 +1,14 @@
 use chrono::{DateTime, Utc};
 use core::{f64, fmt};
 use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+use opentelemetry_sdk::metrics::exporter::{
+    MetricsLendingIter, ResourceMetrics, ScopeMetricsCollector,
+};
 use opentelemetry_sdk::metrics::Temporality;
 use opentelemetry_sdk::{
     error::OTelSdkResult,
     metrics::{
-        data::{
-            Gauge, GaugeDataPoint, Histogram, HistogramDataPoint, ResourceMetrics, ScopeMetrics,
-            Sum, SumDataPoint,
-        },
+        data::{Gauge, GaugeDataPoint, Histogram, HistogramDataPoint, Sum, SumDataPoint},
         exporter::PushMetricExporter,
     },
 };
@@ -42,7 +42,7 @@ impl fmt::Debug for MetricExporter {
 
 impl PushMetricExporter for MetricExporter {
     /// Write Metrics to stdout
-    async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
+    async fn export(&self, metrics: ResourceMetrics<'_>) -> OTelSdkResult {
         if self.is_shutdown.load(atomic::Ordering::SeqCst) {
             Err(opentelemetry_sdk::error::OTelSdkError::AlreadyShutdown)
         } else {
@@ -55,7 +55,7 @@ impl PushMetricExporter for MetricExporter {
             metrics.resource.iter().for_each(|(k, v)| {
                 println!("\t ->  {}={:?}", k, v);
             });
-            print_metrics(&metrics.scope_metrics);
+            print_scope_metrics(metrics.scope_metrics);
             Ok(())
         }
     }
@@ -79,61 +79,71 @@ impl PushMetricExporter for MetricExporter {
     }
 }
 
-fn print_metrics(metrics: &[ScopeMetrics]) {
-    for (i, metric) in metrics.iter().enumerate() {
-        println!("\tInstrumentation Scope #{}", i);
-        println!("\t\tName         : {}", &metric.scope.name());
-        if let Some(version) = &metric.scope.version() {
-            println!("\t\tVersion  : {:?}", version);
+fn print_scope_metrics(scope_metrics: ScopeMetricsCollector<'_>) {
+    scope_metrics.collect(|mut metrics| {
+        let mut iter = 0;
+        while let Some(scope_metric) = metrics.next_scope_metrics() {
+            iter += 1;
+            println!("\tInstrumentation Scope #{}", iter);
+            println!("\t\tName         : {}", &scope_metric.scope.name());
+            if let Some(version) = &scope_metric.scope.version() {
+                println!("\t\tVersion  : {:?}", version);
+            }
+            if let Some(schema_url) = &scope_metric.scope.schema_url() {
+                println!("\t\tSchemaUrl: {:?}", schema_url);
+            }
+            scope_metric
+                .scope
+                .attributes()
+                .enumerate()
+                .for_each(|(index, kv)| {
+                    if index == 0 {
+                        println!("\t\tScope Attributes:");
+                    }
+                    println!("\t\t\t ->  {}: {}", kv.key, kv.value);
+                });
+            print_metrics(scope_metric.metrics);
         }
-        if let Some(schema_url) = &metric.scope.schema_url() {
-            println!("\t\tSchemaUrl: {:?}", schema_url);
-        }
-        metric
-            .scope
-            .attributes()
-            .enumerate()
-            .for_each(|(index, kv)| {
-                if index == 0 {
-                    println!("\t\tScope Attributes:");
+    });
+}
+
+fn print_metrics(mut metrics: MetricsLendingIter<'_>) {
+    let mut iter = 0;
+    while let Some(metric) = metrics.next_metric() {
+        iter += 1;
+
+        println!("Metric #{}", iter);
+        println!("\t\tName         : {}", &metric.instrument.name);
+        println!("\t\tDescription  : {}", &metric.instrument.description);
+        println!("\t\tUnit         : {}", &metric.instrument.unit);
+
+        fn print_info<T>(data: &MetricData<T>)
+        where
+            T: Debug,
+        {
+            match data {
+                MetricData::Gauge(gauge) => {
+                    println!("\t\tType         : Gauge");
+                    print_gauge(gauge);
                 }
-                println!("\t\t\t ->  {}: {}", kv.key, kv.value);
-            });
-
-        metric.metrics.iter().enumerate().for_each(|(i, metric)| {
-            println!("Metric #{}", i);
-            println!("\t\tName         : {}", &metric.name);
-            println!("\t\tDescription  : {}", &metric.description);
-            println!("\t\tUnit         : {}", &metric.unit);
-
-            fn print_info<T>(data: &MetricData<T>)
-            where
-                T: Debug,
-            {
-                match data {
-                    MetricData::Gauge(gauge) => {
-                        println!("\t\tType         : Gauge");
-                        print_gauge(gauge);
-                    }
-                    MetricData::Sum(sum) => {
-                        println!("\t\tType         : Sum");
-                        print_sum(sum);
-                    }
-                    MetricData::Histogram(hist) => {
-                        println!("\t\tType         : Histogram");
-                        print_histogram(hist);
-                    }
-                    MetricData::ExponentialHistogram(_) => {
-                        println!("\t\tType         : Exponential Histogram");
-                    }
+                MetricData::Sum(sum) => {
+                    println!("\t\tType         : Sum");
+                    print_sum(sum);
+                }
+                MetricData::Histogram(hist) => {
+                    println!("\t\tType         : Histogram");
+                    print_histogram(hist);
+                }
+                MetricData::ExponentialHistogram(_) => {
+                    println!("\t\tType         : Exponential Histogram");
                 }
             }
-            match &metric.data {
-                AggregatedMetrics::F64(data) => print_info(data),
-                AggregatedMetrics::U64(data) => print_info(data),
-                AggregatedMetrics::I64(data) => print_info(data),
-            }
-        });
+        }
+        match &metric.data {
+            AggregatedMetrics::F64(data) => print_info(data),
+            AggregatedMetrics::U64(data) => print_info(data),
+            AggregatedMetrics::I64(data) => print_info(data),
+        }
     }
 }
 


### PR DESCRIPTION
## Changes

Changed `PushMetricExporer::export` signature. `fn export(&self, metrics: ResourceMetricsRef<'_>) -> ...`. It is very similar to `LogExporter::export`, with one differences, it doesn't expose `iter()` method on items (metrics), but provide a `collect` function which accepts a lambda function which receives a [lending](https://blog.rust-lang.org/2022/10/28/gats-stabilization.html#what-are-gats) iterator as an argument.

This design, although doesn't look very friendly from user perspective, allow to maximum flexibility on internal implementation side. 
*  `collect` function limits lock scope, while we iterate over internal implementation.
* lending iterator allows zero-allocation collection implementation (PoC #2921).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
