### PR TITLE
fix: add openssl-dev to benchmark container env

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup container environment
         run: |
-          apt-get update && apt-get install --fix-missing -y unzip cmake build-essential pkg-config curl git
+          apt-get update && apt-get install --fix-missing -y unzip cmake build-essential pkg-config curl git libssl-dev
           cargo install cargo-criterion
 
       - name: Make repo safe for Git inside container


### PR DESCRIPTION
Fixes the benchmark suite. At some point we've made it depend on openssl-dev, but haven't added the dep to the container env. 

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
