### PR TITLE
chore(opentelemetry-otlp): Make invalid combinations of transport & encoding unrepresentable

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -4,6 +4,28 @@
 
 - Add partial success response handling for OTLP exporters (traces, metrics, logs) per OTLP spec. Exporters now log warnings when the server returns partial success responses with rejected items and error messages. [#865](https://github.com/open-telemetry/opentelemetry-rust/issues/865)
 - Refactor `internal-logs` feature in `opentelemetry-otlp` to reduce unnecessary dependencies[3191](https://github.com/open-telemetry/opentelemetry-rust/pull/3192)
+- **Breaking** Make invalid protocol/transport combinations unrepresentable [#3082](https://github.com/open-telemetry/opentelemetry-rust/issues/3082)
+  - Removed `protocol` field from `ExportConfig` and `with_protocol()` method from `WithExportConfig` trait
+  - Added new HTTP-specific `Protocol` enum with `HttpProtobuf` and `HttpJson` variants
+  - Added `with_protocol()` method to `WithHttpConfig` trait that accepts the HTTP-specific `Protocol` enum
+  - The `Protocol` enum is now only available and only needed when using HTTP transport
+  - This change makes invalid protocol/transport combinations (like using HTTP protocol with gRPC transport) impossible to express
+  - Migration example:
+    ```rust
+    // Before:
+    SpanExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)  // old Protocol from ExportConfig
+        .build()
+
+    // After:
+    use opentelemetry_otlp::Protocol; 
+
+    SpanExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpProtobuf)  // HTTP-specific Protocol enum
+        .build()
+    ```
 
 ## 0.31.0
 

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -4,8 +4,8 @@ use opentelemetry::{
     InstrumentationScope, KeyValue,
 };
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
-use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_otlp::{LogExporter, MetricExporter, Protocol, SpanExporter};
+use opentelemetry_otlp::{LogExporter, MetricExporter, SpanExporter};
+use opentelemetry_otlp::{Protocol, WithHttpConfig};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::{
     logs::SdkLoggerProvider, metrics::SdkMeterProvider, trace::SdkTracerProvider,
@@ -29,7 +29,7 @@ fn get_resource() -> Resource {
 fn init_logs() -> SdkLoggerProvider {
     let exporter = LogExporter::builder()
         .with_http()
-        .with_protocol(Protocol::HttpBinary)
+        .with_protocol(Protocol::HttpProtobuf)
         .build()
         .expect("Failed to create log exporter");
 
@@ -42,7 +42,7 @@ fn init_logs() -> SdkLoggerProvider {
 fn init_traces() -> SdkTracerProvider {
     let exporter = SpanExporter::builder()
         .with_http()
-        .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
+        .with_protocol(Protocol::HttpProtobuf)
         .build()
         .expect("Failed to create trace exporter");
 
@@ -55,7 +55,7 @@ fn init_traces() -> SdkTracerProvider {
 fn init_metrics() -> SdkMeterProvider {
     let exporter = MetricExporter::builder()
         .with_http()
-        .with_protocol(Protocol::HttpBinary) //can be changed to `Protocol::HttpJson` to export in JSON format
+        .with_protocol(Protocol::HttpProtobuf)
         .build()
         .expect("Failed to create metric exporter");
 

--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -1,11 +1,10 @@
 use crate::metric::MetricsClient;
-use crate::Protocol;
 use opentelemetry::{otel_debug, otel_warn};
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
 use opentelemetry_sdk::metrics::data::ResourceMetrics;
 use prost::Message;
 
-use super::OtlpHttpClient;
+use super::{OtlpHttpClient, Protocol};
 
 impl MetricsClient for OtlpHttpClient {
     async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
@@ -47,7 +46,15 @@ fn handle_partial_success(response_body: &[u8], protocol: Protocol) {
                 return;
             }
         },
-        _ => match Message::decode(response_body) {
+        Protocol::HttpProtobuf => match Message::decode(response_body) {
+            Ok(r) => r,
+            Err(e) => {
+                otel_debug!(name: "HttpMetricsClient.ResponseParseError", error = e.to_string());
+                return;
+            }
+        },
+        #[cfg(not(feature = "http-json"))]
+        Protocol::HttpJson => match Message::decode(response_body) {
             Ok(r) => r,
             Err(e) => {
                 otel_debug!(name: "HttpMetricsClient.ResponseParseError", error = e.to_string());
@@ -77,7 +84,7 @@ mod tests {
         let invalid = vec![0xFF, 0xFF, 0xFF, 0xFF];
 
         // Should not panic - logs debug and returns early
-        handle_partial_success(&invalid, Protocol::HttpBinary);
+        handle_partial_success(&invalid, Protocol::HttpProtobuf);
     }
 
     #[test]
@@ -85,7 +92,7 @@ mod tests {
         let empty = vec![];
 
         // Should not panic
-        handle_partial_success(&empty, Protocol::HttpBinary);
+        handle_partial_success(&empty, Protocol::HttpProtobuf);
     }
 
     #[cfg(feature = "http-json")]

--- a/opentelemetry-otlp/src/exporter/http/trace.rs
+++ b/opentelemetry-otlp/src/exporter/http/trace.rs
@@ -1,5 +1,4 @@
-use super::OtlpHttpClient;
-use crate::Protocol;
+use super::{OtlpHttpClient, Protocol};
 use opentelemetry::{otel_debug, otel_warn};
 use opentelemetry_sdk::{
     error::{OTelSdkError, OTelSdkResult},
@@ -52,7 +51,15 @@ fn handle_partial_success(response_body: &[u8], protocol: Protocol) {
                 return;
             }
         },
-        _ => match Message::decode(response_body) {
+        Protocol::HttpProtobuf => match Message::decode(response_body) {
+            Ok(r) => r,
+            Err(e) => {
+                otel_debug!(name: "HttpTraceClient.ResponseParseError", error = e.to_string());
+                return;
+            }
+        },
+        #[cfg(not(feature = "http-json"))]
+        Protocol::HttpJson => match Message::decode(response_body) {
             Ok(r) => r,
             Err(e) => {
                 otel_debug!(name: "HttpTraceClient.ResponseParseError", error = e.to_string());
@@ -82,7 +89,7 @@ mod tests {
         let invalid = vec![0xFF, 0xFF, 0xFF, 0xFF];
 
         // Should not panic - logs debug and returns early
-        handle_partial_success(&invalid, Protocol::HttpBinary);
+        handle_partial_success(&invalid, Protocol::HttpProtobuf);
     }
 
     #[test]
@@ -90,7 +97,7 @@ mod tests {
         let empty = vec![];
 
         // Should not panic
-        handle_partial_success(&empty, Protocol::HttpBinary);
+        handle_partial_success(&empty, Protocol::HttpProtobuf);
     }
 
     #[cfg(feature = "http-json")]

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -156,10 +156,7 @@ impl Default for TonicExporterBuilder {
                 #[cfg(feature = "experimental-grpc-retry")]
                 retry_policy: None,
             },
-            exporter_config: ExportConfig {
-                protocol: crate::Protocol::Grpc,
-                ..Default::default()
-            },
+            exporter_config: ExportConfig::default(),
         }
     }
 }

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -28,14 +28,13 @@
 //! # {
 //! use opentelemetry::global;
 //! use opentelemetry::trace::Tracer;
-//! use opentelemetry_otlp::Protocol;
-//! use opentelemetry_otlp::WithExportConfig;
+//! use opentelemetry_otlp::{Protocol, WithExportConfig, WithHttpConfig};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-//!     // Initialize OTLP exporter using HTTP binary protocol
+//!     // Initialize OTLP exporter with protobuf encoding and HTTP transport
 //!     let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
 //!         .with_http()
-//!         .with_protocol(Protocol::HttpBinary)
+//!         .with_protocol(Protocol::HttpProtobuf)
 //!         .build()?;
 //!
 //!     // Create a tracer provider with the exporter
@@ -167,14 +166,13 @@
 //! use opentelemetry::global;
 //! use opentelemetry::metrics::Meter;
 //! use opentelemetry::KeyValue;
-//! use opentelemetry_otlp::Protocol;
-//! use opentelemetry_otlp::WithExportConfig;
+//! use opentelemetry_otlp::{Protocol, WithExportConfig, WithHttpConfig};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-//!     // Initialize OTLP exporter using HTTP binary protocol
+//!     // Initialize OTLP exporter with protobuf encoding and HTTP transport
 //!     let exporter = opentelemetry_otlp::MetricExporter::builder()
 //!         .with_http()
-//!         .with_protocol(Protocol::HttpBinary)
+//!         .with_protocol(Protocol::HttpProtobuf)
 //!         .with_endpoint("http://localhost:9090/api/v1/otlp/v1/metrics")
 //!         .build()?;
 //!
@@ -249,11 +247,11 @@
 //! use opentelemetry_sdk::{trace::{self, RandomIdGenerator, Sampler}, Resource};
 //! # #[cfg(feature = "metrics")]
 //! use opentelemetry_sdk::metrics::Temporality;
-//! use opentelemetry_otlp::{Protocol, WithExportConfig, Compression};
+//! use opentelemetry_otlp::{WithExportConfig, Compression};
 //! # #[cfg(feature = "grpc-tonic")]
 //! use opentelemetry_otlp::WithTonicConfig;
 //! # #[cfg(any(feature = "http-proto", feature = "http-json"))]
-//! use opentelemetry_otlp::WithHttpConfig;
+//! use opentelemetry_otlp::{Protocol, WithHttpConfig};
 //! use std::time::Duration;
 //! # #[cfg(feature = "grpc-tonic")]
 //! use tonic::metadata::*;
@@ -293,7 +291,7 @@
 //!         .with_http()
 //!         .with_endpoint("http://localhost:4318/v1/traces")
 //!         .with_timeout(Duration::from_secs(3))
-//!         .with_protocol(Protocol::HttpBinary)
+//!         .with_protocol(Protocol::HttpProtobuf)
 //!         .with_compression(Compression::Gzip)  // Requires gzip-http feature
 //!         .build()?;
 //!         # exporter
@@ -304,7 +302,6 @@
 //!     let exporter = opentelemetry_otlp::MetricExporter::builder()
 //!        .with_tonic()
 //!        .with_endpoint("http://localhost:4318/v1/metrics")
-//!        .with_protocol(Protocol::Grpc)
 //!        .with_timeout(Duration::from_secs(3))
 //!        .build()
 //!        .unwrap();
@@ -321,7 +318,7 @@
 //!     let exporter = opentelemetry_otlp::MetricExporter::builder()
 //!        .with_http()
 //!        .with_endpoint("http://localhost:4318/v1/metrics")
-//!        .with_protocol(Protocol::HttpBinary)
+//!        .with_protocol(Protocol::HttpProtobuf)
 //!        .with_timeout(Duration::from_secs(3))
 //!        .with_compression(Compression::Zstd)  // Requires zstd-http feature
 //!        .build()
@@ -401,7 +398,7 @@ pub use crate::logs::{
 };
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
-pub use crate::exporter::http::{HasHttpConfig, WithHttpConfig};
+pub use crate::exporter::http::{HasHttpConfig, Protocol, WithHttpConfig};
 
 #[cfg(feature = "grpc-tonic")]
 pub use crate::exporter::tonic::{HasTonicConfig, WithTonicConfig};
@@ -441,21 +438,6 @@ pub use crate::exporter::http::HttpExporterBuilder;
 
 #[cfg(feature = "grpc-tonic")]
 pub use crate::exporter::tonic::{TonicConfig, TonicExporterBuilder};
-
-#[cfg(feature = "serialize")]
-use serde::{Deserialize, Serialize};
-
-/// The communication protocol to use when exporting data.
-#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Protocol {
-    /// GRPC protocol
-    Grpc,
-    /// HTTP protocol with binary protobuf
-    HttpBinary,
-    /// HTTP protocol with JSON payload
-    HttpJson,
-}
 
 #[derive(Debug, Default)]
 #[doc(hidden)]


### PR DESCRIPTION
# Really A Draft: Trying a different approach; please hold off on reviews!

Fixes #3082 
This PR removes the ability to specify invalid combinations of transport (HTTP/gRPC) and encoding (JSON/Protobuf) by making the invalid combinations unrepresentable. 

For completeness, I [staged a separate branch](https://github.com/open-telemetry/opentelemetry-rust/compare/main...scottgerring:opentelemetry-rust:chore/protocol-cleanup-1?expand=1) that simply errors out when a user specifies an invalid combination. This has less impact on the API surface and is a smaller change, but doesn't _prevent_ the user from specifying the invalid combinations. I prefer this variant here where we use the type system! 

## Changes

We do this by:

* Removing `with_protocol` from the `WithExportConfig`  shared between both gRPC and HTTP exporters
* Introducing `HttpEncodingProtocol`, and supporting methods on `WithHttpConfig` to configure JSON or Protobuf encoding

I wanted to draw a clear line between 'protocol' and 'encoding' as this feels like where the confusion has crept in, but [the spec itself](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specify-protocol) uses the term protocol to refer to both application layer protocol and body encoding.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
