### PR TITLE
refactor(metrics): replace swap-and-drain delta collection with in-place iteration

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## vNext
 
-- Refactored delta metrics collection to use in-place iteration instead of
-  swap-and-drain. Entries are now tracked via a `has_been_updated` flag and only
-  exported when updated since the last collection cycle. Stale unbound entries are
-  evicted under a write lock with TOCTOU re-check. This eliminates O(n) write-lock
-  acquisitions on the hot path per collection cycle in steady state.
+- Delta metrics collection now uses in-place eviction instead of draining the
+  HashMap on every collect cycle. Stale attribute sets that received no measurements
+  since the last collection are evicted. Note: recovery from cardinality overflow
+  now requires 2 collect cycles — the first marks entries as stale, the second
+  evicts them.
 - **Breaking** The SDK `testing` feature is now runtime agnostic. [#3407][3407]
   - `TokioSpanExporter` and `new_tokio_test_exporter` have been renamed to `TestSpanExporter` and `new_test_exporter`.
   - The following transitive dependencies and features have been removed: `tokio/rt`, `tokio/time`, `tokio/macros`, `tokio/rt-multi-thread`, `tokio-stream`, `experimental_async_runtime`

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+- Refactored delta metrics collection to use in-place iteration instead of
+  swap-and-drain. Entries are now tracked via a `has_been_updated` flag and only
+  exported when updated since the last collection cycle. Stale unbound entries are
+  evicted under a write lock with TOCTOU re-check. This eliminates O(n) write-lock
+  acquisitions on the hot path per collection cycle in steady state.
 - **Breaking** The SDK `testing` feature is now runtime agnostic. [#3407][3407]
   - `TokioSpanExporter` and `new_tokio_test_exporter` have been renamed to `TestSpanExporter` and `new_test_exporter`.
   - The following transitive dependencies and features have been removed: `tokio/rt`, `tokio/time`, `tokio/macros`, `tokio/rt-multi-thread`, `tokio-stream`, `experimental_async_runtime`

--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -412,9 +412,11 @@ impl<T: Number> ExpoHistogram<T> {
         h.start_time = time.start;
         h.time = time.current;
 
+        let config = *self.value_map.config();
         self.value_map
             .collect_and_reset(&mut h.data_points, |attributes, attr| {
-                let b = attr.into_inner().unwrap_or_else(|err| err.into_inner());
+                let reset = attr.clone_and_reset(&config);
+                let b = reset.into_inner().unwrap_or_else(|err| err.into_inner());
                 data::ExponentialHistogramDataPoint {
                     attributes,
                     count: b.count,
@@ -721,7 +723,7 @@ mod tests {
             for v in test.values {
                 Measure::call(&h, v, &[]);
             }
-            let dp = h.value_map.no_attribute_tracker.lock().unwrap();
+            let dp = h.value_map.no_attribute_tracker.aggregator.lock().unwrap();
 
             assert_eq!(test.expected.max, dp.max);
             assert_eq!(test.expected.min, dp.min);
@@ -778,7 +780,7 @@ mod tests {
             for v in test.values {
                 Measure::call(&h, v, &[]);
             }
-            let dp = h.value_map.no_attribute_tracker.lock().unwrap();
+            let dp = h.value_map.no_attribute_tracker.aggregator.lock().unwrap();
 
             assert_eq!(test.expected.max, dp.max);
             assert_eq!(test.expected.min, dp.min);

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -7,12 +7,8 @@ use crate::metrics::data::{AggregatedMetrics, HistogramDataPoint};
 use crate::metrics::Temporality;
 use opentelemetry::KeyValue;
 
-use super::aggregate::AggregateTimeInitiator;
-use super::aggregate::AttributeSetFilter;
-use super::ComputeAggregation;
-use super::Measure;
-use super::ValueMap;
-use super::{Aggregator, Number};
+use super::{Aggregator, ComputeAggregation, Measure, Number, ValueMap};
+use super::aggregate::{AggregateTimeInitiator, AttributeSetFilter};
 
 impl<T> Aggregator for Mutex<Buckets<T>>
 where
@@ -133,9 +129,11 @@ impl<T: Number> Histogram<T> {
         h.start_time = time.start;
         h.time = time.current;
 
+        let buckets_count = *self.value_map.config();
         self.value_map
             .collect_and_reset(&mut h.data_points, |attributes, aggr| {
-                let b = aggr.into_inner().unwrap_or_else(|err| err.into_inner());
+                let reset = aggr.clone_and_reset(&buckets_count);
+                let b = reset.into_inner().unwrap_or_else(|err| err.into_inner());
                 HistogramDataPoint {
                     attributes,
                     count: b.count,

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -7,8 +7,8 @@ use crate::metrics::data::{AggregatedMetrics, HistogramDataPoint};
 use crate::metrics::Temporality;
 use opentelemetry::KeyValue;
 
-use super::{Aggregator, ComputeAggregation, Measure, Number, ValueMap};
 use super::aggregate::{AggregateTimeInitiator, AttributeSetFilter};
+use super::{Aggregator, ComputeAggregation, Measure, Number, ValueMap};
 
 impl<T> Aggregator for Mutex<Buckets<T>>
 where

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -89,7 +89,7 @@ impl<T: Number> LastValue<T> {
         self.value_map
             .collect_and_reset(&mut s_data.data_points, |attributes, aggr| GaugeDataPoint {
                 attributes,
-                value: aggr.value.get_value(),
+                value: aggr.value.get_and_reset_value(),
                 exemplars: vec![],
             });
 

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -51,19 +51,14 @@ pub(crate) trait Aggregator {
     fn clone_and_reset(&self, init: &Self::InitConfig) -> Self;
 }
 
-/// Wraps an aggregator with status tracking for delta collection and bound instruments.
+/// Wraps an aggregator with status tracking for delta collection.
 ///
 /// `has_been_updated` tracks whether the aggregator received measurements since the last
 /// collection cycle. This enables in-place delta collection: only updated entries are exported,
-/// and stale unbound entries are evicted to prevent unbounded memory growth.
-///
-/// `bound_count` tracks how many bound instrument handles reference this entry. Entries with
-/// bound_count > 0 are never evicted from the map, even if they had no updates in a cycle
-/// (they simply produce no export). This ensures bound handles always point to a live tracker.
+/// and stale entries are evicted to prevent unbounded memory growth.
 pub(crate) struct TrackerEntry<A: Aggregator> {
     pub(crate) aggregator: A,
     pub(crate) has_been_updated: AtomicBool,
-    pub(crate) bound_count: AtomicUsize,
 }
 
 impl<A: Aggregator> TrackerEntry<A> {
@@ -71,7 +66,6 @@ impl<A: Aggregator> TrackerEntry<A> {
         TrackerEntry {
             aggregator: A::create(config),
             has_been_updated: AtomicBool::new(false),
-            bound_count: AtomicUsize::new(0),
         }
     }
 }
@@ -220,9 +214,7 @@ where
 
     /// Iterate through all attribute sets in-place, populate `DataPoints` and reset.
     /// Only entries updated since the last collection (tracked via `has_been_updated`)
-    /// are exported. Stale unbound entries are evicted to prevent unbounded memory growth.
-    /// Bound entries (bound_count > 0) are never evicted — they persist until explicitly
-    /// unbound, but produce no export when they have no updates.
+    /// are exported. Stale entries are evicted to prevent unbounded memory growth.
     ///
     /// Used for synchronous instruments (Counter, Histogram, etc.) in Delta temporality mode.
     pub(crate) fn collect_and_reset<Res, MapFn>(&self, dest: &mut Vec<Res>, mut map_fn: MapFn)
@@ -252,10 +244,8 @@ where
                 if seen.insert(Arc::as_ptr(tracker)) {
                     if tracker.has_been_updated.swap(false, Ordering::Relaxed) {
                         dest.push(map_fn(attrs.clone(), &tracker.aggregator));
-                    } else if attrs.as_slice() != overflow_attrs.as_slice()
-                        && tracker.bound_count.load(Ordering::Relaxed) == 0
-                    {
-                        // Stale and not bound — candidate for eviction
+                    } else if attrs.as_slice() != overflow_attrs.as_slice() {
+                        // Stale — candidate for eviction
                         stale_entries.push(Arc::clone(tracker));
                     }
                 }

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -86,8 +86,6 @@ where
 
     /// Number of different attribute set stored in the `trackers` map.
     count: AtomicUsize,
-    /// Indicates whether a value with no attributes has been stored.
-    has_no_attribute_value: AtomicBool,
     /// Tracker for values with no attributes attached.
     no_attribute_tracker: TrackerEntry<A>,
     /// Configuration for an Aggregator
@@ -108,7 +106,6 @@ where
             trackers: RwLock::new(HashMap::with_capacity(
                 1 + min(DEFAULT_CARDINALITY_LIMIT, cardinality_limit),
             )),
-            has_no_attribute_value: AtomicBool::new(false),
             no_attribute_tracker: TrackerEntry::new(&config),
             count: AtomicUsize::new(0),
             config,
@@ -126,8 +123,7 @@ where
             self.no_attribute_tracker.aggregator.update(value);
             self.no_attribute_tracker
                 .has_been_updated
-                .store(true, Ordering::Relaxed);
-            self.has_no_attribute_value.store(true, Ordering::Release);
+                .store(true, Ordering::Release);
             return;
         }
 
@@ -196,7 +192,11 @@ where
         MapFn: FnMut(Vec<KeyValue>, &A) -> Res,
     {
         prepare_data(dest, self.count.load(Ordering::SeqCst));
-        if self.has_no_attribute_value.load(Ordering::Acquire) {
+        if self
+            .no_attribute_tracker
+            .has_been_updated
+            .load(Ordering::Acquire)
+        {
             dest.push(map_fn(vec![], &self.no_attribute_tracker.aggregator));
         }
 
@@ -222,11 +222,10 @@ where
         MapFn: FnMut(Vec<KeyValue>, &A) -> Res,
     {
         prepare_data(dest, self.count.load(Ordering::SeqCst));
-        if self.has_no_attribute_value.load(Ordering::Acquire)
-            && self
-                .no_attribute_tracker
-                .has_been_updated
-                .swap(false, Ordering::AcqRel)
+        if self
+            .no_attribute_tracker
+            .has_been_updated
+            .swap(false, Ordering::AcqRel)
         {
             dest.push(map_fn(vec![], &self.no_attribute_tracker.aggregator));
         }
@@ -278,7 +277,11 @@ where
         MapFn: FnMut(Vec<KeyValue>, A) -> Res,
     {
         prepare_data(dest, self.count.load(Ordering::SeqCst));
-        if self.has_no_attribute_value.swap(false, Ordering::AcqRel) {
+        if self
+            .no_attribute_tracker
+            .has_been_updated
+            .swap(false, Ordering::AcqRel)
+        {
             dest.push(map_fn(
                 vec![],
                 self.no_attribute_tracker

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -10,8 +10,7 @@ use core::fmt;
 use portable_atomic::{AtomicI64, AtomicU64};
 use std::cmp::min;
 use std::collections::{HashMap, HashSet};
-use std::mem::swap;
-use std::ops::{Add, AddAssign, DerefMut, Sub};
+use std::ops::{Add, AddAssign, Sub};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 #[cfg(target_has_atomic = "64")]
 use std::sync::atomic::{AtomicI64, AtomicU64};
@@ -52,6 +51,34 @@ pub(crate) trait Aggregator {
     fn clone_and_reset(&self, init: &Self::InitConfig) -> Self;
 }
 
+/// Wraps an aggregator with status tracking for delta collection and bound instruments.
+///
+/// `has_been_updated` tracks whether the aggregator received measurements since the last
+/// collection cycle. This enables in-place delta collection: only updated entries are exported,
+/// and stale unbound entries are evicted to prevent unbounded memory growth.
+///
+/// `bound_count` tracks how many bound instrument handles reference this entry. Entries with
+/// bound_count > 0 are never evicted from the map, even if they had no updates in a cycle
+/// (they simply produce no export). This ensures bound handles always point to a live tracker.
+pub(crate) struct TrackerEntry<A: Aggregator> {
+    pub(crate) aggregator: A,
+    pub(crate) has_been_updated: AtomicBool,
+    pub(crate) bound_count: AtomicUsize,
+}
+
+impl<A: Aggregator> TrackerEntry<A> {
+    fn new(config: &A::InitConfig) -> Self {
+        TrackerEntry {
+            aggregator: A::create(config),
+            has_been_updated: AtomicBool::new(false),
+            bound_count: AtomicUsize::new(0),
+        }
+    }
+}
+
+/// Map from attribute sets to their aggregator tracker entries.
+type TrackerMap<A> = HashMap<Vec<KeyValue>, Arc<TrackerEntry<A>>>;
+
 /// The storage for sums.
 ///
 /// This structure is parametrized by an `Operation` that indicates how
@@ -61,19 +88,14 @@ where
     A: Aggregator,
 {
     /// Trackers store the values associated with different attribute sets.
-    trackers: RwLock<HashMap<Vec<KeyValue>, Arc<A>>>,
-
-    /// Used ONLY by Delta collect. The data type must match the one used in
-    /// `trackers` to allow mem::swap. Wrapping the type in `OnceLock` to
-    /// avoid this allocation for Cumulative aggregation.
-    trackers_for_collect: OnceLock<RwLock<HashMap<Vec<KeyValue>, Arc<A>>>>,
+    trackers: RwLock<TrackerMap<A>>,
 
     /// Number of different attribute set stored in the `trackers` map.
     count: AtomicUsize,
     /// Indicates whether a value with no attributes has been stored.
     has_no_attribute_value: AtomicBool,
     /// Tracker for values with no attributes attached.
-    no_attribute_tracker: A,
+    no_attribute_tracker: TrackerEntry<A>,
     /// Configuration for an Aggregator
     config: A::InitConfig,
     cardinality_limit: usize,
@@ -83,27 +105,21 @@ impl<A> ValueMap<A>
 where
     A: Aggregator,
 {
+    pub(crate) fn config(&self) -> &A::InitConfig {
+        &self.config
+    }
+
     fn new(config: A::InitConfig, cardinality_limit: usize) -> Self {
         ValueMap {
             trackers: RwLock::new(HashMap::with_capacity(
                 1 + min(DEFAULT_CARDINALITY_LIMIT, cardinality_limit),
             )),
-            trackers_for_collect: OnceLock::new(),
             has_no_attribute_value: AtomicBool::new(false),
-            no_attribute_tracker: A::create(&config),
+            no_attribute_tracker: TrackerEntry::new(&config),
             count: AtomicUsize::new(0),
             config,
             cardinality_limit,
         }
-    }
-
-    #[inline]
-    fn trackers_for_collect(&self) -> &RwLock<HashMap<Vec<KeyValue>, Arc<A>>> {
-        self.trackers_for_collect.get_or_init(|| {
-            RwLock::new(HashMap::with_capacity(
-                1 + min(DEFAULT_CARDINALITY_LIMIT, self.cardinality_limit),
-            ))
-        })
     }
 
     /// Checks whether aggregator has hit cardinality limit for metric streams
@@ -113,7 +129,10 @@ where
 
     fn measure(&self, value: A::PreComputedValue, attributes: &[KeyValue]) {
         if attributes.is_empty() {
-            self.no_attribute_tracker.update(value);
+            self.no_attribute_tracker.aggregator.update(value);
+            self.no_attribute_tracker
+                .has_been_updated
+                .store(true, Ordering::Relaxed);
             self.has_no_attribute_value.store(true, Ordering::Release);
             return;
         }
@@ -124,14 +143,16 @@ where
 
         // Try to retrieve and update the tracker with the attributes in the provided order first
         if let Some(tracker) = trackers.get(attributes) {
-            tracker.update(value);
+            tracker.aggregator.update(value);
+            tracker.has_been_updated.store(true, Ordering::Relaxed);
             return;
         }
 
         // Try to retrieve and update the tracker with the attributes sorted.
         let sorted_attrs = sort_and_dedup(attributes);
         if let Some(tracker) = trackers.get(sorted_attrs.as_slice()) {
-            tracker.update(value);
+            tracker.aggregator.update(value);
+            tracker.has_been_updated.store(true, Ordering::Relaxed);
             return;
         }
 
@@ -145,12 +166,15 @@ where
         // Recheck both the provided and sorted orders after acquiring the write lock
         // in case another thread has pushed an update in the meantime.
         if let Some(tracker) = trackers.get(attributes) {
-            tracker.update(value);
+            tracker.aggregator.update(value);
+            tracker.has_been_updated.store(true, Ordering::Relaxed);
         } else if let Some(tracker) = trackers.get(sorted_attrs.as_slice()) {
-            tracker.update(value);
+            tracker.aggregator.update(value);
+            tracker.has_been_updated.store(true, Ordering::Relaxed);
         } else if self.is_under_cardinality_limit() {
-            let new_tracker = Arc::new(A::create(&self.config));
-            new_tracker.update(value);
+            let new_tracker = Arc::new(TrackerEntry::<A>::new(&self.config));
+            new_tracker.aggregator.update(value);
+            new_tracker.has_been_updated.store(true, Ordering::Relaxed);
 
             // Insert tracker with the attributes in the provided and sorted orders
             trackers.insert(attributes.to_vec(), new_tracker.clone());
@@ -158,10 +182,14 @@ where
 
             self.count.fetch_add(1, Ordering::SeqCst);
         } else if let Some(overflow_value) = trackers.get(stream_overflow_attributes().as_slice()) {
-            overflow_value.update(value);
+            overflow_value.aggregator.update(value);
+            overflow_value
+                .has_been_updated
+                .store(true, Ordering::Relaxed);
         } else {
-            let new_tracker = A::create(&self.config);
-            new_tracker.update(value);
+            let new_tracker = TrackerEntry::<A>::new(&self.config);
+            new_tracker.aggregator.update(value);
+            new_tracker.has_been_updated.store(true, Ordering::Relaxed);
             trackers.insert(stream_overflow_attributes().clone(), Arc::new(new_tracker));
         }
     }
@@ -175,7 +203,7 @@ where
     {
         prepare_data(dest, self.count.load(Ordering::SeqCst));
         if self.has_no_attribute_value.load(Ordering::Acquire) {
-            dest.push(map_fn(vec![], &self.no_attribute_tracker));
+            dest.push(map_fn(vec![], &self.no_attribute_tracker.aggregator));
         }
 
         let Ok(trackers) = self.trackers.read() else {
@@ -185,19 +213,77 @@ where
         let mut seen = HashSet::new();
         for (attrs, tracker) in trackers.iter() {
             if seen.insert(Arc::as_ptr(tracker)) {
-                dest.push(map_fn(attrs.clone(), tracker));
+                dest.push(map_fn(attrs.clone(), &tracker.aggregator));
             }
         }
     }
 
-    /// Iterate through all attribute sets, populate `DataPoints` and reset.
-    /// This is used for:
-    /// - Synchronous instruments in Delta temporality mode
-    /// - Asynchronous instruments (Observable) in both Delta and Cumulative temporality modes
+    /// Iterate through all attribute sets in-place, populate `DataPoints` and reset.
+    /// Only entries updated since the last collection (tracked via `has_been_updated`)
+    /// are exported. Stale unbound entries are evicted to prevent unbounded memory growth.
+    /// Bound entries (bound_count > 0) are never evicted — they persist until explicitly
+    /// unbound, but produce no export when they have no updates.
     ///
-    /// For asynchronous instruments, this removes stale attribute sets that were not observed
-    /// in the current callback, ensuring only currently active attributes are reported.
+    /// Used for synchronous instruments (Counter, Histogram, etc.) in Delta temporality mode.
     pub(crate) fn collect_and_reset<Res, MapFn>(&self, dest: &mut Vec<Res>, mut map_fn: MapFn)
+    where
+        MapFn: FnMut(Vec<KeyValue>, &A) -> Res,
+    {
+        prepare_data(dest, self.count.load(Ordering::SeqCst));
+        if self.has_no_attribute_value.load(Ordering::Acquire)
+            && self
+                .no_attribute_tracker
+                .has_been_updated
+                .swap(false, Ordering::AcqRel)
+        {
+            dest.push(map_fn(vec![], &self.no_attribute_tracker.aggregator));
+        }
+
+        let overflow_attrs = stream_overflow_attributes();
+        let mut stale_entries: Vec<Arc<TrackerEntry<A>>> = Vec::new();
+
+        {
+            let Ok(trackers) = self.trackers.read() else {
+                return;
+            };
+
+            let mut seen = HashSet::new();
+            for (attrs, tracker) in trackers.iter() {
+                if seen.insert(Arc::as_ptr(tracker)) {
+                    if tracker.has_been_updated.swap(false, Ordering::Relaxed) {
+                        dest.push(map_fn(attrs.clone(), &tracker.aggregator));
+                    } else if attrs.as_slice() != overflow_attrs.as_slice()
+                        && tracker.bound_count.load(Ordering::Relaxed) == 0
+                    {
+                        // Stale and not bound — candidate for eviction
+                        stale_entries.push(Arc::clone(tracker));
+                    }
+                }
+            }
+            // Read lock released here
+        }
+
+        if !stale_entries.is_empty() {
+            if let Ok(mut trackers) = self.trackers.write() {
+                // Re-check under write lock to avoid TOCTOU race: a measure() call between
+                // dropping the read lock and acquiring the write lock could have updated
+                // an entry we marked as stale.
+                stale_entries.retain(|entry| !entry.has_been_updated.load(Ordering::Relaxed));
+
+                if !stale_entries.is_empty() {
+                    let stale_pointers: HashSet<*const TrackerEntry<A>> =
+                        stale_entries.iter().map(Arc::as_ptr).collect();
+                    trackers.retain(|_, tracker| !stale_pointers.contains(&Arc::as_ptr(tracker)));
+                    self.count.fetch_sub(stale_entries.len(), Ordering::SeqCst);
+                }
+            }
+        }
+    }
+
+    /// Iterate through all attribute sets, populate `DataPoints` and reset by draining the map.
+    /// This is used for asynchronous instruments (Observable/PrecomputedSum) in both Delta and
+    /// Cumulative temporality modes, where map clearing is needed for staleness detection.
+    pub(crate) fn drain_and_reset<Res, MapFn>(&self, dest: &mut Vec<Res>, mut map_fn: MapFn)
     where
         MapFn: FnMut(Vec<KeyValue>, A) -> Res,
     {
@@ -205,27 +291,30 @@ where
         if self.has_no_attribute_value.swap(false, Ordering::AcqRel) {
             dest.push(map_fn(
                 vec![],
-                self.no_attribute_tracker.clone_and_reset(&self.config),
+                self.no_attribute_tracker
+                    .aggregator
+                    .clone_and_reset(&self.config),
             ));
         }
 
-        if let Ok(mut trackers_collect) = self.trackers_for_collect().write() {
-            if let Ok(mut trackers_current) = self.trackers.write() {
-                swap(trackers_collect.deref_mut(), trackers_current.deref_mut());
-                self.count.store(0, Ordering::SeqCst);
-            } else {
+        let old_trackers = {
+            let Ok(mut trackers) = self.trackers.write() else {
                 otel_warn!(name: "MeterProvider.InternalError", message = "Metric collection failed. Report this issue in OpenTelemetry repo.", details ="ValueMap trackers lock poisoned");
                 return;
-            }
+            };
+            self.count.store(0, Ordering::SeqCst);
+            std::mem::take(&mut *trackers)
+            // Write lock released here
+        };
 
-            let mut seen = HashSet::new();
-            for (attrs, tracker) in trackers_collect.drain() {
-                if seen.insert(Arc::as_ptr(&tracker)) {
-                    dest.push(map_fn(attrs, tracker.clone_and_reset(&self.config)));
-                }
+        let mut seen = HashSet::new();
+        for (attrs, tracker) in old_trackers {
+            if seen.insert(Arc::as_ptr(&tracker)) {
+                dest.push(map_fn(
+                    attrs,
+                    tracker.aggregator.clone_and_reset(&self.config),
+                ));
             }
-        } else {
-            otel_warn!(name: "MeterProvider.InternalError", message = "Metric collection failed. Report this issue in OpenTelemetry repo.", details ="ValueMap trackers for collect lock poisoned");
         }
     }
 }
@@ -649,8 +738,6 @@ mod tests {
         // This is a regression test for panics that used to occur for large cardinality limits
 
         // Should not panic
-        let value_map = ValueMap::<Assign<i64>>::new((), usize::MAX);
-        // Should not panic
-        let _ = value_map.trackers_for_collect();
+        let _value_map = ValueMap::<Assign<i64>>::new((), usize::MAX);
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -733,4 +733,56 @@ mod tests {
         // Should not panic
         let _value_map = ValueMap::<Assign<i64>>::new((), usize::MAX);
     }
+
+    #[test]
+    fn stale_entry_evicts_both_unsorted_and_sorted_keys() {
+        // ValueMap stores two HashMap keys per attribute set: one for the insertion
+        // order and one for the sorted (canonical) order, both pointing to the same
+        // Arc<TrackerEntry>. This test verifies that stale eviction removes *both*
+        // keys so no zombie entries remain in the map.
+        let value_map = ValueMap::<Assign<i64>>::new((), 10);
+
+        // Insert with attributes deliberately in non-sorted order.
+        // measure() inserts two keys:
+        //   - unsorted: [("b", ...), ("a", ...)]
+        //   - sorted:   [("a", ...), ("b", ...)]
+        // both pointing to the same Arc<TrackerEntry>.
+        let attrs = vec![KeyValue::new("b", 1_i64), KeyValue::new("a", 2_i64)];
+        value_map.measure(1_i64, attrs.as_slice());
+
+        {
+            let trackers = value_map.trackers.read().unwrap();
+            assert_eq!(
+                trackers.len(),
+                2,
+                "should have 2 HashMap keys (unsorted + sorted) for one logical attr-set"
+            );
+        }
+        assert_eq!(value_map.count.load(Ordering::SeqCst), 1);
+
+        // First collect: entry was updated, so it is exported and has_been_updated is reset.
+        let mut dest: Vec<Vec<KeyValue>> = Vec::new();
+        value_map.collect_and_reset(&mut dest, |attrs, _| attrs);
+        assert_eq!(dest.len(), 1, "first collect should export the entry");
+
+        // Second collect: entry was not updated since last collect, so it is stale.
+        // Both HashMap keys (unsorted + sorted) must be evicted.
+        dest.clear();
+        value_map.collect_and_reset(&mut dest, |attrs, _| attrs);
+        assert_eq!(dest.len(), 0, "stale entry should not be exported");
+
+        {
+            let trackers = value_map.trackers.read().unwrap();
+            assert_eq!(
+                trackers.len(),
+                0,
+                "both HashMap keys (unsorted + sorted) must be evicted for the stale entry"
+            );
+        }
+        assert_eq!(
+            value_map.count.load(Ordering::SeqCst),
+            0,
+            "count should reach 0 after eviction"
+        );
+    }
 }

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -134,7 +134,7 @@ where
         // Try to retrieve and update the tracker with the attributes in the provided order first
         if let Some(tracker) = trackers.get(attributes) {
             tracker.aggregator.update(value);
-            tracker.has_been_updated.store(true, Ordering::Relaxed);
+            tracker.has_been_updated.store(true, Ordering::Release);
             return;
         }
 
@@ -142,7 +142,7 @@ where
         let sorted_attrs = sort_and_dedup(attributes);
         if let Some(tracker) = trackers.get(sorted_attrs.as_slice()) {
             tracker.aggregator.update(value);
-            tracker.has_been_updated.store(true, Ordering::Relaxed);
+            tracker.has_been_updated.store(true, Ordering::Release);
             return;
         }
 
@@ -157,14 +157,14 @@ where
         // in case another thread has pushed an update in the meantime.
         if let Some(tracker) = trackers.get(attributes) {
             tracker.aggregator.update(value);
-            tracker.has_been_updated.store(true, Ordering::Relaxed);
+            tracker.has_been_updated.store(true, Ordering::Release);
         } else if let Some(tracker) = trackers.get(sorted_attrs.as_slice()) {
             tracker.aggregator.update(value);
-            tracker.has_been_updated.store(true, Ordering::Relaxed);
+            tracker.has_been_updated.store(true, Ordering::Release);
         } else if self.is_under_cardinality_limit() {
             let new_tracker = Arc::new(TrackerEntry::<A>::new(&self.config));
             new_tracker.aggregator.update(value);
-            new_tracker.has_been_updated.store(true, Ordering::Relaxed);
+            new_tracker.has_been_updated.store(true, Ordering::Release);
 
             // Insert tracker with the attributes in the provided and sorted orders
             trackers.insert(attributes.to_vec(), new_tracker.clone());
@@ -175,11 +175,11 @@ where
             overflow_value.aggregator.update(value);
             overflow_value
                 .has_been_updated
-                .store(true, Ordering::Relaxed);
+                .store(true, Ordering::Release);
         } else {
             let new_tracker = TrackerEntry::<A>::new(&self.config);
             new_tracker.aggregator.update(value);
-            new_tracker.has_been_updated.store(true, Ordering::Relaxed);
+            new_tracker.has_been_updated.store(true, Ordering::Release);
             trackers.insert(stream_overflow_attributes().clone(), Arc::new(new_tracker));
         }
     }
@@ -241,7 +241,7 @@ where
             let mut seen = HashSet::new();
             for (attrs, tracker) in trackers.iter() {
                 if seen.insert(Arc::as_ptr(tracker)) {
-                    if tracker.has_been_updated.swap(false, Ordering::Relaxed) {
+                    if tracker.has_been_updated.swap(false, Ordering::Acquire) {
                         dest.push(map_fn(attrs.clone(), &tracker.aggregator));
                     } else if attrs.as_slice() != overflow_attrs.as_slice() {
                         // Stale — candidate for eviction
@@ -257,7 +257,7 @@ where
                 // Re-check under write lock to avoid TOCTOU race: a measure() call between
                 // dropping the read lock and acquiring the write lock could have updated
                 // an entry we marked as stale.
-                stale_entries.retain(|entry| !entry.has_been_updated.load(Ordering::Relaxed));
+                stale_entries.retain(|entry| !entry.has_been_updated.load(Ordering::Acquire));
 
                 if !stale_entries.is_empty() {
                     let stale_pointers: HashSet<*const TrackerEntry<A>> =

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -69,7 +69,7 @@ impl<T: Number> PrecomputedSum<T> {
         let mut new_reported = HashMap::with_capacity(reported.len());
 
         self.value_map
-            .collect_and_reset(&mut s_data.data_points, |attributes, aggr| {
+            .drain_and_reset(&mut s_data.data_points, |attributes, aggr| {
                 let value = aggr.value.get_value();
                 new_reported.insert(attributes.clone(), value);
                 let delta = value - *reported.get(&attributes).unwrap_or(&T::default());
@@ -116,10 +116,10 @@ impl<T: Number> PrecomputedSum<T> {
         s_data.temporality = Temporality::Cumulative;
         s_data.is_monotonic = self.monotonic;
 
-        // Use collect_and_reset to remove stale attributes (not observed in current callback)
+        // Use drain_and_reset to remove stale attributes (not observed in current callback)
         // For cumulative, report absolute values (no delta calculation needed)
         self.value_map
-            .collect_and_reset(&mut s_data.data_points, |attributes, aggr| SumDataPoint {
+            .drain_and_reset(&mut s_data.data_points, |attributes, aggr| SumDataPoint {
                 attributes,
                 value: aggr.value.get_value(),
                 exemplars: vec![],

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -96,7 +96,7 @@ impl<T: Number> Sum<T> {
         self.value_map
             .collect_and_reset(&mut s_data.data_points, |attributes, aggr| SumDataPoint {
                 attributes,
-                value: aggr.value.get_value(),
+                value: aggr.value.get_and_reset_value(),
                 exemplars: vec![],
             });
 

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -4075,9 +4075,15 @@ mod tests {
             "Empty attributes value should be 3+3=6"
         );
 
-        // Phase 2 - for delta temporality, after each collect, data points are cleared
-        // but for cumulative, they are not cleared.
+        // Phase 2 - for delta temporality, collect_and_reset uses in-place eviction:
+        // the first collect marks entries as not-updated, and the second collect evicts
+        // those still-stale entries. We need an extra flush to trigger that eviction
+        // before adding new measurements that should fit under the cardinality limit.
         test_context.reset_metrics();
+        if temporality == Temporality::Delta {
+            test_context.flush_metrics();
+            test_context.reset_metrics();
+        }
         // The following should be aggregated normally for Delta,
         // and should go into overflow for Cumulative.
         counter.add(100, &[KeyValue::new("A", "foo")]);
@@ -4181,9 +4187,15 @@ mod tests {
             "Empty attributes value should be 3+3=6"
         );
 
-        // Phase 2 - for delta temporality, after each collect, data points are cleared
-        // but for cumulative, they are not cleared.
+        // Phase 2 - for delta temporality, collect_and_reset uses in-place eviction:
+        // the first collect marks entries as not-updated, and the second collect evicts
+        // those still-stale entries. We need an extra flush to trigger that eviction
+        // before adding new measurements that should fit under the cardinality limit.
         test_context.reset_metrics();
+        if temporality == Temporality::Delta {
+            test_context.flush_metrics();
+            test_context.reset_metrics();
+        }
         // The following should be aggregated normally for Delta,
         // and should go into overflow for Cumulative.
         counter.add(100, &[KeyValue::new("A", "foo")]);


### PR DESCRIPTION
Splits from #3392, per [maintainer feedback](https://github.com/open-telemetry/opentelemetry-rust/pull/3392#pullrequestreview-3949240401). Refs #2328.

## Summary

- Replaces the two-HashMap swap-and-drain pattern in `collect_and_reset` with in-place iteration using `TrackerEntry` status tracking
- `TrackerEntry` wraps each aggregator with `has_been_updated` (AtomicBool) to track whether measurements occurred since the last collection cycle
- Removes `has_no_attribute_value` — the `no_attribute_tracker.has_been_updated` flag now serves the same purpose
- `collect_and_reset` now iterates under a **read lock** (no write lock in steady state), exports only updated entries, and evicts stale entries under a write lock with TOCTOU re-check
- Adds `drain_and_reset` for Observable/async instruments that need true staleness detection via map clearing
- Eliminates O(n) write-lock acquisitions on the hot path per collection cycle when attribute sets are reused (the common case)

## User-facing behavior change

Recovery from cardinality overflow now requires **2 collect cycles** instead of 1 — the first cycle marks entries as stale (no updates), the second cycle evicts them. This trade-off enables the in-place iteration pattern that avoids write-lock contention in steady state.

## Locking trade-offs (discussed with @cijothomas and @utpilla in #3392)

| Scenario | Old (swap-and-drain) | New (in-place) |
|----------|---------------------|----------------|
| Steady state (reused attrs) | O(n) write locks per cycle | Read locks only |
| New/returning attrs during collect | Write lock for insert | Write lock for insert (competes with read lock held by collect) |
| Stale eviction | Implicit (map cleared) | Write lock proportional to stale count |

## Test plan

- [x] All 149 existing metrics tests pass
- [x] `counter_aggregation_overflow_delta` tests updated for two-phase eviction semantics
- [x] No changes to cumulative collection path (`collect_readonly`)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p opentelemetry_sdk --features metrics -- -D warnings` passes