### PR TITLE
feat: adds helpers for KeyValue collection

### DIFF
--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - *Breaking* Change return type of `opentelemetry::global::set_tracer_provider` to Unit to align with metrics counterpart
 - Add `get_all` method to `opentelemetry::propagation::Extractor` to return all values of the given propagation key and provide a default implementation.
+- Adds `opentelemetry::AsKeyValues` trait and supporting `opentelemetry::KeyValueCollector` struct to convert types into `KeyValue`s for use as attributes.
 
 ## 0.30.0
 

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -260,7 +260,8 @@ mod common;
 pub mod testing;
 
 pub use common::{
-    Array, InstrumentationScope, InstrumentationScopeBuilder, Key, KeyValue, StringValue, Value,
+    Array, AsKeyValues, InstrumentationScope, InstrumentationScopeBuilder, Key, KeyValue,
+    KeyValueCollector, StringValue, Value,
 };
 
 #[cfg(feature = "metrics")]


### PR DESCRIPTION
Fixes # N/A
Design discussion issue (if applicable) # N/A

## Changes

In my project, I found it overly verbose to create the `KeyValue` slice inline for attributes. I hope this can simplify it and allow data types how they prefer to be attributed.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
