### PR TITLE
fix(sdk): resolve exporter deadlock on constrained tokio runtimes

### DIFF
--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -37,7 +37,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 criterion = { workspace = true, features = ["html_reports"] }
 rstest = { workspace = true }
 temp-env = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time"] }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { workspace = true }

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -17,6 +17,7 @@
 
 use crate::error::{OTelSdkError, OTelSdkResult};
 use crate::logs::log_processor::LogProcessor;
+use crate::util::BlockingStrategy;
 use crate::{
     logs::{LogBatch, LogExporter, SdkLogRecord},
     Resource,
@@ -380,6 +381,7 @@ impl BatchLogProcessor {
         let max_export_batch_size = config.max_export_batch_size;
         let current_batch_size = Arc::new(AtomicUsize::new(0));
         let current_batch_size_for_thread = current_batch_size.clone();
+        let blocking_strategy = BlockingStrategy::new();
 
         let handle = thread::Builder::new()
             .name("OpenTelemetry.Logs.BatchProcessor".to_string())
@@ -406,6 +408,7 @@ impl BatchLogProcessor {
                     last_export_time: &mut Instant,
                     current_batch_size: &AtomicUsize,
                     max_export_size: usize,
+                    blocking_strategy: &BlockingStrategy,
                 ) -> OTelSdkResult
                 where
                     E: LogExporter + Send + Sync + 'static,
@@ -431,13 +434,15 @@ impl BatchLogProcessor {
                         }
                         total_exported_logs += count_of_logs;
 
-                        result = export_batch_sync(exporter, logs, last_export_time); // This method clears the logs vec after exporting
+                        result =
+                            export_batch_sync(exporter, logs, last_export_time, blocking_strategy); // This method clears the logs vec after exporting
 
                         current_batch_size.fetch_sub(count_of_logs, Ordering::AcqRel);
                     }
                     result
                 }
 
+                let blocking_strategy = blocking_strategy;
                 loop {
                     let remaining_time = config
                         .scheduled_delay
@@ -460,6 +465,7 @@ impl BatchLogProcessor {
                                 &mut last_export_time,
                                 &current_batch_size,
                                 max_export_batch_size,
+                                &blocking_strategy,
                             );
                         }
                         Ok(BatchMessage::ForceFlush(sender)) => {
@@ -471,6 +477,7 @@ impl BatchLogProcessor {
                                 &mut last_export_time,
                                 &current_batch_size,
                                 max_export_batch_size,
+                                &blocking_strategy,
                             );
                             let _ = sender.send(result);
                         }
@@ -483,6 +490,7 @@ impl BatchLogProcessor {
                                 &mut last_export_time,
                                 &current_batch_size,
                                 max_export_batch_size,
+                                &blocking_strategy,
                             );
                             let _ = exporter.shutdown();
                             let _ = sender.send(result);
@@ -511,6 +519,7 @@ impl BatchLogProcessor {
                                 &mut last_export_time,
                                 &current_batch_size,
                                 max_export_batch_size,
+                                &blocking_strategy,
                             );
                         }
                         Err(RecvTimeoutError::Disconnected) => {
@@ -609,6 +618,7 @@ fn export_batch_sync<E>(
     exporter: &E,
     batch: &mut Vec<Box<(SdkLogRecord, InstrumentationScope)>>,
     last_export_time: &mut Instant,
+    blocking_strategy: &BlockingStrategy,
 ) -> OTelSdkResult
 where
     E: LogExporter + ?Sized,
@@ -620,7 +630,7 @@ where
     }
 
     let export = exporter.export(LogBatch::new_with_owned_data(batch.as_slice()));
-    let export_result = futures_executor::block_on(export);
+    let export_result = blocking_strategy.block_on(export);
 
     // Clear the batch vec after exporting
     batch.clear();

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -1122,6 +1122,66 @@ mod tests {
         processor.shutdown().unwrap();
     }
 
+    // Mock exporter that uses tokio::spawn internally, simulating tonic/gRPC
+    // exporters where the export future depends on tokio tasks. Without
+    // BlockingStrategy, this deadlocks on constrained runtimes because
+    // futures_executor::block_on() cannot drive tokio::spawn-ed tasks.
+    #[derive(Debug, Clone)]
+    struct TokioSpawnLogExporter {
+        exported_count: Arc<AtomicUsize>,
+    }
+
+    impl TokioSpawnLogExporter {
+        fn new() -> Self {
+            Self {
+                exported_count: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    impl LogExporter for TokioSpawnLogExporter {
+        async fn export(&self, batch: LogBatch<'_>) -> OTelSdkResult {
+            let count = batch.len();
+            // Simulate tonic/gRPC: the export future depends on a tokio::spawn-ed task.
+            let result = tokio::spawn(async move { count }).await.unwrap();
+            assert_eq!(result, count);
+            self.exported_count.fetch_add(count, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn shutdown(&self) -> OTelSdkResult {
+            Ok(())
+        }
+    }
+
+    // Regression test for deadlock on constrained tokio runtimes (#2802, #3356).
+    // Uses TokioSpawnLogExporter which internally calls tokio::spawn(),
+    // simulating tonic/gRPC exporters where the export future depends on
+    // tokio-spawned tasks. Without BlockingStrategy, this deadlocks because
+    // futures_executor::block_on() cannot drive tokio::spawn-ed tasks
+    // without the runtime context.
+    //
+    // Note: current_thread runtime is not tested here because it has a
+    // fundamental limitation — the single runtime thread is blocked by
+    // force_flush()'s recv(), so no thread is available to drive spawned
+    // tasks. The multi_thread(1) scenario (1-vCPU k8s pods) is the primary
+    // target of this fix.
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_batch_log_processor_multi_thread_1_worker_with_tokio_spawn_exporter() {
+        let exporter = TokioSpawnLogExporter::new();
+        let exported_count = exporter.exported_count.clone();
+        let processor = BatchLogProcessor::new(exporter, BatchConfig::default());
+
+        let mut record = SdkLogRecord::new();
+        let instrumentation = InstrumentationScope::default();
+        processor.emit(&mut record, &instrumentation);
+
+        processor.force_flush().unwrap();
+
+        assert_eq!(exported_count.load(Ordering::Relaxed), 1);
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_log_processor_shutdown_with_async_runtime_multi_flavor_current_thread() {
         let exporter = InMemoryLogExporterBuilder::default().build();

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -317,27 +317,28 @@ impl LogProcessor for BatchLogProcessor {
                         }
                         OTelSdkResult::Ok(())
                     })
-                    .map_err(|err| match err {
-                        RecvTimeoutError::Timeout => {
-                            // TODO: When shutdown times out, log records still
-                            // in the queue or mid-export are silently lost. The
-                            // background thread is not joined and may continue
-                            // running. Consider: (1) recording the lost count
-                            // in the self-diagnostics counter, (2) joining the
-                            // thread with a best-effort wait, or (3) signalling
-                            // the thread to abort the current export.
-                            otel_error!(
-                                name: "BatchLogProcessor.Shutdown.Timeout",
-                                message = "BatchLogProcessor shutdown timing out."
-                            );
-                            OTelSdkError::Timeout(timeout)
-                        }
-                        _ => {
-                            otel_error!(
-                                name: "BatchLogProcessor.Shutdown.Error",
-                                error = format!("{}", err)
-                            );
-                            OTelSdkError::InternalFailure(format!("{err}"))
+                    .map_err(|err| {
+                        // The worker thread is unreachable from here: Timeout
+                        // means it is hung in `block_on(export_future)` and
+                        // joining would deadlock; Disconnected means it has
+                        // already exited. Take the handle out so subsequent
+                        // shutdown attempts do not see a stale `Some(_)`.
+                        drop(self.handle.lock().unwrap().take());
+                        match err {
+                            RecvTimeoutError::Timeout => {
+                                otel_error!(
+                                    name: "BatchLogProcessor.Shutdown.Timeout",
+                                    message = "BatchLogProcessor shutdown timing out."
+                                );
+                                OTelSdkError::Timeout(timeout)
+                            }
+                            _ => {
+                                otel_error!(
+                                    name: "BatchLogProcessor.Shutdown.Error",
+                                    error = format!("{}", err)
+                                );
+                                OTelSdkError::InternalFailure(format!("{err}"))
+                            }
                         }
                     })?
             }

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -846,7 +846,7 @@ mod tests {
     };
     #[cfg(feature = "experimental_logs_batch_log_processor_with_async_runtime")]
     use super::{OTEL_BLRP_EXPORT_TIMEOUT, OTEL_BLRP_EXPORT_TIMEOUT_DEFAULT};
-    use crate::error::OTelSdkResult;
+    use crate::error::{OTelSdkError, OTelSdkResult};
     use crate::logs::log_processor::tests::MockLogExporter;
     use crate::logs::SdkLogRecord;
     use crate::logs::{LogBatch, LogExporter};
@@ -1142,8 +1142,14 @@ mod tests {
     impl LogExporter for TokioSpawnLogExporter {
         async fn export(&self, batch: LogBatch<'_>) -> OTelSdkResult {
             let count = batch.len();
-            // Simulate tonic/gRPC: the export future depends on a tokio::spawn-ed task.
-            let result = tokio::spawn(async move { count }).await.unwrap();
+            // Simulate tonic/gRPC: the export future needs tokio::spawn plus
+            // live timer and IO drivers on the worker thread.
+            let result = tokio::spawn(async move {
+                crate::util::exercise_tokio_drivers().await;
+                count
+            })
+            .await
+            .unwrap();
             assert_eq!(result, count);
             self.exported_count.fetch_add(count, Ordering::Relaxed);
             Ok(())
@@ -1180,6 +1186,108 @@ mod tests {
         processor.force_flush().unwrap();
 
         assert_eq!(exported_count.load(Ordering::Relaxed), 1);
+    }
+
+    // Exercises BatchMessage::Shutdown's drain path, which has a 5s timeout
+    // wrapper instead of force_flush's infinite recv().
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_batch_log_processor_multi_thread_1_worker_with_tokio_spawn_exporter_shutdown() {
+        let exporter = TokioSpawnLogExporter::new();
+        let exported_count = exporter.exported_count.clone();
+        let processor = BatchLogProcessor::new(exporter, BatchConfig::default());
+
+        let mut record = SdkLogRecord::new();
+        let instrumentation = InstrumentationScope::default();
+        processor.emit(&mut record, &instrumentation);
+
+        processor.shutdown().unwrap();
+
+        assert_eq!(exported_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_batch_log_processor_multi_thread_default_with_tokio_spawn_exporter_force_flush() {
+        let exporter = TokioSpawnLogExporter::new();
+        let exported_count = exporter.exported_count.clone();
+        let processor = BatchLogProcessor::new(exporter, BatchConfig::default());
+
+        let mut record = SdkLogRecord::new();
+        let instrumentation = InstrumentationScope::default();
+        processor.emit(&mut record, &instrumentation);
+
+        processor.force_flush().unwrap();
+
+        assert_eq!(exported_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_batch_log_processor_multi_thread_default_with_tokio_spawn_exporter_shutdown() {
+        let exporter = TokioSpawnLogExporter::new();
+        let exported_count = exporter.exported_count.clone();
+        let processor = BatchLogProcessor::new(exporter, BatchConfig::default());
+
+        let mut record = SdkLogRecord::new();
+        let instrumentation = InstrumentationScope::default();
+        processor.emit(&mut record, &instrumentation);
+
+        processor.shutdown().unwrap();
+
+        assert_eq!(exported_count.load(Ordering::Relaxed), 1);
+    }
+
+    // Edge case: shutdown on a processor with no pending data — the drain path
+    // must complete cleanly without invoking the exporter or hanging.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_batch_log_processor_multi_thread_1_worker_with_tokio_spawn_exporter_shutdown_empty(
+    ) {
+        let exporter = TokioSpawnLogExporter::new();
+        let exported_count = exporter.exported_count.clone();
+        let processor = BatchLogProcessor::new(exporter, BatchConfig::default());
+
+        processor.shutdown().unwrap();
+
+        assert_eq!(exported_count.load(Ordering::Relaxed), 0);
+    }
+
+    // Verifies the BlockingStrategy::FuturesExecutor branch — used when
+    // processors are constructed outside any tokio runtime context. A regular
+    // `#[test]` (not `#[tokio::test]`) means `Handle::try_current()` returns
+    // Err and the strategy falls back to plain `futures_executor::block_on`.
+    #[test]
+    fn test_batch_log_processor_blocking_strategy_futures_executor_branch() {
+        // `keep_records_on_shutdown` is required because InMemoryLogExporter
+        // clears its buffer in shutdown by default.
+        let exporter = InMemoryLogExporterBuilder::default()
+            .keep_records_on_shutdown()
+            .build();
+        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default());
+
+        let mut record = SdkLogRecord::new();
+        let instrumentation = InstrumentationScope::default();
+        processor.emit(&mut record, &instrumentation);
+
+        processor.force_flush().unwrap();
+        processor.shutdown().unwrap();
+
+        let exported = exporter.get_emitted_logs().unwrap();
+        assert_eq!(exported.len(), 1);
+    }
+
+    // Pins the documented current_thread limitation: with a tokio-spawn-dependent
+    // exporter, the runtime's only thread is blocked in shutdown_with_timeout's
+    // recv_timeout, so the spawned task never makes progress and the timeout fires.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_batch_log_processor_current_thread_with_tokio_spawn_exporter_shutdown_times_out()
+    {
+        let exporter = TokioSpawnLogExporter::new();
+        let processor = BatchLogProcessor::new(exporter, BatchConfig::default());
+
+        let mut record = SdkLogRecord::new();
+        let instrumentation = InstrumentationScope::default();
+        processor.emit(&mut record, &instrumentation);
+
+        let result = processor.shutdown_with_timeout(Duration::from_millis(100));
+        assert!(matches!(result, Err(OTelSdkError::Timeout(_))));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -436,7 +436,7 @@ impl BatchLogProcessor {
                         total_exported_logs += count_of_logs;
 
                         result =
-                            export_batch_sync(exporter, logs, last_export_time, blocking_strategy); // This method clears the logs vec after exporting
+                            export_batch_sync(exporter, logs, last_export_time, blocking_strategy);
 
                         current_batch_size.fetch_sub(count_of_logs, Ordering::AcqRel);
                     }
@@ -1236,8 +1236,7 @@ mod tests {
         assert_eq!(exported_count.load(Ordering::Relaxed), 1);
     }
 
-    // Edge case: shutdown on a processor with no pending data — the drain path
-    // must complete cleanly without invoking the exporter or hanging.
+    // Drain path must not hang when the buffer is empty.
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_batch_log_processor_multi_thread_1_worker_with_tokio_spawn_exporter_shutdown_empty(
     ) {

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -110,12 +110,12 @@ impl SdkMeterProvider {
     ///
     /// There is no guaranteed that all telemetry be flushed or all resources have
     /// been released on error.
-    pub fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+    pub fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         otel_debug!(
             name: "MeterProvider.Shutdown",
             message = "User initiated shutdown of MeterProvider."
         );
-        self.inner.shutdown()
+        self.inner.shutdown_with_timeout(timeout)
     }
 
     /// shutdown with default timeout
@@ -136,7 +136,7 @@ impl SdkMeterProviderInner {
         }
     }
 
-    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         if self
             .shutdown_invoked
             .swap(true, std::sync::atomic::Ordering::SeqCst)
@@ -144,7 +144,7 @@ impl SdkMeterProviderInner {
             // If the previous value was true, shutdown was already invoked.
             Err(crate::error::OTelSdkError::AlreadyShutdown)
         } else {
-            self.pipes.shutdown()
+            self.pipes.shutdown(timeout)
         }
     }
 

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -765,10 +765,10 @@ mod tests {
         assert!(is_shutdown.load(Ordering::Relaxed));
     }
 
-    // Edge case: shutdown on a reader with no recorded measurements — the drain
-    // path must complete cleanly without hanging. Whether the exporter is invoked
-    // depends on whether `collect()` produces an empty `ResourceMetrics`; we only
-    // require the shutdown propagates and is_shutdown is set.
+    // Drain path must not hang on a reader with no recorded measurements.
+    // Whether the exporter is invoked depends on whether `collect()` produces
+    // an empty `ResourceMetrics`, so we only assert that shutdown propagates
+    // and `is_shutdown` is set.
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_periodic_reader_multi_thread_1_worker_with_tokio_spawn_exporter_shutdown_empty() {
         let exporter = TokioSpawnMetricExporter::default();

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -13,6 +13,7 @@ use opentelemetry::{otel_debug, otel_error, otel_info, otel_warn, Context};
 use crate::{
     error::{OTelSdkError, OTelSdkResult},
     metrics::{exporter::PushMetricExporter, reader::SdkProducer},
+    util::BlockingStrategy,
     Resource,
 };
 
@@ -159,6 +160,7 @@ impl<E: PushMetricExporter> PeriodicReader<E> {
                 message_sender,
                 producer: Mutex::new(None),
                 exporter: exporter_arc.clone(),
+                blocking_strategy: BlockingStrategy::new(),
             }),
         };
         let cloned_reader = reader.clone();
@@ -358,6 +360,7 @@ struct PeriodicReaderInner<E: PushMetricExporter> {
     exporter: Arc<E>,
     message_sender: mpsc::Sender<Message>,
     producer: Mutex<Option<Weak<dyn SdkProducer>>>,
+    blocking_strategy: BlockingStrategy,
 }
 
 impl<E: PushMetricExporter> PeriodicReaderInner<E> {
@@ -414,9 +417,8 @@ impl<E: PushMetricExporter> PeriodicReaderInner<E> {
         });
         otel_debug!(name: "PeriodicReaderMetricsCollected", count = metrics_count, time_taken_in_millis = time_taken_for_collect.as_millis());
 
-        // Relying on futures executor to execute async call.
         // TODO: Pass timeout to exporter
-        futures_executor::block_on(self.exporter.export(rm))
+        self.blocking_strategy.block_on(self.exporter.export(rm))
     }
 
     fn force_flush(&self) -> OTelSdkResult {

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -613,6 +613,75 @@ mod tests {
         }
     }
 
+    // Mock exporter that uses tokio::spawn internally, simulating tonic/gRPC
+    // exporters where the export future depends on tokio tasks. Without
+    // BlockingStrategy, this deadlocks on constrained runtimes because
+    // futures_executor::block_on() cannot drive tokio::spawn-ed tasks.
+    #[derive(Debug, Clone, Default)]
+    struct TokioSpawnMetricExporter {
+        exported_count: Arc<AtomicUsize>,
+        is_shutdown: Arc<AtomicBool>,
+    }
+
+    impl PushMetricExporter for TokioSpawnMetricExporter {
+        async fn export(&self, _metrics: &ResourceMetrics) -> OTelSdkResult {
+            // Simulate tonic/gRPC: the export future depends on a tokio::spawn-ed task.
+            let result = tokio::spawn(async { 42 }).await.unwrap();
+            assert_eq!(result, 42);
+            self.exported_count.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn force_flush(&self) -> OTelSdkResult {
+            Ok(())
+        }
+
+        fn shutdown(&self) -> OTelSdkResult {
+            self.is_shutdown.store(true, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+            self.shutdown()
+        }
+
+        fn temporality(&self) -> Temporality {
+            Temporality::Cumulative
+        }
+    }
+
+    // Regression test for deadlock on constrained tokio runtimes (#2802, #3356).
+    // Uses TokioSpawnMetricExporter which internally calls tokio::spawn(),
+    // simulating tonic/gRPC exporters where the export future depends on
+    // tokio-spawned tasks. Without BlockingStrategy, this deadlocks because
+    // futures_executor::block_on() cannot drive tokio::spawn-ed tasks
+    // without the runtime context.
+    //
+    // Note: current_thread runtime is not tested here because it has a
+    // fundamental limitation — the single runtime thread is blocked by
+    // force_flush()'s recv(), so no thread is available to drive spawned
+    // tasks. The multi_thread(1) scenario (1-vCPU k8s pods) is the primary
+    // target of this fix.
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_periodic_reader_multi_thread_1_worker_with_tokio_spawn_exporter() {
+        let exporter = TokioSpawnMetricExporter::default();
+        let exported_count = exporter.exported_count.clone();
+
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(Duration::from_secs(120))
+            .build();
+
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = meter_provider.meter("test");
+        let counter = meter.u64_counter("test.counter").build();
+        counter.add(1, &[]);
+
+        meter_provider.force_flush().unwrap();
+
+        assert!(exported_count.load(Ordering::Relaxed) >= 1);
+    }
+
     #[test]
     fn collection_triggered_by_interval_multiple() {
         // Arrange

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -452,15 +452,14 @@ impl<E: PushMetricExporter> PeriodicReaderInner<E> {
         }
     }
 
-    fn shutdown(&self) -> OTelSdkResult {
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         // TODO: See if this is better to be created upfront.
         let (response_tx, response_rx) = mpsc::channel();
         self.message_sender
             .send(Message::Shutdown(response_tx))
             .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
 
-        // TODO: Make this timeout configurable.
-        match response_rx.recv_timeout(Duration::from_secs(5)) {
+        match response_rx.recv_timeout(timeout) {
             Ok(response) => {
                 if response {
                     Ok(())
@@ -468,9 +467,7 @@ impl<E: PushMetricExporter> PeriodicReaderInner<E> {
                     Err(OTelSdkError::InternalFailure("Failed to shutdown".into()))
                 }
             }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                Err(OTelSdkError::Timeout(Duration::from_secs(5)))
-            }
+            Err(mpsc::RecvTimeoutError::Timeout) => Err(OTelSdkError::Timeout(timeout)),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 Err(OTelSdkError::InternalFailure("Failed to shutdown".into()))
             }
@@ -501,8 +498,8 @@ impl<E: PushMetricExporter> MetricReader for PeriodicReader<E> {
     // completion, and avoid blocking the thread. The default shutdown on drop
     // can still use blocking call. If user already explicitly called shutdown,
     // drop won't call shutdown again.
-    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
-        self.inner.shutdown()
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
+        self.inner.shutdown_with_timeout(timeout)
     }
 
     /// To construct a [MetricReader][metric-reader] when setting up an SDK,
@@ -802,14 +799,10 @@ mod tests {
     // exporter, the runtime's only thread is blocked in shutdown's recv_timeout,
     // so the spawned task never makes progress and the timeout fires.
     //
-    // Two oddities affect the assertion shape and runtime here:
-    //   - `PeriodicReader::shutdown_with_timeout` currently ignores its timeout
-    //     argument and uses a hardcoded 5s wait — see `// TODO: Make this timeout
-    //     configurable.` in `PeriodicReaderInner::shutdown`. As a result this
-    //     test takes ~5s.
-    //   - `Pipelines::shutdown` aggregates per-reader errors into a single
-    //     `OTelSdkError::InternalFailure` with the underlying `Timeout` formatted
-    //     as a debug string. So we assert the call errored, not its exact variant.
+    // Note: `Pipelines::shutdown` aggregates per-reader errors into a single
+    // `OTelSdkError::InternalFailure` with the underlying `Timeout` formatted
+    // as a debug string, so we assert on `InternalFailure` rather than the
+    // direct `Timeout` variant the trace/log siblings see.
     #[tokio::test(flavor = "current_thread")]
     async fn test_periodic_reader_current_thread_with_tokio_spawn_exporter_shutdown_times_out() {
         let exporter = TokioSpawnMetricExporter::default();

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -161,6 +161,7 @@ impl<E: PushMetricExporter> PeriodicReader<E> {
                 producer: Mutex::new(None),
                 exporter: exporter_arc.clone(),
                 blocking_strategy: BlockingStrategy::new(),
+                handle: Mutex::new(None),
             }),
         };
         let cloned_reader = reader.clone();
@@ -334,13 +335,17 @@ impl<E: PushMetricExporter> PeriodicReader<E> {
             });
 
         // TODO: Should we fail-fast here and bubble up the error to user?
-        #[allow(unused_variables)]
-        if let Err(e) = result_thread_creation {
-            otel_error!(
-                name: "PeriodReaderThreadStartError",
-                message = "Failed to start PeriodicReader thread. Metrics will not be exported.",
-                error = format!("{:?}", e)
-            );
+        match result_thread_creation {
+            Ok(handle) => {
+                *reader.inner.handle.lock().unwrap() = Some(handle);
+            }
+            Err(e) => {
+                otel_error!(
+                    name: "PeriodReaderThreadStartError",
+                    message = "Failed to start PeriodicReader thread. Metrics will not be exported.",
+                    error = format!("{:?}", e)
+                );
+            }
         }
         reader
     }
@@ -361,6 +366,7 @@ struct PeriodicReaderInner<E: PushMetricExporter> {
     message_sender: mpsc::Sender<Message>,
     producer: Mutex<Option<Weak<dyn SdkProducer>>>,
     blocking_strategy: BlockingStrategy,
+    handle: Mutex<Option<thread::JoinHandle<()>>>,
 }
 
 impl<E: PushMetricExporter> PeriodicReaderInner<E> {
@@ -459,19 +465,26 @@ impl<E: PushMetricExporter> PeriodicReaderInner<E> {
             .send(Message::Shutdown(response_tx))
             .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
 
-        match response_rx.recv_timeout(timeout) {
-            Ok(response) => {
-                if response {
-                    Ok(())
-                } else {
-                    Err(OTelSdkError::InternalFailure("Failed to shutdown".into()))
-                }
-            }
+        let result = match response_rx.recv_timeout(timeout) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(OTelSdkError::InternalFailure("Failed to shutdown".into())),
             Err(mpsc::RecvTimeoutError::Timeout) => Err(OTelSdkError::Timeout(timeout)),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 Err(OTelSdkError::InternalFailure("Failed to shutdown".into()))
             }
+        };
+
+        // On success the worker has acknowledged shutdown and exited its loop,
+        // so joining is near-instant. On timeout the worker is hung in
+        // `block_on` of an export future; we leave the handle in place so a
+        // subsequent shutdown attempt or `Drop` can retry rather than risk
+        // deadlocking the caller here.
+        if result.is_ok() {
+            if let Some(handle) = self.handle.lock().unwrap().take() {
+                let _ = handle.join();
+            }
         }
+        result
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/periodic_reader.rs
+++ b/opentelemetry-sdk/src/metrics/periodic_reader.rs
@@ -613,6 +613,10 @@ mod tests {
         }
     }
 
+    // Long enough that the periodic interval timer never fires during these
+    // tests; flush/shutdown is what drives export.
+    const LONG_INTERVAL: Duration = Duration::from_secs(120);
+
     // Mock exporter that uses tokio::spawn internally, simulating tonic/gRPC
     // exporters where the export future depends on tokio tasks. Without
     // BlockingStrategy, this deadlocks on constrained runtimes because
@@ -625,8 +629,14 @@ mod tests {
 
     impl PushMetricExporter for TokioSpawnMetricExporter {
         async fn export(&self, _metrics: &ResourceMetrics) -> OTelSdkResult {
-            // Simulate tonic/gRPC: the export future depends on a tokio::spawn-ed task.
-            let result = tokio::spawn(async { 42 }).await.unwrap();
+            // Simulate tonic/gRPC: the export future needs tokio::spawn plus
+            // live timer and IO drivers on the worker thread.
+            let result = tokio::spawn(async {
+                crate::util::exercise_tokio_drivers().await;
+                42
+            })
+            .await
+            .unwrap();
             assert_eq!(result, 42);
             self.exported_count.fetch_add(1, Ordering::Relaxed);
             Ok(())
@@ -669,7 +679,7 @@ mod tests {
         let exported_count = exporter.exported_count.clone();
 
         let reader = PeriodicReader::builder(exporter)
-            .with_interval(Duration::from_secs(120))
+            .with_interval(LONG_INTERVAL)
             .build();
 
         let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
@@ -680,6 +690,139 @@ mod tests {
         meter_provider.force_flush().unwrap();
 
         assert!(exported_count.load(Ordering::Relaxed) >= 1);
+    }
+
+    // Exercises the reader's shutdown drain, which performs one final
+    // collect+export before stopping.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_periodic_reader_multi_thread_1_worker_with_tokio_spawn_exporter_shutdown() {
+        let exporter = TokioSpawnMetricExporter::default();
+        let exported_count = exporter.exported_count.clone();
+        let is_shutdown = exporter.is_shutdown.clone();
+
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(LONG_INTERVAL)
+            .build();
+
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = meter_provider.meter("test");
+        let counter = meter.u64_counter("test.counter").build();
+        counter.add(1, &[]);
+
+        meter_provider.shutdown().unwrap();
+
+        assert_eq!(exported_count.load(Ordering::Relaxed), 1);
+        assert!(is_shutdown.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_periodic_reader_multi_thread_default_with_tokio_spawn_exporter_force_flush() {
+        let exporter = TokioSpawnMetricExporter::default();
+        let exported_count = exporter.exported_count.clone();
+
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(LONG_INTERVAL)
+            .build();
+
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = meter_provider.meter("test");
+        let counter = meter.u64_counter("test.counter").build();
+        counter.add(1, &[]);
+
+        meter_provider.force_flush().unwrap();
+
+        assert_eq!(exported_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_periodic_reader_multi_thread_default_with_tokio_spawn_exporter_shutdown() {
+        let exporter = TokioSpawnMetricExporter::default();
+        let exported_count = exporter.exported_count.clone();
+        let is_shutdown = exporter.is_shutdown.clone();
+
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(LONG_INTERVAL)
+            .build();
+
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = meter_provider.meter("test");
+        let counter = meter.u64_counter("test.counter").build();
+        counter.add(1, &[]);
+
+        meter_provider.shutdown().unwrap();
+
+        assert_eq!(exported_count.load(Ordering::Relaxed), 1);
+        assert!(is_shutdown.load(Ordering::Relaxed));
+    }
+
+    // Edge case: shutdown on a reader with no recorded measurements — the drain
+    // path must complete cleanly without hanging. Whether the exporter is invoked
+    // depends on whether `collect()` produces an empty `ResourceMetrics`; we only
+    // require the shutdown propagates and is_shutdown is set.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_periodic_reader_multi_thread_1_worker_with_tokio_spawn_exporter_shutdown_empty() {
+        let exporter = TokioSpawnMetricExporter::default();
+        let is_shutdown = exporter.is_shutdown.clone();
+
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(LONG_INTERVAL)
+            .build();
+
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+        meter_provider.shutdown().unwrap();
+
+        assert!(is_shutdown.load(Ordering::Relaxed));
+    }
+
+    // Verifies the BlockingStrategy::FuturesExecutor branch — used when the
+    // reader is constructed outside any tokio runtime context. A regular
+    // `#[test]` (not `#[tokio::test]`) means `Handle::try_current()` returns
+    // Err and the strategy falls back to plain `futures_executor::block_on`.
+    #[test]
+    fn test_periodic_reader_blocking_strategy_futures_executor_branch() {
+        let exporter = InMemoryMetricExporter::default();
+        let exporter_shared = exporter.clone();
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(LONG_INTERVAL)
+            .build();
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = meter_provider.meter("test");
+        let counter = meter.u64_counter("test.counter").build();
+        counter.add(1, &[]);
+
+        meter_provider.force_flush().unwrap();
+        meter_provider.shutdown().unwrap();
+
+        let exported = exporter_shared.get_finished_metrics().unwrap();
+        assert!(!exported.is_empty());
+    }
+
+    // Pins the documented current_thread limitation: with a tokio-spawn-dependent
+    // exporter, the runtime's only thread is blocked in shutdown's recv_timeout,
+    // so the spawned task never makes progress and the timeout fires.
+    //
+    // Two oddities affect the assertion shape and runtime here:
+    //   - `PeriodicReader::shutdown_with_timeout` currently ignores its timeout
+    //     argument and uses a hardcoded 5s wait — see `// TODO: Make this timeout
+    //     configurable.` in `PeriodicReaderInner::shutdown`. As a result this
+    //     test takes ~5s.
+    //   - `Pipelines::shutdown` aggregates per-reader errors into a single
+    //     `OTelSdkError::InternalFailure` with the underlying `Timeout` formatted
+    //     as a debug string. So we assert the call errored, not its exact variant.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_periodic_reader_current_thread_with_tokio_spawn_exporter_shutdown_times_out() {
+        let exporter = TokioSpawnMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(LONG_INTERVAL)
+            .build();
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = meter_provider.meter("test");
+        let counter = meter.u64_counter("test.counter").build();
+        counter.add(1, &[]);
+
+        let result = meter_provider.shutdown_with_timeout(Duration::from_millis(100));
+        assert!(matches!(result, Err(OTelSdkError::InternalFailure(_))));
     }
 
     #[test]

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -3,6 +3,7 @@ use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use opentelemetry::{otel_debug, otel_warn, InstrumentationScope, KeyValue};
@@ -93,8 +94,8 @@ impl Pipeline {
     }
 
     /// Shut down pipeline
-    fn shutdown(&self) -> OTelSdkResult {
-        self.reader.shutdown()
+    fn shutdown(&self, timeout: Duration) -> OTelSdkResult {
+        self.reader.shutdown_with_timeout(timeout)
     }
 }
 
@@ -704,10 +705,10 @@ impl Pipelines {
     }
 
     /// Shut down all pipelines
-    pub(crate) fn shutdown(&self) -> OTelSdkResult {
+    pub(crate) fn shutdown(&self, timeout: Duration) -> OTelSdkResult {
         let mut errs = vec![];
         for pipeline in &self.0 {
-            if let Err(err) = pipeline.shutdown() {
+            if let Err(err) = pipeline.shutdown(timeout) {
                 errs.push(err);
             }
         }

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -38,6 +38,7 @@ use crate::error::{OTelSdkError, OTelSdkResult};
 use crate::resource::Resource;
 use crate::trace::Span;
 use crate::trace::{SpanData, SpanExporter};
+use crate::util::BlockingStrategy;
 use opentelemetry::Context;
 use opentelemetry::{otel_debug, otel_error, otel_warn};
 use std::cmp::min;
@@ -361,6 +362,7 @@ impl BatchSpanProcessor {
         let max_export_batch_size = config.max_export_batch_size;
         let current_batch_size = Arc::new(AtomicUsize::new(0));
         let current_batch_size_for_thread = current_batch_size.clone();
+        let blocking_strategy = BlockingStrategy::new();
 
         let handle = thread::Builder::new()
             .name("OpenTelemetry.Traces.BatchProcessor".to_string())
@@ -375,6 +377,7 @@ impl BatchSpanProcessor {
                 let mut spans = Vec::with_capacity(config.max_export_batch_size);
                 let mut last_export_time = Instant::now();
                 let current_batch_size = current_batch_size_for_thread;
+                let blocking_strategy = blocking_strategy;
                 loop {
                     let remaining_time_option = config
                         .scheduled_delay
@@ -398,6 +401,7 @@ impl BatchSpanProcessor {
                                     &mut last_export_time,
                                     &current_batch_size,
                                     &config,
+                                    &blocking_strategy,
                                 );
                             }
                             BatchMessage::ForceFlush(sender) => {
@@ -409,6 +413,7 @@ impl BatchSpanProcessor {
                                     &mut last_export_time,
                                     &current_batch_size,
                                     &config,
+                                    &blocking_strategy,
                                 );
                                 let _ = sender.send(result);
                             }
@@ -421,6 +426,7 @@ impl BatchSpanProcessor {
                                     &mut last_export_time,
                                     &current_batch_size,
                                     &config,
+                                    &blocking_strategy,
                                 );
                                 let _ = exporter.shutdown();
                                 let _ = sender.send(result);
@@ -450,6 +456,7 @@ impl BatchSpanProcessor {
                                 &mut last_export_time,
                                 &current_batch_size,
                                 &config,
+                                &blocking_strategy,
                             );
                         }
                         Err(RecvTimeoutError::Disconnected) => {
@@ -504,6 +511,7 @@ impl BatchSpanProcessor {
         last_export_time: &mut Instant,
         current_batch_size: &AtomicUsize,
         config: &BatchConfig,
+        blocking_strategy: &BlockingStrategy,
     ) -> OTelSdkResult
     where
         E: SpanExporter + Send + Sync + 'static,
@@ -531,7 +539,7 @@ impl BatchSpanProcessor {
             }
             total_exported_spans += count_of_spans;
 
-            result = Self::export_batch_sync(exporter, spans, last_export_time); // This method clears the spans vec after exporting
+            result = Self::export_batch_sync(exporter, spans, last_export_time, blocking_strategy); // This method clears the spans vec after exporting
 
             current_batch_size.fetch_sub(count_of_spans, Ordering::AcqRel);
         }
@@ -543,6 +551,7 @@ impl BatchSpanProcessor {
         exporter: &E,
         batch: &mut Vec<SpanData>,
         last_export_time: &mut Instant,
+        blocking_strategy: &BlockingStrategy,
     ) -> OTelSdkResult
     where
         E: SpanExporter + ?Sized,
@@ -560,7 +569,7 @@ impl BatchSpanProcessor {
         // every export. See if this can be optimized by
         // *not* requiring ownership in the exporter.
         let export = exporter.export(batch.split_off(0));
-        let export_result = futures_executor::block_on(export);
+        let export_result = blocking_strategy.block_on(export);
 
         match export_result {
             Ok(_) => OTelSdkResult::Ok(()),

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -720,20 +720,28 @@ impl SpanProcessor for BatchSpanProcessor {
                         }
                         OTelSdkResult::Ok(())
                     })
-                    .map_err(|err| match err {
-                        std::sync::mpsc::RecvTimeoutError::Timeout => {
-                            otel_error!(
-                                name: "BatchSpanProcessor.Shutdown.Timeout",
-                                message = "BatchSpanProcessor shutdown timing out."
-                            );
-                            OTelSdkError::Timeout(timeout)
-                        }
-                        _ => {
-                            otel_error!(
-                                name: "BatchSpanProcessor.Shutdown.Error",
-                                error = format!("{}", err)
-                            );
-                            OTelSdkError::InternalFailure(format!("{err}"))
+                    .map_err(|err| {
+                        // The worker thread is unreachable from here: Timeout
+                        // means it is hung in `block_on(export_future)` and
+                        // joining would deadlock; Disconnected means it has
+                        // already exited. Take the handle out so subsequent
+                        // shutdown attempts do not see a stale `Some(_)`.
+                        drop(self.handle.lock().unwrap().take());
+                        match err {
+                            std::sync::mpsc::RecvTimeoutError::Timeout => {
+                                otel_error!(
+                                    name: "BatchSpanProcessor.Shutdown.Timeout",
+                                    message = "BatchSpanProcessor shutdown timing out."
+                                );
+                                OTelSdkError::Timeout(timeout)
+                            }
+                            _ => {
+                                otel_error!(
+                                    name: "BatchSpanProcessor.Shutdown.Error",
+                                    error = format!("{}", err)
+                                );
+                                OTelSdkError::InternalFailure(format!("{err}"))
+                            }
                         }
                     })?
             }

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -1003,7 +1003,7 @@ mod tests {
         OTEL_BSP_MAX_EXPORT_BATCH_SIZE, OTEL_BSP_MAX_QUEUE_SIZE, OTEL_BSP_MAX_QUEUE_SIZE_DEFAULT,
         OTEL_BSP_SCHEDULE_DELAY, OTEL_BSP_SCHEDULE_DELAY_DEFAULT,
     };
-    use crate::error::OTelSdkResult;
+    use crate::error::{OTelSdkError, OTelSdkResult};
     use crate::testing::trace::new_test_export_span_data;
     use crate::trace::span_processor::{
         OTEL_BSP_EXPORT_TIMEOUT_DEFAULT, OTEL_BSP_MAX_CONCURRENT_EXPORTS,
@@ -1584,10 +1584,15 @@ mod tests {
 
     impl SpanExporter for TokioSpawnSpanExporter {
         async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
-            // Simulate tonic/gRPC: the export future depends on a tokio::spawn-ed task.
-            // Without tokio runtime context, this panics or deadlocks.
+            // Simulate tonic/gRPC: the export future needs tokio::spawn plus
+            // live timer and IO drivers on the worker thread.
             let count = batch.len();
-            let result = tokio::spawn(async move { count }).await.unwrap();
+            let result = tokio::spawn(async move {
+                crate::util::exercise_tokio_drivers().await;
+                count
+            })
+            .await
+            .unwrap();
             assert_eq!(result, batch.len());
             self.exported_spans.lock().unwrap().extend(batch);
             Ok(())
@@ -1678,6 +1683,125 @@ mod tests {
 
         let exported_spans = exporter_shared.lock().unwrap();
         assert_eq!(exported_spans.len(), 4);
+    }
+
+    // Exercises BatchMessage::Shutdown's drain path, which has a 5s timeout
+    // wrapper instead of force_flush's infinite recv().
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_batch_processor_multi_thread_1_worker_with_tokio_spawn_exporter_shutdown() {
+        let exporter = TokioSpawnSpanExporter::new();
+        let exporter_shared = exporter.exported_spans.clone();
+
+        let config = BatchConfigBuilder::default()
+            .with_max_queue_size(5)
+            .with_max_export_batch_size(3)
+            .build();
+
+        let processor = BatchSpanProcessor::new(exporter, config);
+
+        for _ in 0..4 {
+            let span = new_test_export_span_data();
+            processor.on_end(span);
+        }
+
+        processor.shutdown().unwrap();
+
+        let exported_spans = exporter_shared.lock().unwrap();
+        assert_eq!(exported_spans.len(), 4);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_batch_processor_multi_thread_default_with_tokio_spawn_exporter_force_flush() {
+        let exporter = TokioSpawnSpanExporter::new();
+        let exporter_shared = exporter.exported_spans.clone();
+
+        let config = BatchConfigBuilder::default()
+            .with_max_queue_size(5)
+            .with_max_export_batch_size(3)
+            .build();
+
+        let processor = BatchSpanProcessor::new(exporter, config);
+
+        for _ in 0..4 {
+            processor.on_end(new_test_export_span_data());
+        }
+
+        processor.force_flush().unwrap();
+
+        let exported_spans = exporter_shared.lock().unwrap();
+        assert_eq!(exported_spans.len(), 4);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_batch_processor_multi_thread_default_with_tokio_spawn_exporter_shutdown() {
+        let exporter = TokioSpawnSpanExporter::new();
+        let exporter_shared = exporter.exported_spans.clone();
+
+        let config = BatchConfigBuilder::default()
+            .with_max_queue_size(5)
+            .with_max_export_batch_size(3)
+            .build();
+
+        let processor = BatchSpanProcessor::new(exporter, config);
+
+        for _ in 0..4 {
+            processor.on_end(new_test_export_span_data());
+        }
+
+        processor.shutdown().unwrap();
+
+        let exported_spans = exporter_shared.lock().unwrap();
+        assert_eq!(exported_spans.len(), 4);
+    }
+
+    // Edge case: shutdown on a processor with no pending data — the drain path
+    // must complete cleanly without invoking the exporter or hanging.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_batch_processor_multi_thread_1_worker_with_tokio_spawn_exporter_shutdown_empty() {
+        let exporter = TokioSpawnSpanExporter::new();
+        let exporter_shared = exporter.exported_spans.clone();
+
+        let processor = BatchSpanProcessor::new(exporter, BatchConfigBuilder::default().build());
+
+        processor.shutdown().unwrap();
+
+        let exported_spans = exporter_shared.lock().unwrap();
+        assert_eq!(exported_spans.len(), 0);
+    }
+
+    // Verifies the BlockingStrategy::FuturesExecutor branch — used when
+    // processors are constructed outside any tokio runtime context. A regular
+    // `#[test]` (not `#[tokio::test]`) means `Handle::try_current()` returns
+    // Err and the strategy falls back to plain `futures_executor::block_on`.
+    #[test]
+    fn test_batch_processor_blocking_strategy_futures_executor_branch() {
+        let exporter = MockSpanExporter::new();
+        let exporter_shared = exporter.exported_spans.clone();
+        let processor = BatchSpanProcessor::new(exporter, BatchConfigBuilder::default().build());
+
+        for _ in 0..4 {
+            processor.on_end(new_test_export_span_data());
+        }
+
+        processor.force_flush().unwrap();
+        processor.shutdown().unwrap();
+
+        let exported_spans = exporter_shared.lock().unwrap();
+        assert_eq!(exported_spans.len(), 4);
+    }
+
+    // Pins the documented current_thread limitation: with a tokio-spawn-dependent
+    // exporter, the runtime's only thread is blocked in shutdown_with_timeout's
+    // recv_timeout, so the spawned task never makes progress and the timeout fires.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_batch_processor_current_thread_with_tokio_spawn_exporter_shutdown_times_out() {
+        let exporter = TokioSpawnSpanExporter::new();
+        let processor = BatchSpanProcessor::new(exporter, BatchConfigBuilder::default().build());
+
+        processor.on_end(new_test_export_span_data());
+
+        let result = processor.shutdown_with_timeout(Duration::from_millis(100));
+        assert!(matches!(result, Err(OTelSdkError::Timeout(_))));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -1762,8 +1762,7 @@ mod tests {
         assert_eq!(exported_spans.len(), 4);
     }
 
-    // Edge case: shutdown on a processor with no pending data — the drain path
-    // must complete cleanly without invoking the exporter or hanging.
+    // Drain path must not hang when the buffer is empty.
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_batch_processor_multi_thread_1_worker_with_tokio_spawn_exporter_shutdown_empty() {
         let exporter = TokioSpawnSpanExporter::new();

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -1012,6 +1012,7 @@ mod tests {
     use crate::trace::InMemorySpanExporterBuilder;
     use crate::trace::{BatchConfig, BatchConfigBuilder, SpanEvents, SpanLinks};
     use crate::trace::{SpanData, SpanExporter};
+    use crate::util::BlockingStrategy;
     use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status};
     use std::fmt::Debug;
     use std::time::Duration;
@@ -1318,6 +1319,7 @@ mod tests {
         sender.send(create_test_span("counted")).unwrap();
         sender.send(create_test_span("unaccounted")).unwrap();
 
+        let blocking_strategy = BlockingStrategy::new();
         let result = BatchSpanProcessor::get_spans_and_export(
             &receiver,
             &exporter,
@@ -1325,6 +1327,7 @@ mod tests {
             &mut last_export_time,
             &current_batch_size,
             &config,
+            &blocking_strategy,
         );
 
         assert!(result.is_ok(), "export should succeed");
@@ -1562,6 +1565,39 @@ mod tests {
         );
     }
 
+    // Mock exporter that uses tokio::spawn internally, simulating tonic/gRPC
+    // exporters where the export future depends on tokio tasks. Without
+    // BlockingStrategy, this deadlocks on constrained runtimes because
+    // futures_executor::block_on() cannot drive tokio::spawn-ed tasks.
+    #[derive(Debug, Clone)]
+    struct TokioSpawnSpanExporter {
+        exported_spans: Arc<Mutex<Vec<SpanData>>>,
+    }
+
+    impl TokioSpawnSpanExporter {
+        fn new() -> Self {
+            Self {
+                exported_spans: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    impl SpanExporter for TokioSpawnSpanExporter {
+        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+            // Simulate tonic/gRPC: the export future depends on a tokio::spawn-ed task.
+            // Without tokio runtime context, this panics or deadlocks.
+            let count = batch.len();
+            let result = tokio::spawn(async move { count }).await.unwrap();
+            assert_eq!(result, batch.len());
+            self.exported_spans.lock().unwrap().extend(batch);
+            Ok(())
+        }
+
+        fn shutdown(&self) -> OTelSdkResult {
+            Ok(())
+        }
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn test_batch_processor_current_thread_runtime() {
         let exporter = MockSpanExporter::new();
@@ -1588,6 +1624,42 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_batch_processor_multi_thread_count_1_runtime() {
         let exporter = MockSpanExporter::new();
+        let exporter_shared = exporter.exported_spans.clone();
+
+        let config = BatchConfigBuilder::default()
+            .with_max_queue_size(5)
+            .with_max_export_batch_size(3)
+            .build();
+
+        let processor = BatchSpanProcessor::new(exporter, config);
+
+        for _ in 0..4 {
+            let span = new_test_export_span_data();
+            processor.on_end(span);
+        }
+
+        processor.force_flush().unwrap();
+
+        let exported_spans = exporter_shared.lock().unwrap();
+        assert_eq!(exported_spans.len(), 4);
+    }
+
+    // Regression test for deadlock on constrained tokio runtimes (#2802, #3356).
+    // Uses TokioSpawnSpanExporter which internally calls tokio::spawn(),
+    // simulating tonic/gRPC exporters where the export future depends on
+    // tokio-spawned tasks. Without BlockingStrategy, this deadlocks because
+    // futures_executor::block_on() cannot drive tokio::spawn-ed tasks
+    // without the runtime context.
+    //
+    // Note: current_thread runtime is not tested here because it has a
+    // fundamental limitation — the single runtime thread is blocked by
+    // force_flush()'s recv(), so no thread is available to drive spawned
+    // tasks. The multi_thread(1) scenario (1-vCPU k8s pods) is the primary
+    // target of this fix.
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn test_batch_processor_multi_thread_1_worker_with_tokio_spawn_exporter() {
+        let exporter = TokioSpawnSpanExporter::new();
         let exporter_shared = exporter.exported_spans.clone();
 
         let config = BatchConfigBuilder::default()

--- a/opentelemetry-sdk/src/util.rs
+++ b/opentelemetry-sdk/src/util.rs
@@ -7,3 +7,44 @@ pub fn tokio_interval_stream(
 ) -> tokio_stream::wrappers::IntervalStream {
     tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(period))
 }
+
+/// Strategy for blocking on async futures from synchronous contexts.
+///
+/// When constructed within a tokio runtime, captures the runtime handle
+/// and enters the runtime context via [`tokio::runtime::Handle::enter()`]
+/// before blocking with [`futures_executor::block_on()`]. This makes tokio
+/// types (spawn, timers, IO resources) available on dedicated background
+/// threads without taking ownership of the reactor — IO continues to be
+/// driven by the runtime's own threads.
+///
+/// Falls back to plain [`futures_executor::block_on()`] when no tokio runtime
+/// is available (e.g., non-tokio environments).
+#[cfg(any(feature = "trace", feature = "logs", feature = "metrics"))]
+#[derive(Clone, Debug)]
+pub(crate) enum BlockingStrategy {
+    #[cfg(feature = "rt-tokio")]
+    TokioHandle(tokio::runtime::Handle),
+    FuturesExecutor,
+}
+
+#[cfg(any(feature = "trace", feature = "logs", feature = "metrics"))]
+impl BlockingStrategy {
+    pub(crate) fn new() -> Self {
+        #[cfg(feature = "rt-tokio")]
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            return Self::TokioHandle(handle);
+        }
+        Self::FuturesExecutor
+    }
+
+    pub(crate) fn block_on<F: std::future::Future>(&self, future: F) -> F::Output {
+        match self {
+            #[cfg(feature = "rt-tokio")]
+            Self::TokioHandle(handle) => {
+                let _guard = handle.enter();
+                futures_executor::block_on(future)
+            }
+            Self::FuturesExecutor => futures_executor::block_on(future),
+        }
+    }
+}

--- a/opentelemetry-sdk/src/util.rs
+++ b/opentelemetry-sdk/src/util.rs
@@ -49,15 +49,14 @@ impl BlockingStrategy {
     }
 }
 
-/// Test-only: exercise the tokio timer and IO drivers from a spawned task.
-/// Used by mock exporters to verify processors keep the runtime drivers alive
-/// on their dedicated worker threads. Without this, the deadlock fix could
-/// silently regress for exporters that depend on either driver (e.g. tonic).
+/// Exercise the tokio timer and IO drivers from a spawned task. Mock
+/// exporters call this so a processor that stops keeping the runtime
+/// drivers alive on its worker thread shows up as a test failure rather
+/// than silently regressing the deadlock fix.
 #[cfg(test)]
 pub(crate) async fn exercise_tokio_drivers() {
-    // Timer driver.
     tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-    // IO driver — bind registers an FD with the reactor; immediate drop is fine.
+    // bind registers an FD with the reactor; immediate drop is fine.
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let _ = listener.local_addr().unwrap();
 }

--- a/opentelemetry-sdk/src/util.rs
+++ b/opentelemetry-sdk/src/util.rs
@@ -48,3 +48,16 @@ impl BlockingStrategy {
         }
     }
 }
+
+/// Test-only: exercise the tokio timer and IO drivers from a spawned task.
+/// Used by mock exporters to verify processors keep the runtime drivers alive
+/// on their dedicated worker threads. Without this, the deadlock fix could
+/// silently regress for exporters that depend on either driver (e.g. tonic).
+#[cfg(test)]
+pub(crate) async fn exercise_tokio_drivers() {
+    // Timer driver.
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    // IO driver — bind registers an FD with the reactor; immediate drop is fine.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let _ = listener.local_addr().unwrap();
+}


### PR DESCRIPTION
## Summary

- Add `BlockingStrategy` that captures the tokio runtime handle at construction and enters the runtime context via `Handle::enter()` before calling `futures_executor::block_on()` on dedicated background threads
- Update `BatchSpanProcessor`, `BatchLogProcessor`, and `PeriodicReader` to use `BlockingStrategy` instead of bare `futures_executor::block_on()`
- Falls back to plain `futures_executor::block_on()` when no tokio runtime is available

## Problem

The default thread-based processors call `futures_executor::block_on(exporter.export(...))` on their dedicated worker threads. When the exporter uses tonic/gRPC, the export future depends on tokio tasks (e.g. tonic's `Buffer` worker spawned via `tokio::spawn`) that can only be polled by tokio worker threads. If all tokio worker threads are blocked — single-threaded runtime (`current_thread`), or `multi_thread` with 1 worker (common in 1-vCPU k8s pods) — this creates a circular wait: the worker thread waits for the export to complete, but the export can't complete because no tokio thread is available to poll the Buffer worker.

Reproduction and detailed analysis in #3356 (comment): https://github.com/open-telemetry/opentelemetry-rust/pull/3356#issuecomment-3935459655

Minimal repro gist: https://gist.github.com/bryantbiggs/62737e105525fe341090d0ad97de2178

| Scenario | `force_flush()` | `shutdown()` |
|----------|-----------------|--------------|
| `current_thread` | Hangs forever | Returns `Err(Timeout(5s))`, worker thread stays stuck |
| `multi_thread(1)` + `tokio::spawn` | Hangs forever (entire runtime freezes) | Same pattern |
| `multi_thread(default workers)` | Returns immediately | Returns immediately |

## Solution

`BlockingStrategy::new()` is called during processor construction (while inside the tokio runtime context). It calls `Handle::try_current()` to capture the runtime handle. On the dedicated background thread, `blocking_strategy.block_on(future)` enters the runtime context via `Handle::enter()` before calling `futures_executor::block_on()`. This makes tokio types (spawn, timers, IO) available without taking ownership of the reactor — IO continues to be driven by the runtime's own threads.

When no tokio runtime is available (e.g., non-tokio environments), it falls back to plain `futures_executor::block_on()` — preserving existing behavior.

## Scope

This is the scoped-down version of #3356, containing only the bug fix as suggested by @scottgerring in https://github.com/open-telemetry/opentelemetry-rust/pull/3356#issuecomment-3935741213. The experimental async runtime removal is intentionally excluded and can be discussed separately.

Fixes #2802

## Additional shutdown improvements

While responding to @thalesfragoso's review, the mock exporters were strengthened to also exercise the timer and IO drivers (not just `tokio::spawn`), and test coverage expanded to shutdown, `current_thread`, multi-worker, and empty-buffer scenarios. That work uncovered three latent bugs in the shutdown path. Each is addressed in a follow-on commit so the area isn't left in a known-poor state.

The first is that the metric shutdown chain ignored its timeout argument. `SdkMeterProvider::shutdown_with_timeout` and the downstream `Pipelines` / `Pipeline` / `PeriodicReader` chain dropped the caller's value and used a hardcoded 5s wait inside `PeriodicReaderInner::shutdown`, where the `// TODO: Make this timeout configurable.` comment lives. The follow-on commit threads the timeout through each layer.

The second is that `PeriodicReader` detached its worker thread. `PeriodicReader::new` was dropping the `JoinHandle` returned from `thread::Builder::spawn`. The follow-on commit stores the handle and joins it on successful shutdown, matching the pattern already used by `BatchSpanProcessor` and `BatchLogProcessor`. On timeout the handle is left in place because the worker is hung in `block_on(export_future)` and joining would deadlock the caller.

The third is that `BatchSpanProcessor` and `BatchLogProcessor` left a stale `JoinHandle` in `self.handle` on the timeout and disconnected branches of `shutdown_with_timeout`. The follow-on commit takes the handle out on the error arm so subsequent shutdown calls don't see stale state. The underlying worker-thread leak when hung in `block_on` is fundamental and would need cancellation primitives in the export path; a follow-up issue will track that.

## Test plan

- [x] `cargo check -p opentelemetry_sdk --all-features`
- [x] `cargo check -p opentelemetry_sdk --no-default-features`
- [x] `cargo clippy -p opentelemetry_sdk --all-features -- -Dwarnings`
- [x] `cargo test -p opentelemetry_sdk --all-features --lib` — 391 passed, 0 failed, 13 ignored (pre-existing)
- [x] `cargo check -p opentelemetry-otlp --all-features`
