### PR TITLE
chore: Unify `SpanExporter` with `LogExporter` and `PushMetricExporter`

### DIFF
--- a/opentelemetry-otlp/src/exporter/http/trace.rs
+++ b/opentelemetry-otlp/src/exporter/http/trace.rs
@@ -22,7 +22,7 @@ impl SpanExporter for OtlpHttpClient {
         Ok(())
     }
 
-    fn shutdown(&mut self) -> OTelSdkResult {
+    fn shutdown(&self) -> OTelSdkResult {
         let mut client_guard = self.client.lock().map_err(|e| {
             OTelSdkError::InternalFailure(format!("Failed to acquire client lock: {e}"))
         })?;

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Fix `SpanExporter::shutdown()` default timeout from 5 nanoseconds to 5 seconds.
+- **Breaking** `SpanExporter` trait methods `shutdown`, `shutdown_with_timeout`, and `force_flush` now take `&self` instead of `&mut self` for consistency with `LogExporter` and `PushMetricExporter`. Implementers using interior mutability (e.g., `Mutex`, `AtomicBool`) require no changes.
 - Added `Resource::get_ref(&self, key: &Key) -> Option<&Value>` to allow retrieving a reference to a resource value without cloning.
 - **Breaking** Removed the following public hidden methods from the `SdkTracer` [#3227][3227]:
   - `id_generator`, `should_sample`

--- a/opentelemetry-sdk/src/testing/trace/span_exporters.rs
+++ b/opentelemetry-sdk/src/testing/trace/span_exporters.rs
@@ -50,7 +50,7 @@ impl SpanExporter for TokioSpanExporter {
         })
     }
 
-    fn shutdown(&mut self) -> OTelSdkResult {
+    fn shutdown(&self) -> OTelSdkResult {
         self.tx_shutdown.send(()).map_err(|_| {
             OTelSdkError::InternalFailure("Failed to send shutdown signal".to_string())
         })

--- a/opentelemetry-sdk/src/trace/export.rs
+++ b/opentelemetry-sdk/src/trace/export.rs
@@ -43,12 +43,12 @@ pub trait SpanExporter: Send + Sync + Debug {
     /// flush the data and the destination is unavailable). SDK authors
     /// can decide if they want to make the shutdown timeout
     /// configurable.
-    fn shutdown_with_timeout(&mut self, _timeout: Duration) -> OTelSdkResult {
+    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
         Ok(())
     }
     /// Shuts down the exporter with default timeout.
-    fn shutdown(&mut self) -> OTelSdkResult {
-        self.shutdown_with_timeout(Duration::from_nanos(5))
+    fn shutdown(&self) -> OTelSdkResult {
+        self.shutdown_with_timeout(Duration::from_secs(5))
     }
 
     /// This is a hint to ensure that the export of any Spans the exporter
@@ -66,7 +66,7 @@ pub trait SpanExporter: Send + Sync + Debug {
     /// implemented as a blocking API or an asynchronous API which notifies the caller via
     /// a callback or an event. OpenTelemetry client authors can decide if they want to
     /// make the flush timeout configurable.
-    fn force_flush(&mut self) -> OTelSdkResult {
+    fn force_flush(&self) -> OTelSdkResult {
         Ok(())
     }
 

--- a/opentelemetry-sdk/src/trace/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/trace/in_memory_exporter.rs
@@ -162,7 +162,7 @@ impl SpanExporter for InMemorySpanExporter {
         result
     }
 
-    fn shutdown_with_timeout(&mut self, _timeout: Duration) -> OTelSdkResult {
+    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
         self.shutdown_called
             .store(true, std::sync::atomic::Ordering::Relaxed);
         if self.should_reset_on_shutdown {

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -159,7 +159,7 @@ impl<T: SpanExporter> SpanProcessor for SimpleSpanProcessor<T> {
     }
 
     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
-        if let Ok(mut exporter) = self.exporter.lock() {
+        if let Ok(exporter) = self.exporter.lock() {
             exporter.shutdown_with_timeout(timeout)
         } else {
             Err(OTelSdkError::InternalFailure(
@@ -1171,7 +1171,7 @@ mod tests {
             Ok(())
         }
 
-        fn shutdown(&mut self) -> OTelSdkResult {
+        fn shutdown(&self) -> OTelSdkResult {
             Ok(())
         }
         fn set_resource(&mut self, resource: &Resource) {

--- a/opentelemetry-stdout/src/trace/exporter.rs
+++ b/opentelemetry-stdout/src/trace/exporter.rs
@@ -59,7 +59,7 @@ impl opentelemetry_sdk::trace::SpanExporter for SpanExporter {
         }
     }
 
-    fn shutdown(&mut self) -> OTelSdkResult {
+    fn shutdown(&self) -> OTelSdkResult {
         self.is_shutdown.store(true, Ordering::SeqCst);
         Ok(())
     }


### PR DESCRIPTION
Fixes #2262

## Changes

  Changes `SpanExporter` trait methods from `&mut self` to `&self`:
  - `shutdown(&self)`
  - `shutdown_with_timeout(&self, timeout)`
  - `force_flush(&self)`

  Also fixes `shutdown()` default timeout from 5 nanoseconds to 5 seconds to make it consistent with the others (assume this was a typo!).

  Refactors `TonicTracesClient` to wrap `inner` in `Mutex<Option<...>>` for interior mutability, aligning its structure
  and export pattern with `TonicLogsClient` and `TonicMetricsClient`.

This is **breaking change** -  Implementers of `SpanExporter` must update method signatures. Those already using interior mutability are good. 