### PR TITLE
feat: add support for OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -6,6 +6,7 @@
   - *Fix* SpanProcessor::on_start is no longer called on non recording spans
 - **Fix**: Restore true parallel exports in the async-native `BatchSpanProcessor` by honoring `OTEL_BSP_MAX_CONCURRENT_EXPORTS` ([#2959](https://github.com/open-telemetry/opentelemetry-rust/pull/3028)). A regression in [#2685](https://github.com/open-telemetry/opentelemetry-rust/pull/2685) inadvertently awaited the `export()` future directly in `opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs` instead of spawning it on the runtime, forcing all exports to run sequentially.
 - **Feature**: Added `Clone` implementation to `SdkLogger` for API consistency with `SdkTracer` ([#3058](https://github.com/open-telemetry/opentelemetry-rust/issues/3058)).
+- Add support for max span attribute value length; Applies to `Value::String` and `Array::String` only.
 
 ## 0.30.0
 

--- a/opentelemetry-sdk/src/trace/config.rs
+++ b/opentelemetry-sdk/src/trace/config.rs
@@ -43,6 +43,13 @@ impl Default for Config {
             config.span_limits.max_attributes_per_span = max_attributes_per_span;
         }
 
+        if let Some(max_attribute_value_length) = env::var("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT")
+            .ok()
+            .and_then(|count_limit| i32::from_str(&count_limit).ok())
+        {
+            config.span_limits.max_attribute_value_length = max_attribute_value_length;
+        }
+
         if let Some(max_events_per_span) = env::var("OTEL_SPAN_EVENT_COUNT_LIMIT")
             .ok()
             .and_then(|max_events| u32::from_str(&max_events).ok())

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -378,6 +378,15 @@ impl TracerProviderBuilder {
         self
     }
 
+    /// Specify the maximum allowed length of attribute values.
+    ///
+    /// This limit applies to [Value::String](opentelemetry::Value::String) and [Array::String](opentelemetry::Array::String)
+    /// attributes only. When the limit is exceeded, the value is truncated without any indication that truncation has occurred.
+    pub fn with_max_attribute_value_length(mut self, max_attribute_value_length: u32) -> Self {
+        self.config.span_limits.max_attribute_value_length = max_attribute_value_length as i32;
+        self
+    }
+
     /// Specify the number of events to be recorded per span.
     pub fn with_max_links_per_span(mut self, max_links: u32) -> Self {
         self.config.span_limits.max_links_per_span = max_links;

--- a/opentelemetry-sdk/src/trace/span_limit.rs
+++ b/opentelemetry-sdk/src/trace/span_limit.rs
@@ -14,6 +14,7 @@
 /// index in the collection. The one added to collections later will be dropped first.
 pub(crate) const DEFAULT_MAX_EVENT_PER_SPAN: u32 = 128;
 pub(crate) const DEFAULT_MAX_ATTRIBUTES_PER_SPAN: u32 = 128;
+pub(crate) const DEFAULT_MAX_ATTRIBUTE_VALUE_LENGTH: i32 = -1;
 pub(crate) const DEFAULT_MAX_LINKS_PER_SPAN: u32 = 128;
 pub(crate) const DEFAULT_MAX_ATTRIBUTES_PER_EVENT: u32 = 128;
 pub(crate) const DEFAULT_MAX_ATTRIBUTES_PER_LINK: u32 = 128;
@@ -25,6 +26,8 @@ pub struct SpanLimits {
     pub max_events_per_span: u32,
     /// The max attributes that can be added to a `Span`.
     pub max_attributes_per_span: u32,
+    /// The max length of attribute values added to a `Span`.
+    pub max_attribute_value_length: i32,
     /// The max links that can be added to a `Span`.
     pub max_links_per_span: u32,
     /// The max attributes that can be added into an `Event`
@@ -38,6 +41,7 @@ impl Default for SpanLimits {
         SpanLimits {
             max_events_per_span: DEFAULT_MAX_EVENT_PER_SPAN,
             max_attributes_per_span: DEFAULT_MAX_ATTRIBUTES_PER_SPAN,
+            max_attribute_value_length: DEFAULT_MAX_ATTRIBUTE_VALUE_LENGTH,
             max_links_per_span: DEFAULT_MAX_LINKS_PER_SPAN,
             max_attributes_per_link: DEFAULT_MAX_ATTRIBUTES_PER_LINK,
             max_attributes_per_event: DEFAULT_MAX_ATTRIBUTES_PER_EVENT,

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -73,6 +73,14 @@ impl SdkTracer {
             .saturating_sub(span_attributes_limit);
         attribute_options.truncate(span_attributes_limit);
         let dropped_attributes_count = dropped_attributes_count as u32;
+        let span_attribute_value_limit = span_limits.max_attribute_value_length;
+        if span_attribute_value_limit > -1 {
+            for attribute in attribute_options.iter_mut() {
+                attribute
+                    .value
+                    .truncate(span_attribute_value_limit as usize);
+            }
+        }
 
         // Links are available as Option<Vec<Link>> in the builder
         // If it is None, then there are no links to process.


### PR DESCRIPTION
### **User description**
Fixes https://github.com/open-telemetry/opentelemetry-rust/discussions/2214

## Changes

Add support for the `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` environment variable as explained in [Opentelemetry SDK environment variable doc](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#attribute-limits). This will truncate `Value::String` and `Array::String` attribute values if they exceed the limit.

- Adds `TracerProviderBuilder::with_max_attribute_value_length()` 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
