### PR TITLE
fix: add validation not to accept negative values for monotonic counters

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -7,6 +7,8 @@
   - `id_generator`, `should_sample`
 
 [3227]: https://github.com/open-telemetry/opentelemetry-rust/pull/3227
+- Fixed Sum and PrecomputedSum not to accept negative values if monotonic
+[#3260](https://github.com/open-telemetry/opentelemetry-rust/pull/3260)
 
 ## 0.31.0
 

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -1,4 +1,4 @@
-use opentelemetry::{otel_warn, KeyValue};
+use opentelemetry::{otel_debug, KeyValue};
 
 use crate::metrics::data::{self, AggregatedMetrics, MetricData, SumDataPoint};
 use crate::metrics::Temporality;
@@ -134,7 +134,7 @@ where
     fn call(&self, measurement: T, attrs: &[KeyValue]) {
         // Validate monotonic counter increment is non-negative
         if self.monotonic && measurement < T::default() {
-            otel_warn!(
+            otel_debug!(
                 name: "ObservableCounter.NegativeValue",
                 message = "Observable counters are monotonic and can only accept non-negative values. This measurement will be dropped.",
                 value = format!("{:?}", measurement)

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -1,6 +1,6 @@
 use crate::metrics::data::{self, AggregatedMetrics, MetricData, SumDataPoint};
 use crate::metrics::Temporality;
-use opentelemetry::{otel_warn, KeyValue};
+use opentelemetry::{otel_debug, KeyValue};
 
 use super::aggregate::{AggregateTimeInitiator, AttributeSetFilter};
 use super::{Aggregator, AtomicTracker, ComputeAggregation, Measure, Number};
@@ -151,7 +151,7 @@ where
     fn call(&self, measurement: T, attrs: &[KeyValue]) {
         // Validate monotonic counter increment is non-negative
         if self.monotonic && measurement < T::default() {
-            otel_warn!(
+            otel_debug!(
                 name: "Counter.NegativeValue",
                 message = "Counters are monotonic and can only accept non-negative values. This measurement will be dropped.",
                 value = format!("{:?}", measurement)

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -7,6 +7,10 @@
   - `trace_id`, `span_id`, `end_time`, `status`, `sampling_result`
   - `with_trace_id`, `with_span_id`, `with_end_time`, `with_status`, `with_sampling_result`
 - **Added** `#[must_use]` attribute to `opentelemetry::metrics::AsyncInstrumentBuilder` to add compile time warning when `.build()` is not called on observable instrument builders, preventing silent failures where callbacks are never registered and metrics are never reported.
+- **Documentation** Enhanced documentation for `Counter` and `ObservableCounter` to clarify monotonic behavior:
+  - Updated `Counter` and `ObservableCounter` struct documentation to explicitly state they are monotonic instruments that only accept non-negative values
+  - Enhanced `Counter::add()` method documentation to specify that negative values violate the monotonic contract and will be dropped by the SDK
+  - Updated `InstrumentProvider` trait method documentation for counter creation methods to clarify monotonic behavior
 
 [3227]: https://github.com/open-telemetry/opentelemetry-rust/pull/3227
 

--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -4,7 +4,14 @@ use std::sync::Arc;
 
 use super::SyncInstrument;
 
-/// An instrument that records increasing values.
+/// A monotonic instrument that records increasing values.
+///
+/// Counters are used to measure values that only increase over time, such as the number
+/// of requests received, bytes sent, or errors encountered. Only non-negative values
+/// should be recorded. Negative values violate the monotonic property and will be
+/// dropped by the SDK with a warning.
+///
+/// # Cloning
 ///
 /// [`Counter`] can be cloned to create multiple handles to the same instrument. If a [`Counter`] needs to be shared,
 /// users are recommended to clone the [`Counter`] instead of creating duplicate [`Counter`]s for the same metric. Creating
@@ -29,12 +36,31 @@ impl<T> Counter<T> {
     }
 
     /// Records an increment to the counter.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - A non-negative value to add to the counter. According to the
+    ///   OpenTelemetry specification, counters are monotonic instruments that record
+    ///   increasing values. Passing a negative value violates this contract.
+    ///
+    /// * `attributes` - A set of key-value pairs that describe the measurement context.
+    ///
+    /// # Behavior with negative values
+    ///
+    /// The API does not validate the value, but the SDK implementation will log a warning
+    /// and drop negative values to maintain the monotonic property of counters. Applications
+    /// should ensure only non-negative values are passed to this method.
     pub fn add(&self, value: T, attributes: &[KeyValue]) {
         self.0.measure(value, attributes)
     }
 }
 
-/// An async instrument that records increasing values.
+/// A monotonic asynchronous instrument that records increasing values.
+///
+/// Observable counters are used to measure values that only increase over time and are
+/// observed via callbacks, such as process CPU time or total memory usage. Only non-negative
+/// values should be recorded. Negative values violate the monotonic property and will be
+/// dropped by the SDK with a warning.
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct ObservableCounter<T> {

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -18,17 +18,23 @@ pub use noop::NoopMeterProvider;
 
 /// SDK implemented trait for creating instruments
 pub trait InstrumentProvider {
-    /// creates an instrument for recording increasing values.
+    /// Creates a monotonic counter for recording increasing values.
+    ///
+    /// Counters only accept non-negative values. Negative values will be dropped by the SDK.
     fn u64_counter(&self, _builder: InstrumentBuilder<'_, Counter<u64>>) -> Counter<u64> {
         Counter::new(Arc::new(noop::NoopSyncInstrument::new()))
     }
 
-    /// creates an instrument for recording increasing values.
+    /// Creates a monotonic counter for recording increasing values.
+    ///
+    /// Counters only accept non-negative values. Negative values will be dropped by the SDK.
     fn f64_counter(&self, _builder: InstrumentBuilder<'_, Counter<f64>>) -> Counter<f64> {
         Counter::new(Arc::new(noop::NoopSyncInstrument::new()))
     }
 
-    /// creates an instrument for recording increasing values via callback.
+    /// Creates a monotonic observable counter for recording increasing values via callback.
+    ///
+    /// Observable counters only accept non-negative values. Negative values will be dropped by the SDK.
     fn u64_observable_counter(
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableCounter<u64>, u64>,
@@ -36,7 +42,9 @@ pub trait InstrumentProvider {
         ObservableCounter::new()
     }
 
-    /// creates an instrument for recording increasing values via callback.
+    /// Creates a monotonic observable counter for recording increasing values via callback.
+    ///
+    /// Observable counters only accept non-negative values. Negative values will be dropped by the SDK.
     fn f64_observable_counter(
         &self,
         _builder: AsyncInstrumentBuilder<'_, ObservableCounter<f64>, f64>,


### PR DESCRIPTION
Fixes #3037 

## Changes

* Add clear documentation for monotonic counters, mentioning that negative values are dropped
* Add validations to reject negative values in sdk for Counter and ObservableCounter

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
