### PR TITLE
fix: Use path+version dependencies for publishing to crates.io otel-http 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ opentelemetry = { path = "opentelemetry", default-features = false }
 opentelemetry_sdk = { path = "opentelemetry-sdk", default-features = false }
 opentelemetry-appender-log = { path = "opentelemetry-appender-log", default-features = false }
 opentelemetry-appender-tracing = { path = "opentelemetry-appender-tracing", default-features = false }
-opentelemetry-http = { path = "opentelemetry-http", version = "0.30.1", default-features = false }
+opentelemetry-http = { path = "opentelemetry-http", default-features = false }
 opentelemetry-jaeger-propagator = { path = "opentelemetry-jaeger-propagator", default-features = false }
 opentelemetry-otlp = { path = "opentelemetry-otlp", default-features = false }
 opentelemetry-proto = { path = "opentelemetry-proto", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ opentelemetry = { path = "opentelemetry", default-features = false }
 opentelemetry_sdk = { path = "opentelemetry-sdk", default-features = false }
 opentelemetry-appender-log = { path = "opentelemetry-appender-log", default-features = false }
 opentelemetry-appender-tracing = { path = "opentelemetry-appender-tracing", default-features = false }
-opentelemetry-http = { path = "opentelemetry-http", default-features = false }
+opentelemetry-http = { path = "opentelemetry-http", version = "0.30.1", default-features = false }
 opentelemetry-jaeger-propagator = { path = "opentelemetry-jaeger-propagator", default-features = false }
 opentelemetry-otlp = { path = "opentelemetry-otlp", default-features = false }
 opentelemetry-proto = { path = "opentelemetry-proto", default-features = false }

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## vNext
+## 0.30.1
+
+Released 2025-Sep-16
 
 - Implementation of `Extractor::get_all` for `HeaderExtractor`
 - Support `HttpClient` implementation for `HyperClient<C>` with custom connectors beyond `HttpConnector`, enabling Unix Domain Socket connections and other custom transports

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-http"
-version = "0.30.0"
+version = "0.30.1"
 description = "Helper implementations for sending HTTP requests. Uses include propagating and extracting context over http, exporting telemetry, requesting sampling strategies."
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-http"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-http"

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ## 0.30.1
 
-Released 2025-Sep-11
+Released 2025-Sep-16
 
-- Update `opentelemetry-proto` dependency version to 0.30.1
+- Update `opentelemetry-proto` and `opentelemetry-http` dependency version to 0.30.1
 - Add HTTP compression support with `gzip-http` and `zstd-http` feature flags
 
 ## 0.30.0

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -29,7 +29,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 opentelemetry = { path = "../opentelemetry", version = "0.30.0", default-features = false }
 opentelemetry_sdk = { path = "../opentelemetry-sdk", version = "0.30.0", default-features = false }
-opentelemetry-http = { path = "../opentelemetry-http", version = "0.30.0", optional = true, default-features = false }
+opentelemetry-http = { path = "../opentelemetry-http", version = "0.30.1", optional = true, default-features = false }
 opentelemetry-proto = { path = "../opentelemetry-proto", version = "0.30.1", default-features = false }
 tracing = {workspace = true, optional = true}
 


### PR DESCRIPTION
## Changes

otel-otlp has dependency on new features added in otel-http. So we need to publish that too,

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
