### PR TITLE
revert: reintroduce external producers

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - TODO: Placeholder for Span processor related things
   - *Fix* SpanProcessor::on_start is no longer called on non recording spans
+- Revert removal of `MetricProducer` which allowed metrics from
+  external sources to be sent through OpenTelemetry.
 
 ## 0.30.0
 

--- a/opentelemetry-sdk/src/metrics/reader.rs
+++ b/opentelemetry-sdk/src/metrics/reader.rs
@@ -1,9 +1,14 @@
 //! Interfaces for reading and producing metrics
-use crate::error::OTelSdkResult;
+use crate::error::{OTelSdkError, OTelSdkResult};
 use std::time::Duration;
 use std::{fmt, sync::Weak};
 
-use super::{data::ResourceMetrics, instrument::InstrumentKind, pipeline::Pipeline, Temporality};
+use super::{
+    data::{ResourceMetrics, ScopeMetrics},
+    instrument::InstrumentKind,
+    pipeline::Pipeline,
+    Temporality,
+};
 
 /// The interface used between the SDK and an exporter.
 ///
@@ -64,4 +69,10 @@ pub trait MetricReader: fmt::Debug + Send + Sync + 'static {
 pub(crate) trait SdkProducer: fmt::Debug + Send + Sync {
     /// Returns aggregated metrics from a single collection.
     fn produce(&self, rm: &mut ResourceMetrics) -> OTelSdkResult;
+}
+
+/// Produces metrics for a [MetricReader] from an external source.
+pub trait MetricProducer: fmt::Debug + Send + Sync {
+    /// Returns aggregated metrics from an external source.
+    fn produce(&self) -> Result<ScopeMetrics, OTelSdkError>;
 }


### PR DESCRIPTION
Fixes #2505 

## Changes

We re-introduce a way to get data from external sources after its removal in #2105.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
