### PR TITLE
perf(sdk): store InstrumentationScope in Arc for cheaper tracer clones

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -13,7 +13,7 @@
 - **Breaking** The SDK `testing` feature is now runtime agnostic. [#3407][3407]
   - `TokioSpanExporter` and `new_tokio_test_exporter` have been renamed to `TestSpanExporter` and `new_test_exporter`.
   - The following transitive dependencies and features have been removed: `tokio/rt`, `tokio/time`, `tokio/macros`, `tokio/rt-multi-thread`, `tokio-stream`, `experimental_async_runtime`
-- Store `InstrumentationScope` in `Arc` internally in `SdkTracer`, making tracer cloning cheaper and avoiding redundant scope clones in the multi-processor span export path.
+- Store `InstrumentationScope` in `Arc` internally in `SdkTracer`, making tracer clones cheaper (Arc refcount increment instead of deep copy). The multi-processor span export path now builds export data once instead of per processor.
 - Add 32-bit platform support by using `portable-atomic` for `AtomicI64` and `AtomicU64` in the metrics module. This enables compilation on 32-bit ARM targets (e.g., `armv5te-unknown-linux-gnueabi`, `armv7-unknown-linux-gnueabihf`).
 - `Aggregation` enum and `StreamBuilder::with_aggregation()` are now stable and no longer require the `spec_unstable_metrics_views` feature flag.
 - Fix `service.name` Resource attribute fallback to follow OpenTelemetry

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -13,7 +13,7 @@
 - **Breaking** The SDK `testing` feature is now runtime agnostic. [#3407][3407]
   - `TokioSpanExporter` and `new_tokio_test_exporter` have been renamed to `TestSpanExporter` and `new_test_exporter`.
   - The following transitive dependencies and features have been removed: `tokio/rt`, `tokio/time`, `tokio/macros`, `tokio/rt-multi-thread`, `tokio-stream`, `experimental_async_runtime`
-- Store `InstrumentationScope` in `Arc` internally in `SdkTracer`, making tracer clones cheaper (Arc refcount increment instead of deep copy). The multi-processor span export path now builds export data once and clones for additional processors, instead of rebuilding per processor.
+- Store `InstrumentationScope` in `Arc` internally in `SdkTracer`, making tracer clones cheaper (Arc refcount increment instead of deep copy).
 - Add 32-bit platform support by using `portable-atomic` for `AtomicI64` and `AtomicU64` in the metrics module. This enables compilation on 32-bit ARM targets (e.g., `armv5te-unknown-linux-gnueabi`, `armv7-unknown-linux-gnueabihf`).
 - `Aggregation` enum and `StreamBuilder::with_aggregation()` are now stable and no longer require the `spec_unstable_metrics_views` feature flag.
 - Fix `service.name` Resource attribute fallback to follow OpenTelemetry

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Breaking** The SDK `testing` feature is now runtime agnostic. [#3407][3407]
   - `TokioSpanExporter` and `new_tokio_test_exporter` have been renamed to `TestSpanExporter` and `new_test_exporter`.
   - The following transitive dependencies and features have been removed: `tokio/rt`, `tokio/time`, `tokio/macros`, `tokio/rt-multi-thread`, `tokio-stream`, `experimental_async_runtime`
+- Store `InstrumentationScope` in `Arc` internally in `SdkTracer`, making tracer cloning cheaper and avoiding redundant scope clones in the multi-processor span export path.
 - Add 32-bit platform support by using `portable-atomic` for `AtomicI64` and `AtomicU64` in the metrics module. This enables compilation on 32-bit ARM targets (e.g., `armv5te-unknown-linux-gnueabi`, `armv7-unknown-linux-gnueabihf`).
 - `Aggregation` enum and `StreamBuilder::with_aggregation()` are now stable and no longer require the `spec_unstable_metrics_views` feature flag.
 - Fix `service.name` Resource attribute fallback to follow OpenTelemetry

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -13,7 +13,7 @@
 - **Breaking** The SDK `testing` feature is now runtime agnostic. [#3407][3407]
   - `TokioSpanExporter` and `new_tokio_test_exporter` have been renamed to `TestSpanExporter` and `new_test_exporter`.
   - The following transitive dependencies and features have been removed: `tokio/rt`, `tokio/time`, `tokio/macros`, `tokio/rt-multi-thread`, `tokio-stream`, `experimental_async_runtime`
-- Store `InstrumentationScope` in `Arc` internally in `SdkTracer`, making tracer clones cheaper (Arc refcount increment instead of deep copy). The multi-processor span export path now builds export data once instead of per processor.
+- Store `InstrumentationScope` in `Arc` internally in `SdkTracer`, making tracer clones cheaper (Arc refcount increment instead of deep copy). The multi-processor span export path now builds export data once and clones for additional processors, instead of rebuilding per processor.
 - Add 32-bit platform support by using `portable-atomic` for `AtomicI64` and `AtomicU64` in the metrics module. This enables compilation on 32-bit ARM targets (e.g., `armv5te-unknown-linux-gnueabi`, `armv7-unknown-linux-gnueabihf`).
 - `Aggregation` enum and `StreamBuilder::with_aggregation()` are now stable and no longer require the `spec_unstable_metrics_views` feature flag.
 - Fix `service.name` Resource attribute fallback to follow OpenTelemetry

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -229,8 +229,7 @@ impl Span {
                 ));
             }
             processors => {
-                let export_data =
-                    build_export_data(data, self.span_context.clone(), &self.tracer);
+                let export_data = build_export_data(data, self.span_context.clone(), &self.tracer);
                 let (last, rest) = processors.split_last().unwrap();
                 for processor in rest {
                     processor.on_end(export_data.clone());

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -231,15 +231,11 @@ impl Span {
             processors => {
                 let export_data =
                     build_export_data(data, self.span_context.clone(), &self.tracer);
-                let last_idx = processors.len() - 1;
-                for (i, processor) in processors.iter().enumerate() {
-                    if i < last_idx {
-                        processor.on_end(export_data.clone());
-                    } else {
-                        processor.on_end(export_data);
-                        break;
-                    }
+                let (last, rest) = processors.split_last().unwrap();
+                for processor in rest {
+                    processor.on_end(export_data.clone());
                 }
+                last.on_end(export_data);
             }
         }
     }

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -229,12 +229,16 @@ impl Span {
                 ));
             }
             processors => {
-                for processor in processors {
-                    processor.on_end(build_export_data(
-                        data.clone(),
-                        self.span_context.clone(),
-                        &self.tracer,
-                    ));
+                let export_data =
+                    build_export_data(data, self.span_context.clone(), &self.tracer);
+                let last_idx = processors.len() - 1;
+                for (i, processor) in processors.iter().enumerate() {
+                    if i < last_idx {
+                        processor.on_end(export_data.clone());
+                    } else {
+                        processor.on_end(export_data);
+                        break;
+                    }
                 }
             }
         }

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -229,12 +229,13 @@ impl Span {
                 ));
             }
             processors => {
-                let export_data = build_export_data(data, self.span_context.clone(), &self.tracer);
-                let (last, rest) = processors.split_last().unwrap();
-                for processor in rest {
-                    processor.on_end(export_data.clone());
+                for processor in processors {
+                    processor.on_end(build_export_data(
+                        data.clone(),
+                        self.span_context.clone(),
+                        &self.tracer,
+                    ));
                 }
-                last.on_end(export_data);
             }
         }
     }

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -733,6 +733,13 @@ mod tests {
         assert_eq!(spans1[0].name, "multi_processor_span");
         assert_eq!(spans2[0].name, "multi_processor_span");
         assert_eq!(spans1[0].attributes, spans2[0].attributes);
+        // Verify instrumentation scope is correctly propagated to both processors
+        assert_eq!(spans1[0].instrumentation_scope.name(), "test");
+        assert_eq!(spans2[0].instrumentation_scope.name(), "test");
+        assert_eq!(
+            spans1[0].instrumentation_scope,
+            spans2[0].instrumentation_scope
+        );
 
         let _ = provider.shutdown();
     }

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -17,11 +17,12 @@ use opentelemetry::{
     Context, InstrumentationScope, KeyValue,
 };
 use std::fmt;
+use std::sync::Arc;
 
 /// `Tracer` implementation to create and manage spans
 #[derive(Clone)]
 pub struct SdkTracer {
-    scope: InstrumentationScope,
+    scope: Arc<InstrumentationScope>,
     provider: SdkTracerProvider,
 }
 
@@ -39,7 +40,10 @@ impl fmt::Debug for SdkTracer {
 impl SdkTracer {
     /// Create a new tracer (used internally by `TracerProvider`s).
     pub(crate) fn new(scope: InstrumentationScope, provider: SdkTracerProvider) -> Self {
-        SdkTracer { scope, provider }
+        SdkTracer {
+            scope: Arc::new(scope),
+            provider,
+        }
     }
 
     /// TracerProvider associated with this tracer.


### PR DESCRIPTION
## Summary

`SdkTracer` now stores its `InstrumentationScope` in `Arc`. Since tracers are cloned on every span creation (`build_recording_span` calls `self.clone()`), this turns the scope copy from a deep clone (allocates a new `Vec` for attributes) into an Arc refcount increment.

This is a non-breaking change. `SpanData.instrumentation_scope` remains `InstrumentationScope`, not `Arc<InstrumentationScope>`. The `instrumentation_scope()` accessor still returns `&InstrumentationScope` via `Deref`.

Supersedes #3267 — thanks to @taisho6339 for the original approach and discussion.

Relates to #3368.

**Note:** The multi-processor `on_end` build-once optimization that was previously in this PR has been removed — it is superseded by the `FinishedSpan` approach in #3410.

## Changes
- `SdkTracer.scope`: `InstrumentationScope` → `Arc<InstrumentationScope>` (internal field, not public API)
- Added test for multi-processor span delivery with `instrumentation_scope` propagation assertions