### PR TITLE
ci: add continuous benchmark tracking dashboard

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,17 +1,18 @@
 # This workflow has two jobs:
 # 1. compareBenchmark: Runs on PRs with the "performance" label, comparing Criterion
 #    benchmark results against the base branch using criterion-compare-action.
-# 2. continuousBenchmark: Runs on pushes to main, storing benchmark results in the
-#    gh-pages branch and publishing a dashboard via github-action-benchmark.
+# 2. continuousBenchmark: Runs daily on main via schedule, storing benchmark results
+#    in the gh-pages branch and publishing a dashboard via github-action-benchmark.
+#    Skips runs where the HEAD commit has already been benchmarked.
 #
 # The PR job runs on shared GitHub runners to save resources.
 # The continuous job runs on a self-hosted bare-metal runner for consistent, accurate results.
 on:
   pull_request:
     types: [labeled, synchronize]
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '0 6 * * *' # daily at 06:00 UTC
+  workflow_dispatch:
 name: benchmark
 permissions:
   contents: read
@@ -57,11 +58,11 @@ jobs:
           branchName: ${{ env.BRANCH_NAME }}
 
   # ---------------------------------------------------------------------------
-  # Continuous benchmark tracking (push to main only)
+  # Continuous benchmark tracking (daily schedule)
   # ---------------------------------------------------------------------------
   continuousBenchmark:
     name: continuous benchmark tracking
-    if: github.event_name == 'push'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     # Use bare-metal runner on the upstream repo for consistent results; fall back to shared runners elsewhere
     runs-on: ${{ github.repository == 'open-telemetry/opentelemetry-rust' && 'oracle-bare-metal-64cpu-512gb-x86-64' || 'ubuntu-latest' }}
     permissions:
@@ -85,14 +86,29 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Check if commit already benchmarked
+        id: check_duplicate
+        run: |
+          # Fetch the benchmark data file from gh-pages and see if this commit is already recorded
+          DATA_URL="https://raw.githubusercontent.com/${{ github.repository }}/gh-pages/dev/bench/data.js"
+          if curl -sf "$DATA_URL" | grep -q "${{ github.sha }}"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Commit ${{ github.sha }} already benchmarked, skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        if: steps.check_duplicate.outputs.skip != 'true'
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run benchmarks
+        if: steps.check_duplicate.outputs.skip != 'true'
         run: cargo bench --workspace --all-features -- --output-format bencher | tee output.txt
 
       - name: Store benchmark result
+        if: steps.check_duplicate.outputs.skip != 'true'
         uses: benchmark-action/github-action-benchmark@a7bc2366eda11037936ea57d811a43b3418d3073 # v1.21.0
         with:
           tool: 'cargo'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -323,8 +323,8 @@ projects in this workspace.
 - Run `cargo bench` - this will run benchmarks to show performance
 regressions
 
-Benchmarks are run automatically on every push to `main` and results are
-tracked over time. The continuous benchmark dashboard is published at
+Benchmarks are run daily against `main` and results are tracked over time.
+The continuous benchmark dashboard is published at
 <https://open-telemetry.github.io/opentelemetry-rust/dev/bench/>.
 PRs with the `performance` label will also get a benchmark comparison
 comment showing any regressions or improvements.


### PR DESCRIPTION
## Summary

- Adds a `continuousBenchmark` job that runs on every push to `main`, storing Criterion results via `github-action-benchmark` and publishing a dashboard to GitHub Pages. This follows the pattern used in [otel-collector-contrib](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/) and [otel-arrow](https://open-telemetry.github.io/otel-arrow/benchmarks/continuous/) 
- Manually add `libssl-dev` (#3401 is needed to fix benchmarks anyway) 
- Mentions the benchmark dashboard in CONTRIBUTING.md

Dashboard will be at: https://open-telemetry.github.io/opentelemetry-rust/dev/bench/

Requires enabling GitHub Pages on the `gh-pages` branch (the action creates the branch automatically on first run). We'll need to chat with someone in opentelemetry-community to validate this is well and good and do the repo modifications. I will chase this up once we are happy before we merge.

  ## Testing

   - Sample dashboard (on fork): https://scottgerring.github.io/opentelemetry-rust/dev/bench/ - FYI I've only run this multiple times for a small subset of benchmarks - the rest need another run to show deltas 
   - Sample PR showing `performance` label still triggers comparison job:
   https://github.com/scottgerring/opentelemetry-rust/pull/1