### PR TITLE
feat(otlp): support per-signal protocol environment variables

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -33,8 +33,15 @@
   `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`,
   `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`. These allow configuring different transport protocols
   per signal type. Signal-specific vars take precedence over generic `OTEL_EXPORTER_OTLP_PROTOCOL`.
-- Add `resolve_protocol()` for protocol resolution with proper priority chain.
-  HTTP transport now validates that gRPC protocol is not requested (returns `InvalidConfig` error).
+  The auto-select `build()` method on each exporter builder now respects the full priority chain:
+  signal-specific env var > generic env var > feature-based default.
+- Transport/protocol mismatch validation: HTTP transport returns `InvalidConfig` when gRPC protocol
+  is requested; gRPC transport returns `InvalidConfig` when an HTTP protocol is requested.
+- **Breaking**: `Protocol::default()` no longer consults the `OTEL_EXPORTER_OTLP_PROTOCOL`
+  environment variable. It now returns only the feature-based default (http-json > http-proto >
+  grpc-tonic). Protocol resolution from environment variables is handled internally by the
+  exporter builders. Users who relied on `Protocol::default()` to read env vars should use
+  `Protocol::from_env()` instead.
 - Add support for `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable
   to configure metrics temporality. Accepted values: `cumulative` (default), `delta`,
   `lowmemory` (case-insensitive). Programmatic `.with_temporality()` overrides the env var.

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -29,6 +29,12 @@
   DEBUG-only to preserve the auth-token leak safeguards from
   [#3021](https://github.com/open-telemetry/opentelemetry-rust/issues/3021).
   [#3331](https://github.com/open-telemetry/opentelemetry-rust/issues/3331)
+- Add support for per-signal protocol environment variables:
+  `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`,
+  `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`. These allow configuring different transport protocols
+  per signal type. Signal-specific vars take precedence over generic `OTEL_EXPORTER_OTLP_PROTOCOL`.
+- Add `resolve_protocol()` for protocol resolution with proper priority chain.
+  HTTP transport now validates that gRPC protocol is not requested (returns `InvalidConfig` error).
 - Add support for `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable
   to configure metrics temporality. Accepted values: `cumulative` (default), `delta`,
   `lowmemory` (case-insensitive). Programmatic `.with_temporality()` overrides the env var.

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -156,10 +156,7 @@ pub struct HttpExporterBuilder {
 impl Default for HttpExporterBuilder {
     fn default() -> Self {
         HttpExporterBuilder {
-            exporter_config: ExportConfig {
-                protocol: Protocol::default(),
-                ..ExportConfig::default()
-            },
+            exporter_config: ExportConfig::default(),
             http_config: HttpConfig {
                 headers: Some(default_headers()),
                 ..HttpConfig::default()
@@ -176,7 +173,19 @@ impl HttpExporterBuilder {
         signal_timeout_var: &str,
         signal_http_headers_var: &str,
         signal_compression_var: &str,
+        signal_protocol_var: &str,
     ) -> Result<OtlpHttpClient, ExporterBuildError> {
+        let protocol = super::resolve_protocol(signal_protocol_var, self.exporter_config.protocol);
+
+        // Validate protocol is compatible with HTTP transport
+        #[cfg(feature = "grpc-tonic")]
+        if matches!(protocol, Protocol::Grpc) {
+            return Err(ExporterBuildError::InvalidConfig {
+                name: "protocol".to_string(),
+                reason: "gRPC protocol is not compatible with HTTP transport. Use `.with_tonic()` instead.".to_string(),
+            });
+        }
+
         let endpoint = resolve_http_endpoint(
             signal_endpoint_var,
             signal_endpoint_path,
@@ -284,7 +293,7 @@ impl HttpExporterBuilder {
             http_client,
             endpoint,
             headers,
-            self.exporter_config.protocol,
+            protocol,
             timeout,
             compression,
             #[cfg(feature = "experimental-http-retry")]
@@ -299,12 +308,13 @@ impl HttpExporterBuilder {
         super::resolve_compression_from_env(self.http_config.compression, env_override)
     }
 
-    /// Create a log exporter with the current configuration
+    /// Create a span exporter with the current configuration
     #[cfg(feature = "trace")]
     pub fn build_span_exporter(mut self) -> Result<crate::SpanExporter, ExporterBuildError> {
         use crate::{
             OTEL_EXPORTER_OTLP_TRACES_COMPRESSION, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-            OTEL_EXPORTER_OTLP_TRACES_HEADERS, OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
+            OTEL_EXPORTER_OTLP_TRACES_HEADERS, OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
+            OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
         };
 
         let client = self.build_client(
@@ -313,6 +323,7 @@ impl HttpExporterBuilder {
             OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
             OTEL_EXPORTER_OTLP_TRACES_HEADERS,
             OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
+            OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
         )?;
 
         Ok(crate::SpanExporter::from_http(client))
@@ -323,7 +334,8 @@ impl HttpExporterBuilder {
     pub fn build_log_exporter(mut self) -> Result<crate::LogExporter, ExporterBuildError> {
         use crate::{
             OTEL_EXPORTER_OTLP_LOGS_COMPRESSION, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
-            OTEL_EXPORTER_OTLP_LOGS_HEADERS, OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
+            OTEL_EXPORTER_OTLP_LOGS_HEADERS, OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
+            OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
         };
 
         let client = self.build_client(
@@ -332,6 +344,7 @@ impl HttpExporterBuilder {
             OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
             OTEL_EXPORTER_OTLP_LOGS_HEADERS,
             OTEL_EXPORTER_OTLP_LOGS_COMPRESSION,
+            OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
         )?;
 
         Ok(crate::LogExporter::from_http(client))
@@ -345,7 +358,8 @@ impl HttpExporterBuilder {
     ) -> Result<crate::MetricExporter, ExporterBuildError> {
         use crate::{
             OTEL_EXPORTER_OTLP_METRICS_COMPRESSION, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
-            OTEL_EXPORTER_OTLP_METRICS_HEADERS, OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
+            OTEL_EXPORTER_OTLP_METRICS_HEADERS, OTEL_EXPORTER_OTLP_METRICS_PROTOCOL,
+            OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
         };
 
         let client = self.build_client(
@@ -354,6 +368,7 @@ impl HttpExporterBuilder {
             OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
             OTEL_EXPORTER_OTLP_METRICS_HEADERS,
             OTEL_EXPORTER_OTLP_METRICS_COMPRESSION,
+            OTEL_EXPORTER_OTLP_METRICS_PROTOCOL,
         )?;
 
         Ok(crate::MetricExporter::from_http(client, temporality))

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -77,7 +77,7 @@ pub(crate) struct ExportConfig {
 /// 2. Signal-specific environment variable
 /// 3. Generic OTEL_EXPORTER_OTLP_PROTOCOL environment variable
 /// 4. Feature-based default
-#[cfg(any(feature = "http-proto", feature = "http-json"))]
+#[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
 pub(crate) fn resolve_protocol(
     signal_protocol_var: &str,
     provided_protocol: Option<Protocol>,
@@ -195,17 +195,19 @@ fn resolve_compression_from_env(
     }
 }
 
-/// Returns the default protocol based on environment variable or enabled features.
+/// Returns the default protocol based on enabled features.
+///
+/// Note: This does not consult environment variables. Use [`resolve_protocol`]
+/// for full priority resolution including signal-specific and generic env vars.
 ///
 /// Priority order (first available wins):
-/// 1. OTEL_EXPORTER_OTLP_PROTOCOL environment variable (if set and feature is enabled)
-/// 2. http-json (if enabled)
-/// 3. http-proto (if enabled)
-/// 4. grpc-tonic (if enabled)
+/// 1. http-json (if enabled)
+/// 2. http-proto (if enabled)
+/// 3. grpc-tonic (if enabled)
 #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
 impl Default for Protocol {
     fn default() -> Self {
-        Protocol::from_env().unwrap_or_else(Protocol::feature_default)
+        Protocol::feature_default()
     }
 }
 
@@ -496,21 +498,26 @@ mod tests {
     }
 
     #[test]
-    fn test_default_protocol_respects_env() {
-        // Test that env var takes precedence over feature-based defaults
-        #[cfg(all(feature = "http-json", feature = "http-proto"))]
-        run_env_test(
-            vec![(crate::OTEL_EXPORTER_OTLP_PROTOCOL, "http/protobuf")],
-            || {
-                // Even though http-json would be the default, env var should override
-                assert_eq!(crate::Protocol::default(), crate::Protocol::HttpBinary);
-            },
-        );
+    fn test_default_protocol_ignores_env() {
+        // Protocol::default() should always return the feature-based default,
+        // NOT consult environment variables. Env var resolution is handled
+        // by resolve_protocol().
 
+        // Without any env vars, default() equals feature_default()
+        run_env_test(vec![], || {
+            assert_eq!(
+                crate::Protocol::default(),
+                crate::Protocol::feature_default()
+            );
+        });
+
+        // Even with a valid env var set, default() still equals feature_default()
         #[cfg(all(feature = "grpc-tonic", feature = "http-json"))]
         run_env_test(vec![(crate::OTEL_EXPORTER_OTLP_PROTOCOL, "grpc")], || {
-            // Even though http-json would be the default, env var should override
-            assert_eq!(crate::Protocol::default(), crate::Protocol::Grpc);
+            assert_eq!(
+                crate::Protocol::default(),
+                crate::Protocol::feature_default()
+            );
         });
     }
 

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -77,7 +77,7 @@ pub(crate) struct ExportConfig {
 /// 2. Signal-specific environment variable
 /// 3. Generic OTEL_EXPORTER_OTLP_PROTOCOL environment variable
 /// 4. Feature-based default
-#[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
 pub(crate) fn resolve_protocol(
     signal_protocol_var: &str,
     provided_protocol: Option<Protocol>,

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -52,7 +52,7 @@ pub(crate) mod http;
 pub(crate) mod tonic;
 
 /// Configuration for the OTLP exporter.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct ExportConfig {
     /// The address of the OTLP collector.
     /// Default address will be used based on the protocol.
@@ -61,7 +61,9 @@ pub(crate) struct ExportConfig {
     pub endpoint: Option<String>,
 
     /// The protocol to use when communicating with the collector.
-    pub protocol: Protocol,
+    /// `None` means the protocol will be resolved from environment variables
+    /// or feature defaults at build time.
+    pub protocol: Option<Protocol>,
 
     /// The timeout to the collector.
     /// The default value is 10 seconds.
@@ -70,19 +72,26 @@ pub(crate) struct ExportConfig {
     pub timeout: Option<Duration>,
 }
 
+/// Resolve protocol with priority:
+/// 1. Programmatic configuration (provided value)
+/// 2. Signal-specific environment variable
+/// 3. Generic OTEL_EXPORTER_OTLP_PROTOCOL environment variable
+/// 4. Feature-based default
 #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
-impl Default for ExportConfig {
-    fn default() -> Self {
-        let protocol = Protocol::default();
-
-        Self {
-            endpoint: None,
-            // don't use default_endpoint(protocol) here otherwise we
-            // won't know if user provided a value
-            protocol,
-            timeout: None,
-        }
+pub(crate) fn resolve_protocol(
+    signal_protocol_var: &str,
+    provided_protocol: Option<Protocol>,
+) -> Protocol {
+    if let Some(protocol) = provided_protocol {
+        return protocol;
     }
+    if let Some(protocol) = Protocol::parse_from_env_var(signal_protocol_var) {
+        return protocol;
+    }
+    if let Some(protocol) = Protocol::from_env() {
+        return protocol;
+    }
+    Protocol::feature_default()
 }
 
 #[derive(Error, Debug)]
@@ -196,23 +205,7 @@ fn resolve_compression_from_env(
 #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
 impl Default for Protocol {
     fn default() -> Self {
-        // Check environment variable first
-        if let Some(protocol) = Protocol::from_env() {
-            return protocol;
-        }
-
-        // Fall back to feature-based defaults
-        #[cfg(feature = "http-json")]
-        return Protocol::HttpJson;
-
-        #[cfg(all(feature = "http-proto", not(feature = "http-json")))]
-        return Protocol::HttpBinary;
-
-        #[cfg(all(
-            feature = "grpc-tonic",
-            not(any(feature = "http-proto", feature = "http-json"))
-        ))]
-        return Protocol::Grpc;
+        Protocol::from_env().unwrap_or_else(Protocol::feature_default)
     }
 }
 
@@ -287,7 +280,7 @@ impl<B: HasExportConfig> WithExportConfig for B {
     }
 
     fn with_protocol(mut self, protocol: Protocol) -> Self {
-        self.export_config().protocol = protocol;
+        self.export_config().protocol = Some(protocol);
         self
     }
 
@@ -624,6 +617,96 @@ mod tests {
         run_env_test(vec![], || {
             let timeout = super::resolve_timeout(crate::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT, None);
             assert_eq!(timeout.as_millis(), 10_000);
+        });
+    }
+
+    #[test]
+    fn test_protocol_parse_from_env_var() {
+        use crate::Protocol;
+
+        // Test with custom env var name
+        temp_env::with_var_unset("MY_CUSTOM_PROTOCOL_VAR", || {
+            assert_eq!(Protocol::parse_from_env_var("MY_CUSTOM_PROTOCOL_VAR"), None);
+        });
+
+        #[cfg(feature = "http-proto")]
+        run_env_test(vec![("MY_CUSTOM_PROTOCOL_VAR", "http/protobuf")], || {
+            assert_eq!(
+                Protocol::parse_from_env_var("MY_CUSTOM_PROTOCOL_VAR"),
+                Some(Protocol::HttpBinary)
+            );
+        });
+
+        #[cfg(feature = "grpc-tonic")]
+        run_env_test(vec![("MY_CUSTOM_PROTOCOL_VAR", "grpc")], || {
+            assert_eq!(
+                Protocol::parse_from_env_var("MY_CUSTOM_PROTOCOL_VAR"),
+                Some(Protocol::Grpc)
+            );
+        });
+
+        // Invalid value returns None
+        run_env_test(vec![("MY_CUSTOM_PROTOCOL_VAR", "invalid")], || {
+            assert_eq!(Protocol::parse_from_env_var("MY_CUSTOM_PROTOCOL_VAR"), None);
+        });
+    }
+
+    #[cfg(feature = "http-proto")]
+    #[test]
+    fn test_resolve_protocol_signal_env_overrides_generic() {
+        use crate::Protocol;
+
+        run_env_test(
+            vec![
+                (crate::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, "http/protobuf"),
+                (crate::OTEL_EXPORTER_OTLP_PROTOCOL, "grpc"),
+            ],
+            || {
+                let protocol =
+                    super::resolve_protocol(crate::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, None);
+                assert_eq!(protocol, Protocol::HttpBinary);
+            },
+        );
+    }
+
+    #[cfg(feature = "http-proto")]
+    #[test]
+    fn test_resolve_protocol_code_overrides_all_envs() {
+        use crate::Protocol;
+
+        run_env_test(
+            vec![
+                (crate::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, "grpc"),
+                (crate::OTEL_EXPORTER_OTLP_PROTOCOL, "grpc"),
+            ],
+            || {
+                let protocol = super::resolve_protocol(
+                    crate::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
+                    Some(Protocol::HttpBinary),
+                );
+                assert_eq!(protocol, Protocol::HttpBinary);
+            },
+        );
+    }
+
+    #[cfg(all(feature = "grpc-tonic", feature = "http-proto"))]
+    #[test]
+    fn test_resolve_protocol_falls_back_to_generic_env() {
+        use crate::Protocol;
+
+        run_env_test(vec![(crate::OTEL_EXPORTER_OTLP_PROTOCOL, "grpc")], || {
+            let protocol = super::resolve_protocol(crate::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, None);
+            assert_eq!(protocol, Protocol::Grpc);
+        });
+    }
+
+    #[test]
+    fn test_resolve_protocol_falls_back_to_feature_default() {
+        use crate::Protocol;
+
+        run_env_test(vec![], || {
+            let protocol = super::resolve_protocol(crate::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, None);
+            assert_eq!(protocol, Protocol::feature_default());
         });
     }
 }

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -197,8 +197,8 @@ fn resolve_compression_from_env(
 
 /// Returns the default protocol based on enabled features.
 ///
-/// Note: This does not consult environment variables. Use [`resolve_protocol`]
-/// for full priority resolution including signal-specific and generic env vars.
+/// Note: This does not consult environment variables. Protocol resolution
+/// from environment variables is handled internally by the exporter builders.
 ///
 /// Priority order (first available wins):
 /// 1. http-json (if enabled)

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -19,9 +19,7 @@ use tonic::transport::ClientTlsConfig;
 use super::{default_headers, parse_header_string, OTEL_EXPORTER_OTLP_GRPC_ENDPOINT_DEFAULT};
 use super::{resolve_timeout, ExporterBuildError};
 use crate::exporter::Compression;
-use crate::{
-    exporter::ExportConfig, Protocol, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS,
-};
+use crate::{exporter::ExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS};
 
 #[cfg(all(
     feature = "experimental-grpc-retry",
@@ -209,18 +207,26 @@ impl TonicExporterBuilder {
         // Env var-based transport selection is handled at the auto-select layer
         // (e.g., SpanExporter::builder().build()), which routes to the correct
         // transport before reaching this code.
-        let protocol = super::resolve_protocol(signal_protocol_var, self.exporter_config.protocol);
+        #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
+        {
+            let protocol =
+                super::resolve_protocol(signal_protocol_var, self.exporter_config.protocol);
 
-        let is_http_protocol = false;
-        #[cfg(feature = "http-proto")]
-        let is_http_protocol = is_http_protocol || matches!(protocol, Protocol::HttpBinary);
-        #[cfg(feature = "http-json")]
-        let is_http_protocol = is_http_protocol || matches!(protocol, Protocol::HttpJson);
-        if is_http_protocol {
-            return Err(ExporterBuildError::InvalidConfig {
-                name: "protocol".to_string(),
-                reason: "HTTP protocol is not compatible with gRPC transport. Use `.with_http()` instead.".to_string(),
-            });
+            let is_http_protocol = false;
+            #[cfg(feature = "http-proto")]
+            let is_http_protocol =
+                is_http_protocol || matches!(protocol, crate::Protocol::HttpBinary);
+            #[cfg(feature = "http-json")]
+            let is_http_protocol =
+                is_http_protocol || matches!(protocol, crate::Protocol::HttpJson);
+            if is_http_protocol {
+                return Err(ExporterBuildError::InvalidConfig {
+                    name: "protocol".to_string(),
+                    reason:
+                        "HTTP protocol is not compatible with gRPC transport. Use `.with_http()` instead."
+                            .to_string(),
+                });
+            }
         }
 
         let compression = self.resolve_compression(signal_compression_var)?;

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -172,7 +172,7 @@ impl Default for TonicExporterBuilder {
                 retry_policy: None,
             },
             exporter_config: ExportConfig {
-                protocol: crate::Protocol::Grpc,
+                protocol: Some(crate::Protocol::Grpc),
                 ..Default::default()
             },
         }

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -209,8 +209,7 @@ impl TonicExporterBuilder {
         // Env var-based transport selection is handled at the auto-select layer
         // (e.g., SpanExporter::builder().build()), which routes to the correct
         // transport before reaching this code.
-        let protocol =
-            super::resolve_protocol(signal_protocol_var, self.exporter_config.protocol);
+        let protocol = super::resolve_protocol(signal_protocol_var, self.exporter_config.protocol);
 
         let is_http_protocol = false;
         #[cfg(feature = "http-proto")]

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -19,7 +19,9 @@ use tonic::transport::ClientTlsConfig;
 use super::{default_headers, parse_header_string, OTEL_EXPORTER_OTLP_GRPC_ENDPOINT_DEFAULT};
 use super::{resolve_timeout, ExporterBuildError};
 use crate::exporter::Compression;
-use crate::{exporter::ExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS};
+use crate::{
+    exporter::ExportConfig, Protocol, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS,
+};
 
 #[cfg(all(
     feature = "experimental-grpc-retry",
@@ -188,6 +190,7 @@ impl TonicExporterBuilder {
         signal_timeout_var: &str,
         signal_compression_var: &str,
         signal_headers_var: &str,
+        signal_protocol_var: &str,
     ) -> Result<
         (
             Channel,
@@ -197,6 +200,30 @@ impl TonicExporterBuilder {
         ),
         ExporterBuildError,
     > {
+        // Resolve protocol and validate compatibility with gRPC transport.
+        // Note: TonicExporterBuilder defaults protocol to Some(Grpc), so for the
+        // typical `.with_tonic().build()` path, resolve_protocol returns Grpc
+        // immediately (env vars are skipped because programmatic config takes
+        // precedence). This validation primarily catches programmatic misuse like
+        // `.with_tonic().with_protocol(Protocol::HttpBinary).build()`.
+        // Env var-based transport selection is handled at the auto-select layer
+        // (e.g., SpanExporter::builder().build()), which routes to the correct
+        // transport before reaching this code.
+        let protocol =
+            super::resolve_protocol(signal_protocol_var, self.exporter_config.protocol);
+
+        let is_http_protocol = false;
+        #[cfg(feature = "http-proto")]
+        let is_http_protocol = is_http_protocol || matches!(protocol, Protocol::HttpBinary);
+        #[cfg(feature = "http-json")]
+        let is_http_protocol = is_http_protocol || matches!(protocol, Protocol::HttpJson);
+        if is_http_protocol {
+            return Err(ExporterBuildError::InvalidConfig {
+                name: "protocol".to_string(),
+                reason: "HTTP protocol is not compatible with gRPC transport. Use `.with_http()` instead.".to_string(),
+            });
+        }
+
         let compression = self.resolve_compression(signal_compression_var)?;
 
         let (headers_from_env, headers_for_logging) = parse_headers_from_env(signal_headers_var);
@@ -355,6 +382,7 @@ impl TonicExporterBuilder {
             crate::logs::OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
             crate::logs::OTEL_EXPORTER_OTLP_LOGS_COMPRESSION,
             crate::logs::OTEL_EXPORTER_OTLP_LOGS_HEADERS,
+            crate::logs::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
         )?;
 
         let client = TonicLogsClient::new(channel, interceptor, compression, retry_policy);
@@ -378,6 +406,7 @@ impl TonicExporterBuilder {
             crate::metric::OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
             crate::metric::OTEL_EXPORTER_OTLP_METRICS_COMPRESSION,
             crate::metric::OTEL_EXPORTER_OTLP_METRICS_HEADERS,
+            crate::metric::OTEL_EXPORTER_OTLP_METRICS_PROTOCOL,
         )?;
 
         let client = TonicMetricsClient::new(channel, interceptor, compression, retry_policy);
@@ -397,6 +426,7 @@ impl TonicExporterBuilder {
             crate::span::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
             crate::span::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
             crate::span::OTEL_EXPORTER_OTLP_TRACES_HEADERS,
+            crate::span::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
         )?;
 
         let client = TonicTracesClient::new(channel, interceptor, compression, retry_policy);

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -230,6 +230,7 @@
 //! | Variable | Description |
 //! |---|---|
 //! | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Signal-specific endpoint for trace exports. |
+//! | `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | Signal-specific protocol for trace exports. Valid values: `grpc`, `http/protobuf`, `http/json`. |
 //! | `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` | Signal-specific timeout (in milliseconds) for trace exports. |
 //! | `OTEL_EXPORTER_OTLP_TRACES_HEADERS` | Signal-specific headers for trace exports. |
 //! | `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` | Signal-specific compression for trace exports. |
@@ -239,6 +240,7 @@
 //! | Variable | Description |
 //! |---|---|
 //! | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Signal-specific endpoint for metrics exports. |
+//! | `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` | Signal-specific protocol for metrics exports. Valid values: `grpc`, `http/protobuf`, `http/json`. |
 //! | `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` | Signal-specific timeout (in milliseconds) for metrics exports. |
 //! | `OTEL_EXPORTER_OTLP_METRICS_HEADERS` | Signal-specific headers for metrics exports. |
 //! | `OTEL_EXPORTER_OTLP_METRICS_COMPRESSION` | Signal-specific compression for metrics exports. |
@@ -249,6 +251,7 @@
 //! | Variable | Description |
 //! |---|---|
 //! | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Signal-specific endpoint for log exports. |
+//! | `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` | Signal-specific protocol for log exports. Valid values: `grpc`, `http/protobuf`, `http/json`. |
 //! | `OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` | Signal-specific timeout (in milliseconds) for log exports. |
 //! | `OTEL_EXPORTER_OTLP_LOGS_HEADERS` | Signal-specific headers for log exports. |
 //! | `OTEL_EXPORTER_OTLP_LOGS_COMPRESSION` | Signal-specific compression for log exports. |
@@ -652,7 +655,7 @@ pub use crate::exporter::ExporterBuildError;
 pub use crate::span::{
     SpanExporter, SpanExporterBuilder, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_HEADERS,
-    OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
+    OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
 };
 
 #[cfg(feature = "metrics")]
@@ -660,7 +663,8 @@ pub use crate::span::{
 pub use crate::metric::{
     MetricExporter, MetricExporterBuilder, OTEL_EXPORTER_OTLP_METRICS_COMPRESSION,
     OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_HEADERS,
-    OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
+    OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
+    OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
 };
 
 #[cfg(feature = "logs")]
@@ -668,7 +672,7 @@ pub use crate::metric::{
 pub use crate::logs::{
     LogExporter, LogExporterBuilder, OTEL_EXPORTER_OTLP_LOGS_COMPRESSION,
     OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, OTEL_EXPORTER_OTLP_LOGS_HEADERS,
-    OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
+    OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
 };
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
@@ -744,12 +748,22 @@ impl Protocol {
     /// - The value doesn't match a known protocol
     /// - The specified protocol's feature is not enabled
     pub fn from_env() -> Option<Self> {
+        Self::parse_from_env_var(OTEL_EXPORTER_OTLP_PROTOCOL)
+    }
+
+    /// Attempts to parse a protocol from the given environment variable.
+    ///
+    /// Returns `None` if:
+    /// - The environment variable is not set
+    /// - The value doesn't match a known protocol
+    /// - The specified protocol's feature is not enabled
+    pub fn parse_from_env_var(env_var: &str) -> Option<Self> {
         use crate::exporter::{
             OTEL_EXPORTER_OTLP_PROTOCOL_GRPC, OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_JSON,
             OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF,
         };
 
-        let protocol = std::env::var(OTEL_EXPORTER_OTLP_PROTOCOL).ok()?;
+        let protocol = std::env::var(env_var).ok()?;
 
         match protocol.as_str() {
             OTEL_EXPORTER_OTLP_PROTOCOL_GRPC => {
@@ -796,6 +810,27 @@ impl Protocol {
             }
             _ => None,
         }
+    }
+
+    /// Returns the default protocol based on enabled features, without
+    /// consulting environment variables.
+    ///
+    /// Priority order (first available wins):
+    /// 1. http-json (if enabled)
+    /// 2. http-proto (if enabled)
+    /// 3. grpc-tonic (if enabled)
+    pub fn feature_default() -> Self {
+        #[cfg(feature = "http-json")]
+        return Protocol::HttpJson;
+
+        #[cfg(all(feature = "http-proto", not(feature = "http-json")))]
+        return Protocol::HttpBinary;
+
+        #[cfg(all(
+            feature = "grpc-tonic",
+            not(any(feature = "http-proto", feature = "http-json"))
+        ))]
+        return Protocol::Grpc;
     }
 }
 

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -757,7 +757,7 @@ impl Protocol {
     /// - The environment variable is not set
     /// - The value doesn't match a known protocol
     /// - The specified protocol's feature is not enabled
-    pub fn parse_from_env_var(env_var: &str) -> Option<Self> {
+    pub(crate) fn parse_from_env_var(env_var: &str) -> Option<Self> {
         use crate::exporter::{
             OTEL_EXPORTER_OTLP_PROTOCOL_GRPC, OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_JSON,
             OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF,
@@ -819,7 +819,7 @@ impl Protocol {
     /// 1. http-json (if enabled)
     /// 2. http-proto (if enabled)
     /// 3. grpc-tonic (if enabled)
-    pub fn feature_default() -> Self {
+    pub(crate) fn feature_default() -> Self {
         #[cfg(feature = "http-json")]
         return Protocol::HttpJson;
 

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -30,6 +30,8 @@ pub const OTEL_EXPORTER_OTLP_LOGS_TIMEOUT: &str = "OTEL_EXPORTER_OTLP_LOGS_TIMEO
 /// Example: `k1=v1,k2=v2`
 /// Note: this is only supported for HTTP.
 pub const OTEL_EXPORTER_OTLP_LOGS_HEADERS: &str = "OTEL_EXPORTER_OTLP_LOGS_HEADERS";
+/// Protocol to use for log exports. Valid values: `grpc`, `http/protobuf`, `http/json`.
+pub const OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL";
 
 /// Builder for creating a new [LogExporter].
 #[derive(Debug, Default, Clone)]

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -79,8 +79,7 @@ impl LogExporterBuilder<NoExporterBuilderSet> {
         // NOTE: The transport-specific builder will call resolve_protocol again
         // internally (for HTTP sub-protocol selection or tonic validation), but
         // that's harmless — the result is the same.
-        let protocol =
-            crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, None);
+        let protocol = crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, None);
         match protocol {
             #[cfg(feature = "grpc-tonic")]
             crate::Protocol::Grpc => self.with_tonic().build(),

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -68,15 +68,20 @@ impl LogExporterBuilder<NoExporterBuilderSet> {
     /// variable or feature flags.
     ///
     /// The transport is chosen based on:
-    /// 1. The `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable (if set and the
-    ///    corresponding feature is enabled)
-    /// 2. Enabled features, with priority: `http-json` > `http-proto` > `grpc-tonic`
+    /// 1. `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` environment variable
+    /// 2. `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable
+    /// 3. Enabled features, with priority: `http-json` > `http-proto` > `grpc-tonic`
     ///
     /// Use [`with_tonic`](Self::with_tonic) or [`with_http`](Self::with_http) to
     /// explicitly select a transport and access transport-specific configuration.
     #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
     pub fn build(self) -> Result<LogExporter, ExporterBuildError> {
-        match crate::Protocol::default() {
+        // NOTE: The transport-specific builder will call resolve_protocol again
+        // internally (for HTTP sub-protocol selection or tonic validation), but
+        // that's harmless — the result is the same.
+        let protocol =
+            crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, None);
+        match protocol {
             #[cfg(feature = "grpc-tonic")]
             crate::Protocol::Grpc => self.with_tonic().build(),
             #[cfg(feature = "http-proto")]

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -65,15 +65,20 @@ impl MetricExporterBuilder<NoExporterBuilderSet> {
     /// variable or feature flags.
     ///
     /// The transport is chosen based on:
-    /// 1. The `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable (if set and the
-    ///    corresponding feature is enabled)
-    /// 2. Enabled features, with priority: `http-json` > `http-proto` > `grpc-tonic`
+    /// 1. `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` environment variable
+    /// 2. `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable
+    /// 3. Enabled features, with priority: `http-json` > `http-proto` > `grpc-tonic`
     ///
     /// Use [`with_tonic`](Self::with_tonic) or [`with_http`](Self::with_http) to
     /// explicitly select a transport and access transport-specific configuration.
     #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
     pub fn build(self) -> Result<MetricExporter, ExporterBuildError> {
-        match crate::Protocol::default() {
+        // NOTE: The transport-specific builder will call resolve_protocol again
+        // internally (for HTTP sub-protocol selection or tonic validation), but
+        // that's harmless — the result is the same.
+        let protocol =
+            crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, None);
+        match protocol {
             #[cfg(feature = "grpc-tonic")]
             crate::Protocol::Grpc => self.with_tonic().build(),
             #[cfg(feature = "http-proto")]

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -76,8 +76,7 @@ impl MetricExporterBuilder<NoExporterBuilderSet> {
         // NOTE: The transport-specific builder will call resolve_protocol again
         // internally (for HTTP sub-protocol selection or tonic validation), but
         // that's harmless — the result is the same.
-        let protocol =
-            crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, None);
+        let protocol = crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, None);
         match protocol {
             #[cfg(feature = "grpc-tonic")]
             crate::Protocol::Grpc => self.with_tonic().build(),

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -42,6 +42,8 @@ pub const OTEL_EXPORTER_OTLP_METRICS_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_MET
 /// Example: `k1=v1,k2=v2`
 /// Note: this is only supported for HTTP.
 pub const OTEL_EXPORTER_OTLP_METRICS_HEADERS: &str = "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
+/// Protocol to use for metrics exports. Valid values: `grpc`, `http/protobuf`, `http/json`.
+pub const OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL";
 /// Temporality preference for metrics, defaults to cumulative.
 pub const OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: &str =
     "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE";

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -35,6 +35,8 @@ pub const OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_TRAC
 /// Example: `k1=v1,k2=v2`
 /// Note: this is only supported for HTTP.
 pub const OTEL_EXPORTER_OTLP_TRACES_HEADERS: &str = "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
+/// Protocol to use for trace exports. Valid values: `grpc`, `http/protobuf`, `http/json`.
+pub const OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL";
 
 /// OTLP span exporter builder
 #[derive(Debug, Default, Clone)]

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -70,15 +70,19 @@ impl SpanExporterBuilder<NoExporterBuilderSet> {
     /// variable or feature flags.
     ///
     /// The transport is chosen based on:
-    /// 1. The `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable (if set and the
-    ///    corresponding feature is enabled)
-    /// 2. Enabled features, with priority: `http-json` > `http-proto` > `grpc-tonic`
+    /// 1. `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` environment variable
+    /// 2. `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable
+    /// 3. Enabled features, with priority: `http-json` > `http-proto` > `grpc-tonic`
     ///
     /// Use [`with_tonic`](Self::with_tonic) or [`with_http`](Self::with_http) to
     /// explicitly select a transport and access transport-specific configuration.
     #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
     pub fn build(self) -> Result<SpanExporter, ExporterBuildError> {
-        match crate::Protocol::default() {
+        // NOTE: The transport-specific builder will call resolve_protocol again
+        // internally (for HTTP sub-protocol selection or tonic validation), but
+        // that's harmless — the result is the same.
+        let protocol = crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, None);
+        match protocol {
             #[cfg(feature = "grpc-tonic")]
             crate::Protocol::Grpc => self.with_tonic().build(),
             #[cfg(feature = "http-proto")]
@@ -200,5 +204,118 @@ mod tests {
     fn build_with_default_transport() {
         let result = SpanExporter::builder().build();
         assert!(result.is_ok(), "build() should succeed: {:?}", result.err());
+    }
+
+    /// Verifies that `SpanExporter::builder().build()` respects the
+    /// signal-specific `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` env var
+    /// when selecting the transport.
+    #[cfg(all(feature = "grpc-tonic", feature = "http-proto"))]
+    #[test]
+    fn build_auto_select_respects_signal_protocol_env() {
+        // Tokio runtime is required because tonic's channel setup needs an active reactor.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            // With signal-specific env var set to grpc, build() should pick tonic
+            temp_env::with_vars(
+                vec![
+                    (super::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, Some("grpc")),
+                    (crate::OTEL_EXPORTER_OTLP_PROTOCOL, None::<&str>),
+                ],
+                || {
+                    let result = SpanExporter::builder().build();
+                    assert!(
+                        result.is_ok(),
+                        "build() with TRACES_PROTOCOL=grpc should succeed: {:?}",
+                        result.err()
+                    );
+                },
+            );
+
+            // With signal-specific env var set to http/protobuf, build() should pick HTTP
+            temp_env::with_vars(
+                vec![
+                    (
+                        super::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
+                        Some("http/protobuf"),
+                    ),
+                    (crate::OTEL_EXPORTER_OTLP_PROTOCOL, None::<&str>),
+                ],
+                || {
+                    let result = SpanExporter::builder().build();
+                    assert!(
+                        result.is_ok(),
+                        "build() with TRACES_PROTOCOL=http/protobuf should succeed: {:?}",
+                        result.err()
+                    );
+                },
+            );
+        });
+    }
+
+    /// Verifies that signal-specific protocol env var takes precedence
+    /// over the generic `OTEL_EXPORTER_OTLP_PROTOCOL` for transport selection.
+    #[cfg(all(feature = "grpc-tonic", feature = "http-proto"))]
+    #[test]
+    fn build_auto_select_signal_env_overrides_generic() {
+        // Tokio runtime is required because tonic's channel setup needs an active reactor.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            temp_env::with_vars(
+                vec![
+                    (super::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, Some("grpc")),
+                    (crate::OTEL_EXPORTER_OTLP_PROTOCOL, Some("http/protobuf")),
+                ],
+                || {
+                    let result = SpanExporter::builder().build();
+                    assert!(
+                        result.is_ok(),
+                        "signal-specific protocol should override generic: {:?}",
+                        result.err()
+                    );
+                },
+            );
+        });
+    }
+
+    /// Verifies that explicitly selecting tonic transport with an HTTP protocol
+    /// via `.with_protocol()` returns an error.
+    #[cfg(all(feature = "grpc-tonic", feature = "http-proto"))]
+    #[test]
+    fn build_tonic_with_http_protocol_returns_error() {
+        use crate::exporter::WithExportConfig;
+
+        // Tokio runtime is required because tonic's channel setup needs an active reactor.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let result = SpanExporter::builder()
+                .with_tonic()
+                .with_protocol(crate::Protocol::HttpBinary)
+                .build();
+            assert!(result.is_err(), "tonic with HTTP protocol should fail");
+            let err = result.unwrap_err().to_string();
+            assert!(
+                err.contains("not compatible with gRPC transport"),
+                "error should mention transport incompatibility, got: {err}"
+            );
+        });
+    }
+
+    /// Verifies that explicitly selecting HTTP transport with a gRPC protocol
+    /// via `.with_protocol()` returns an error.
+    #[cfg(all(feature = "grpc-tonic", feature = "http-proto"))]
+    #[test]
+    fn build_http_with_grpc_protocol_returns_error() {
+        use crate::exporter::WithExportConfig;
+
+        let result = SpanExporter::builder()
+            .with_http()
+            .with_protocol(crate::Protocol::Grpc)
+            .build();
+        assert!(result.is_err(), "HTTP with gRPC protocol should fail");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not compatible with HTTP transport"),
+            "error should mention transport incompatibility, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add support for `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`, and `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` environment variables per the [OTLP exporter specification](https://opentelemetry.io/docs/specs/otel/protocol/exporter/)
- Refactor `ExportConfig.protocol` from `Protocol` to `Option<Protocol>` to distinguish explicit configuration from defaults (consistent with `endpoint` and `timeout` fields)
- Add `Protocol::parse_from_env_var()` and `Protocol::feature_default()` for generalized protocol resolution
- Add `resolve_protocol()` with proper priority: **code config > signal env var > generic env var > feature default**
- Auto-select `build()` on `SpanExporterBuilder`, `LogExporterBuilder`, and `MetricExporterBuilder` now uses `resolve_protocol()` with the signal-specific env var, so `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc` correctly routes to tonic transport
- Transport/protocol mismatch validation in both directions:
  - HTTP builder returns `InvalidConfig` when gRPC protocol is configured
  - gRPC/tonic builder returns `InvalidConfig` when an HTTP protocol is configured
- **Breaking**: `Protocol::default()` no longer consults env vars — returns only the feature-based default. Use `Protocol::from_env()` for env var resolution.

### PR Series

This is **PR 1 of 3** for full OTLP exporter spec compliance:
1. **Per-signal protocol env vars** (this PR) — 3 new env vars
2. TLS certificate env vars — 12 new env vars (supersedes stalled #2465)
3. INSECURE env var support — 4 new env vars

Partially addresses #774, #984.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p opentelemetry-otlp --all-features -- -D warnings`
- [x] `cargo test -p opentelemetry-otlp --all-features` — 87 lib tests + 21 doc tests pass
- [x] Compiles cleanly with individual transport features (`grpc-tonic`, `http-proto`, `http-json`)
- [x] New unit tests: `test_protocol_parse_from_env_var`, `test_resolve_protocol_signal_env_overrides_generic`, `test_resolve_protocol_code_overrides_all_envs`, `test_resolve_protocol_falls_back_to_generic_env`, `test_resolve_protocol_falls_back_to_feature_default`, `test_default_protocol_ignores_env`
- [x] New integration tests: `build_auto_select_respects_signal_protocol_env`, `build_auto_select_signal_env_overrides_generic`, `build_tonic_with_http_protocol_returns_error`, `build_http_with_grpc_protocol_returns_error`