### PR TITLE
docs: A few small doc touch-ups in some of the various in_memory_exporter modules

### DIFF
--- a/opentelemetry-sdk/src/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/logs/in_memory_exporter.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time;
 
-/// An in-memory logs exporter that stores logs data in memory..
+/// An in-memory logs exporter that stores logs data in memory.
 ///
 /// This exporter is useful for testing and debugging purposes.
 /// It stores logs in a `Vec<OwnedLogData>`. Logs can be retrieved using
@@ -73,7 +73,7 @@ pub struct LogDataWithResource {
     pub resource: Cow<'static, Resource>,
 }
 
-///Builder for ['InMemoryLogExporter'].
+///Builder for [`InMemoryLogExporter`].
 /// # Example
 ///
 /// ```no_run

--- a/opentelemetry-sdk/src/trace/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/trace/in_memory_exporter.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 /// An in-memory span exporter that stores span data in memory.
 ///
 /// This exporter is useful for testing and debugging purposes. It stores
-/// metric data in a `Vec<SpanData>`. Metrics can be retrieved
+/// span data in a `Vec<SpanData>`. Spans can be retrieved
 /// using the `get_finished_spans` method.
 /// # Example
 /// ```


### PR DESCRIPTION
## Changes

- Fix incorrect "metrics" references in the trace `in_memory_exporter` docs.
- Fix a broken `InMemoryLogExporter` doc link.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
