### PR TITLE
fix: retry_classification tests

### DIFF
--- a/opentelemetry-otlp/src/retry_classification.rs
+++ b/opentelemetry-otlp/src/retry_classification.rs
@@ -163,13 +163,12 @@ pub mod grpc {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::time::Duration;
-
     // Tests for HTTP error classification
+    #[cfg(feature = "experimental-http-retry")]
     mod http_tests {
-        use super::*;
+        use crate::retry::RetryErrorType;
         use crate::retry_classification::http::*;
+        use std::time::Duration;
 
         #[test]
         fn test_http_429_with_retry_after_seconds() {


### PR DESCRIPTION
Small fix to allow `cargo test --all` to execute without immediately erroring.

## Changes

- Add #[cfg(feature = "experimental-http-retry")] gate to http_tests module
- Replace wildcard imports with explicit imports in test modules
- Remove unused imports from parent tests module
- Move Duration import into http_tests submodule scope

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
