### PR TITLE
fix: Add feature flag to otel-http crate to better reflect purpose

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Implementation of `Extractor::get_all` for `HeaderExtractor`
 - Support `HttpClient` implementation for `HyperClient<C>` with custom connectors beyond `HttpConnector`, enabling Unix Domain Socket connections and other custom transports
+- Add `reqwest` and `reqwest-blocking` features to enable async and blocking
+  reqwest HTTP clients
 
 ## 0.30.0
 

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -13,8 +13,10 @@ autobenches = false
 [features]
 default = ["internal-logs"]
 hyper = ["dep:http-body-util", "dep:hyper", "dep:hyper-util", "dep:tokio"]
-reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
-reqwest-rustls-webpki-roots = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
+reqwest = ["dep:reqwest"]
+reqwest-blocking = ["dep:reqwest", "reqwest/blocking"]
+reqwest-rustls = ["dep:reqwest", "reqwest/rustls-tls-native-roots"]
+reqwest-rustls-webpki-roots = ["dep:reqwest", "reqwest/rustls-tls-webpki-roots"]
 internal-logs = ["opentelemetry/internal-logs"]
 
 [dependencies]
@@ -25,7 +27,7 @@ http-body-util = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }
 hyper-util = { workspace = true, features = ["client-legacy", "http1", "http2"], optional = true }
 opentelemetry = { workspace = true, features = ["trace"] }
-reqwest = { workspace = true, features = ["blocking"], optional = true }
+reqwest = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["time"], optional = true }
 
 [lints]

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -108,6 +108,7 @@ mod reqwest {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "reqwest-blocking")]
     #[async_trait]
     impl HttpClient for reqwest::blocking::Client {
         async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -74,7 +74,7 @@ tls-webpki-roots = ["tls", "tonic/tls-webpki-roots"]
 # http binary
 http-proto = ["prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "http", "trace", "metrics"]
 http-json = ["serde_json", "prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "opentelemetry-proto/with-serde", "http", "trace", "metrics"]
-reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
+reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest-blocking"]
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 reqwest-rustls = ["reqwest", "opentelemetry-http/reqwest-rustls"]
 reqwest-rustls-webpki-roots = ["reqwest", "opentelemetry-http/reqwest-rustls-webpki-roots"]

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -22,7 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["reqwest-blocking-client", "reqwest/native-tls"]
-reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest"]
+reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest-blocking"]
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 reqwest-rustls = ["reqwest", "reqwest/rustls-tls-native-roots"]
 


### PR DESCRIPTION
OTLP was enabling feature flag "request" in otel-http which did not exist! This adds feature flags to the otel-http crate corresponding to the client being used. 