### PR TITLE
feat: Redesigns the `InMemoryMetricExporter`

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added `Resource::get_ref(&self, key: &Key) -> Option<&Value>` to allow retrieving a reference to a resource value without cloning.
 - **Breaking** Removed the following public hidden methods from the `SdkTracer` [#3227][3227]:
   - `id_generator`, `should_sample`
+- **Breaking** Removed `Default` and `Clone` implementation from `InMemoryMetricExporter`.
+- **Breaking** `InMemoryMetricExporterBuilder` requires mandatory `metrics` field to be set via
+  `.with_metrics` method.
 
 [3227]: https://github.com/open-telemetry/opentelemetry-rust/pull/3227
 

--- a/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
@@ -114,7 +114,10 @@ impl Default for InMemoryMetricExporterBuilder {
 impl InMemoryMetricExporterBuilder {
     /// Creates a new instance of the `InMemoryMetricExporterBuilder`.
     pub fn new() -> Self {
-        Self { temporality: None, metrics: None }
+        Self {
+            temporality: None,
+            metrics: None,
+        }
     }
 
     /// Set the [Temporality] of the exporter.

--- a/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
@@ -16,7 +16,7 @@ type InMemoryMetrics = Vec<ResourceMetrics>;
 /// An in-memory metrics exporter that stores metrics data in memory.
 ///
 /// This exporter is useful for testing and debugging purposes. It stores
-/// metric data in a user-provided `Vec<ResourceMetrics>`, from which the 
+/// metric data in a user-provided `Vec<ResourceMetrics>`, from which the
 /// exported data can be retrieved as well.
 ///
 /// # Panics

--- a/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
@@ -28,6 +28,7 @@ type InMemoryMetrics = Vec<ResourceMetrics>;
 /// # Example
 ///
 /// ```
+///# use std::sync::{Arc, Mutex};
 ///# use opentelemetry_sdk::metrics;
 ///# use opentelemetry::{KeyValue};
 ///# use opentelemetry::metrics::MeterProvider;
@@ -36,15 +37,15 @@ type InMemoryMetrics = Vec<ResourceMetrics>;
 ///
 ///# #[tokio::main]
 ///# async fn main() {
-/// // Create an InMemoryMetricExporter
-///  let exporter = InMemoryMetricExporter::builder();
+///  // Create an InMemoryMetricExporter
 ///  let metrics = Arc::new(Mutex::new(Vec::new()));
-///  let exporter = InMemoryMetricExporterBuilder::new()
-///                .with_metrics(metrics.clone()).build();
+///  let exporter = InMemoryMetricExporter::builder()
+///      .with_metrics(metrics.clone())
+///      .build();
 ///
 ///  // Create a MeterProvider and register the exporter
 ///  let meter_provider = metrics::SdkMeterProvider::builder()
-///      .with_reader(PeriodicReader::builder(exporter.clone()).build())
+///      .with_reader(PeriodicReader::builder(exporter).build())
 ///      .build();
 ///
 ///  // Create and record metrics using the MeterProvider
@@ -54,11 +55,8 @@ type InMemoryMetrics = Vec<ResourceMetrics>;
 ///
 ///  meter_provider.force_flush().unwrap();
 ///
-///  // Retrieve the finished metrics from the exporter
-///  let finished_metrics = exporter.get_finished_metrics().unwrap();
-///
 ///  // Print the finished metrics
-/// for resource_metrics in finished_metrics {
+///  for resource_metrics in metrics.lock().unwrap().iter() {
 ///      println!("{:?}", resource_metrics);
 ///  }
 ///# }
@@ -87,12 +85,12 @@ impl fmt::Debug for InMemoryMetricExporter {
 /// # Example
 ///
 /// ```
-/// use opentelemetry_sdk::metrics::{InMemoryMetricExporter, InMemoryMetricExporterBuilder};
-/// use std::sync::{Arc, Mutex};
+///# use opentelemetry_sdk::metrics::{InMemoryMetricExporter, InMemoryMetricExporterBuilder};
+///# use std::sync::{Arc, Mutex};
 ///
 /// let metrics = Arc::new(Mutex::new(Vec::new()));
 /// let exporter = InMemoryMetricExporterBuilder::new()
-///                .with_metrics(metrics.clone()).build();
+///                 .with_metrics(metrics.clone()).build();
 /// ```
 pub struct InMemoryMetricExporterBuilder {
     temporality: Option<Temporality>,
@@ -149,6 +147,7 @@ impl InMemoryMetricExporter {
     ///
     /// ```
     /// use opentelemetry_sdk::metrics::InMemoryMetricExporter;
+    /// use std::sync::{Arc, Mutex};
     ///
     /// let metrics = Arc::new(Mutex::new(Vec::new()));
     /// let exporter = InMemoryMetricExporter::builder()

--- a/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
@@ -16,8 +16,8 @@ type InMemoryMetrics = Vec<ResourceMetrics>;
 /// An in-memory metrics exporter that stores metrics data in memory.
 ///
 /// This exporter is useful for testing and debugging purposes. It stores
-/// metric data in a user-provided [`Vec<ResourceMetrics>`][1], from which the
-/// Metrics can be retrieved as well.
+/// metric data in a user-provided `Vec<ResourceMetrics>`, from which the 
+/// exported data can be retrieved as well.
 ///
 /// # Panics
 ///
@@ -61,8 +61,6 @@ type InMemoryMetrics = Vec<ResourceMetrics>;
 ///  }
 ///# }
 /// ```
-///
-/// [1]: InMemoryMetrics
 pub struct InMemoryMetricExporter {
     metrics: Arc<Mutex<InMemoryMetrics>>,
     temporality: Temporality,

--- a/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/metrics/in_memory_exporter.rs
@@ -4,19 +4,20 @@ use crate::metrics::data::{
 };
 use crate::metrics::exporter::PushMetricExporter;
 use crate::metrics::Temporality;
-use crate::InMemoryExporterError;
-use std::collections::VecDeque;
 use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use super::data::{AggregatedMetrics, Metric, ScopeMetrics};
 
+// Not a user-facing type, just a type alias for clarity within this module.
+type InMemoryMetrics = Vec<ResourceMetrics>;
+
 /// An in-memory metrics exporter that stores metrics data in memory.
 ///
 /// This exporter is useful for testing and debugging purposes. It stores
-/// metric data in a `VecDeque<ResourceMetrics>`. Metrics can be retrieved
-/// using the `get_finished_metrics` method.
+/// metric data in a user-provided [`Vec<ResourceMetrics>`][1], from which the
+/// Metrics can be retrieved as well.
 ///
 /// # Panics
 ///
@@ -36,7 +37,10 @@ use super::data::{AggregatedMetrics, Metric, ScopeMetrics};
 ///# #[tokio::main]
 ///# async fn main() {
 /// // Create an InMemoryMetricExporter
-///  let exporter = InMemoryMetricExporter::default();
+///  let exporter = InMemoryMetricExporter::builder();
+///  let metrics = Arc::new(Mutex::new(Vec::new()));
+///  let exporter = InMemoryMetricExporterBuilder::new()
+///                .with_metrics(metrics.clone()).build();
 ///
 ///  // Create a MeterProvider and register the exporter
 ///  let meter_provider = metrics::SdkMeterProvider::builder()
@@ -59,17 +63,17 @@ use super::data::{AggregatedMetrics, Metric, ScopeMetrics};
 ///  }
 ///# }
 /// ```
+///
+/// [1]: InMemoryMetrics
 pub struct InMemoryMetricExporter {
-    metrics: Arc<Mutex<VecDeque<ResourceMetrics>>>,
+    metrics: Arc<Mutex<InMemoryMetrics>>,
     temporality: Temporality,
 }
 
-impl Clone for InMemoryMetricExporter {
-    fn clone(&self) -> Self {
-        InMemoryMetricExporter {
-            metrics: self.metrics.clone(),
-            temporality: self.temporality,
-        }
+impl InMemoryMetricExporter {
+    /// Creates a new instance of the [`InMemoryMetricExporterBuilder`].
+    pub fn builder() -> InMemoryMetricExporterBuilder {
+        InMemoryMetricExporterBuilder::new()
     }
 }
 
@@ -79,22 +83,20 @@ impl fmt::Debug for InMemoryMetricExporter {
     }
 }
 
-impl Default for InMemoryMetricExporter {
-    fn default() -> Self {
-        InMemoryMetricExporterBuilder::new().build()
-    }
-}
-
 /// Builder for [`InMemoryMetricExporter`].
 /// # Example
 ///
 /// ```
-/// # use opentelemetry_sdk::metrics::{InMemoryMetricExporter, InMemoryMetricExporterBuilder};
+/// use opentelemetry_sdk::metrics::{InMemoryMetricExporter, InMemoryMetricExporterBuilder};
+/// use std::sync::{Arc, Mutex};
 ///
-/// let exporter = InMemoryMetricExporterBuilder::new().build();
+/// let metrics = Arc::new(Mutex::new(Vec::new()));
+/// let exporter = InMemoryMetricExporterBuilder::new()
+///                .with_metrics(metrics.clone()).build();
 /// ```
 pub struct InMemoryMetricExporterBuilder {
     temporality: Option<Temporality>,
+    metrics: Option<Arc<Mutex<InMemoryMetrics>>>,
 }
 
 impl fmt::Debug for InMemoryMetricExporterBuilder {
@@ -112,7 +114,7 @@ impl Default for InMemoryMetricExporterBuilder {
 impl InMemoryMetricExporterBuilder {
     /// Creates a new instance of the `InMemoryMetricExporterBuilder`.
     pub fn new() -> Self {
-        Self { temporality: None }
+        Self { temporality: None, metrics: None }
     }
 
     /// Set the [Temporality] of the exporter.
@@ -121,48 +123,33 @@ impl InMemoryMetricExporterBuilder {
         self
     }
 
+    /// Set the internal collection to store the metrics.
+    pub fn with_metrics(mut self, metrics: Arc<Mutex<InMemoryMetrics>>) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
     /// Creates a new instance of the `InMemoryMetricExporter`.
     ///
     pub fn build(self) -> InMemoryMetricExporter {
         InMemoryMetricExporter {
-            metrics: Arc::new(Mutex::new(VecDeque::new())),
+            metrics: self.metrics.expect("Metrics must be provided"),
             temporality: self.temporality.unwrap_or_default(),
         }
     }
 }
 
 impl InMemoryMetricExporter {
-    /// Returns the finished metrics as a vector of `ResourceMetrics`.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `MetricError` if the internal lock cannot be acquired.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use opentelemetry_sdk::metrics::InMemoryMetricExporter;
-    ///
-    /// let exporter = InMemoryMetricExporter::default();
-    /// let finished_metrics = exporter.get_finished_metrics().unwrap();
-    /// ```
-    pub fn get_finished_metrics(&self) -> Result<Vec<ResourceMetrics>, InMemoryExporterError> {
-        let metrics = self
-            .metrics
-            .lock()
-            .map(|metrics_guard| metrics_guard.iter().map(Self::clone_metrics).collect())
-            .map_err(InMemoryExporterError::from)?;
-        Ok(metrics)
-    }
-
     /// Clears the internal storage of finished metrics.
     ///
     /// # Example
     ///
     /// ```
-    /// # use opentelemetry_sdk::metrics::InMemoryMetricExporter;
+    /// use opentelemetry_sdk::metrics::InMemoryMetricExporter;
     ///
-    /// let exporter = InMemoryMetricExporter::default();
+    /// let metrics = Arc::new(Mutex::new(Vec::new()));
+    /// let exporter = InMemoryMetricExporter::builder()
+    ///                .with_metrics(metrics.clone()).build();
     /// exporter.reset();
     /// ```
     pub fn reset(&self) {
@@ -241,7 +228,7 @@ impl PushMetricExporter for InMemoryMetricExporter {
         self.metrics
             .lock()
             .map(|mut metrics_guard| {
-                metrics_guard.push_back(InMemoryMetricExporter::clone_metrics(metrics))
+                metrics_guard.push(InMemoryMetricExporter::clone_metrics(metrics))
             })
             .map_err(|_| OTelSdkError::InternalFailure("Failed to lock metrics".to_string()))
     }

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -895,7 +895,9 @@ mod tests {
         // cargo test histogram_aggregation_with_invalid_aggregation_should_proceed_as_if_view_not_exist --features=testing -- --nocapture
 
         // Arrange
-        let exporter = InMemoryMetricExporter::default();
+        let metrics = Arc::new(Mutex::new(Vec::new()));
+        let exporter = InMemoryMetricExporter::builder().with_metrics(metrics.clone()).build();
+
         let view = |i: &Instrument| {
             if i.name == "test_histogram" {
                 Stream::builder()
@@ -912,7 +914,7 @@ mod tests {
             }
         };
         let meter_provider = SdkMeterProvider::builder()
-            .with_periodic_exporter(exporter.clone())
+            .with_periodic_exporter(exporter)
             .with_view(view)
             .build();
 
@@ -927,9 +929,7 @@ mod tests {
         meter_provider.force_flush().unwrap();
 
         // Assert
-        let resource_metrics = exporter
-            .get_finished_metrics()
-            .expect("metrics are expected to be exported.");
+        let resource_metrics = metrics.lock().unwrap();
         assert!(!resource_metrics.is_empty());
         let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
         assert_eq!(
@@ -949,7 +949,9 @@ mod tests {
         // cargo test metrics::tests::spatial_aggregation_when_view_drops_attributes_observable_counter --features=testing
 
         // Arrange
-        let exporter = InMemoryMetricExporter::default();
+        let metrics = Arc::new(Mutex::new(Vec::new()));
+        let exporter = InMemoryMetricExporter::builder().with_metrics(metrics.clone()).build();
+
         // View drops all attributes.
         let view = |i: &Instrument| {
             if i.name == "my_observable_counter" {
@@ -962,7 +964,7 @@ mod tests {
             }
         };
         let meter_provider = SdkMeterProvider::builder()
-            .with_periodic_exporter(exporter.clone())
+            .with_periodic_exporter(exporter)
             .with_view(view)
             .build();
 
@@ -1000,9 +1002,7 @@ mod tests {
         meter_provider.force_flush().unwrap();
 
         // Assert
-        let resource_metrics = exporter
-            .get_finished_metrics()
-            .expect("metrics are expected to be exported.");
+        let resource_metrics = metrics.lock().unwrap();
         assert!(!resource_metrics.is_empty());
         let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
         assert_eq!(metric.name, "my_observable_counter",);
@@ -1029,7 +1029,9 @@ mod tests {
         // cargo test spatial_aggregation_when_view_drops_attributes_counter --features=testing
 
         // Arrange
-        let exporter = InMemoryMetricExporter::default();
+        let metrics = Arc::new(Mutex::new(Vec::new()));
+        let exporter = InMemoryMetricExporter::builder().with_metrics(metrics.clone()).build();
+
         // View drops all attributes.
         let view = |i: &Instrument| {
             if i.name == "my_counter" {
@@ -1044,7 +1046,7 @@ mod tests {
             }
         };
         let meter_provider = SdkMeterProvider::builder()
-            .with_periodic_exporter(exporter.clone())
+            .with_periodic_exporter(exporter)
             .with_view(view)
             .build();
 
@@ -1084,9 +1086,7 @@ mod tests {
         meter_provider.force_flush().unwrap();
 
         // Assert
-        let resource_metrics = exporter
-            .get_finished_metrics()
-            .expect("metrics are expected to be exported.");
+        let resource_metrics = metrics.lock().unwrap();
         assert!(!resource_metrics.is_empty());
         let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
         assert_eq!(metric.name, "my_counter",);

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -627,7 +627,8 @@ mod tests {
             // Assert
             let resource_metrics = metrics.lock().unwrap();
             assert_eq!(
-                resource_metrics[0].scope_metrics[0].metrics.len(), 1,
+                resource_metrics[0].scope_metrics[0].metrics.len(),
+                1,
                 "There should be a single metric"
             );
             let meter_name = resource_metrics[0].scope_metrics[0].scope.name();
@@ -636,7 +637,8 @@ mod tests {
 
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
 
         let meter_provider = SdkMeterProvider::builder()
             .with_periodic_exporter(exporter)
@@ -656,7 +658,8 @@ mod tests {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
         let meter_provider = SdkMeterProvider::builder()
             .with_periodic_exporter(exporter)
             .build();
@@ -684,7 +687,8 @@ mod tests {
         // Assert
         let resource_metrics = metrics.lock().unwrap();
         assert_eq!(
-            resource_metrics[0].scope_metrics[0].metrics.len(), 1,
+            resource_metrics[0].scope_metrics[0].metrics.len(),
+            1,
             "There should be single metric merging duplicate instruments"
         );
         let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
@@ -708,7 +712,8 @@ mod tests {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
 
         let meter_provider = SdkMeterProvider::builder()
             .with_periodic_exporter(exporter)
@@ -738,15 +743,18 @@ mod tests {
         // Assert
         let resource_metrics = metrics.lock().unwrap();
         assert_eq!(
-            resource_metrics[0].scope_metrics.len(), 2,
+            resource_metrics[0].scope_metrics.len(),
+            2,
             "There should be 2 separate scope"
         );
         assert_eq!(
-            resource_metrics[0].scope_metrics[0].metrics.len(), 1,
+            resource_metrics[0].scope_metrics[0].metrics.len(),
+            1,
             "There should be single metric for the scope"
         );
         assert_eq!(
-            resource_metrics[0].scope_metrics[1].metrics.len(), 1,
+            resource_metrics[0].scope_metrics[1].metrics.len(),
+            1,
             "There should be single metric for the scope"
         );
 
@@ -800,7 +808,8 @@ mod tests {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
 
         let meter_provider = SdkMeterProvider::builder()
             .with_periodic_exporter(exporter)
@@ -1104,7 +1113,6 @@ mod tests {
 
         counter.add(50, &[]);
         test_context.flush_metrics();
-
 
         test_context.with_aggregation::<i64>("my_counter", Some("my_unit"), |metric| {
             let MetricData::Sum(sum) = metric else {
@@ -1426,9 +1434,10 @@ mod tests {
                         };
 
                         assert_eq!(histogram_data.data_points.len(), 2);
-                        let zero_attribute_datapoint =
-                            find_histogram_datapoint_with_no_attributes(&histogram_data.data_points)
-                                .expect("datapoint with no attributes expected");
+                        let zero_attribute_datapoint = find_histogram_datapoint_with_no_attributes(
+                            &histogram_data.data_points,
+                        )
+                        .expect("datapoint with no attributes expected");
                         assert_eq!(zero_attribute_datapoint.count, 1);
                         assert_eq!(zero_attribute_datapoint.sum, 25);
                         assert_eq!(zero_attribute_datapoint.min, Some(25));
@@ -1438,7 +1447,7 @@ mod tests {
                             "key1",
                             "value1",
                         )
-                            .expect("datapoint with key1=value1 expected");
+                        .expect("datapoint with key1=value1 expected");
                         assert_eq!(data_point1.count, 1);
                         assert_eq!(data_point1.sum, 30);
                         assert_eq!(data_point1.min, Some(30));
@@ -1461,7 +1470,7 @@ mod tests {
                             "key1",
                             "value1",
                         )
-                            .expect("datapoint with key1=value1 expected");
+                        .expect("datapoint with key1=value1 expected");
                         assert_eq!(data_point1.value, 40);
                     });
                 }
@@ -1660,7 +1669,8 @@ mod tests {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
         let meter_provider = SdkMeterProvider::builder()
             .with_periodic_exporter(exporter)
             .with_view(view_function)
@@ -1730,7 +1740,8 @@ mod tests {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
         let meter_provider = SdkMeterProvider::builder()
             .with_periodic_exporter(exporter)
             .with_view(view1)
@@ -1773,7 +1784,8 @@ mod tests {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
         let meter_provider = SdkMeterProvider::builder()
             .with_periodic_exporter(exporter)
             .with_view(view)
@@ -1873,7 +1885,7 @@ mod tests {
             match instrument_name {
                 "counter" => {
                     test_context.with_aggregation::<u64>("test_counter", None, |metric| {
-                        let MetricData::Sum(sum) = metric     else {
+                        let MetricData::Sum(sum) = metric else {
                             unreachable!()
                         };
 
@@ -1923,7 +1935,7 @@ mod tests {
                             "key1",
                             "value1",
                         )
-                            .expect("datapoint with key1=value1 expected");
+                        .expect("datapoint with key1=value1 expected");
                         assert_eq!(data_point1.value, 30);
                     });
                 }
@@ -1963,37 +1975,37 @@ mod tests {
 
         // Assert
         // We invoke `test_context.flush_metrics()` six times.
-        test_context
-            .with_multiple_aggregations::<u64>("my_counter", None, 6, |metrics| {
-                let sums = metrics.into_iter()
-                    .map(|data| {
-                        if let MetricData::Sum(sum) = data {
-                            sum
-                        } else {
-                            unreachable!()
-                        }
-                    })
-                    .collect::<Vec<_>>();
-
-                let mut sum_zero_attributes = 0;
-                let mut sum_key1_value1 = 0;
-                sums.iter().for_each(|sum| {
-                    assert_eq!(sum.data_points.len(), 2); // Expecting 1 time-series.
-                    assert!(sum.is_monotonic, "Counter should produce monotonic.");
-                    assert_eq!(sum.temporality, temporality);
-
-                    if temporality == Temporality::Delta {
-                        sum_zero_attributes += sum.data_points[0].value;
-                        sum_key1_value1 += sum.data_points[1].value;
+        test_context.with_multiple_aggregations::<u64>("my_counter", None, 6, |metrics| {
+            let sums = metrics
+                .into_iter()
+                .map(|data| {
+                    if let MetricData::Sum(sum) = data {
+                        sum
                     } else {
-                        sum_zero_attributes = sum.data_points[0].value;
-                        sum_key1_value1 = sum.data_points[1].value;
-                    };
-                });
+                        unreachable!()
+                    }
+                })
+                .collect::<Vec<_>>();
 
-                assert_eq!(sum_zero_attributes, 10);
-                assert_eq!(sum_key1_value1, 50); // Each of the 10 update threads record measurements summing up to 5.
+            let mut sum_zero_attributes = 0;
+            let mut sum_key1_value1 = 0;
+            sums.iter().for_each(|sum| {
+                assert_eq!(sum.data_points.len(), 2); // Expecting 1 time-series.
+                assert!(sum.is_monotonic, "Counter should produce monotonic.");
+                assert_eq!(sum.temporality, temporality);
+
+                if temporality == Temporality::Delta {
+                    sum_zero_attributes += sum.data_points[0].value;
+                    sum_key1_value1 += sum.data_points[1].value;
+                } else {
+                    sum_zero_attributes = sum.data_points[0].value;
+                    sum_key1_value1 = sum.data_points[1].value;
+                };
             });
+
+            assert_eq!(sum_zero_attributes, 10);
+            assert_eq!(sum_key1_value1, 50); // Each of the 10 update threads record measurements summing up to 5.
+        });
     }
 
     fn counter_f64_multithreaded_aggregation_helper(temporality: Temporality) {
@@ -2024,40 +2036,39 @@ mod tests {
 
         test_context.flush_metrics();
 
-
         // Assert
         // We invoke `test_context.flush_metrics()` six times.
-        test_context
-            .with_multiple_aggregations::<f64>("test_counter", None, 6, |metrics| {
-                let sums = metrics.into_iter()
-                    .map(|data| {
-                        if let MetricData::Sum(sum) = data {
-                            sum
-                        } else {
-                            unreachable!()
-                        }
-                    })
-                    .collect::<Vec<_>>();
-
-                let mut sum_zero_attributes = 0.0;
-                let mut sum_key1_value1 = 0.0;
-                sums.iter().for_each(|sum| {
-                    assert_eq!(sum.data_points.len(), 2); // Expecting 1 time-series.
-                    assert!(sum.is_monotonic, "Counter should produce monotonic.");
-                    assert_eq!(sum.temporality, temporality);
-
-                    if temporality == Temporality::Delta {
-                        sum_zero_attributes += sum.data_points[0].value;
-                        sum_key1_value1 += sum.data_points[1].value;
+        test_context.with_multiple_aggregations::<f64>("test_counter", None, 6, |metrics| {
+            let sums = metrics
+                .into_iter()
+                .map(|data| {
+                    if let MetricData::Sum(sum) = data {
+                        sum
                     } else {
-                        sum_zero_attributes = sum.data_points[0].value;
-                        sum_key1_value1 = sum.data_points[1].value;
-                    };
-                });
+                        unreachable!()
+                    }
+                })
+                .collect::<Vec<_>>();
 
-                assert!(f64::abs(12.3 - sum_zero_attributes) < 0.0001);
-                assert!(f64::abs(61.5 - sum_key1_value1) < 0.0001); // Each of the 10 update threads record measurements 5 times = 10 * 5 * 1.23 = 61.5
+            let mut sum_zero_attributes = 0.0;
+            let mut sum_key1_value1 = 0.0;
+            sums.iter().for_each(|sum| {
+                assert_eq!(sum.data_points.len(), 2); // Expecting 1 time-series.
+                assert!(sum.is_monotonic, "Counter should produce monotonic.");
+                assert_eq!(sum.temporality, temporality);
+
+                if temporality == Temporality::Delta {
+                    sum_zero_attributes += sum.data_points[0].value;
+                    sum_key1_value1 += sum.data_points[1].value;
+                } else {
+                    sum_zero_attributes = sum.data_points[0].value;
+                    sum_key1_value1 = sum.data_points[1].value;
+                };
             });
+
+            assert!(f64::abs(12.3 - sum_zero_attributes) < 0.0001);
+            assert!(f64::abs(61.5 - sum_key1_value1) < 0.0001); // Each of the 10 update threads record measurements 5 times = 10 * 5 * 1.23 = 61.5
+        });
     }
 
     fn histogram_multithreaded_aggregation_helper(temporality: Temporality) {
@@ -2091,117 +2102,126 @@ mod tests {
 
         // Assert
         // We invoke `test_context.flush_metrics()` six times.
-        test_context
-            .with_multiple_aggregations::<u64>("test_histogram", None, 6, |metrics| {
-                let histograms = metrics.into_iter()
-                    .map(|data| {
-                        if let MetricData::Histogram(hist) = data {
-                            hist
-                        } else {
-                            unreachable!()
-                        }
-                    })
-                    .collect::<Vec<_>>();
-
-                let (
-                    mut sum_zero_attributes,
-                    mut count_zero_attributes,
-                    mut min_zero_attributes,
-                    mut max_zero_attributes,
-                ) = (0, 0, u64::MAX, u64::MIN);
-                let (mut sum_key1_value1, mut count_key1_value1, mut min_key1_value1, mut max_key1_value1) =
-                    (0, 0, u64::MAX, u64::MIN);
-
-                let mut bucket_counts_zero_attributes = vec![0; 16]; // There are 16 buckets for the default configuration
-                let mut bucket_counts_key1_value1 = vec![0; 16];
-
-                histograms.iter().for_each(|histogram| {
-                    assert_eq!(histogram.data_points.len(), 2); // Expecting 1 time-series.
-                    assert_eq!(histogram.temporality, temporality);
-
-                    let data_point_zero_attributes =
-                        find_histogram_datapoint_with_no_attributes(&histogram.data_points).unwrap();
-                    let data_point_key1_value1 =
-                        find_histogram_datapoint_with_key_value(&histogram.data_points, "key1", "value1")
-                            .unwrap();
-
-                    if temporality == Temporality::Delta {
-                        sum_zero_attributes += data_point_zero_attributes.sum;
-                        sum_key1_value1 += data_point_key1_value1.sum;
-
-                        count_zero_attributes += data_point_zero_attributes.count;
-                        count_key1_value1 += data_point_key1_value1.count;
-
-                        min_zero_attributes =
-                            min(min_zero_attributes, data_point_zero_attributes.min.unwrap());
-                        min_key1_value1 = min(min_key1_value1, data_point_key1_value1.min.unwrap());
-
-                        max_zero_attributes =
-                            max(max_zero_attributes, data_point_zero_attributes.max.unwrap());
-                        max_key1_value1 = max(max_key1_value1, data_point_key1_value1.max.unwrap());
-
-                        assert_eq!(data_point_zero_attributes.bucket_counts.len(), 16);
-                        assert_eq!(data_point_key1_value1.bucket_counts.len(), 16);
-
-                        for (i, _) in data_point_zero_attributes.bucket_counts.iter().enumerate() {
-                            bucket_counts_zero_attributes[i] += data_point_zero_attributes.bucket_counts[i];
-                        }
-
-                        for (i, _) in data_point_key1_value1.bucket_counts.iter().enumerate() {
-                            bucket_counts_key1_value1[i] += data_point_key1_value1.bucket_counts[i];
-                        }
+        test_context.with_multiple_aggregations::<u64>("test_histogram", None, 6, |metrics| {
+            let histograms = metrics
+                .into_iter()
+                .map(|data| {
+                    if let MetricData::Histogram(hist) = data {
+                        hist
                     } else {
-                        sum_zero_attributes = data_point_zero_attributes.sum;
-                        sum_key1_value1 = data_point_key1_value1.sum;
-
-                        count_zero_attributes = data_point_zero_attributes.count;
-                        count_key1_value1 = data_point_key1_value1.count;
-
-                        min_zero_attributes = data_point_zero_attributes.min.unwrap();
-                        min_key1_value1 = data_point_key1_value1.min.unwrap();
-
-                        max_zero_attributes = data_point_zero_attributes.max.unwrap();
-                        max_key1_value1 = data_point_key1_value1.max.unwrap();
-
-                        assert_eq!(data_point_zero_attributes.bucket_counts.len(), 16);
-                        assert_eq!(data_point_key1_value1.bucket_counts.len(), 16);
-
-                        bucket_counts_zero_attributes.clone_from(&data_point_zero_attributes.bucket_counts);
-                        bucket_counts_key1_value1.clone_from(&data_point_key1_value1.bucket_counts);
-                    };
-                });
-
-                // Default buckets:
-                // (-∞, 0], (0, 5.0], (5.0, 10.0], (10.0, 25.0], (25.0, 50.0], (50.0, 75.0], (75.0, 100.0], (100.0, 250.0], (250.0, 500.0],
-                // (500.0, 750.0], (750.0, 1000.0], (1000.0, 2500.0], (2500.0, 5000.0], (5000.0, 7500.0], (7500.0, 10000.0], (10000.0, +∞).
-
-                assert_eq!(count_zero_attributes, 20); // Each of the 10 update threads record two measurements.
-                assert_eq!(sum_zero_attributes, 50); // Each of the 10 update threads record measurements summing up to 5.
-                assert_eq!(min_zero_attributes, 1);
-                assert_eq!(max_zero_attributes, 4);
-
-                for (i, count) in bucket_counts_zero_attributes.iter().enumerate() {
-                    match i {
-                        1 => assert_eq!(*count, 20), // For each of the 10 update threads, both the recorded values 1 and 4 fall under the bucket (0, 5].
-                        _ => assert_eq!(*count, 0),
+                        unreachable!()
                     }
-                }
+                })
+                .collect::<Vec<_>>();
 
-                assert_eq!(count_key1_value1, 50); // Each of the 10 update threads record 5 measurements.
-                assert_eq!(sum_key1_value1, 1000); // Each of the 10 update threads record measurements summing up to 100 (5 + 7 + 18 + 35 + 35).
-                assert_eq!(min_key1_value1, 5);
-                assert_eq!(max_key1_value1, 35);
+            let (
+                mut sum_zero_attributes,
+                mut count_zero_attributes,
+                mut min_zero_attributes,
+                mut max_zero_attributes,
+            ) = (0, 0, u64::MAX, u64::MIN);
+            let (
+                mut sum_key1_value1,
+                mut count_key1_value1,
+                mut min_key1_value1,
+                mut max_key1_value1,
+            ) = (0, 0, u64::MAX, u64::MIN);
 
-                for (i, count) in bucket_counts_key1_value1.iter().enumerate() {
-                    match i {
-                        1 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 5 falls under the bucket (0, 5].
-                        2 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 7 falls under the bucket (5, 10].
-                        3 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 18 falls under the bucket (10, 25].
-                        4 => assert_eq!(*count, 20), // For each of the 10 update threads, the recorded value 35 (recorded twice) falls under the bucket (25, 50].
-                        _ => assert_eq!(*count, 0),
+            let mut bucket_counts_zero_attributes = vec![0; 16]; // There are 16 buckets for the default configuration
+            let mut bucket_counts_key1_value1 = vec![0; 16];
+
+            histograms.iter().for_each(|histogram| {
+                assert_eq!(histogram.data_points.len(), 2); // Expecting 1 time-series.
+                assert_eq!(histogram.temporality, temporality);
+
+                let data_point_zero_attributes =
+                    find_histogram_datapoint_with_no_attributes(&histogram.data_points).unwrap();
+                let data_point_key1_value1 = find_histogram_datapoint_with_key_value(
+                    &histogram.data_points,
+                    "key1",
+                    "value1",
+                )
+                .unwrap();
+
+                if temporality == Temporality::Delta {
+                    sum_zero_attributes += data_point_zero_attributes.sum;
+                    sum_key1_value1 += data_point_key1_value1.sum;
+
+                    count_zero_attributes += data_point_zero_attributes.count;
+                    count_key1_value1 += data_point_key1_value1.count;
+
+                    min_zero_attributes =
+                        min(min_zero_attributes, data_point_zero_attributes.min.unwrap());
+                    min_key1_value1 = min(min_key1_value1, data_point_key1_value1.min.unwrap());
+
+                    max_zero_attributes =
+                        max(max_zero_attributes, data_point_zero_attributes.max.unwrap());
+                    max_key1_value1 = max(max_key1_value1, data_point_key1_value1.max.unwrap());
+
+                    assert_eq!(data_point_zero_attributes.bucket_counts.len(), 16);
+                    assert_eq!(data_point_key1_value1.bucket_counts.len(), 16);
+
+                    for (i, _) in data_point_zero_attributes.bucket_counts.iter().enumerate() {
+                        bucket_counts_zero_attributes[i] +=
+                            data_point_zero_attributes.bucket_counts[i];
                     }
-                }
+
+                    for (i, _) in data_point_key1_value1.bucket_counts.iter().enumerate() {
+                        bucket_counts_key1_value1[i] += data_point_key1_value1.bucket_counts[i];
+                    }
+                } else {
+                    sum_zero_attributes = data_point_zero_attributes.sum;
+                    sum_key1_value1 = data_point_key1_value1.sum;
+
+                    count_zero_attributes = data_point_zero_attributes.count;
+                    count_key1_value1 = data_point_key1_value1.count;
+
+                    min_zero_attributes = data_point_zero_attributes.min.unwrap();
+                    min_key1_value1 = data_point_key1_value1.min.unwrap();
+
+                    max_zero_attributes = data_point_zero_attributes.max.unwrap();
+                    max_key1_value1 = data_point_key1_value1.max.unwrap();
+
+                    assert_eq!(data_point_zero_attributes.bucket_counts.len(), 16);
+                    assert_eq!(data_point_key1_value1.bucket_counts.len(), 16);
+
+                    bucket_counts_zero_attributes
+                        .clone_from(&data_point_zero_attributes.bucket_counts);
+                    bucket_counts_key1_value1.clone_from(&data_point_key1_value1.bucket_counts);
+                };
             });
+
+            // Default buckets:
+            // (-∞, 0], (0, 5.0], (5.0, 10.0], (10.0, 25.0], (25.0, 50.0], (50.0, 75.0], (75.0, 100.0], (100.0, 250.0], (250.0, 500.0],
+            // (500.0, 750.0], (750.0, 1000.0], (1000.0, 2500.0], (2500.0, 5000.0], (5000.0, 7500.0], (7500.0, 10000.0], (10000.0, +∞).
+
+            assert_eq!(count_zero_attributes, 20); // Each of the 10 update threads record two measurements.
+            assert_eq!(sum_zero_attributes, 50); // Each of the 10 update threads record measurements summing up to 5.
+            assert_eq!(min_zero_attributes, 1);
+            assert_eq!(max_zero_attributes, 4);
+
+            for (i, count) in bucket_counts_zero_attributes.iter().enumerate() {
+                match i {
+                    1 => assert_eq!(*count, 20), // For each of the 10 update threads, both the recorded values 1 and 4 fall under the bucket (0, 5].
+                    _ => assert_eq!(*count, 0),
+                }
+            }
+
+            assert_eq!(count_key1_value1, 50); // Each of the 10 update threads record 5 measurements.
+            assert_eq!(sum_key1_value1, 1000); // Each of the 10 update threads record measurements summing up to 100 (5 + 7 + 18 + 35 + 35).
+            assert_eq!(min_key1_value1, 5);
+            assert_eq!(max_key1_value1, 35);
+
+            for (i, count) in bucket_counts_key1_value1.iter().enumerate() {
+                match i {
+                    1 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 5 falls under the bucket (0, 5].
+                    2 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 7 falls under the bucket (5, 10].
+                    3 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 18 falls under the bucket (10, 25].
+                    4 => assert_eq!(*count, 20), // For each of the 10 update threads, the recorded value 35 (recorded twice) falls under the bucket (25, 50].
+                    _ => assert_eq!(*count, 0),
+                }
+            }
+        });
     }
 
     fn histogram_f64_multithreaded_aggregation_helper(temporality: Temporality) {
@@ -2235,117 +2255,126 @@ mod tests {
 
         // Assert
         // We invoke `test_context.flush_metrics()` six times.
-        test_context
-            .with_multiple_aggregations::<f64>("test_histogram", None, 6, |metrics| {
-                let histograms = metrics.into_iter()
-                    .map(|data| {
-                        if let MetricData::Histogram(hist) = data {
-                            hist
-                        } else {
-                            unreachable!()
-                        }
-                    })
-                    .collect::<Vec<_>>();
-
-                let (
-                    mut sum_zero_attributes,
-                    mut count_zero_attributes,
-                    mut min_zero_attributes,
-                    mut max_zero_attributes,
-                ) = (0.0, 0, f64::MAX, f64::MIN);
-                let (mut sum_key1_value1, mut count_key1_value1, mut min_key1_value1, mut max_key1_value1) =
-                    (0.0, 0, f64::MAX, f64::MIN);
-
-                let mut bucket_counts_zero_attributes = vec![0; 16]; // There are 16 buckets for the default configuration
-                let mut bucket_counts_key1_value1 = vec![0; 16];
-
-                histograms.iter().for_each(|histogram| {
-                    assert_eq!(histogram.data_points.len(), 2); // Expecting 1 time-series.
-                    assert_eq!(histogram.temporality, temporality);
-
-                    let data_point_zero_attributes =
-                        find_histogram_datapoint_with_no_attributes(&histogram.data_points).unwrap();
-                    let data_point_key1_value1 =
-                        find_histogram_datapoint_with_key_value(&histogram.data_points, "key1", "value1")
-                            .unwrap();
-
-                    if temporality == Temporality::Delta {
-                        sum_zero_attributes += data_point_zero_attributes.sum;
-                        sum_key1_value1 += data_point_key1_value1.sum;
-
-                        count_zero_attributes += data_point_zero_attributes.count;
-                        count_key1_value1 += data_point_key1_value1.count;
-
-                        min_zero_attributes =
-                            min_zero_attributes.min(data_point_zero_attributes.min.unwrap());
-                        min_key1_value1 = min_key1_value1.min(data_point_key1_value1.min.unwrap());
-
-                        max_zero_attributes =
-                            max_zero_attributes.max(data_point_zero_attributes.max.unwrap());
-                        max_key1_value1 = max_key1_value1.max(data_point_key1_value1.max.unwrap());
-
-                        assert_eq!(data_point_zero_attributes.bucket_counts.len(), 16);
-                        assert_eq!(data_point_key1_value1.bucket_counts.len(), 16);
-
-                        for (i, _) in data_point_zero_attributes.bucket_counts.iter().enumerate() {
-                            bucket_counts_zero_attributes[i] += data_point_zero_attributes.bucket_counts[i];
-                        }
-
-                        for (i, _) in data_point_key1_value1.bucket_counts.iter().enumerate() {
-                            bucket_counts_key1_value1[i] += data_point_key1_value1.bucket_counts[i];
-                        }
+        test_context.with_multiple_aggregations::<f64>("test_histogram", None, 6, |metrics| {
+            let histograms = metrics
+                .into_iter()
+                .map(|data| {
+                    if let MetricData::Histogram(hist) = data {
+                        hist
                     } else {
-                        sum_zero_attributes = data_point_zero_attributes.sum;
-                        sum_key1_value1 = data_point_key1_value1.sum;
-
-                        count_zero_attributes = data_point_zero_attributes.count;
-                        count_key1_value1 = data_point_key1_value1.count;
-
-                        min_zero_attributes = data_point_zero_attributes.min.unwrap();
-                        min_key1_value1 = data_point_key1_value1.min.unwrap();
-
-                        max_zero_attributes = data_point_zero_attributes.max.unwrap();
-                        max_key1_value1 = data_point_key1_value1.max.unwrap();
-
-                        assert_eq!(data_point_zero_attributes.bucket_counts.len(), 16);
-                        assert_eq!(data_point_key1_value1.bucket_counts.len(), 16);
-
-                        bucket_counts_zero_attributes.clone_from(&data_point_zero_attributes.bucket_counts);
-                        bucket_counts_key1_value1.clone_from(&data_point_key1_value1.bucket_counts);
-                    };
-                });
-
-                // Default buckets:
-                // (-∞, 0], (0, 5.0], (5.0, 10.0], (10.0, 25.0], (25.0, 50.0], (50.0, 75.0], (75.0, 100.0], (100.0, 250.0], (250.0, 500.0],
-                // (500.0, 750.0], (750.0, 1000.0], (1000.0, 2500.0], (2500.0, 5000.0], (5000.0, 7500.0], (7500.0, 10000.0], (10000.0, +∞).
-
-                assert_eq!(count_zero_attributes, 20); // Each of the 10 update threads record two measurements.
-                assert!(f64::abs(61.0 - sum_zero_attributes) < 0.0001); // Each of the 10 update threads record measurements summing up to 6.1 (1.5 + 4.6)
-                assert_eq!(min_zero_attributes, 1.5);
-                assert_eq!(max_zero_attributes, 4.6);
-
-                for (i, count) in bucket_counts_zero_attributes.iter().enumerate() {
-                    match i {
-                        1 => assert_eq!(*count, 20), // For each of the 10 update threads, both the recorded values 1.5 and 4.6 fall under the bucket (0, 5.0].
-                        _ => assert_eq!(*count, 0),
+                        unreachable!()
                     }
-                }
+                })
+                .collect::<Vec<_>>();
 
-                assert_eq!(count_key1_value1, 50); // Each of the 10 update threads record 5 measurements.
-                assert!(f64::abs(1006.0 - sum_key1_value1) < 0.0001); // Each of the 10 update threads record measurements summing up to 100.4 (5.0 + 7.3 + 18.1 + 35.1 + 35.1).
-                assert_eq!(min_key1_value1, 5.0);
-                assert_eq!(max_key1_value1, 35.1);
+            let (
+                mut sum_zero_attributes,
+                mut count_zero_attributes,
+                mut min_zero_attributes,
+                mut max_zero_attributes,
+            ) = (0.0, 0, f64::MAX, f64::MIN);
+            let (
+                mut sum_key1_value1,
+                mut count_key1_value1,
+                mut min_key1_value1,
+                mut max_key1_value1,
+            ) = (0.0, 0, f64::MAX, f64::MIN);
 
-                for (i, count) in bucket_counts_key1_value1.iter().enumerate() {
-                    match i {
-                        1 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 5.0 falls under the bucket (0, 5.0].
-                        2 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 7.3 falls under the bucket (5.0, 10.0].
-                        3 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 18.1 falls under the bucket (10.0, 25.0].
-                        4 => assert_eq!(*count, 20), // For each of the 10 update threads, the recorded value 35.1 (recorded twice) falls under the bucket (25.0, 50.0].
-                        _ => assert_eq!(*count, 0),
+            let mut bucket_counts_zero_attributes = vec![0; 16]; // There are 16 buckets for the default configuration
+            let mut bucket_counts_key1_value1 = vec![0; 16];
+
+            histograms.iter().for_each(|histogram| {
+                assert_eq!(histogram.data_points.len(), 2); // Expecting 1 time-series.
+                assert_eq!(histogram.temporality, temporality);
+
+                let data_point_zero_attributes =
+                    find_histogram_datapoint_with_no_attributes(&histogram.data_points).unwrap();
+                let data_point_key1_value1 = find_histogram_datapoint_with_key_value(
+                    &histogram.data_points,
+                    "key1",
+                    "value1",
+                )
+                .unwrap();
+
+                if temporality == Temporality::Delta {
+                    sum_zero_attributes += data_point_zero_attributes.sum;
+                    sum_key1_value1 += data_point_key1_value1.sum;
+
+                    count_zero_attributes += data_point_zero_attributes.count;
+                    count_key1_value1 += data_point_key1_value1.count;
+
+                    min_zero_attributes =
+                        min_zero_attributes.min(data_point_zero_attributes.min.unwrap());
+                    min_key1_value1 = min_key1_value1.min(data_point_key1_value1.min.unwrap());
+
+                    max_zero_attributes =
+                        max_zero_attributes.max(data_point_zero_attributes.max.unwrap());
+                    max_key1_value1 = max_key1_value1.max(data_point_key1_value1.max.unwrap());
+
+                    assert_eq!(data_point_zero_attributes.bucket_counts.len(), 16);
+                    assert_eq!(data_point_key1_value1.bucket_counts.len(), 16);
+
+                    for (i, _) in data_point_zero_attributes.bucket_counts.iter().enumerate() {
+                        bucket_counts_zero_attributes[i] +=
+                            data_point_zero_attributes.bucket_counts[i];
                     }
-                }
+
+                    for (i, _) in data_point_key1_value1.bucket_counts.iter().enumerate() {
+                        bucket_counts_key1_value1[i] += data_point_key1_value1.bucket_counts[i];
+                    }
+                } else {
+                    sum_zero_attributes = data_point_zero_attributes.sum;
+                    sum_key1_value1 = data_point_key1_value1.sum;
+
+                    count_zero_attributes = data_point_zero_attributes.count;
+                    count_key1_value1 = data_point_key1_value1.count;
+
+                    min_zero_attributes = data_point_zero_attributes.min.unwrap();
+                    min_key1_value1 = data_point_key1_value1.min.unwrap();
+
+                    max_zero_attributes = data_point_zero_attributes.max.unwrap();
+                    max_key1_value1 = data_point_key1_value1.max.unwrap();
+
+                    assert_eq!(data_point_zero_attributes.bucket_counts.len(), 16);
+                    assert_eq!(data_point_key1_value1.bucket_counts.len(), 16);
+
+                    bucket_counts_zero_attributes
+                        .clone_from(&data_point_zero_attributes.bucket_counts);
+                    bucket_counts_key1_value1.clone_from(&data_point_key1_value1.bucket_counts);
+                };
             });
+
+            // Default buckets:
+            // (-∞, 0], (0, 5.0], (5.0, 10.0], (10.0, 25.0], (25.0, 50.0], (50.0, 75.0], (75.0, 100.0], (100.0, 250.0], (250.0, 500.0],
+            // (500.0, 750.0], (750.0, 1000.0], (1000.0, 2500.0], (2500.0, 5000.0], (5000.0, 7500.0], (7500.0, 10000.0], (10000.0, +∞).
+
+            assert_eq!(count_zero_attributes, 20); // Each of the 10 update threads record two measurements.
+            assert!(f64::abs(61.0 - sum_zero_attributes) < 0.0001); // Each of the 10 update threads record measurements summing up to 6.1 (1.5 + 4.6)
+            assert_eq!(min_zero_attributes, 1.5);
+            assert_eq!(max_zero_attributes, 4.6);
+
+            for (i, count) in bucket_counts_zero_attributes.iter().enumerate() {
+                match i {
+                    1 => assert_eq!(*count, 20), // For each of the 10 update threads, both the recorded values 1.5 and 4.6 fall under the bucket (0, 5.0].
+                    _ => assert_eq!(*count, 0),
+                }
+            }
+
+            assert_eq!(count_key1_value1, 50); // Each of the 10 update threads record 5 measurements.
+            assert!(f64::abs(1006.0 - sum_key1_value1) < 0.0001); // Each of the 10 update threads record measurements summing up to 100.4 (5.0 + 7.3 + 18.1 + 35.1 + 35.1).
+            assert_eq!(min_key1_value1, 5.0);
+            assert_eq!(max_key1_value1, 35.1);
+
+            for (i, count) in bucket_counts_key1_value1.iter().enumerate() {
+                match i {
+                    1 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 5.0 falls under the bucket (0, 5.0].
+                    2 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 7.3 falls under the bucket (5.0, 10.0].
+                    3 => assert_eq!(*count, 10), // For each of the 10 update threads, the recorded value 18.1 falls under the bucket (10.0, 25.0].
+                    4 => assert_eq!(*count, 20), // For each of the 10 update threads, the recorded value 35.1 (recorded twice) falls under the bucket (25.0, 50.0].
+                    _ => assert_eq!(*count, 0),
+                }
+            }
+        });
     }
 
     fn histogram_aggregation_helper(temporality: Temporality) {
@@ -2394,17 +2423,23 @@ mod tests {
             }
 
             // find and validate key1=value2 datapoint
-            let data_point1 =
-                find_histogram_datapoint_with_key_value(&histogram_data.data_points, "key1", "value1")
-                    .expect("datapoint with key1=value1 expected");
+            let data_point1 = find_histogram_datapoint_with_key_value(
+                &histogram_data.data_points,
+                "key1",
+                "value1",
+            )
+            .expect("datapoint with key1=value1 expected");
             assert_eq!(data_point1.count, values_kv1.len() as u64);
             assert_eq!(data_point1.sum, values_kv1.iter().sum::<u64>());
             assert_eq!(data_point1.min.unwrap(), *values_kv1.iter().min().unwrap());
             assert_eq!(data_point1.max.unwrap(), *values_kv1.iter().max().unwrap());
 
-            let data_point2 =
-                find_histogram_datapoint_with_key_value(&histogram_data.data_points, "key1", "value2")
-                    .expect("datapoint with key1=value2 expected");
+            let data_point2 = find_histogram_datapoint_with_key_value(
+                &histogram_data.data_points,
+                "key1",
+                "value2",
+            )
+            .expect("datapoint with key1=value2 expected");
             assert_eq!(data_point2.count, values_kv2.len() as u64);
             assert_eq!(data_point2.sum, values_kv2.iter().sum::<u64>());
             assert_eq!(data_point2.min.unwrap(), *values_kv2.iter().min().unwrap());
@@ -2423,16 +2458,18 @@ mod tests {
 
         test_context.flush_metrics();
 
-
         test_context.with_aggregation::<u64>("my_histogram", None, |metric| {
             let MetricData::Histogram(histogram_data) = metric else {
                 unreachable!()
             };
 
             assert_eq!(histogram_data.data_points.len(), 2);
-            let data_point1 =
-                find_histogram_datapoint_with_key_value(&histogram_data.data_points, "key1", "value1")
-                    .expect("datapoint with key1=value1 expected");
+            let data_point1 = find_histogram_datapoint_with_key_value(
+                &histogram_data.data_points,
+                "key1",
+                "value1",
+            )
+            .expect("datapoint with key1=value1 expected");
             if temporality == Temporality::Cumulative {
                 assert_eq!(data_point1.count, 2 * (values_kv1.len() as u64));
                 assert_eq!(data_point1.sum, 2 * (values_kv1.iter().sum::<u64>()));
@@ -2445,9 +2482,12 @@ mod tests {
                 assert_eq!(data_point1.max.unwrap(), *values_kv1.iter().max().unwrap());
             }
 
-            let data_point1 =
-                find_histogram_datapoint_with_key_value(&histogram_data.data_points, "key1", "value2")
-                    .expect("datapoint with key1=value1 expected");
+            let data_point1 = find_histogram_datapoint_with_key_value(
+                &histogram_data.data_points,
+                "key1",
+                "value2",
+            )
+            .expect("datapoint with key1=value1 expected");
             if temporality == Temporality::Cumulative {
                 assert_eq!(data_point1.count, 2 * (values_kv2.len() as u64));
                 assert_eq!(data_point1.sum, 2 * (values_kv2.iter().sum::<u64>()));
@@ -2501,9 +2541,12 @@ mod tests {
             }
 
             // find and validate key1=value1 datapoint
-            let data_point =
-                find_histogram_datapoint_with_key_value(&histogram_data.data_points, "key1", "value1")
-                    .expect("datapoint with key1=value1 expected");
+            let data_point = find_histogram_datapoint_with_key_value(
+                &histogram_data.data_points,
+                "key1",
+                "value1",
+            )
+            .expect("datapoint with key1=value1 expected");
 
             assert_eq!(data_point.count, 5);
             assert_eq!(data_point.sum, 15);
@@ -2558,9 +2601,12 @@ mod tests {
             }
 
             // find and validate key1=value1 datapoint
-            let data_point =
-                find_histogram_datapoint_with_key_value(&histogram_data.data_points, "key1", "value1")
-                    .expect("datapoint with key1=value1 expected");
+            let data_point = find_histogram_datapoint_with_key_value(
+                &histogram_data.data_points,
+                "key1",
+                "value1",
+            )
+            .expect("datapoint with key1=value1 expected");
 
             assert_eq!(data_point.count, 5);
             assert_eq!(data_point.sum, 15);
@@ -2598,14 +2644,20 @@ mod tests {
             assert_eq!(gauge_data_point.data_points.len(), 2);
 
             // find and validate key1=value2 datapoint
-            let data_point1 =
-                find_gauge_datapoint_with_key_value(&gauge_data_point.data_points, "key1", "value1")
-                    .expect("datapoint with key1=value1 expected");
+            let data_point1 = find_gauge_datapoint_with_key_value(
+                &gauge_data_point.data_points,
+                "key1",
+                "value1",
+            )
+            .expect("datapoint with key1=value1 expected");
             assert_eq!(data_point1.value, 4);
 
-            let data_point1 =
-                find_gauge_datapoint_with_key_value(&gauge_data_point.data_points, "key1", "value2")
-                    .expect("datapoint with key1=value2 expected");
+            let data_point1 = find_gauge_datapoint_with_key_value(
+                &gauge_data_point.data_points,
+                "key1",
+                "value2",
+            )
+            .expect("datapoint with key1=value2 expected");
             assert_eq!(data_point1.value, 6);
         });
 
@@ -2629,12 +2681,14 @@ mod tests {
             };
 
             assert_eq!(gauge.data_points.len(), 2);
-            let data_point1 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
-                .expect("datapoint with key1=value1 expected");
+            let data_point1 =
+                find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
+                    .expect("datapoint with key1=value1 expected");
             assert_eq!(data_point1.value, 41);
 
-            let data_point1 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value2")
-                .expect("datapoint with key1=value2 expected");
+            let data_point1 =
+                find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value2")
+                    .expect("datapoint with key1=value2 expected");
             assert_eq!(data_point1.value, 54);
         });
     }
@@ -2676,13 +2730,15 @@ mod tests {
             }
 
             // find and validate key1=value1 datapoint
-            let data_point1 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
-                .expect("datapoint with key1=value1 expected");
+            let data_point1 =
+                find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
+                    .expect("datapoint with key1=value1 expected");
             assert_eq!(data_point1.value, 4);
 
             // find and validate key2=value2 datapoint
-            let data_point2 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key2", "value2")
-                .expect("datapoint with key2=value2 expected");
+            let data_point2 =
+                find_gauge_datapoint_with_key_value(&gauge.data_points, "key2", "value2")
+                    .expect("datapoint with key2=value2 expected");
             assert_eq!(data_point2.value, 5);
         });
 
@@ -2690,7 +2746,6 @@ mod tests {
         test_context.reset_metrics();
 
         test_context.flush_metrics();
-
 
         test_context.with_aggregation::<i64>("test_observable_gauge", None, |metric| {
             let MetricData::Gauge(gauge) = metric else {
@@ -2706,12 +2761,14 @@ mod tests {
                 assert_eq!(zero_attribute_datapoint.value, 1);
             }
 
-            let data_point1 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
-                .expect("datapoint with key1=value1 expected");
+            let data_point1 =
+                find_gauge_datapoint_with_key_value(&gauge.data_points, "key1", "value1")
+                    .expect("datapoint with key1=value1 expected");
             assert_eq!(data_point1.value, 4);
 
-            let data_point2 = find_gauge_datapoint_with_key_value(&gauge.data_points, "key2", "value2")
-                .expect("datapoint with key2=value2 expected");
+            let data_point2 =
+                find_gauge_datapoint_with_key_value(&gauge.data_points, "key2", "value2")
+                    .expect("datapoint with key2=value2 expected");
             assert_eq!(data_point2.value, 5);
         });
     }
@@ -2869,8 +2926,9 @@ mod tests {
                     .expect("point expected");
                 assert_eq!(data_point.value, 100);
 
-                let data_point = find_sum_datapoint_with_key_value(&sum.data_points, "A", "another")
-                    .expect("point expected");
+                let data_point =
+                    find_sum_datapoint_with_key_value(&sum.data_points, "A", "another")
+                        .expect("point expected");
                 assert_eq!(data_point.value, 100);
 
                 let data_point =
@@ -2887,7 +2945,8 @@ mod tests {
                 let data_point = find_sum_datapoint_with_key_value(&sum.data_points, "A", "foo");
                 assert!(data_point.is_none(), "point should not be present");
 
-                let data_point = find_sum_datapoint_with_key_value(&sum.data_points, "A", "another");
+                let data_point =
+                    find_sum_datapoint_with_key_value(&sum.data_points, "A", "another");
                 assert!(data_point.is_none(), "point should not be present");
 
                 let data_point =
@@ -2979,8 +3038,9 @@ mod tests {
                     .expect("point expected");
                 assert_eq!(data_point.value, 100);
 
-                let data_point = find_sum_datapoint_with_key_value(&sum.data_points, "A", "another")
-                    .expect("point expected");
+                let data_point =
+                    find_sum_datapoint_with_key_value(&sum.data_points, "A", "another")
+                        .expect("point expected");
                 assert_eq!(data_point.value, 100);
 
                 let data_point =
@@ -2997,7 +3057,8 @@ mod tests {
                 let data_point = find_sum_datapoint_with_key_value(&sum.data_points, "A", "foo");
                 assert!(data_point.is_none(), "point should not be present");
 
-                let data_point = find_sum_datapoint_with_key_value(&sum.data_points, "A", "another");
+                let data_point =
+                    find_sum_datapoint_with_key_value(&sum.data_points, "A", "another");
                 assert!(data_point.is_none(), "point should not be present");
 
                 let data_point =
@@ -3343,13 +3404,11 @@ mod tests {
         ) {
             let resource_metrics = self.resource_metrics.lock().unwrap();
 
-            assert!(
-                !resource_metrics.is_empty(),
-                "no metrics were exported"
-            );
+            assert!(!resource_metrics.is_empty(), "no metrics were exported");
 
             assert_eq!(
-                resource_metrics.len(), 1,
+                resource_metrics.len(),
+                1,
                 "Expected single resource metrics."
             );
             let resource_metric = resource_metrics
@@ -3383,10 +3442,7 @@ mod tests {
         ) {
             let resource_metrics = self.resource_metrics.lock().unwrap();
 
-            assert!(
-                !resource_metrics.is_empty(),
-                "no metrics were exported"
-            );
+            assert!(!resource_metrics.is_empty(), "no metrics were exported");
 
             assert_eq!(
                 resource_metrics.len(),

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -271,11 +271,7 @@ mod tests {
             test_context.flush_metrics();
 
             // As instrument name are valid because of the feature flag, metrics should be exported
-            let resource_metrics = test_context
-                .exporter
-                .get_finished_metrics()
-                .expect("metrics expected to be exported");
-
+            let resource_metrics = test_context.resource_metrics.lock().unwrap();
             assert!(!resource_metrics.is_empty(), "metrics should be exported");
         }
 
@@ -896,7 +892,9 @@ mod tests {
 
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
-        let exporter = InMemoryMetricExporter::builder().with_metrics(metrics.clone()).build();
+        let exporter = InMemoryMetricExporter::builder()
+            .with_metrics(metrics.clone())
+            .build();
 
         let view = |i: &Instrument| {
             if i.name == "test_histogram" {
@@ -950,7 +948,9 @@ mod tests {
 
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
-        let exporter = InMemoryMetricExporter::builder().with_metrics(metrics.clone()).build();
+        let exporter = InMemoryMetricExporter::builder()
+            .with_metrics(metrics.clone())
+            .build();
 
         // View drops all attributes.
         let view = |i: &Instrument| {
@@ -1030,7 +1030,9 @@ mod tests {
 
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
-        let exporter = InMemoryMetricExporter::builder().with_metrics(metrics.clone()).build();
+        let exporter = InMemoryMetricExporter::builder()
+            .with_metrics(metrics.clone())
+            .build();
 
         // View drops all attributes.
         let view = |i: &Instrument| {

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -510,6 +510,9 @@ impl<E: PushMetricExporter> MetricReader for PeriodicReader<E> {
 
 #[cfg(all(test, feature = "testing"))]
 mod tests {
+    //! Use below command to run all tests:
+    //! `cargo test metrics::periodic_reader::tests --features=testing,spec_unstable_metrics_views -- --nocapture`
+
     use super::PeriodicReader;
     use crate::{
         error::{OTelSdkError, OTelSdkResult},
@@ -528,8 +531,6 @@ mod tests {
         },
         time::Duration,
     };
-    // use below command to run all tests
-    // cargo test metrics::periodic_reader::tests --features=testing,spec_unstable_metrics_views -- --nocapture
 
     #[derive(Debug, Clone)]
     struct MetricExporterThatFailsOnlyOnFirst {

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -520,6 +520,7 @@ mod tests {
         Resource,
     };
     use opentelemetry::metrics::MeterProvider;
+    use std::sync::Mutex;
     use std::{
         sync::{
             atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -527,7 +528,6 @@ mod tests {
         },
         time::Duration,
     };
-    use std::sync::Mutex;
     // use below command to run all tests
     // cargo test metrics::periodic_reader::tests --features=testing,spec_unstable_metrics_views -- --nocapture
 
@@ -611,7 +611,8 @@ mod tests {
 
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
 
         let reader = PeriodicReader::builder(exporter)
             .with_interval(interval)
@@ -645,7 +646,8 @@ mod tests {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
 
         let reader = PeriodicReader::builder(exporter).build();
 
@@ -669,7 +671,8 @@ mod tests {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
 
         let reader = PeriodicReader::builder(exporter).build();
 
@@ -690,7 +693,8 @@ mod tests {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
 
         let reader = PeriodicReader::builder(exporter).build();
 
@@ -708,7 +712,8 @@ mod tests {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
 
         let reader = PeriodicReader::builder(exporter).build();
 
@@ -854,7 +859,8 @@ mod tests {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
 
         let reader = PeriodicReader::builder(exporter).build();
         let (sender, receiver) = mpsc::channel();
@@ -913,7 +919,8 @@ mod tests {
         let interval = Duration::from_millis(10);
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
 
         let reader = PeriodicReader::builder(exporter)
             .with_interval(interval)
@@ -969,7 +976,8 @@ mod tests {
     fn tokio_async_inside_observable_callback_helper(use_current_tokio_runtime: bool) {
         let metrics = Arc::new(Mutex::new(Vec::new()));
         let exporter = InMemoryMetricExporter::builder()
-            .with_metrics(metrics.clone()).build();
+            .with_metrics(metrics.clone())
+            .build();
 
         let reader = PeriodicReader::builder(exporter).build();
 

--- a/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
@@ -492,8 +492,10 @@ mod tests {
     #[test]
     fn unregistered_collect() {
         // Arrange
-        let exporter = InMemoryMetricExporter::default();
-        let reader = PeriodicReader::builder(exporter.clone(), runtime::Tokio).build();
+        let metrics = Arc::new(Mutex::new(Vec::new()));
+        let exporter = InMemoryMetricExporter::builder().with_metrics(metrics.clone()).build();
+
+        let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
         let mut rm = ResourceMetrics {
             resource: Resource::empty(),
             scope_metrics: Vec::new(),
@@ -513,8 +515,11 @@ mod tests {
         RT: crate::runtime::Runtime,
     {
         let interval = std::time::Duration::from_millis(1);
-        let exporter = InMemoryMetricExporter::default();
-        let reader = PeriodicReader::builder(exporter.clone(), runtime)
+
+        let metrics = Arc::new(Mutex::new(Vec::new()));
+        let exporter = InMemoryMetricExporter::builder().with_metrics(metrics.clone()).build();
+
+        let reader = PeriodicReader::builder(exporter, runtime)
             .with_interval(interval)
             .build();
         let (sender, receiver) = mpsc::channel();

--- a/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader_with_async_runtime.rs
@@ -449,7 +449,7 @@ mod tests {
         runtime, Resource,
     };
     use opentelemetry::metrics::MeterProvider;
-    use std::sync::mpsc;
+    use std::sync::{mpsc, Arc, Mutex};
 
     #[test]
     fn collection_triggered_by_interval_tokio_current() {
@@ -493,7 +493,9 @@ mod tests {
     fn unregistered_collect() {
         // Arrange
         let metrics = Arc::new(Mutex::new(Vec::new()));
-        let exporter = InMemoryMetricExporter::builder().with_metrics(metrics.clone()).build();
+        let exporter = InMemoryMetricExporter::builder()
+            .with_metrics(metrics.clone())
+            .build();
 
         let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
         let mut rm = ResourceMetrics {
@@ -517,7 +519,9 @@ mod tests {
         let interval = std::time::Duration::from_millis(1);
 
         let metrics = Arc::new(Mutex::new(Vec::new()));
-        let exporter = InMemoryMetricExporter::builder().with_metrics(metrics.clone()).build();
+        let exporter = InMemoryMetricExporter::builder()
+            .with_metrics(metrics.clone())
+            .build();
 
         let reader = PeriodicReader::builder(exporter, runtime)
             .with_interval(interval)


### PR DESCRIPTION
# Redesigned `InMemoryMetricExporter`

Fixes #2725.

## Changes

Updates `InMemoryMetricExporter` (similar to what was suggested in #2649) to accept and use a user-specified data collection to store the metrics data, rather than creating one internally and returning it eventually. This makes the exporter more consistent with the 'production' exporters, which are given their sink by the user (e.g., by being passed a gRPC channel to write to) - rather than owning where the data goes. This also means we no longer need to be able to clone the exporter simply to access the data back out in unit tests. 

If we are happy with this approach, we can extend it to the other in memory exporters - `InMemoryLogExporter` and `InMemorySpanExporter`. 

API Changes
- The `InMemoryMetricExporter` now must be instanciated through `InMemoryMetricExporterBuilder` and it no longer has `Default` and `Clone` implementations.
- `InMemoryMetricExporterBuilder` has the mandatory `metrics: Arc<Mutex<Vec<_>>>` field to be set.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests ~~added/~~ updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
