### PR TITLE
feat(sdk): add 32-bit platform support using portable-atomic

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNext
 
+- Add 32-bit platform support by using `portable-atomic` for `AtomicI64` and `AtomicU64` in the metrics module. This enables compilation on 32-bit ARM targets (e.g., `armv5te-unknown-linux-gnueabi`, `armv7-unknown-linux-gnueabihf`).
 - `Aggregation` enum and `StreamBuilder::with_aggregation()` are now stable and no longer require the `spec_unstable_metrics_views` feature flag.
 - Fix `service.name` Resource attribute fallback to follow OpenTelemetry
   specification by using `unknown_service:<process.executable.name>` format when

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -26,6 +26,9 @@ tokio = { workspace = true, default-features = false, optional = true }
 tokio-stream = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 
+[target.'cfg(not(target_has_atomic = "64"))'.dependencies]
+portable-atomic = { version = "1", default-features = false, features = ["fallback"] }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Add 32-bit platform support by using `portable-atomic` for `AtomicI64` and `AtomicU64` in the metrics module.

## Motivation

32-bit ARM platforms (e.g., `armv5te-unknown-linux-gnueabi`, `armv7-unknown-linux-gnueabihf`) lack native 64-bit atomic operations. The current use of `std::sync::atomic::AtomicI64` and `AtomicU64` causes compilation failures on these targets:

```
error[E0432]: unresolved imports `std::sync::atomic::AtomicI64`, `std::sync::atomic::AtomicU64`
```

These platforms are common in embedded/IoT environments where lightweight OpenTelemetry collection is valuable. I need this change to unblock https://github.com/streamfold/rotel/pull/304

## Solution

Replace `std::sync::atomic::{AtomicI64, AtomicU64}` with `portable_atomic::{AtomicI64, AtomicU64}`.

The `portable-atomic` crate:
- Uses native atomics on 64-bit platforms (zero overhead)
- Provides software-based fallback on 32-bit platforms via the `fallback` feature
- Is widely used and well-maintained