### PR TITLE
feat(tracing): allow span processor to keep span reference

### DIFF
--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -39,7 +39,7 @@ pub use id_generator::{IdGenerator, RandomIdGenerator};
 pub use links::SpanLinks;
 pub use provider::{SdkTracerProvider, TracerProviderBuilder};
 pub use sampler::{Sampler, SamplingDecision, SamplingResult, ShouldSample};
-pub use span::Span;
+pub use span::{Span, SpanHandle};
 pub use span_limit::SpanLimits;
 pub use span_processor::{
     BatchConfig, BatchConfigBuilder, BatchSpanProcessor, BatchSpanProcessorBuilder,

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -1464,4 +1464,95 @@ mod tests {
         let exported_spans = exporter_shared.lock().unwrap();
         assert_eq!(exported_spans.len(), 10);
     }
+
+    #[test]
+    fn processor_has_access_to_span_handle() {
+        use crate::trace::{InMemorySpanExporter, SimpleSpanProcessor, SpanHandle};
+        use opentelemetry::trace::{Span as SpanTrait, SpanId, Tracer, TracerProvider};
+        use opentelemetry::Context;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        // A processor that keeps SpanHandle in shared state
+        #[derive(Debug)]
+        struct ProcessorWithSharedState {
+            active_spans: Arc<Mutex<HashMap<SpanId, SpanHandle>>>,
+        }
+
+        impl SpanProcessor for ProcessorWithSharedState {
+            fn on_start(&self, span: &mut crate::trace::Span, _cx: &Context) {
+                let handle = span.get_handle();
+                let span_id = handle.span_context().span_id();
+                if let Ok(mut spans) = self.active_spans.lock() {
+                    spans.insert(span_id, handle);
+                }
+            }
+
+            fn on_end(&self, span: SpanData) {
+                if let Ok(mut spans) = self.active_spans.lock() {
+                    spans.remove(&span.span_context.span_id());
+                }
+            }
+
+            fn force_flush(&self) -> OTelSdkResult {
+                Ok(())
+            }
+
+            fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+                Ok(())
+            }
+        }
+
+        let active_spans = Arc::new(Mutex::new(HashMap::<SpanId, SpanHandle>::new()));
+        let exporter = InMemorySpanExporter::default();
+        let processor = ProcessorWithSharedState {
+            active_spans: active_spans.clone(),
+        };
+        let provider = crate::trace::SdkTracerProvider::builder()
+            .with_span_processor(processor)
+            .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
+            .build();
+        let tracer = provider.tracer("test");
+
+        let mut span_1 = tracer.start("test_span_1");
+        let span_1_id = span_1.span_context().span_id();
+        let mut span_2 = tracer.start("test_span_2");
+
+        {
+            let mut active_spans = active_spans.lock().unwrap();
+            assert_eq!(2, active_spans.len());
+            if let Some(handle) = active_spans.get_mut(&span_1_id) {
+                handle.set_attribute(KeyValue::new("added_via_handle", "yes"));
+            } else {
+                panic!("failed to get lock")
+            }
+        }
+
+        span_2.end();
+        span_1.end();
+
+        {
+            let active_spans = active_spans.lock().unwrap();
+            assert!(
+                active_spans.is_empty(),
+                "expected all spans to be ended and removed from active spans"
+            );
+        }
+
+        provider.force_flush().unwrap();
+
+        let finished_spans = exporter.get_finished_spans().unwrap();
+        assert_eq!(finished_spans.len(), 2);
+
+        // check that the attribute set via SpanHandle is in the span
+        let has_handle_attr = finished_spans
+            .iter()
+            .cloned()
+            .flat_map(|span| span.attributes)
+            .any(|kv| kv.key.as_str() == "added_via_handle" && kv.value.as_str() == "yes");
+        assert!(
+            has_handle_attr,
+            "expected added_via_handle attribute set through SpanHandle to be found in the exported spans"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #602 

## Changes

Adds a `get_handle` method to `Span` that allows obtaining an instance of `SpanHandle`: a structure that shares the same fields as the span, where the SpanData is protected by a Mutex.

This allows holding a reference to a Span, which enables use cases such as span processors keeping track of active spans, as mentioned in [the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#onstart).

Example:

```rust
impl SpanProcessor for MyProcessor {
    fn on_start(&self, span: &mut Span, _cx: &Context) {
        let handle = span.get_handle();
        // Store handle for later use
    }
}
```

### Notes

First contribution here. The change ended up being a bit more invasive than I would've hoped, if there's a cleaner or more idiomatic way to achieve the goal, I'm very happy to adjust the approach and keep iterating on it. Thanks!

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
