### PR TITLE
fix: downgrade NoopMeterProvider log to TRACE

### DIFF
--- a/opentelemetry/src/metrics/noop.rs
+++ b/opentelemetry/src/metrics/noop.rs
@@ -5,7 +5,7 @@
 //! runtime impact.
 use crate::{
     metrics::{InstrumentProvider, Meter, MeterProvider},
-    otel_debug, KeyValue,
+    otel_trace, KeyValue,
 };
 use std::sync::Arc;
 
@@ -26,7 +26,7 @@ impl NoopMeterProvider {
 
 impl MeterProvider for NoopMeterProvider {
     fn meter_with_scope(&self, scope: crate::InstrumentationScope) -> Meter {
-        otel_debug!(name: "NoopMeterProvider.MeterCreation", meter_name = scope.name(), message = "Meter was obtained from a NoopMeterProvider. No metrics will be recorded. If global::meter_with_scope()/meter() was used, ensure that a valid MeterProvider is set globally before creating Meter.");
+        otel_trace!(name: "NoopMeterProvider.MeterCreation", meter_name = scope.name(), message = "Meter was obtained from a NoopMeterProvider. No metrics will be recorded. If global::meter_with_scope()/meter() was used, ensure that a valid MeterProvider is set globally before creating Meter.");
         Meter::new(Arc::new(NoopMeter::new()))
     }
 }


### PR DESCRIPTION
## Changes

Downgrade the log about a meter being obtained from the `NoopMeterProvider` to TRACE. This can be very spammy on systems that request many meters but might have metric collection temporarily disabled.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
