### PR TITLE
Fix: remove cardinality capping via instrument advice

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -21,9 +21,7 @@ also modified to suppress telemetry before invoking exporters.
   - The default cardinality limit is 2000 and can be customized using Views.  
   - This feature was previously removed in version 0.28 due to the lack of
     configurability but has now been reintroduced with the ability to configure
-    the limit.  
-  - There is ability to configure cardinality limits via Instrument
-    advisory. [#2903](https://github.com/open-telemetry/opentelemetry-rust/pull/2903)
+    the limit.
   - Fixed the overflow attribute to correctly use the boolean value `true`
     instead of the string `"true"`.
     [#2878](https://github.com/open-telemetry/opentelemetry-rust/issues/2878)

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -96,7 +96,6 @@ impl SdkMeter {
                 builder.description,
                 builder.unit,
                 None,
-                builder.cardinality_limit,
             )
             .map(|i| Counter::new(Arc::new(i)))
         {
@@ -139,7 +138,6 @@ impl SdkMeter {
             builder.description,
             builder.unit,
             None,
-            builder.cardinality_limit,
         ) {
             Ok(ms) => {
                 if ms.is_empty() {
@@ -199,7 +197,6 @@ impl SdkMeter {
             builder.description,
             builder.unit,
             None,
-            builder.cardinality_limit,
         ) {
             Ok(ms) => {
                 if ms.is_empty() {
@@ -259,7 +256,6 @@ impl SdkMeter {
             builder.description,
             builder.unit,
             None,
-            builder.cardinality_limit,
         ) {
             Ok(ms) => {
                 if ms.is_empty() {
@@ -321,7 +317,6 @@ impl SdkMeter {
                 builder.description,
                 builder.unit,
                 None,
-                builder.cardinality_limit,
             )
             .map(|i| UpDownCounter::new(Arc::new(i)))
         {
@@ -366,7 +361,6 @@ impl SdkMeter {
                 builder.description,
                 builder.unit,
                 None,
-                builder.cardinality_limit,
             )
             .map(|i| Gauge::new(Arc::new(i)))
         {
@@ -428,7 +422,6 @@ impl SdkMeter {
                 builder.description,
                 builder.unit,
                 builder.boundaries,
-                builder.cardinality_limit,
             )
             .map(|i| Histogram::new(Arc::new(i)))
         {
@@ -661,10 +654,8 @@ where
         description: Option<Cow<'static, str>>,
         unit: Option<Cow<'static, str>>,
         boundaries: Option<Vec<f64>>,
-        cardinality_limit: Option<usize>,
     ) -> MetricResult<ResolvedMeasures<T>> {
-        let aggregators =
-            self.measures(kind, name, description, unit, boundaries, cardinality_limit)?;
+        let aggregators = self.measures(kind, name, description, unit, boundaries)?;
         Ok(ResolvedMeasures {
             measures: aggregators,
         })
@@ -677,7 +668,6 @@ where
         description: Option<Cow<'static, str>>,
         unit: Option<Cow<'static, str>>,
         boundaries: Option<Vec<f64>>,
-        cardinality_limit: Option<usize>,
     ) -> MetricResult<Vec<Arc<dyn internal::Measure<T>>>> {
         let inst = Instrument {
             name,
@@ -687,7 +677,7 @@ where
             scope: self.meter.scope.clone(),
         };
 
-        self.resolve.measures(inst, boundaries, cardinality_limit)
+        self.resolve.measures(inst, boundaries)
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -254,7 +254,6 @@ where
         &self,
         inst: Instrument,
         boundaries: Option<&[f64]>,
-        cardinality_limit: Option<usize>,
     ) -> MetricResult<Vec<Arc<dyn internal::Measure<T>>>> {
         let mut matched = false;
         let mut measures = vec![];
@@ -312,7 +311,7 @@ where
             unit: Some(inst.unit),
             aggregation: None,
             allowed_attribute_keys: None,
-            cardinality_limit,
+            cardinality_limit: None,
         };
 
         // Override default histogram boundaries if provided.
@@ -737,12 +736,11 @@ where
         &self,
         id: Instrument,
         boundaries: Option<Vec<f64>>,
-        cardinality_limit: Option<usize>,
     ) -> MetricResult<Vec<Arc<dyn internal::Measure<T>>>> {
         let (mut measures, mut errs) = (vec![], vec![]);
 
         for inserter in &self.inserters {
-            match inserter.instrument(id.clone(), boundaries.as_deref(), cardinality_limit) {
+            match inserter.instrument(id.clone(), boundaries.as_deref()) {
                 Ok(ms) => measures.extend(ms),
                 Err(err) => errs.push(err),
             }

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -24,8 +24,6 @@ disable telemetry generation during their internal operations, ensuring more
 predictable and efficient observability pipelines.
 
 - re-export `tracing` for `internal-logs` feature to remove the need of adding `tracing` as a dependency
-- Added ability to configure cardinality limits via Instrument
-  advisory. [#2903](https://github.com/open-telemetry/opentelemetry-rust/pull/2903)
 
 ## 0.29.1
 

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -45,9 +45,6 @@ pub struct HistogramBuilder<'a, T> {
     /// Unit of the Histogram.
     pub unit: Option<Cow<'static, str>>,
 
-    /// Cardinality limit for the Histogram.
-    pub cardinality_limit: Option<usize>,
-
     /// Bucket boundaries for the histogram.
     pub boundaries: Option<Vec<f64>>,
 
@@ -63,7 +60,6 @@ impl<'a, T> HistogramBuilder<'a, T> {
             name,
             description: None,
             unit: None,
-            cardinality_limit: None,
             boundaries: None,
             _marker: marker::PhantomData,
         }
@@ -84,14 +80,6 @@ impl<'a, T> HistogramBuilder<'a, T> {
     /// - No longer than 63 characters
     pub fn with_unit<S: Into<Cow<'static, str>>>(mut self, unit: S) -> Self {
         self.unit = Some(unit.into());
-        self
-    }
-
-    /// Set the cardinality limit for this Histogram.
-    /// Setting cardinality limit is optional. By default, the limit will be set
-    /// to 2000.
-    pub fn with_cardinality_limit(mut self, limit: usize) -> Self {
-        self.cardinality_limit = Some(limit);
         self
     }
 
@@ -162,9 +150,6 @@ pub struct InstrumentBuilder<'a, T> {
     /// Unit of the instrument.
     pub unit: Option<Cow<'static, str>>,
 
-    /// Cardinality limit for the instrument.
-    pub cardinality_limit: Option<usize>,
-
     _marker: marker::PhantomData<T>,
 }
 
@@ -176,7 +161,6 @@ impl<'a, T> InstrumentBuilder<'a, T> {
             name,
             description: None,
             unit: None,
-            cardinality_limit: None,
             _marker: marker::PhantomData,
         }
     }
@@ -196,14 +180,6 @@ impl<'a, T> InstrumentBuilder<'a, T> {
     /// - No longer than 63 characters
     pub fn with_unit<S: Into<Cow<'static, str>>>(mut self, unit: S) -> Self {
         self.unit = Some(unit.into());
-        self
-    }
-
-    /// Set the cardinality limit for this instrument.
-    /// Setting cardinality limit is optional. By default, the limit will be set
-    /// to 2000.
-    pub fn with_cardinality_limit(mut self, limit: usize) -> Self {
-        self.cardinality_limit = Some(limit);
         self
     }
 }
@@ -235,7 +211,6 @@ impl<T> fmt::Debug for InstrumentBuilder<'_, T> {
             .field("name", &self.name)
             .field("description", &self.description)
             .field("unit", &self.unit)
-            .field("cardinality_limit", &self.cardinality_limit)
             .field("kind", &std::any::type_name::<T>())
             .finish()
     }
@@ -247,7 +222,6 @@ impl<T> fmt::Debug for HistogramBuilder<'_, T> {
             .field("name", &self.name)
             .field("description", &self.description)
             .field("unit", &self.unit)
-            .field("cardinality_limit", &self.cardinality_limit)
             .field("boundaries", &self.boundaries)
             .field(
                 "kind",
@@ -281,9 +255,6 @@ pub struct AsyncInstrumentBuilder<'a, I, M> {
     /// Unit of the instrument.
     pub unit: Option<Cow<'static, str>>,
 
-    /// Cardinality limit for the instrument.
-    pub cardinality_limit: Option<usize>,
-
     /// Callbacks to be called for this instrument.
     pub callbacks: Vec<Callback<M>>,
 
@@ -298,7 +269,6 @@ impl<'a, I, M> AsyncInstrumentBuilder<'a, I, M> {
             name,
             description: None,
             unit: None,
-            cardinality_limit: None,
             _inst: marker::PhantomData,
             callbacks: Vec::new(),
         }
@@ -319,14 +289,6 @@ impl<'a, I, M> AsyncInstrumentBuilder<'a, I, M> {
     /// - No longer than 63 characters
     pub fn with_unit<S: Into<Cow<'static, str>>>(mut self, unit: S) -> Self {
         self.unit = Some(unit.into());
-        self
-    }
-
-    /// Set the cardinality limit for this async instrument.
-    /// Setting cardinality limit is optional. By default, the limit will be set
-    /// to 2000.
-    pub fn with_cardinality_limit(mut self, limit: usize) -> Self {
-        self.cardinality_limit = Some(limit);
         self
     }
 
@@ -378,7 +340,6 @@ where
             .field("name", &self.name)
             .field("description", &self.description)
             .field("unit", &self.unit)
-            .field("cardinality_limit", &self.cardinality_limit)
             .field("kind", &std::any::type_name::<I>())
             .field("callbacks_len", &self.callbacks.len())
             .finish()


### PR DESCRIPTION
Reversing https://github.com/open-telemetry/opentelemetry-rust/pull/2903
Cardinality cap is settable via Views, and Views no longer requiring opting in to experimental feature flag.

Additionally, its tricky to give a guidance to users on how to leverage Advice API to set cardinality limit, as cardinality is affected/influenced by export interval and temporality, both of which are pure SDK concerns....  Its possible that we can bring this capability back in the future with some redesign.