### PR TITLE
fix(span_processor): only call on_start with recording spans

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- TODO: Placeholder for Span processor related things
+  - *Fix* SpanProcessor::on_start is no longer called on non recording spans
+
 ## 0.30.0
 
 Released 2025-May-23

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -13,7 +13,10 @@ use crate::trace::{
     IdGenerator, ShouldSample, SpanEvents, SpanLimits, SpanLinks,
 };
 use opentelemetry::{
-    trace::{SamplingDecision, Span as _, SpanBuilder, SpanContext, SpanKind, TraceContextExt, TraceFlags},
+    trace::{
+        SamplingDecision, Span as _, SpanBuilder, SpanContext, SpanKind, TraceContextExt,
+        TraceFlags,
+    },
     Context, InstrumentationScope, KeyValue,
 };
 use std::fmt;

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -13,7 +13,7 @@ use crate::trace::{
     IdGenerator, ShouldSample, SpanEvents, SpanLimits, SpanLinks,
 };
 use opentelemetry::{
-    trace::{SamplingDecision, SpanBuilder, SpanContext, SpanKind, TraceContextExt, TraceFlags},
+    trace::{SamplingDecision, Span as _, SpanBuilder, SpanContext, SpanKind, TraceContextExt, TraceFlags},
     Context, InstrumentationScope, KeyValue,
 };
 use std::fmt;
@@ -281,9 +281,11 @@ impl opentelemetry::trace::Tracer for SdkTracer {
             }
         };
 
-        // Call `on_start` for all processors
-        for processor in provider.span_processors() {
-            processor.on_start(&mut span, parent_cx)
+        if span.is_recording() {
+            // Call `on_start` for all processors
+            for processor in provider.span_processors() {
+                processor.on_start(&mut span, parent_cx)
+            }
         }
 
         span


### PR DESCRIPTION
## Issue

SpanProcessor API refactor https://github.com/open-telemetry/opentelemetry-rust/issues/2940

## Changes

According to the spec, spans that are not recording should not be passed to span processors.
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#recording-sampled-reaction-table

This PR fixes this interaction.


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
