### PR TITLE
fix(integration-tests): remove per-test file truncation that caused flaky metrics tests

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/src/metric_helpers.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/metric_helpers.rs
@@ -11,9 +11,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::io::Read;
 use std::time::Duration;
-use tracing::info;
 
-static RESULT_PATH: &str = "actual/metrics.json";
 pub const SLEEP_DURATION: Duration = Duration::from_secs(5);
 
 ///
@@ -58,10 +56,6 @@ fn init_meter_provider() -> SdkMeterProvider {
 ///
 pub async fn setup_metrics_tokio() -> SdkMeterProvider {
     let _ = test_utils::start_collector_container().await;
-    // Truncate results
-    _ = File::create(RESULT_PATH).expect("it's good");
-    info!("Truncated metrics file");
-
     init_meter_provider()
 }
 


### PR DESCRIPTION
## Root cause

`setup_metrics_tokio()` was truncating the shared metrics output file on every call:

```rust
// Truncate results
_ = File::create(RESULT_PATH).expect("it's good");
```

Rust runs tests within a binary in parallel by default. When multiple tests called `setup_metrics_tokio()` concurrently, they would race to truncate the file — wiping out data that a concurrent test had already exported. The UUID lookup would then fail:

```
Expected content c531d372-... not found in actual content {...}
```

First observed as a flake in #3420.

## Why it's safe to remove

The file is already initialized empty once per binary run by `start_collector_container()` → `upsert_empty_file()`. Each cargo test file compiles to its own binary with its own container, so the file starts fresh every run.

Tests already use unique UUIDs (`metrics.rs`) and unique scope names (`metrics_roundtrip.rs`) for isolation, so accumulated output within a run is fine — each test only checks for its own data.

## Affected test suites

Both `metrics.rs` (UUID-based assertions) and `metrics_roundtrip.rs` (scope-based assertions via `fetch_latest_metrics_for_scope`) were affected since both call `setup_metrics_tokio()`.