### PR TITLE
fix: allow span links to be added to a SpanRef

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Update `tonic` dependency version to 0.13
 - Re-export `tonic` types under `tonic_types`
   [2898](https://github.com/open-telemetry/opentelemetry-rust/pull/2898)
+- It is now possible to add links to a `Span` via the `SpanRef` that you get from
+  a `Context`. [2959](https://github.com/open-telemetry/opentelemetry-rust/pull/2959)
 
 ## 0.29.0
 

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -234,6 +234,16 @@ mod tests {
             span.update_name("span_name_updated");
             span.set_attribute(KeyValue::new("attribute1", "value1"));
             span.add_event("test-event".to_string(), vec![]);
+            span.add_link(
+                SpanContext::new(
+                    TraceId::from(47),
+                    SpanId::from(11),
+                    TraceFlags::default(),
+                    false,
+                    Default::default(),
+                ),
+                vec![],
+            );
         });
 
         // Assert
@@ -247,6 +257,9 @@ mod tests {
         assert_eq!(span.attributes.len(), 1);
         assert_eq!(span.events.len(), 1);
         assert_eq!(span.events[0].name, "test-event");
+        assert_eq!(span.links.len(), 1);
+        assert_eq!(span.links[0].span_context.trace_id(), TraceId::from(47));
+        assert_eq!(span.links[0].span_context.span_id(), SpanId::from(11));
         assert_eq!(span.span_context.trace_flags(), TraceFlags::SAMPLED);
         assert!(!span.span_context.is_remote());
         assert_eq!(span.status, Status::Unset);

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -185,6 +185,30 @@ impl SpanRef<'_> {
         self.with_inner_mut(move |inner| inner.update_name(new_name))
     }
 
+    /// Adds a [`Link`] to another [`SpanContext`].
+    ///
+    /// This method allows linking the current span to another span, identified by
+    /// its `SpanContext`. Links can be used to connect spans from different traces
+    /// or within the same trace. Attributes can be attached to the link to provide
+    /// additional context or metadata.
+    ///
+    /// # Arguments
+    ///
+    /// * `span_context` - The `SpanContext` of the span to link to. This represents
+    ///   the target span's unique identifiers and trace information.
+    /// * `attributes` - A vector of `KeyValue` pairs that describe additional
+    ///   attributes of the link. These attributes can include any contextual
+    ///   information relevant to the link between the spans.
+    ///
+    /// Note - Any [`Link`] added via this mechanism is not accessible to a `Sampler`.
+    /// It is recommended to add Links at [`Span`] creation time, rather than adding
+    /// them afterwards.
+    ///
+    /// [`Link`]: crate::trace::Link
+    pub fn add_link(&self, span_context: SpanContext, attributes: Vec<KeyValue>) {
+        self.with_inner_mut(move |inner| inner.add_link(span_context, attributes));
+    }
+
     /// Signals that the operation described by this span has now ended.
     pub fn end(&self) {
         self.end_with_timestamp(crate::time::now());


### PR DESCRIPTION
## Changes

This adds the ability to add a `Link` to a `Span` via a `SpanRef`. Since you can only access a `SpanRef` from the current `Context`, there was no way to add a new `Link` to that span.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
