### PR TITLE
chore: upgrade tracing-opentelemetry to 0.32.0 and bump opentelemetry-appender-tracing to 0.31.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ num_cpus = "1.15.0"
 opentelemetry = { path = "opentelemetry", version = "0.31", default-features = false }
 opentelemetry_sdk = { path = "opentelemetry-sdk", version = "0.31", default-features = false }
 opentelemetry-appender-log = { path = "opentelemetry-appender-log", version = "0.31", default-features = false }
-opentelemetry-appender-tracing = { path = "opentelemetry-appender-tracing", version = "0.31", default-features = false }
+opentelemetry-appender-tracing = { path = "opentelemetry-appender-tracing", version = "0.31.1", default-features = false }
 opentelemetry-http = { path = "opentelemetry-http", version = "0.31", default-features = false }
 opentelemetry-jaeger-propagator = { path = "opentelemetry-jaeger-propagator", version = "0.31", default-features = false }
 opentelemetry-otlp = { path = "opentelemetry-otlp", version = "0.31", default-features = false }
@@ -81,7 +81,7 @@ sysinfo = "0.32"
 tempfile = "3.3.0"
 testcontainers = "0.23.1"
 tracing-log = "0.2"
-tracing-opentelemetry = "0.31"
+tracing-opentelemetry = "0.32"
 typed-builder = "0.20"
 uuid = "1.3"
 

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+## 0.31.1
+
+Released 2025-Oct-1
+
+- Bump `tracing-opentelemetry` to 0.32
+
 ## 0.31.0
 
 Released 2025-Sep-25

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-appender-tracing"
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 description = "An OpenTelemetry log appender for the tracing crate"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-tracing"
@@ -28,7 +28,7 @@ tracing = { workspace = true, features = ["std"]}
 tracing-subscriber = { workspace = true, features = ["env-filter","registry", "std", "fmt"] }
 tracing-log = { workspace = true }
 criterion = { workspace = true }
-tokio = { workspace = true, features = ["full"]}
+#tokio = { workspace = true, features = ["full"]}
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { version = "0.14", features = ["flamegraph", "criterion"] }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -688,7 +688,7 @@ mod tests {
         tracing::error_span!("outer-span").in_scope(|| {
             let span = tracing::Span::current();
             let parent_context = Context::current().with_remote_span_context(remote_span_context);
-            span.set_parent(parent_context);
+            let _ = span.set_parent(parent_context);
 
             error!("first-event");
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -250,7 +250,7 @@ where
             if let Some(otd) = span.extensions().get::<OtelData>() {
                 if let Some(span_id) = otd.span_id() {
                     // Try the trace_id of the current span first;
-                    // If it is not already established (still in the Builder state), try rooting the span.
+                    // If it is not already established (still in the Builder state), try finding the root span.
                     let opt_trace_id = otd.trace_id().or_else(|| {
                         span.scope().last().and_then(|root_span| {
                             root_span

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -244,7 +244,7 @@ where
         // Visit fields.
         event.record(&mut visitor);
 
-        /*#[cfg(feature = "experimental_use_tracing_span_context")]
+        #[cfg(feature = "experimental_use_tracing_span_context")]
         if let Some(span) = _ctx.event_span(event) {
             use opentelemetry::trace::TraceContextExt;
             use tracing_opentelemetry::OtelData;
@@ -265,7 +265,7 @@ where
                     }
                 }
             }
-        }*/
+        }
 
         //emit record
         self.logger.emit(log_record);
@@ -611,7 +611,7 @@ mod tests {
         }
     }
 
-    /*#[cfg(feature = "experimental_use_tracing_span_context")]
+    #[cfg(feature = "experimental_use_tracing_span_context")]
     #[test]
     fn tracing_appender_inside_tracing_crate_context() {
         use opentelemetry::{trace::SpanContext, Context, SpanId, TraceId};
@@ -722,7 +722,6 @@ mod tests {
         assert_eq!(trace_ctx0.span_id, outer_span_id);
         assert_eq!(trace_ctx1.span_id, inner_span_id);
     }
-    */
 
     #[test]
     fn tracing_appender_standalone_with_tracing_log() {

--- a/opentelemetry-appender-tracing/src/lib.rs
+++ b/opentelemetry-appender-tracing/src/lib.rs
@@ -30,9 +30,9 @@
 //! tracing = ">=0.1.40"
 //! tracing-core = { version = ">=0.1.33" }
 //! tracing-subscriber = { version = "0.3", features = ["registry", "std", "fmt"] }
-//! opentelemetry = { version = "0.28", features = ["logs"] }
-//! opentelemetry-sdk = { version = "0.28", features = ["logs"] }
-//! opentelemetry-appender-tracing = { version = "0.28.1" }
+//! opentelemetry = { version = "0.31", features = ["logs"] }
+//! opentelemetry-sdk = { version = "0.31", features = ["logs"] }
+//! opentelemetry-appender-tracing = { version = "0.31.1" }
 //! ```
 //!
 //! ### 2. Set Up the OpenTelemetry Logger Provider


### PR DESCRIPTION
chore: upgrade tracing-opentelemetry to 0.32.0 and bump opentelemetry-appender-tracing to 0.31.1

- Update tracing-opentelemetry dependency from 0.31 to 0.32
- Bump opentelemetry-appender-tracing crate version to 0.31.1
- Adjust related dependencies and features for compatibility

cc @cijothomas 

Fixes #
Design discussion issue (if applicable) #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
