### PR TITLE
fix: Further trim public API on views

### DIFF
--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -109,10 +109,7 @@ impl MetricReader for SharedReader {
 //                         time:   [726.87 ns 736.52 ns 747.09 ns]
 type ViewFn = Box<dyn Fn(&Instrument) -> Option<Stream> + Send + Sync + 'static>;
 
-fn bench_counter(
-    view: Option<ViewFn>,
-    temporality: &str,
-) -> (SharedReader, Counter<u64>) {
+fn bench_counter(view: Option<ViewFn>, temporality: &str) -> (SharedReader, Counter<u64>) {
     let rdr = if temporality == "cumulative" {
         SharedReader(Arc::new(ManualReader::builder().build()))
     } else {

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -107,8 +107,10 @@ impl MetricReader for SharedReader {
 //                         time:   [643.75 ns 649.05 ns 655.14 ns]
 // Histogram/Record10Attrs1000bounds
 //                         time:   [726.87 ns 736.52 ns 747.09 ns]
+type ViewFn = Box<dyn Fn(&Instrument) -> Option<Stream> + Send + Sync + 'static>;
+
 fn bench_counter(
-    view: Option<Box<dyn Fn(&Instrument) -> Option<Stream> + Send + Sync + 'static>>,
+    view: Option<ViewFn>,
     temporality: &str,
 ) -> (SharedReader, Counter<u64>) {
     let rdr = if temporality == "cumulative" {

--- a/opentelemetry-sdk/benches/metric.rs
+++ b/opentelemetry-sdk/benches/metric.rs
@@ -7,7 +7,7 @@ use opentelemetry_sdk::{
     error::OTelSdkResult,
     metrics::{
         data::ResourceMetrics, reader::MetricReader, Aggregation, Instrument, InstrumentKind,
-        ManualReader, Pipeline, SdkMeterProvider, Stream, Temporality, View,
+        ManualReader, Pipeline, SdkMeterProvider, Stream, Temporality,
     },
 };
 use rand::Rng;
@@ -107,7 +107,10 @@ impl MetricReader for SharedReader {
 //                         time:   [643.75 ns 649.05 ns 655.14 ns]
 // Histogram/Record10Attrs1000bounds
 //                         time:   [726.87 ns 736.52 ns 747.09 ns]
-fn bench_counter(view: Option<Box<dyn View>>, temporality: &str) -> (SharedReader, Counter<u64>) {
+fn bench_counter(
+    view: Option<Box<dyn Fn(&Instrument) -> Option<Stream> + Send + Sync + 'static>>,
+    temporality: &str,
+) -> (SharedReader, Counter<u64>) {
     let rdr = if temporality == "cumulative" {
         SharedReader(Arc::new(ManualReader::builder().build()))
     } else {
@@ -273,7 +276,7 @@ fn bench_histogram(bound_count: usize) -> (SharedReader, Histogram<u64>) {
     let r = SharedReader(Arc::new(ManualReader::default()));
     let builder = SdkMeterProvider::builder()
         .with_reader(r.clone())
-        .with_view(Box::new(move |i: &Instrument| {
+        .with_view(move |i: &Instrument| {
             if i.name().starts_with("histogram_") {
                 Stream::builder()
                     .with_aggregation(Aggregation::ExplicitBucketHistogram {
@@ -285,7 +288,7 @@ fn bench_histogram(bound_count: usize) -> (SharedReader, Histogram<u64>) {
             } else {
                 None
             }
-        }));
+        });
 
     let mtr = builder.build().meter("test_meter");
     let hist = mtr

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -64,12 +64,12 @@ impl InstrumentKind {
         }
     }
 }
-
-/// Describes properties an instrument is created with, used for filtering in
-/// [View](crate::metrics::View)s.
+/// Describes the properties of an instrument at creation, used for filtering in
+/// views. This is utilized in the `with_view` methods on `MeterProviderBuilder`
+/// to customize metric output.
 ///
-/// Users can utilize a reference to `Instrument` to select the instrument(s)
-/// for which the [Stream] should be applied.
+/// Users can use a reference to `Instrument` to select which instrument(s) a
+/// [Stream] should be applied to.
 ///
 /// # Example
 ///
@@ -265,8 +265,8 @@ fn validate_bucket_boundaries(boundaries: &[f64]) -> Result<(), String> {
     Ok(())
 }
 
-/// Describes the stream of data an instrument produces. Used in
-/// [View](crate::metrics::View)s to customize the metric output.
+/// Describes the stream of data an instrument produces. Used in `with_view`
+/// methods on `MeterProviderBuilder` to customize the metric output.
 #[derive(Default, Debug)]
 pub struct Stream {
     /// The human-readable identifier of the stream.

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -186,7 +186,7 @@ impl StreamBuilder {
     ///
     /// Any attribute recorded for the stream with a key not in this set will be
     /// dropped. If the set is empty, all attributes will be dropped.
-    /// If not set, all attributes will be kept.
+    /// If this method is not used, all attributes will be kept.
     pub fn with_allowed_attribute_keys(
         mut self,
         attribute_keys: impl IntoIterator<Item = Key>,

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -68,8 +68,8 @@ impl InstrumentKind {
 /// Describes properties an instrument is created with, used for filtering in
 /// [View](crate::metrics::View)s.
 ///
-/// A reference to `Instrument` is provided to the `view` to select the
-/// instrument(s) for which the [Stream] should be applied.
+/// Users can utilize a reference to `Instrument` to select the instrument(s)
+/// for which the [Stream] should be applied.
 ///
 /// # Example
 ///
@@ -78,7 +78,7 @@ impl InstrumentKind {
 ///
 /// let my_view_change_cardinality = |i: &Instrument| {
 ///     if i.name() == "my_second_histogram" {
-///         // Note: If Stream is invalid, build() will return an error. By
+///         // Note: If Stream is invalid, `build()` will return an error. By
 ///         // calling `.ok()`, any such error is ignored and treated as if the
 ///         // view does not match the instrument. If this is not the desired
 ///         // behavior, consider handling the error explicitly.
@@ -185,8 +185,8 @@ impl StreamBuilder {
     /// Set the stream allowed attribute keys.
     ///
     /// Any attribute recorded for the stream with a key not in this set will be
-    /// dropped. If the set is empty, all attributes will be dropped, if `None` all
-    /// attributes will be kept.
+    /// dropped. If the set is empty, all attributes will be dropped.
+    /// If not set, all attributes will be kept.
     pub fn with_allowed_attribute_keys(
         mut self,
         attribute_keys: impl IntoIterator<Item = Key>,
@@ -256,7 +256,9 @@ fn validate_bucket_boundaries(boundaries: &[f64]) -> Result<(), String> {
     // validate that buckets are sorted and non-duplicate
     for i in 1..boundaries.len() {
         if boundaries[i] <= boundaries[i - 1] {
-            return Err("Bucket boundaries must be sorted and non-duplicate".to_string());
+            return Err(
+                "Bucket boundaries must be sorted and not contain any duplicates".to_string(),
+            );
         }
     }
 

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -348,7 +348,7 @@ impl MeterProviderBuilder {
     ///         // By calling `.ok()`, any such error is ignored and treated as if the view does not match
     ///         // the instrument.
     ///         // If this is not the desired behavior, consider handling the error explicitly.
-    ///         Stream::builder().with_cardinality_limit(100).build().ok()
+    ///         Stream::builder().with_cardinality_limit(0).build().ok()
     ///     } else {
     ///         None
     ///     }

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -18,12 +18,13 @@ use crate::Resource;
 use super::{
     exporter::PushMetricExporter, meter::SdkMeter, noop::NoopMeter,
     periodic_reader::PeriodicReader, pipeline::Pipelines, reader::MetricReader, view::View,
+    Instrument, Stream,
 };
 
 /// Handles the creation and coordination of [Meter]s.
 ///
 /// All `Meter`s created by a `MeterProvider` will be associated with the same
-/// [Resource], have the same [View]s applied to them, and have their produced
+/// [Resource], have the same views applied to them, and have their produced
 /// metric telemetry passed to the configured [MetricReader]s. This is a
 /// clonable handle to the MeterProvider implementation itself, and cloning it
 /// will create a new reference, not a new instance of a MeterProvider. Dropping
@@ -287,14 +288,14 @@ impl MeterProviderBuilder {
         self
     }
 
-    /// Adds a [View] to the [MeterProvider].
+    /// Adds a view to the [MeterProvider].
     ///
     /// Views allow you to customize how metrics are aggregated, renamed, or
     /// otherwise transformed before export, without modifying instrument
     /// definitions in your application or library code.
     ///
-    /// You can pass any type implementing the [`View`] trait, including
-    /// closures matching the pattern `Fn(&Instrument) -> Option<Stream>`. The
+    /// You can pass any function or closure matching the signature
+    /// `Fn(&Instrument) -> Option<Stream> + Send + Sync + 'static`. The
     /// function receives a reference to the [`Instrument`] and can return an
     /// [`Option`] of [`Stream`] to specify how matching instruments should be
     /// exported. Returning `None` means the view does not apply to the given
@@ -361,10 +362,12 @@ impl MeterProviderBuilder {
     /// If no views are added, the [MeterProvider] uses the default view.
     ///
     /// [`Instrument`]: crate::metrics::Instrument
-    /// [`View`]: crate::metrics::View
     /// [`Stream`]: crate::metrics::Stream
     /// [`Option`]: core::option::Option
-    pub fn with_view<T: View>(mut self, view: T) -> Self {
+    pub fn with_view<T>(mut self, view: T) -> Self
+    where
+        T: Fn(&Instrument) -> Option<Stream> + Send + Sync + 'static,
+    {
         self.views.push(Arc::new(view));
         self
     }

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -940,12 +940,10 @@ mod tests {
         // View drops all attributes.
         let view = |i: &Instrument| {
             if i.name == "my_observable_counter" {
-                Some(
-                    Stream::builder()
-                        .with_allowed_attribute_keys(vec![])
-                        .build()
-                        .unwrap(),
-                )
+                Stream::builder()
+                    .with_allowed_attribute_keys(vec![])
+                    .build()
+                    .ok()
             } else {
                 None
             }

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -3,7 +3,7 @@
 //! ## Configuration
 //!
 //! The metrics SDK configuration is stored with each [SdkMeterProvider].
-//! Configuration for [Resource]s, [View]s, and [ManualReader] or
+//! Configuration for [Resource]s, views, and [ManualReader] or
 //! [PeriodicReader] instances can be specified.
 //!
 //! ### Example
@@ -81,7 +81,6 @@ pub use periodic_reader::*;
 pub use pipeline::Pipeline;
 
 pub use instrument::{Instrument, InstrumentKind, Stream, StreamBuilder};
-pub use view::View;
 
 use std::hash::Hash;
 
@@ -113,7 +112,6 @@ mod tests {
     use self::data::{HistogramDataPoint, ScopeMetrics, SumDataPoint};
     use super::data::MetricData;
     use super::internal::Number;
-    use super::view::View;
     use super::*;
     use crate::metrics::data::ResourceMetrics;
     use crate::metrics::internal::AggregatedMetricsAccess;
@@ -3312,7 +3310,10 @@ mod tests {
             }
         }
 
-        fn new_with_view<T: View>(temporality: Temporality, view: T) -> Self {
+        fn new_with_view<T>(temporality: Temporality, view: T) -> Self
+        where
+            T: Fn(&Instrument) -> Option<Stream> + Send + Sync + 'static,
+        {
             let exporter = InMemoryMetricExporterBuilder::new().with_temporality(temporality);
             let exporter = exporter.build();
             let meter_provider = SdkMeterProvider::builder()

--- a/opentelemetry-sdk/src/metrics/view.rs
+++ b/opentelemetry-sdk/src/metrics/view.rs
@@ -36,9 +36,7 @@ use super::instrument::{Instrument, Stream};
 /// let provider = SdkMeterProvider::builder().with_view(my_view).build();
 /// # drop(provider)
 /// ```
-// TODO: This trait need not be public, if we modify MeterProvider to take a
-// Fn(&Instrument) -> Option<Stream> instead of View.
-pub trait View: Send + Sync + 'static {
+pub(crate) trait View: Send + Sync + 'static {
     /// Defines how data should be collected for certain instruments.
     ///
     /// Return [Stream] to use for matching [Instrument]s,
@@ -52,11 +50,5 @@ where
 {
     fn match_inst(&self, inst: &Instrument) -> Option<Stream> {
         self(inst)
-    }
-}
-
-impl View for Box<dyn View> {
-    fn match_inst(&self, inst: &Instrument) -> Option<Stream> {
-        (**self).match_inst(inst)
     }
 }


### PR DESCRIPTION
Leftover cleanup from https://github.com/open-telemetry/opentelemetry-rust/pull/2988

`View` trait itself is not required to be public - no functionality change.
Plus few other leftover nits from PR comments earlier.