### PR TITLE
feat: support the new W3C random-trace-id flag

### DIFF
--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -538,7 +538,7 @@ mod tests {
         );
         assert_eq!(
             log.record.trace_context().unwrap().trace_flags.unwrap(),
-            TraceFlags::SAMPLED
+            TraceFlags::SAMPLED | TraceFlags::RANDOM
         );
 
         // validate attributes.
@@ -721,7 +721,7 @@ mod tests {
         );
         assert_eq!(
             log.record.trace_context().unwrap().trace_flags.unwrap(),
-            TraceFlags::SAMPLED
+            TraceFlags::SAMPLED | TraceFlags::RANDOM
         );
 
         for attribute in log.record.attributes_iter() {

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -11,10 +11,12 @@
   - `SamplingDecision`, `SamplingResult`
   - These types are SDK implementation details and should be imported from `opentelemetry_sdk::trace` instead.
 - Fix panics and exploding memory usage from large cardinality limit [#3290][3290]
+- Add support for the new W3C `random-trace-id` flag [#3304][3304]
 
 [3227]: https://github.com/open-telemetry/opentelemetry-rust/pull/3227
 [3277]: https://github.com/open-telemetry/opentelemetry-rust/pull/3277
 [3290]: https://github.com/open-telemetry/opentelemetry-rust/pull/3290
+[3304]: https://github.com/open-telemetry/opentelemetry-rust/pull/3304
 
 - "spec_unstable_logs_enabled" feature flag is removed. The capability (and the
   backing specification) is now stable and is enabled by default.

--- a/opentelemetry-sdk/src/trace/id_generator/mod.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/mod.rs
@@ -14,7 +14,7 @@ pub trait IdGenerator: Send + Sync + fmt::Debug {
     /// Returns `true` if this generator produces random IDs.
     ///
     /// When `true`, spans created with IDs from this generator should
-    /// have the [`TraceFlags::RANDOM`] flag set.
+    /// have the random trace id flag set.
     fn is_random(&self) -> bool;
 }
 

--- a/opentelemetry-sdk/src/trace/id_generator/mod.rs
+++ b/opentelemetry-sdk/src/trace/id_generator/mod.rs
@@ -10,6 +10,12 @@ pub trait IdGenerator: Send + Sync + fmt::Debug {
 
     /// Generate a new `SpanId`
     fn new_span_id(&self) -> SpanId;
+
+    /// Returns `true` if this generator produces random IDs.
+    ///
+    /// When `true`, spans created with IDs from this generator should
+    /// have the [`TraceFlags::RANDOM`] flag set.
+    fn is_random(&self) -> bool;
 }
 
 /// Default [`IdGenerator`] implementation.
@@ -27,6 +33,10 @@ impl IdGenerator for RandomIdGenerator {
 
     fn new_span_id(&self) -> SpanId {
         CURRENT_RNG.with(|rng| SpanId::from(rng.borrow_mut().random::<u64>()))
+    }
+
+    fn is_random(&self) -> bool {
+        true
     }
 }
 

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -262,7 +262,10 @@ mod tests {
         assert_eq!(span.links.len(), 1);
         assert_eq!(span.links[0].span_context.trace_id(), TraceId::from(47));
         assert_eq!(span.links[0].span_context.span_id(), SpanId::from(11));
-        assert_eq!(span.span_context.trace_flags(), TraceFlags::SAMPLED);
+        assert_eq!(
+            span.span_context.trace_flags(),
+            TraceFlags::SAMPLED | TraceFlags::RANDOM
+        );
         assert!(!span.span_context.is_remote());
         assert_eq!(span.status, Status::Unset);
     }
@@ -297,7 +300,10 @@ mod tests {
         assert_eq!(span.attributes.len(), 1);
         assert_eq!(span.events.len(), 1);
         assert_eq!(span.events[0].name, "test-event");
-        assert_eq!(span.span_context.trace_flags(), TraceFlags::SAMPLED);
+        assert_eq!(
+            span.span_context.trace_flags(),
+            TraceFlags::SAMPLED | TraceFlags::RANDOM
+        );
         assert!(!span.span_context.is_remote());
         let status_expected = Status::error("cancelled");
         assert_eq!(span.status, status_expected);
@@ -334,7 +340,10 @@ mod tests {
         assert_eq!(span.attributes.len(), 1);
         assert_eq!(span.events.len(), 1);
         assert_eq!(span.events[0].name, "test-event");
-        assert_eq!(span.span_context.trace_flags(), TraceFlags::SAMPLED);
+        assert_eq!(
+            span.span_context.trace_flags(),
+            TraceFlags::SAMPLED | TraceFlags::RANDOM
+        );
         assert!(!span.span_context.is_remote());
         assert_eq!(span.status, Status::Ok);
     }

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -183,6 +183,7 @@ impl opentelemetry::trace::Tracer for SdkTracer {
         let config = provider.config();
         let span_id = config.id_generator.new_span_id();
         let trace_id;
+        let mut trace_flags = parent_cx.span().span_context().trace_flags();
         let mut psc = &SpanContext::empty_context();
 
         let parent_span = if parent_cx.has_active_span() {
@@ -197,6 +198,7 @@ impl opentelemetry::trace::Tracer for SdkTracer {
             psc = sc;
         } else {
             trace_id = config.id_generator.new_trace_id();
+            trace_flags = trace_flags.with_random(config.id_generator.is_random());
         };
 
         let samplings_result = config.sampler.should_sample(
@@ -208,7 +210,6 @@ impl opentelemetry::trace::Tracer for SdkTracer {
             builder.links.as_deref().unwrap_or(&[]),
         );
 
-        let trace_flags = parent_cx.span().span_context().trace_flags();
         let trace_state = samplings_result.trace_state;
         let span_limits = config.span_limits;
         // Build optional inner context, `None` if not recording.
@@ -265,6 +266,7 @@ impl opentelemetry::trace::Tracer for SdkTracer {
 
 #[cfg(all(test, feature = "testing", feature = "trace"))]
 mod tests {
+    use crate::trace::{IdGenerator, RandomIdGenerator};
     use crate::{
         testing::trace::TestSpan,
         trace::{Sampler, SamplingDecision, SamplingResult, ShouldSample},
@@ -301,6 +303,23 @@ mod tests {
                 attributes: Vec::new(),
                 trace_state: trace_state.insert("foo", "notbar").unwrap(),
             }
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestNonRandomIdGenerator;
+
+    impl IdGenerator for TestNonRandomIdGenerator {
+        fn new_trace_id(&self) -> TraceId {
+            TraceId::from(1)
+        }
+
+        fn new_span_id(&self) -> SpanId {
+            SpanId::from(1)
+        }
+
+        fn is_random(&self) -> bool {
+            false
         }
     }
 
@@ -359,7 +378,7 @@ mod tests {
             cx.with_remote_span_context(SpanContext::new(
                 TraceId::from(1),
                 SpanId::from(1),
-                TraceFlags::default(),
+                TraceFlags::EMPTY,
                 true,
                 Default::default(),
             ))
@@ -368,5 +387,39 @@ mod tests {
         let span = tracer.span_builder("must_not_be_sampled").start(&tracer);
 
         assert!(!span.span_context().is_sampled());
+        assert!(!span.span_context().trace_flags().is_random());
+        assert!(!span.span_context().trace_flags().is_sampled());
+    }
+
+    #[test]
+    fn new_trace_has_random_flag_set() {
+        let tracer_provider = crate::trace::SdkTracerProvider::builder()
+            .with_sampler(Sampler::AlwaysOn)
+            .with_id_generator(RandomIdGenerator::default())
+            .build();
+        let tracer = tracer_provider.tracer("test");
+
+        // Start a new root span with no parent context
+        let span = tracer.start("root_span");
+        let span_context = span.span_context();
+
+        assert!(span_context.is_sampled());
+        assert!(span_context.trace_flags().is_random());
+    }
+
+    #[test]
+    fn new_trace_does_not_have_random_flag_set() {
+        let tracer_provider = crate::trace::SdkTracerProvider::builder()
+            .with_sampler(Sampler::AlwaysOn)
+            .with_id_generator(TestNonRandomIdGenerator)
+            .build();
+        let tracer = tracer_provider.tracer("test");
+
+        // Start a new root span with no parent context
+        let span = tracer.start("root_span");
+        let span_context = span.span_context();
+
+        assert!(span_context.is_sampled());
+        assert!(!span_context.trace_flags().is_random());
     }
 }

--- a/opentelemetry-zipkin/src/propagator/mod.rs
+++ b/opentelemetry-zipkin/src/propagator/mod.rs
@@ -31,8 +31,8 @@ const B3_SPAN_ID_HEADER: &str = "x-b3-spanid";
 const B3_SAMPLED_HEADER: &str = "x-b3-sampled";
 const B3_PARENT_SPAN_ID_HEADER: &str = "x-b3-parentspanid";
 
-const TRACE_FLAG_DEFERRED: TraceFlags = TraceFlags::new(0x02);
-const TRACE_FLAG_DEBUG: TraceFlags = TraceFlags::new(0x04);
+const TRACE_FLAG_DEFERRED: TraceFlags = TraceFlags::new(0x40);
+const TRACE_FLAG_DEBUG: TraceFlags = TraceFlags::new(0x80);
 
 static B3_SINGLE_FIELDS: Lazy<[String; 1]> = Lazy::new(|| [B3_SINGLE_HEADER.to_owned()]);
 static B3_MULTI_FIELDS: Lazy<[String; 4]> = Lazy::new(|| {

--- a/opentelemetry/src/trace/span_context.rs
+++ b/opentelemetry/src/trace/span_context.rs
@@ -304,7 +304,7 @@ impl SpanContext {
     pub const NONE: SpanContext = SpanContext {
         trace_id: TraceId::INVALID,
         span_id: SpanId::INVALID,
-        trace_flags: TraceFlags::NOT_SAMPLED,
+        trace_flags: TraceFlags::EMPTY,
         is_remote: false,
         trace_state: TraceState::NONE,
     };


### PR DESCRIPTION
Implements #3270 

## Changes

Introduces an additional `RANDOM` flag to the `TraceFlags` bitfield with relevant supporting functions. Adds the `is_random` function to the `IdGenerator` trait to allow id generator implementations to specify if trace IDs are randomly generated with respect to the W3C trace context spec. These changes also add logic to add the `random-trace-id` flag to the current context only if there is no parent context available. 
 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
