### PR TITLE
fix: PeriodicReader to reuse data structures across collect

### DIFF
--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -409,7 +409,7 @@ impl<E: PushMetricExporter> PeriodicReaderInner<E> {
 
         // Relying on futures executor to execute async call.
         // TODO: Pass timeout to exporter
-        futures_executor::block_on(self.exporter.export(&rm))
+        futures_executor::block_on(self.exporter.export(rm))
     }
 
     fn force_flush(&self) -> OTelSdkResult {

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -384,7 +384,6 @@ impl<E: PushMetricExporter> PeriodicReaderInner<E> {
     }
 
     fn collect_and_export(&self, rm: &mut ResourceMetrics) -> OTelSdkResult {
-
         let current_time = Instant::now();
         let collect_result = self.collect(rm);
         let time_taken_for_collect = current_time.elapsed();

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -156,6 +156,11 @@ impl<E: PushMetricExporter> PeriodicReader<E> {
         };
         let cloned_reader = reader.clone();
 
+        let mut rm = ResourceMetrics {
+            resource: Resource::empty(),
+            scope_metrics: Vec::new(),
+        };
+
         let result_thread_creation = thread::Builder::new()
             .name("OpenTelemetry.Metrics.PeriodicReader".to_string())
             .spawn(move || {
@@ -175,7 +180,7 @@ impl<E: PushMetricExporter> PeriodicReader<E> {
                             otel_debug!(
                                 name: "PeriodReaderThreadExportingDueToFlush"
                             );
-                            let export_result = cloned_reader.collect_and_export();
+                            let export_result = cloned_reader.collect_and_export(&mut rm);
                             otel_debug!(
                                 name: "PeriodReaderInvokedExport",
                                 export_result = format!("{:?}", export_result)
@@ -231,7 +236,7 @@ impl<E: PushMetricExporter> PeriodicReader<E> {
                         Ok(Message::Shutdown(response_sender)) => {
                             // Perform final export and break out of loop and exit the thread
                             otel_debug!(name: "PeriodReaderThreadExportingDueToShutdown");
-                            let export_result = cloned_reader.collect_and_export();
+                            let export_result = cloned_reader.collect_and_export(&mut rm);
                             otel_debug!(
                                 name: "PeriodReaderInvokedExport",
                                 export_result = format!("{:?}", export_result)
@@ -279,7 +284,7 @@ impl<E: PushMetricExporter> PeriodicReader<E> {
                                 name: "PeriodReaderThreadExportingDueToTimer"
                             );
 
-                            let export_result = cloned_reader.collect_and_export();
+                            let export_result = cloned_reader.collect_and_export(&mut rm);
                             otel_debug!(
                                 name: "PeriodReaderInvokedExport",
                                 export_result = format!("{:?}", export_result)
@@ -331,8 +336,8 @@ impl<E: PushMetricExporter> PeriodicReader<E> {
         reader
     }
 
-    fn collect_and_export(&self) -> OTelSdkResult {
-        self.inner.collect_and_export()
+    fn collect_and_export(&self, rm: &mut ResourceMetrics) -> OTelSdkResult {
+        self.inner.collect_and_export(rm)
     }
 }
 
@@ -378,16 +383,10 @@ impl<E: PushMetricExporter> PeriodicReaderInner<E> {
         }
     }
 
-    fn collect_and_export(&self) -> OTelSdkResult {
-        // TODO: Reuse the internal vectors. Or refactor to avoid needing any
-        // owned data structures to be passed to exporters.
-        let mut rm = ResourceMetrics {
-            resource: Resource::empty(),
-            scope_metrics: Vec::new(),
-        };
+    fn collect_and_export(&self, rm: &mut ResourceMetrics) -> OTelSdkResult {
 
         let current_time = Instant::now();
-        let collect_result = self.collect(&mut rm);
+        let collect_result = self.collect(rm);
         let time_taken_for_collect = current_time.elapsed();
 
         #[allow(clippy::question_mark)]


### PR DESCRIPTION
PeriodicReader was unnecessarily creating a new empty `ResourceMetrics` during every collect. This PR modifies periodic reader to create once at startup, and re-use it throughout. Of course, the actual contents change for each collect, but the backing arrays for vectors will be re-used.
