### PR TITLE
feat(otlp): support TLS certificate environment variables

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -46,6 +46,13 @@ Released 2026-May-08
   grpc-tonic). Protocol resolution from environment variables is handled internally by the
   exporter builders. Users who relied on `Protocol::default()` to read env vars should use
   `Protocol::from_env()` instead.
+- Add support for TLS certificate environment variables per the OTLP exporter spec:
+  `OTEL_EXPORTER_OTLP_CERTIFICATE`, `OTEL_EXPORTER_OTLP_CLIENT_KEY`,
+  `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` (generic), plus per-signal variants for traces,
+  metrics, and logs. These env vars point to PEM-encoded files for server TLS verification and
+  mTLS client authentication. Programmatic `.with_tls_config()` takes precedence over env vars.
+  [#774](https://github.com/open-telemetry/opentelemetry-rust/issues/774)
+  [#984](https://github.com/open-telemetry/opentelemetry-rust/issues/984)
 - Add support for `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable
   to configure metrics temporality. Accepted values: `cumulative` (default), `delta`,
   `lowmemory` (case-insensitive). Programmatic `.with_temporality()` overrides the env var.

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## vNext
 
+- Add support for TLS certificate environment variables per the OTLP exporter spec:
+  `OTEL_EXPORTER_OTLP_CERTIFICATE`, `OTEL_EXPORTER_OTLP_CLIENT_KEY`,
+  `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` (generic), plus per-signal variants for traces,
+  metrics, and logs. These env vars point to PEM-encoded files for server TLS verification and
+  mTLS client authentication. Programmatic `.with_tls_config()` takes precedence over env vars.
+  For HTTP, the env vars are only applied to auto-created `reqwest` clients; hyper and
+  user-supplied clients (via `.with_http_client()`) must configure TLS themselves.
+  [#774](https://github.com/open-telemetry/opentelemetry-rust/issues/774)
+  [#984](https://github.com/open-telemetry/opentelemetry-rust/issues/984)
+
 ## 0.32.0
 
 Released 2026-May-08
@@ -46,13 +56,6 @@ Released 2026-May-08
   grpc-tonic). Protocol resolution from environment variables is handled internally by the
   exporter builders. Users who relied on `Protocol::default()` to read env vars should use
   `Protocol::from_env()` instead.
-- Add support for TLS certificate environment variables per the OTLP exporter spec:
-  `OTEL_EXPORTER_OTLP_CERTIFICATE`, `OTEL_EXPORTER_OTLP_CLIENT_KEY`,
-  `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` (generic), plus per-signal variants for traces,
-  metrics, and logs. These env vars point to PEM-encoded files for server TLS verification and
-  mTLS client authentication. Programmatic `.with_tls_config()` takes precedence over env vars.
-  [#774](https://github.com/open-telemetry/opentelemetry-rust/issues/774)
-  [#984](https://github.com/open-telemetry/opentelemetry-rust/issues/984)
 - Add support for `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable
   to configure metrics temporality. Accepted values: `cumulative` (default), `delta`,
   `lowmemory` (case-insensitive). Programmatic `.with_temporality()` overrides the env var.

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -54,6 +54,7 @@ opentelemetry_sdk = { workspace = true, features = ["trace", "testing"], default
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 futures-util = { workspace = true }
 temp-env = { workspace = true }
+tempfile = { workspace = true }
 tonic = { workspace = true, features = ["router", "server"] }
 async-trait = { workspace = true }
 

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -184,17 +184,14 @@ struct ReqwestTlsCerts {
 ))]
 impl ReqwestTlsCerts {
     /// Apply TLS certs to an async reqwest client builder.
-    fn apply(
-        &self,
-        mut builder: reqwest::ClientBuilder,
-    ) -> Result<reqwest::ClientBuilder, ExporterBuildError> {
+    fn apply(&self, mut builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
         if let Some(ref cert) = self.ca_cert {
             builder = builder.add_root_certificate(cert.clone());
         }
         if let Some(ref identity) = self.identity {
             builder = builder.identity(identity.clone());
         }
-        Ok(builder)
+        builder
     }
 
     /// Apply TLS certs to a blocking reqwest client builder.
@@ -298,7 +295,7 @@ impl HttpExporterBuilder {
 
                 #[cfg(any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"))]
                 if let Some(ref certs) = tls_certs {
-                    builder = certs.apply(builder)?;
+                    builder = certs.apply(builder);
                 }
 
                 http_client =
@@ -400,8 +397,7 @@ impl HttpExporterBuilder {
             OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_CLIENT_KEY,
         };
 
-        let ca_pem =
-            resolve_tls_env_and_read(tls_vars.cert_var, OTEL_EXPORTER_OTLP_CERTIFICATE)?;
+        let ca_pem = resolve_tls_env_and_read(tls_vars.cert_var, OTEL_EXPORTER_OTLP_CERTIFICATE)?;
         let client_key_pem =
             resolve_tls_env_and_read(tls_vars.client_key_var, OTEL_EXPORTER_OTLP_CLIENT_KEY)?;
         let client_cert_pem = resolve_tls_env_and_read(
@@ -429,13 +425,11 @@ impl HttpExporterBuilder {
             (Some(key), Some(cert)) => {
                 let mut identity_pem = cert;
                 identity_pem.extend_from_slice(&key);
-                Some(
-                    reqwest::Identity::from_pem(&identity_pem).map_err(|e| {
-                        ExporterBuildError::InternalFailure(format!(
-                            "Failed to parse client identity: {e}"
-                        ))
-                    })?,
-                )
+                Some(reqwest::Identity::from_pem(&identity_pem).map_err(|e| {
+                    ExporterBuildError::InternalFailure(format!(
+                        "Failed to parse client identity: {e}"
+                    ))
+                })?)
             }
             (Some(_), None) | (None, Some(_)) => {
                 opentelemetry::otel_warn!(

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -184,6 +184,7 @@ struct ReqwestTlsCerts {
 ))]
 impl ReqwestTlsCerts {
     /// Apply TLS certs to an async reqwest client builder.
+    #[cfg(feature = "reqwest-client")]
     fn apply(&self, mut builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
         if let Some(ref cert) = self.ca_cert {
             builder = builder.add_root_certificate(cert.clone());
@@ -195,7 +196,7 @@ impl ReqwestTlsCerts {
     }
 
     /// Apply TLS certs to a blocking reqwest client builder.
-    #[allow(dead_code)] // only used when reqwest-blocking-client is the selected client
+    #[cfg(all(not(feature = "reqwest-client"), feature = "reqwest-blocking-client"))]
     fn apply_blocking(
         &self,
         mut builder: reqwest::blocking::ClientBuilder,
@@ -268,13 +269,6 @@ impl HttpExporterBuilder {
 
         let timeout = resolve_timeout(signal_timeout_var, self.exporter_config.timeout.as_ref());
 
-        // Resolve and parse TLS certificates from env vars (only when TLS features and a reqwest client are enabled)
-        #[cfg(all(
-            any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"),
-            any(feature = "reqwest-client", feature = "reqwest-blocking-client"),
-        ))]
-        let tls_certs = Self::resolve_reqwest_tls_certs(&signal_tls_vars)?;
-
         #[allow(unused_mut)] // TODO - clippy thinks mut is not needed, but it is
         let mut http_client = self.http_config.client.take();
 
@@ -285,24 +279,43 @@ impl HttpExporterBuilder {
         // 2. hyper-client
         // 3. reqwest-blocking-client (default)
         //
-        // TLS certificates from env vars are only applied to auto-created reqwest clients.
-        // Custom clients provided via .with_http_client() are not affected.
+        // TLS certificates from env vars are only resolved and applied to auto-created
+        // reqwest clients. For hyper or user-supplied clients (via .with_http_client())
+        // the env vars cannot be honored, so we warn instead of silently ignoring them.
         if http_client.is_none() {
             #[cfg(feature = "reqwest-client")]
             {
                 #[allow(unused_mut)] // mut needed when TLS features are enabled
                 let mut builder = reqwest::Client::builder().timeout(timeout);
 
+                // Resolve TLS certs only here, where they are actually applied, so an
+                // invalid env var cannot fail a build that would not use these certs.
                 #[cfg(any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"))]
-                if let Some(ref certs) = tls_certs {
+                if let Some(certs) = Self::resolve_reqwest_tls_certs(&signal_tls_vars)? {
                     builder = certs.apply(builder);
                 }
 
-                http_client =
-                    Some(Arc::new(builder.build().unwrap_or_default()) as Arc<dyn HttpClient>);
+                // Without a reqwest-rustls feature the env certs cannot be applied to the
+                // auto-created reqwest client, so warn rather than silently dropping them.
+                #[cfg(not(any(
+                    feature = "reqwest-rustls",
+                    feature = "reqwest-rustls-webpki-roots"
+                )))]
+                super::warn_if_tls_env_ignored(
+                    &signal_tls_vars,
+                    "reqwest-client (built without a reqwest-rustls feature)",
+                );
+
+                let client = builder.build().map_err(|e| {
+                    ExporterBuildError::InternalFailure(format!(
+                        "Failed to build reqwest client: {e}"
+                    ))
+                })?;
+                http_client = Some(Arc::new(client) as Arc<dyn HttpClient>);
             }
             #[cfg(all(not(feature = "reqwest-client"), feature = "hyper-client"))]
             {
+                super::warn_if_tls_env_ignored(&signal_tls_vars, "hyper-client");
                 // TODO - support configuring custom connector and executor
                 http_client = Some(Arc::new(HyperClient::with_default_connector(timeout, None))
                     as Arc<dyn HttpClient>);
@@ -315,8 +328,21 @@ impl HttpExporterBuilder {
             {
                 let timeout_clone = timeout;
 
+                // Resolve TLS certs only here, where they are actually applied, so an
+                // invalid env var cannot fail a build that would not use these certs.
                 #[cfg(any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"))]
-                let tls_certs_clone = tls_certs.clone();
+                let tls_certs = Self::resolve_reqwest_tls_certs(&signal_tls_vars)?;
+
+                // Without a reqwest-rustls feature the env certs cannot be applied to the
+                // auto-created reqwest client, so warn rather than silently dropping them.
+                #[cfg(not(any(
+                    feature = "reqwest-rustls",
+                    feature = "reqwest-rustls-webpki-roots"
+                )))]
+                super::warn_if_tls_env_ignored(
+                    &signal_tls_vars,
+                    "reqwest-blocking-client (built without a reqwest-rustls feature)",
+                );
 
                 let client = std::thread::spawn(move || {
                     #[allow(unused_mut)] // mut needed when TLS features are enabled
@@ -326,18 +352,24 @@ impl HttpExporterBuilder {
                         feature = "reqwest-rustls",
                         feature = "reqwest-rustls-webpki-roots"
                     ))]
-                    if let Some(ref certs) = tls_certs_clone {
+                    if let Some(ref certs) = tls_certs {
                         builder = certs.apply_blocking(builder);
                     }
 
-                    builder
-                        .build()
-                        .unwrap_or_else(|_| reqwest::blocking::Client::new())
+                    builder.build()
                 })
                 .join()
-                .unwrap(); // TODO: Return ExporterBuildError::ThreadSpawnFailed
+                .unwrap() // TODO: Return ExporterBuildError::ThreadSpawnFailed
+                .map_err(|e| {
+                    ExporterBuildError::InternalFailure(format!(
+                        "Failed to build reqwest blocking client: {e}"
+                    ))
+                })?;
                 http_client = Some(Arc::new(client) as Arc<dyn HttpClient>);
             }
+        } else {
+            // A custom client was supplied; TLS env vars cannot be applied to it.
+            super::warn_if_tls_env_ignored(&signal_tls_vars, "custom HttpClient");
         }
 
         let http_client = http_client.ok_or(ExporterBuildError::NoHttpClient)?;
@@ -424,6 +456,12 @@ impl HttpExporterBuilder {
         let identity = match (client_key_pem, client_cert_pem) {
             (Some(key), Some(cert)) => {
                 let mut identity_pem = cert;
+                // reqwest expects the cert and key PEM blocks concatenated. Ensure a
+                // newline boundary so a cert file without a trailing newline does not
+                // fuse the `-----END...-----`/`-----BEGIN...-----` markers onto one line.
+                if !identity_pem.ends_with(b"\n") {
+                    identity_pem.push(b'\n');
+                }
                 identity_pem.extend_from_slice(&key);
                 Some(reqwest::Identity::from_pem(&identity_pem).map_err(|e| {
                     ExporterBuildError::InternalFailure(format!(
@@ -431,10 +469,21 @@ impl HttpExporterBuilder {
                     ))
                 })?)
             }
-            (Some(_), None) | (None, Some(_)) => {
+            (Some(_), None) => {
                 opentelemetry::otel_warn!(
                     name: "TlsConfig.PartialMtls",
-                    message = "mTLS requires both CLIENT_KEY and CLIENT_CERTIFICATE to be set; only one was provided, skipping mTLS configuration"
+                    message = "mTLS requires both a client key and a client certificate; only the client key was provided, skipping mTLS configuration",
+                    client_key_var = tls_vars.client_key_var,
+                    client_cert_var = tls_vars.client_cert_var
+                );
+                None
+            }
+            (None, Some(_)) => {
+                opentelemetry::otel_warn!(
+                    name: "TlsConfig.PartialMtls",
+                    message = "mTLS requires both a client key and a client certificate; only the client certificate was provided, skipping mTLS configuration",
+                    client_key_var = tls_vars.client_key_var,
+                    client_cert_var = tls_vars.client_cert_var
                 );
                 None
             }

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -96,11 +96,9 @@ pub(crate) mod logs;
 #[cfg(feature = "trace")]
 mod trace;
 
-#[cfg(all(
-    not(feature = "reqwest-client"),
-    not(feature = "reqwest-blocking-client"),
-    feature = "hyper-client"
-))]
+// Must match the cfg on the HyperClient use-site below: the hyper branch is selected
+// whenever hyper-client is on and reqwest-client is off, regardless of reqwest-blocking-client.
+#[cfg(all(not(feature = "reqwest-client"), feature = "hyper-client"))]
 use opentelemetry_http::hyper::HyperClient;
 
 /// Configuration of the http transport

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -165,7 +165,56 @@ impl Default for HttpExporterBuilder {
     }
 }
 
+/// Pre-parsed TLS certificates for reqwest client configuration.
+/// Parsing is done eagerly at build time so that invalid PEM files produce
+/// immediate errors rather than being silently ignored.
+#[cfg(all(
+    any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"),
+    any(feature = "reqwest-client", feature = "reqwest-blocking-client"),
+))]
+#[derive(Clone)]
+struct ReqwestTlsCerts {
+    ca_cert: Option<reqwest::Certificate>,
+    identity: Option<reqwest::Identity>,
+}
+
+#[cfg(all(
+    any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"),
+    any(feature = "reqwest-client", feature = "reqwest-blocking-client"),
+))]
+impl ReqwestTlsCerts {
+    /// Apply TLS certs to an async reqwest client builder.
+    fn apply(
+        &self,
+        mut builder: reqwest::ClientBuilder,
+    ) -> Result<reqwest::ClientBuilder, ExporterBuildError> {
+        if let Some(ref cert) = self.ca_cert {
+            builder = builder.add_root_certificate(cert.clone());
+        }
+        if let Some(ref identity) = self.identity {
+            builder = builder.identity(identity.clone());
+        }
+        Ok(builder)
+    }
+
+    /// Apply TLS certs to a blocking reqwest client builder.
+    #[allow(dead_code)] // only used when reqwest-blocking-client is the selected client
+    fn apply_blocking(
+        &self,
+        mut builder: reqwest::blocking::ClientBuilder,
+    ) -> reqwest::blocking::ClientBuilder {
+        if let Some(ref cert) = self.ca_cert {
+            builder = builder.add_root_certificate(cert.clone());
+        }
+        if let Some(ref identity) = self.identity {
+            builder = builder.identity(identity.clone());
+        }
+        builder
+    }
+}
+
 impl HttpExporterBuilder {
+    #[allow(clippy::too_many_arguments)]
     fn build_client(
         &mut self,
         signal_endpoint_var: &str,
@@ -174,7 +223,9 @@ impl HttpExporterBuilder {
         signal_http_headers_var: &str,
         signal_compression_var: &str,
         signal_protocol_var: &str,
+        signal_tls_vars: super::SignalTlsEnvVars,
     ) -> Result<OtlpHttpClient, ExporterBuildError> {
+        let _ = &signal_tls_vars; // used only when TLS features are enabled
         let protocol = super::resolve_protocol(signal_protocol_var, self.exporter_config.protocol);
 
         // Validate protocol is compatible with HTTP transport
@@ -220,6 +271,13 @@ impl HttpExporterBuilder {
 
         let timeout = resolve_timeout(signal_timeout_var, self.exporter_config.timeout.as_ref());
 
+        // Resolve and parse TLS certificates from env vars (only when TLS features and a reqwest client are enabled)
+        #[cfg(all(
+            any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"),
+            any(feature = "reqwest-client", feature = "reqwest-blocking-client"),
+        ))]
+        let tls_certs = Self::resolve_reqwest_tls_certs(&signal_tls_vars)?;
+
         #[allow(unused_mut)] // TODO - clippy thinks mut is not needed, but it is
         let mut http_client = self.http_config.client.take();
 
@@ -229,15 +287,22 @@ impl HttpExporterBuilder {
         // 1. reqwest-client (async)
         // 2. hyper-client
         // 3. reqwest-blocking-client (default)
+        //
+        // TLS certificates from env vars are only applied to auto-created reqwest clients.
+        // Custom clients provided via .with_http_client() are not affected.
         if http_client.is_none() {
             #[cfg(feature = "reqwest-client")]
             {
-                http_client = Some(Arc::new(
-                    reqwest::Client::builder()
-                        .timeout(timeout)
-                        .build()
-                        .unwrap_or_default(),
-                ) as Arc<dyn HttpClient>);
+                #[allow(unused_mut)] // mut needed when TLS features are enabled
+                let mut builder = reqwest::Client::builder().timeout(timeout);
+
+                #[cfg(any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"))]
+                if let Some(ref certs) = tls_certs {
+                    builder = certs.apply(builder)?;
+                }
+
+                http_client =
+                    Some(Arc::new(builder.build().unwrap_or_default()) as Arc<dyn HttpClient>);
             }
             #[cfg(all(not(feature = "reqwest-client"), feature = "hyper-client"))]
             {
@@ -252,16 +317,29 @@ impl HttpExporterBuilder {
             ))]
             {
                 let timeout_clone = timeout;
-                http_client = Some(Arc::new(
-                    std::thread::spawn(move || {
-                        reqwest::blocking::Client::builder()
-                            .timeout(timeout_clone)
-                            .build()
-                            .unwrap_or_else(|_| reqwest::blocking::Client::new())
-                    })
-                    .join()
-                    .unwrap(), // TODO: Return ExporterBuildError::ThreadSpawnFailed
-                ) as Arc<dyn HttpClient>);
+
+                #[cfg(any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"))]
+                let tls_certs_clone = tls_certs.clone();
+
+                let client = std::thread::spawn(move || {
+                    #[allow(unused_mut)] // mut needed when TLS features are enabled
+                    let mut builder = reqwest::blocking::Client::builder().timeout(timeout_clone);
+
+                    #[cfg(any(
+                        feature = "reqwest-rustls",
+                        feature = "reqwest-rustls-webpki-roots"
+                    ))]
+                    if let Some(ref certs) = tls_certs_clone {
+                        builder = certs.apply_blocking(builder);
+                    }
+
+                    builder
+                        .build()
+                        .unwrap_or_else(|_| reqwest::blocking::Client::new())
+                })
+                .join()
+                .unwrap(); // TODO: Return ExporterBuildError::ThreadSpawnFailed
+                http_client = Some(Arc::new(client) as Arc<dyn HttpClient>);
             }
         }
 
@@ -308,6 +386,70 @@ impl HttpExporterBuilder {
         super::resolve_compression_from_env(self.http_config.compression, env_override)
     }
 
+    /// Resolve and pre-parse TLS certificates from environment variables for reqwest clients.
+    /// PEM parsing errors are caught here at build time, not deferred to the client.
+    #[cfg(all(
+        any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"),
+        any(feature = "reqwest-client", feature = "reqwest-blocking-client"),
+    ))]
+    fn resolve_reqwest_tls_certs(
+        tls_vars: &super::SignalTlsEnvVars,
+    ) -> Result<Option<ReqwestTlsCerts>, ExporterBuildError> {
+        use super::{
+            resolve_tls_env_and_read, OTEL_EXPORTER_OTLP_CERTIFICATE,
+            OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_CLIENT_KEY,
+        };
+
+        let ca_pem =
+            resolve_tls_env_and_read(tls_vars.cert_var, OTEL_EXPORTER_OTLP_CERTIFICATE)?;
+        let client_key_pem =
+            resolve_tls_env_and_read(tls_vars.client_key_var, OTEL_EXPORTER_OTLP_CLIENT_KEY)?;
+        let client_cert_pem = resolve_tls_env_and_read(
+            tls_vars.client_cert_var,
+            OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE,
+        )?;
+
+        if ca_pem.is_none() && client_key_pem.is_none() && client_cert_pem.is_none() {
+            return Ok(None);
+        }
+
+        // Parse CA certificate eagerly so invalid PEM fails at build time
+        let ca_cert = ca_pem
+            .map(|pem| {
+                reqwest::Certificate::from_pem(&pem).map_err(|e| {
+                    ExporterBuildError::InternalFailure(format!(
+                        "Failed to parse CA certificate: {e}"
+                    ))
+                })
+            })
+            .transpose()?;
+
+        // Parse mTLS identity eagerly; warn and skip if only one of key/cert is set
+        let identity = match (client_key_pem, client_cert_pem) {
+            (Some(key), Some(cert)) => {
+                let mut identity_pem = cert;
+                identity_pem.extend_from_slice(&key);
+                Some(
+                    reqwest::Identity::from_pem(&identity_pem).map_err(|e| {
+                        ExporterBuildError::InternalFailure(format!(
+                            "Failed to parse client identity: {e}"
+                        ))
+                    })?,
+                )
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                opentelemetry::otel_warn!(
+                    name: "TlsConfig.PartialMtls",
+                    message = "mTLS requires both CLIENT_KEY and CLIENT_CERTIFICATE to be set; only one was provided, skipping mTLS configuration"
+                );
+                None
+            }
+            (None, None) => None,
+        };
+
+        Ok(Some(ReqwestTlsCerts { ca_cert, identity }))
+    }
+
     /// Create a span exporter with the current configuration
     #[cfg(feature = "trace")]
     pub fn build_span_exporter(mut self) -> Result<crate::SpanExporter, ExporterBuildError> {
@@ -324,6 +466,11 @@ impl HttpExporterBuilder {
             OTEL_EXPORTER_OTLP_TRACES_HEADERS,
             OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
             OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
+            super::SignalTlsEnvVars {
+                cert_var: crate::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
+                client_key_var: crate::OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY,
+                client_cert_var: crate::OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE,
+            },
         )?;
 
         Ok(crate::SpanExporter::from_http(client))
@@ -345,6 +492,11 @@ impl HttpExporterBuilder {
             OTEL_EXPORTER_OTLP_LOGS_HEADERS,
             OTEL_EXPORTER_OTLP_LOGS_COMPRESSION,
             OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
+            super::SignalTlsEnvVars {
+                cert_var: crate::OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE,
+                client_key_var: crate::OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY,
+                client_cert_var: crate::OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE,
+            },
         )?;
 
         Ok(crate::LogExporter::from_http(client))
@@ -369,6 +521,11 @@ impl HttpExporterBuilder {
             OTEL_EXPORTER_OTLP_METRICS_HEADERS,
             OTEL_EXPORTER_OTLP_METRICS_COMPRESSION,
             OTEL_EXPORTER_OTLP_METRICS_PROTOCOL,
+            super::SignalTlsEnvVars {
+                cert_var: crate::OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
+                client_key_var: crate::OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY,
+                client_cert_var: crate::OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE,
+            },
         )?;
 
         Ok(crate::MetricExporter::from_http(client, temporality))

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -490,6 +490,12 @@ impl HttpExporterBuilder {
             (None, None) => None,
         };
 
+        // A partial mTLS pair (only key or only cert) is discarded above, so re-check:
+        // if nothing usable survived, return None rather than a Some wrapping two Nones.
+        if ca_cert.is_none() && identity.is_none() {
+            return Ok(None);
+        }
+
         Ok(Some(ReqwestTlsCerts { ca_cert, identity }))
     }
 

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -225,7 +225,12 @@ pub(crate) struct SignalTlsEnvVars {
 #[cfg(any(
     all(
         feature = "grpc-tonic",
-        any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc")
+        any(
+            feature = "tls",
+            feature = "tls-ring",
+            feature = "tls-aws-lc",
+            feature = "tls-provider-agnostic"
+        )
     ),
     all(
         any(feature = "http-proto", feature = "http-json"),
@@ -237,11 +242,14 @@ pub(crate) fn resolve_tls_env_and_read(
     signal_var: &str,
     generic_var: &str,
 ) -> Result<Option<Vec<u8>>, ExporterBuildError> {
+    // An empty signal-specific var must not suppress fallback to a set generic var,
+    // so filter out empty values before applying precedence.
     let path = std::env::var(signal_var)
         .ok()
-        .or_else(|| std::env::var(generic_var).ok());
+        .filter(|v| !v.is_empty())
+        .or_else(|| std::env::var(generic_var).ok().filter(|v| !v.is_empty()));
     match path {
-        Some(path) if !path.is_empty() => {
+        Some(path) => {
             let data = std::fs::read(&path).map_err(|e| {
                 ExporterBuildError::InternalFailure(format!(
                     "Failed to read TLS file '{}': {}",
@@ -250,7 +258,33 @@ pub(crate) fn resolve_tls_env_and_read(
             })?;
             Ok(Some(data))
         }
-        _ => Ok(None),
+        None => Ok(None),
+    }
+}
+
+/// Warn when TLS certificate env vars are set but the selected HTTP client cannot
+/// honor them. Only auto-created reqwest clients apply these env vars; hyper and
+/// user-supplied clients must configure TLS themselves. This is a cheap presence
+/// check (no file IO) so it never fails the build.
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
+pub(crate) fn warn_if_tls_env_ignored(tls_vars: &SignalTlsEnvVars, client: &'static str) {
+    let is_set = |signal_var: &str, generic_var: &str| {
+        std::env::var(signal_var).is_ok_and(|v| !v.is_empty())
+            || std::env::var(generic_var).is_ok_and(|v| !v.is_empty())
+    };
+
+    if is_set(tls_vars.cert_var, OTEL_EXPORTER_OTLP_CERTIFICATE)
+        || is_set(tls_vars.client_key_var, OTEL_EXPORTER_OTLP_CLIENT_KEY)
+        || is_set(
+            tls_vars.client_cert_var,
+            OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE,
+        )
+    {
+        opentelemetry::otel_warn!(
+            name: "TlsConfig.EnvVarsIgnored",
+            message = "TLS certificate environment variables are set but the active HTTP client cannot apply them; only auto-created reqwest clients honor these env vars. Configure TLS on the client directly.",
+            client = client
+        );
     }
 }
 
@@ -779,7 +813,12 @@ mod tests {
     #[cfg(any(
         all(
             feature = "grpc-tonic",
-            any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc")
+            any(
+                feature = "tls",
+                feature = "tls-ring",
+                feature = "tls-aws-lc",
+                feature = "tls-provider-agnostic"
+            )
         ),
         all(
             any(feature = "http-proto", feature = "http-json"),
@@ -879,6 +918,32 @@ mod tests {
             temp_env::with_vars(
                 [
                     (SIGNAL_CERT_VAR, None),
+                    (
+                        super::super::OTEL_EXPORTER_OTLP_CERTIFICATE,
+                        Some(generic_str.as_str()),
+                    ),
+                ],
+                || {
+                    let result = super::super::resolve_tls_env_and_read(
+                        SIGNAL_CERT_VAR,
+                        super::super::OTEL_EXPORTER_OTLP_CERTIFICATE,
+                    );
+                    assert_eq!(result.unwrap().unwrap(), b"generic-cert-data");
+                },
+            );
+        }
+
+        #[test]
+        fn resolve_tls_env_empty_signal_falls_back_to_generic() {
+            use std::io::Write;
+            let mut generic_file = tempfile::NamedTempFile::new().unwrap();
+            generic_file.write_all(b"generic-cert-data").unwrap();
+
+            let generic_str = generic_file.path().to_str().unwrap().to_string();
+            // An empty signal-specific var must not suppress fallback to a set generic var.
+            temp_env::with_vars(
+                [
+                    (SIGNAL_CERT_VAR, Some("")),
                     (
                         super::super::OTEL_EXPORTER_OTLP_CERTIFICATE,
                         Some(generic_str.as_str()),

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -41,6 +41,16 @@ pub const OTEL_EXPORTER_OTLP_TIMEOUT: &str = "OTEL_EXPORTER_OTLP_TIMEOUT";
 /// Default max waiting time for the backend to process each signal batch.
 pub const OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT: Duration = Duration::from_millis(10000);
 
+/// Path to the TLS certificate to use for verifying an OTLP server's TLS credentials.
+/// The file must contain PEM encoded data.
+pub const OTEL_EXPORTER_OTLP_CERTIFICATE: &str = "OTEL_EXPORTER_OTLP_CERTIFICATE";
+/// Path to the TLS client key to use for mTLS authentication.
+/// The file must contain PEM encoded data.
+pub const OTEL_EXPORTER_OTLP_CLIENT_KEY: &str = "OTEL_EXPORTER_OTLP_CLIENT_KEY";
+/// Path to the TLS client certificate to use for mTLS authentication.
+/// The file must contain PEM encoded data.
+pub const OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE: &str = "OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE";
+
 // Endpoints per protocol https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md
 #[cfg(feature = "grpc-tonic")]
 const OTEL_EXPORTER_OTLP_GRPC_ENDPOINT_DEFAULT: &str = "http://localhost:4317";
@@ -192,6 +202,55 @@ fn resolve_compression_from_env(
         Ok(Some(compression.parse::<Compression>()?))
     } else {
         Ok(None)
+    }
+}
+
+/// Signal-specific TLS environment variable names.
+///
+/// Groups the per-signal TLS env var names for certificate, client key,
+/// and client certificate to avoid excessive function parameters.
+#[allow(dead_code)] // Fields are only read when TLS features are enabled
+#[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
+pub(crate) struct SignalTlsEnvVars {
+    pub cert_var: &'static str,
+    pub client_key_var: &'static str,
+    pub client_cert_var: &'static str,
+}
+
+/// Resolve a TLS file path from environment variables and read the PEM file.
+/// Signal-specific env var takes precedence over generic.
+///
+/// Returns `Ok(None)` if neither env var is set.
+/// Returns `Err` if the env var is set but the file cannot be read.
+#[cfg(any(
+    all(
+        feature = "grpc-tonic",
+        any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc")
+    ),
+    all(
+        any(feature = "http-proto", feature = "http-json"),
+        any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"),
+        any(feature = "reqwest-client", feature = "reqwest-blocking-client"),
+    ),
+))]
+pub(crate) fn resolve_tls_env_and_read(
+    signal_var: &str,
+    generic_var: &str,
+) -> Result<Option<Vec<u8>>, ExporterBuildError> {
+    let path = std::env::var(signal_var)
+        .ok()
+        .or_else(|| std::env::var(generic_var).ok());
+    match path {
+        Some(path) if !path.is_empty() => {
+            let data = std::fs::read(&path).map_err(|e| {
+                ExporterBuildError::InternalFailure(format!(
+                    "Failed to read TLS file '{}': {}",
+                    path, e
+                ))
+            })?;
+            Ok(Some(data))
+        }
+        _ => Ok(None),
     }
 }
 
@@ -715,5 +774,125 @@ mod tests {
             let protocol = super::resolve_protocol(crate::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, None);
             assert_eq!(protocol, Protocol::feature_default());
         });
+    }
+
+    #[cfg(any(
+        all(
+            feature = "grpc-tonic",
+            any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc")
+        ),
+        all(
+            any(feature = "http-proto", feature = "http-json"),
+            any(feature = "reqwest-rustls", feature = "reqwest-rustls-webpki-roots"),
+            any(feature = "reqwest-client", feature = "reqwest-blocking-client"),
+        ),
+    ))]
+    mod tls_env_tests {
+        use super::*;
+
+        const SIGNAL_CERT_VAR: &str = "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE";
+
+        #[test]
+        fn resolve_tls_env_returns_none_when_unset() {
+            temp_env::with_vars_unset(
+                [SIGNAL_CERT_VAR, super::super::OTEL_EXPORTER_OTLP_CERTIFICATE],
+                || {
+                    let result = super::super::resolve_tls_env_and_read(
+                        SIGNAL_CERT_VAR,
+                        super::super::OTEL_EXPORTER_OTLP_CERTIFICATE,
+                    );
+                    assert!(result.unwrap().is_none());
+                },
+            );
+        }
+
+        #[test]
+        fn resolve_tls_env_returns_none_for_empty_string() {
+            run_env_test(vec![(SIGNAL_CERT_VAR, "")], || {
+                temp_env::with_var_unset(super::super::OTEL_EXPORTER_OTLP_CERTIFICATE, || {
+                    let result = super::super::resolve_tls_env_and_read(
+                        SIGNAL_CERT_VAR,
+                        super::super::OTEL_EXPORTER_OTLP_CERTIFICATE,
+                    );
+                    assert!(result.unwrap().is_none());
+                });
+            });
+        }
+
+        #[test]
+        fn resolve_tls_env_errors_on_missing_file() {
+            run_env_test(
+                vec![(SIGNAL_CERT_VAR, "/nonexistent/path/cert.pem")],
+                || {
+                    let result = super::super::resolve_tls_env_and_read(
+                        SIGNAL_CERT_VAR,
+                        super::super::OTEL_EXPORTER_OTLP_CERTIFICATE,
+                    );
+                    assert!(result.is_err());
+                    let err = result.unwrap_err().to_string();
+                    assert!(
+                        err.contains("/nonexistent/path/cert.pem"),
+                        "Error should contain the file path, got: {err}"
+                    );
+                },
+            );
+        }
+
+        #[test]
+        fn resolve_tls_env_signal_overrides_generic() {
+            let signal_path = std::env::temp_dir().join("otel_test_signal_cert.pem");
+            let generic_path = std::env::temp_dir().join("otel_test_generic_cert.pem");
+            std::fs::write(&signal_path, b"signal-cert-data").unwrap();
+            std::fs::write(&generic_path, b"generic-cert-data").unwrap();
+
+            // Use temp_env directly instead of run_env_test to avoid 'static requirement
+            let signal_str = signal_path.to_str().unwrap().to_string();
+            let generic_str = generic_path.to_str().unwrap().to_string();
+            temp_env::with_vars(
+                [
+                    (SIGNAL_CERT_VAR, Some(signal_str.as_str())),
+                    (
+                        super::super::OTEL_EXPORTER_OTLP_CERTIFICATE,
+                        Some(generic_str.as_str()),
+                    ),
+                ],
+                || {
+                    let result = super::super::resolve_tls_env_and_read(
+                        SIGNAL_CERT_VAR,
+                        super::super::OTEL_EXPORTER_OTLP_CERTIFICATE,
+                    );
+                    assert_eq!(result.unwrap().unwrap(), b"signal-cert-data");
+                },
+            );
+
+            let _ = std::fs::remove_file(&signal_path);
+            let _ = std::fs::remove_file(&generic_path);
+        }
+
+        #[test]
+        fn resolve_tls_env_falls_back_to_generic() {
+            let generic_path = std::env::temp_dir().join("otel_test_generic_fallback.pem");
+            std::fs::write(&generic_path, b"generic-cert-data").unwrap();
+
+            let generic_str = generic_path.to_str().unwrap().to_string();
+            temp_env::with_vars(
+                [
+                    (SIGNAL_CERT_VAR, None),
+                    (
+                        super::super::OTEL_EXPORTER_OTLP_CERTIFICATE,
+                        Some(generic_str.as_str()),
+                    ),
+                ],
+                || {
+                    let result = super::super::resolve_tls_env_and_read(
+                        SIGNAL_CERT_VAR,
+                        super::super::OTEL_EXPORTER_OTLP_CERTIFICATE,
+                    );
+                    assert_eq!(result.unwrap().unwrap(), b"generic-cert-data");
+                },
+            );
+
+            let _ = std::fs::remove_file(&generic_path);
+        }
     }
 }

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -795,7 +795,10 @@ mod tests {
         #[test]
         fn resolve_tls_env_returns_none_when_unset() {
             temp_env::with_vars_unset(
-                [SIGNAL_CERT_VAR, super::super::OTEL_EXPORTER_OTLP_CERTIFICATE],
+                [
+                    SIGNAL_CERT_VAR,
+                    super::super::OTEL_EXPORTER_OTLP_CERTIFICATE,
+                ],
                 || {
                     let result = super::super::resolve_tls_env_and_read(
                         SIGNAL_CERT_VAR,
@@ -840,14 +843,14 @@ mod tests {
 
         #[test]
         fn resolve_tls_env_signal_overrides_generic() {
-            let signal_path = std::env::temp_dir().join("otel_test_signal_cert.pem");
-            let generic_path = std::env::temp_dir().join("otel_test_generic_cert.pem");
-            std::fs::write(&signal_path, b"signal-cert-data").unwrap();
-            std::fs::write(&generic_path, b"generic-cert-data").unwrap();
+            use std::io::Write;
+            let mut signal_file = tempfile::NamedTempFile::new().unwrap();
+            signal_file.write_all(b"signal-cert-data").unwrap();
+            let mut generic_file = tempfile::NamedTempFile::new().unwrap();
+            generic_file.write_all(b"generic-cert-data").unwrap();
 
-            // Use temp_env directly instead of run_env_test to avoid 'static requirement
-            let signal_str = signal_path.to_str().unwrap().to_string();
-            let generic_str = generic_path.to_str().unwrap().to_string();
+            let signal_str = signal_file.path().to_str().unwrap().to_string();
+            let generic_str = generic_file.path().to_str().unwrap().to_string();
             temp_env::with_vars(
                 [
                     (SIGNAL_CERT_VAR, Some(signal_str.as_str())),
@@ -864,17 +867,15 @@ mod tests {
                     assert_eq!(result.unwrap().unwrap(), b"signal-cert-data");
                 },
             );
-
-            let _ = std::fs::remove_file(&signal_path);
-            let _ = std::fs::remove_file(&generic_path);
         }
 
         #[test]
         fn resolve_tls_env_falls_back_to_generic() {
-            let generic_path = std::env::temp_dir().join("otel_test_generic_fallback.pem");
-            std::fs::write(&generic_path, b"generic-cert-data").unwrap();
+            use std::io::Write;
+            let mut generic_file = tempfile::NamedTempFile::new().unwrap();
+            generic_file.write_all(b"generic-cert-data").unwrap();
 
-            let generic_str = generic_path.to_str().unwrap().to_string();
+            let generic_str = generic_file.path().to_str().unwrap().to_string();
             temp_env::with_vars(
                 [
                     (SIGNAL_CERT_VAR, None),
@@ -891,8 +892,6 @@ mod tests {
                     assert_eq!(result.unwrap().unwrap(), b"generic-cert-data");
                 },
             );
-
-            let _ = std::fs::remove_file(&generic_path);
         }
     }
 }

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -51,7 +51,7 @@ pub(crate) mod trace;
 /// Configuration for [tonic]
 ///
 /// [tonic]: https://github.com/hyperium/tonic
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[non_exhaustive]
 pub(crate) struct TonicConfig {
     /// Custom metadata entries to send to the collector.
@@ -71,6 +71,29 @@ pub(crate) struct TonicConfig {
     /// The retry policy to use for gRPC requests.
     #[cfg(feature = "experimental-grpc-retry")]
     pub(crate) retry_policy: Option<RetryPolicy>,
+}
+
+impl std::fmt::Debug for TonicConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut dbg = f.debug_struct("TonicConfig");
+        dbg.field("metadata", &self.metadata);
+        #[cfg(any(
+            feature = "tls",
+            feature = "tls-ring",
+            feature = "tls-aws-lc",
+            feature = "tls-provider-agnostic"
+        ))]
+        dbg.field(
+            "tls_config",
+            &self.tls_config.as_ref().map(|_| "<redacted>"),
+        );
+        dbg.field("compression", &self.compression);
+        dbg.field("channel", &self.channel);
+        dbg.field("interceptor", &self.interceptor);
+        #[cfg(feature = "experimental-grpc-retry")]
+        dbg.field("retry_policy", &self.retry_policy);
+        dbg.finish()
+    }
 }
 
 impl TryFrom<Compression> for tonic::codec::CompressionEncoding {

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -349,9 +349,23 @@ impl TonicExporterBuilder {
                 // Try to build TLS config from environment variables
                 let tls_config_from_env = Self::build_tls_config_from_env(&signal_tls_vars)?;
                 match tls_config_from_env {
-                    Some(tls_config) => endpoint
+                    // Env TLS config is only applied to HTTPS endpoints, mirroring the
+                    // default-config arm below and the HTTP/reqwest transport (which keys
+                    // TLS off the URL scheme). Forcing TLS onto a plaintext `http://`
+                    // endpoint would break the connection.
+                    Some(tls_config) if is_https => endpoint
                         .tls_config(tls_config)
                         .map_err(|er| ExporterBuildError::InternalFailure(er.to_string()))?,
+                    // Env TLS config set but the endpoint is plaintext: ignore it (don't
+                    // force TLS) and warn, since this is almost certainly a misconfiguration.
+                    Some(_) => {
+                        opentelemetry::otel_warn!(
+                            name: "TlsConfig.IgnoredForPlaintextEndpoint",
+                            message = "TLS certificate environment variables are set but the endpoint is not HTTPS; TLS will not be applied",
+                            endpoint = endpoint_clone.clone()
+                        );
+                        endpoint
+                    }
                     // No env vars set, but HTTPS endpoint: apply default TLS config
                     None if is_https => endpoint
                         .tls_config(ClientTlsConfig::new())
@@ -385,7 +399,12 @@ impl TonicExporterBuilder {
 
     /// Build a `ClientTlsConfig` from TLS-related environment variables.
     /// Returns `None` if no TLS env vars are set.
-    #[cfg(any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc"))]
+    #[cfg(any(
+        feature = "tls",
+        feature = "tls-ring",
+        feature = "tls-aws-lc",
+        feature = "tls-provider-agnostic"
+    ))]
     fn build_tls_config_from_env(
         tls_vars: &super::SignalTlsEnvVars,
     ) -> Result<Option<ClientTlsConfig>, ExporterBuildError> {
@@ -406,10 +425,21 @@ impl TonicExporterBuilder {
         // Warn and skip if only one of key/cert is set (incomplete mTLS)
         let has_identity = match (&client_key, &client_cert) {
             (Some(_), Some(_)) => true,
-            (Some(_), None) | (None, Some(_)) => {
+            (Some(_), None) => {
                 opentelemetry::otel_warn!(
                     name: "TlsConfig.PartialMtls",
-                    message = "mTLS requires both CLIENT_KEY and CLIENT_CERTIFICATE to be set; only one was provided, skipping mTLS configuration"
+                    message = "mTLS requires both a client key and a client certificate; only the client key was provided, skipping mTLS configuration",
+                    client_key_var = tls_vars.client_key_var,
+                    client_cert_var = tls_vars.client_cert_var
+                );
+                false
+            }
+            (None, Some(_)) => {
+                opentelemetry::otel_warn!(
+                    name: "TlsConfig.PartialMtls",
+                    message = "mTLS requires both a client key and a client certificate; only the client certificate was provided, skipping mTLS configuration",
+                    client_key_var = tls_vars.client_key_var,
+                    client_cert_var = tls_vars.client_cert_var
                 );
                 false
             }

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -189,6 +189,7 @@ impl TonicExporterBuilder {
         signal_compression_var: &str,
         signal_headers_var: &str,
         signal_protocol_var: &str,
+        signal_tls_vars: super::SignalTlsEnvVars,
     ) -> Result<
         (
             Channel,
@@ -317,13 +318,24 @@ impl TonicExporterBuilder {
             feature = "tls-provider-agnostic"
         ))]
         let channel = match self.tonic_config.tls_config {
+            // Programmatic TLS config takes full precedence over env vars
             Some(tls_config) => endpoint
                 .tls_config(tls_config)
                 .map_err(|er| ExporterBuildError::InternalFailure(er.to_string()))?,
-            None if is_https => endpoint
-                .tls_config(ClientTlsConfig::new())
-                .map_err(|er| ExporterBuildError::InternalFailure(er.to_string()))?,
-            None => endpoint,
+            None => {
+                // Try to build TLS config from environment variables
+                let tls_config_from_env = Self::build_tls_config_from_env(&signal_tls_vars)?;
+                match tls_config_from_env {
+                    Some(tls_config) => endpoint
+                        .tls_config(tls_config)
+                        .map_err(|er| ExporterBuildError::InternalFailure(er.to_string()))?,
+                    // No env vars set, but HTTPS endpoint: apply default TLS config
+                    None if is_https => endpoint
+                        .tls_config(ClientTlsConfig::new())
+                        .map_err(|er| ExporterBuildError::InternalFailure(er.to_string()))?,
+                    None => endpoint,
+                }
+            }
         }
         .timeout(timeout)
         .connect_lazy();
@@ -346,6 +358,57 @@ impl TonicExporterBuilder {
             #[cfg(not(feature = "experimental-grpc-retry"))]
             None,
         ))
+    }
+
+    /// Build a `ClientTlsConfig` from TLS-related environment variables.
+    /// Returns `None` if no TLS env vars are set.
+    #[cfg(any(feature = "tls", feature = "tls-ring", feature = "tls-aws-lc"))]
+    fn build_tls_config_from_env(
+        tls_vars: &super::SignalTlsEnvVars,
+    ) -> Result<Option<ClientTlsConfig>, ExporterBuildError> {
+        use super::{
+            resolve_tls_env_and_read, OTEL_EXPORTER_OTLP_CERTIFICATE,
+            OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_CLIENT_KEY,
+        };
+        use tonic::transport::{Certificate, Identity};
+
+        let ca_cert = resolve_tls_env_and_read(tls_vars.cert_var, OTEL_EXPORTER_OTLP_CERTIFICATE)?;
+        let client_key =
+            resolve_tls_env_and_read(tls_vars.client_key_var, OTEL_EXPORTER_OTLP_CLIENT_KEY)?;
+        let client_cert = resolve_tls_env_and_read(
+            tls_vars.client_cert_var,
+            OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE,
+        )?;
+
+        // Warn and skip if only one of key/cert is set (incomplete mTLS)
+        let has_identity = match (&client_key, &client_cert) {
+            (Some(_), Some(_)) => true,
+            (Some(_), None) | (None, Some(_)) => {
+                opentelemetry::otel_warn!(
+                    name: "TlsConfig.PartialMtls",
+                    message = "mTLS requires both CLIENT_KEY and CLIENT_CERTIFICATE to be set; only one was provided, skipping mTLS configuration"
+                );
+                false
+            }
+            (None, None) => false,
+        };
+
+        // If nothing usable is set, return None so the caller falls through to default behavior
+        if ca_cert.is_none() && !has_identity {
+            return Ok(None);
+        }
+
+        let mut tls_config = ClientTlsConfig::new();
+
+        if let Some(ca_cert) = ca_cert {
+            tls_config = tls_config.ca_certificate(Certificate::from_pem(ca_cert));
+        }
+
+        if let (Some(key), Some(cert)) = (client_key, client_cert) {
+            tls_config = tls_config.identity(Identity::from_pem(cert, key));
+        }
+
+        Ok(Some(tls_config))
     }
 
     fn resolve_endpoint(default_endpoint_var: &str, provided_endpoint: Option<String>) -> String {
@@ -389,6 +452,11 @@ impl TonicExporterBuilder {
             crate::logs::OTEL_EXPORTER_OTLP_LOGS_COMPRESSION,
             crate::logs::OTEL_EXPORTER_OTLP_LOGS_HEADERS,
             crate::logs::OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
+            super::SignalTlsEnvVars {
+                cert_var: crate::logs::OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE,
+                client_key_var: crate::logs::OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY,
+                client_cert_var: crate::logs::OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE,
+            },
         )?;
 
         let client = TonicLogsClient::new(channel, interceptor, compression, retry_policy);
@@ -413,6 +481,11 @@ impl TonicExporterBuilder {
             crate::metric::OTEL_EXPORTER_OTLP_METRICS_COMPRESSION,
             crate::metric::OTEL_EXPORTER_OTLP_METRICS_HEADERS,
             crate::metric::OTEL_EXPORTER_OTLP_METRICS_PROTOCOL,
+            super::SignalTlsEnvVars {
+                cert_var: crate::metric::OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
+                client_key_var: crate::metric::OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY,
+                client_cert_var: crate::metric::OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE,
+            },
         )?;
 
         let client = TonicMetricsClient::new(channel, interceptor, compression, retry_policy);
@@ -433,6 +506,11 @@ impl TonicExporterBuilder {
             crate::span::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
             crate::span::OTEL_EXPORTER_OTLP_TRACES_HEADERS,
             crate::span::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
+            super::SignalTlsEnvVars {
+                cert_var: crate::span::OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
+                client_key_var: crate::span::OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY,
+                client_cert_var: crate::span::OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE,
+            },
         )?;
 
         let client = TonicTracesClient::new(channel, interceptor, compression, retry_policy);

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -228,6 +228,21 @@
 //! | `OTEL_EXPORTER_OTLP_CLIENT_KEY` | Path to PEM-encoded TLS client key for mTLS. | (none) |
 //! | `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` | Path to PEM-encoded TLS client certificate for mTLS. | (none) |
 //!
+//! ### TLS certificate caveats
+//!
+//! The TLS certificate environment variables above are honored only when the exporter
+//! creates the transport client itself:
+//!
+//! - **gRPC (tonic):** applied when a `tls*` feature is enabled.
+//! - **HTTP:** applied only to auto-created `reqwest` clients (the `reqwest-client` or
+//!   `reqwest-blocking-client` features together with a `reqwest-rustls*` feature). They are
+//!   **not** applied to the `hyper-client`, nor to a custom client supplied via
+//!   `.with_http_client(...)` — those must configure TLS themselves. When env vars are set but
+//!   the active HTTP client cannot apply them, the exporter logs a warning at build time.
+//!
+//! Note that when multiple HTTP client features are enabled, `hyper-client` is selected ahead of
+//! the default blocking `reqwest` client, in which case these env vars are not applied.
+//!
 //! ## Traces
 //!
 //! | Variable | Description |

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -224,6 +224,9 @@
 //! | `OTEL_EXPORTER_OTLP_TIMEOUT` | Maximum wait time (in milliseconds) for the backend to process each batch. | `10000` |
 //! | `OTEL_EXPORTER_OTLP_HEADERS` | Key-value pairs for request headers. Format: `key1=value1,key2=value2`. Values are URL-decoded. | (none) |
 //! | `OTEL_EXPORTER_OTLP_COMPRESSION` | Compression algorithm. Valid values: `gzip`, `zstd`. | (none) |
+//! | `OTEL_EXPORTER_OTLP_CERTIFICATE` | Path to PEM-encoded TLS certificate for server verification. | (none) |
+//! | `OTEL_EXPORTER_OTLP_CLIENT_KEY` | Path to PEM-encoded TLS client key for mTLS. | (none) |
+//! | `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` | Path to PEM-encoded TLS client certificate for mTLS. | (none) |
 //!
 //! ## Traces
 //!
@@ -234,6 +237,9 @@
 //! | `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` | Signal-specific timeout (in milliseconds) for trace exports. |
 //! | `OTEL_EXPORTER_OTLP_TRACES_HEADERS` | Signal-specific headers for trace exports. |
 //! | `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` | Signal-specific compression for trace exports. |
+//! | `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE` | Signal-specific TLS certificate for trace exports. |
+//! | `OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY` | Signal-specific TLS client key for trace exports. |
+//! | `OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE` | Signal-specific TLS client certificate for trace exports. |
 //!
 //! ## Metrics
 //!
@@ -245,6 +251,9 @@
 //! | `OTEL_EXPORTER_OTLP_METRICS_HEADERS` | Signal-specific headers for metrics exports. |
 //! | `OTEL_EXPORTER_OTLP_METRICS_COMPRESSION` | Signal-specific compression for metrics exports. |
 //! | `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | Temporality preference for metrics. Valid values: `cumulative`, `delta`, `lowmemory` (case-insensitive). | `cumulative` |
+//! | `OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE` | Signal-specific TLS certificate for metrics exports. |
+//! | `OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY` | Signal-specific TLS client key for metrics exports. |
+//! | `OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE` | Signal-specific TLS client certificate for metrics exports. |
 //!
 //! ## Logs
 //!
@@ -255,6 +264,9 @@
 //! | `OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` | Signal-specific timeout (in milliseconds) for log exports. |
 //! | `OTEL_EXPORTER_OTLP_LOGS_HEADERS` | Signal-specific headers for log exports. |
 //! | `OTEL_EXPORTER_OTLP_LOGS_COMPRESSION` | Signal-specific compression for log exports. |
+//! | `OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE` | Signal-specific TLS certificate for log exports. |
+//! | `OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY` | Signal-specific TLS client key for log exports. |
+//! | `OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE` | Signal-specific TLS client certificate for log exports. |
 //!
 //! # Feature Flags
 //! The following feature flags can enable exporters for different telemetry signals:
@@ -660,26 +672,31 @@ pub use crate::exporter::ExporterBuildError;
 #[cfg(feature = "trace")]
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 pub use crate::span::{
-    SpanExporter, SpanExporterBuilder, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
-    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_HEADERS,
-    OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
+    SpanExporter, SpanExporterBuilder, OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY,
+    OTEL_EXPORTER_OTLP_TRACES_COMPRESSION, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
+    OTEL_EXPORTER_OTLP_TRACES_HEADERS, OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
+    OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
 };
 
 #[cfg(feature = "metrics")]
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 pub use crate::metric::{
-    MetricExporter, MetricExporterBuilder, OTEL_EXPORTER_OTLP_METRICS_COMPRESSION,
-    OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_HEADERS,
-    OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
-    OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
+    MetricExporter, MetricExporterBuilder, OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY,
+    OTEL_EXPORTER_OTLP_METRICS_COMPRESSION, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
+    OTEL_EXPORTER_OTLP_METRICS_HEADERS, OTEL_EXPORTER_OTLP_METRICS_PROTOCOL,
+    OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
 };
 
 #[cfg(feature = "logs")]
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 pub use crate::logs::{
-    LogExporter, LogExporterBuilder, OTEL_EXPORTER_OTLP_LOGS_COMPRESSION,
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, OTEL_EXPORTER_OTLP_LOGS_HEADERS,
-    OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
+    LogExporter, LogExporterBuilder, OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY,
+    OTEL_EXPORTER_OTLP_LOGS_COMPRESSION, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
+    OTEL_EXPORTER_OTLP_LOGS_HEADERS, OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
+    OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
 };
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
@@ -689,7 +706,8 @@ pub use crate::exporter::http::WithHttpConfig;
 pub use crate::exporter::tonic::WithTonicConfig;
 
 pub use crate::exporter::{
-    WithExportConfig, OTEL_EXPORTER_OTLP_COMPRESSION, OTEL_EXPORTER_OTLP_ENDPOINT,
+    WithExportConfig, OTEL_EXPORTER_OTLP_CERTIFICATE, OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_CLIENT_KEY, OTEL_EXPORTER_OTLP_COMPRESSION, OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT, OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_PROTOCOL,
     OTEL_EXPORTER_OTLP_PROTOCOL_GRPC, OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_JSON,
     OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF, OTEL_EXPORTER_OTLP_TIMEOUT,

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -32,6 +32,13 @@ pub const OTEL_EXPORTER_OTLP_LOGS_TIMEOUT: &str = "OTEL_EXPORTER_OTLP_LOGS_TIMEO
 pub const OTEL_EXPORTER_OTLP_LOGS_HEADERS: &str = "OTEL_EXPORTER_OTLP_LOGS_HEADERS";
 /// Protocol to use for log exports. Valid values: `grpc`, `http/protobuf`, `http/json`.
 pub const OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL";
+/// Path to the TLS certificate for verifying the server's TLS credentials for log exports.
+pub const OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE: &str = "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE";
+/// Path to the TLS client key for mTLS authentication for log exports.
+pub const OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY: &str = "OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY";
+/// Path to the TLS client certificate for mTLS authentication for log exports.
+pub const OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE: &str =
+    "OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE";
 
 /// Builder for creating a new [LogExporter].
 #[derive(Debug, Default, Clone)]

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -103,7 +103,7 @@ impl LogExporterBuilder<TonicExporterBuilderSet> {
     /// Build the [LogExporter] with the gRPC Tonic transport.
     pub fn build(self) -> Result<LogExporter, ExporterBuildError> {
         let result = self.client.0.build_log_exporter();
-        otel_debug!(name: "LogExporterBuilt", result = format!("{:?}", &result));
+        otel_debug!(name: "LogExporterBuilt");
         result
     }
 }

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -44,6 +44,13 @@ pub const OTEL_EXPORTER_OTLP_METRICS_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_MET
 pub const OTEL_EXPORTER_OTLP_METRICS_HEADERS: &str = "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
 /// Protocol to use for metrics exports. Valid values: `grpc`, `http/protobuf`, `http/json`.
 pub const OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL";
+/// Path to the TLS certificate for verifying the server's TLS credentials for metrics exports.
+pub const OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE: &str = "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE";
+/// Path to the TLS client key for mTLS authentication for metrics exports.
+pub const OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY: &str = "OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY";
+/// Path to the TLS client certificate for mTLS authentication for metrics exports.
+pub const OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE: &str =
+    "OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE";
 /// Temporality preference for metrics, defaults to cumulative.
 pub const OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: &str =
     "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE";

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -37,6 +37,13 @@ pub const OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_TRAC
 pub const OTEL_EXPORTER_OTLP_TRACES_HEADERS: &str = "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
 /// Protocol to use for trace exports. Valid values: `grpc`, `http/protobuf`, `http/json`.
 pub const OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: &str = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL";
+/// Path to the TLS certificate for verifying the server's TLS credentials for trace exports.
+pub const OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE: &str = "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE";
+/// Path to the TLS client key for mTLS authentication for trace exports.
+pub const OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY: &str = "OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY";
+/// Path to the TLS client certificate for mTLS authentication for trace exports.
+pub const OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE: &str =
+    "OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE";
 
 /// OTLP span exporter builder
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
## Summary

- Add support for 12 TLS-related environment variables per the [OTLP exporter specification](https://opentelemetry.io/docs/specs/otel/protocol/exporter/):
  - `OTEL_EXPORTER_OTLP_CERTIFICATE` / `_CLIENT_KEY` / `_CLIENT_CERTIFICATE` (generic)
  - `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE` / `_CLIENT_KEY` / `_CLIENT_CERTIFICATE`
  - `OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE` / `_CLIENT_KEY` / `_CLIENT_CERTIFICATE`
  - `OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE` / `_CLIENT_KEY` / `_CLIENT_CERTIFICATE`
- These env vars point to PEM-encoded files for server TLS verification and mTLS client authentication
- Signal-specific vars take precedence over generic vars; programmatic `.with_tls_config()` takes full precedence over all env vars
- For tonic (gRPC): builds `ClientTlsConfig` from env vars when no programmatic TLS config is set
- For HTTP/reqwest: applies CA cert and mTLS identity to the reqwest client builder (both async and blocking)
- Partial mTLS config (only key or only cert set) logs a warning and skips mTLS

**PR 2 of 3** for OTLP exporter spec compliance. Merge order:
1. #3363 — per-signal protocol env vars
2. **This PR** — TLS certificate env vars
3. PR 3 (upcoming) — INSECURE env vars

Supersedes #2465 (stalled for 10+ months with merge conflicts).

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p opentelemetry-otlp --all-targets --all-features -- -D warnings` passes
- [x] `cargo test -p opentelemetry-otlp --all-features` — 106 unit + 2 integration + 13 doc-tests pass
- [ ] Manual verification with actual TLS certificates against an OTLP collector
- [ ] Verify env var resolution priority: code config > signal env var > generic env var

Refs: #774, #984