### PR TITLE
fix: resolve clippy unnecessary_unwrap in GrowableArray (backport to 0.31.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,22 +137,22 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Check advisories
-        uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
+        uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
         with:
           command: check advisories
 
       - name: Check licenses
-        uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
+        uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
         with:
           command: check licenses
 
       - name: Check bans
-        uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
+        uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
         with:
           command: check bans
       
       - name: Check sources
-        uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
+        uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
         with:
           command: check sources
 

--- a/opentelemetry-sdk/src/growable_array.rs
+++ b/opentelemetry-sdk/src/growable_array.rs
@@ -96,15 +96,14 @@ impl<
     #[allow(dead_code)]
     #[inline]
     pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {
-        if self.overflow.is_none() || self.overflow.as_ref().unwrap().is_empty() {
-            self.inline.iter().take(self.count).chain([].iter()) // Chaining with an empty array
-                                                                 // so that both `if` and `else` branch return the same type
-        } else {
-            self.inline
-                .iter()
-                .take(self.count)
-                .chain(self.overflow.as_ref().unwrap().iter())
-        }
+        let overflow_slice = match &self.overflow {
+            Some(v) if !v.is_empty() => v.as_slice(),
+            _ => &[],
+        };
+        self.inline
+            .iter()
+            .take(self.count)
+            .chain(overflow_slice.iter())
     }
 }
 
@@ -148,19 +147,15 @@ impl<T: Default + Clone + PartialEq, const INLINE_CAPACITY: usize>
         std::iter::Take<std::array::IntoIter<T, INLINE_CAPACITY>>,
         std::vec::IntoIter<T>,
     > {
-        if source.overflow.is_none() || source.overflow.as_ref().unwrap().is_empty() {
-            source
-                .inline
-                .into_iter()
-                .take(source.count)
-                .chain(Vec::<T>::new())
-        } else {
-            source
-                .inline
-                .into_iter()
-                .take(source.count)
-                .chain(source.overflow.unwrap())
-        }
+        let overflow_vec = match source.overflow {
+            Some(v) if !v.is_empty() => v,
+            _ => Vec::new(),
+        };
+        source
+            .inline
+            .into_iter()
+            .take(source.count)
+            .chain(overflow_vec)
     }
 }
 


### PR DESCRIPTION
## Description

Backports the clippy fix from `main` to `release/0.31.x`.

Newer Rust toolchains (1.94.0+) flag `clippy::unnecessary_unwrap` on the `is_none()` + `.unwrap()` pattern in `GrowableArray::iter()` and `GrowableArrayIntoIter::get_iterator()`. This causes CI failures for all PRs targeting `release/0.31.x`.

### Changes

Replaces `if is_none() || .unwrap().is_empty()` + `.unwrap()` with idiomatic `match` expressions, matching the fix already on `main` ([#3325](https://github.com/open-telemetry/opentelemetry-rust/pull/3325)).