### PR TITLE
fix: template for telemetry schema URL

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -76,7 +76,7 @@ use opentelemetry::KeyValue;
 
 let scope = InstrumentationScope::builder("my_company.my_product.my_library")
         .with_version("0.17")
-        .with_schema_url("https://opentelemetry.io/schema/1.2.0")
+        .with_schema_url("https://opentelemetry.io/schemas/1.2.0")
         .with_attributes([KeyValue::new("key", "value")])
         .build();
 

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -379,7 +379,7 @@ fn prometheus_exporter_integration() {
 
         let scope = InstrumentationScope::builder("testmeter")
             .with_version("v0.1.0")
-            .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+            .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
             .with_attributes(vec![KeyValue::new("k", "v")])
             .build();
 
@@ -437,7 +437,7 @@ fn multiple_scopes() {
 
     let scope_foo = InstrumentationScope::builder("meterfoo")
         .with_version("v0.1.0")
-        .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+        .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
         .with_attributes(vec![KeyValue::new("k", "v")])
         .build();
 
@@ -451,7 +451,7 @@ fn multiple_scopes() {
 
     let scope_bar = InstrumentationScope::builder("meterbar")
         .with_version("v0.1.0")
-        .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+        .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
         .with_attributes(vec![KeyValue::new("k", "v")])
         .build();
 
@@ -785,13 +785,13 @@ fn duplicate_metrics() {
 
         let scope_ma = InstrumentationScope::builder("ma")
             .with_version("v0.1.0")
-            .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+            .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
             .with_attributes(vec![KeyValue::new("k", "v")])
             .build();
 
         let scope_mb = InstrumentationScope::builder("mb")
             .with_version("v0.1.0")
-            .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+            .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
             .with_attributes(vec![KeyValue::new("k", "v")])
             .build();
 

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -127,7 +127,7 @@ mod tests {
             .build();
 
         let scope = InstrumentationScope::builder("test_logger")
-            .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+            .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
             .with_attributes(vec![(KeyValue::new("test_k", "test_v"))])
             .build();
 
@@ -149,7 +149,7 @@ mod tests {
         assert_eq!(instrumentation_scope.name(), "test_logger");
         assert_eq!(
             instrumentation_scope.schema_url(),
-            Some("https://opentelemetry.io/schema/1.0.0")
+            Some("https://opentelemetry.io/schemas/1.0.0")
         );
         assert!(instrumentation_scope
             .attributes()

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -267,7 +267,7 @@ Before:
 let logger = provider.versioned_logger(
     "my-logger-name",
     Some(env!("CARGO_PKG_VERSION")),
-    Some("https://opentelemetry.io/schema/1.0.0"),
+    Some("https://opentelemetry.io/schemas/1.0.0"),
     Some(vec![KeyValue::new("key", "value")]),
 );
 ```
@@ -278,7 +278,7 @@ After:
 let logger = provider
     .logger_builder("my-logger-name")
     .with_version(env!("CARGO_PKG_VERSION"))
-    .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+    .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
     .with_attributes(vec![KeyValue::new("key", "value")])
     .build();
 ```
@@ -291,7 +291,7 @@ Before:
 let tracer = provider.versioned_tracer(
     "my-tracer-name",
     Some(env!("CARGO_PKG_VERSION")),
-    Some("https://opentelemetry.io/schema/1.0.0"),
+    Some("https://opentelemetry.io/schemas/1.0.0"),
     Some(vec![KeyValue::new("key", "value")]),
 );
 ```
@@ -302,7 +302,7 @@ After:
 let tracer = provider
     .tracer_builder("my-tracer-name")
     .with_version(env!("CARGO_PKG_VERSION"))
-    .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+    .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
     .with_attributes(vec![KeyValue::new("key", "value")])
     .build();
 ```

--- a/opentelemetry/src/global/metrics.rs
+++ b/opentelemetry/src/global/metrics.rs
@@ -71,7 +71,7 @@ pub fn meter(name: &'static str) -> Meter {
 ///
 /// let scope = InstrumentationScope::builder("io.opentelemetry")
 ///     .with_version("0.17")
-///     .with_schema_url("https://opentelemetry.io/schema/1.2.0")
+///     .with_schema_url("https://opentelemetry.io/schemas/1.2.0")
 ///     .with_attributes(vec![(KeyValue::new("key", "value"))])
 ///     .build();
 ///

--- a/opentelemetry/src/global/trace.rs
+++ b/opentelemetry/src/global/trace.rs
@@ -408,7 +408,7 @@ pub fn tracer(name: impl Into<Cow<'static, str>>) -> BoxedTracer {
 ///
 /// let scope = InstrumentationScope::builder("io.opentelemetry")
 ///     .with_version("0.17")
-///     .with_schema_url("https://opentelemetry.io/schema/1.2.0")
+///     .with_schema_url("https://opentelemetry.io/schemas/1.2.0")
 ///     .with_attributes(vec![(KeyValue::new("key", "value"))])
 ///     .build();
 ///

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -44,7 +44,7 @@ pub trait LoggerProvider {
     /// // logger used in libraries/crates that optionally includes version and schema url
     /// let scope = InstrumentationScope::builder(env!("CARGO_PKG_NAME"))
     ///     .with_version(env!("CARGO_PKG_VERSION"))
-    ///     .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+    ///     .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
     ///     .build();
     ///
     /// let logger = provider.logger_with_scope(scope);

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -54,7 +54,7 @@ pub trait MeterProvider {
     /// // meter used in libraries/crates that optionally includes version and schema url
     /// let scope = InstrumentationScope::builder(env!("CARGO_PKG_NAME"))
     ///     .with_version(env!("CARGO_PKG_VERSION"))
-    ///     .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+    ///     .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
     ///     .build();
     ///
     /// let meter = provider.meter_with_scope(scope);

--- a/opentelemetry/src/trace/tracer_provider.rs
+++ b/opentelemetry/src/trace/tracer_provider.rs
@@ -49,7 +49,7 @@ pub trait TracerProvider {
     /// let scope =
     ///     InstrumentationScope::builder(env!("CARGO_PKG_NAME"))
     ///         .with_version(env!("CARGO_PKG_VERSION"))
-    ///         .with_schema_url("https://opentelemetry.io/schema/1.0.0")
+    ///         .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
     ///         .build();
     ///
     /// let tracer = provider.tracer_with_scope(scope);


### PR DESCRIPTION
Fixes N/A
Design discussion issue (if applicable) N/A

## Changes

fix: template for telemetry schema URL.
I was googling for the example how the template looks like. One of the results is otel rust docs. I spend some time to ivnestigate why https://opentelemetry.io/schema/1.33.0 is not working,. The reals url is https://opentelemetry.io/schemas/1.33.0

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
