### PR TITLE
fix(tests): update test expectations for proto entityRefs and env var resilience

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/src/metric_helpers.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/metric_helpers.rs
@@ -3,7 +3,7 @@ use crate::test_utils;
 use anyhow::Result;
 use anyhow::{Context, Ok};
 use opentelemetry_otlp::MetricExporter;
-use opentelemetry_sdk::metrics::{MeterProviderBuilder, SdkMeterProvider};
+use opentelemetry_sdk::metrics::{MeterProviderBuilder, SdkMeterProvider, Temporality};
 use opentelemetry_sdk::Resource;
 use serde_json::Value;
 use std::fs;
@@ -34,6 +34,7 @@ fn create_exporter() -> MetricExporter {
     let exporter_builder = exporter_builder.with_http();
 
     exporter_builder
+        .with_temporality(Temporality::Cumulative)
         .build()
         .expect("Failed to build MetricExporter")
 }

--- a/opentelemetry-proto/tests/json_serde.rs
+++ b/opentelemetry-proto/tests/json_serde.rs
@@ -104,7 +104,8 @@ mod json_serde {
             }
           }
         ],
-        "droppedAttributesCount": 0
+        "droppedAttributesCount": 0,
+        "entityRefs": []
       },
       "scopeSpans": [
         {
@@ -349,7 +350,8 @@ mod json_serde {
             }
           }
         ],
-        "droppedAttributesCount": 1
+        "droppedAttributesCount": 1,
+        "entityRefs": []
       },
       "scopeSpans": [
         {
@@ -911,7 +913,8 @@ mod json_serde {
             }
           }
         ],
-        "droppedAttributesCount": 0
+        "droppedAttributesCount": 0,
+        "entityRefs": []
       },
       "scopeMetrics": [
         {
@@ -1298,7 +1301,8 @@ mod json_serde {
             }
           }
         ],
-        "droppedAttributesCount": 0
+        "droppedAttributesCount": 0,
+        "entityRefs": []
       },
       "scopeLogs": [
         {


### PR DESCRIPTION
## Summary

Two categories of test failures exist on `main` that this PR fixes:

- **Integration metric tests (`test_histogram`, `test_u64_counter`)**: After [#3351](https://github.com/open-telemetry/opentelemetry-rust/pull/3351) added support for `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`, the integration test's `create_exporter()` no longer hardcodes a temporality. This means if the env var is set (e.g., `=delta`), the tests get Delta temporality instead of the expected Cumulative, causing assertion failures. Fixed by explicitly setting `Temporality::Cumulative` in the test helper so tests are deterministic regardless of environment.

- **JSON serde serialization tests (`export_*_service_request::*::serialize`)**: The proto submodule's `Resource` message now includes an `entityRefs` field. When serialized with serde, empty vecs produce `"entityRefs": []` in the JSON output, but the expected canonical JSON strings in the tests didn't include this field. Fixed by adding `"entityRefs": []` to the expected JSON.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features` passes (0 warnings)
- [x] `cargo test --all-features` passes (0 failures)