### PR TITLE
feat: add support for the environment variable propagation spec

### DIFF
--- a/opentelemetry-jaeger-propagator/src/propagator.rs
+++ b/opentelemetry-jaeger-propagator/src/propagator.rs
@@ -74,7 +74,7 @@ impl Propagator {
     /// Extract span context from header value
     fn extract_span_context(&self, extractor: &dyn Extractor) -> Option<SpanContext> {
         let mut header_value =
-            Cow::from(extractor.get(self.header_name).unwrap_or(Cow::Borrowed("")));
+            extractor.get(self.header_name).unwrap_or(Cow::Borrowed(""));
         // if there is no :, it means header_value could be encoded as url, try decode first
         if !header_value.contains(':') {
             header_value = Cow::from(header_value.replace("%3A", ":"));

--- a/opentelemetry-jaeger-propagator/src/propagator.rs
+++ b/opentelemetry-jaeger-propagator/src/propagator.rs
@@ -73,8 +73,7 @@ impl Propagator {
 
     /// Extract span context from header value
     fn extract_span_context(&self, extractor: &dyn Extractor) -> Option<SpanContext> {
-        let mut header_value =
-            extractor.get(self.header_name).unwrap_or(Cow::Borrowed(""));
+        let mut header_value = extractor.get(self.header_name).unwrap_or(Cow::Borrowed(""));
         // if there is no :, it means header_value could be encoded as url, try decode first
         if !header_value.contains(':') {
             header_value = Cow::from(header_value.replace("%3A", ":"));

--- a/opentelemetry-jaeger-propagator/src/propagator.rs
+++ b/opentelemetry-jaeger-propagator/src/propagator.rs
@@ -73,7 +73,8 @@ impl Propagator {
 
     /// Extract span context from header value
     fn extract_span_context(&self, extractor: &dyn Extractor) -> Option<SpanContext> {
-        let mut header_value = Cow::from(extractor.get(self.header_name).unwrap_or(""));
+        let mut header_value =
+            Cow::from(extractor.get(self.header_name).unwrap_or(Cow::Borrowed("")));
         // if there is no :, it means header_value could be encoded as url, try decode first
         if !header_value.contains(':') {
             header_value = Cow::from(header_value.replace("%3A", ":"));
@@ -165,7 +166,7 @@ impl Propagator {
             .filter(|key| key.starts_with(self.baggage_prefix))
             .filter_map(|key| {
                 extractor
-                    .get(key)
+                    .get(&key)
                     .map(|value| (key.to_string(), value.to_string()))
             });
 

--- a/opentelemetry-sdk/src/propagation/baggage.rs
+++ b/opentelemetry-sdk/src/propagation/baggage.rs
@@ -131,7 +131,7 @@ impl TextMapPropagator for BaggagePropagator {
                             otel_warn!(
                                 name: "BaggagePropagator.Extract.InvalidUTF8",
                                 message = "Invalid UTF8 string in key values",
-                                baggage_header = header_value,
+                                baggage_header = header_value.as_ref(),
                             );
                             None
                         }
@@ -139,7 +139,7 @@ impl TextMapPropagator for BaggagePropagator {
                         otel_warn!(
                             name: "BaggagePropagator.Extract.InvalidKeyValueFormat",
                             message = "Invalid baggage key-value format",
-                            baggage_header = header_value,
+                            baggage_header = header_value.as_ref(),
                         );
                         None
                     }
@@ -147,7 +147,8 @@ impl TextMapPropagator for BaggagePropagator {
                     otel_warn!(
                         name: "BaggagePropagator.Extract.InvalidFormat",
                         message = "Invalid baggage format",
-                        baggage_header = header_value);
+                        baggage_header = header_value.as_ref(),
+                    );
                     None
                 }
             });

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -10,9 +10,11 @@
 - **Breaking** Moved the following SDK sampling types from `opentelemetry::trace` to `opentelemetry_sdk::trace` [#3277][3277]:
   - `SamplingDecision`, `SamplingResult`
   - These types are SDK implementation details and should be imported from `opentelemetry_sdk::trace` instead.
+- Add support for the environment variable propagation spec [#3305][3305]
 
 [3227]: https://github.com/open-telemetry/opentelemetry-rust/pull/3227
 [3277]: https://github.com/open-telemetry/opentelemetry-rust/pull/3277
+[3305]: https://github.com/open-telemetry/opentelemetry-rust/pull/3305
 
 - "spec_unstable_logs_enabled" feature flag is removed. The capability (and the
   backing specification) is now stable and is enabled by default.

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -45,6 +45,7 @@ opentelemetry_sdk = { path = "../opentelemetry-sdk"} # for documentation tests
 criterion = { workspace = true }
 rand = { workspace = true, features = ["os_rng", "thread_rng"] }
 tokio = { version = "1.0", features = ["full"] }
+temp-env = { workspace = true }
 
 [[bench]]
 name = "metrics"

--- a/opentelemetry/src/propagation/composite.rs
+++ b/opentelemetry/src/propagation/composite.rs
@@ -155,7 +155,7 @@ mod tests {
             match (self.header, extractor.get(self.header)) {
                 ("span-id", Some(val)) => cx.with_remote_span_context(SpanContext::new(
                     TraceId::from(1),
-                    SpanId::from(u64::from_str_radix(val, 16).unwrap()),
+                    SpanId::from(u64::from_str_radix(&val, 16).unwrap()),
                     TraceFlags::default(),
                     false,
                     TraceState::default(),


### PR DESCRIPTION
Implements #3285 

## Changes

Updated the extractor trait methods to return instances of `Option<Cow<'_, str>>` instead of `Option<&str>` in order to support returning owned values. Create a simple `EnvExtractor` type to implement the `Extractor` trait for environment variable extraction. Implemented the `Injector` trait for `std::process::Command` to support environment variable propagation to child processes.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
