### PR TITLE
chore: Switch from unmaintained hex dependency to const-hex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,11 @@ tonic = { version = "0.13", default-features = false }
 tonic-build = "0.13"
 tokio = { version = "1", default-features = false }
 tokio-stream = "0.1"
-# Using `tracing 0.1.40` because 0.1.39 (which is yanked) introduces the ability to set event names in macros, 
+# Using `tracing 0.1.40` because 0.1.39 (which is yanked) introduces the ability to set event names in macros,
 # required for OpenTelemetry's internal logging macros.
 tracing = { version = ">=0.1.40", default-features = false }
 # `tracing-core >=0.1.33` is required for compatibility with `tracing >=0.1.40`.
-tracing-core = { version = ">=0.1.33", default-features = false } 
+tracing-core = { version = ">=0.1.33", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }
 url = { version = "2.5", default-features = false }
 anyhow = "1.0.94"
@@ -59,7 +59,7 @@ ctor = "0.2.9"
 ctrlc = "3.2.5"
 futures-channel = "0.3"
 futures-sink = "0.3"
-hex = "0.4.3"
+const-hex = "1.14.1"
 lazy_static = "1.4.0"
 num-format = "0.4.4"
 num_cpus = "1.15.0"

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -49,7 +49,7 @@ testing = ["opentelemetry/testing"]
 # add ons
 internal-logs = ["opentelemetry/internal-logs"]
 with-schemars = ["schemars"]
-with-serde = ["serde", "hex", "base64"]
+with-serde = ["serde", "const-hex", "base64"]
 
 [dependencies]
 tonic = { workspace = true, optional = true, features = ["codegen", "prost"] }
@@ -58,7 +58,7 @@ opentelemetry = { version = "0.30", default-features = false, path = "../opentel
 opentelemetry_sdk = { version = "0.30", default-features = false, path = "../opentelemetry-sdk" }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["serde_derive"] }
-hex = { workspace = true, optional = true }
+const-hex = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/opentelemetry-proto/src/proto.rs
+++ b/opentelemetry-proto/src/proto.rs
@@ -16,7 +16,7 @@ pub(crate) mod serializers {
     where
         S: Serializer,
     {
-        let hex_string = hex::encode(bytes);
+        let hex_string = const_hex::encode(bytes);
         serializer.serialize_str(&hex_string)
     }
 
@@ -37,7 +37,7 @@ pub(crate) mod serializers {
             where
                 E: de::Error,
             {
-                hex::decode(value).map_err(E::custom)
+                const_hex::decode(value).map_err(E::custom)
             }
         }
 

--- a/opentelemetry-proto/tests/json_serde.rs
+++ b/opentelemetry-proto/tests/json_serde.rs
@@ -61,10 +61,11 @@ mod json_serde {
                                 dropped_attributes_count: 0,
                             }),
                             spans: vec![Span {
-                                trace_id: hex::decode("5b8efff798038103d269b633813fc60c").unwrap(),
-                                span_id: hex::decode("eee19b7ec3c1b174").unwrap(),
+                                trace_id: const_hex::decode("5b8efff798038103d269b633813fc60c")
+                                    .unwrap(),
+                                span_id: const_hex::decode("eee19b7ec3c1b174").unwrap(),
                                 trace_state: String::new(),
-                                parent_span_id: hex::decode("eee19b7ec3c1b173").unwrap(),
+                                parent_span_id: const_hex::decode("eee19b7ec3c1b173").unwrap(),
                                 flags: 0,
                                 name: String::from("I'm a server span"),
                                 kind: 2,
@@ -267,10 +268,11 @@ mod json_serde {
                                 dropped_attributes_count: 1,
                             }),
                             spans: vec![Span {
-                                trace_id: hex::decode("5b8efff798038103d269b633813fc60c").unwrap(),
-                                span_id: hex::decode("eee19b7ec3c1b174").unwrap(),
+                                trace_id: const_hex::decode("5b8efff798038103d269b633813fc60c")
+                                    .unwrap(),
+                                span_id: const_hex::decode("eee19b7ec3c1b174").unwrap(),
                                 trace_state: String::from("browser=firefox,os=linux"),
-                                parent_span_id: hex::decode("eee19b7ec3c1b173").unwrap(),
+                                parent_span_id: const_hex::decode("eee19b7ec3c1b173").unwrap(),
                                 flags: 1,
                                 name: String::from("I'm a server span"),
                                 kind: 2,
@@ -308,9 +310,9 @@ mod json_serde {
                                 }],
                                 dropped_events_count: 1,
                                 links: vec![Link {
-                                    trace_id: hex::decode("5b8efff798038103d269b633813fc60b")
+                                    trace_id: const_hex::decode("5b8efff798038103d269b633813fc60b")
                                         .unwrap(),
-                                    span_id: hex::decode("eee19b7ec3c1b172").unwrap(),
+                                    span_id: const_hex::decode("eee19b7ec3c1b172").unwrap(),
                                     trace_state: String::from("food=pizza,color=red"),
                                     attributes: vec![KeyValue {
                                         key: String::from("my.link.attr"),
@@ -1272,8 +1274,9 @@ mod json_serde {
                                 ],
                                 dropped_attributes_count: 0,
                                 flags: 0,
-                                trace_id: hex::decode("5b8efff798038103d269b633813fc60c").unwrap(),
-                                span_id: hex::decode("eee19b7ec3c1b174").unwrap(),
+                                trace_id: const_hex::decode("5b8efff798038103d269b633813fc60c")
+                                    .unwrap(),
+                                span_id: const_hex::decode("eee19b7ec3c1b174").unwrap(),
                             }],
                             schema_url: String::new(),
                         }],


### PR DESCRIPTION
## Changes

Replace unmaintaned dependency with newer, faster, maintained version.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
