### PR TITLE
chore: Update metric sdk to stable status

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ documentation.
 | Baggage               | RC                 |
 | Propagators           | Beta               |
 | Logs-API              | Stable*            |
-| Logs-SDK              | Stable              |
+| Logs-SDK              | Stable             |
 | Logs-OTLP Exporter    | RC                 |
 | Logs-Appender-Tracing | Stable             |
 | Metrics-API           | Stable             |
-| Metrics-SDK           | RC                 |
+| Metrics-SDK           | Stable             |
 | Metrics-OTLP Exporter | RC                 |
 | Traces-API            | Beta               |
 | Traces-SDK            | Beta               |


### PR DESCRIPTION
Time to make Metric SDK Stable!
No major perf issues, no major bugs.
Views are brought out of experimental status.
Cardinality capping applied by default (and configurable via Views)
Trimmed down questionable public APIs or hid behind opt-in experimental feature flags.