### PR TITLE
chore: replace `cargo-machete` with `cargo-shear`, removed unused deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         toolchain: stable
         components: rustfmt, clippy
-    - uses: taiki-e/install-action@47be02f2de8a32619316956f6117e150bdc6763f # v2.62.44
+    - uses: taiki-e/install-action@6f9c7cc51aa54b13cbcbd12f8bbf69d8ba405b4b # v2.62.47
       with:
           tool: cargo-hack
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -93,7 +93,7 @@ jobs:
           # https://github.com/awslabs/cargo-check-external-types/releases
           toolchain: nightly-2025-05-04
           components: rustfmt
-      - uses: taiki-e/install-action@47be02f2de8a32619316956f6117e150bdc6763f # v2.62.44
+      - uses: taiki-e/install-action@6f9c7cc51aa54b13cbcbd12f8bbf69d8ba405b4b # v2.62.47
         with:
           tool: cargo-check-external-types@0.2.0
       - name: external-type-check
@@ -117,7 +117,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           toolchain: stable
-      - uses: taiki-e/install-action@47be02f2de8a32619316956f6117e150bdc6763f # v2.62.44
+      - uses: taiki-e/install-action@6f9c7cc51aa54b13cbcbd12f8bbf69d8ba405b4b # v2.62.47
         with:
           tool: cargo-msrv
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -150,7 +150,7 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
         with:
           command: check bans
-      
+
       - name: Check sources
         uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
         with:
@@ -199,7 +199,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@47be02f2de8a32619316956f6117e150bdc6763f # v2.62.44
+        uses: taiki-e/install-action@6f9c7cc51aa54b13cbcbd12f8bbf69d8ba405b4b # v2.62.47
         with:
           tool: cargo-llvm-cov
       - name: cargo generate-lockfile
@@ -232,7 +232,7 @@ jobs:
               cargo build
             fi
           done
-  cargo-machete:
+  cargo-shear:
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
@@ -246,9 +246,12 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
-          toolchain: stable
-      - uses: taiki-e/install-action@47be02f2de8a32619316956f6117e150bdc6763f # v2.62.44
+          toolchain: nightly
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
-          tool: cargo-machete
-      - name: cargo machete
-        run: cargo machete
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: taiki-e/install-action@6f9c7cc51aa54b13cbcbd12f8bbf69d8ba405b4b # v2.62.47
+        with:
+          tool: cargo-shear
+      - name: cargo shear
+        run: cargo shear --expand

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,6 @@ log = "0.4.21"
 once_cell = "1.13"
 pin-project-lite = "0.2"
 prost = "0.14"
-prost-build = "0.14"
-prost-types = "0.14"
 rand = { version = "0.9", default-features = false }
 reqwest = { version = "0.12", default-features = false }
 serde = { version = "1.0", default-features = false }
@@ -100,3 +98,10 @@ tail_expr_drop_order = "allow"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = 1 }
+
+[workspace.metadata.cargo-shear]
+ignored = [
+    # workspace crates
+    "opentelemetry-appender-log",
+    "opentelemetry-jaeger-propagator",
+]

--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -28,9 +28,3 @@ tonic-prost = { workspace = true }
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }
-
-[package.metadata.cargo-machete]
-ignored = [
-    "prost", # needed for `tonic-prost-build`
-    "tonic-prost" # needed for `tonic-prost-build`
-]

--- a/opentelemetry-otlp/tests/integration_test/Cargo.toml
+++ b/opentelemetry-otlp/tests/integration_test/Cargo.toml
@@ -23,7 +23,6 @@ tracing = {workspace = true}
 [target.'cfg(unix)'.dependencies]
 opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-tracing", default-features = false}
 opentelemetry-otlp = { path = "../../../opentelemetry-otlp", default-features = false }
-opentelemetry-semantic-conventions = { path = "../../../opentelemetry-semantic-conventions" }
 
 [features]
 hyper-client = ["opentelemetry-otlp/hyper-client", "opentelemetry-otlp/http-proto", "opentelemetry-otlp/trace", "opentelemetry-otlp/logs", "opentelemetry-otlp/metrics", "internal-logs"]

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -37,8 +37,3 @@ tokio = { version = "1", features = ["full"] }
 default = ["internal-logs"]
 prometheus-encoding = []
 internal-logs = ["tracing"]
-
-[package.metadata.cargo-machete]
-ignored = [
-    "tracing" # needed for `internal-logs`
-]

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -66,7 +66,6 @@ base64 = { workspace = true, optional = true }
 [dev-dependencies]
 opentelemetry = { workspace = true, features = ["testing"] }
 tonic-prost-build = { workspace = true }
-prost-build = { workspace = true }
 tempfile = { workspace = true }
 serde_json = { workspace = true }
 

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -46,7 +46,6 @@ opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["spec_unstable_
 criterion = { workspace = true }
 rand = { workspace = true, features = ["os_rng", "thread_rng"] }
 tokio = { version = "1.0", features = ["full"] }
-futures = "0.3"
 
 [[bench]]
 name = "metrics"


### PR DESCRIPTION
## Changes

Replaced `cargo-machete` with [`cargo-shear`](https://github.com/boshen/cargo-shear) for detecting unused dependencies.

`cargo-shear` uses syn to parse Rust code to find unused deps, rather than relying on regex like `cargo-machete`. It also has some additional features, like parsing doc blocks for imports, and running against expanded code (requiring nightly). Tends to give fewer false positives as a result. It is slower to run, though.

Had to bump `taiki-e/install-action` in order to get a newer version of `cargo-shear`, which has a needed fix around doc block parsing.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)