### PR TITLE
chore: opentelemetry-appender-log set_observed_timestamp

### DIFF
--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -148,6 +148,7 @@ where
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             let mut log_record = self.logger.create_log_record();
+            log_record.set_observed_timestamp(std::time::SystemTime::now());
             log_record.set_severity_number(severity_of_level(record.level()));
             log_record.set_severity_text(record.level().as_str());
             log_record.set_body(AnyValue::from(record.args().to_string()));


### PR DESCRIPTION
Convey some experience in https://github.com/fast/logforth/blob/243650c342d1b2bfae98381212430b4467d8bac5/src/append/opentelemetry.rs#L222