### PR TITLE
fix: Explore how to achieve telemetry suppression with OTLP

### DIFF
--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -61,7 +61,7 @@ fn init_logs() -> SdkLoggerProvider {
 }
 
 thread_local! {
-    static SUPPRESS_GUARD: RefCell<Option<opentelemetry::ContextGuard>> = RefCell::new(None);
+    static SUPPRESS_GUARD: RefCell<Option<opentelemetry::ContextGuard>> = const { RefCell::new(None) };
 }
 
 // #[tokio::main]


### PR DESCRIPTION
One way of addressing https://github.com/open-telemetry/opentelemetry-rust/issues/2877

This PR does not introduce a “fix” inside the OTLP Exporters themselves, but instead demonstrates how users can address the issue without requiring changes in OpenTelemetry.

**Background**

OpenTelemetry provides a mechanism to suppress telemetry based on the current Context. However, this suppression only works if every component involved properly propagates OpenTelemetry’s Context. Libraries like tonic and hyper are not aware of OTel’s Context and therefore do not propagate it across threads.

As a result, OTel’s suppression can fail, leading to telemetry-induced-telemetry—where the act of exporting telemetry (e.g., sending data via tonic/hyper) itself generates additional telemetry. This newly generated telemetry is then exported again, triggering yet more telemetry in a loop, potentially overwhelming the system.

**What this PR does**

OTLP/gRPC exporters rely on the tonic client, which captures the current runtime at creation time and uses it to drive futures. Instead of reusing the application’s existing runtime, this PR creates a dedicated Tokio runtime exclusively for the OTLP Exporter.

In this dedicated runtime:
	1.	We intercept on_start / on_stop events.
	2.	Sets OTel’s suppression flag in the context.

This ensures that telemetry generated by libraries such as hyper/tonic will be suppressed **only** within the exporter’s dedicated runtime. If those same libraries are used elsewhere for application logic, they continue to function normally and emit telemetry as expected.

Depending on the feedback, we could either address this purely through documentation and examples, or we could enhance the OTLP Exporter itself to expose a feature flag that, when enabled, would automatically create the tonic client within its own dedicated runtime.