### PR TITLE
fix: Suppress telemetry emitted inside of `BatchLogProcessor::emit`

### DIFF
--- a/opentelemetry-appender-tracing/tests/test_no_stack_overflow_after_shutdown.rs
+++ b/opentelemetry-appender-tracing/tests/test_no_stack_overflow_after_shutdown.rs
@@ -1,0 +1,23 @@
+use opentelemetry_appender_tracing::layer;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use tracing::info;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[test]
+fn test_logging_after_shutdown_does_not_cause_telemetry_induced_telemetry() {
+    //! Reproduces [#3161](https://github.com/open-telemetry/opentelemetry-rust/issues/3161)
+    let exporter = opentelemetry_stdout::LogExporter::default();
+    let provider: SdkLoggerProvider = SdkLoggerProvider::builder()
+        .with_batch_exporter(exporter)
+        .build();
+
+    let otel_layer = layer::OpenTelemetryTracingBridge::new(&provider);
+
+    tracing_subscriber::registry().with(otel_layer).init();
+
+    provider.shutdown().unwrap();
+
+    // If logging causes telemetry-induced-telemetry after shutting down the provider, then a stack
+    // overflow may occur.
+    info!("Don't crash")
+}

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -151,6 +151,8 @@ impl Debug for BatchLogProcessor {
 
 impl LogProcessor for BatchLogProcessor {
     fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+        let _guard = Context::enter_telemetry_suppressed_scope();
+
         let result = self
             .logs_sender
             .try_send(Box::new((record.clone(), instrumentation.clone())));


### PR DESCRIPTION
Fixes #3161
Design discussion issue (if applicable) #

## Changes
The `BatchLogProcessor` background thread itself runs with a telemetry suppressed context, however, `BatchLogProcessor::emit` does not use a telemetry suppressed context as it is executed in the caller's thread, as opposed to the suppressed background thread.

Using a telemetry suppressed context whilst calling `BatchLogProcessor::emit` fixes the issue where telemetry-induced-telemetry is generated whilst calling `emit` on a shutdown `BatchLogProcessor`, avoiding a stack overflow.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
