### PR TITLE
ci: split lint into parallel jobs and remove redundant checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,6 @@ jobs:
       with:
         toolchain: stable
         components: rustfmt, clippy
-    - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2.75.28
-      with:
-          tool: cargo-hack
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -76,6 +73,29 @@ jobs:
       run: cargo fmt --all -- --check
     - name: Lint
       run: bash ./scripts/lint.sh
+  lint-feature-matrix:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        submodules: true
+    - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+      with:
+        toolchain: stable
+        components: clippy
+    - uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2.75.28
+      with:
+          tool: cargo-hack
+    - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+      with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Lint (per-feature matrix)
+      run: bash ./scripts/lint_feature_matrix.sh
   external-types:
     strategy:
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,10 +311,13 @@ All such features should adhere to naming convention  `<signal>_<feature_name>`
 
 ## Style Guide
 
-- Run `cargo clippy --all` - this will catch common mistakes and improve
-your Rust code
-- Run `cargo fmt` - this will find and fix code formatting
-issues.
+- Run `cargo fmt` - this will find and fix code formatting issues.
+- Run `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` - this will catch common
+  mistakes and improve your Rust code.
+- Run `cargo hack --each-feature --no-dev-deps clippy -- -Dwarnings` - this checks clippy for each
+  feature in isolation and catches issues like dead code or unused imports that only appear when
+  individual features are enabled. Install with `cargo install cargo-hack` if you don't have it.
+  This is the most common source of CI lint failures on PRs.
 
 ## Testing and Benchmarking
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -9,33 +9,23 @@ cargo_feature() {
     -Dwarnings
 }
 
-if rustup component add clippy && \
-  ((cargo --list | grep -q hack) || cargo install cargo-hack); then
+if rustup component add clippy; then
   # Exit with a nonzero code if there are clippy warnings
   cargo clippy --workspace --all-targets --all-features -- -Dwarnings
-
-  # Run through all the features one by one and exit if there are clippy warnings
-  cargo hack --each-feature --no-dev-deps clippy -- -Dwarnings
 
   # `opentelemetry-prometheus` doesn't belong to the workspace
   cargo clippy --manifest-path=opentelemetry-prometheus/Cargo.toml --all-targets --all-features -- \
     -Dwarnings
 
+  # Multi-feature combinations not covered by per-feature checks
   cargo_feature opentelemetry "trace,metrics,logs,testing"
 
-  cargo_feature opentelemetry-otlp "default"
   cargo_feature opentelemetry-otlp "default,tls"
   cargo_feature opentelemetry-otlp "default,tls-roots"
-  cargo_feature opentelemetry-otlp "http-proto"
   cargo_feature opentelemetry-otlp "http-proto, reqwest-blocking-client"
   cargo_feature opentelemetry-otlp "http-proto, reqwest-client"
   cargo_feature opentelemetry-otlp "http-proto, reqwest-rustls"
-  cargo_feature opentelemetry-otlp "metrics"
 
-  cargo_feature opentelemetry-jaeger-propagator "default"
-
-  cargo_feature opentelemetry-proto "default"
-  cargo_feature opentelemetry-proto "full"
   cargo_feature opentelemetry-proto "gen-tonic,trace"
   cargo_feature opentelemetry-proto "gen-tonic,trace,with-serde"
   cargo_feature opentelemetry-proto "gen-tonic,trace,with-schemars,with-serde"

--- a/scripts/lint_feature_matrix.sh
+++ b/scripts/lint_feature_matrix.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+# Run clippy for each feature individually across all workspace crates.
+# This catches dead code, unused imports, and other warnings that only
+# surface when features are tested in isolation (e.g., a function gated
+# behind feature A but missing #[cfg(feature = "A")]).
+
+if rustup component add clippy && \
+  ((cargo --list | grep -q hack) || cargo install cargo-hack); then
+  cargo hack --each-feature --no-dev-deps clippy -- -Dwarnings
+fi

--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -2,6 +2,6 @@ REPO_ROOT=$(dirname $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null 
 
 pushd "${REPO_ROOT}" > /dev/null
 
-cargo update && cargo fmt --all && ./scripts/lint.sh && ./scripts/test.sh
+cargo update && cargo fmt --all && ./scripts/lint.sh && ./scripts/lint_feature_matrix.sh && ./scripts/test.sh
 
 popd > /dev/null


### PR DESCRIPTION
## Summary

The CI `lint` job is the most frequent source of PR failures. After investigating ~20 recent failures, **every single one was a legitimate clippy error** (dead code, unused variables, etc.) caught by `cargo hack --each-feature` — not resource exhaustion or flakiness.

The root cause: PRs introduce code that compiles fine with `--all-features` but triggers warnings when individual features are tested in isolation (e.g., a function only used with `grpc-tonic` enabled but missing `#[cfg(feature = "grpc-tonic")]`). Contributors don't know to run `cargo hack` locally, so they only discover the issue after pushing.

This PR improves the situation by:

- **Splitting lint into two parallel CI jobs** for faster feedback:
  - `lint`: format, workspace clippy, and multi-feature combo checks (~1-2 min)
  - `lint-feature-matrix`: per-feature clippy via `cargo hack --each-feature` (~5-6 min)
  
  Previously all ~150 clippy invocations ran sequentially in a single job. Now the quick checks give immediate feedback while the thorough feature matrix runs in parallel.

- **Removing 6 redundant `cargo_feature` checks** from `lint.sh` that are already covered by `cargo hack --each-feature`:
  - `opentelemetry-otlp "default"`, `"http-proto"`, `"metrics"` (single-feature, already tested individually by cargo hack)
  - `opentelemetry-jaeger-propagator "default"` (same)
  - `opentelemetry-proto "default"`, `"full"` (same)

- **Updating CONTRIBUTING.md** to document the `cargo hack` lint command so contributors can catch per-feature issues locally before pushing.

- **Updating `scripts/precommit.sh`** to include the feature matrix check.

## Test plan

- [x] Verify `lint` job passes (format + workspace clippy + multi-feature combos)
- [x] Verify `lint-feature-matrix` job passes (cargo hack per-feature checks)
- [x] Confirm both jobs run in parallel, not sequentially
- [x] Confirm no regressions in lint coverage (all multi-feature combos still checked)