### PR TITLE
feat(otlp): add reqwest-native-tls feature flag for HTTP transport

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## vNext
 
 - `reqwest`'s crypto backend has changed from `ring` to `aws-lc-sys`.
+- Add `reqwest-native-tls` feature flag to enable system native TLS (OpenSSL on Linux, Schannel on Windows, Secure Transport on macOS).
+- Update `reqwest-rustls` and `reqwest-rustls-webpki-roots` features to use explicit `rustls-tls` instead of `default-tls` for clarity.
 
 ## 0.31.0
 

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - `reqwest`'s crypto backend has changed from `ring` to `aws-lc-sys`.
 - Add `reqwest-native-tls` feature flag to enable system native TLS (OpenSSL on Linux, Schannel on Windows, Secure Transport on macOS).
-- Update `reqwest-rustls` and `reqwest-rustls-webpki-roots` features to use explicit `rustls-tls` instead of `default-tls` for clarity.
 
 ## 0.31.0
 
@@ -55,7 +54,7 @@ Released 2024-Sep-30
 - Update `opentelemetry` dependency version to 0.25
 - Starting with this version, this crate will align with `opentelemetry` crate
   on major,minor versions.
-  
+
 ## v0.13.0
 
 - **Breaking** Correct the misspelling of "webkpi" to "webpki" in features [#1842](https://github.com/open-telemetry/opentelemetry-rust/pull/1842)

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = ["dep:reqwest"]
 reqwest-blocking = ["dep:reqwest", "reqwest/blocking"]
 reqwest-rustls = ["dep:reqwest", "reqwest/default-tls"]
 reqwest-rustls-webpki-roots = ["dep:reqwest", "reqwest/default-tls", "reqwest/webpki-roots"]
+reqwest-native-tls = ["dep:reqwest", "reqwest/native-tls"]
 internal-logs = ["opentelemetry/internal-logs"]
 
 [dependencies]

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -12,13 +12,13 @@
 - Add support for `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable
   to configure metrics temporality. Accepted values: `cumulative` (default), `delta`,
   `lowmemory` (case-insensitive). Programmatic `.with_temporality()` overrides the env var.
-- Add `reqwest-native-tls` feature flag to enable system native TLS (OpenSSL on Linux, Schannel on Windows, Secure Transport on macOS).
 - Fix `NoHttpClient` error when multiple HTTP client features are enabled by using priority-based selection (`reqwest-client` > `hyper-client` > `reqwest-blocking-client`). [#2994](https://github.com/open-telemetry/opentelemetry-rust/issues/2994)
 - Add partial success response handling for OTLP exporters (traces, metrics, logs) per OTLP spec. Exporters now log warnings when the server returns partial success responses with rejected items and error messages. [#865](https://github.com/open-telemetry/opentelemetry-rust/issues/865)
 - Refactor `internal-logs` feature in `opentelemetry-otlp` to reduce unnecessary dependencies[3191](https://github.com/open-telemetry/opentelemetry-rust/pull/3192)
 - Fixed [#2777](https://github.com/open-telemetry/opentelemetry rust/issues/2777)  to properly handle `shutdown_with_timeout()` when using `grpc-tonic`.
 - Deprecate `tls` feature in favor of explicit `tls-ring` and `tls-aws-lc` features.
   **Migration**: Replace `tls` with `tls-ring` (or `tls-aws-lc`). Users of `tls-roots` or `tls-webpki-roots` must now also enable one of these.
+- Add `reqwest-native-tls` feature flag to enable system native TLS (OpenSSL on Linux, Schannel on Windows, Secure Transport on macOS).
 
 ## 0.31.0
 

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add support for `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable
   to configure metrics temporality. Accepted values: `cumulative` (default), `delta`,
   `lowmemory` (case-insensitive). Programmatic `.with_temporality()` overrides the env var.
+- Add `reqwest-native-tls` feature flag to enable system native TLS (OpenSSL on Linux, Schannel on Windows, Secure Transport on macOS).
 - Fix `NoHttpClient` error when multiple HTTP client features are enabled by using priority-based selection (`reqwest-client` > `hyper-client` > `reqwest-blocking-client`). [#2994](https://github.com/open-telemetry/opentelemetry-rust/issues/2994)
 - Add partial success response handling for OTLP exporters (traces, metrics, logs) per OTLP spec. Exporters now log warnings when the server returns partial success responses with rejected items and error messages. [#865](https://github.com/open-telemetry/opentelemetry-rust/issues/865)
 - Refactor `internal-logs` feature in `opentelemetry-otlp` to reduce unnecessary dependencies[3191](https://github.com/open-telemetry/opentelemetry-rust/pull/3192)

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -97,6 +97,7 @@ reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest-block
 reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
 reqwest-rustls = ["reqwest", "opentelemetry-http/reqwest-rustls"]
 reqwest-rustls-webpki-roots = ["reqwest", "opentelemetry-http/reqwest-rustls-webpki-roots"]
+reqwest-native-tls = ["reqwest", "opentelemetry-http/reqwest-native-tls"]
 hyper-client = ["opentelemetry-http/hyper"]
 
 # test

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -283,6 +283,7 @@
 //! * `reqwest-client`: Use reqwest http client.
 //! * `reqwest-rustls`: Use reqwest with TLS with system trust roots via `rustls-native-certs` crate.
 //! * `reqwest-rustls-webpki-roots`: Use reqwest with TLS with Mozilla's trust roots via `webpki-roots` crate.
+//! * `reqwest-native-tls`: Use reqwest with system native TLS (OpenSSL on Linux, Schannel on Windows, Secure Transport on macOS).
 //!
 //! # Kitchen Sink Full Configuration
 //!


### PR DESCRIPTION
## Changes

Add optional `reqwest-native-tls` feature flag to opentelemetry-http and opentelemetry-otlp crates, enabling the use of system native TLS instead of bundled rustls.

This is particularly beneficial for Linux distribution packagers who need to link against system libraries (OpenSSL) rather than bundling TLS implementations. Using system TLS allows:

- Leveraging system-managed security updates for TLS/OpenSSL
- Reducing binary size by avoiding bundled crypto libraries
- Ensuring consistency with system certificate stores
- Complying with distribution packaging policies that prefer system libs

On other platforms, this uses Schannel (Windows) and Secure Transport (macOS).

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
