### PR TITLE
fix: add timestame for log appender

### DIFF
--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -151,6 +151,7 @@ where
             log_record.set_severity_number(severity_of_level(record.level()));
             log_record.set_severity_text(record.level().as_str());
             log_record.set_body(AnyValue::from(record.args().to_string()));
+            log_record.set_timestamp(SystemTime::now());
 
             #[cfg(feature = "experimental_metadata_attributes")]
             {


### PR DESCRIPTION
Fixes #
The collector cannot display the log correctly because there is no timestamp in the record.

## Changes

Add a timestamp to the record

## Merge requirement checklist

* [x ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
