### PR TITLE
fix(proto): Permissive integers in protobuf JSON parsing

### DIFF
--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Updated `schemars` dependency to version 1.0.0.
+- Fix JSON deserialization to accept both string and integer for 64-bit fields, per OTLP spec.
 
 ## 0.31.0
 

--- a/opentelemetry-proto/src/proto.rs
+++ b/opentelemetry-proto/src/proto.rs
@@ -10,7 +10,7 @@ pub(crate) mod serializers {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use std::fmt;
 
-    /// Visitor for deserializing u64 from either a string or integer.
+    /// Visitor for deserializing a `u64` from either a string or integer.
     struct StringOrU64Visitor;
 
     impl<'de> Visitor<'de> for StringOrU64Visitor {
@@ -29,7 +29,7 @@ pub(crate) mod serializers {
         }
     }
 
-    /// Visitor for deserializing i64 from either a string or integer.
+    /// Visitor for deserializing `i64` from either a string or integer.
     struct StringOrI64Visitor;
 
     impl<'de> Visitor<'de> for StringOrI64Visitor {
@@ -52,7 +52,7 @@ pub(crate) mod serializers {
         }
     }
 
-    /// Visitor for deserializing a Vec<u64> where each element can be a string or integer.
+    /// Visitor for deserializing a `Vec<u64>` where each element can be a string or integer.
     struct StringOrU64VecVisitor;
 
     impl<'de> Visitor<'de> for StringOrU64VecVisitor {
@@ -71,7 +71,7 @@ pub(crate) mod serializers {
         }
     }
 
-    /// Seed for deserializing individual u64 elements within a sequence.
+    /// Seed for deserializing individual `u64` elements within a sequence.
     struct StringOrU64Seed;
 
     impl<'de> de::DeserializeSeed<'de> for StringOrU64Seed {

--- a/opentelemetry-proto/src/proto.rs
+++ b/opentelemetry-proto/src/proto.rs
@@ -170,8 +170,17 @@ pub(crate) mod serializers {
     where
         D: Deserializer<'de>,
     {
-        let s: String = Deserialize::deserialize(deserializer)?;
-        s.parse::<u64>().map_err(de::Error::custom)
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum StringOrU64 {
+            U64(u64),
+            String(String),
+        }
+
+        match StringOrU64::deserialize(deserializer)? {
+            StringOrU64::U64(v) => Ok(v),
+            StringOrU64::String(s) => s.parse().map_err(de::Error::custom),
+        }
     }
 
     pub fn serialize_vec_u64_to_string<S>(value: &[u64], serializer: S) -> Result<S::Ok, S::Error>
@@ -192,9 +201,19 @@ pub(crate) mod serializers {
     where
         D: Deserializer<'de>,
     {
-        let s: Vec<String> = Deserialize::deserialize(deserializer)?;
-        s.into_iter()
-            .map(|v| v.parse::<u64>().map_err(de::Error::custom))
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum StringOrU64 {
+            U64(u64),
+            String(String),
+        }
+
+        let v: Vec<StringOrU64> = Deserialize::deserialize(deserializer)?;
+        v.into_iter()
+            .map(|item| match item {
+                StringOrU64::U64(n) => Ok(n),
+                StringOrU64::String(s) => s.parse().map_err(de::Error::custom),
+            })
             .collect()
     }
 
@@ -210,8 +229,17 @@ pub(crate) mod serializers {
     where
         D: Deserializer<'de>,
     {
-        let s: String = Deserialize::deserialize(deserializer)?;
-        s.parse::<i64>().map_err(de::Error::custom)
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum StringOrI64 {
+            I64(i64),
+            String(String),
+        }
+
+        match StringOrI64::deserialize(deserializer)? {
+            StringOrI64::I64(v) => Ok(v),
+            StringOrI64::String(s) => s.parse().map_err(de::Error::custom),
+        }
     }
 }
 

--- a/opentelemetry-proto/tests/json_serde.rs
+++ b/opentelemetry-proto/tests/json_serde.rs
@@ -773,6 +773,20 @@ mod json_serde {
                 let expected: Event = value();
                 assert_eq!(actual, expected);
             }
+
+            /// OTLP spec: 64-bit integers may be encoded as either strings or integers.
+            #[test]
+            fn deserialize_integer_timestamp() {
+                // language=json
+                const JSON: &str = r#"{
+  "timeUnixNano": 1234567890,
+  "name": "my_event"
+}"#;
+                let actual: Event =
+                    serde_json::from_str(JSON).expect("deserialization must succeed");
+                let expected: Event = value();
+                assert_eq!(actual, expected);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes: #3328

## Changes

Ensure that we accept both `u64` and `String` as inputs for large numbers, as the protobuf spec dictates (see #3328).

Note: This deviates in pattern slightly from established code, using a visitor for `IntOrString` -- I hope this is okay, but there's potential to unify here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)

(Technically it is an API change, since more values are now accepted?)
