### PR TITLE
test(appender-tracing): fix flaky experimental_span_attributes tests

### DIFF
--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1077,8 +1077,14 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let level_filter = tracing_subscriber::filter::LevelFilter::INFO;
-        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(level_filter);
+        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
+            tracing_subscriber::filter::filter_fn(|meta| {
+                // Allow spans at any level (needed for on_new_span to store span attributes),
+                // but only allow ERROR events to prevent internal otel_info! events from leaking
+                // in when internal-logs feature is enabled and tests run in parallel.
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }),
+        );
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1122,8 +1128,14 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let level_filter = tracing_subscriber::filter::LevelFilter::INFO;
-        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(level_filter);
+        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
+            tracing_subscriber::filter::filter_fn(|meta| {
+                // Allow spans at any level (needed for on_new_span to store span attributes),
+                // but only allow ERROR events to prevent internal otel_info! events from leaking
+                // in when internal-logs feature is enabled and tests run in parallel.
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }),
+        );
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1177,8 +1189,14 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let level_filter = tracing_subscriber::filter::LevelFilter::INFO;
-        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(level_filter);
+        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
+            tracing_subscriber::filter::filter_fn(|meta| {
+                // Allow spans at any level (needed for on_new_span to store span attributes),
+                // but only allow ERROR events to prevent internal otel_info! events from leaking
+                // in when internal-logs feature is enabled and tests run in parallel.
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }),
+        );
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1283,8 +1301,14 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let level_filter = tracing_subscriber::filter::LevelFilter::INFO;
-        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(level_filter);
+        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
+            tracing_subscriber::filter::filter_fn(|meta| {
+                // Allow spans at any level (needed for on_new_span to store span attributes),
+                // but only allow ERROR events to prevent internal otel_info! events from leaking
+                // in when internal-logs feature is enabled and tests run in parallel.
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }),
+        );
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1343,7 +1367,10 @@ mod tests {
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_span_attribute_allowlist(["session.id"])
-            .build();
+            .build()
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }));
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1377,7 +1404,10 @@ mod tests {
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_span_attribute_allowlist(["session.id"])
-            .build();
+            .build()
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }));
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1421,7 +1451,10 @@ mod tests {
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_span_attribute_allowlist(std::iter::empty::<&str>())
-            .build();
+            .build()
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }));
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1456,7 +1489,10 @@ mod tests {
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_span_attribute_allowlist(["session.id"])
-            .build();
+            .build()
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }));
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 


### PR DESCRIPTION
## Summary

Fixes flaky `experimental_span_attributes` tests in `opentelemetry-appender-tracing` that fail intermittently when run in parallel (e.g., the `tracing_appender_span_attribute_allowlist_with_on_record` failure seen in CI on macOS).

## Root cause

When the `internal-logs` feature is enabled (which it is via the `testing` feature), internal `otel_info!` macro calls emit tracing events. These events pass through the `OpenTelemetryTracingBridge` layer and get captured by the `InMemoryLogExporter` alongside the test's intended log records. Because `set_default` scopes are per-thread but the tracing subscriber is global, events from parallel tests (or from the OTel SDK's internal logging) can leak into a test's exporter, causing non-deterministic log counts.

The tests previously used `LevelFilter::INFO` which allowed these internal events through.

## Fix

Replace `LevelFilter::INFO` with a custom `filter_fn` on all 8 affected tests:

```rust
tracing_subscriber::filter::filter_fn(|meta| {
    meta.is_span() || *meta.level() <= tracing::Level::ERROR
})
```

This allows spans at any level (needed for `on_new_span` to capture span attributes) while only permitting ERROR-level events, which filters out the internal `otel_info!` noise.

## Test plan

- [x] All 16 `opentelemetry-appender-tracing` tests pass (11 lib + 1 integration + 4 doc)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p opentelemetry-appender-tracing --features experimental_span_attributes -- -D warnings` passes