### PR TITLE
fix: Support HttpClient implementation for HyperClient with custom connectors

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Implementation of `Extractor::get_all` for `HeaderExtractor`
+- Support `HttpClient` implementation for `HyperClient<C>` with custom connectors beyond `HttpConnector`, enabling Unix Domain Socket connections and other custom transports
 
 ## 0.30.0
 

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -179,7 +179,11 @@ pub mod hyper {
     }
 
     #[async_trait]
-    impl HttpClient for HyperClient {
+    impl<C> HttpClient for HyperClient<C>
+    where
+        C: Connect + Clone + Send + Sync + 'static,
+        HyperClient<C>: Debug,
+    {
         async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
             otel_debug!(name: "HyperClient.Send");
             let (parts, body) = request.into_parts();


### PR DESCRIPTION
Fixes #3056
Design discussion issue (if applicable) #

## Changes

The `HttpClient` implementation becomes generic over the connector type `C`, allowing `HyperClient<C>` to implement `HttpClient` for any `C` that satisfies the necessary trait bounds (Connect + Clone + Send + Sync + 'static).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
