### PR TITLE
perf: use line tables only and make profiling optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ resolver = "2"
 exclude = ["opentelemetry-prometheus"]
 
 [profile.bench]
-# https://doc.rust-lang.org/cargo/reference/profiles.html#bench
+# https://doc.rust-lang.org/cargo/reference/profiles.html#debug
 # See function names in profiling reports.
-# 2/true is too much, 0 is not enough, 1 is just right for back traces
-debug = 1
+# 2/true is too much, 0 is not enough, line-tables-only is just right for back traces
+debug = "line-tables-only"
 
 [workspace.dependencies]
 async-trait = "0.1"
@@ -84,6 +84,7 @@ tracing-log = "0.2"
 tracing-opentelemetry = "0.32"
 typed-builder = "0.20"
 uuid = "1.3"
+pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 
 # Aviod use of crates.io version of these crates through the tracing-opentelemetry dependencies
 [patch.crates-io]

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -31,13 +31,14 @@ criterion = { workspace = true }
 #tokio = { workspace = true, features = ["full"]}
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
-pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
+pprof = { workspace = true }
 
 [features]
 default = []
 experimental_metadata_attributes = ["dep:tracing-log"]
 spec_unstable_logs_enabled = ["opentelemetry/spec_unstable_logs_enabled"]
 experimental_use_tracing_span_context = ["tracing-opentelemetry"]
+bench_profiling = []
 
 
 [[bench]]

--- a/opentelemetry-appender-tracing/benches/log-attributes.rs
+++ b/opentelemetry-appender-tracing/benches/log-attributes.rs
@@ -28,7 +28,7 @@ use opentelemetry_appender_tracing::layer as tracing_layer;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::logs::{LogProcessor, SdkLogRecord, SdkLoggerProvider};
 use opentelemetry_sdk::Resource;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
 use tracing::error;
 use tracing_subscriber::prelude::*;
@@ -251,7 +251,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     // }
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 criterion_group! {
     name = benches;
     config = Criterion::default()
@@ -261,7 +261,7 @@ criterion_group! {
     targets = criterion_benchmark
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", not(feature = "bench_profiling")))]
 criterion_group! {
     name = benches;
     config = Criterion::default()

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -29,7 +29,7 @@ use opentelemetry_appender_tracing::layer as tracing_layer;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::logs::{LogProcessor, SdkLogRecord, SdkLoggerProvider};
 use opentelemetry_sdk::Resource;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
 use tracing::error;
 use tracing_subscriber::prelude::*;
@@ -161,7 +161,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     benchmark_with_noop_layer(c, false, "noop_layer_disabled");
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 criterion_group! {
     name = benches;
     config = Criterion::default()
@@ -170,7 +170,8 @@ criterion_group! {
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
-#[cfg(target_os = "windows")]
+
+#[cfg(any(target_os = "windows", not(feature = "bench_profiling")))]
 criterion_group! {
     name = benches;
     config = Criterion::default()

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -36,7 +36,7 @@ rstest = { workspace = true }
 temp-env = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
-pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
+pprof = { workspace = true }
 
 [features]
 default = ["trace", "metrics", "logs", "internal-logs"]
@@ -57,6 +57,7 @@ experimental_logs_batch_log_processor_with_async_runtime = ["logs", "experimenta
 experimental_logs_concurrent_log_processor = ["logs"]
 experimental_trace_batch_span_processor_with_async_runtime = ["tokio/sync", "trace", "experimental_async_runtime"]
 experimental_metrics_disable_name_validation = ["metrics"]
+bench_profiling = []
 
 [[bench]]
 name = "context"

--- a/opentelemetry-sdk/benches/log_enabled.rs
+++ b/opentelemetry-sdk/benches/log_enabled.rs
@@ -53,7 +53,7 @@ where
 
     c.bench_function(name, |b| {
         b.iter(|| {
-            criterion::black_box(logger.event_enabled(
+            std::hint::black_box(logger.event_enabled(
                 opentelemetry::logs::Severity::Debug,
                 "target",
                 Some("name"),

--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -22,7 +22,7 @@ use opentelemetry_sdk::logs::LogBatch;
 use opentelemetry_sdk::logs::LogProcessor;
 use opentelemetry_sdk::logs::SdkLogRecord;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
 use std::fmt::Debug;
 
@@ -164,7 +164,7 @@ fn exporter_without_future(c: &mut Criterion) {
     });
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 criterion_group! {
     name = benches;
     config = Criterion::default()
@@ -173,7 +173,7 @@ criterion_group! {
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", not(feature = "bench_profiling")))]
 criterion_group! {
     name = benches;
     config = Criterion::default()

--- a/opentelemetry-sdk/benches/metrics_counter.rs
+++ b/opentelemetry-sdk/benches/metrics_counter.rs
@@ -20,7 +20,7 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
 use rand::{
     rngs::{self},
@@ -239,7 +239,7 @@ fn random_generator(c: &mut Criterion) {
     });
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 criterion_group! {
     name = benches;
     config = Criterion::default()
@@ -248,7 +248,7 @@ criterion_group! {
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", not(feature = "bench_profiling")))]
 criterion_group! {
     name = benches;
     config = Criterion::default()

--- a/opentelemetry-sdk/benches/metrics_histogram.rs
+++ b/opentelemetry-sdk/benches/metrics_histogram.rs
@@ -18,7 +18,7 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
 use rand::{
     rngs::{self},
@@ -143,7 +143,7 @@ fn histogram_record_with_non_static_values(c: &mut Criterion, attribute_values: 
     });
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 criterion_group! {
     name = benches;
     config = Criterion::default()
@@ -152,7 +152,7 @@ criterion_group! {
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", not(feature = "bench_profiling")))]
 criterion_group! {
     name = benches;
     config = Criterion::default()

--- a/opentelemetry-sdk/benches/span.rs
+++ b/opentelemetry-sdk/benches/span.rs
@@ -28,7 +28,7 @@ use opentelemetry_sdk::{
     error::OTelSdkResult,
     trace::{self as sdktrace, SpanData, SpanExporter},
 };
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -159,7 +159,7 @@ fn trace_benchmark_group<F: Fn(&sdktrace::SdkTracer)>(c: &mut Criterion, name: &
     group.finish();
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 criterion_group! {
     name = benches;
     config = Criterion::default()
@@ -168,7 +168,8 @@ criterion_group! {
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
-#[cfg(target_os = "windows")]
+
+#[cfg(any(target_os = "windows", not(feature = "bench_profiling")))]
 criterion_group! {
     name = benches;
     config = Criterion::default()

--- a/opentelemetry-sdk/benches/span_builder.rs
+++ b/opentelemetry-sdk/benches/span_builder.rs
@@ -8,7 +8,7 @@ use opentelemetry_sdk::{
     trace as sdktrace,
     trace::{SpanData, SpanExporter},
 };
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -80,7 +80,7 @@ const MAP_KEYS: [&str; 64] = [
     "key.56", "key.57", "key.58", "key.59", "key.60", "key.61", "key.62", "key.63", "key.64",
 ];
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 criterion_group! {
     name = benches;
     config = Criterion::default()
@@ -89,7 +89,7 @@ criterion_group! {
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", not(feature = "bench_profiling")))]
 criterion_group! {
     name = benches;
     config = Criterion::default()

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -7,7 +7,7 @@ use opentelemetry_sdk::{
     error::OTelSdkResult,
     trace::{self as sdktrace, SpanData, SpanExporter},
 };
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -89,7 +89,7 @@ fn trace_benchmark_group<F: Fn(&sdktrace::SdkTracer)>(c: &mut Criterion, name: &
     group.finish();
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 criterion_group! {
     name = benches;
     config = Criterion::default()
@@ -98,7 +98,7 @@ criterion_group! {
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = criterion_benchmark
 }
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", not(feature = "bench_profiling")))]
 criterion_group! {
     name = benches;
     config = Criterion::default()

--- a/opentelemetry-sdk/benches/tracer_creation.rs
+++ b/opentelemetry-sdk/benches/tracer_creation.rs
@@ -1,12 +1,13 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::{
     global::{self, BoxedTracer},
     InstrumentationScope, KeyValue,
 };
 use opentelemetry_sdk::trace as sdktrace;
+use std::hint::black_box;
 use std::sync::OnceLock;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
 
 /*
@@ -83,7 +84,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)))
@@ -92,7 +93,7 @@ criterion_group! {
     targets = criterion_benchmark
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", not(feature = "bench_profiling")))]
 criterion_group! {
     name = benches;
     config = Criterion::default().warm_up_time(std::time::Duration::from_secs(1))

--- a/opentelemetry/benches/anyvalue.rs
+++ b/opentelemetry/benches/anyvalue.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::{logs::AnyValue, Value};
+use std::hint::black_box;
 
 // Run this benchmark with:
 // cargo bench --bench anyvalue

--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -14,8 +14,9 @@ RAM: 64.0 GB
 | CreateTupleKeyValueArray                         |     2.73 ns |
 */
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::{Key, KeyValue};
+use std::hint::black_box;
 use std::sync::Arc;
 
 // Run this benchmark with:

--- a/opentelemetry/benches/context_attach.rs
+++ b/opentelemetry/benches/context_attach.rs
@@ -1,17 +1,24 @@
 use criterion::{
-    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
-    Criterion,
+    criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId, Criterion,
 };
 use opentelemetry::{
-    trace::{SpanContext, TraceContextExt},
-    Context,
+    trace::{SpanContext, TraceContextExt, TraceState},
+    Context, SpanId, TraceFlags, TraceId,
 };
+use std::hint::black_box;
 
 // Run this benchmark with:
 // cargo bench --bench context_attach
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let span_context = Context::new().with_remote_span_context(SpanContext::empty_context());
+    let remote_context = SpanContext::new(
+        TraceId::from(47),
+        SpanId::from(11),
+        TraceFlags::SAMPLED,
+        true,
+        TraceState::NONE,
+    );
+    let span_context = Context::new().with_remote_span_context(remote_context);
     let contexts = vec![
         ("empty_cx", Context::new()),
         ("single_value_cx", Context::new().with_value(Value(4711))),

--- a/opentelemetry/benches/context_suppression.rs
+++ b/opentelemetry/benches/context_suppression.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::Context;
+use std::hint::black_box;
 
 // Run this benchmark with:
 // cargo bench --bench context_suppression

--- a/opentelemetry/benches/metrics.rs
+++ b/opentelemetry/benches/metrics.rs
@@ -13,8 +13,9 @@
     | AddWithDynamicAttributes_WithStringAllocation       | 77.338 ns   |
 */
 
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use opentelemetry::{global, metrics::Counter, KeyValue};
+use std::hint::black_box;
 
 // Run this benchmark with:
 // cargo bench --bench metrics


### PR DESCRIPTION
## Changes

Switches the `bench` profile to `line-tables-only`, the `criterion::blackbox` to `std::hint::blackbox` and makes the profiling of benchmarks optional behind a feature flag.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
