### PR TITLE
fix(CI): patch dependencies before running external-types check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
         with:
           toolchain: nightly-2024-06-30
           components: rustfmt
+      - name: Patch dependencies versions
+        run: bash ./scripts/patch_dependencies.sh
       - name: external-type-check
         run: |
           cargo install cargo-check-external-types@0.1.13


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

Dependencies resolved while running the `external-types` in the PR are not compatible with the version of rust used to run the check. The steps have been failing on main for a while.

This PR adds a pass to patch the `Cargo.lock` file, as is done in the msrv check.  

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
