### PR TITLE
fix: timeout being ignored in MeterProvider shutdown_with_timeout

### DIFF
--- a/opentelemetry-sdk/src/metrics/meter_provider.rs
+++ b/opentelemetry-sdk/src/metrics/meter_provider.rs
@@ -110,12 +110,12 @@ impl SdkMeterProvider {
     ///
     /// There is no guaranteed that all telemetry be flushed or all resources have
     /// been released on error.
-    pub fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+    pub fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         otel_debug!(
             name: "MeterProvider.Shutdown",
             message = "User initiated shutdown of MeterProvider."
         );
-        self.inner.shutdown()
+        self.inner.shutdown_with_timeout(timeout)
     }
 
     /// shutdown with default timeout
@@ -136,7 +136,7 @@ impl SdkMeterProviderInner {
         }
     }
 
-    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         if self
             .shutdown_invoked
             .swap(true, std::sync::atomic::Ordering::SeqCst)
@@ -144,7 +144,7 @@ impl SdkMeterProviderInner {
             // If the previous value was true, shutdown was already invoked.
             Err(crate::error::OTelSdkError::AlreadyShutdown)
         } else {
-            self.pipes.shutdown()
+            self.pipes.shutdown_with_timeout(timeout)
         }
     }
 

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -3,6 +3,7 @@ use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use opentelemetry::{otel_debug, otel_warn, InstrumentationScope, KeyValue};
@@ -95,6 +96,11 @@ impl Pipeline {
     /// Shut down pipeline
     fn shutdown(&self) -> OTelSdkResult {
         self.reader.shutdown()
+    }
+
+    /// Shut down pipeline with timeout
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
+        self.reader.shutdown_with_timeout(timeout)
     }
 }
 
@@ -700,6 +706,24 @@ impl Pipelines {
             Ok(())
         } else {
             Err(OTelSdkError::InternalFailure(format!("{errs:?}")))
+        }
+    }
+
+    /// Shut down all pipelines
+    pub(crate) fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
+        let mut errs = vec![];
+        for pipeline in &self.0 {
+            if let Err(err) = pipeline.shutdown_with_timeout(timeout) {
+                errs.push(err);
+            }
+        }
+
+        if errs.is_empty() {
+            Ok(())
+        } else {
+            Err(crate::error::OTelSdkError::InternalFailure(format!(
+                "{errs:?}"
+            )))
         }
     }
 


### PR DESCRIPTION
Fixes #2574 

## Changes

Passed down the ignored timeout argument in shutdown_with_timeout in MeterProvider

When calling the shutdown_with_timeout in MeterProvider the timeout was being ignored and not being passed down the incoming inner function calls
This PR fixes that by calling shutdown_with_timeout at each level and passing timeout along with it.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [X] Unit tests added/updated (if applicable)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [X] Changes in public API reviewed (if applicable)
