### PR TITLE
test: Add unit test in BatchLogProcessor to verify export get called after force_flush()

### DIFF
--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -860,7 +860,7 @@ mod tests {
             .build();
         processor.emit(&mut SdkLogRecord::new(), &scope);
         processor.force_flush().unwrap();
-        assert_eq!(exporter.export_called.load(Ordering::SeqCst), true);
+        assert!(exporter.export_called.load(Ordering::SeqCst));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2345 

## Changes

This PR adds a unit test for the BatchLogProcessor to verify that calling force_flush() on the processor triggers an export of the pending log records.

## Merge requirement checklist 

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
