### PR TITLE
fix: use default endpoint for endpoint when provided empty string

### DIFF
--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -365,7 +365,7 @@ fn resolve_http_endpoint(
     provided_endpoint: Option<&str>,
 ) -> Result<Uri, ExporterBuildError> {
     // programmatic configuration overrides any value set via environment variables
-    if let Some(provider_endpoint) = provided_endpoint {
+    if let Some(provider_endpoint) = provided_endpoint.filter(|s| !s.is_empty()) {
         provider_endpoint
             .parse()
             .map_err(|er: http::uri::InvalidUri| {
@@ -526,6 +526,15 @@ mod tests {
                 assert_eq!(endpoint, "http://localhost:4317");
             },
         );
+    }
+
+    #[test]
+    fn test_use_default_when_empty_string_for_option() {
+        run_env_test(vec![], || {
+            let endpoint =
+                super::resolve_http_endpoint("non_existent_var", "/v1/traces", Some("")).unwrap();
+            assert_eq!(endpoint, "http://localhost:4318/v1/traces");
+        });
     }
 
     #[test]

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -225,7 +225,7 @@ impl TonicExporterBuilder {
         // If users for some reason want to use a custom path, they can use env var or builder to pass it
         //
         // programmatic configuration overrides any value set via environment variables
-        if let Some(endpoint) = provided_endpoint {
+        if let Some(endpoint) = provided_endpoint.filter(|s| !s.is_empty()) {
             endpoint
         } else if let Ok(endpoint) = env::var(default_endpoint_var) {
             endpoint
@@ -663,6 +663,17 @@ mod tests {
         run_env_test(vec![], || {
             let url =
                 TonicExporterBuilder::resolve_endpoint(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, None);
+            assert_eq!(url, "http://localhost:4317");
+        });
+    }
+
+    #[test]
+    fn test_use_default_when_empty_string_for_option() {
+        run_env_test(vec![], || {
+            let url = TonicExporterBuilder::resolve_endpoint(
+                OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
+                Some(String::new()),
+            );
             assert_eq!(url, "http://localhost:4317");
         });
     }


### PR DESCRIPTION
## Changes

According to the [`WithExporterConfig` docs, passing an empty string to`with_endpoint`](https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/trait.WithExportConfig.html#tymethod.with_endpoint) should result in the default endpoint being used, however that's not currently what happens.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
