### PR TITLE
fix: `service.name` fallback

### DIFF
--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -482,9 +482,9 @@ mod tests {
                 .get(&Key::from_static_str(SERVICE_NAME))
                 .map(|v| v.to_string())
                 .unwrap();
-            assert!(
-                service_name.starts_with("unknown_service:opentelemetry_sdk-"),
-                "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
+            assert_eq!(
+                service_name, "unknown_service",
+                "Expected service name to be 'unknown_service', got: {}",
                 service_name
             );
             assert_telemetry_resource(&processor_with_resource, &exporter_with_resource);
@@ -525,9 +525,9 @@ mod tests {
                     .get(&Key::from_static_str(SERVICE_NAME))
                     .map(|v| v.to_string())
                     .unwrap();
-                assert!(
-                    service_name.starts_with("unknown_service:opentelemetry_sdk-"),
-                    "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
+                assert_eq!(
+                    service_name, "unknown_service",
+                    "Expected service name to be 'unknown_service', got: {}",
                     service_name
                 );
                 assert_resource(
@@ -571,9 +571,9 @@ mod tests {
                     .get(&Key::from_static_str(SERVICE_NAME))
                     .map(|v| v.to_string())
                     .unwrap();
-                assert!(
-                    service_name.starts_with("unknown_service:opentelemetry_sdk-"),
-                    "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
+                assert_eq!(
+                    service_name, "unknown_service",
+                    "Expected service name to be 'unknown_service', got: {}",
                     service_name
                 );
                 assert_resource(

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -466,9 +466,9 @@ mod tests {
                 .get(&Key::from_static_str(SERVICE_NAME))
                 .map(|v| v.to_string())
                 .unwrap();
-            assert!(
-                service_name.starts_with("unknown_service:opentelemetry_sdk-"),
-                "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
+            assert_eq!(
+                service_name, "unknown_service",
+                "Expected service name to be 'unknown_service', got: {}",
                 service_name
             );
             assert_telemetry_resource(&default_meter_provider);
@@ -501,9 +501,9 @@ mod tests {
                     .get(&Key::from_static_str(SERVICE_NAME))
                     .map(|v| v.to_string())
                     .unwrap();
-                assert!(
-                    service_name.starts_with("unknown_service:opentelemetry_sdk-"),
-                    "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
+                assert_eq!(
+                    service_name, "unknown_service",
+                    "Expected service name to be 'unknown_service', got: {}",
                     service_name
                 );
                 assert_resource(&env_resource_provider, "key1", Some("value1"));
@@ -535,9 +535,9 @@ mod tests {
                     .get(&Key::from_static_str(SERVICE_NAME))
                     .map(|v| v.to_string())
                     .unwrap();
-                assert!(
-                    service_name.starts_with("unknown_service:opentelemetry_sdk-"),
-                    "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
+                assert_eq!(
+                    service_name, "unknown_service",
+                    "Expected service name to be 'unknown_service', got: {}",
                     service_name
                 );
                 assert_resource(

--- a/opentelemetry-sdk/src/resource/attributes.rs
+++ b/opentelemetry-sdk/src/resource/attributes.rs
@@ -7,6 +7,12 @@
 /// - `shoppingcart`
 pub(crate) const SERVICE_NAME: &str = "service.name";
 
+/// The name of the process executable.
+///
+/// On Linux based systems, can be set to the `Name` in `proc/[pid]/status`.
+/// On Windows, can be set to the base name of `GetProcessImageFileNameW`.
+pub(crate) const PROCESS_EXECUTABLE_NAME: &str = "process.executable.name";
+
 /// The language of the telemetry SDK.
 pub(crate) const TELEMETRY_SDK_LANGUAGE: &str = "telemetry.sdk.language";
 

--- a/opentelemetry-sdk/src/resource/env.rs
+++ b/opentelemetry-sdk/src/resource/env.rs
@@ -74,33 +74,26 @@ pub struct SdkProvidedResourceDetector;
 
 impl ResourceDetector for SdkProvidedResourceDetector {
     fn detect(&self) -> Resource {
-        Resource::builder_empty()
-            .with_attributes([KeyValue::new(
-                super::SERVICE_NAME,
-                env::var(OTEL_SERVICE_NAME)
-                    .ok()
-                    .filter(|s| !s.is_empty())
-                    .map(Value::from)
-                    .or_else(|| {
-                        EnvResourceDetector::new()
-                            .detect()
-                            .get(&Key::new(super::SERVICE_NAME))
-                    })
-                    .unwrap_or_else(|| {
-                        // Fallback to unknown_service:<process.executable.name> per spec
-                        // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#sdk-provided-resource-attributes
-                        env::current_exe()
-                            .ok()
-                            .and_then(|path| {
-                                path.file_name()
-                                    .and_then(|name| name.to_str())
-                                    .map(|name| format!("unknown_service:{}", name))
-                            })
-                            .unwrap_or_else(|| "unknown_service".to_string())
-                            .into()
-                    }),
-            )])
-            .build()
+        // Check OTEL_SERVICE_NAME first, then service.name in OTEL_RESOURCE_ATTRIBUTES.
+        // If neither is set, service.name is left unset here. The fallback to
+        // unknown_service / unknown_service:<process.executable.name> is handled
+        // by ResourceBuilder::build().
+        let service_name = env::var(OTEL_SERVICE_NAME)
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(Value::from)
+            .or_else(|| {
+                EnvResourceDetector::new()
+                    .detect()
+                    .get(&Key::new(super::SERVICE_NAME))
+            });
+
+        match service_name {
+            Some(name) => Resource::builder_empty()
+                .with_attributes([KeyValue::new(super::SERVICE_NAME, name)])
+                .build(),
+            None => Resource::empty(),
+        }
     }
 }
 
@@ -147,18 +140,14 @@ mod tests {
 
     #[test]
     fn test_sdk_provided_resource_detector() {
-        // Ensure no env var set - should fallback to unknown_service:<executable_name>
-        // For cargo tests, the executable name is typically <crate_name>-<hash>
+        // When no env var is set, the detector should not set service.name at all.
+        // The fallback is handled by ResourceBuilder::build().
         let no_env = SdkProvidedResourceDetector.detect();
-        let service_name = no_env
-            .get(&Key::from_static_str(crate::resource::SERVICE_NAME))
-            .map(|v| v.to_string())
-            .unwrap();
-
         assert!(
-            service_name.starts_with("unknown_service:opentelemetry_sdk-"),
-            "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
-            service_name
+            no_env
+                .get(&Key::from_static_str(crate::resource::SERVICE_NAME))
+                .is_none(),
+            "Expected service.name to be absent when no env var is set"
         );
 
         temp_env::with_var(OTEL_SERVICE_NAME, Some("test service"), || {

--- a/opentelemetry-sdk/src/resource/mod.rs
+++ b/opentelemetry-sdk/src/resource/mod.rs
@@ -66,6 +66,7 @@ impl Resource {
                 Box::new(TelemetryResourceDetector),
                 Box::new(EnvResourceDetector::new()),
             ]),
+            apply_service_name_fallback: true,
         }
     }
 
@@ -75,6 +76,7 @@ impl Resource {
     pub fn builder_empty() -> ResourceBuilder {
         ResourceBuilder {
             resource: Resource::empty(),
+            apply_service_name_fallback: false,
         }
     }
 
@@ -274,6 +276,11 @@ pub trait ResourceDetector {
 #[derive(Debug)]
 pub struct ResourceBuilder {
     resource: Resource,
+    /// When true, `build()` will resolve the `service.name` fallback per the
+    /// OpenTelemetry spec: if `service.name` is still `"unknown_service"` and
+    /// `process.executable.name` is available, set it to
+    /// `"unknown_service:<process.executable.name>"`.
+    apply_service_name_fallback: bool,
 }
 
 impl ResourceBuilder {
@@ -324,7 +331,26 @@ impl ResourceBuilder {
     }
 
     /// Create a [Resource] with the options provided to the [ResourceBuilder].
-    pub fn build(self) -> Resource {
+    ///
+    /// Per the [OpenTelemetry spec], if `service.name` was not explicitly set,
+    /// the SDK falls back to `unknown_service:` concatenated with
+    /// `process.executable.name`. If `process.executable.name` is not available,
+    /// it remains `unknown_service`.
+    ///
+    /// [OpenTelemetry spec]: https://opentelemetry.io/docs/specs/semconv/resource/service/
+    pub fn build(mut self) -> Resource {
+        if self.apply_service_name_fallback {
+            let service_name_key = Key::new(SERVICE_NAME);
+            if self.resource.get_ref(&service_name_key).is_none() {
+                let fallback = self
+                    .resource
+                    .get_ref(&Key::new(PROCESS_EXECUTABLE_NAME))
+                    .map(|name| format!("unknown_service:{}", name.as_str()))
+                    .unwrap_or_else(|| "unknown_service".to_string());
+                let inner = Arc::make_mut(&mut self.resource.inner);
+                inner.attrs.insert(service_name_key, Value::from(fallback));
+            }
+        }
         self.resource
     }
 }
@@ -495,10 +521,12 @@ mod tests {
         let base_builder = if let Some(url) = schema_url_a {
             ResourceBuilder {
                 resource: Resource::from_schema_url(vec![KeyValue::new("key", "")], url),
+                apply_service_name_fallback: false,
             }
         } else {
             ResourceBuilder {
                 resource: Resource::empty(),
+                apply_service_name_fallback: false,
             }
         };
 
@@ -551,6 +579,53 @@ mod tests {
                         ])
                         .build()
                 )
+            },
+        )
+    }
+
+    #[test]
+    fn service_name_fallback_with_process_executable_name() {
+        temp_env::with_vars(
+            [
+                ("OTEL_SERVICE_NAME", None::<&str>),
+                ("OTEL_RESOURCE_ATTRIBUTES", None::<&str>),
+            ],
+            || {
+                // When process.executable.name is set, service.name should become
+                // unknown_service:<process.executable.name>
+                let resource = Resource::builder()
+                    .with_attribute(KeyValue::new(PROCESS_EXECUTABLE_NAME, "myapp"))
+                    .build();
+                assert_eq!(
+                    resource.get(&Key::new(SERVICE_NAME)),
+                    Some(Value::from("unknown_service:myapp")),
+                );
+
+                // When process.executable.name is NOT set, service.name stays unknown_service
+                let resource = Resource::builder().build();
+                assert_eq!(
+                    resource.get(&Key::new(SERVICE_NAME)),
+                    Some(Value::from("unknown_service")),
+                );
+
+                // When service.name is explicitly set, process.executable.name doesn't affect it
+                let resource = Resource::builder()
+                    .with_attribute(KeyValue::new(PROCESS_EXECUTABLE_NAME, "myapp"))
+                    .with_service_name("my-service")
+                    .build();
+                assert_eq!(
+                    resource.get(&Key::new(SERVICE_NAME)),
+                    Some(Value::from("my-service")),
+                );
+
+                // builder_empty() should NOT apply the fallback
+                let resource = Resource::builder_empty()
+                    .with_attribute(KeyValue::new(PROCESS_EXECUTABLE_NAME, "myapp"))
+                    .build();
+                assert!(
+                    resource.get(&Key::new(SERVICE_NAME)).is_none(),
+                    "builder_empty() should not add service.name automatically"
+                );
             },
         )
     }

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -629,9 +629,9 @@ mod tests {
                 .get(&Key::from_static_str(SERVICE_NAME))
                 .map(|v| v.to_string())
                 .unwrap();
-            assert!(
-                service_name.starts_with("unknown_service:opentelemetry_sdk-"),
-                "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
+            assert_eq!(
+                service_name, "unknown_service",
+                "Expected service name to be 'unknown_service', got: {}",
                 service_name
             );
             assert_telemetry_resource(&default_config_provider);
@@ -660,9 +660,9 @@ mod tests {
                     .get(&Key::from_static_str(SERVICE_NAME))
                     .map(|v| v.to_string())
                     .unwrap();
-                assert!(
-                    service_name.starts_with("unknown_service:opentelemetry_sdk-"),
-                    "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
+                assert_eq!(
+                    service_name, "unknown_service",
+                    "Expected service name to be 'unknown_service', got: {}",
                     service_name
                 );
                 assert_resource(&env_resource_provider, "key1", Some("value1"));
@@ -693,9 +693,9 @@ mod tests {
                     .get(&Key::from_static_str(SERVICE_NAME))
                     .map(|v| v.to_string())
                     .unwrap();
-                assert!(
-                    service_name.starts_with("unknown_service:opentelemetry_sdk-"),
-                    "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
+                assert_eq!(
+                    service_name, "unknown_service",
+                    "Expected service name to be 'unknown_service', got: {}",
                     service_name
                 );
                 assert_resource(


### PR DESCRIPTION
## Changes

The fallback introduced in #3302 doesn't work properly as the fallback didn't
read from `process.executable.name` as indicated in the [spec](https://opentelemetry.io/docs/specs/semconv/resource/service/#service).

We now read from the resource when it exists, we also do the fallback when building the Resource so that any possible override is done before falling back

I added a flag so that `builder_empty` still returns a properly empty resource but I'm happy to discuss other options.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
        ^ Doesn't need updating because the current changelog item is correct.
* [ ] Changes in public API reviewed (if applicable)
