### PR TITLE
feat: Add description getter to `metrics::Instrument` in SDK

### DIFF
--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -32,12 +32,10 @@ pub enum InstrumentKind {
     /// A group of instruments that record increasing and decreasing values in an
     /// asynchronous callback.
     ObservableUpDownCounter,
-
-    /// a group of instruments that record current value synchronously with
+    /// A group of instruments that record current value synchronously with
     /// the code path they are measuring.
     Gauge,
-    ///
-    /// a group of instruments that record current values in an asynchronous callback.
+    /// A group of instruments that record current values in an asynchronous callback.
     ObservableGauge,
 }
 
@@ -97,33 +95,38 @@ impl InstrumentKind {
 pub struct Instrument {
     /// The human-readable identifier of the instrument.
     pub(crate) name: Cow<'static, str>,
-    /// describes the purpose of the instrument.
+    /// Describes the purpose of the instrument.
     pub(crate) description: Cow<'static, str>,
     /// The functional group of the instrument.
     pub(crate) kind: InstrumentKind,
-    /// Unit is the unit of measurement recorded by the instrument.
+    /// The unit of measurement recorded by the instrument.
     pub(crate) unit: Cow<'static, str>,
-    /// The instrumentation that created the instrument.
+    /// Information about the library that created the instrument.
     pub(crate) scope: InstrumentationScope,
 }
 
 impl Instrument {
-    /// Instrument name.
+    /// The human-readable identifier of the instrument.
     pub fn name(&self) -> &str {
         self.name.as_ref()
     }
 
-    /// Instrument kind.
+    /// Describes the purpose of the instrument.
+    pub fn descripton(&self) -> &str {
+        self.description.as_ref()
+    }
+
+    /// The functional group of the instrument.
     pub fn kind(&self) -> InstrumentKind {
         self.kind
     }
 
-    /// Instrument unit.
+    /// The unit of measurement recorded by the instrument.
     pub fn unit(&self) -> &str {
         self.unit.as_ref()
     }
 
-    /// Instrument scope.
+    /// Information about the library that created the instrument.
     pub fn scope(&self) -> &InstrumentationScope {
         &self.scope
     }

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -112,7 +112,7 @@ impl Instrument {
     }
 
     /// Describes the purpose of the instrument.
-    pub fn descripton(&self) -> &str {
+    pub fn description(&self) -> &str {
         self.description.as_ref()
     }
 


### PR DESCRIPTION
Note: This change is in conflict with <https://github.com/open-telemetry/opentelemetry-rust/issues/2985> by @cijothomas:

> Instrument currently allows users to select an instrument based on description, which is not allowed in the spec. Only name, kind, unit, scope should be exposed.

The spec at <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-selection-criteria> says:

> The SDK MAY accept additional criteria.

So it seems like the description MAY be exposed.

---

I could imagine accessing the description in a View for valid reasons, like wanting to append a "." (or remove a ".") from the end of the descriptions. I admit my motivation for doing this PR is part of a larger hack, however. I want my application to be able to list all of its metrics with descriptions, even for metrics that have been registered but not used. I think the only way I can get access to those currently is with a View, but I know that's not its intended use.

---

## Changes

- Adds a getter for the description field of `metrics::Instrument` in the SDK.
- Updates docs based on the field definitions, which seem more descriptive, and cleans up some others.
- Does this need a `CHANGELOG.md` entry?

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)

