### PR TITLE
chore: Fix CI coverage error for failing to install llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,9 +199,11 @@ jobs:
           components: rustfmt,llvm-tools-preview
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: cargo install cargo-llvm-cov
-        uses: taiki-e/install-action@33734a118689b0b418824fb78ea2bf18e970b43b # cargo-llvm-cov
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@33734a118689b0b418824fb78ea2bf18e970b43b
+        with:
+          tool: cargo-llvm-cov
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@33734a118689b0b418824fb78ea2bf18e970b43b
+        uses: taiki-e/install-action@33734a118689b0b418824fb78ea2bf18e970b43b # v2.50.4
         with:
           tool: cargo-llvm-cov
       - name: cargo generate-lockfile


### PR DESCRIPTION
Fixes the CI error:

![image](https://github.com/user-attachments/assets/5cbf7a20-f355-4f6c-9121-4a5769f81c29)

This error arises because the `cargo-llvm-cov` tool was not installed correctly in the previous step due to the missing tool specification in the `taiki-e/install-action` step.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
