### PR TITLE
fix: Metrics Views - fix a bug that causes unit, description to be lost when applying views that influence other aspects

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -42,6 +42,8 @@ also modified to suppress telemetry before invoking exporters.
   behind feature flag "experimental_metrics_custom_reader".
   [#2928](https://github.com/open-telemetry/opentelemetry-rust/pull/2928)
 
+- TODO: Placeholder for View related changelog.
+
 - *Breaking* `Aggregation` enum moved behind feature flag
   "spec_unstable_metrics_views". This was only required when using Views.
   [#2928](https://github.com/open-telemetry/opentelemetry-rust/pull/2928)

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -42,7 +42,9 @@ also modified to suppress telemetry before invoking exporters.
   behind feature flag "experimental_metrics_custom_reader".
   [#2928](https://github.com/open-telemetry/opentelemetry-rust/pull/2928)
 
-- TODO: Placeholder for View related changelog.
+- TODO: Placeholder for View related changelog. Polish this after all
+  changes are done.
+  Hide public fields from `Stream` struct.
 
 - *Breaking* `Aggregation` enum moved behind feature flag
   "spec_unstable_metrics_views". This was only required when using Views.

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -190,22 +190,22 @@ impl Instrument {
 #[allow(unreachable_pub)]
 pub struct Stream {
     /// The human-readable identifier of the stream.
-    pub name: Option<Cow<'static, str>>,
+    pub(crate) name: Option<Cow<'static, str>>,
     /// Describes the purpose of the data.
-    pub description: Option<Cow<'static, str>>,
+    pub(crate) description: Option<Cow<'static, str>>,
     /// the unit of measurement recorded.
-    pub unit: Option<Cow<'static, str>>,
+    pub(crate) unit: Option<Cow<'static, str>>,
     /// Aggregation the stream uses for an instrument.
-    pub aggregation: Option<Aggregation>,
+    pub(crate) aggregation: Option<Aggregation>,
     /// An allow-list of attribute keys that will be preserved for the stream.
     ///
     /// Any attribute recorded for the stream with a key not in this set will be
     /// dropped. If the set is empty, all attributes will be dropped, if `None` all
     /// attributes will be kept.
-    pub allowed_attribute_keys: Option<Arc<HashSet<Key>>>,
+    pub(crate) allowed_attribute_keys: Option<Arc<HashSet<Key>>>,
 
     /// Cardinality limit for the stream.
-    pub cardinality_limit: Option<usize>,
+    pub(crate) cardinality_limit: Option<usize>,
 }
 
 #[cfg(feature = "spec_unstable_metrics_views")]

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -190,11 +190,11 @@ impl Instrument {
 #[allow(unreachable_pub)]
 pub struct Stream {
     /// The human-readable identifier of the stream.
-    pub name: Cow<'static, str>,
+    pub name: Option<Cow<'static, str>>,
     /// Describes the purpose of the data.
-    pub description: Cow<'static, str>,
+    pub description: Option<Cow<'static, str>>,
     /// the unit of measurement recorded.
-    pub unit: Cow<'static, str>,
+    pub unit: Option<Cow<'static, str>>,
     /// Aggregation the stream uses for an instrument.
     pub aggregation: Option<Aggregation>,
     /// An allow-list of attribute keys that will be preserved for the stream.
@@ -217,19 +217,19 @@ impl Stream {
 
     /// Set the stream name.
     pub fn name(mut self, name: impl Into<Cow<'static, str>>) -> Self {
-        self.name = name.into();
+        self.name = Some(name.into());
         self
     }
 
     /// Set the stream description.
     pub fn description(mut self, description: impl Into<Cow<'static, str>>) -> Self {
-        self.description = description.into();
+        self.description = Some(description.into());
         self
     }
 
     /// Set the stream unit.
     pub fn unit(mut self, unit: impl Into<Cow<'static, str>>) -> Self {
-        self.unit = unit.into();
+        self.unit = Some(unit.into());
         self
     }
 

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -2702,6 +2702,7 @@ mod tests {
             unreachable!()
         };
 
+
         // Expecting (cardinality_limit + 1 overflow + Empty attributes) data points.
         assert_eq!(sum.data_points.len(), cardinality_limit + 1 + 1);
 

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -1514,6 +1514,40 @@ mod tests {
         .await;
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn view_test_match_unit() {
+        test_view_customization(
+            |i| {
+                if i.unit == "my_unit" {
+                    Some(Stream::new().unit("my_unit_new"))
+                } else {
+                    None
+                }
+            },
+            "my_counter",
+            "my_unit_new",
+            "my_description",
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn view_test_match_none() {
+        test_view_customization(
+            |i| {
+                if i.name == "not_expected_to_match" {
+                    Some(Stream::new())
+                } else {
+                    None
+                }
+            },
+            "my_counter",
+            "my_unit",
+            "my_description",
+        )
+        .await;
+    }
+
     /// Helper function to test view customizations
     async fn test_view_customization<F>(
         view_function: F,

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -2702,7 +2702,6 @@ mod tests {
             unreachable!()
         };
 
-
         // Expecting (cardinality_limit + 1 overflow + Empty attributes) data points.
         assert_eq!(sum.data_points.len(), cardinality_limit + 1 + 1);
 

--- a/opentelemetry-sdk/src/metrics/view.rs
+++ b/opentelemetry-sdk/src/metrics/view.rs
@@ -110,7 +110,7 @@ pub fn new_view(criteria: Instrument, mask: Stream) -> MetricResult<Box<dyn View
     let contains_wildcard = criteria.name.contains(['*', '?']);
 
     let match_fn: Box<dyn Fn(&Instrument) -> bool + Send + Sync> = if contains_wildcard {
-        if !mask.name.is_empty() {
+        if !mask.name.is_none() {
             // TODO - The error is getting lost here. Need to return or log.
             return Ok(Box::new(empty_view));
         }
@@ -144,20 +144,20 @@ pub fn new_view(criteria: Instrument, mask: Stream) -> MetricResult<Box<dyn View
     Ok(Box::new(move |i: &Instrument| -> Option<Stream> {
         if match_fn(i) {
             Some(Stream {
-                name: if !mask.name.is_empty() {
+                name: if !mask.name.is_none() {
                     mask.name.clone()
                 } else {
-                    i.name.clone()
+                    Some(i.name.clone())
                 },
-                description: if !mask.description.is_empty() {
+                description: if !mask.description.is_none() {
                     mask.description.clone()
                 } else {
-                    i.description.clone()
+                    Some(i.description.clone())
                 },
-                unit: if !mask.unit.is_empty() {
+                unit: if !mask.unit.is_none() {
                     mask.unit.clone()
                 } else {
-                    i.unit.clone()
+                    Some(i.unit.clone())
                 },
                 aggregation: agg.clone(),
                 allowed_attribute_keys: mask.allowed_attribute_keys.clone(),


### PR DESCRIPTION
unit, desc were lost when the View did not explicitly specify them. This PR fixes this bug. If any aspect is not specified in the View's Stream configuration, it'll use the default (if advisory is available, that is considered first before default)