### PR TITLE
chore: Added devcontainer for local development

### DIFF
--- a/.devcontainer/containerfile
+++ b/.devcontainer/containerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/devcontainers/base:debian13
+
+RUN apt-get update && \
+    apt-get install -y protobuf-compiler

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+    "name": "Rust Dev Container",
+    "build": {
+        "dockerfile": "containerfile"
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/rust:1": {
+            "version": "1.93",
+            "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"
+        },
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "moby": false
+        }
+    },
+    "remoteUser": "vscode",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "rust-lang.rust-analyzer"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Changes

Added `devcontainer` for local development.

### Notes

Devcontainer capabilities:
- `docker in docker`, with `moby` disabled (not present in `debian 13`)
- `Rust` `1.93` with `rust-analyzer`, `rust-src`, `rustfmt`, `clippy`, `rust-docs`
- protobuf installed

#### Justification

Use new popular way to develop code with easy and reproducible environment for everyone.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
