### PR TITLE
chore: Migrate to new bare metal runner (Ubuntu 24)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,7 +64,7 @@ jobs:
     name: continuous benchmark tracking
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     # Use bare-metal runner on the upstream repo for consistent results; fall back to shared runners elsewhere
-    runs-on: ${{ github.repository == 'open-telemetry/opentelemetry-rust' && 'oracle-bare-metal-64cpu-512gb-x86-64' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'open-telemetry/opentelemetry-rust' && 'oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24' || 'ubuntu-latest' }}
     permissions:
       contents: write
     container:


### PR DESCRIPTION
Old runner:

- name: `oracle-bare-metal-64cpu-512gb-x86-64`
- 512gb memory
- Oracle Linux 8

New runner:

-  name: `oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24`
- 1024gb memory
-  Ubuntu 24

I realize this could have some impact on benchmark baselines, so please post on https://github.com/open-telemetry/community/issues/3333 once you have migrated and are comfortable with the old one being removed.
