### PR TITLE
feat: Bump MSRV to `1.85` and replace 3rd party crates with std library APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ http-body-util = "0.1"
 hyper = { version = "1.3", default-features = false }
 hyper-util = "0.1"
 log = "0.4.21"
-once_cell = "1.13"
 pin-project-lite = "0.2"
 prost = "0.14"
 rand = { version = "0.9", default-features = false }
@@ -57,9 +56,6 @@ ctrlc = "3.2.5"
 futures-channel = "0.3"
 futures-sink = "0.3"
 const-hex = "1.14.1"
-lazy_static = "1.4.0"
-num-format = "0.4.4"
-num_cpus = "1.15.0"
 opentelemetry = { path = "opentelemetry", version = "0.32", default-features = false }
 opentelemetry_sdk = { path = "opentelemetry-sdk", version = "0.32", default-features = false }
 opentelemetry-appender-log = { path = "opentelemetry-appender-log", version = "0.32", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.80.0"
+
 [profile.bench]
 # https://doc.rust-lang.org/cargo/reference/profiles.html#debug
 # See function names in profiling reports.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.80.0"
+rust-version = "1.85.0"
 
 [profile.bench]
 # https://doc.rust-lang.org/cargo/reference/profiles.html#debug

--- a/README.md
+++ b/README.md
@@ -143,16 +143,7 @@ Registry](https://opentelemetry.io/ecosystem/registry/?language=rust).
 
 ## Supported Rust Versions
 
-OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75. The current OpenTelemetry version is not guaranteed to build
-on Rust versions earlier than the minimum supported version.
-
-The current stable Rust compiler and the three most recent minor versions
-before it will always be supported. For example, if the current stable compiler
-version is 1.49, the minimum supported version will not be increased past 1.46,
-three minor versions prior. Increasing the minimum supported compiler version
-is not considered a semver breaking change as long as doing so complies with
-this policy.
+[![MSRV](https://img.shields.io/crates/msrv/opentelemetry)](https://crates.io/crates/opentelemetry)
 
 ## Contributing
 

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ allow = [
     "Apache-2.0",
     "ISC",
     "BSD-3-Clause",
+    "Unicode-3.0",
     "Zlib",
 ]
 
@@ -14,26 +15,6 @@ exceptions = [
     { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" }, # This crate is a dependency of `reqwest`.
     { allow = ["CDLA-Permissive-2.0"], crate = "webpki-root-certs" }, # This crate is a dependency of `reqwest`.
     { allow = ["OpenSSL"], crate = "aws-lc-sys" }, # This crate is a dependency of `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "icu_collections" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "icu_locid" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "icu_locid_transform" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "icu_locid_transform_data" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "icu_normalizer" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "icu_normalizer_data" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "icu_properties" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "icu_properties_data" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "icu_provider" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "icu_provider_macros" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "litemap" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "tinystr" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "writeable" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "unicode-ident" }, # This crate gets used transitively by `reqwest` and other crates.
-    { allow = ["Unicode-3.0"], crate = "yoke" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "yoke-derive" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "zerovec" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "zerovec-derive" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "zerofrom" }, # This crate gets used transitively by `reqwest`.
-    { allow = ["Unicode-3.0"], crate = "zerofrom-derive" }, # This crate gets used transitively by `reqwest`.
 ]
 
 [licenses.private]

--- a/deny.toml
+++ b/deny.toml
@@ -7,10 +7,13 @@ allow = [
     "Apache-2.0",
     "ISC",
     "BSD-3-Clause",
+    "Zlib",
 ]
 
 exceptions = [
     { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" }, # This crate is a dependency of `reqwest`.
+    { allow = ["CDLA-Permissive-2.0"], crate = "webpki-root-certs" }, # This crate is a dependency of `reqwest`.
+    { allow = ["OpenSSL"], crate = "aws-lc-sys" }, # This crate is a dependency of `reqwest`.
     { allow = ["Unicode-3.0"], crate = "icu_collections" }, # This crate gets used transitively by `reqwest`.
     { allow = ["Unicode-3.0"], crate = "icu_locid" }, # This crate gets used transitively by `reqwest`.
     { allow = ["Unicode-3.0"], crate = "icu_locid_transform" }, # This crate gets used transitively by `reqwest`.

--- a/deny.toml
+++ b/deny.toml
@@ -11,8 +11,6 @@ allow = [
 
 exceptions = [
     { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" }, # This crate is a dependency of `reqwest`.
-    { allow = ["CDLA-Permissive-2.0"], crate = "webpki-root-certs" }, # This crate is a dependency of `reqwest`.
-    { allow = ["OpenSSL"], crate = "aws-lc-sys" }, # This crate is a dependency of `reqwest`.
     { allow = ["Unicode-3.0"], crate = "icu_collections" }, # This crate gets used transitively by `reqwest`.
     { allow = ["Unicode-3.0"], crate = "icu_locid" }, # This crate gets used transitively by `reqwest`.
     { allow = ["Unicode-3.0"], crate = "icu_locid_transform" }, # This crate gets used transitively by `reqwest`.

--- a/examples/logs-advanced/Cargo.toml
+++ b/examples/logs-advanced/Cargo.toml
@@ -3,7 +3,7 @@ name = "logs-advanced"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version.workspace = true
 publish = false
 autobenches = false
 

--- a/examples/logs-basic/Cargo.toml
+++ b/examples/logs-basic/Cargo.toml
@@ -3,7 +3,7 @@ name = "logs-basic"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version.workspace = true
 publish = false
 autobenches = false
 

--- a/examples/metrics-advanced/Cargo.toml
+++ b/examples/metrics-advanced/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-advanced"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version.workspace = true
 publish = false
 autobenches = false
 

--- a/examples/metrics-basic/Cargo.toml
+++ b/examples/metrics-basic/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-basic"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version.workspace = true
 publish = false
 autobenches = false
 

--- a/examples/tracing-grpc/Cargo.toml
+++ b/examples/tracing-grpc/Cargo.toml
@@ -3,7 +3,7 @@ name = "tracing-grpc"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version.workspace = true
 publish = false
 autobenches = false
 

--- a/examples/tracing-http-propagator/Cargo.toml
+++ b/examples/tracing-http-propagator/Cargo.toml
@@ -3,7 +3,7 @@ name = "tracing-http-propagator"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version.workspace = true
 publish = false
 autobenches = false
 

--- a/opentelemetry-appender-log/CHANGELOG.md
+++ b/opentelemetry-appender-log/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Bump MSRV to 1.80.0
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-appender-log/CHANGELOG.md
+++ b/opentelemetry-appender-log/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- Bump MSRV to 1.80.0
+- Bump MSRV to 1.85.0
 
 ## 0.32.0
 

--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/ope
 readme = "README.md"
 keywords = ["opentelemetry", "log", "logs"]
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version.workspace = true
 edition = "2021"
 autobenches = false
 

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Bump MSRV to 1.80.0
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- Bump MSRV to 1.80.0
+- Bump MSRV to 1.85.0
 
 ## 0.32.0
 

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/ope
 readme = "README.md"
 keywords = ["opentelemetry", "log", "logs", "tracing"]
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version.workspace = true
 autobenches = false
 
 [dependencies]

--- a/opentelemetry-appender-tracing/README.md
+++ b/opentelemetry-appender-tracing/README.md
@@ -41,13 +41,4 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 
 ## Supported Rust Versions
 
-OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
-on Rust versions earlier than the minimum supported version.
-
-The current stable Rust compiler and the three most recent minor versions
-before it will always be supported. For example, if the current stable compiler
-version is 1.49, the minimum supported version will not be increased past 1.46,
-three minor versions prior. Increasing the minimum supported compiler version
-is not considered a semver breaking change as long as doing so complies with
-this policy.
+[![MSRV](https://img.shields.io/crates/msrv/opentelemetry-appender-tracing)](https://crates.io/crates/opentelemetry-appender-tracing)

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Bump MSRV to 1.80.0
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- Bump MSRV to 1.80.0
+- Bump MSRV to 1.85.0
 
 ## 0.32.0
 

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/ope
 keywords = ["opentelemetry", "tracing", "context", "propagation"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version.workspace = true
 autobenches = false
 
 [features]

--- a/opentelemetry-http/README.md
+++ b/opentelemetry-http/README.md
@@ -37,13 +37,4 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 
 ## Supported Rust Versions
 
-OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
-on Rust versions earlier than the minimum supported version.
-
-The current stable Rust compiler and the three most recent minor versions
-before it will always be supported. For example, if the current stable compiler
-version is 1.49, the minimum supported version will not be increased past 1.46,
-three minor versions prior. Increasing the minimum supported compiler version
-is not considered a semver breaking change as long as doing so complies with
-this policy.
+[![MSRV](https://img.shields.io/crates/msrv/opentelemetry-http)](https://crates.io/crates/opentelemetry-http)

--- a/opentelemetry-jaeger-propagator/CHANGELOG.md
+++ b/opentelemetry-jaeger-propagator/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Bump MSRV to 1.80.0
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-jaeger-propagator/CHANGELOG.md
+++ b/opentelemetry-jaeger-propagator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- Bump MSRV to 1.80.0
+- Bump MSRV to 1.85.0
 
 ## 0.32.0
 

--- a/opentelemetry-jaeger-propagator/Cargo.toml
+++ b/opentelemetry-jaeger-propagator/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "jaeger", "propagator"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version.workspace = true
 autobenches = false
 
 [badges]

--- a/opentelemetry-jaeger-propagator/README.md
+++ b/opentelemetry-jaeger-propagator/README.md
@@ -41,13 +41,4 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 
 ## Supported Rust Versions
 
-OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
-on Rust versions earlier than the minimum supported version.
-
-The current stable Rust compiler and the three most recent minor versions
-before it will always be supported. For example, if the current stable compiler
-version is 1.49, the minimum supported version will not be increased past 1.46,
-three minor versions prior. Increasing the minimum supported compiler version
-is not considered a semver breaking change as long as doing so complies with
-this policy.
+[![MSRV](https://img.shields.io/crates/msrv/opentelemetry-jaeger-propagator)](https://crates.io/crates/opentelemetry-jaeger-propagator)

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -7,6 +7,7 @@
 Released 2026-May-08
 
 - Add `tls-provider-agnostic` feature flag for environments that require a custom crypto backend (e.g., OpenSSL for FIPS compliance). Enables TLS code paths without bundling `ring` or `aws-lc-rs`.
+- Bump MSRV to 1.80.0
 - Add `build()` directly on `SpanExporterBuilder`, `MetricExporterBuilder`, and `LogExporterBuilder`
   (before selecting a transport), which auto-selects the transport based on the
   `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable or enabled features.

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -7,7 +7,7 @@
 Released 2026-May-08
 
 - Add `tls-provider-agnostic` feature flag for environments that require a custom crypto backend (e.g., OpenSSL for FIPS compliance). Enables TLS code paths without bundling `ring` or `aws-lc-rs`.
-- Bump MSRV to 1.80.0
+- Bump MSRV to 1.85.0
 - Add `build()` directly on `SpanExporterBuilder`, `MetricExporterBuilder`, and `LogExporterBuilder`
   (before selecting a transport), which auto-selects the transport based on the
   `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable or enabled features.

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version.workspace = true
 autotests = false
 autobenches = false
 

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -45,13 +45,4 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 
 ## Supported Rust Versions
 
-OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
-on Rust versions earlier than the minimum supported version.
-
-The current stable Rust compiler and the three most recent minor versions
-before it will always be supported. For example, if the current stable compiler
-version is 1.49, the minimum supported version will not be increased past 1.46,
-three minor versions prior. Increasing the minimum supported compiler version
-is not considered a semver breaking change as long as doing so complies with
-this policy.
+[![MSRV](https://img.shields.io/crates/msrv/opentelemetry-otlp)](https://crates.io/crates/opentelemetry-otlp)

--- a/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp-http/Cargo.toml
@@ -3,7 +3,7 @@ name = "basic-otlp-http"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version.workspace = true
 publish = false
 autobenches = false
 

--- a/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
+++ b/opentelemetry-otlp/examples/basic-otlp/Cargo.toml
@@ -3,7 +3,7 @@ name = "basic-otlp"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version.workspace = true
 publish = false
 autobenches = false
 

--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Bump MSRV to 1.85.0
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "prometheus", "metrics", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.81.0"
+rust-version = "1.85.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -20,7 +20,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-once_cell = { workspace = true }
 opentelemetry = { workspace = true, features = ["metrics", "internal-logs"] }
 opentelemetry_sdk = { workspace = true, features = ["metrics", "experimental_metrics_custom_reader"] }
 prometheus = { version = "0.14", default-features = false }

--- a/opentelemetry-prometheus/examples/hyper.rs
+++ b/opentelemetry-prometheus/examples/hyper.rs
@@ -6,7 +6,6 @@ use hyper::{
     Method, Request, Response,
 };
 use hyper_util::rt::{TokioExecutor, TokioIo};
-use once_cell::sync::Lazy;
 use opentelemetry::time::now;
 use opentelemetry::{
     metrics::{Counter, Histogram, MeterProvider as _},
@@ -15,10 +14,10 @@ use opentelemetry::{
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use prometheus::{Encoder, Registry, TextEncoder};
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tokio::net::TcpListener;
 
-static HANDLER_ALL: Lazy<[KeyValue; 1]> = Lazy::new(|| [KeyValue::new("handler", "all")]);
+static HANDLER_ALL: LazyLock<[KeyValue; 1]> = LazyLock::new(|| [KeyValue::new("handler", "all")]);
 
 async fn serve_req(
     req: Request<Incoming>,

--- a/opentelemetry-prometheus/src/config.rs
+++ b/opentelemetry-prometheus/src/config.rs
@@ -1,7 +1,6 @@
 use core::fmt;
-use once_cell::sync::OnceCell;
 use opentelemetry_sdk::metrics::ManualReaderBuilder;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::{Collector, PrometheusExporter, ResourceSelector};
 
@@ -124,11 +123,11 @@ impl ExporterBuilder {
             without_units: self.without_units,
             without_counter_suffixes: self.without_counter_suffixes,
             disable_scope_info: self.disable_scope_info,
-            create_target_info_once: OnceCell::new(),
+            create_target_info_once: OnceLock::new(),
             namespace: self.namespace,
             inner: Mutex::new(Default::default()),
             resource_selector: self.resource_selector,
-            resource_labels_once: OnceCell::new(),
+            resource_labels_once: OnceLock::new(),
         };
 
         let registry = self.registry.unwrap_or_default();

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -89,7 +89,6 @@
 )]
 #![cfg_attr(test, deny(warnings))]
 
-use once_cell::sync::OnceCell;
 use opentelemetry::{otel_error, otel_warn, InstrumentationScope, Key, Value};
 use opentelemetry_sdk::{
     error::OTelSdkResult,
@@ -107,7 +106,7 @@ use prometheus::{
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap},
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
 };
 use std::{fmt, sync::Weak};
 
@@ -171,8 +170,8 @@ struct Collector {
     without_units: bool,
     without_counter_suffixes: bool,
     disable_scope_info: bool,
-    create_target_info_once: OnceCell<MetricFamily>,
-    resource_labels_once: OnceCell<Vec<LabelPair>>,
+    create_target_info_once: OnceLock<MetricFamily>,
+    resource_labels_once: OnceLock<Vec<LabelPair>>,
     namespace: Option<String>,
     inner: Mutex<CollectorInner>,
     resource_selector: ResourceSelector,

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -7,7 +7,7 @@
 Released 2026-May-08
 
 - Update proto definitions to v1.10.0.
-- Bump MSRV to 1.80.0
+- Bump MSRV to 1.85.0
 - Updated `schemars` dependency to version 1.0.0.
 - **Bug fix**: `InstrumentationScope` version and attributes are now preserved when logs have a target set. Previously, setting a log target would discard the scope's version and attributes. ([#3276](https://github.com/open-telemetry/opentelemetry-rust/issues/3276))
 

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -7,6 +7,7 @@
 Released 2026-May-08
 
 - Update proto definitions to v1.10.0.
+- Bump MSRV to 1.80.0
 - Updated `schemars` dependency to version 1.0.0.
 - **Bug fix**: `InstrumentationScope` version and attributes are now preserved when logs have a target set. Previously, setting a log target would discard the scope's version and attributes. ([#3276](https://github.com/open-telemetry/opentelemetry-rust/issues/3276))
 

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "otlp", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version.workspace = true
 autotests = false
 autobenches = false
 

--- a/opentelemetry-proto/README.md
+++ b/opentelemetry-proto/README.md
@@ -58,13 +58,4 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 
 ## Supported Rust Versions
 
-OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
-on Rust versions earlier than the minimum supported version.
-
-The current stable Rust compiler and the three most recent minor versions
-before it will always be supported. For example, if the current stable compiler
-version is 1.49, the minimum supported version will not be increased past 1.46,
-three minor versions prior. Increasing the minimum supported compiler version
-is not considered a semver breaking change as long as doing so complies with
-this policy.
+[![MSRV](https://img.shields.io/crates/msrv/opentelemetry-proto)](https://crates.io/crates/opentelemetry-proto)

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Bump MSRV to 1.80.0
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- Bump MSRV to 1.80.0
+- Bump MSRV to 1.85.0
 
 ## 0.32.0
 

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/ope
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version.workspace = true
 autobenches = false
 
 [dependencies]

--- a/opentelemetry-sdk/README.md
+++ b/opentelemetry-sdk/README.md
@@ -106,13 +106,4 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 
 ## Supported Rust Versions
 
-OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
-on Rust versions earlier than the minimum supported version.
-
-The current stable Rust compiler and the three most recent minor versions
-before it will always be supported. For example, if the current stable compiler
-version is 1.49, the minimum supported version will not be increased past 1.46,
-three minor versions prior. Increasing the minimum supported compiler version
-is not considered a semver breaking change as long as doing so complies with
-this policy.
+[![MSRV](https://img.shields.io/crates/msrv/opentelemetry_sdk)](https://crates.io/crates/opentelemetry_sdk)

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::{f64::consts::LOG2_E, mem::replace, ops::DerefMut, sync::Mutex};
 
 use opentelemetry::{otel_debug, KeyValue};
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 use crate::metrics::{
     data::{self, AggregatedMetrics, MetricData},
@@ -170,7 +170,7 @@ impl<T: Number> ExpoHistogramDataPoint<T> {
             }
             return (exp - correction) >> -self.scale;
         }
-        (exp << self.scale) + (frac.ln() * scale_factors()[self.scale as usize]) as i32 - 1
+        (exp << self.scale) + (frac.ln() * SCALE_FACTORS[self.scale as usize]) as i32 - 1
     }
 }
 
@@ -204,38 +204,32 @@ fn scale_change(max_size: i32, bin: i32, start_bin: i32, length: i32) -> u32 {
     count
 }
 
-// TODO - replace it with LazyLock once it is stable
-static SCALE_FACTORS: OnceLock<[f64; 21]> = OnceLock::new();
-
-/// returns constants used in calculating the logarithm index.
-#[inline]
-fn scale_factors() -> &'static [f64; 21] {
-    SCALE_FACTORS.get_or_init(|| {
-        [
-            LOG2_E * 2f64.powi(0),
-            LOG2_E * 2f64.powi(1),
-            LOG2_E * 2f64.powi(2),
-            LOG2_E * 2f64.powi(3),
-            LOG2_E * 2f64.powi(4),
-            LOG2_E * 2f64.powi(5),
-            LOG2_E * 2f64.powi(6),
-            LOG2_E * 2f64.powi(7),
-            LOG2_E * 2f64.powi(8),
-            LOG2_E * 2f64.powi(9),
-            LOG2_E * 2f64.powi(10),
-            LOG2_E * 2f64.powi(11),
-            LOG2_E * 2f64.powi(12),
-            LOG2_E * 2f64.powi(13),
-            LOG2_E * 2f64.powi(14),
-            LOG2_E * 2f64.powi(15),
-            LOG2_E * 2f64.powi(16),
-            LOG2_E * 2f64.powi(17),
-            LOG2_E * 2f64.powi(18),
-            LOG2_E * 2f64.powi(19),
-            LOG2_E * 2f64.powi(20),
-        ]
-    })
-}
+/// Constants used in calculating the logarithm index.
+static SCALE_FACTORS: LazyLock<[f64; 21]> = LazyLock::new(|| {
+    [
+        LOG2_E * 2f64.powi(0),
+        LOG2_E * 2f64.powi(1),
+        LOG2_E * 2f64.powi(2),
+        LOG2_E * 2f64.powi(3),
+        LOG2_E * 2f64.powi(4),
+        LOG2_E * 2f64.powi(5),
+        LOG2_E * 2f64.powi(6),
+        LOG2_E * 2f64.powi(7),
+        LOG2_E * 2f64.powi(8),
+        LOG2_E * 2f64.powi(9),
+        LOG2_E * 2f64.powi(10),
+        LOG2_E * 2f64.powi(11),
+        LOG2_E * 2f64.powi(12),
+        LOG2_E * 2f64.powi(13),
+        LOG2_E * 2f64.powi(14),
+        LOG2_E * 2f64.powi(15),
+        LOG2_E * 2f64.powi(16),
+        LOG2_E * 2f64.powi(17),
+        LOG2_E * 2f64.powi(18),
+        LOG2_E * 2f64.powi(19),
+        LOG2_E * 2f64.powi(20),
+    ]
+});
 
 /// Breaks the number into a normalized fraction and a base-2 exponent.
 ///

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -306,9 +306,10 @@ impl ExpoBuckets {
                 return;
             }
 
-            self.counts.extend(
-                std::iter::repeat(0).take((bin - self.start_bin) as usize - self.counts.len() + 1),
-            );
+            self.counts.extend(std::iter::repeat_n(
+                0,
+                (bin - self.start_bin) as usize - self.counts.len() + 1,
+            ));
             self.counts[(bin - self.start_bin) as usize] = 1
         }
     }

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -13,7 +13,7 @@ use std::ops::{Add, AddAssign, Sub};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 #[cfg(target_has_atomic = "64")]
 use std::sync::atomic::{AtomicI64, AtomicU64};
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, LazyLock, RwLock};
 
 pub(crate) use aggregate::{AggregateBuilder, AggregateFns, ComputeAggregation, Measure};
 #[cfg(feature = "experimental_metrics_bound_instruments")]
@@ -25,13 +25,8 @@ use opentelemetry::{otel_warn, KeyValue};
 
 use super::data::{AggregatedMetrics, MetricData};
 
-// TODO Replace it with LazyLock once it is stable
-pub(crate) static STREAM_OVERFLOW_ATTRIBUTES: OnceLock<Vec<KeyValue>> = OnceLock::new();
-
-#[inline]
-fn stream_overflow_attributes() -> &'static Vec<KeyValue> {
-    STREAM_OVERFLOW_ATTRIBUTES.get_or_init(|| vec![KeyValue::new("otel.metric.overflow", true)])
-}
+pub(crate) static STREAM_OVERFLOW_ATTRIBUTES: LazyLock<Vec<KeyValue>> =
+    LazyLock::new(|| vec![KeyValue::new("otel.metric.overflow", true)]);
 
 pub(crate) trait Aggregator {
     /// A static configuration that is needed in order to initialize aggregator.
@@ -177,7 +172,7 @@ where
             trackers.insert(sorted_attrs, new_tracker);
 
             self.count.fetch_add(1, Ordering::SeqCst);
-        } else if let Some(overflow_value) = trackers.get(stream_overflow_attributes().as_slice()) {
+        } else if let Some(overflow_value) = trackers.get(STREAM_OVERFLOW_ATTRIBUTES.as_slice()) {
             overflow_value.aggregator.update(value);
             overflow_value
                 .has_been_updated
@@ -186,7 +181,7 @@ where
             let new_tracker = TrackerEntry::<A>::new(&self.config);
             new_tracker.aggregator.update(value);
             new_tracker.has_been_updated.store(true, Ordering::Release);
-            trackers.insert(stream_overflow_attributes().clone(), Arc::new(new_tracker));
+            trackers.insert(STREAM_OVERFLOW_ATTRIBUTES.clone(), Arc::new(new_tracker));
         }
     }
 
@@ -268,7 +263,7 @@ where
             // yet — mirrors the lazy creation in `measure()` (line above where
             // overflow is inserted on first overflowing measurement).
             let overflow_tracker = trackers
-                .entry(stream_overflow_attributes().clone())
+                .entry(STREAM_OVERFLOW_ATTRIBUTES.clone())
                 .or_insert_with(|| Arc::new(TrackerEntry::<A>::new(&self.config)))
                 .clone();
             overflow_tracker.bound_count.fetch_add(1, Ordering::Relaxed);
@@ -328,7 +323,7 @@ where
             dest.push(map_fn(vec![], &self.no_attribute_tracker.aggregator));
         }
 
-        let overflow_attrs = stream_overflow_attributes();
+        let overflow_attrs = &*STREAM_OVERFLOW_ATTRIBUTES;
         let mut stale_entries: Vec<Arc<TrackerEntry<A>>> = Vec::new();
 
         {

--- a/opentelemetry-sdk/src/propagation/baggage.rs
+++ b/opentelemetry-sdk/src/propagation/baggage.rs
@@ -6,17 +6,12 @@ use opentelemetry::{
 };
 use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
 use std::iter;
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 static BAGGAGE_HEADER: &str = "baggage";
 const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b';').add(b',').add(b'=');
 
-// TODO Replace this with LazyLock once it is stable.
-static BAGGAGE_FIELDS: OnceLock<[String; 1]> = OnceLock::new();
-#[inline]
-fn baggage_fields() -> &'static [String; 1] {
-    BAGGAGE_FIELDS.get_or_init(|| [BAGGAGE_HEADER.to_owned()])
-}
+static BAGGAGE_FIELDS: LazyLock<[String; 1]> = LazyLock::new(|| [BAGGAGE_HEADER.to_owned()]);
 
 /// Propagates name-value pairs in [W3C Baggage] format.
 ///
@@ -158,7 +153,7 @@ impl TextMapPropagator for BaggagePropagator {
     }
 
     fn fields(&self) -> FieldIter<'_> {
-        FieldIter::new(baggage_fields())
+        FieldIter::new(&*BAGGAGE_FIELDS)
     }
 }
 

--- a/opentelemetry-sdk/src/propagation/trace_context.rs
+++ b/opentelemetry-sdk/src/propagation/trace_context.rs
@@ -7,20 +7,15 @@ use opentelemetry::{
     Context,
 };
 use std::str::FromStr;
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 const SUPPORTED_VERSION: u8 = 0;
 const MAX_VERSION: u8 = 254;
 const TRACEPARENT_HEADER: &str = "traceparent";
 const TRACESTATE_HEADER: &str = "tracestate";
 
-// TODO Replace this with LazyLock once it is stable.
-static TRACE_CONTEXT_HEADER_FIELDS: OnceLock<[String; 2]> = OnceLock::new();
-
-fn trace_context_header_fields() -> &'static [String; 2] {
-    TRACE_CONTEXT_HEADER_FIELDS
-        .get_or_init(|| [TRACEPARENT_HEADER.to_owned(), TRACESTATE_HEADER.to_owned()])
-}
+static TRACE_CONTEXT_HEADER_FIELDS: LazyLock<[String; 2]> =
+    LazyLock::new(|| [TRACEPARENT_HEADER.to_owned(), TRACESTATE_HEADER.to_owned()]);
 
 /// Propagates `SpanContext`s in [W3C TraceContext] format under `traceparent` and `tracestate` header.
 ///
@@ -152,7 +147,7 @@ impl TextMapPropagator for TraceContextPropagator {
     }
 
     fn fields(&self) -> FieldIter<'_> {
-        FieldIter::new(trace_context_header_fields())
+        FieldIter::new(&*TRACE_CONTEXT_HEADER_FIELDS)
     }
 }
 

--- a/opentelemetry-semantic-conventions/CHANGELOG.md
+++ b/opentelemetry-semantic-conventions/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Bump MSRV to 1.80.0
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-semantic-conventions/CHANGELOG.md
+++ b/opentelemetry-semantic-conventions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- Bump MSRV to 1.80.0
+- Bump MSRV to 1.85.0
 
 ## 0.32.0
 

--- a/opentelemetry-semantic-conventions/Cargo.toml
+++ b/opentelemetry-semantic-conventions/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version.workspace = true
 autobenches = false
 
 [package.metadata.docs.rs]

--- a/opentelemetry-semantic-conventions/README.md
+++ b/opentelemetry-semantic-conventions/README.md
@@ -31,13 +31,4 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 
 ## Supported Rust Versions
 
-OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
-on Rust versions earlier than the minimum supported version.
-
-The current stable Rust compiler and the three most recent minor versions
-before it will always be supported. For example, if the current stable compiler
-version is 1.49, the minimum supported version will not be increased past 1.46,
-three minor versions prior. Increasing the minimum supported compiler version
-is not considered a semver breaking change as long as doing so complies with
-this policy.
+[![MSRV](https://img.shields.io/crates/msrv/opentelemetry-semantic-conventions)](https://crates.io/crates/opentelemetry-semantic-conventions)

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "tracing", "metrics", "logs"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.80.0"
 autobenches = false
 
 [package.metadata.docs.rs]
@@ -36,7 +36,6 @@ opentelemetry-appender-tracing = { workspace = true }
 tracing = { workspace = true, features = ["std"]}
 tracing-subscriber = { workspace = true, features = ["registry", "std"] }
 tokio = { workspace = true, features = ["full"] }
-once_cell = { workspace = true }
 
 [lints]
 workspace = true

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "tracing", "metrics", "logs"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version.workspace = true
 autobenches = false
 
 [package.metadata.docs.rs]

--- a/opentelemetry-stdout/README.md
+++ b/opentelemetry-stdout/README.md
@@ -52,13 +52,4 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 
 ## Supported Rust Versions
 
-OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
-on Rust versions earlier than the minimum supported version.
-
-The current stable Rust compiler and the three most recent minor versions
-before it will always be supported. For example, if the current stable compiler
-version is 1.49, the minimum supported version will not be increased past 1.46,
-three minor versions prior. Increasing the minimum supported compiler version
-is not considered a semver breaking change as long as doing so complies with
-this policy.
+[![MSRV](https://img.shields.io/crates/msrv/opentelemetry-stdout)](https://crates.io/crates/opentelemetry-stdout)

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -1,7 +1,7 @@
 //! run with `$ cargo run --example basic
 
-use once_cell::sync::Lazy;
 use opentelemetry::{global, KeyValue};
+use std::sync::LazyLock;
 
 #[cfg(feature = "trace")]
 use opentelemetry::trace::Tracer;
@@ -13,7 +13,7 @@ use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_sdk::Resource;
 
-static RESOURCE: Lazy<Resource> = Lazy::new(|| {
+static RESOURCE: LazyLock<Resource> = LazyLock::new(|| {
     Resource::builder()
         .with_service_name("basic-stdout-example")
         .build()

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.80.0"
 autobenches = false
 
 [badges]
@@ -30,7 +30,6 @@ reqwest-client = ["dep:reqwest", "opentelemetry-http/reqwest"]
 reqwest-rustls = ["dep:reqwest", "reqwest/default-tls"]
 
 [dependencies]
-once_cell = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["trace"] }
 opentelemetry-http = { workspace = true }

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["opentelemetry", "zipkin", "tracing", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version.workspace = true
 autobenches = false
 
 [badges]

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -116,13 +116,4 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 
 ## Supported Rust Versions
 
-OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build on
-Rust versions earlier than the minimum supported version.
-
-The current stable Rust compiler and the three most recent minor versions before
-it will always be supported. For example, if the current stable compiler version
-is 1.49, the minimum supported version will not be increased past 1.46, three
-minor versions prior. Increasing the minimum supported compiler version is not
-considered a semver breaking change as long as doing so complies with this
-policy.
+[![MSRV](https://img.shields.io/crates/msrv/opentelemetry-zipkin)](https://crates.io/crates/opentelemetry-zipkin)

--- a/opentelemetry-zipkin/src/propagator/mod.rs
+++ b/opentelemetry-zipkin/src/propagator/mod.rs
@@ -13,12 +13,12 @@
 //!
 //! If `inject_encoding` is set to `B3Encoding::SingleHeader` then `b3` header is used to inject
 //! and extract. Otherwise, separate headers are used to inject and extract.
-use once_cell::sync::Lazy;
 use opentelemetry::{
     propagation::{text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator},
     trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState},
     Context,
 };
+use std::sync::LazyLock;
 
 const B3_SINGLE_HEADER: &str = "b3";
 /// As per spec, the multiple header should be case sensitive. But different protocol will use
@@ -34,8 +34,8 @@ const B3_PARENT_SPAN_ID_HEADER: &str = "x-b3-parentspanid";
 const TRACE_FLAG_DEFERRED: TraceFlags = TraceFlags::new(0x02);
 const TRACE_FLAG_DEBUG: TraceFlags = TraceFlags::new(0x04);
 
-static B3_SINGLE_FIELDS: Lazy<[String; 1]> = Lazy::new(|| [B3_SINGLE_HEADER.to_owned()]);
-static B3_MULTI_FIELDS: Lazy<[String; 4]> = Lazy::new(|| {
+static B3_SINGLE_FIELDS: LazyLock<[String; 1]> = LazyLock::new(|| [B3_SINGLE_HEADER.to_owned()]);
+static B3_MULTI_FIELDS: LazyLock<[String; 4]> = LazyLock::new(|| {
     [
         B3_TRACE_ID_HEADER.to_owned(),
         B3_SPAN_ID_HEADER.to_owned(),
@@ -43,7 +43,7 @@ static B3_MULTI_FIELDS: Lazy<[String; 4]> = Lazy::new(|| {
         B3_DEBUG_FLAG_HEADER.to_owned(),
     ]
 });
-static B3_SINGLE_AND_MULTI_FIELDS: Lazy<[String; 5]> = Lazy::new(|| {
+static B3_SINGLE_AND_MULTI_FIELDS: LazyLock<[String; 5]> = LazyLock::new(|| {
     [
         B3_SINGLE_HEADER.to_owned(),
         B3_TRACE_ID_HEADER.to_owned(),

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Bump MSRV to 1.80.0
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- Bump MSRV to 1.80.0
+- Bump MSRV to 1.85.0
 
 ## 0.32.0
 

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -14,7 +14,7 @@ categories = [
 keywords = ["opentelemetry", "logging", "tracing", "metrics"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version.workspace = true
 autobenches = false
 
 [package.metadata.docs.rs]

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -135,13 +135,4 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 
 ## Supported Rust Versions
 
-OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
-on Rust versions earlier than the minimum supported version.
-
-The current stable Rust compiler and the three most recent minor versions
-before it will always be supported. For example, if the current stable compiler
-version is 1.49, the minimum supported version will not be increased past 1.46,
-three minor versions prior. Increasing the minimum supported compiler version
-is not considered a semver breaking change as long as doing so complies with
-this policy.
+[![MSRV](https://img.shields.io/crates/msrv/opentelemetry)](https://crates.io/crates/opentelemetry)

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -3,7 +3,7 @@ name = "stress"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.80.0"
+rust-version.workspace = true
 publish = false
 autobenches = false
 

--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -3,7 +3,7 @@ name = "stress"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75.0"
+rust-version = "1.80.0"
 publish = false
 autobenches = false
 
@@ -51,15 +51,12 @@ bench = false
 
 [dependencies]
 ctrlc = { workspace = true }
-lazy_static = { workspace = true }
-num_cpus = { workspace = true }
 opentelemetry = { path = "../opentelemetry", features = ["metrics", "logs", "trace"] }
 opentelemetry_sdk = { path = "../opentelemetry-sdk", features = ["metrics", "logs", "trace", "experimental_metrics_custom_reader"] }
 opentelemetry-appender-tracing = { workspace = true }
 rand = { workspace = true, features = ["small_rng", "os_rng"] }
 tracing = { workspace = true, features = ["std"]}
 tracing-subscriber = { workspace = true, features = ["registry", "std"] }
-num-format = { workspace = true }
 sysinfo = { workspace = true, optional = true }
 
 [features]

--- a/stress/src/metrics_counter.rs
+++ b/stress/src/metrics_counter.rs
@@ -9,7 +9,6 @@
     ~20 M /sec
 */
 
-use lazy_static::lazy_static;
 use opentelemetry::{
     metrics::{Counter, MeterProvider as _},
     KeyValue,
@@ -20,19 +19,23 @@ use rand::{
     Rng, SeedableRng,
 };
 use std::cell::RefCell;
+use std::sync::LazyLock;
 
 mod throughput;
 
-lazy_static! {
-    static ref PROVIDER: SdkMeterProvider = SdkMeterProvider::builder()
+static PROVIDER: LazyLock<SdkMeterProvider> = LazyLock::new(|| {
+    SdkMeterProvider::builder()
         .with_reader(ManualReader::builder().build())
-        .build();
-    static ref ATTRIBUTE_VALUES: [&'static str; 10] = [
+        .build()
+});
+static ATTRIBUTE_VALUES: LazyLock<[&str; 10]> = LazyLock::new(|| {
+    [
         "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
-        "value10"
-    ];
-    static ref COUNTER: Counter<u64> = PROVIDER.meter("test").u64_counter("hello").build();
-}
+        "value10",
+    ]
+});
+static COUNTER: LazyLock<Counter<u64>> =
+    LazyLock::new(|| PROVIDER.meter("test").u64_counter("hello").build());
 
 thread_local! {
     /// Store random number generator for each thread

--- a/stress/src/metrics_gauge.rs
+++ b/stress/src/metrics_gauge.rs
@@ -6,7 +6,6 @@
     ~11.5 M/sec
 */
 
-use lazy_static::lazy_static;
 use opentelemetry::{
     metrics::{Gauge, MeterProvider as _},
     KeyValue,
@@ -17,19 +16,23 @@ use rand::{
     Rng, SeedableRng,
 };
 use std::cell::RefCell;
+use std::sync::LazyLock;
 
 mod throughput;
 
-lazy_static! {
-    static ref PROVIDER: SdkMeterProvider = SdkMeterProvider::builder()
+static PROVIDER: LazyLock<SdkMeterProvider> = LazyLock::new(|| {
+    SdkMeterProvider::builder()
         .with_reader(ManualReader::builder().build())
-        .build();
-    static ref ATTRIBUTE_VALUES: [&'static str; 10] = [
+        .build()
+});
+static ATTRIBUTE_VALUES: LazyLock<[&str; 10]> = LazyLock::new(|| {
+    [
         "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
-        "value10"
-    ];
-    static ref GAUGE: Gauge<u64> = PROVIDER.meter("test").u64_gauge("test_gauge").build();
-}
+        "value10",
+    ]
+});
+static GAUGE: LazyLock<Gauge<u64>> =
+    LazyLock::new(|| PROVIDER.meter("test").u64_gauge("test_gauge").build());
 
 thread_local! {
     /// Store random number generator for each thread

--- a/stress/src/metrics_histogram.rs
+++ b/stress/src/metrics_histogram.rs
@@ -9,7 +9,6 @@
     ~12.0 M /sec
 */
 
-use lazy_static::lazy_static;
 use opentelemetry::{
     metrics::{Histogram, MeterProvider as _},
     KeyValue,
@@ -20,19 +19,23 @@ use rand::{
     Rng, SeedableRng,
 };
 use std::cell::RefCell;
+use std::sync::LazyLock;
 
 mod throughput;
 
-lazy_static! {
-    static ref PROVIDER: SdkMeterProvider = SdkMeterProvider::builder()
+static PROVIDER: LazyLock<SdkMeterProvider> = LazyLock::new(|| {
+    SdkMeterProvider::builder()
         .with_reader(ManualReader::builder().build())
-        .build();
-    static ref ATTRIBUTE_VALUES: [&'static str; 10] = [
+        .build()
+});
+static ATTRIBUTE_VALUES: LazyLock<[&str; 10]> = LazyLock::new(|| {
+    [
         "value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9",
-        "value10"
-    ];
-    static ref HISTOGRAM: Histogram<u64> = PROVIDER.meter("test").u64_histogram("hello").build();
-}
+        "value10",
+    ]
+});
+static HISTOGRAM: LazyLock<Histogram<u64>> =
+    LazyLock::new(|| PROVIDER.meter("test").u64_histogram("hello").build());
 
 thread_local! {
     /// Store random number generator for each thread

--- a/stress/src/metrics_overflow.rs
+++ b/stress/src/metrics_overflow.rs
@@ -6,7 +6,6 @@
     ~1.9 M/sec
 */
 
-use lazy_static::lazy_static;
 use opentelemetry::{
     metrics::{Counter, MeterProvider as _},
     KeyValue,
@@ -17,15 +16,17 @@ use rand::{
     Rng, SeedableRng,
 };
 use std::cell::RefCell;
+use std::sync::LazyLock;
 
 mod throughput;
 
-lazy_static! {
-    static ref PROVIDER: SdkMeterProvider = SdkMeterProvider::builder()
+static PROVIDER: LazyLock<SdkMeterProvider> = LazyLock::new(|| {
+    SdkMeterProvider::builder()
         .with_reader(ManualReader::builder().build())
-        .build();
-    static ref COUNTER: Counter<u64> = PROVIDER.meter("test").u64_counter("hello").build();
-}
+        .build()
+});
+static COUNTER: LazyLock<Counter<u64>> =
+    LazyLock::new(|| PROVIDER.meter("test").u64_counter("hello").build());
 
 thread_local! {
     /// Store random number generator for each thread

--- a/stress/src/traces.rs
+++ b/stress/src/traces.rs
@@ -8,7 +8,6 @@
     Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
     ~10.6 M /sec
 */
-use lazy_static::lazy_static;
 use opentelemetry::{
     trace::{Span, SpanBuilder, Tracer, TracerProvider},
     Context, KeyValue,
@@ -17,17 +16,18 @@ use opentelemetry_sdk::{
     error::OTelSdkResult,
     trace::{self as sdktrace, SpanData, SpanProcessor},
 };
+use std::sync::LazyLock;
 use std::time::Duration;
 
 mod throughput;
 
-lazy_static! {
-    static ref PROVIDER: sdktrace::SdkTracerProvider = sdktrace::SdkTracerProvider::builder()
+static PROVIDER: LazyLock<sdktrace::SdkTracerProvider> = LazyLock::new(|| {
+    sdktrace::SdkTracerProvider::builder()
         .with_sampler(sdktrace::Sampler::AlwaysOn)
         .with_span_processor(NoOpSpanProcessor {})
-        .build();
-    static ref TRACER: sdktrace::SdkTracer = PROVIDER.tracer("stress");
-}
+        .build()
+});
+static TRACER: LazyLock<sdktrace::SdkTracer> = LazyLock::new(|| PROVIDER.tracer("stress"));
 
 #[derive(Debug)]
 pub struct NoOpSpanProcessor;


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes
- By bumping the MSRV from 1.75 to 1.85 we are able to remove the following 3rd party crates for rust std library APIs:
  - `once_cell`
  - `lazy_static`
  - `num-format`
  - `num_cpus`
- Resolves 6 TODO comments in opentelemetry-sdk that were waiting for LazyLock stabilization (stable since Rust 1.80). Each OnceLock paired with a getter function is now a single LazyLock static declaration

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
