### PR TITLE
refactor(otlp): deprecate tls feature in favor of explicit tls-ring and tls-aws-lc

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Add partial success response handling for OTLP exporters (traces, metrics, logs) per OTLP spec. Exporters now log warnings when the server returns partial success responses with rejected items and error messages. [#865](https://github.com/open-telemetry/opentelemetry-rust/issues/865)
 - Refactor `internal-logs` feature in `opentelemetry-otlp` to reduce unnecessary dependencies[3191](https://github.com/open-telemetry/opentelemetry-rust/pull/3192)
 - Fixed [#2777](https://github.com/open-telemetry/opentelemetry rust/issues/2777)  to properly handle `shutdown_with_timeout()` when using `grpc-tonic`.
+- Deprecate `tls` feature in favor of explicit `tls-ring` and `tls-aws-lc` features.
+  **Migration**: Replace `tls` with `tls-ring` (or `tls-aws-lc`). Users of `tls-roots` or `tls-webpki-roots` must now also enable one of these.
 
 ## 0.31.0
 

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -80,9 +80,11 @@ experimental-grpc-retry = ["grpc-tonic", "opentelemetry_sdk/experimental_async_r
 # http compression
 gzip-http = ["flate2"]
 zstd-http = ["zstd"]
-tls = ["tonic/tls-ring"]
-tls-roots = ["tls", "tonic/tls-native-roots"]
-tls-webpki-roots = ["tls", "tonic/tls-webpki-roots"]
+tls = ["tls-ring"] # Deprecated: use tls-ring or tls-aws-lc.
+tls-ring = ["tonic/tls-ring"]
+tls-aws-lc = ["tonic/tls-aws-lc"]
+tls-roots = ["tonic/tls-native-roots"]
+tls-webpki-roots = ["tonic/tls-webpki-roots"]
 
 # http binary
 http-proto = ["prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "http", "trace", "metrics"]

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -8,7 +8,7 @@ use tonic::codec::CompressionEncoding;
 use tonic::metadata::{KeyAndValueRef, MetadataMap};
 use tonic::service::Interceptor;
 use tonic::transport::Channel;
-#[cfg(feature = "tls")]
+#[cfg(any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc"))]
 use tonic::transport::ClientTlsConfig;
 
 use super::{default_headers, parse_header_string, OTEL_EXPORTER_OTLP_GRPC_ENDPOINT_DEFAULT};
@@ -52,7 +52,7 @@ pub struct TonicConfig {
     /// Custom metadata entries to send to the collector.
     pub(crate) metadata: Option<MetadataMap>,
     /// TLS settings for the collector endpoint.
-    #[cfg(feature = "tls")]
+    #[cfg(any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc"))]
     pub(crate) tls_config: Option<ClientTlsConfig>,
     /// The compression algorithm to use when communicating with the collector.
     pub(crate) compression: Option<Compression>,
@@ -90,7 +90,7 @@ impl TryFrom<Compression> for tonic::codec::CompressionEncoding {
 ///
 /// It allows you to
 /// - add additional metadata
-/// - set tls config (via the  `tls` feature)
+/// - set tls config (via the `tls-ring` or `tls-aws-lc` features)
 /// - specify custom [channel]s
 ///
 /// [tonic]: <https://github.com/hyperium/tonic>
@@ -148,7 +148,7 @@ impl Default for TonicExporterBuilder {
                         .try_into()
                         .expect("Invalid tonic headers"),
                 )),
-                #[cfg(feature = "tls")]
+                #[cfg(any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc"))]
                 tls_config: None,
                 compression: None,
                 channel: Option::default(),
@@ -240,7 +240,7 @@ impl TonicExporterBuilder {
             .map_err(|op| ExporterBuildError::InvalidUri(endpoint_clone.clone(), op.to_string()))?;
         let timeout = resolve_timeout(signal_timeout_var, config.timeout.as_ref());
 
-        #[cfg(feature = "tls")]
+        #[cfg(any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc"))]
         let channel = match self.tonic_config.tls_config {
             Some(tls_config) => endpoint
                 .tls_config(tls_config)
@@ -250,7 +250,7 @@ impl TonicExporterBuilder {
         .timeout(timeout)
         .connect_lazy();
 
-        #[cfg(not(feature = "tls"))]
+        #[cfg(not(any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc")))]
         let channel = endpoint.timeout(timeout).connect_lazy();
 
         otel_debug!(name: "TonicChannelBuilt", endpoint = endpoint_clone, timeout_in_millisecs = timeout.as_millis(), compression = format!("{:?}", compression), headers = format!("{:?}", headers_for_logging));
@@ -463,7 +463,7 @@ impl HasTonicConfig for TonicExporterBuilder {
 /// ```
 pub trait WithTonicConfig {
     /// Set the TLS settings for the collector endpoint.
-    #[cfg(feature = "tls")]
+    #[cfg(any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc"))]
     fn with_tls_config(self, tls_config: ClientTlsConfig) -> Self;
 
     /// Set custom metadata entries to send to the collector.
@@ -576,7 +576,7 @@ pub trait WithTonicConfig {
 }
 
 impl<B: HasTonicConfig> WithTonicConfig for B {
-    #[cfg(feature = "tls")]
+    #[cfg(any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc"))]
     fn with_tls_config(mut self, tls_config: ClientTlsConfig) -> Self {
         self.tonic_config().tls_config = Some(tls_config);
         self

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -221,8 +221,11 @@
 //! * `grpc-tonic`: Use `tonic` as grpc layer.
 //! * `gzip-tonic`: Use gzip compression for `tonic` grpc layer.
 //! * `zstd-tonic`: Use zstd compression for `tonic` grpc layer.
-//! * `tls-roots`: Adds system trust roots to rustls-based gRPC clients using the rustls-native-certs crate
-//! * `tls-webpki-roots`: Embeds Mozilla's trust roots to rustls-based gRPC clients using the webpki-roots crate
+//! * `tls-ring`: Enable rustls TLS support using ring for `tonic`.
+//! * `tls-aws-lc`: Enable rustls TLS support using aws-lc for `tonic`.
+//! * `tls` (deprecated): Use `tls-ring` or `tls-aws-lc` instead.
+//! * `tls-roots`: Adds system trust roots to rustls-based gRPC clients using the rustls-native-certs crate (use with `tls-ring` or `tls-aws-lc`).
+//! * `tls-webpki-roots`: Embeds Mozilla's trust roots to rustls-based gRPC clients using the webpki-roots crate (use with `tls-ring` or `tls-aws-lc`).
 //!
 //! The following feature flags offer additional configurations on http:
 //!
@@ -540,7 +543,7 @@ pub mod tonic_types {
     }
 
     /// Re-exported types from `tonic::transport`.
-    #[cfg(feature = "tls")]
+    #[cfg(any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc"))]
     pub mod transport {
         #[doc(no_inline)]
         pub use tonic::transport::{Certificate, ClientTlsConfig, Identity};


### PR DESCRIPTION
The generic tls feature currently enables tonic/tls-ring, which implicitly selects the ring rustls crypto provider.
This makes it difficult or impossible for downstream users to use alternative rustls providers such as aws-lc, and can lead to feature unification conflicts when combined with other TLS-enabled dependencies.

This PR deprecates the generic tls feature and introduces explicit tls-ring and tls-aws-lc features, exposing both underlying tonic TLS options and allowing consumers to consistently select a single rustls crypto provider.

## Motivation

Rustls 0.23 requires a single, unambiguous crypto provider (ring or aws-lc).
Because Cargo features are additive, the existing tls feature could silently force ring even when users explicitly opted into aws-lc elsewhere, resulting in runtime panics during TLS initialization.

Providing explicit TLS feature flags avoids this class of failure and aligns with tonic’s provider model.

## Changes
- Deprecate the existing tls feature
- Introduce:
  - tls-ring → enables tonic/tls-ring
  - tls-aws-lc → enables tonic/tls-aws-lc
- Update documentation to recommend selecting exactly one TLS feature

## Migration

Users currently relying on tls should switch to one of:
```toml
features = ["tls-ring"]
```

or

```toml
features = ["tls-aws-lc"]
```

The deprecated tls feature remains temporarily for compatibility but should not be used in new configurations.

## Caveat
The feature `tls-roots` and `tls-webpki-roots` can no longer explicitly enable `tls`. This could lead to issues with users that relied on this impicit feature map.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
