### PR TITLE
chore: remove disk space cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,6 @@ jobs:
       with:
         egress-policy: audit
 
-    - name: Check disk space
-      if: ${{ matrix.os == 'ubuntu-latest'}}
-      run: |
-        df -h
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         submodules: true
@@ -54,10 +50,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
       run: bash ./scripts/test.sh
-    - name: Check disk space
-      if: ${{ matrix.os == 'ubuntu-latest'}}
-      run: |
-        df -h
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,9 +18,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check disk space
-        run: |
-          df -h
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
@@ -33,6 +30,3 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run integration tests
         run: ./scripts/integration_tests.sh
-      - name: Check disk space
-        run: |
-          df -h


### PR DESCRIPTION
## Changes

- I checked and the current build takes up roughly 4GB, while still having 22GB left. Maybe it was needed in the past on older runners, but nowadays this shouldn't be an issue anymore

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
