### PR TITLE
feat(sdk): support OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -37,7 +37,8 @@ Released 2026-May-08
   - `TokioSpanExporter` and `new_tokio_test_exporter` have been renamed to `TestSpanExporter` and `new_test_exporter`.
   - The following transitive dependencies and features have been removed: `tokio/rt`, `tokio/time`, `tokio/macros`, `tokio/rt-multi-thread`, `tokio-stream`, `experimental_async_runtime`
 - Store `InstrumentationScope` in `Arc` internally in `SdkTracer`, making tracer clones cheaper (Arc refcount increment instead of deep copy).
-- Add support for `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` environment variable and `TracerProviderBuilder::with_max_attribute_value_length()`. When configured, `Value::String` and `Array::String` attribute values on spans, span events, and span links are truncated to the specified number of Unicode characters.
+- Add support for `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` environment variable and `TracerProviderBuilder::with_max_attribute_value_length()`. When configured, string attribute values on spans, span events, and span links are truncated to the specified number of Unicode characters.
+- **Breaking** `SpanLimits` has a new field `max_attribute_value_length: Option<u32>`. Code constructing `SpanLimits` via struct literal will need to add this field (use `None` for no limit). This will be addressed by adding `#[non_exhaustive]` to `SpanLimits` before 1.0 (see #2551).
 - Add 32-bit platform support by using `portable-atomic` for `AtomicI64` and `AtomicU64` in the metrics module. This enables compilation on 32-bit ARM targets (e.g., `armv5te-unknown-linux-gnueabi`, `armv7-unknown-linux-gnueabihf`).
 - `Aggregation` enum and `StreamBuilder::with_aggregation()` are now stable and no longer require the `spec_unstable_metrics_views` feature flag.
 - Fix `service.name` Resource attribute fallback to follow OpenTelemetry

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -37,6 +37,7 @@ Released 2026-May-08
   - `TokioSpanExporter` and `new_tokio_test_exporter` have been renamed to `TestSpanExporter` and `new_test_exporter`.
   - The following transitive dependencies and features have been removed: `tokio/rt`, `tokio/time`, `tokio/macros`, `tokio/rt-multi-thread`, `tokio-stream`, `experimental_async_runtime`
 - Store `InstrumentationScope` in `Arc` internally in `SdkTracer`, making tracer clones cheaper (Arc refcount increment instead of deep copy).
+- Add support for `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` environment variable and `TracerProviderBuilder::with_max_attribute_value_length()`. When configured, `Value::String` and `Array::String` attribute values on spans, span events, and span links are truncated to the specified number of Unicode characters.
 - Add 32-bit platform support by using `portable-atomic` for `AtomicI64` and `AtomicU64` in the metrics module. This enables compilation on 32-bit ARM targets (e.g., `armv5te-unknown-linux-gnueabi`, `armv7-unknown-linux-gnueabihf`).
 - `Aggregation` enum and `StreamBuilder::with_aggregation()` are now stable and no longer require the `spec_unstable_metrics_views` feature flag.
 - Fix `service.name` Resource attribute fallback to follow OpenTelemetry

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -395,6 +395,27 @@ impl TracerProviderBuilder {
         self
     }
 
+    /// Specify the maximum allowed length of string attribute values.
+    ///
+    /// This limit applies to [`Value::String`](opentelemetry::Value::String) and
+    /// [`Array::String`](opentelemetry::Array::String) attributes only. When a
+    /// string attribute value exceeds this limit it is truncated to the given
+    /// number of Unicode characters (not bytes). Truncation is silent -- no
+    /// ellipsis or other indicator is appended, and there is no way for a
+    /// downstream consumer to tell that the value was shortened.
+    ///
+    /// Non-string attribute types (bool, i64, f64, and their array variants) are
+    /// never affected.
+    ///
+    /// This can also be configured via the
+    /// `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` environment variable.
+    /// A value set through this builder method takes precedence over the
+    /// environment variable.
+    pub fn with_max_attribute_value_length(mut self, max_attribute_value_length: u32) -> Self {
+        self.config.span_limits.max_attribute_value_length = Some(max_attribute_value_length);
+        self
+    }
+
     /// Specify the number of events to be recorded per span.
     pub fn with_max_links_per_span(mut self, max_links: u32) -> Self {
         self.config.span_limits.max_links_per_span = max_links;

--- a/opentelemetry-sdk/src/trace/span_limit.rs
+++ b/opentelemetry-sdk/src/trace/span_limit.rs
@@ -1,3 +1,5 @@
+use opentelemetry::KeyValue;
+
 /// # Span limit
 /// Erroneous code can add unintended attributes, events, and links to a span. If these collections
 /// are unbounded, they can quickly exhaust available memory, resulting in crashes that are
@@ -46,6 +48,20 @@ pub struct SpanLimits {
     /// [`Value::String`]: opentelemetry::Value::String
     /// [`Array::String`]: opentelemetry::Array::String
     pub max_attribute_value_length: Option<u32>,
+}
+
+impl SpanLimits {
+    /// Truncate string attribute values to the configured maximum length.
+    ///
+    /// If `max_attribute_value_length` is `None`, this is a no-op.
+    pub(crate) fn truncate_string_values(&self, attributes: &mut [KeyValue]) {
+        if let Some(max_chars) = self.max_attribute_value_length {
+            let max = max_chars as usize;
+            for attr in attributes.iter_mut() {
+                attr.value.truncate(max);
+            }
+        }
+    }
 }
 
 impl Default for SpanLimits {

--- a/opentelemetry-sdk/src/trace/span_limit.rs
+++ b/opentelemetry-sdk/src/trace/span_limit.rs
@@ -9,6 +9,7 @@
 ///  - Maximum allowed span link count
 ///  - Maximum allowed attribute per span event count
 ///  - Maximum allowed attribute per span link count
+///  - Maximum allowed attribute value length
 ///
 /// If the limit has been breached. The attributes, events or links will be dropped based on their
 /// index in the collection. The one added to collections later will be dropped first.
@@ -31,6 +32,20 @@ pub struct SpanLimits {
     pub max_attributes_per_event: u32,
     /// The max attributes that can be added into a `Link`
     pub max_attributes_per_link: u32,
+    /// The maximum length of string attribute values. Applies to
+    /// [`Value::String`] and [`Array::String`] only. When set, values that
+    /// exceed this limit are truncated to the specified number of Unicode
+    /// characters. Truncation is silent -- no indicator is appended.
+    /// Non-string attribute types are never affected.
+    ///
+    /// Defaults to `None` (unlimited).
+    ///
+    /// Can be configured via the `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`
+    /// environment variable.
+    ///
+    /// [`Value::String`]: opentelemetry::Value::String
+    /// [`Array::String`]: opentelemetry::Array::String
+    pub max_attribute_value_length: Option<u32>,
 }
 
 impl Default for SpanLimits {
@@ -41,6 +56,7 @@ impl Default for SpanLimits {
             max_links_per_span: DEFAULT_MAX_LINKS_PER_SPAN,
             max_attributes_per_link: DEFAULT_MAX_ATTRIBUTES_PER_LINK,
             max_attributes_per_event: DEFAULT_MAX_ATTRIBUTES_PER_EVENT,
+            max_attribute_value_length: None,
         }
     }
 }

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -75,13 +75,7 @@ impl SdkTracer {
         attribute_options.truncate(span_attributes_limit);
         let dropped_attributes_count = dropped_attributes_count as u32;
 
-        // Truncate string attribute values if a length limit is configured.
-        if let Some(max_chars) = span_limits.max_attribute_value_length {
-            let max = max_chars as usize;
-            for attr in attribute_options.iter_mut() {
-                attr.value.truncate(max);
-            }
-        }
+        span_limits.truncate_string_values(&mut attribute_options);
 
         // Links are available as Option<Vec<Link>> in the builder
         // If it is None, then there are no links to process.
@@ -102,12 +96,7 @@ impl SdkTracer {
                     link.attributes.len().saturating_sub(link_attributes_limit);
                 link.attributes.truncate(link_attributes_limit);
                 link.dropped_attributes_count = dropped_attributes_count as u32;
-                if let Some(max_chars) = span_limits.max_attribute_value_length {
-                    let max = max_chars as usize;
-                    for attr in link.attributes.iter_mut() {
-                        attr.value.truncate(max);
-                    }
-                }
+                span_limits.truncate_string_values(&mut link.attributes);
             }
             SpanLinks {
                 links,
@@ -137,12 +126,7 @@ impl SdkTracer {
                     .saturating_sub(event_attributes_limit);
                 event.attributes.truncate(event_attributes_limit);
                 event.dropped_attributes_count = dropped_attributes_count as u32;
-                if let Some(max_chars) = span_limits.max_attribute_value_length {
-                    let max = max_chars as usize;
-                    for attr in event.attributes.iter_mut() {
-                        attr.value.truncate(max);
-                    }
-                }
+                span_limits.truncate_string_values(&mut event.attributes);
             }
             SpanEvents {
                 events,

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -75,6 +75,14 @@ impl SdkTracer {
         attribute_options.truncate(span_attributes_limit);
         let dropped_attributes_count = dropped_attributes_count as u32;
 
+        // Truncate string attribute values if a length limit is configured.
+        if let Some(max_chars) = span_limits.max_attribute_value_length {
+            let max = max_chars as usize;
+            for attr in attribute_options.iter_mut() {
+                attr.value.truncate(max);
+            }
+        }
+
         // Links are available as Option<Vec<Link>> in the builder
         // If it is None, then there are no links to process.
         // In that case Span.Links will be default (empty Vec<Link>, 0 drop count)
@@ -94,6 +102,12 @@ impl SdkTracer {
                     link.attributes.len().saturating_sub(link_attributes_limit);
                 link.attributes.truncate(link_attributes_limit);
                 link.dropped_attributes_count = dropped_attributes_count as u32;
+                if let Some(max_chars) = span_limits.max_attribute_value_length {
+                    let max = max_chars as usize;
+                    for attr in link.attributes.iter_mut() {
+                        attr.value.truncate(max);
+                    }
+                }
             }
             SpanLinks {
                 links,
@@ -123,6 +137,12 @@ impl SdkTracer {
                     .saturating_sub(event_attributes_limit);
                 event.attributes.truncate(event_attributes_limit);
                 event.dropped_attributes_count = dropped_attributes_count as u32;
+                if let Some(max_chars) = span_limits.max_attribute_value_length {
+                    let max = max_chars as usize;
+                    for attr in event.attributes.iter_mut() {
+                        attr.value.truncate(max);
+                    }
+                }
             }
             SpanEvents {
                 events,

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -16,6 +16,7 @@ Released 2026-May-08
   for SDK implementors; the trait method has a no-op default so custom
   `SyncInstrument` impls degrade gracefully without panicking. Gated behind the
   `experimental_metrics_bound_instruments` feature flag.
+- Add `Value::truncate()` and `StringValue::truncate()` methods for truncating string values to a maximum number of Unicode characters. Respects UTF-8 character boundaries and avoids allocation when the string is already within the limit.
 - Add `reserve` method to `opentelemetry::propagation::Injector` to hint at the number of elements that will be added to avoid multiple resize operations of the underlying data structure. Has an empty default implementation.
 - **Breaking** Removed the following public fields and methods from the `SpanBuilder` [#3227][3227]:
   - `trace_id`, `span_id`, `end_time`, `status`, `sampling_result`


### PR DESCRIPTION
## Summary

Implements `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` per the [SDK environment variable specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#attribute-limits). When configured, `Value::String` and `Array::String` attribute values are truncated to the specified number of Unicode characters on spans, span events, and span links.

This is a spec-required feature that Go and Java SDKs have supported since their 1.0 releases. Its absence is tracked as part of #3374 (missing spec-required environment variables). The stale PR #3090 by @msierks-pcln attempted this 6+ months ago but stalled after CLA issues; this implementation incorporates the maintainer review feedback from that PR.

Supersedes #3090.

### Why this belongs in a single PR

The changes span two crates but form a single logical unit:

1. **`opentelemetry` crate** — `Value::truncate()` and `StringValue::truncate()` are general-purpose string truncation methods needed because `StringValue`'s internal storage is `pub(crate)`, so the SDK crate cannot manipulate it directly. These methods contain no enforcement logic — they are utilities.

2. **`opentelemetry-sdk` crate** — The enforcement: reading the env var, storing the limit in `SpanLimits`, and calling `truncate()` at every attribute ingestion point (span build, `set_attribute`, `add_event`, `add_link`).

Splitting these into separate PRs would leave the API methods without a caller, or the SDK enforcement without the methods it calls.

### Design decisions

- **`u32` not `i32`** — only positive values are meaningful (addresses #3090 reviewer feedback)
- **`Option<u32>` with `None` default** — no sentinel needed; unlimited by default per spec
- **Only `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`, not `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`** — the global fallback should wait until logs also support it (per maintainer feedback on #3090: "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT is not something we can add right now, as Logs don't respect this at all"). This is consistent with how `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` exists without a global `OTEL_ATTRIBUTE_COUNT_LIMIT` fallback in this codebase.
- **Truncation is silent** — no ellipsis appended, matching spec behavior (addresses #3090 reviewer feedback about being explicit about implications)
- **Truncation respects UTF-8 character boundaries** — uses `char_indices().nth()` to find the byte offset, never splits a multi-byte character

### Breaking change

`SpanLimits` gains a new public field `max_attribute_value_length: Option<u32>`. Code that constructs `SpanLimits` via struct literal will need to add this field (use `None` for unlimited). This is a known limitation of `SpanLimits` not being `#[non_exhaustive]`, tracked in #2551.

## Changes

- **`opentelemetry`**: add `Value::truncate()` and `StringValue::truncate()` with 8 unit tests
- **`SpanLimits`**: add `max_attribute_value_length: Option<u32>` field and `truncate_string_values()` helper
- **`Config`**: read `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` env var with 4 unit tests
- **`TracerProviderBuilder`**: add `with_max_attribute_value_length(u32)` builder method
- **`Span` / `SdkTracer`**: apply truncation at all attribute ingestion points with 5 integration tests

## Test plan

- [x] `StringValue::truncate`: ASCII, empty, zero-length, multi-byte UTF-8 (euro sign, CJK, accented chars)
- [x] `Value::truncate`: only affects String/Array::String, leaves bool/i64/f64 and their arrays unchanged
- [x] Span attribute truncation via builder and `set_attribute`
- [x] UTF-8 boundary correctness
- [x] Event attribute truncation
- [x] Link attribute truncation
- [x] No truncation when limit is not set
- [x] Env var parsing: valid, invalid, negative
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy` (both crates)
- [x] `bash ./scripts/lint.sh`
- [x] Full workspace `cargo check`
- [x] 85 trace tests pass, 13 common tests pass