### PR TITLE
fix: Expose SpanExporterBuilder and MetricExporterBuilder

### DIFF
--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -374,22 +374,25 @@ pub use crate::exporter::ExporterBuildError;
 #[cfg(feature = "trace")]
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 pub use crate::span::{
-    SpanExporter, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-    OTEL_EXPORTER_OTLP_TRACES_HEADERS, OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
+    SpanExporter, SpanExporterBuilder, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_HEADERS,
+    OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
 };
 
 #[cfg(feature = "metrics")]
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 pub use crate::metric::{
-    MetricExporter, OTEL_EXPORTER_OTLP_METRICS_COMPRESSION, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
-    OTEL_EXPORTER_OTLP_METRICS_HEADERS, OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
+    MetricExporter, MetricExporterBuilder, OTEL_EXPORTER_OTLP_METRICS_COMPRESSION,
+    OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_HEADERS,
+    OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
 };
 
 #[cfg(feature = "logs")]
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 pub use crate::logs::{
-    LogExporter, OTEL_EXPORTER_OTLP_LOGS_COMPRESSION, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
-    OTEL_EXPORTER_OTLP_LOGS_HEADERS, OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
+    LogExporter, LogExporterBuilder, OTEL_EXPORTER_OTLP_LOGS_COMPRESSION,
+    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, OTEL_EXPORTER_OTLP_LOGS_HEADERS,
+    OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
 };
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -31,6 +31,7 @@ pub const OTEL_EXPORTER_OTLP_LOGS_TIMEOUT: &str = "OTEL_EXPORTER_OTLP_LOGS_TIMEO
 /// Note: this is only supported for HTTP.
 pub const OTEL_EXPORTER_OTLP_LOGS_HEADERS: &str = "OTEL_EXPORTER_OTLP_LOGS_HEADERS";
 
+/// Builder for creating a new [LogExporter].
 #[derive(Debug, Default, Clone)]
 pub struct LogExporterBuilder<C> {
     client: C,
@@ -38,10 +39,12 @@ pub struct LogExporterBuilder<C> {
 }
 
 impl LogExporterBuilder<NoExporterBuilderSet> {
+    /// Create a new [LogExporterBuilder] with default settings.
     pub fn new() -> Self {
         LogExporterBuilder::default()
     }
 
+    /// With the gRPC Tonic transport.
     #[cfg(feature = "grpc-tonic")]
     pub fn with_tonic(self) -> LogExporterBuilder<TonicExporterBuilderSet> {
         LogExporterBuilder {
@@ -50,6 +53,7 @@ impl LogExporterBuilder<NoExporterBuilderSet> {
         }
     }
 
+    /// With the HTTP transport.
     #[cfg(any(feature = "http-proto", feature = "http-json"))]
     pub fn with_http(self) -> LogExporterBuilder<HttpExporterBuilderSet> {
         LogExporterBuilder {
@@ -61,6 +65,7 @@ impl LogExporterBuilder<NoExporterBuilderSet> {
 
 #[cfg(feature = "grpc-tonic")]
 impl LogExporterBuilder<TonicExporterBuilderSet> {
+    /// Build the [LogExporter] with the gRPC Tonic transport.
     pub fn build(self) -> Result<LogExporter, ExporterBuildError> {
         let result = self.client.0.build_log_exporter();
         otel_debug!(name: "LogExporterBuilt", result = format!("{:?}", &result));
@@ -70,6 +75,7 @@ impl LogExporterBuilder<TonicExporterBuilderSet> {
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
 impl LogExporterBuilder<HttpExporterBuilderSet> {
+    /// Build the [LogExporter] with the HTTP transport.
     pub fn build(self) -> Result<LogExporter, ExporterBuildError> {
         self.client.0.build_log_exporter()
     }

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -37,6 +37,7 @@ pub const OTEL_EXPORTER_OTLP_METRICS_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_MET
 /// Note: this is only supported for HTTP.
 pub const OTEL_EXPORTER_OTLP_METRICS_HEADERS: &str = "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
 
+/// A builder for creating a new [MetricExporter].
 #[derive(Debug, Default, Clone)]
 pub struct MetricExporterBuilder<C> {
     client: C,
@@ -44,12 +45,14 @@ pub struct MetricExporterBuilder<C> {
 }
 
 impl MetricExporterBuilder<NoExporterBuilderSet> {
+    /// Create a new [MetricExporterBuilder] with default settings.
     pub fn new() -> Self {
         MetricExporterBuilder::default()
     }
 }
 
 impl<C> MetricExporterBuilder<C> {
+    /// With the gRPC Tonic transport.
     #[cfg(feature = "grpc-tonic")]
     pub fn with_tonic(self) -> MetricExporterBuilder<TonicExporterBuilderSet> {
         MetricExporterBuilder {
@@ -58,6 +61,7 @@ impl<C> MetricExporterBuilder<C> {
         }
     }
 
+    /// With the HTTP transport.
     #[cfg(any(feature = "http-proto", feature = "http-json"))]
     pub fn with_http(self) -> MetricExporterBuilder<HttpExporterBuilderSet> {
         MetricExporterBuilder {
@@ -66,6 +70,7 @@ impl<C> MetricExporterBuilder<C> {
         }
     }
 
+    /// Set the temporality for the metrics.
     pub fn with_temporality(self, temporality: Temporality) -> MetricExporterBuilder<C> {
         MetricExporterBuilder {
             client: self.client,
@@ -76,6 +81,7 @@ impl<C> MetricExporterBuilder<C> {
 
 #[cfg(feature = "grpc-tonic")]
 impl MetricExporterBuilder<TonicExporterBuilderSet> {
+    /// Build the [MetricExporter] with the gRPC Tonic transport.
     pub fn build(self) -> Result<MetricExporter, ExporterBuildError> {
         let exporter = self.client.0.build_metrics_exporter(self.temporality)?;
         opentelemetry::otel_debug!(name: "MetricExporterBuilt");
@@ -85,6 +91,7 @@ impl MetricExporterBuilder<TonicExporterBuilderSet> {
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
 impl MetricExporterBuilder<HttpExporterBuilderSet> {
+    /// Build the [MetricExporter] with the HTTP transport.
     pub fn build(self) -> Result<MetricExporter, ExporterBuildError> {
         let exporter = self.client.0.build_metrics_exporter(self.temporality)?;
         Ok(exporter)

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -36,16 +36,19 @@ pub const OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_TRAC
 /// Note: this is only supported for HTTP.
 pub const OTEL_EXPORTER_OTLP_TRACES_HEADERS: &str = "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
 
+/// OTLP span exporter builder
 #[derive(Debug, Default, Clone)]
 pub struct SpanExporterBuilder<C> {
     client: C,
 }
 
 impl SpanExporterBuilder<NoExporterBuilderSet> {
+    /// Create a new [SpanExporterBuilder] with default settings.
     pub fn new() -> Self {
         SpanExporterBuilder::default()
     }
 
+    /// With the gRPC Tonic transport.
     #[cfg(feature = "grpc-tonic")]
     pub fn with_tonic(self) -> SpanExporterBuilder<TonicExporterBuilderSet> {
         SpanExporterBuilder {
@@ -53,6 +56,7 @@ impl SpanExporterBuilder<NoExporterBuilderSet> {
         }
     }
 
+    /// With the HTTP transport.
     #[cfg(any(feature = "http-proto", feature = "http-json"))]
     pub fn with_http(self) -> SpanExporterBuilder<HttpExporterBuilderSet> {
         SpanExporterBuilder {
@@ -63,6 +67,7 @@ impl SpanExporterBuilder<NoExporterBuilderSet> {
 
 #[cfg(feature = "grpc-tonic")]
 impl SpanExporterBuilder<TonicExporterBuilderSet> {
+    /// Build the [SpanExporter] with the gRPC Tonic transport.
     pub fn build(self) -> Result<SpanExporter, ExporterBuildError> {
         let span_exporter = self.client.0.build_span_exporter()?;
         opentelemetry::otel_debug!(name: "SpanExporterBuilt");
@@ -72,6 +77,7 @@ impl SpanExporterBuilder<TonicExporterBuilderSet> {
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
 impl SpanExporterBuilder<HttpExporterBuilderSet> {
+    /// Build the [SpanExporter] with the HTTP transport.
     pub fn build(self) -> Result<SpanExporter, ExporterBuildError> {
         let span_exporter = self.client.0.build_span_exporter()?;
         Ok(span_exporter)


### PR DESCRIPTION
Fixes #2358

## Changes
Exposes `SpanExporterBuilder` and `MetricExporterBuilder`
Currently these are hidden even though they are exposed: https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/struct.SpanExporter.html#method.builder
