### PR TITLE
chore: Nit improvemenst to docs and test

### DIFF
--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -105,6 +105,8 @@ type LogsData = Box<(SdkLogRecord, InstrumentationScope)>;
 /// ### Using a BatchLogProcessor:
 ///
 /// ```rust
+/// # #[cfg(feature = "testing")]
+/// # {
 /// use opentelemetry_sdk::logs::{BatchLogProcessor, BatchConfigBuilder, SdkLoggerProvider};
 /// use opentelemetry::global;
 /// use std::time::Duration;
@@ -124,6 +126,7 @@ type LogsData = Box<(SdkLogRecord, InstrumentationScope)>;
 /// let provider = SdkLoggerProvider::builder()
 ///     .with_log_processor(processor)
 ///     .build();
+/// # }
 ///
 pub struct BatchLogProcessor {
     logs_sender: SyncSender<LogsData>, // Data channel to store log records and instrumentation scopes

--- a/opentelemetry-sdk/src/logs/simple_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/simple_log_processor.rs
@@ -48,6 +48,8 @@ use std::time::Duration;
 /// ### Using a SimpleLogProcessor
 ///
 /// ```rust
+/// # #[cfg(feature = "testing")]
+/// # {
 /// use opentelemetry_sdk::logs::{SimpleLogProcessor, SdkLoggerProvider, LogExporter};
 /// use opentelemetry::global;
 /// use opentelemetry_sdk::logs::InMemoryLogExporter;
@@ -56,7 +58,7 @@ use std::time::Duration;
 /// let provider = SdkLoggerProvider::builder()
 ///     .with_simple_exporter(exporter)
 ///     .build();
-///
+/// # }
 /// ```
 ///
 #[derive(Debug)]

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -133,13 +133,13 @@ impl Instrument {
 ///
 /// # Example
 ///
-/// ```
-/// use opentelemetry_sdk::metrics::{Aggregation, Stream};
-/// use opentelemetry::Key;
+/// ```rust
+/// use opentelemetry_sdk::metrics::Stream;
 ///
 /// let stream = Stream::builder()
 ///     .with_name("my_stream")
-///     .with_aggregation(Aggregation::Sum)
+///     .with_description("A custom stream")
+///     .with_unit("ms")
 ///     .with_cardinality_limit(100)
 ///     .build()
 ///     .unwrap();

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -25,7 +25,7 @@ use super::{
 ///
 /// All `Meter`s created by a `MeterProvider` will be associated with the same
 /// [Resource], have the same views applied to them, and have their produced
-/// metric telemetry passed to the configured [MetricReader]s. This is a
+/// metric telemetry passed to the configured `MetricReader`s. This is a
 /// clonable handle to the MeterProvider implementation itself, and cloning it
 /// will create a new reference, not a new instance of a MeterProvider. Dropping
 /// the last reference to it will trigger shutdown of the provider. Shutdown can
@@ -256,11 +256,11 @@ impl MeterProviderBuilder {
         self
     }
 
-    /// Associates a [MetricReader] with a [MeterProvider].
-    /// [`MeterProviderBuilder::with_periodic_exporter()] can be used to add a PeriodicReader which is
+    /// Associates a `MetricReader` with a [MeterProvider].
+    /// [`MeterProviderBuilder::with_periodic_exporter()`] can be used to add a PeriodicReader which is
     /// the most common use case.
     ///
-    /// A [MeterProvider] will export no metrics without [MetricReader]
+    /// A [MeterProvider] will export no metrics without a `MetricReader`
     /// added.
     pub fn with_reader<T: MetricReader>(mut self, reader: T) -> Self {
         self.readers.push(Box::new(reader));

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -3,7 +3,7 @@
 //! ## Configuration
 //!
 //! The metrics SDK configuration is stored with each [SdkMeterProvider].
-//! Configuration for [Resource]s, views, and [ManualReader] or
+//! Configuration for [Resource]s, views, and `ManualReader` or
 //! [PeriodicReader] instances can be specified.
 //!
 //! ### Example

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -195,45 +195,44 @@ impl<T: SpanExporter> SpanProcessor for SimpleSpanProcessor<T> {
 /// to manage the export process.
 ///
 /// ```rust
+/// # #[cfg(feature = "testing")]
+/// # {
 /// use opentelemetry::global;
-/// use opentelemetry_sdk::{
-///     trace::{BatchSpanProcessor, BatchConfigBuilder, SdkTracerProvider},
-///     runtime,
-///     testing::trace::NoopSpanExporter,
+/// use opentelemetry_sdk::trace::{
+///     BatchSpanProcessor, BatchConfigBuilder, SdkTracerProvider, InMemorySpanExporter,
 /// };
 /// use opentelemetry::trace::Tracer as _;
 /// use opentelemetry::trace::Span;
 /// use std::time::Duration;
 ///
-/// fn main() {
-///     // Step 1: Create an exporter (e.g., a No-Op Exporter for demonstration).
-///     let exporter = NoopSpanExporter::new();
+/// // Step 1: Create an exporter (e.g., an In-Memory Exporter for demonstration).
+/// let exporter = InMemorySpanExporter::default();
 ///
-///     // Step 2: Configure the BatchSpanProcessor.
-///     let batch_processor = BatchSpanProcessor::builder(exporter)
-///         .with_batch_config(
-///             BatchConfigBuilder::default()
-///                 .with_max_queue_size(1024) // Buffer up to 1024 spans.
-///                 .with_max_export_batch_size(256) // Export in batches of up to 256 spans.
-///                 .with_scheduled_delay(Duration::from_secs(5)) // Export every 5 seconds.
-///                 .build(),
-///         )
-///         .build();
+/// // Step 2: Configure the BatchSpanProcessor.
+/// let batch_processor = BatchSpanProcessor::builder(exporter)
+///     .with_batch_config(
+///         BatchConfigBuilder::default()
+///             .with_max_queue_size(1024) // Buffer up to 1024 spans.
+///             .with_max_export_batch_size(256) // Export in batches of up to 256 spans.
+///             .with_scheduled_delay(Duration::from_secs(5)) // Export every 5 seconds.
+///             .build(),
+///     )
+///     .build();
 ///
-///     // Step 3: Set up a TracerProvider with the configured processor.
-///     let provider = SdkTracerProvider::builder()
-///         .with_span_processor(batch_processor)
-///         .build();
-///     global::set_tracer_provider(provider.clone());
+/// // Step 3: Set up a TracerProvider with the configured processor.
+/// let provider = SdkTracerProvider::builder()
+///     .with_span_processor(batch_processor)
+///     .build();
+/// global::set_tracer_provider(provider.clone());
 ///
-///     // Step 4: Create spans and record operations.
-///     let tracer = global::tracer("example-tracer");
-///     let mut span = tracer.start("example-span");
-///     span.end(); // Mark the span as completed.
+/// // Step 4: Create spans and record operations.
+/// let tracer = global::tracer("example-tracer");
+/// let mut span = tracer.start("example-span");
+/// span.end(); // Mark the span as completed.
 ///
-///     // Step 5: Ensure all spans are flushed before exiting.
-///     provider.shutdown();
-/// }
+/// // Step 5: Ensure all spans are flushed before exiting.
+/// provider.shutdown();
+/// # }
 /// ```
 use std::sync::mpsc::sync_channel;
 use std::sync::mpsc::Receiver;


### PR DESCRIPTION
InMemoryExporter is used in docs, but it is only available when `testing` feature is enabled. This PR adds conditional build.