### PR TITLE
feat: Metrics SDK to offer dynamic memory resizing for delta aggregations

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -5,17 +5,18 @@
 - Fix `SpanExporter::shutdown()` default timeout from 5 nanoseconds to 5 seconds.
 - **Breaking** `SpanExporter` trait methods `shutdown`, `shutdown_with_timeout`, and `force_flush` now take `&self` instead of `&mut self` for consistency with `LogExporter` and `PushMetricExporter`. Implementers using interior mutability (e.g., `Mutex`, `AtomicBool`) require no changes.
 - Added `Resource::get_ref(&self, key: &Key) -> Option<&Value>` to allow retrieving a reference to a resource value without cloning.
-- Added `MeterProviderBuilder::with_dynamic_memory_allocation_delta()` to enable
-  dynamic memory allocation for delta temporality metrics. When enabled,
-  internal storage grows and shrinks based on actual cardinality instead of
-  pre-allocating to the cardinality limit. Default remains static pre-allocation
-  for predictable performance.
 - **Breaking** Removed the following public hidden methods from the `SdkTracer` [#3227][3227]:
   - `id_generator`, `should_sample`
 - **Breaking** Moved the following SDK sampling types from `opentelemetry::trace` to `opentelemetry_sdk::trace` [#3277][3277]:
   - `SamplingDecision`, `SamplingResult`
   - These types are SDK implementation details and should be imported from `opentelemetry_sdk::trace` instead.
-- Fix panics and exploding memory usage from large cardinality limit [#3290][3290]
+- Added `MeterProviderBuilder::with_dynamic_memory_allocation_delta()` to enable
+  dynamic memory allocation for delta temporality metrics. When enabled,
+  internal storage grows and shrinks based on actual cardinality instead of
+  pre-allocating to the cardinality limit. Default remains static pre-allocation
+  for predictable performance.
+  This can be used to fix [#3290][3290], by using dynamic memory allocation when
+  large cardinality limit is set for handling rare spikes.
 
 [3227]: https://github.com/open-telemetry/opentelemetry-rust/pull/3227
 [3277]: https://github.com/open-telemetry/opentelemetry-rust/pull/3277

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Fix `SpanExporter::shutdown()` default timeout from 5 nanoseconds to 5 seconds.
 - **Breaking** `SpanExporter` trait methods `shutdown`, `shutdown_with_timeout`, and `force_flush` now take `&self` instead of `&mut self` for consistency with `LogExporter` and `PushMetricExporter`. Implementers using interior mutability (e.g., `Mutex`, `AtomicBool`) require no changes.
 - Added `Resource::get_ref(&self, key: &Key) -> Option<&Value>` to allow retrieving a reference to a resource value without cloning.
+- Added `MeterProviderBuilder::with_dynamic_memory_allocation_delta()` to enable
+  dynamic memory allocation for delta temporality metrics. When enabled,
+  internal storage grows and shrinks based on actual cardinality instead of
+  pre-allocating to the cardinality limit. Default remains static pre-allocation
+  for predictable performance.
 - **Breaking** Removed the following public hidden methods from the `SdkTracer` [#3227][3227]:
   - `id_generator`, `should_sample`
 - **Breaking** Moved the following SDK sampling types from `opentelemetry::trace` to `opentelemetry_sdk::trace` [#3277][3277]:

--- a/opentelemetry-sdk/src/metrics/internal/aggregate.rs
+++ b/opentelemetry-sdk/src/metrics/internal/aggregate.rs
@@ -126,6 +126,8 @@ pub(crate) struct AggregateBuilder<T> {
     /// Cardinality limit for the metric stream
     cardinality_limit: usize,
 
+    dynamic_memory_allocation_delta: bool,
+
     _marker: marker::PhantomData<T>,
 }
 
@@ -134,11 +136,13 @@ impl<T: Number> AggregateBuilder<T> {
         temporality: Temporality,
         filter: Option<Filter>,
         cardinality_limit: usize,
+        dynamic_memory_allocation_delta: bool,
     ) -> Self {
         AggregateBuilder {
             temporality,
             filter: AttributeSetFilter::new(filter),
             cardinality_limit,
+            dynamic_memory_allocation_delta,
             _marker: marker::PhantomData,
         }
     }
@@ -149,6 +153,7 @@ impl<T: Number> AggregateBuilder<T> {
             overwrite_temporality.unwrap_or(self.temporality),
             self.filter.clone(),
             self.cardinality_limit,
+            self.dynamic_memory_allocation_delta,
         )
         .into()
     }
@@ -160,6 +165,7 @@ impl<T: Number> AggregateBuilder<T> {
             self.filter.clone(),
             monotonic,
             self.cardinality_limit,
+            self.dynamic_memory_allocation_delta,
         )
         .into()
     }
@@ -171,6 +177,7 @@ impl<T: Number> AggregateBuilder<T> {
             self.filter.clone(),
             monotonic,
             self.cardinality_limit,
+            self.dynamic_memory_allocation_delta,
         )
         .into()
     }
@@ -189,6 +196,7 @@ impl<T: Number> AggregateBuilder<T> {
             record_min_max,
             record_sum,
             self.cardinality_limit,
+            self.dynamic_memory_allocation_delta,
         )
         .into()
     }
@@ -209,6 +217,7 @@ impl<T: Number> AggregateBuilder<T> {
             record_min_max,
             record_sum,
             self.cardinality_limit,
+            self.dynamic_memory_allocation_delta,
         )
         .into()
     }
@@ -228,9 +237,13 @@ mod tests {
 
     #[test]
     fn last_value_aggregation() {
-        let AggregateFns { measure, collect } =
-            AggregateBuilder::<u64>::new(Temporality::Cumulative, None, CARDINALITY_LIMIT_DEFAULT)
-                .last_value(None);
+        let AggregateFns { measure, collect } = AggregateBuilder::<u64>::new(
+            Temporality::Cumulative,
+            None,
+            CARDINALITY_LIMIT_DEFAULT,
+            false,
+        )
+        .last_value(None);
         let mut a = MetricData::Gauge(Gauge {
             data_points: vec![GaugeDataPoint {
                 attributes: vec![KeyValue::new("a", 1)],
@@ -260,7 +273,7 @@ mod tests {
     fn precomputed_sum_aggregation() {
         for temporality in [Temporality::Delta, Temporality::Cumulative] {
             let AggregateFns { measure, collect } =
-                AggregateBuilder::<u64>::new(temporality, None, CARDINALITY_LIMIT_DEFAULT)
+                AggregateBuilder::<u64>::new(temporality, None, CARDINALITY_LIMIT_DEFAULT, false)
                     .precomputed_sum(true);
             let mut a = MetricData::Sum(Sum {
                 data_points: vec![
@@ -307,7 +320,7 @@ mod tests {
     fn sum_aggregation() {
         for temporality in [Temporality::Delta, Temporality::Cumulative] {
             let AggregateFns { measure, collect } =
-                AggregateBuilder::<u64>::new(temporality, None, CARDINALITY_LIMIT_DEFAULT)
+                AggregateBuilder::<u64>::new(temporality, None, CARDINALITY_LIMIT_DEFAULT, false)
                     .sum(true);
             let mut a = MetricData::Sum(Sum {
                 data_points: vec![
@@ -354,7 +367,7 @@ mod tests {
     fn explicit_bucket_histogram_aggregation() {
         for temporality in [Temporality::Delta, Temporality::Cumulative] {
             let AggregateFns { measure, collect } =
-                AggregateBuilder::<u64>::new(temporality, None, CARDINALITY_LIMIT_DEFAULT)
+                AggregateBuilder::<u64>::new(temporality, None, CARDINALITY_LIMIT_DEFAULT, false)
                     .explicit_bucket_histogram(vec![1.0], true, true);
             let mut a = MetricData::Histogram(Histogram {
                 data_points: vec![HistogramDataPoint {
@@ -402,7 +415,7 @@ mod tests {
     fn exponential_histogram_aggregation() {
         for temporality in [Temporality::Delta, Temporality::Cumulative] {
             let AggregateFns { measure, collect } =
-                AggregateBuilder::<u64>::new(temporality, None, CARDINALITY_LIMIT_DEFAULT)
+                AggregateBuilder::<u64>::new(temporality, None, CARDINALITY_LIMIT_DEFAULT, false)
                     .exponential_bucket_histogram(4, 20, true, true);
             let mut a = MetricData::ExponentialHistogram(ExponentialHistogram {
                 data_points: vec![ExponentialHistogramDataPoint {

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -361,7 +361,6 @@ pub(crate) struct ExpoHistogram<T: Number> {
 }
 
 impl<T: Number> ExpoHistogram<T> {
-    /// Create a new exponential histogram.
     pub(crate) fn new(
         temporality: Temporality,
         filter: AttributeSetFilter,
@@ -370,6 +369,7 @@ impl<T: Number> ExpoHistogram<T> {
         record_min_max: bool,
         record_sum: bool,
         cardinality_limit: usize,
+        dynamic_memory_allocation_delta: bool,
     ) -> Self {
         ExpoHistogram {
             value_map: ValueMap::new(
@@ -378,6 +378,7 @@ impl<T: Number> ExpoHistogram<T> {
                     max_scale,
                 },
                 cardinality_limit,
+                dynamic_memory_allocation_delta,
             ),
             init_time: AggregateTimeInitiator::default(),
             temporality,
@@ -717,6 +718,7 @@ mod tests {
                 true,
                 true,
                 CARDINALITY_LIMIT_DEFAULT,
+                false,
             );
             for v in test.values {
                 Measure::call(&h, v, &[]);
@@ -774,6 +776,7 @@ mod tests {
                 true,
                 true,
                 CARDINALITY_LIMIT_DEFAULT,
+                false,
             );
             for v in test.values {
                 Measure::call(&h, v, &[]);
@@ -1286,13 +1289,18 @@ mod tests {
             TestCase {
                 name: "Delta Single",
                 build: Box::new(move || {
-                    AggregateBuilder::new(Temporality::Delta, None, CARDINALITY_LIMIT_DEFAULT)
-                        .exponential_bucket_histogram(
-                            max_size,
-                            max_scale,
-                            record_min_max,
-                            record_sum,
-                        )
+                    AggregateBuilder::new(
+                        Temporality::Delta,
+                        None,
+                        CARDINALITY_LIMIT_DEFAULT,
+                        false,
+                    )
+                    .exponential_bucket_histogram(
+                        max_size,
+                        max_scale,
+                        record_min_max,
+                        record_sum,
+                    )
                 }),
                 input: vec![vec![4, 4, 4, 2, 16, 1]
                     .into_iter()
@@ -1331,6 +1339,7 @@ mod tests {
                         Temporality::Cumulative,
                         None,
                         CARDINALITY_LIMIT_DEFAULT,
+                        false,
                     )
                     .exponential_bucket_histogram(
                         max_size,
@@ -1376,6 +1385,7 @@ mod tests {
                         Temporality::Delta,
                         None,
                         CARDINALITY_LIMIT_DEFAULT,
+                        false,
                     )
                     .exponential_bucket_histogram(
                         max_size,
@@ -1424,6 +1434,7 @@ mod tests {
                         Temporality::Cumulative,
                         None,
                         CARDINALITY_LIMIT_DEFAULT,
+                        false,
                     )
                     .exponential_bucket_histogram(
                         max_size,

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -361,6 +361,7 @@ pub(crate) struct ExpoHistogram<T: Number> {
 }
 
 impl<T: Number> ExpoHistogram<T> {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         temporality: Temporality,
         filter: AttributeSetFilter,

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -91,6 +91,7 @@ impl<T: Number> Histogram<T> {
         record_min_max: bool,
         record_sum: bool,
         cardinality_limit: usize,
+        dynamic_memory_allocation_delta: bool,
     ) -> Self {
         #[cfg(feature = "spec_unstable_metrics_views")]
         {
@@ -106,7 +107,11 @@ impl<T: Number> Histogram<T> {
         };
 
         Histogram {
-            value_map: ValueMap::new(buckets_count, cardinality_limit),
+            value_map: ValueMap::new(
+                buckets_count,
+                cardinality_limit,
+                dynamic_memory_allocation_delta,
+            ),
             init_time: AggregateTimeInitiator::default(),
             temporality,
             filter,
@@ -272,6 +277,7 @@ mod tests {
             false,
             false,
             2000,
+            false,
         );
         for v in 1..11 {
             Measure::call(&hist, v, &[]);

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -54,9 +54,10 @@ impl<T: Number> LastValue<T> {
         temporality: Temporality,
         filter: AttributeSetFilter,
         cardinality_limit: usize,
+        dynamic_memory_allocation_delta: bool,
     ) -> Self {
         LastValue {
-            value_map: ValueMap::new((), cardinality_limit),
+            value_map: ValueMap::new((), cardinality_limit, dynamic_memory_allocation_delta),
             init_time: AggregateTimeInitiator::default(),
             temporality,
             filter,

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -24,9 +24,10 @@ impl<T: Number> PrecomputedSum<T> {
         filter: AttributeSetFilter,
         monotonic: bool,
         cardinality_limit: usize,
+        dynamic_memory_allocation_delta: bool,
     ) -> Self {
         PrecomputedSum {
-            value_map: ValueMap::new((), cardinality_limit),
+            value_map: ValueMap::new((), cardinality_limit, dynamic_memory_allocation_delta),
             init_time: AggregateTimeInitiator::default(),
             temporality,
             filter,

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -47,19 +47,15 @@ pub(crate) struct Sum<T: Number> {
 }
 
 impl<T: Number> Sum<T> {
-    /// Returns an aggregator that summarizes a set of measurements as their
-    /// arithmetic sum.
-    ///
-    /// Each sum is scoped by attributes and the aggregation cycle the measurements
-    /// were made in.
     pub(crate) fn new(
         temporality: Temporality,
         filter: AttributeSetFilter,
         monotonic: bool,
         cardinality_limit: usize,
+        dynamic_memory_allocation_delta: bool,
     ) -> Self {
         Sum {
-            value_map: ValueMap::new((), cardinality_limit),
+            value_map: ValueMap::new((), cardinality_limit, dynamic_memory_allocation_delta),
             init_time: AggregateTimeInitiator::default(),
             temporality,
             filter,

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -39,6 +39,7 @@ pub struct Pipeline {
     reader: Box<dyn MetricReader>,
     views: Vec<Arc<dyn View>>,
     inner: Mutex<PipelineInner>,
+    dynamic_memory_allocation_delta: bool,
 }
 
 impl fmt::Debug for Pipeline {
@@ -404,6 +405,7 @@ where
                 self.pipeline.reader.temporality(kind),
                 filter,
                 cardinality_limit,
+                self.pipeline.dynamic_memory_allocation_delta,
             );
             let AggregateFns { measure, collect } = match aggregate_fn(b, &agg, kind) {
                 Ok(Some(inst)) => inst,
@@ -646,6 +648,7 @@ impl Pipelines {
         res: Resource,
         readers: Vec<Box<dyn MetricReader>>,
         views: Vec<Arc<dyn View>>,
+        dynamic_memory_allocation_delta: bool,
     ) -> Self {
         let mut pipes = Vec::with_capacity(readers.len());
         for r in readers {
@@ -654,6 +657,7 @@ impl Pipelines {
                 reader: r,
                 views: views.clone(),
                 inner: Default::default(),
+                dynamic_memory_allocation_delta,
             });
             p.reader.register_pipeline(Arc::downgrade(&p));
             pipes.push(p);


### PR DESCRIPTION
Addresses https://github.com/open-telemetry/opentelemetry-rust/pull/3290#discussion_r2677338361 , reverting the original fix.