### PR TITLE
fix: Remove pub fields and replace with getter method consistently across …

### DIFF
--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -250,11 +250,11 @@ pub mod tonic {
                         zero_count: dp.zero_count(),
                         positive: Some(TonicBuckets {
                             offset: dp.positive_bucket().offset(),
-                            bucket_counts: dp.positive_bucket().counts().to_vec(),
+                            bucket_counts: dp.positive_bucket().counts().collect(),
                         }),
                         negative: Some(TonicBuckets {
                             offset: dp.negative_bucket().offset(),
-                            bucket_counts: dp.negative_bucket().counts().to_vec(),
+                            bucket_counts: dp.negative_bucket().counts().collect(),
                         }),
                         flags: TonicDataPointFlags::default() as u32,
                         exemplars: dp.exemplars().map(Into::into).collect(),

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -282,7 +282,7 @@ pub mod tonic {
                         time_unix_nano: to_nanos(sum.time()),
                         exemplars: dp.exemplars().map(Into::into).collect(),
                         flags: TonicDataPointFlags::default() as u32,
-                        value: Some(dp.value.into()),
+                        value: Some(dp.value().into()),
                     })
                     .collect(),
                 aggregation_temporality: TonicTemporality::from(sum.temporality()).into(),
@@ -305,7 +305,7 @@ pub mod tonic {
                         time_unix_nano: to_nanos(gauge.time()),
                         exemplars: dp.exemplars().map(Into::into).collect(),
                         flags: TonicDataPointFlags::default() as u32,
-                        value: Some(dp.value.into()),
+                        value: Some(dp.value().into()),
                     })
                     .collect(),
             }

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -258,8 +258,8 @@ pub mod tonic {
                         }),
                         flags: TonicDataPointFlags::default() as u32,
                         exemplars: dp.exemplars().map(Into::into).collect(),
-                        min: dp.min.map(Numeric::into_f64),
-                        max: dp.max.map(Numeric::into_f64),
+                        min: dp.min().map(Numeric::into_f64),
+                        max: dp.max().map(Numeric::into_f64),
                         zero_threshold: dp.zero_threshold(),
                     })
                     .collect(),

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -223,8 +223,8 @@ pub mod tonic {
                         explicit_bounds: dp.bounds().collect(),
                         exemplars: dp.exemplars().map(Into::into).collect(),
                         flags: TonicDataPointFlags::default() as u32,
-                        min: dp.min.map(Numeric::into_f64),
-                        max: dp.max.map(Numeric::into_f64),
+                        min: dp.min().map(Numeric::into_f64),
+                        max: dp.max().map(Numeric::into_f64),
                     })
                     .collect(),
                 aggregation_temporality: TonicTemporality::from(hist.temporality()).into(),

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -215,10 +215,10 @@ pub mod tonic {
                     .data_points()
                     .map(|dp| TonicHistogramDataPoint {
                         attributes: dp.attributes().map(Into::into).collect(),
-                        start_time_unix_nano: to_nanos(hist.start_time),
-                        time_unix_nano: to_nanos(hist.time),
-                        count: dp.count,
-                        sum: Some(dp.sum.into_f64()),
+                        start_time_unix_nano: to_nanos(hist.start_time()),
+                        time_unix_nano: to_nanos(hist.time()),
+                        count: dp.count(),
+                        sum: Some(dp.sum().into_f64()),
                         bucket_counts: dp.bucket_counts().collect(),
                         explicit_bounds: dp.bounds().collect(),
                         exemplars: dp.exemplars().map(Into::into).collect(),
@@ -227,7 +227,7 @@ pub mod tonic {
                         max: dp.max.map(Numeric::into_f64),
                     })
                     .collect(),
-                aggregation_temporality: TonicTemporality::from(hist.temporality).into(),
+                aggregation_temporality: TonicTemporality::from(hist.temporality()).into(),
             }
         }
     }
@@ -242,28 +242,28 @@ pub mod tonic {
                     .data_points()
                     .map(|dp| TonicExponentialHistogramDataPoint {
                         attributes: dp.attributes().map(Into::into).collect(),
-                        start_time_unix_nano: to_nanos(hist.start_time),
-                        time_unix_nano: to_nanos(hist.time),
-                        count: dp.count as u64,
-                        sum: Some(dp.sum.into_f64()),
-                        scale: dp.scale.into(),
-                        zero_count: dp.zero_count,
+                        start_time_unix_nano: to_nanos(hist.start_time()),
+                        time_unix_nano: to_nanos(hist.time()),
+                        count: dp.count() as u64,
+                        sum: Some(dp.sum().into_f64()),
+                        scale: dp.scale().into(),
+                        zero_count: dp.zero_count(),
                         positive: Some(TonicBuckets {
-                            offset: dp.positive_bucket.offset,
-                            bucket_counts: dp.positive_bucket.counts.clone(),
+                            offset: dp.positive_bucket().offset(),
+                            bucket_counts: dp.positive_bucket().counts().iter().copied().collect(),
                         }),
                         negative: Some(TonicBuckets {
-                            offset: dp.negative_bucket.offset,
-                            bucket_counts: dp.negative_bucket.counts.clone(),
+                            offset: dp.negative_bucket().offset(),
+                            bucket_counts: dp.negative_bucket().counts().iter().copied().collect(),
                         }),
                         flags: TonicDataPointFlags::default() as u32,
                         exemplars: dp.exemplars().map(Into::into).collect(),
                         min: dp.min.map(Numeric::into_f64),
                         max: dp.max.map(Numeric::into_f64),
-                        zero_threshold: dp.zero_threshold,
+                        zero_threshold: dp.zero_threshold(),
                     })
                     .collect(),
-                aggregation_temporality: TonicTemporality::from(hist.temporality).into(),
+                aggregation_temporality: TonicTemporality::from(hist.temporality()).into(),
             }
         }
     }
@@ -278,15 +278,15 @@ pub mod tonic {
                     .data_points()
                     .map(|dp| TonicNumberDataPoint {
                         attributes: dp.attributes().map(Into::into).collect(),
-                        start_time_unix_nano: to_nanos(sum.start_time),
-                        time_unix_nano: to_nanos(sum.time),
+                        start_time_unix_nano: to_nanos(sum.start_time()),
+                        time_unix_nano: to_nanos(sum.time()),
                         exemplars: dp.exemplars().map(Into::into).collect(),
                         flags: TonicDataPointFlags::default() as u32,
                         value: Some(dp.value.into()),
                     })
                     .collect(),
-                aggregation_temporality: TonicTemporality::from(sum.temporality).into(),
-                is_monotonic: sum.is_monotonic,
+                aggregation_temporality: TonicTemporality::from(sum.temporality()).into(),
+                is_monotonic: sum.is_monotonic(),
             }
         }
     }
@@ -301,8 +301,8 @@ pub mod tonic {
                     .data_points()
                     .map(|dp| TonicNumberDataPoint {
                         attributes: dp.attributes().map(Into::into).collect(),
-                        start_time_unix_nano: gauge.start_time.map(to_nanos).unwrap_or_default(),
-                        time_unix_nano: to_nanos(gauge.time),
+                        start_time_unix_nano: gauge.start_time().map(to_nanos).unwrap_or_default(),
+                        time_unix_nano: to_nanos(gauge.time()),
                         exemplars: dp.exemplars().map(Into::into).collect(),
                         flags: TonicDataPointFlags::default() as u32,
                         value: Some(dp.value.into()),
@@ -322,9 +322,9 @@ pub mod tonic {
                     .filtered_attributes()
                     .map(|kv| (&kv.key, &kv.value).into())
                     .collect(),
-                time_unix_nano: to_nanos(ex.time),
-                span_id: ex.span_id.into(),
-                trace_id: ex.trace_id.into(),
+                time_unix_nano: to_nanos(ex.time()),
+                span_id: ex.span_id().into(),
+                trace_id: ex.trace_id().into(),
                 value: Some(ex.value.into()),
             }
         }

--- a/opentelemetry-proto/src/transform/metrics.rs
+++ b/opentelemetry-proto/src/transform/metrics.rs
@@ -250,11 +250,11 @@ pub mod tonic {
                         zero_count: dp.zero_count(),
                         positive: Some(TonicBuckets {
                             offset: dp.positive_bucket().offset(),
-                            bucket_counts: dp.positive_bucket().counts().iter().copied().collect(),
+                            bucket_counts: dp.positive_bucket().counts().to_vec(),
                         }),
                         negative: Some(TonicBuckets {
                             offset: dp.negative_bucket().offset(),
-                            bucket_counts: dp.negative_bucket().counts().iter().copied().collect(),
+                            bucket_counts: dp.negative_bucket().counts().to_vec(),
                         }),
                         flags: TonicDataPointFlags::default() as u32,
                         exemplars: dp.exemplars().map(Into::into).collect(),

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -383,11 +383,6 @@ impl<T> HistogramDataPoint<T> {
     pub fn count(&self) -> u64 {
         self.count
     }
-
-    /// Returns the sum of the values recorded.
-    pub fn sum(&self) -> &T {
-        &self.sum
-    }
 }
 
 impl<T: Copy> HistogramDataPoint<T> {
@@ -399,6 +394,11 @@ impl<T: Copy> HistogramDataPoint<T> {
     /// Returns the maximum value recorded.
     pub fn max(&self) -> Option<T> {
         self.max
+    }
+
+    /// Returns the sum of the values recorded.
+    pub fn sum(&self) -> T {
+        self.sum
     }
 }
 
@@ -500,11 +500,6 @@ impl<T> ExponentialHistogramDataPoint<T> {
         self.count
     }
 
-    /// Returns the sum of the values recorded.
-    pub fn sum(&self) -> &T {
-        &self.sum
-    }
-
     /// Returns the resolution of the histogram.
     pub fn scale(&self) -> i8 {
         self.scale
@@ -540,6 +535,11 @@ impl<T: Copy> ExponentialHistogramDataPoint<T> {
     /// Returns the maximum value recorded.
     pub fn max(&self) -> Option<T> {
         self.max
+    }
+
+    /// Returns the sum of the values recorded.
+    pub fn sum(&self) -> T {
+        self.sum
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -562,9 +562,9 @@ impl ExponentialBucket {
         self.offset
     }
 
-    /// Returns a reference to the counts vec.
-    pub fn counts(&self) -> &[u64] {
-        &self.counts
+    /// Returns an iterator over the counts.
+    pub fn counts(&self) -> impl Iterator<Item = u64> + '_ {
+        self.counts.iter().copied()
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -531,7 +531,7 @@ impl<T> ExponentialHistogramDataPoint<T> {
     }
 }
 
-impl <T: Copy> ExponentialHistogramDataPoint<T> {
+impl<T: Copy> ExponentialHistogramDataPoint<T> {
     /// Returns the minimum value recorded.
     pub fn min(&self) -> Option<T> {
         self.min

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -169,7 +169,7 @@ pub struct GaugeDataPoint<T> {
     /// time series.
     pub(crate) attributes: Vec<KeyValue>,
     /// The value of this data point.
-    pub value: T,
+    pub(crate) value: T,
     /// The sampled [Exemplar]s collected during the time series.
     pub(crate) exemplars: Vec<Exemplar<T>>,
 }
@@ -183,6 +183,13 @@ impl<T> GaugeDataPoint<T> {
     /// Returns an iterator over the [Exemplar]s in [GaugeDataPoint].
     pub fn exemplars(&self) -> impl Iterator<Item = &Exemplar<T>> {
         self.exemplars.iter()
+    }
+}
+
+impl<T: Copy> GaugeDataPoint<T> {
+    /// Returns the value of this data point.
+    pub fn value(&self) -> T {
+        self.value
     }
 }
 
@@ -235,6 +242,13 @@ impl<T> SumDataPoint<T> {
     /// Returns an iterator over the [Exemplar]s in [SumDataPoint].
     pub fn exemplars(&self) -> impl Iterator<Item = &Exemplar<T>> {
         self.exemplars.iter()
+    }
+}
+
+impl<T: Copy> SumDataPoint<T> {
+    /// Returns the value of this data point.
+    pub fn value(&self) -> T {
+        self.value
     }
 }
 
@@ -334,9 +348,9 @@ pub struct HistogramDataPoint<T> {
     pub(crate) bucket_counts: Vec<u64>,
 
     /// The minimum value recorded.
-    pub min: Option<T>,
+    pub(crate) min: Option<T>,
     /// The maximum value recorded.
-    pub max: Option<T>,
+    pub(crate) max: Option<T>,
     /// The sum of the values recorded.
     pub(crate) sum: T,
 
@@ -373,6 +387,18 @@ impl<T> HistogramDataPoint<T> {
     /// Returns the sum of the values recorded.
     pub fn sum(&self) -> &T {
         &self.sum
+    }
+}
+
+impl<T: Copy> HistogramDataPoint<T> {
+    /// Returns the minimum value recorded.
+    pub fn min(&self) -> Option<T> {
+        self.min
+    }
+
+    /// Returns the maximum value recorded.
+    pub fn max(&self) -> Option<T> {
+        self.max
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -169,7 +169,7 @@ pub struct GaugeDataPoint<T> {
     /// time series.
     pub(crate) attributes: Vec<KeyValue>,
     /// The value of this data point.
-    pub value: T,
+    pub(crate) value: T,
     /// The sampled [Exemplar]s collected during the time series.
     pub(crate) exemplars: Vec<Exemplar<T>>,
 }
@@ -226,7 +226,7 @@ pub struct SumDataPoint<T> {
     /// time series.
     pub(crate) attributes: Vec<KeyValue>,
     /// The value of this data point.
-    pub value: T,
+    pub(crate) value: T,
     /// The sampled [Exemplar]s collected during the time series.
     pub(crate) exemplars: Vec<Exemplar<T>>,
 }
@@ -269,23 +269,23 @@ impl<T> Sum<T> {
     pub fn data_points(&self) -> impl Iterator<Item = &SumDataPoint<T>> {
         self.data_points.iter()
     }
-    
+
     /// Returns the time when the time series was started.
     pub fn start_time(&self) -> SystemTime {
         self.start_time
     }
-    
+
     /// Returns the time when the time series was recorded.
     pub fn time(&self) -> SystemTime {
         self.time
     }
-    
-    /// Returns the temporality describing if the aggregation is reported as the change 
+
+    /// Returns the temporality describing if the aggregation is reported as the change
     /// from the last report time, or the cumulative changes since a fixed start time.
     pub fn temporality(&self) -> Temporality {
         self.temporality
     }
-    
+
     /// Returns whether this aggregation only increases or decreases.
     pub fn is_monotonic(&self) -> bool {
         self.is_monotonic
@@ -311,18 +311,18 @@ impl<T> Histogram<T> {
     pub fn data_points(&self) -> impl Iterator<Item = &HistogramDataPoint<T>> {
         self.data_points.iter()
     }
-    
+
     /// Returns the time when the time series was started.
     pub fn start_time(&self) -> SystemTime {
         self.start_time
     }
-    
+
     /// Returns the time when the time series was recorded.
     pub fn time(&self) -> SystemTime {
         self.time
     }
-    
-    /// Returns the temporality describing if the aggregation is reported as the change 
+
+    /// Returns the temporality describing if the aggregation is reported as the change
     /// from the last report time, or the cumulative changes since a fixed start time.
     pub fn temporality(&self) -> Temporality {
         self.temporality
@@ -374,22 +374,22 @@ impl<T> HistogramDataPoint<T> {
     pub fn bucket_counts(&self) -> impl Iterator<Item = u64> + '_ {
         self.bucket_counts.iter().copied()
     }
-    
+
     /// Returns the number of updates this histogram has been calculated with.
     pub fn count(&self) -> u64 {
         self.count
     }
-    
+
     /// Returns the minimum value recorded.
     pub fn min(&self) -> Option<&T> {
         self.min.as_ref()
     }
-    
+
     /// Returns the maximum value recorded.
     pub fn max(&self) -> Option<&T> {
         self.max.as_ref()
     }
-    
+
     /// Returns the sum of the values recorded.
     pub fn sum(&self) -> &T {
         &self.sum
@@ -415,18 +415,18 @@ impl<T> ExponentialHistogram<T> {
     pub fn data_points(&self) -> impl Iterator<Item = &ExponentialHistogramDataPoint<T>> {
         self.data_points.iter()
     }
-    
+
     /// Returns the time when the time series was started.
     pub fn start_time(&self) -> SystemTime {
         self.start_time
     }
-    
+
     /// Returns the time when the time series was recorded.
     pub fn time(&self) -> SystemTime {
         self.time
     }
-    
-    /// Returns the temporality describing if the aggregation is reported as the change 
+
+    /// Returns the temporality describing if the aggregation is reported as the change
     /// from the last report time, or the cumulative changes since a fixed start time.
     pub fn temporality(&self) -> Temporality {
         self.temporality
@@ -488,47 +488,47 @@ impl<T> ExponentialHistogramDataPoint<T> {
     pub fn exemplars(&self) -> impl Iterator<Item = &Exemplar<T>> {
         self.exemplars.iter()
     }
-    
+
     /// Returns the number of updates this histogram has been calculated with.
     pub fn count(&self) -> usize {
         self.count
     }
-    
+
     /// Returns the minimum value recorded.
     pub fn min(&self) -> Option<&T> {
         self.min.as_ref()
     }
-    
+
     /// Returns the maximum value recorded.
     pub fn max(&self) -> Option<&T> {
         self.max.as_ref()
     }
-    
+
     /// Returns the sum of the values recorded.
     pub fn sum(&self) -> &T {
         &self.sum
     }
-    
+
     /// Returns the resolution of the histogram.
     pub fn scale(&self) -> i8 {
         self.scale
     }
-    
+
     /// Returns the number of values whose absolute value is less than or equal to zero_threshold.
     pub fn zero_count(&self) -> u64 {
         self.zero_count
     }
-    
+
     /// Returns the range of positive value bucket counts.
     pub fn positive_bucket(&self) -> &ExponentialBucket {
         &self.positive_bucket
     }
-    
+
     /// Returns the range of negative value bucket counts.
     pub fn negative_bucket(&self) -> &ExponentialBucket {
         &self.negative_bucket
     }
-    
+
     /// Returns the width of the zero region.
     pub fn zero_threshold(&self) -> f64 {
         self.zero_threshold
@@ -553,7 +553,7 @@ impl ExponentialBucket {
     pub fn offset(&self) -> i32 {
         self.offset
     }
-    
+
     /// Returns a reference to the counts vec.
     pub fn counts(&self) -> &[u64] {
         &self.counts

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -197,9 +197,9 @@ pub struct Gauge<T> {
     /// Represents individual aggregated measurements with unique attributes.
     pub(crate) data_points: Vec<GaugeDataPoint<T>>,
     /// The time when the time series was started.
-    pub start_time: Option<SystemTime>,
+    pub(crate) start_time: Option<SystemTime>,
     /// The time when the time series was recorded.
-    pub time: SystemTime,
+    pub(crate) time: SystemTime,
 }
 
 impl<T> Gauge<T> {
@@ -567,17 +567,17 @@ pub struct Exemplar<T> {
     /// time series' aggregated data.
     pub(crate) filtered_attributes: Vec<KeyValue>,
     /// The time when the measurement was recorded.
-    pub time: SystemTime,
+    pub(crate) time: SystemTime,
     /// The measured value.
-    pub value: T,
+    pub(crate) value: T,
     /// The ID of the span that was active during the measurement.
     ///
     /// If no span was active or the span was not sampled this will be empty.
-    pub span_id: [u8; 8],
+    pub(crate) span_id: [u8; 8],
     /// The ID of the trace the active span belonged to during the measurement.
     ///
     /// If no span was active or the span was not sampled this will be empty.
-    pub trace_id: [u8; 16],
+    pub(crate) trace_id: [u8; 16],
 }
 
 impl<T> Exemplar<T> {

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -169,7 +169,7 @@ pub struct GaugeDataPoint<T> {
     /// time series.
     pub(crate) attributes: Vec<KeyValue>,
     /// The value of this data point.
-    pub(crate) value: T,
+    pub value: T,
     /// The sampled [Exemplar]s collected during the time series.
     pub(crate) exemplars: Vec<Exemplar<T>>,
 }
@@ -183,11 +183,6 @@ impl<T> GaugeDataPoint<T> {
     /// Returns an iterator over the [Exemplar]s in [GaugeDataPoint].
     pub fn exemplars(&self) -> impl Iterator<Item = &Exemplar<T>> {
         self.exemplars.iter()
-    }
-
-    /// Returns the value of this data point.
-    pub fn value(&self) -> &T {
-        &self.value
     }
 }
 
@@ -226,7 +221,7 @@ pub struct SumDataPoint<T> {
     /// time series.
     pub(crate) attributes: Vec<KeyValue>,
     /// The value of this data point.
-    pub(crate) value: T,
+    pub value: T,
     /// The sampled [Exemplar]s collected during the time series.
     pub(crate) exemplars: Vec<Exemplar<T>>,
 }
@@ -240,11 +235,6 @@ impl<T> SumDataPoint<T> {
     /// Returns an iterator over the [Exemplar]s in [SumDataPoint].
     pub fn exemplars(&self) -> impl Iterator<Item = &Exemplar<T>> {
         self.exemplars.iter()
-    }
-
-    /// Returns the value of this data point.
-    pub fn value(&self) -> &T {
-        &self.value
     }
 }
 
@@ -344,9 +334,9 @@ pub struct HistogramDataPoint<T> {
     pub(crate) bucket_counts: Vec<u64>,
 
     /// The minimum value recorded.
-    pub(crate) min: Option<T>,
+    pub min: Option<T>,
     /// The maximum value recorded.
-    pub(crate) max: Option<T>,
+    pub max: Option<T>,
     /// The sum of the values recorded.
     pub(crate) sum: T,
 
@@ -378,16 +368,6 @@ impl<T> HistogramDataPoint<T> {
     /// Returns the number of updates this histogram has been calculated with.
     pub fn count(&self) -> u64 {
         self.count
-    }
-
-    /// Returns the minimum value recorded.
-    pub fn min(&self) -> Option<&T> {
-        self.min.as_ref()
-    }
-
-    /// Returns the maximum value recorded.
-    pub fn max(&self) -> Option<&T> {
-        self.max.as_ref()
     }
 
     /// Returns the sum of the values recorded.
@@ -442,9 +422,9 @@ pub struct ExponentialHistogramDataPoint<T> {
     /// The number of updates this histogram has been calculated with.
     pub(crate) count: usize,
     /// The minimum value recorded.
-    pub(crate) min: Option<T>,
+    pub min: Option<T>,
     /// The maximum value recorded.
-    pub(crate) max: Option<T>,
+    pub max: Option<T>,
     /// The sum of the values recorded.
     pub(crate) sum: T,
 
@@ -492,16 +472,6 @@ impl<T> ExponentialHistogramDataPoint<T> {
     /// Returns the number of updates this histogram has been calculated with.
     pub fn count(&self) -> usize {
         self.count
-    }
-
-    /// Returns the minimum value recorded.
-    pub fn min(&self) -> Option<&T> {
-        self.min.as_ref()
-    }
-
-    /// Returns the maximum value recorded.
-    pub fn max(&self) -> Option<&T> {
-        self.max.as_ref()
     }
 
     /// Returns the sum of the values recorded.
@@ -569,7 +539,7 @@ pub struct Exemplar<T> {
     /// The time when the measurement was recorded.
     pub(crate) time: SystemTime,
     /// The measured value.
-    pub(crate) value: T,
+    pub value: T,
     /// The ID of the span that was active during the measurement.
     ///
     /// If no span was active or the span was not sampled this will be empty.
@@ -589,11 +559,6 @@ impl<T> Exemplar<T> {
     /// Returns the time when the measurement was recorded.
     pub fn time(&self) -> SystemTime {
         self.time
-    }
-
-    /// Returns the measured value.
-    pub fn value(&self) -> &T {
-        &self.value
     }
 
     /// Returns the ID of the span that was active during the measurement.

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -448,9 +448,9 @@ pub struct ExponentialHistogramDataPoint<T> {
     /// The number of updates this histogram has been calculated with.
     pub(crate) count: usize,
     /// The minimum value recorded.
-    pub min: Option<T>,
+    pub(crate) min: Option<T>,
     /// The maximum value recorded.
-    pub max: Option<T>,
+    pub(crate) max: Option<T>,
     /// The sum of the values recorded.
     pub(crate) sum: T,
 
@@ -528,6 +528,18 @@ impl<T> ExponentialHistogramDataPoint<T> {
     /// Returns the width of the zero region.
     pub fn zero_threshold(&self) -> f64 {
         self.zero_threshold
+    }
+}
+
+impl <T: Copy> ExponentialHistogramDataPoint<T> {
+    /// Returns the minimum value recorded.
+    pub fn min(&self) -> Option<T> {
+        self.min
+    }
+
+    /// Returns the maximum value recorded.
+    pub fn max(&self) -> Option<T> {
+        self.max
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -228,7 +228,7 @@ pub struct SumDataPoint<T> {
     /// time series.
     pub(crate) attributes: Vec<KeyValue>,
     /// The value of this data point.
-    pub value: T,
+    pub(crate) value: T,
     /// The sampled [Exemplar]s collected during the time series.
     pub(crate) exemplars: Vec<Exemplar<T>>,
 }

--- a/opentelemetry-sdk/src/metrics/data/mod.rs
+++ b/opentelemetry-sdk/src/metrics/data/mod.rs
@@ -184,6 +184,11 @@ impl<T> GaugeDataPoint<T> {
     pub fn exemplars(&self) -> impl Iterator<Item = &Exemplar<T>> {
         self.exemplars.iter()
     }
+
+    /// Returns the value of this data point.
+    pub fn value(&self) -> &T {
+        &self.value
+    }
 }
 
 /// A measurement of the current value of an instrument.
@@ -201,6 +206,16 @@ impl<T> Gauge<T> {
     /// Returns an iterator over the [GaugeDataPoint]s in [Gauge].
     pub fn data_points(&self) -> impl Iterator<Item = &GaugeDataPoint<T>> {
         self.data_points.iter()
+    }
+
+    /// Returns the time when the time series was started.
+    pub fn start_time(&self) -> Option<SystemTime> {
+        self.start_time
+    }
+
+    /// Returns the time when the time series was recorded.
+    pub fn time(&self) -> SystemTime {
+        self.time
     }
 }
 
@@ -226,6 +241,11 @@ impl<T> SumDataPoint<T> {
     pub fn exemplars(&self) -> impl Iterator<Item = &Exemplar<T>> {
         self.exemplars.iter()
     }
+
+    /// Returns the value of this data point.
+    pub fn value(&self) -> &T {
+        &self.value
+    }
 }
 
 /// Represents the sum of all measurements of values from an instrument.
@@ -234,20 +254,41 @@ pub struct Sum<T> {
     /// Represents individual aggregated measurements with unique attributes.
     pub(crate) data_points: Vec<SumDataPoint<T>>,
     /// The time when the time series was started.
-    pub start_time: SystemTime,
+    pub(crate) start_time: SystemTime,
     /// The time when the time series was recorded.
-    pub time: SystemTime,
+    pub(crate) time: SystemTime,
     /// Describes if the aggregation is reported as the change from the last report
     /// time, or the cumulative changes since a fixed start time.
-    pub temporality: Temporality,
+    pub(crate) temporality: Temporality,
     /// Whether this aggregation only increases or decreases.
-    pub is_monotonic: bool,
+    pub(crate) is_monotonic: bool,
 }
 
 impl<T> Sum<T> {
     /// Returns an iterator over the [SumDataPoint]s in [Sum].
     pub fn data_points(&self) -> impl Iterator<Item = &SumDataPoint<T>> {
         self.data_points.iter()
+    }
+    
+    /// Returns the time when the time series was started.
+    pub fn start_time(&self) -> SystemTime {
+        self.start_time
+    }
+    
+    /// Returns the time when the time series was recorded.
+    pub fn time(&self) -> SystemTime {
+        self.time
+    }
+    
+    /// Returns the temporality describing if the aggregation is reported as the change 
+    /// from the last report time, or the cumulative changes since a fixed start time.
+    pub fn temporality(&self) -> Temporality {
+        self.temporality
+    }
+    
+    /// Returns whether this aggregation only increases or decreases.
+    pub fn is_monotonic(&self) -> bool {
+        self.is_monotonic
     }
 }
 
@@ -257,18 +298,34 @@ pub struct Histogram<T> {
     /// Individual aggregated measurements with unique attributes.
     pub(crate) data_points: Vec<HistogramDataPoint<T>>,
     /// The time when the time series was started.
-    pub start_time: SystemTime,
+    pub(crate) start_time: SystemTime,
     /// The time when the time series was recorded.
-    pub time: SystemTime,
+    pub(crate) time: SystemTime,
     /// Describes if the aggregation is reported as the change from the last report
     /// time, or the cumulative changes since a fixed start time.
-    pub temporality: Temporality,
+    pub(crate) temporality: Temporality,
 }
 
 impl<T> Histogram<T> {
     /// Returns an iterator over the [HistogramDataPoint]s in [Histogram].
     pub fn data_points(&self) -> impl Iterator<Item = &HistogramDataPoint<T>> {
         self.data_points.iter()
+    }
+    
+    /// Returns the time when the time series was started.
+    pub fn start_time(&self) -> SystemTime {
+        self.start_time
+    }
+    
+    /// Returns the time when the time series was recorded.
+    pub fn time(&self) -> SystemTime {
+        self.time
+    }
+    
+    /// Returns the temporality describing if the aggregation is reported as the change 
+    /// from the last report time, or the cumulative changes since a fixed start time.
+    pub fn temporality(&self) -> Temporality {
+        self.temporality
     }
 }
 
@@ -278,7 +335,7 @@ pub struct HistogramDataPoint<T> {
     /// The set of key value pairs that uniquely identify the time series.
     pub(crate) attributes: Vec<KeyValue>,
     /// The number of updates this histogram has been calculated with.
-    pub count: u64,
+    pub(crate) count: u64,
     /// The upper bounds of the buckets of the histogram.
     ///
     /// Because the last boundary is +infinity this one is implied.
@@ -287,11 +344,11 @@ pub struct HistogramDataPoint<T> {
     pub(crate) bucket_counts: Vec<u64>,
 
     /// The minimum value recorded.
-    pub min: Option<T>,
+    pub(crate) min: Option<T>,
     /// The maximum value recorded.
-    pub max: Option<T>,
+    pub(crate) max: Option<T>,
     /// The sum of the values recorded.
-    pub sum: T,
+    pub(crate) sum: T,
 
     /// The sampled [Exemplar]s collected during the time series.
     pub(crate) exemplars: Vec<Exemplar<T>>,
@@ -317,6 +374,26 @@ impl<T> HistogramDataPoint<T> {
     pub fn bucket_counts(&self) -> impl Iterator<Item = u64> + '_ {
         self.bucket_counts.iter().copied()
     }
+    
+    /// Returns the number of updates this histogram has been calculated with.
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+    
+    /// Returns the minimum value recorded.
+    pub fn min(&self) -> Option<&T> {
+        self.min.as_ref()
+    }
+    
+    /// Returns the maximum value recorded.
+    pub fn max(&self) -> Option<&T> {
+        self.max.as_ref()
+    }
+    
+    /// Returns the sum of the values recorded.
+    pub fn sum(&self) -> &T {
+        &self.sum
+    }
 }
 
 /// The histogram of all measurements of values from an instrument.
@@ -325,18 +402,34 @@ pub struct ExponentialHistogram<T> {
     /// The individual aggregated measurements with unique attributes.
     pub(crate) data_points: Vec<ExponentialHistogramDataPoint<T>>,
     /// When the time series was started.
-    pub start_time: SystemTime,
+    pub(crate) start_time: SystemTime,
     /// The time when the time series was recorded.
-    pub time: SystemTime,
+    pub(crate) time: SystemTime,
     /// Describes if the aggregation is reported as the change from the last report
     /// time, or the cumulative changes since a fixed start time.
-    pub temporality: Temporality,
+    pub(crate) temporality: Temporality,
 }
 
 impl<T> ExponentialHistogram<T> {
     /// Returns an iterator over the [ExponentialHistogramDataPoint]s in [ExponentialHistogram].
     pub fn data_points(&self) -> impl Iterator<Item = &ExponentialHistogramDataPoint<T>> {
         self.data_points.iter()
+    }
+    
+    /// Returns the time when the time series was started.
+    pub fn start_time(&self) -> SystemTime {
+        self.start_time
+    }
+    
+    /// Returns the time when the time series was recorded.
+    pub fn time(&self) -> SystemTime {
+        self.time
+    }
+    
+    /// Returns the temporality describing if the aggregation is reported as the change 
+    /// from the last report time, or the cumulative changes since a fixed start time.
+    pub fn temporality(&self) -> Temporality {
+        self.temporality
     }
 }
 
@@ -347,20 +440,20 @@ pub struct ExponentialHistogramDataPoint<T> {
     pub(crate) attributes: Vec<KeyValue>,
 
     /// The number of updates this histogram has been calculated with.
-    pub count: usize,
+    pub(crate) count: usize,
     /// The minimum value recorded.
-    pub min: Option<T>,
+    pub(crate) min: Option<T>,
     /// The maximum value recorded.
-    pub max: Option<T>,
+    pub(crate) max: Option<T>,
     /// The sum of the values recorded.
-    pub sum: T,
+    pub(crate) sum: T,
 
     /// Describes the resolution of the histogram.
     ///
     /// Boundaries are located at powers of the base, where:
     ///
     ///   base = 2 ^ (2 ^ -scale)
-    pub scale: i8,
+    pub(crate) scale: i8,
 
     /// The number of values whose absolute value is less than or equal to
     /// `zero_threshold`.
@@ -368,18 +461,18 @@ pub struct ExponentialHistogramDataPoint<T> {
     /// When `zero_threshold` is `0`, this is the number of values that cannot be
     /// expressed using the standard exponential formula as well as values that have
     /// been rounded to zero.
-    pub zero_count: u64,
+    pub(crate) zero_count: u64,
 
     /// The range of positive value bucket counts.
-    pub positive_bucket: ExponentialBucket,
+    pub(crate) positive_bucket: ExponentialBucket,
     /// The range of negative value bucket counts.
-    pub negative_bucket: ExponentialBucket,
+    pub(crate) negative_bucket: ExponentialBucket,
 
     /// The width of the zero region.
     ///
     /// Where the zero region is defined as the closed interval
     /// [-zero_threshold, zero_threshold].
-    pub zero_threshold: f64,
+    pub(crate) zero_threshold: f64,
 
     /// The sampled exemplars collected during the time series.
     pub(crate) exemplars: Vec<Exemplar<T>>,
@@ -395,19 +488,76 @@ impl<T> ExponentialHistogramDataPoint<T> {
     pub fn exemplars(&self) -> impl Iterator<Item = &Exemplar<T>> {
         self.exemplars.iter()
     }
+    
+    /// Returns the number of updates this histogram has been calculated with.
+    pub fn count(&self) -> usize {
+        self.count
+    }
+    
+    /// Returns the minimum value recorded.
+    pub fn min(&self) -> Option<&T> {
+        self.min.as_ref()
+    }
+    
+    /// Returns the maximum value recorded.
+    pub fn max(&self) -> Option<&T> {
+        self.max.as_ref()
+    }
+    
+    /// Returns the sum of the values recorded.
+    pub fn sum(&self) -> &T {
+        &self.sum
+    }
+    
+    /// Returns the resolution of the histogram.
+    pub fn scale(&self) -> i8 {
+        self.scale
+    }
+    
+    /// Returns the number of values whose absolute value is less than or equal to zero_threshold.
+    pub fn zero_count(&self) -> u64 {
+        self.zero_count
+    }
+    
+    /// Returns the range of positive value bucket counts.
+    pub fn positive_bucket(&self) -> &ExponentialBucket {
+        &self.positive_bucket
+    }
+    
+    /// Returns the range of negative value bucket counts.
+    pub fn negative_bucket(&self) -> &ExponentialBucket {
+        &self.negative_bucket
+    }
+    
+    /// Returns the width of the zero region.
+    pub fn zero_threshold(&self) -> f64 {
+        self.zero_threshold
+    }
 }
 
 /// A set of bucket counts, encoded in a contiguous array of counts.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExponentialBucket {
     /// The bucket index of the first entry in the `counts` vec.
-    pub offset: i32,
+    pub(crate) offset: i32,
 
     /// A vec where `counts[i]` carries the count of the bucket at index `offset + i`.
     ///
     /// `counts[i]` is the count of values greater than base^(offset+i) and less than
     /// or equal to base^(offset+i+1).
-    pub counts: Vec<u64>,
+    pub(crate) counts: Vec<u64>,
+}
+
+impl ExponentialBucket {
+    /// Returns the bucket index of the first entry in the counts vec.
+    pub fn offset(&self) -> i32 {
+        self.offset
+    }
+    
+    /// Returns a reference to the counts vec.
+    pub fn counts(&self) -> &[u64] {
+        &self.counts
+    }
 }
 
 /// A measurement sampled from a time series providing a typical example.
@@ -434,6 +584,26 @@ impl<T> Exemplar<T> {
     /// Returns an iterator over the filtered attributes in [Exemplar].
     pub fn filtered_attributes(&self) -> impl Iterator<Item = &KeyValue> {
         self.filtered_attributes.iter()
+    }
+
+    /// Returns the time when the measurement was recorded.
+    pub fn time(&self) -> SystemTime {
+        self.time
+    }
+
+    /// Returns the measured value.
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    /// Returns the ID of the span that was active during the measurement.
+    pub fn span_id(&self) -> &[u8; 8] {
+        &self.span_id
+    }
+
+    /// Returns the ID of the trace the active span belonged to during the measurement.
+    pub fn trace_id(&self) -> &[u8; 16] {
+        &self.trace_id
     }
 }
 

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -105,7 +105,7 @@ fn print_metrics<'a>(metrics: impl Iterator<Item = &'a ScopeMetrics>) {
 
             fn print_info<T>(data: &MetricData<T>)
             where
-                T: Debug,
+                T: Debug + Copy,
             {
                 match data {
                     MetricData::Gauge(gauge) => {
@@ -156,7 +156,7 @@ fn print_sum<T: Debug>(sum: &Sum<T>) {
     print_sum_data_points(sum.data_points());
 }
 
-fn print_gauge<T: Debug>(gauge: &Gauge<T>) {
+fn print_gauge<T: Debug + Copy>(gauge: &Gauge<T>) {
     println!("\t\tGauge DataPoints");
     if let Some(start_time) = gauge.start_time() {
         let datetime: DateTime<Utc> = start_time.into();
@@ -173,7 +173,7 @@ fn print_gauge<T: Debug>(gauge: &Gauge<T>) {
     print_gauge_data_points(gauge.data_points());
 }
 
-fn print_histogram<T: Debug>(histogram: &Histogram<T>) {
+fn print_histogram<T: Debug + Copy>(histogram: &Histogram<T>) {
     if histogram.temporality() == Temporality::Cumulative {
         println!("\t\tTemporality  : Cumulative");
     } else {
@@ -206,12 +206,12 @@ fn print_sum_data_points<'a, T: Debug + 'a>(
     }
 }
 
-fn print_gauge_data_points<'a, T: Debug + 'a>(
+fn print_gauge_data_points<'a, T: Debug + Copy + 'a>(
     data_points: impl Iterator<Item = &'a GaugeDataPoint<T>>,
 ) {
     for (i, data_point) in data_points.enumerate() {
         println!("\t\tDataPoint #{}", i);
-        println!("\t\t\tValue        : {:#?}", data_point.value);
+        println!("\t\t\tValue        : {:#?}", data_point.value());
         println!("\t\t\tAttributes   :");
         for kv in data_point.attributes() {
             println!("\t\t\t\t ->  {}: {}", kv.key, kv.value.as_str());
@@ -219,18 +219,18 @@ fn print_gauge_data_points<'a, T: Debug + 'a>(
     }
 }
 
-fn print_hist_data_points<'a, T: Debug + 'a>(
+fn print_hist_data_points<'a, T: Debug + Copy + 'a>(
     data_points: impl Iterator<Item = &'a HistogramDataPoint<T>>,
 ) {
     for (i, data_point) in data_points.enumerate() {
         println!("\t\tDataPoint #{}", i);
         println!("\t\t\tCount        : {}", data_point.count());
         println!("\t\t\tSum          : {:?}", data_point.sum());
-        if let Some(min) = &data_point.min {
+        if let Some(min) = &data_point.min() {
             println!("\t\t\tMin          : {:?}", min);
         }
 
-        if let Some(max) = &data_point.max {
+        if let Some(max) = &data_point.max() {
             println!("\t\t\tMax          : {:?}", max);
         }
 

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -198,7 +198,7 @@ fn print_sum_data_points<'a, T: Debug + 'a>(
 ) {
     for (i, data_point) in data_points.enumerate() {
         println!("\t\tDataPoint #{}", i);
-        println!("\t\t\tValue        : {:#?}", data_point.value());
+        println!("\t\t\tValue        : {:#?}", data_point.value);
         println!("\t\t\tAttributes   :");
         for kv in data_point.attributes() {
             println!("\t\t\t\t ->  {}: {}", kv.key, kv.value.as_str());
@@ -211,7 +211,7 @@ fn print_gauge_data_points<'a, T: Debug + 'a>(
 ) {
     for (i, data_point) in data_points.enumerate() {
         println!("\t\tDataPoint #{}", i);
-        println!("\t\t\tValue        : {:#?}", data_point.value());
+        println!("\t\t\tValue        : {:#?}", data_point.value);
         println!("\t\t\tAttributes   :");
         for kv in data_point.attributes() {
             println!("\t\t\t\t ->  {}: {}", kv.key, kv.value.as_str());
@@ -226,11 +226,11 @@ fn print_hist_data_points<'a, T: Debug + 'a>(
         println!("\t\tDataPoint #{}", i);
         println!("\t\t\tCount        : {}", data_point.count());
         println!("\t\t\tSum          : {:?}", data_point.sum());
-        if let Some(min) = data_point.min() {
+        if let Some(min) = &data_point.min {
             println!("\t\t\tMin          : {:?}", min);
         }
 
-        if let Some(max) = data_point.max() {
+        if let Some(max) = &data_point.max {
             println!("\t\t\tMax          : {:?}", max);
         }
 

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -135,7 +135,7 @@ fn print_metrics<'a>(metrics: impl Iterator<Item = &'a ScopeMetrics>) {
     }
 }
 
-fn print_sum<T: Debug>(sum: &Sum<T>) {
+fn print_sum<T: Debug + Copy>(sum: &Sum<T>) {
     println!("\t\tSum DataPoints");
     println!("\t\tMonotonic    : {}", sum.is_monotonic());
     if sum.temporality() == Temporality::Cumulative {
@@ -193,12 +193,12 @@ fn print_histogram<T: Debug + Copy>(histogram: &Histogram<T>) {
     print_hist_data_points(histogram.data_points());
 }
 
-fn print_sum_data_points<'a, T: Debug + 'a>(
+fn print_sum_data_points<'a, T: Debug + Copy + 'a>(
     data_points: impl Iterator<Item = &'a SumDataPoint<T>>,
 ) {
     for (i, data_point) in data_points.enumerate() {
         println!("\t\tDataPoint #{}", i);
-        println!("\t\t\tValue        : {:#?}", data_point.value);
+        println!("\t\t\tValue        : {:#?}", data_point.value());
         println!("\t\t\tAttributes   :");
         for kv in data_point.attributes() {
             println!("\t\t\t\t ->  {}: {}", kv.key, kv.value.as_str());

--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -137,18 +137,18 @@ fn print_metrics<'a>(metrics: impl Iterator<Item = &'a ScopeMetrics>) {
 
 fn print_sum<T: Debug>(sum: &Sum<T>) {
     println!("\t\tSum DataPoints");
-    println!("\t\tMonotonic    : {}", sum.is_monotonic);
-    if sum.temporality == Temporality::Cumulative {
+    println!("\t\tMonotonic    : {}", sum.is_monotonic());
+    if sum.temporality() == Temporality::Cumulative {
         println!("\t\tTemporality  : Cumulative");
     } else {
         println!("\t\tTemporality  : Delta");
     }
-    let datetime: DateTime<Utc> = sum.start_time.into();
+    let datetime: DateTime<Utc> = sum.start_time().into();
     println!(
         "\t\tStartTime    : {}",
         datetime.format("%Y-%m-%d %H:%M:%S%.6f")
     );
-    let datetime: DateTime<Utc> = sum.time.into();
+    let datetime: DateTime<Utc> = sum.time().into();
     println!(
         "\t\tEndTime      : {}",
         datetime.format("%Y-%m-%d %H:%M:%S%.6f")
@@ -158,14 +158,14 @@ fn print_sum<T: Debug>(sum: &Sum<T>) {
 
 fn print_gauge<T: Debug>(gauge: &Gauge<T>) {
     println!("\t\tGauge DataPoints");
-    if let Some(start_time) = gauge.start_time {
+    if let Some(start_time) = gauge.start_time() {
         let datetime: DateTime<Utc> = start_time.into();
         println!(
             "\t\tStartTime    : {}",
             datetime.format("%Y-%m-%d %H:%M:%S%.6f")
         );
     }
-    let datetime: DateTime<Utc> = gauge.time.into();
+    let datetime: DateTime<Utc> = gauge.time().into();
     println!(
         "\t\tEndTime      : {}",
         datetime.format("%Y-%m-%d %H:%M:%S%.6f")
@@ -174,17 +174,17 @@ fn print_gauge<T: Debug>(gauge: &Gauge<T>) {
 }
 
 fn print_histogram<T: Debug>(histogram: &Histogram<T>) {
-    if histogram.temporality == Temporality::Cumulative {
+    if histogram.temporality() == Temporality::Cumulative {
         println!("\t\tTemporality  : Cumulative");
     } else {
         println!("\t\tTemporality  : Delta");
     }
-    let datetime: DateTime<Utc> = histogram.start_time.into();
+    let datetime: DateTime<Utc> = histogram.start_time().into();
     println!(
         "\t\tStartTime    : {}",
         datetime.format("%Y-%m-%d %H:%M:%S%.6f")
     );
-    let datetime: DateTime<Utc> = histogram.time.into();
+    let datetime: DateTime<Utc> = histogram.time().into();
     println!(
         "\t\tEndTime      : {}",
         datetime.format("%Y-%m-%d %H:%M:%S%.6f")
@@ -198,7 +198,7 @@ fn print_sum_data_points<'a, T: Debug + 'a>(
 ) {
     for (i, data_point) in data_points.enumerate() {
         println!("\t\tDataPoint #{}", i);
-        println!("\t\t\tValue        : {:#?}", data_point.value);
+        println!("\t\t\tValue        : {:#?}", data_point.value());
         println!("\t\t\tAttributes   :");
         for kv in data_point.attributes() {
             println!("\t\t\t\t ->  {}: {}", kv.key, kv.value.as_str());
@@ -211,7 +211,7 @@ fn print_gauge_data_points<'a, T: Debug + 'a>(
 ) {
     for (i, data_point) in data_points.enumerate() {
         println!("\t\tDataPoint #{}", i);
-        println!("\t\t\tValue        : {:#?}", data_point.value);
+        println!("\t\t\tValue        : {:#?}", data_point.value());
         println!("\t\t\tAttributes   :");
         for kv in data_point.attributes() {
             println!("\t\t\t\t ->  {}: {}", kv.key, kv.value.as_str());
@@ -224,13 +224,13 @@ fn print_hist_data_points<'a, T: Debug + 'a>(
 ) {
     for (i, data_point) in data_points.enumerate() {
         println!("\t\tDataPoint #{}", i);
-        println!("\t\t\tCount        : {}", data_point.count);
-        println!("\t\t\tSum          : {:?}", data_point.sum);
-        if let Some(min) = &data_point.min {
+        println!("\t\t\tCount        : {}", data_point.count());
+        println!("\t\t\tSum          : {:?}", data_point.sum());
+        if let Some(min) = data_point.min() {
             println!("\t\t\tMin          : {:?}", min);
         }
 
-        if let Some(max) = &data_point.max {
+        if let Some(max) = data_point.max() {
             println!("\t\t\tMax          : {:?}", max);
         }
 


### PR DESCRIPTION
We previously hid the implementation details (eg: Vec!), and exposed getter returning slices. To ensure consistency, this PR changes all fields to be accessible via getter methods only.