### PR TITLE
feat(appender-tracing): add builder support for custom instrumentation scope

### DIFF
--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- Add custom `InstrumentationScope` support via
+- Add custom instrumentation scope attributes support via
   `OpenTelemetryTracingBridge::builder_with_scope_attributes(..)`.
   [3415](https://github.com/open-telemetry/opentelemetry-rust/issues/3415)
 

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- Add `OpenTelemetryTracingBridgeBuilder::with_scope()` to configure the
+- Add `OpenTelemetryTracingBridge::with_scope()` to configure the
   OpenTelemetry `InstrumentationScope` used by the appender logger.
   [3415](https://github.com/open-telemetry/opentelemetry-rust/issues/3415)
 

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## vNext
 
-- Add `OpenTelemetryTracingBridge::with_scope()` to configure the
-  OpenTelemetry `InstrumentationScope` used by the appender logger.
+- Add custom `InstrumentationScope` support via
+  `OpenTelemetryTracingBridge::with_scope()` and
+  `OpenTelemetryTracingBridge::builder_with_scope()`.
   [3415](https://github.com/open-telemetry/opentelemetry-rust/issues/3415)
 
 ## 0.32.0

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## vNext
 
 - Add custom `InstrumentationScope` support via
-  `OpenTelemetryTracingBridge::with_scope()` and
   `OpenTelemetryTracingBridge::builder_with_scope()`.
   [3415](https://github.com/open-telemetry/opentelemetry-rust/issues/3415)
 

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## vNext
 
 - Add custom `InstrumentationScope` support via
-  `OpenTelemetryTracingBridge::builder_with_scope()`.
+  `OpenTelemetryTracingBridge::builder_with_scope(..)`.
   [3415](https://github.com/open-telemetry/opentelemetry-rust/issues/3415)
 
 ## 0.32.0

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -79,11 +79,13 @@ Released 2025-May-23
 
 - Updated `opentelemetry` dependency to version 0.30.0.
 
+
 ## 0.29.1
 
 Released 2025-Mar-24
 
 - Bump `tracing-opentelemetry` to 0.30
+
 
 ## 0.29.0
 
@@ -125,16 +127,16 @@ Receivers (processors, exporters) are expected to use `LogRecord.target()` as
 scope name. This is already done in OTLP Exporters, so this change should be
 transparent to most users.
 
-- Passes event name to the `event_enabled` method on the `Logger`. This allows
+- Passes event name  to the `event_enabled` method on the `Logger`. This allows
   implementations (SDK, processor, exporters) to leverage this additional
   information to determine if an event is enabled.
 
 - `u64`, `i128`, `u128` and `usize` values are stored as `opentelemetry::logs::AnyValue::Int`
-  when conversion is feasible. Otherwise stored as
-  `opentelemetry::logs::AnyValue::String`. This avoids unnecessary string
-  allocation when values can be represented in their original types.
+when conversion is feasible. Otherwise stored as
+`opentelemetry::logs::AnyValue::String`. This avoids unnecessary string
+allocation when values can be represented in their original types.
 - Byte arrays are stored as `opentelemetry::logs::AnyValue::Bytes` instead
-  of string.
+of string.
 - `Error` fields are reported using attribute named "exception.message". For
   example, the below will now report an attribute named "exception.message",
   instead of previously reporting the user provided attribute "error".
@@ -146,7 +148,7 @@ transparent to most users.
 
 Released 2025-Feb-12
 
-- New _experimental_ feature to use trace_id & span_id from spans created through the [tracing](https://crates.io/crates/tracing) crate (experimental_use_tracing_span_context) [#2438](https://github.com/open-telemetry/opentelemetry-rust/pull/2438)
+- New *experimental* feature to use trace_id & span_id from spans created through the [tracing](https://crates.io/crates/tracing) crate (experimental_use_tracing_span_context) [#2438](https://github.com/open-telemetry/opentelemetry-rust/pull/2438)
 
 ## 0.28.0
 
@@ -196,7 +198,7 @@ Released 2024-Sep-30
 
 ### Added
 
-- New experimental metadata attributes feature (experimental_metadata_attributes) [#1380](https://github.com/open-telemetry/opentelemetry-rust/pull/1380)
+- New experimental metadata attributes feature (experimental\_metadata\_attributes) [#1380](https://github.com/open-telemetry/opentelemetry-rust/pull/1380)
   - Experimental new attributes for tracing metadata
   - Fixes the following for events emitted using log crate
     - Normalized metadata fields

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## vNext
 
 - Add custom `InstrumentationScope` support via
-  `OpenTelemetryTracingBridge::builder_with_scope(..)`.
+  `OpenTelemetryTracingBridge::builder_with_scope_attributes(..)`.
   [3415](https://github.com/open-telemetry/opentelemetry-rust/issues/3415)
 
 ## 0.32.0

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+- Add `OpenTelemetryTracingBridgeBuilder::with_scope()` to configure the
+  OpenTelemetry `InstrumentationScope` used by the appender logger.
+  [3415](https://github.com/open-telemetry/opentelemetry-rust/issues/3415)
+
 ## 0.32.0
 
 Released 2026-May-08
@@ -75,13 +79,11 @@ Released 2025-May-23
 
 - Updated `opentelemetry` dependency to version 0.30.0.
 
-
 ## 0.29.1
 
 Released 2025-Mar-24
 
 - Bump `tracing-opentelemetry` to 0.30
-
 
 ## 0.29.0
 
@@ -123,16 +125,16 @@ Receivers (processors, exporters) are expected to use `LogRecord.target()` as
 scope name. This is already done in OTLP Exporters, so this change should be
 transparent to most users.
 
-- Passes event name  to the `event_enabled` method on the `Logger`. This allows
+- Passes event name to the `event_enabled` method on the `Logger`. This allows
   implementations (SDK, processor, exporters) to leverage this additional
   information to determine if an event is enabled.
 
 - `u64`, `i128`, `u128` and `usize` values are stored as `opentelemetry::logs::AnyValue::Int`
-when conversion is feasible. Otherwise stored as
-`opentelemetry::logs::AnyValue::String`. This avoids unnecessary string
-allocation when values can be represented in their original types.
+  when conversion is feasible. Otherwise stored as
+  `opentelemetry::logs::AnyValue::String`. This avoids unnecessary string
+  allocation when values can be represented in their original types.
 - Byte arrays are stored as `opentelemetry::logs::AnyValue::Bytes` instead
-of string.
+  of string.
 - `Error` fields are reported using attribute named "exception.message". For
   example, the below will now report an attribute named "exception.message",
   instead of previously reporting the user provided attribute "error".
@@ -144,7 +146,7 @@ of string.
 
 Released 2025-Feb-12
 
-- New *experimental* feature to use trace_id & span_id from spans created through the [tracing](https://crates.io/crates/tracing) crate (experimental_use_tracing_span_context) [#2438](https://github.com/open-telemetry/opentelemetry-rust/pull/2438)
+- New _experimental_ feature to use trace_id & span_id from spans created through the [tracing](https://crates.io/crates/tracing) crate (experimental_use_tracing_span_context) [#2438](https://github.com/open-telemetry/opentelemetry-rust/pull/2438)
 
 ## 0.28.0
 
@@ -194,7 +196,7 @@ Released 2024-Sep-30
 
 ### Added
 
-- New experimental metadata attributes feature (experimental\_metadata\_attributes) [#1380](https://github.com/open-telemetry/opentelemetry-rust/pull/1380)
+- New experimental metadata attributes feature (experimental_metadata_attributes) [#1380](https://github.com/open-telemetry/opentelemetry-rust/pull/1380)
   - Experimental new attributes for tracing metadata
   - Fixes the following for events emitted using log crate
     - Normalized metadata fields

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -395,7 +395,7 @@ where
             logger: provider.logger(""),
             _phantom: Default::default(),
             #[cfg(feature = "experimental_span_attributes")]
-            span_attribute_allowlist: None,
+            span_attributes: None,
         }
     }
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -378,15 +378,10 @@ where
     /// Creates a bridge using the default OpenTelemetry logger scope.
     ///
     /// The default scope uses an empty scope name for the appender logger.
-    /// Use [`Self::with_scope`] or [`Self::builder_with_scope`] to provide a
+    /// Use [`Self::builder_with_scope`] to provide a
     /// custom [`InstrumentationScope`].
     pub fn new(provider: &P) -> Self {
         Self::builder(provider).build()
-    }
-
-    /// Creates the bridge with a custom OpenTelemetry [`InstrumentationScope`].
-    pub fn with_scope(provider: &P, scope: InstrumentationScope) -> Self {
-        Self::builder_with_scope(provider, scope).build()
     }
 
     /// Creates a builder using the default OpenTelemetry logger scope.
@@ -956,48 +951,35 @@ mod tests {
             .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
             .with_attributes([KeyValue::new("scope-key", "scope-value")])
             .build();
-        let subscribers = [
-            tracing_subscriber::registry().with(
-                layer::OpenTelemetryTracingBridge::builder_with_scope(
-                    &logger_provider,
-                    scope.clone(),
-                )
+        let subscriber = tracing_subscriber::registry().with(
+            layer::OpenTelemetryTracingBridge::builder_with_scope(&logger_provider, scope.clone())
                 .build(),
-            ),
-            tracing_subscriber::registry().with(layer::OpenTelemetryTracingBridge::with_scope(
-                &logger_provider,
-                scope,
-            )),
-        ];
+        );
 
-        for subscriber in subscribers {
-            let _guard = tracing::subscriber::set_default(subscriber);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
-            error!(name: "scoped-event", target: "my-system", event_id = 20);
-            assert!(logger_provider.force_flush().is_ok());
+        error!(name: "scoped-event", target: "my-system", event_id = 20);
+        assert!(logger_provider.force_flush().is_ok());
 
-            let exported_logs = exporter
-                .get_emitted_logs()
-                .expect("Logs are expected to be exported.");
-            assert_eq!(exported_logs.len(), 1);
-            let log = exported_logs
-                .first()
-                .expect("At least one log is expected to be present.");
+        let exported_logs = exporter
+            .get_emitted_logs()
+            .expect("Logs are expected to be exported.");
+        assert_eq!(exported_logs.len(), 1);
+        let log = exported_logs
+            .first()
+            .expect("At least one log is expected to be present.");
 
-            let instrumentation_scope = &log.instrumentation;
-            assert_eq!(instrumentation_scope.name(), "test.scope");
-            assert_eq!(instrumentation_scope.version(), Some("1.2.3"));
-            assert_eq!(
-                instrumentation_scope.schema_url(),
-                Some("https://opentelemetry.io/schemas/1.0.0")
-            );
-            assert!(instrumentation_scope.attributes().eq([KeyValue::new(
-                "scope-key",
-                "scope-value"
-            )]
-            .iter()));
-            exporter.reset();
-        }
+        let instrumentation_scope = &log.instrumentation;
+        assert_eq!(instrumentation_scope.name(), "test.scope");
+        assert_eq!(instrumentation_scope.version(), Some("1.2.3"));
+        assert_eq!(
+            instrumentation_scope.schema_url(),
+            Some("https://opentelemetry.io/schemas/1.0.0")
+        );
+        assert!(instrumentation_scope
+            .attributes()
+            .eq([KeyValue::new("scope-key", "scope-value")].iter()));
+        exporter.reset();
     }
 
     #[test]

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -956,33 +956,48 @@ mod tests {
             .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
             .with_attributes([KeyValue::new("scope-key", "scope-value")])
             .build();
+        let subscribers = [
+            tracing_subscriber::registry().with(
+                layer::OpenTelemetryTracingBridge::builder_with_scope(
+                    &logger_provider,
+                    scope.clone(),
+                )
+                .build(),
+            ),
+            tracing_subscriber::registry().with(layer::OpenTelemetryTracingBridge::with_scope(
+                &logger_provider,
+                scope,
+            )),
+        ];
 
-        let subscriber = tracing_subscriber::registry().with(
-            layer::OpenTelemetryTracingBridge::builder_with_scope(&logger_provider, scope).build(),
-        );
-        let _guard = tracing::subscriber::set_default(subscriber);
+        for subscriber in subscribers {
+            let _guard = tracing::subscriber::set_default(subscriber);
 
-        error!(name: "scoped-event", target: "my-system", event_id = 20);
-        assert!(logger_provider.force_flush().is_ok());
+            error!(name: "scoped-event", target: "my-system", event_id = 20);
+            assert!(logger_provider.force_flush().is_ok());
 
-        let exported_logs = exporter
-            .get_emitted_logs()
-            .expect("Logs are expected to be exported.");
-        assert_eq!(exported_logs.len(), 1);
-        let log = exported_logs
-            .first()
-            .expect("At least one log is expected to be present.");
+            let exported_logs = exporter
+                .get_emitted_logs()
+                .expect("Logs are expected to be exported.");
+            assert_eq!(exported_logs.len(), 1);
+            let log = exported_logs
+                .first()
+                .expect("At least one log is expected to be present.");
 
-        let instrumentation_scope = &log.instrumentation;
-        assert_eq!(instrumentation_scope.name(), "test.scope");
-        assert_eq!(instrumentation_scope.version(), Some("1.2.3"));
-        assert_eq!(
-            instrumentation_scope.schema_url(),
-            Some("https://opentelemetry.io/schemas/1.0.0")
-        );
-        assert!(instrumentation_scope
-            .attributes()
-            .eq([KeyValue::new("scope-key", "scope-value")].iter()));
+            let instrumentation_scope = &log.instrumentation;
+            assert_eq!(instrumentation_scope.name(), "test.scope");
+            assert_eq!(instrumentation_scope.version(), Some("1.2.3"));
+            assert_eq!(
+                instrumentation_scope.schema_url(),
+                Some("https://opentelemetry.io/schemas/1.0.0")
+            );
+            assert!(instrumentation_scope.attributes().eq([KeyValue::new(
+                "scope-key",
+                "scope-value"
+            )]
+            .iter()));
+            exporter.reset();
+        }
     }
 
     #[test]

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,6 +1,6 @@
 use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    Key,
+    InstrumentationScope, Key,
 };
 #[cfg(feature = "experimental_span_attributes")]
 use std::borrow::Cow;
@@ -379,14 +379,15 @@ where
         Self::builder(provider).build()
     }
 
-    pub fn builder(provider: &P) -> OpenTelemetryTracingBridgeBuilder<P, L> {
+    pub fn builder<'a>(provider: &'a P) -> OpenTelemetryTracingBridgeBuilder<'a, P, L> {
         OpenTelemetryTracingBridgeBuilder {
             // Using empty scope name.
             // The name/version of this library itself can be added
             // as a Scope attribute, once a semantic convention is
             // defined for the same.
             // See https://github.com/open-telemetry/semantic-conventions/issues/1550
-            logger: provider.logger(""),
+            provider,
+            scope: None,
             _phantom: Default::default(),
             #[cfg(feature = "experimental_span_attributes")]
             span_attributes: None,
@@ -394,18 +395,19 @@ where
     }
 }
 
-pub struct OpenTelemetryTracingBridgeBuilder<P, L>
+pub struct OpenTelemetryTracingBridgeBuilder<'a, P, L>
 where
     P: LoggerProvider<Logger = L> + Send + Sync,
     L: Logger + Send + Sync,
 {
-    logger: L,
+    provider: &'a P,
+    scope: Option<InstrumentationScope>,
     _phantom: std::marker::PhantomData<P>,
     #[cfg(feature = "experimental_span_attributes")]
     span_attributes: Option<TracingSpanAttributesInner>,
 }
 
-impl<P, L> OpenTelemetryTracingBridgeBuilder<P, L>
+impl<'a, P, L> OpenTelemetryTracingBridgeBuilder<'a, P, L>
 where
     P: LoggerProvider<Logger = L> + Send + Sync,
     L: Logger + Send + Sync,
@@ -432,9 +434,21 @@ where
         self
     }
 
+    /// Configures the OpenTelemetry `InstrumentationScope` used to create the
+    /// logger for this bridge.
+    ///
+    /// When not set, the bridge preserves the existing behavior and creates a
+    /// logger with an empty scope name.
+    pub fn with_scope(mut self, scope: InstrumentationScope) -> Self {
+        self.scope = Some(scope);
+        self
+    }
+
     pub fn build(self) -> OpenTelemetryTracingBridge<P, L> {
         OpenTelemetryTracingBridge {
-            logger: self.logger,
+            logger: self.scope.map(|scope|
+                self.provider.logger_with_scope(scope)
+            ).unwrap_or_else(||self.provider.logger("")),
             _phantom: self._phantom,
             #[cfg(feature = "experimental_span_attributes")]
             span_attributes: self.span_attributes,
@@ -597,7 +611,7 @@ mod tests {
     use opentelemetry::trace::TracerProvider;
     use opentelemetry::trace::{TraceContextExt, TraceFlags, Tracer};
     use opentelemetry::InstrumentationScope;
-    use opentelemetry::{logs::AnyValue, Key};
+    use opentelemetry::{logs::AnyValue, Key, KeyValue};
     use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
     use opentelemetry_sdk::logs::{InMemoryLogExporter, LogProcessor};
     use opentelemetry_sdk::logs::{SdkLogRecord, SdkLoggerProvider};
@@ -917,6 +931,49 @@ mod tests {
             assert!(attributes_key.contains(&Key::new("code.lineno")));
             assert!(!attributes_key.contains(&Key::new("log.target")));
         }
+    }
+
+    #[test]
+    fn tracing_appender_with_custom_scope() {
+        let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
+        let logger_provider = SdkLoggerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+
+        let scope = InstrumentationScope::builder("test.scope")
+            .with_version("1.2.3")
+            .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
+            .with_attributes([KeyValue::new("scope-key", "scope-value")])
+            .build();
+
+        let subscriber = tracing_subscriber::registry().with(
+            layer::OpenTelemetryTracingBridge::builder(&logger_provider)
+                .with_scope(scope)
+                .build(),
+        );
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        error!(name: "scoped-event", target: "my-system", event_id = 20);
+        assert!(logger_provider.force_flush().is_ok());
+
+        let exported_logs = exporter
+            .get_emitted_logs()
+            .expect("Logs are expected to be exported.");
+        assert_eq!(exported_logs.len(), 1);
+        let log = exported_logs
+            .first()
+            .expect("At least one log is expected to be present.");
+
+        let instrumentation_scope = &log.instrumentation;
+        assert_eq!(instrumentation_scope.name(), "test.scope");
+        assert_eq!(instrumentation_scope.version(), Some("1.2.3"));
+        assert_eq!(
+            instrumentation_scope.schema_url(),
+            Some("https://opentelemetry.io/schemas/1.0.0")
+        );
+        assert!(instrumentation_scope
+            .attributes()
+            .eq([KeyValue::new("scope-key", "scope-value")].iter()));
     }
 
     #[test]

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -378,7 +378,7 @@ where
     /// Creates a bridge using the default OpenTelemetry logger scope.
     ///
     /// The default scope uses an empty scope name for the appender logger.
-    /// Use [`Self::builder_with_scope`] to provide a
+    /// Use [`Self::builder_with_scope_attributes`] to provide a
     /// custom [`InstrumentationScope`].
     pub fn new(provider: &P) -> Self {
         Self::builder(provider).build()
@@ -401,7 +401,7 @@ where
 
     /// Creates a builder that uses a custom OpenTelemetry [`InstrumentationScope`]
     /// for the appender logger.
-    pub fn builder_with_scope(
+    pub fn builder_with_scope_attributes(
         provider: &P,
         scope: InstrumentationScope,
     ) -> OpenTelemetryTracingBridgeBuilder<P, L> {
@@ -952,8 +952,11 @@ mod tests {
             .with_attributes([KeyValue::new("scope-key", "scope-value")])
             .build();
         let subscriber = tracing_subscriber::registry().with(
-            layer::OpenTelemetryTracingBridge::builder_with_scope(&logger_provider, scope.clone())
-                .build(),
+            layer::OpenTelemetryTracingBridge::builder_with_scope_attributes(
+                &logger_provider,
+                scope.clone(),
+            )
+            .build(),
         );
 
         let _guard = tracing::subscriber::set_default(subscriber);

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -376,18 +376,32 @@ where
     L: Logger + Send + Sync,
 {
     pub fn new(provider: &P) -> Self {
-        Self::builder(provider).build()
+        Self::builder(provider, None).build()
     }
 
-    pub fn builder<'a>(provider: &'a P) -> OpenTelemetryTracingBridgeBuilder<'a, P, L> {
+    /// Creates the bridge with a custom OpenTelemetry `InstrumentationScope`.
+    ///
+    /// Use this when you want emitted logs to carry a specific scope name,
+    /// version, schema URL, or scope attributes.
+    ///
+    /// For the default behavior (empty scope name), use [`Self::new`].
+    pub fn with_scope(provider: &P, scope: InstrumentationScope) -> Self {
+        Self::builder(provider, Some(scope)).build()
+    }
+
+    pub fn builder(
+        provider: &P,
+        scope: Option<InstrumentationScope>,
+    ) -> OpenTelemetryTracingBridgeBuilder<P, L> {
         OpenTelemetryTracingBridgeBuilder {
             // Using empty scope name.
             // The name/version of this library itself can be added
             // as a Scope attribute, once a semantic convention is
             // defined for the same.
             // See https://github.com/open-telemetry/semantic-conventions/issues/1550
-            provider,
-            scope: None,
+            logger: scope
+                .map(|scope| provider.logger_with_scope(scope))
+                .unwrap_or_else(|| provider.logger("")),
             _phantom: Default::default(),
             #[cfg(feature = "experimental_span_attributes")]
             span_attributes: None,
@@ -395,19 +409,18 @@ where
     }
 }
 
-pub struct OpenTelemetryTracingBridgeBuilder<'a, P, L>
+pub struct OpenTelemetryTracingBridgeBuilder<P, L>
 where
     P: LoggerProvider<Logger = L> + Send + Sync,
     L: Logger + Send + Sync,
 {
-    provider: &'a P,
-    scope: Option<InstrumentationScope>,
+    logger: L,
     _phantom: std::marker::PhantomData<P>,
     #[cfg(feature = "experimental_span_attributes")]
     span_attributes: Option<TracingSpanAttributesInner>,
 }
 
-impl<'a, P, L> OpenTelemetryTracingBridgeBuilder<'a, P, L>
+impl<P, L> OpenTelemetryTracingBridgeBuilder<P, L>
 where
     P: LoggerProvider<Logger = L> + Send + Sync,
     L: Logger + Send + Sync,
@@ -434,21 +447,9 @@ where
         self
     }
 
-    /// Configures the OpenTelemetry `InstrumentationScope` used to create the
-    /// logger for this bridge.
-    ///
-    /// When not set, the bridge preserves the existing behavior and creates a
-    /// logger with an empty scope name.
-    pub fn with_scope(mut self, scope: InstrumentationScope) -> Self {
-        self.scope = Some(scope);
-        self
-    }
-
     pub fn build(self) -> OpenTelemetryTracingBridge<P, L> {
         OpenTelemetryTracingBridge {
-            logger: self.scope.map(|scope|
-                self.provider.logger_with_scope(scope)
-            ).unwrap_or_else(||self.provider.logger("")),
+            logger: self.logger,
             _phantom: self._phantom,
             #[cfg(feature = "experimental_span_attributes")]
             span_attributes: self.span_attributes,
@@ -947,9 +948,7 @@ mod tests {
             .build();
 
         let subscriber = tracing_subscriber::registry().with(
-            layer::OpenTelemetryTracingBridge::builder(&logger_provider)
-                .with_scope(scope)
-                .build(),
+            layer::OpenTelemetryTracingBridge::with_scope(&logger_provider, scope),
         );
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1557,7 +1556,7 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider, None)
             .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
@@ -1594,7 +1593,7 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider, None)
             .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
@@ -1641,7 +1640,7 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider, None)
             .with_tracing_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
@@ -1679,7 +1678,7 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider, None)
             .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -375,33 +375,43 @@ where
     P: LoggerProvider<Logger = L> + Send + Sync,
     L: Logger + Send + Sync,
 {
+    /// Creates a bridge using the default OpenTelemetry logger scope.
+    ///
+    /// The default scope uses an empty scope name for the appender logger.
+    /// Use [`Self::with_scope`] or [`Self::builder_with_scope`] to provide a
+    /// custom [`InstrumentationScope`].
     pub fn new(provider: &P) -> Self {
-        Self::builder(provider, None).build()
+        Self::builder(provider).build()
     }
 
-    /// Creates the bridge with a custom OpenTelemetry `InstrumentationScope`.
-    ///
-    /// Use this when you want emitted logs to carry a specific scope name,
-    /// version, schema URL, or scope attributes.
-    ///
-    /// For the default behavior (empty scope name), use [`Self::new`].
+    /// Creates the bridge with a custom OpenTelemetry [`InstrumentationScope`].
     pub fn with_scope(provider: &P, scope: InstrumentationScope) -> Self {
-        Self::builder(provider, Some(scope)).build()
+        Self::builder_with_scope(provider, scope).build()
     }
 
-    pub fn builder(
-        provider: &P,
-        scope: Option<InstrumentationScope>,
-    ) -> OpenTelemetryTracingBridgeBuilder<P, L> {
+    /// Creates a builder using the default OpenTelemetry logger scope.
+    pub fn builder(provider: &P) -> OpenTelemetryTracingBridgeBuilder<P, L> {
         OpenTelemetryTracingBridgeBuilder {
             // Using empty scope name.
             // The name/version of this library itself can be added
             // as a Scope attribute, once a semantic convention is
             // defined for the same.
             // See https://github.com/open-telemetry/semantic-conventions/issues/1550
-            logger: scope
-                .map(|scope| provider.logger_with_scope(scope))
-                .unwrap_or_else(|| provider.logger("")),
+            logger: provider.logger(""),
+            _phantom: Default::default(),
+            #[cfg(feature = "experimental_span_attributes")]
+            span_attribute_allowlist: None,
+        }
+    }
+
+    /// Creates a builder that uses a custom OpenTelemetry [`InstrumentationScope`]
+    /// for the appender logger.
+    pub fn builder_with_scope(
+        provider: &P,
+        scope: InstrumentationScope,
+    ) -> OpenTelemetryTracingBridgeBuilder<P, L> {
+        OpenTelemetryTracingBridgeBuilder {
+            logger: provider.logger_with_scope(scope),
             _phantom: Default::default(),
             #[cfg(feature = "experimental_span_attributes")]
             span_attributes: None,
@@ -948,7 +958,7 @@ mod tests {
             .build();
 
         let subscriber = tracing_subscriber::registry().with(
-            layer::OpenTelemetryTracingBridge::with_scope(&logger_provider, scope),
+            layer::OpenTelemetryTracingBridge::builder_with_scope(&logger_provider, scope).build(),
         );
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1556,7 +1566,7 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::builder(&provider, None)
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
@@ -1593,7 +1603,7 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::builder(&provider, None)
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
@@ -1640,7 +1650,7 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::builder(&provider, None)
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_tracing_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
@@ -1678,7 +1688,7 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::builder(&provider, None)
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,6 +1,6 @@
 use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    InstrumentationScope, Key,
+    InstrumentationScope, Key, KeyValue,
 };
 #[cfg(feature = "experimental_span_attributes")]
 use std::borrow::Cow;
@@ -379,7 +379,7 @@ where
     ///
     /// The default scope uses an empty scope name for the appender logger.
     /// Use [`Self::builder_with_scope_attributes`] to provide a
-    /// custom [`InstrumentationScope`].
+    /// custom set of instrumentation scope attributes.
     pub fn new(provider: &P) -> Self {
         Self::builder(provider).build()
     }
@@ -399,12 +399,15 @@ where
         }
     }
 
-    /// Creates a builder that uses a custom OpenTelemetry [`InstrumentationScope`]
-    /// for the appender logger.
+    /// Creates a builder that uses custom OpenTelemetry instrumentation scope
+    /// attributes for the appender logger.
     pub fn builder_with_scope_attributes(
         provider: &P,
-        scope: InstrumentationScope,
+        attributes: impl IntoIterator<Item = KeyValue>,
     ) -> OpenTelemetryTracingBridgeBuilder<P, L> {
+        let scope = InstrumentationScope::builder("")
+            .with_attributes(attributes)
+            .build();
         OpenTelemetryTracingBridgeBuilder {
             logger: provider.logger_with_scope(scope),
             _phantom: Default::default(),
@@ -940,21 +943,16 @@ mod tests {
     }
 
     #[test]
-    fn tracing_appender_with_custom_scope() {
+    fn tracing_appender_with_custom_scope_attributes() {
         let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let scope = InstrumentationScope::builder("test.scope")
-            .with_version("1.2.3")
-            .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
-            .with_attributes([KeyValue::new("scope-key", "scope-value")])
-            .build();
         let subscriber = tracing_subscriber::registry().with(
             layer::OpenTelemetryTracingBridge::builder_with_scope_attributes(
                 &logger_provider,
-                scope.clone(),
+                [KeyValue::new("scope-key", "scope-value")],
             )
             .build(),
         );
@@ -972,14 +970,8 @@ mod tests {
             .first()
             .expect("At least one log is expected to be present.");
 
-        let instrumentation_scope = &log.instrumentation;
-        assert_eq!(instrumentation_scope.name(), "test.scope");
-        assert_eq!(instrumentation_scope.version(), Some("1.2.3"));
-        assert_eq!(
-            instrumentation_scope.schema_url(),
-            Some("https://opentelemetry.io/schemas/1.0.0")
-        );
-        assert!(instrumentation_scope
+        assert!(log
+            .instrumentation
             .attributes()
             .eq([KeyValue::new("scope-key", "scope-value")].iter()));
         exporter.reset();


### PR DESCRIPTION
## Changes

This PR adds `OpenTelemetryTracingBridgeBuilder::with_scope()` to allow configuring the OpenTelemetry `InstrumentationScope` used by the appender logger.

The implementation also updates `OpenTelemetryTracingBridgeBuilder` to hold the logger provider until `build()`, so the builder can expose a set of configuration methods:
- `with_scope()`
- `with_span_attribute_allowlist()`
-  and potentially additional builder options in the future

## Design Notes

This change introduces a lifetime parameter on `OpenTelemetryTracingBridgeBuilder<'a>`. That was done to keep the builder aligned with the existing style, where the bridge is constructed from a provider reference rather than from a pre-created logger. 

In return, this keeps the API shape cleaner and gives us a more natural builder surface with related configuration methods grouped together.

## Compatibility

Technically, adding the lifetime to the public builder type is a breaking API change.

However, this builder API has not yet shipped in a released version, so this does not affect production users of published crates. In practice, the change is limited to the unreleased API surface.

## Testing

Added a unit test (`tracing_appender_with_custom_scope`) covering `with_scope()` and verifying that the configured `InstrumentationScope` is propagated to emitted logs.

## Related

* Fix: #3415

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
