### PR TITLE
fix(opentelemetry-proto): avoid tonic for gen-tonic-messages

### DIFF
--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -35,8 +35,8 @@ default = ["full"]
 full = ["gen-tonic", "trace", "logs", "metrics", "zpages", "with-serde", "internal-logs"]
 
 # crates used to generate rs files
-gen-tonic = ["gen-tonic-messages", "tonic/channel"]
-gen-tonic-messages = ["tonic", "tonic-prost", "prost"]
+gen-tonic = ["gen-tonic-messages", "tonic", "tonic-prost", "tonic/channel"]
+gen-tonic-messages = ["prost"]
 
 # telemetry pillars and functions
 trace = ["opentelemetry/trace", "opentelemetry_sdk/trace"]

--- a/opentelemetry-proto/src/lib.rs
+++ b/opentelemetry-proto/src/lib.rs
@@ -17,8 +17,8 @@
 //! - `zpages`: generate types that used in zPages. Currently only tracez related types will be generated. Currently supports `gen-tonic`.
 //!
 //! ## Creates used to generate files
-//! - `gen-tonic-messages`: generate rs files using [tonic](https://github.com/hyperium/tonic) and [prost](https://github.com/tokio-rs/prost).
-//! - `gen-tonic`: adding tonic transport to "`gen-tonic-messages"
+//! - `gen-tonic-messages`: generate OTLP message types using [prost](https://github.com/tokio-rs/prost).
+//! - `gen-tonic`: add tonic gRPC client/server transport support on top of `gen-tonic-messages`.
 //!
 //! ## Misc
 //! - `full`: enabled all features above.


### PR DESCRIPTION
Fixes #3454.

`http-proto` and `http-json` both use `opentelemetry-proto/gen-tonic-messages`, but that feature currently pulls `tonic` and `tonic-prost` in addition to `prost`.

This change keeps `gen-tonic-messages` as the message-only path and moves the tonic-specific dependencies under `gen-tonic`, which already gates the generated gRPC client/server code.

<img width="3040" height="2942" alt="image" src="https://github.com/user-attachments/assets/582c5d12-ec24-43af-8a2d-37f91106856d" />

