### PR TITLE
chore: Ignore RUSTSEC-2026-0009 for time crate in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -44,6 +44,10 @@ ignore = true
 [advisories]
 unmaintained = "none"
 yanked = "deny"
+# `time` is only used transitively in test infrastructure (integration_test_runner → testcontainers → bollard → time).
+# No published crate depends on it. If a published crate ever adds a dependency on `time`,
+# this ignore will silently suppress the advisory — revisit this entry if that happens.
+ignore = ["RUSTSEC-2026-0009"]
 
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:

--- a/deny.toml
+++ b/deny.toml
@@ -47,7 +47,7 @@ yanked = "deny"
 # `time` is only used transitively in test infrastructure (integration_test_runner → testcontainers → bollard → time).
 # No published crate depends on it. If a published crate ever adds a dependency on `time`,
 # this ignore will silently suppress the advisory — revisit this entry if that happens.
-ignore = ["RUSTSEC-2026-0009"]
+ignore = [{ id = "RUSTSEC-2026-0009", reason = "currently dev-only via test infra" }]
 
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:


### PR DESCRIPTION
The `time` crate vulnerability (DoS via stack exhaustion in RFC 2822 parsing) only affects test infrastructure through the chain: `integration_test_runner → testcontainers → bollard → time`.

No published crate depends on `time`. The patched version (>=0.3.47) cannot be resolved due to MSRV constraints (workspace MSRV is 1.75.0), and `Cargo.lock` is not tracked in git.

**Changes:**
- `deny.toml` — Added `RUSTSEC-2026-0009` to the advisories ignore list with a comment explaining rationale and future risk.