### PR TITLE
fix: Fix stack-overflow inducing infinite feedback loop when calling `tracing::event!` after `SdkLoggerProvider::shutdown`

### DIFF
--- a/opentelemetry-appender-tracing/tests/test_no_stack_overflow_after_shutdown.rs
+++ b/opentelemetry-appender-tracing/tests/test_no_stack_overflow_after_shutdown.rs
@@ -1,0 +1,20 @@
+use opentelemetry_appender_tracing::layer;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use tracing::info;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[test]
+fn test_no_stack_overflow_when_event_is_emitted_after_shutdown() {
+    let exporter = opentelemetry_stdout::LogExporter::default();
+    let provider: SdkLoggerProvider = SdkLoggerProvider::builder()
+        .with_batch_exporter(exporter)
+        .build();
+
+    let otel_layer = layer::OpenTelemetryTracingBridge::new(&provider);
+
+    tracing_subscriber::registry().with(otel_layer).init();
+
+    provider.shutdown().unwrap();
+
+    info!("Don't crash")
+}

--- a/opentelemetry-sdk/src/logs/logger.rs
+++ b/opentelemetry-sdk/src/logs/logger.rs
@@ -33,7 +33,7 @@ impl opentelemetry::logs::Logger for SdkLogger {
 
     /// Emit a `LogRecord`.
     fn emit(&self, mut record: Self::LogRecord) {
-        if Context::is_current_telemetry_suppressed() {
+        if Context::is_current_telemetry_suppressed() || self.provider.is_shutdown() {
             return;
         }
         let provider = &self.provider;

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -129,6 +129,10 @@ impl SdkLoggerProvider {
     pub fn shutdown(&self) -> OTelSdkResult {
         self.shutdown_with_timeout(Duration::from_secs(5))
     }
+
+    pub(crate) fn is_shutdown(&self) -> bool {
+        self.inner.is_shutdown.load(Ordering::SeqCst)
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Fixes #3161
Design discussion issue (if applicable) #

## Changes

When integrating the opentelemetry crate with the tracing_subscriber crate, calling tracing::event! and its derivates after the SdkLoggerProvider has been called leads to a stack overflow due to BatchLogProcessor::emit using otel_warn! when trying to report the mpsc::TrySendError:Disconnected error.

This PR prevents `otel_warn!` from being called when handling the `mpsc::TrySendError:Disconnected` error in `BatchLogProcessor::emit` if the name of the log record is the same as that emitted by the `otel_warn!` in the same branch.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
