### PR TITLE
docs: improve with_resource() guidance to preserve SDK defaults

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -730,10 +730,12 @@ Follow these guidelines when deciding where to attach metric attributes:
 
     ```rust
     // Example: Setting resource-level attributes
-    let resource = Resource::new(vec![
-        KeyValue::new("service.name", "payment-processor"),
-        KeyValue::new("deployment.environment", "production"),
-    ]);
+    // Use Resource::builder() to preserve SDK-provided defaults
+    // (telemetry.sdk.*, service.name).
+    let resource = Resource::builder()
+        .with_service_name("payment-processor")
+        .with_attributes([KeyValue::new("deployment.environment.name", "production")])
+        .build();
     ```
 
   * **Meter-level attributes**: If the dimension applies only to a subset of

--- a/opentelemetry-sdk/src/logs/log_processor_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/logs/log_processor_with_async_runtime.rs
@@ -775,13 +775,17 @@ mod tests {
             BatchLogProcessor::new(exporter.clone(), BatchConfig::default(), runtime::Tokio);
         let provider = SdkLoggerProvider::builder()
             .with_log_processor(processor)
-            .with_resource(Resource::new(vec![
-                KeyValue::new("k1", "v1"),
-                KeyValue::new("k2", "v3"),
-                KeyValue::new("k3", "v3"),
-                KeyValue::new("k4", "v4"),
-                KeyValue::new("k5", "v5"),
-            ]))
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![
+                        KeyValue::new("k1", "v1"),
+                        KeyValue::new("k2", "v3"),
+                        KeyValue::new("k3", "v3"),
+                        KeyValue::new("k4", "v4"),
+                        KeyValue::new("k5", "v5"),
+                    ])
+                    .build(),
+            )
             .build();
         provider.force_flush().unwrap();
         assert_eq!(exporter.get_resource().unwrap().into_iter().count(), 5);

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -246,10 +246,38 @@ impl LoggerProviderBuilder {
         LoggerProviderBuilder { processors, ..self }
     }
 
-    /// The `Resource` to be associated with this Provider.
+    /// Associates a [Resource] with a [SdkLoggerProvider].
+    ///
+    /// This [Resource] represents the entity producing telemetry and is associated
+    /// with all `Logger`s the [SdkLoggerProvider] will create.
+    ///
+    /// By default, if this option is not used, the default [Resource] will be used.
+    ///
+    /// When constructing a [Resource], use [`Resource::builder()`] to preserve
+    /// SDK-provided defaults such as `telemetry.sdk.*` and `service.name`.
+    /// Using [`Resource::builder_empty()`] will **not** include these attributes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use opentelemetry_sdk::{Resource, logs::SdkLoggerProvider};
+    /// use opentelemetry::KeyValue;
+    ///
+    /// let provider = SdkLoggerProvider::builder()
+    ///     .with_resource(
+    ///         Resource::builder()
+    ///             .with_service_name("my-service")
+    ///             .with_attributes([KeyValue::new("deployment.environment.name", "production")])
+    ///             .build(),
+    ///     )
+    ///     .build();
+    /// ```
     ///
     /// *Note*: Calls to this method are additive, each call merges the provided
     /// resource with the previous one.
+    ///
+    /// [`Resource::builder()`]: Resource::builder
+    /// [`Resource::builder_empty()`]: Resource::builder_empty
     pub fn with_resource(self, resource: Resource) -> Self {
         let resource = match self.resource {
             Some(existing) => Some(existing.merge(&resource)),
@@ -876,14 +904,26 @@ mod tests {
     #[test]
     fn with_resource_multiple_calls_ensure_additive() {
         let builder = SdkLoggerProvider::builder()
-            .with_resource(Resource::new(vec![KeyValue::new("key1", "value1")]))
-            .with_resource(Resource::new(vec![KeyValue::new("key2", "value2")]))
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![KeyValue::new("key1", "value1")])
+                    .build(),
+            )
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![KeyValue::new("key2", "value2")])
+                    .build(),
+            )
             .with_resource(
                 Resource::builder_empty()
                     .with_schema_url(vec![], "http://example.com")
                     .build(),
             )
-            .with_resource(Resource::new(vec![KeyValue::new("key3", "value3")]));
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![KeyValue::new("key3", "value3")])
+                    .build(),
+            );
 
         let resource = builder.resource.unwrap();
 

--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -243,10 +243,32 @@ impl MeterProviderBuilder {
     ///
     /// By default, if this option is not used, the default [Resource] will be used.
     ///
+    /// When constructing a [Resource], use [`Resource::builder()`] to preserve
+    /// SDK-provided defaults such as `telemetry.sdk.*` and `service.name`.
+    /// Using [`Resource::builder_empty()`] will **not** include these attributes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
+    /// use opentelemetry::KeyValue;
+    ///
+    /// let provider = SdkMeterProvider::builder()
+    ///     .with_resource(
+    ///         Resource::builder()
+    ///             .with_service_name("my-service")
+    ///             .with_attributes([KeyValue::new("deployment.environment.name", "production")])
+    ///             .build(),
+    ///     )
+    ///     .build();
+    /// ```
+    ///
     /// *Note*: Calls to this method are additive, each call merges the provided
     /// resource with the previous one.
     ///
     /// [Meter]: opentelemetry::metrics::Meter
+    /// [`Resource::builder()`]: Resource::builder
+    /// [`Resource::builder_empty()`]: Resource::builder_empty
     pub fn with_resource(mut self, resource: Resource) -> Self {
         self.resource = match self.resource {
             Some(existing) => Some(existing.merge(&resource)),
@@ -719,14 +741,26 @@ mod tests {
     #[test]
     fn with_resource_multiple_calls_ensure_additive() {
         let builder = SdkMeterProvider::builder()
-            .with_resource(Resource::new(vec![KeyValue::new("key1", "value1")]))
-            .with_resource(Resource::new(vec![KeyValue::new("key2", "value2")]))
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![KeyValue::new("key1", "value1")])
+                    .build(),
+            )
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![KeyValue::new("key2", "value2")])
+                    .build(),
+            )
             .with_resource(
                 Resource::builder_empty()
                     .with_schema_url(vec![], "http://example.com")
                     .build(),
             )
-            .with_resource(Resource::new(vec![KeyValue::new("key3", "value3")]));
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![KeyValue::new("key3", "value3")])
+                    .build(),
+            );
 
         let resource = builder.resource.unwrap();
 

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -426,10 +426,32 @@ impl TracerProviderBuilder {
     ///
     /// By default, if this option is not used, the default [Resource] will be used.
     ///
+    /// When constructing a [Resource], use [`Resource::builder()`] to preserve
+    /// SDK-provided defaults such as `telemetry.sdk.*` and `service.name`.
+    /// Using [`Resource::builder_empty()`] will **not** include these attributes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use opentelemetry_sdk::{Resource, trace::SdkTracerProvider};
+    /// use opentelemetry::KeyValue;
+    ///
+    /// let provider = SdkTracerProvider::builder()
+    ///     .with_resource(
+    ///         Resource::builder()
+    ///             .with_service_name("my-service")
+    ///             .with_attributes([KeyValue::new("deployment.environment.name", "production")])
+    ///             .build(),
+    ///     )
+    ///     .build();
+    /// ```
+    ///
     /// *Note*: Calls to this method are additive, each call merges the provided
     /// resource with the previous one.
     ///
     /// [Tracer]: opentelemetry::trace::Tracer
+    /// [`Resource::builder()`]: Resource::builder
+    /// [`Resource::builder_empty()`]: Resource::builder_empty
     pub fn with_resource(self, resource: Resource) -> Self {
         let resource = match self.resource {
             Some(existing) => Some(existing.merge(&resource)),
@@ -778,14 +800,26 @@ mod tests {
     #[test]
     fn with_resource_multiple_calls_ensure_additive() {
         let resource = SdkTracerProvider::builder()
-            .with_resource(Resource::new(vec![KeyValue::new("key1", "value1")]))
-            .with_resource(Resource::new(vec![KeyValue::new("key2", "value2")]))
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![KeyValue::new("key1", "value1")])
+                    .build(),
+            )
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![KeyValue::new("key2", "value2")])
+                    .build(),
+            )
             .with_resource(
                 Resource::builder_empty()
                     .with_schema_url(vec![], "http://example.com")
                     .build(),
             )
-            .with_resource(Resource::new(vec![KeyValue::new("key3", "value3")]))
+            .with_resource(
+                Resource::builder_empty()
+                    .with_attributes(vec![KeyValue::new("key3", "value3")])
+                    .build(),
+            )
             .build()
             .inner
             .config

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -1457,7 +1457,9 @@ mod tests {
         let mut processor = BatchSpanProcessor::new(exporter, config);
 
         // Set a resource for the processor
-        let resource = Resource::new(vec![KeyValue::new("service.name", "test_service")]);
+        let resource = Resource::builder_empty()
+            .with_attributes(vec![KeyValue::new("service.name", "test_service")])
+            .build();
         processor.set_resource(&resource);
 
         // Create a span and send it to the processor


### PR DESCRIPTION
## Summary

- Updated `with_resource()` doc comments on `LoggerProviderBuilder`, `TracerProviderBuilder`, and `MeterProviderBuilder` to explain that `Resource::builder()` preserves SDK-provided defaults (`telemetry.sdk.*`, `service.name`) while `Resource::builder_empty()` does not.
- Added inline code examples to each `with_resource()` method showing the recommended usage pattern.
- Updated `docs/metrics.md` resource example from `Resource::new(...)` to the builder pattern.
- Updated internal tests to use `Resource::builder_empty().with_attributes(...)` instead of `Resource::new(...)` for consistency.

Fixes #1940