### PR TITLE
fix: Use path+version dependencies for publishing to crates.io

### DIFF
--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -27,10 +27,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true }
-opentelemetry-http = { workspace = true, optional = true }
-opentelemetry-proto = { workspace = true }
+opentelemetry = { path = "../opentelemetry", version = "0.30.0", default-features = false }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", version = "0.30.0", default-features = false }
+opentelemetry-http = { path = "../opentelemetry-http", version = "0.30.0", optional = true, default-features = false }
+opentelemetry-proto = { path = "../opentelemetry-proto", version = "0.30.1", default-features = false }
 tracing = {workspace = true, optional = true}
 
 prost = { workspace = true, optional = true }
@@ -49,7 +49,7 @@ zstd = { version = "0.13", optional = true }
 
 [dev-dependencies]
 tokio-stream = { workspace = true, features = ["net"] }
-opentelemetry_sdk = { workspace = true, features = ["trace", "testing"] }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", version = "0.30.0", features = ["trace", "testing"], default-features = false }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 futures-util = { workspace = true }
 temp-env = { workspace = true }

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -55,8 +55,8 @@ with-serde = ["serde", "const-hex", "base64", "serde_json"]
 tonic = { workspace = true, optional = true, features = ["codegen"] }
 tonic-prost = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
-opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true }
+opentelemetry = { path = "../opentelemetry", version = "0.30.0", default-features = false }
+opentelemetry_sdk = { path = "../opentelemetry-sdk", version = "0.30.0", default-features = false }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["serde_derive", "std"] }
 serde_json = { workspace = true, optional = true }


### PR DESCRIPTION
Replace workspace dependencies with `path+version` format in `opentelemetry-proto` and `opentelemetry-otlp` Cargo.toml files. This allows cargo publish to work properly.

Note: opentelemetry-otlp publishing depends on opentelemetry-proto v0.30.1 being published first, following the dependency order.


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
