### PR TITLE
fix: Deserialize `"value": {}` in OTLP/JSON kvList

### DIFF
--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Updated `schemars` dependency to version 1.0.0.
+- Fix JSON deserialization of kvList entries that serialize `None` values as `{key: "name", value: {}}`
 
 ## 0.31.0
 


### PR DESCRIPTION
## Changes

Some serializers for OTLP/JSON format are serializing attributes with
empty values, e.g.
`"http.route": None` becomes in OTLP/JSON:
`{ "key": "http.route", "value": {} }`

This commit allows deserializer to return `None` for a value in a
key-value pair, if the value is an empty object.

Ref: <https://github.com/open-telemetry/opentelemetry-proto/blob/a8951735f7801e8adfaec5c0ace9262771cfec6e/opentelemetry/proto/common/v1/common.proto#L25C1-L30C62>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] ~~Unit tests added/updated (if applicable)~~ no unit tests found in the modified file
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes~~
* [ ] ~~Changes in public API reviewed (if applicable~~
