### PR TITLE
fix(appender-tracing): add level filter to experimental_span_attributes tests

### DIFF
--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -982,7 +982,8 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::new(&provider);
+        let level_filter = tracing_subscriber::filter::LevelFilter::INFO;
+        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(level_filter);
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1026,7 +1027,8 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::new(&provider);
+        let level_filter = tracing_subscriber::filter::LevelFilter::INFO;
+        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(level_filter);
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1080,7 +1082,8 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::new(&provider);
+        let level_filter = tracing_subscriber::filter::LevelFilter::INFO;
+        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(level_filter);
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1185,7 +1188,8 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::new(&provider);
+        let level_filter = tracing_subscriber::filter::LevelFilter::INFO;
+        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(level_filter);
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 


### PR DESCRIPTION
## Summary

- Add `LevelFilter::INFO` to the 4 `experimental_span_attributes` tests that were missing a level filter, matching the pattern used by all other stable tests in the file
- Without a filter, internal SDK debug logs (`otel_debug!` → `tracing::debug!()` via `--all-features`) could be captured as extra log records, causing intermittent `logs.len() == 2` instead of `1`
- `INFO` is chosen because these tests use `info_span!()` for span creation and `error!()` for assertions — this filters out `DEBUG`/`TRACE`-level internal telemetry while preserving test functionality

## Root Cause

The existing `create_tracing_subscriber()` helper (used by stable tests) applies `LevelFilter::WARN`. The 4 `experimental_span_attributes` tests bypassed this helper and created subscribers with no filter at all. When `--all-features` enables `internal-logs`, `otel_debug!()` macros expand to `tracing::debug!()` — these get captured by the unfiltered subscriber as extra log records.

The SDK's telemetry suppression mechanism (`enter_telemetry_suppressed_scope()`) correctly prevents recursive telemetry during `emit()`, but the extra debug event originates outside the suppression scope (during initialization or background work).

This flaky test is currently blocking CI on #3363 and #3364.

## Test plan

- [x] All 7 `opentelemetry-appender-tracing` tests pass with `--all-features`
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean

Closes #3333