### PR TITLE
feat(sdk)!: provider builder build() returns Result instead of panicking

### DIFF
--- a/examples/logs-advanced/src/main.rs
+++ b/examples/logs-advanced/src/main.rs
@@ -17,7 +17,8 @@ fn main() {
                 .build(),
         )
         .with_log_processor(enriching_processor)
-        .build();
+        .build()
+        .expect("Failed to build logger provider");
 
     // To prevent a telemetry-induced-telemetry loop, OpenTelemetry's own internal
     // logging is properly suppressed. However, logs emitted by external components

--- a/examples/logs-basic/src/main.rs
+++ b/examples/logs-basic/src/main.rs
@@ -13,7 +13,8 @@ fn main() {
                 .build(),
         )
         .with_simple_exporter(exporter)
-        .build();
+        .build()
+        .expect("Failed to build logger provider");
 
     // To prevent a telemetry-induced-telemetry loop, OpenTelemetry's own internal
     // logging is properly suppressed. However, logs emitted by external components

--- a/examples/tracing-grpc/src/client.rs
+++ b/examples/tracing-grpc/src/client.rs
@@ -14,7 +14,8 @@ fn init_tracer() -> sdktrace::SdkTracerProvider {
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     let provider = sdktrace::SdkTracerProvider::builder()
         .with_simple_exporter(SpanExporter::default())
-        .build();
+        .build()
+        .expect("Failed to build tracer provider");
 
     global::set_tracer_provider(provider.clone());
     provider

--- a/examples/tracing-grpc/src/server.rs
+++ b/examples/tracing-grpc/src/server.rs
@@ -15,7 +15,8 @@ fn init_tracer() -> SdkTracerProvider {
     // Install stdout exporter pipeline to be able to retrieve the collected spans.
     let provider = SdkTracerProvider::builder()
         .with_simple_exporter(SpanExporter::default())
-        .build();
+        .build()
+        .expect("Failed to build tracer provider");
 
     global::set_tracer_provider(provider.clone());
     provider

--- a/examples/tracing-http-propagator/src/client.rs
+++ b/examples/tracing-http-propagator/src/client.rs
@@ -20,7 +20,8 @@ fn init_tracer() -> SdkTracerProvider {
     // For the demonstration, use `Sampler::AlwaysOn` sampler to sample all traces.
     let provider = SdkTracerProvider::builder()
         .with_simple_exporter(SpanExporter::default())
-        .build();
+        .build()
+        .expect("Failed to build tracer provider");
 
     global::set_tracer_provider(provider.clone());
     provider
@@ -31,7 +32,8 @@ fn init_logs() -> SdkLoggerProvider {
     // that prints the spans to stdout.
     let logger_provider = SdkLoggerProvider::builder()
         .with_simple_exporter(LogExporter::default())
-        .build();
+        .build()
+        .expect("Failed to build logger provider");
     let otel_layer = OpenTelemetryTracingBridge::new(&logger_provider);
     tracing_subscriber::registry()
         .with(otel_layer)

--- a/examples/tracing-http-propagator/src/server.rs
+++ b/examples/tracing-http-propagator/src/server.rs
@@ -164,7 +164,8 @@ fn init_tracer() -> SdkTracerProvider {
     let provider = SdkTracerProvider::builder()
         .with_span_processor(EnrichWithBaggageSpanProcessor)
         .with_simple_exporter(SpanExporter::default())
-        .build();
+        .build()
+        .expect("Failed to build tracer provider");
 
     global::set_tracer_provider(provider.clone());
     provider
@@ -176,7 +177,8 @@ fn init_logs() -> SdkLoggerProvider {
     let logger_provider = SdkLoggerProvider::builder()
         .with_log_processor(EnrichWithBaggageLogProcessor)
         .with_simple_exporter(LogExporter::default())
-        .build();
+        .build()
+        .expect("Failed to build logger provider");
     let otel_layer = OpenTelemetryTracingBridge::new(&logger_provider);
     tracing_subscriber::registry().with(otel_layer).init();
 

--- a/opentelemetry-appender-log/examples/logs-basic.rs
+++ b/opentelemetry-appender-log/examples/logs-basic.rs
@@ -24,7 +24,8 @@ async fn main() {
                 .build(),
         )
         .with_simple_exporter(exporter)
-        .build();
+        .build()
+        .expect("Failed to build logger provider");
 
     // Setup Log Appender for the log crate.
     let otel_log_appender = OpenTelemetryLogBridge::new(&logger_provider);

--- a/opentelemetry-appender-log/src/lib.rs
+++ b/opentelemetry-appender-log/src/lib.rs
@@ -17,8 +17,9 @@
 //! let exporter = opentelemetry_stdout::LogExporter::default();
 //!
 //! let logger_provider = SdkLoggerProvider::builder()
-//!     .with_log_processor(BatchLogProcessor::builder(exporter).build())
-//!     .build();
+//!     .with_log_processor(BatchLogProcessor::builder(exporter).build().unwrap())
+//!     .build()
+//!     .unwrap();
 //! # }
 //! ```
 //!
@@ -31,8 +32,9 @@
 //! # use opentelemetry_appender_log::OpenTelemetryLogBridge;
 //! # let exporter = opentelemetry_stdout::LogExporter::default();
 //! # let logger_provider = SdkLoggerProvider::builder()
-//! #     .with_log_processor(BatchLogProcessor::builder(exporter).build())
-//! #     .build();
+//! #     .with_log_processor(BatchLogProcessor::builder(exporter).build().unwrap())
+//! #     .build()
+//! #     .unwrap();
 //! let otel_log_appender = OpenTelemetryLogBridge::new(&logger_provider);
 //!
 //! log::set_boxed_logger(Box::new(otel_log_appender)).unwrap();
@@ -777,7 +779,8 @@ mod tests {
 
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter)
-            .build();
+            .build()
+            .unwrap();
 
         let otel_log_appender = OpenTelemetryLogBridge::new(&logger_provider);
 
@@ -793,7 +796,8 @@ mod tests {
 
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let otel_log_appender = OpenTelemetryLogBridge::new(&logger_provider);
 
@@ -907,7 +911,8 @@ mod tests {
 
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let otel_log_appender = OpenTelemetryLogBridge::new(&logger_provider);
 
@@ -1177,7 +1182,8 @@ mod tests {
 
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let otel_log_appender = OpenTelemetryLogBridge::new(&logger_provider);
 
@@ -1224,7 +1230,8 @@ mod tests {
 
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter)
-            .build();
+            .build()
+            .unwrap();
 
         let otel_log_appender = OpenTelemetryLogBridge::new(&logger_provider);
         otel_log_appender.flush();

--- a/opentelemetry-appender-tracing/benches/log-attributes.rs
+++ b/opentelemetry-appender-tracing/benches/log-attributes.rs
@@ -60,7 +60,8 @@ fn create_benchmark(c: &mut Criterion, num_attributes: usize) {
                 .build(),
         )
         .with_log_processor(NoopProcessor)
-        .build();
+        .build()
+        .unwrap();
 
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::new(&provider);
     let subscriber = Registry::default().with(ot_layer);

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -122,7 +122,8 @@ fn benchmark_with_ot_layer(c: &mut Criterion, enabled: bool, bench_name: &str) {
                 .build(),
         )
         .with_log_processor(processor)
-        .build();
+        .build()
+        .unwrap();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::new(&provider);
     let subscriber = Registry::default().with(ot_layer);
 

--- a/opentelemetry-appender-tracing/benches/span-attributes.rs
+++ b/opentelemetry-appender-tracing/benches/span-attributes.rs
@@ -65,7 +65,8 @@ fn benchmark_span_attributes(c: &mut Criterion, num_attributes: usize) {
                 .build(),
         )
         .with_log_processor(NoopProcessor)
-        .build();
+        .build()
+        .unwrap();
 
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::new(&provider);
     let subscriber = Registry::default().with(ot_layer);
@@ -127,7 +128,8 @@ fn benchmark_nested_spans(c: &mut Criterion, depth: usize) {
                 .build(),
         )
         .with_log_processor(NoopProcessor)
-        .build();
+        .build()
+        .unwrap();
 
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::new(&provider);
     let subscriber = Registry::default().with(ot_layer);
@@ -238,6 +240,7 @@ fn make_provider() -> SdkLoggerProvider {
         )
         .with_log_processor(NoopProcessor)
         .build()
+        .unwrap()
 }
 
 /// Baseline: emit an error log with 1 attribute, no enclosing span (total = 1 attr).

--- a/opentelemetry-appender-tracing/examples/basic.rs
+++ b/opentelemetry-appender-tracing/examples/basic.rs
@@ -14,7 +14,8 @@ fn main() {
                 .build(),
         )
         .with_simple_exporter(exporter)
-        .build();
+        .build()
+        .expect("Failed to build logger provider");
 
     // To prevent a telemetry-induced-telemetry loop, OpenTelemetry's own internal
     // logging is properly suppressed. However, logs emitted by external components

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -540,7 +540,8 @@ mod tests {
         let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let subscriber = create_tracing_subscriber(&logger_provider);
 
@@ -721,7 +722,8 @@ mod tests {
         let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let subscriber = create_tracing_subscriber(&logger_provider);
 
@@ -732,7 +734,8 @@ mod tests {
         // setup tracing as well.
         let tracer_provider = SdkTracerProvider::builder()
             .with_sampler(Sampler::AlwaysOn)
-            .build();
+            .build()
+            .unwrap();
         let tracer = tracer_provider.tracer("test-tracer");
 
         // Act
@@ -838,7 +841,8 @@ mod tests {
         let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let subscriber = create_tracing_subscriber(&logger_provider);
 
@@ -915,7 +919,8 @@ mod tests {
         let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let subscriber = create_tracing_subscriber(&logger_provider);
 
@@ -927,7 +932,8 @@ mod tests {
         // setup tracing as well.
         let tracer_provider = SdkTracerProvider::builder()
             .with_sampler(Sampler::AlwaysOn)
-            .build();
+            .build()
+            .unwrap();
         let tracer = tracer_provider.tracer("test-tracer");
 
         // Act
@@ -1055,7 +1061,8 @@ mod tests {
                 "my-event-name".to_string(),
                 "my-system".to_string(),
             ))
-            .build();
+            .build()
+            .unwrap();
 
         let subscriber = create_tracing_subscriber(&logger_provider);
 
@@ -1075,7 +1082,8 @@ mod tests {
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
             tracing_subscriber::filter::filter_fn(|meta| {
@@ -1126,7 +1134,8 @@ mod tests {
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
             tracing_subscriber::filter::filter_fn(|meta| {
@@ -1187,7 +1196,8 @@ mod tests {
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
             tracing_subscriber::filter::filter_fn(|meta| {
@@ -1299,7 +1309,8 @@ mod tests {
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
             tracing_subscriber::filter::filter_fn(|meta| {
@@ -1363,7 +1374,8 @@ mod tests {
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_span_attribute_allowlist(["session.id"])
@@ -1400,7 +1412,8 @@ mod tests {
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_span_attribute_allowlist(["session.id"])
@@ -1447,7 +1460,8 @@ mod tests {
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_span_attribute_allowlist(std::iter::empty::<&str>())
@@ -1485,7 +1499,8 @@ mod tests {
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_span_attribute_allowlist(["session.id"])

--- a/opentelemetry-appender-tracing/src/lib.rs
+++ b/opentelemetry-appender-tracing/src/lib.rs
@@ -46,7 +46,8 @@
 //! let exporter = LogExporter::default();
 //! let provider = SdkLoggerProvider::builder()
 //!     .with_simple_exporter(exporter)
-//!     .build();
+//!     .build()
+//!     .unwrap();
 //! ```
 //!
 //! In this example, `SdkLoggerProvider` is configured to use the `opentelemetry_stdout` crate to export logs to stdout. You can replace it with any other OpenTelemetry-compatible exporter.
@@ -63,7 +64,8 @@
 //! # let exporter = LogExporter::default();
 //! # let provider = SdkLoggerProvider::builder()
 //! #    .with_simple_exporter(exporter)
-//! #    .build();
+//! #    .build()
+//! #    .unwrap();
 //! let otel_layer = OpenTelemetryTracingBridge::new(&provider);
 //! ```
 //!
@@ -75,7 +77,7 @@
 //! # use opentelemetry_sdk::logs::SdkLoggerProvider;
 //! # use opentelemetry_stdout::LogExporter;
 //! # let exporter = LogExporter::default();
-//! # let provider = SdkLoggerProvider::builder().with_simple_exporter(exporter).build();
+//! # let provider = SdkLoggerProvider::builder().with_simple_exporter(exporter).build().unwrap();
 //! # use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 //! # let otel_layer = OpenTelemetryTracingBridge::new(&provider);
 //! use tracing_subscriber::prelude::*;

--- a/opentelemetry-appender-tracing/tests/test_no_stack_overflow_after_shutdown.rs
+++ b/opentelemetry-appender-tracing/tests/test_no_stack_overflow_after_shutdown.rs
@@ -1,5 +1,5 @@
 use opentelemetry_appender_tracing::layer;
-use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::logs::{BatchLogProcessor, SdkLoggerProvider};
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -7,9 +7,11 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 fn test_logging_after_shutdown_does_not_cause_telemetry_induced_telemetry() {
     //! Reproduces [#3161](https://github.com/open-telemetry/opentelemetry-rust/issues/3161)
     let exporter = opentelemetry_stdout::LogExporter::default();
+    let processor = BatchLogProcessor::builder(exporter).build().unwrap();
     let provider: SdkLoggerProvider = SdkLoggerProvider::builder()
-        .with_batch_exporter(exporter)
-        .build();
+        .with_log_processor(processor)
+        .build()
+        .unwrap();
 
     let otel_layer = layer::OpenTelemetryTracingBridge::new(&provider);
 

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - `reqwest`'s crypto backend has changed from `ring` to `aws-lc-sys`.
+- Added `HttpClient::requires_async_runtime() -> bool` method (default: `false`). `reqwest::Client` and `HyperClient` return `true`. Used by batch processors to detect invalid client/processor combinations at build time.
 
 ## 0.31.0
 

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -88,6 +88,21 @@ pub trait HttpClient: Debug + Send + Sync {
     /// Returns an error if it can't connect to the server or the request could not be completed,
     /// e.g. because of a timeout, infinite redirects, or a loss of connection.
     async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError>;
+
+    /// Returns `true` if this client requires an async runtime (e.g. Tokio) to be active.
+    ///
+    /// Async clients like `reqwest::Client` and `HyperClient` require a Tokio runtime.
+    /// Sync clients like `reqwest::blocking::Client` do not.
+    ///
+    /// This is used by batch processors to detect invalid client/processor combinations
+    /// at build time, before they would panic at export time.
+    ///
+    /// **Note:** This check is best-effort. Third-party clients that wrap async HTTP
+    /// clients but do not override this method will return `false` and may panic at
+    /// export time when used with a sync batch processor.
+    fn requires_async_runtime(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(feature = "reqwest")]
@@ -109,6 +124,10 @@ mod reqwest {
             *http_response.headers_mut() = headers;
 
             Ok(http_response)
+        }
+
+        fn requires_async_runtime(&self) -> bool {
+            true
         }
     }
 
@@ -208,6 +227,10 @@ pub mod hyper {
             *http_response.headers_mut() = headers;
 
             Ok(http_response.error_for_status()?)
+        }
+
+        fn requires_async_runtime(&self) -> bool {
+            true
         }
     }
 

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNext
 
+- OTLP HTTP span and log exporters now propagate `requires_async_runtime()` from the underlying `HttpClient`, enabling batch processors to reject async-only clients at build time instead of panicking at export time.
 - Add `tls-provider-agnostic` feature flag for environments that require a custom crypto backend (e.g., OpenSSL for FIPS compliance). Enables TLS code paths without bundling `ring` or `aws-lc-rs`.
 - Add `build()` directly on `SpanExporterBuilder`, `MetricExporterBuilder`, and `LogExporterBuilder`
   (before selecting a transport), which auto-selects the transport based on the

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -8,7 +8,9 @@ use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_otlp::{LogExporter, MetricExporter, Protocol, SpanExporter};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::{
-    logs::SdkLoggerProvider, metrics::SdkMeterProvider, trace::SdkTracerProvider,
+    logs::{BatchLogProcessor, SdkLoggerProvider},
+    metrics::SdkMeterProvider,
+    trace::{BatchSpanProcessor, SdkTracerProvider},
 };
 use std::{error::Error, sync::OnceLock};
 use tracing::info;
@@ -33,10 +35,14 @@ fn init_logs() -> SdkLoggerProvider {
         .build()
         .expect("Failed to create log exporter");
 
+    let processor = BatchLogProcessor::builder(exporter)
+        .build()
+        .expect("Failed to create batch log processor");
     SdkLoggerProvider::builder()
-        .with_batch_exporter(exporter)
+        .with_log_processor(processor)
         .with_resource(get_resource())
         .build()
+        .expect("Failed to build logger provider")
 }
 
 fn init_traces() -> SdkTracerProvider {
@@ -46,10 +52,14 @@ fn init_traces() -> SdkTracerProvider {
         .build()
         .expect("Failed to create trace exporter");
 
+    let processor = BatchSpanProcessor::builder(exporter)
+        .build()
+        .expect("Failed to create batch span processor");
     SdkTracerProvider::builder()
-        .with_batch_exporter(exporter)
+        .with_span_processor(processor)
         .with_resource(get_resource())
         .build()
+        .expect("Failed to build tracer provider")
 }
 
 fn init_metrics() -> SdkMeterProvider {

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -3,9 +3,9 @@ use opentelemetry::KeyValue;
 use opentelemetry::{global, InstrumentationScope};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{LogExporter, MetricExporter, SpanExporter};
-use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::logs::{BatchLogProcessor, SdkLoggerProvider};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
-use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::trace::{BatchSpanProcessor, SdkTracerProvider};
 use opentelemetry_sdk::Resource;
 use std::error::Error;
 use std::sync::OnceLock;
@@ -28,10 +28,14 @@ fn init_traces() -> SdkTracerProvider {
     let exporter = SpanExporter::builder()
         .build()
         .expect("Failed to create span exporter");
+    let processor = BatchSpanProcessor::builder(exporter)
+        .build()
+        .expect("Failed to create batch span processor");
     SdkTracerProvider::builder()
         .with_resource(get_resource())
-        .with_batch_exporter(exporter)
+        .with_span_processor(processor)
         .build()
+        .expect("Failed to build tracer provider")
 }
 
 fn init_metrics() -> SdkMeterProvider {
@@ -50,10 +54,14 @@ fn init_logs() -> SdkLoggerProvider {
         .build()
         .expect("Failed to create log exporter");
 
+    let processor = BatchLogProcessor::builder(exporter)
+        .build()
+        .expect("Failed to create batch log processor");
     SdkLoggerProvider::builder()
         .with_resource(get_resource())
-        .with_batch_exporter(exporter)
+        .with_log_processor(processor)
         .build()
+        .expect("Failed to build logger provider")
 }
 
 #[tokio::main]

--- a/opentelemetry-otlp/src/exporter/http/logs.rs
+++ b/opentelemetry-otlp/src/exporter/http/logs.rs
@@ -36,6 +36,10 @@ impl LogExporter for OtlpHttpClient {
     fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
         self.resource = resource.into();
     }
+
+    fn requires_async_runtime(&self) -> bool {
+        self.needs_async_runtime
+    }
 }
 
 /// Handles partial success returned by OTLP endpoints. We log the rejected log records,

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -373,6 +373,8 @@ pub(crate) struct OtlpHttpClient {
     #[allow(dead_code)]
     // <allow dead> would be removed once we support set_resource for metrics and traces.
     resource: opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema,
+    /// Whether the underlying HTTP client requires an async runtime (e.g. Tokio).
+    needs_async_runtime: bool,
 }
 
 impl OtlpHttpClient {
@@ -579,6 +581,7 @@ impl OtlpHttpClient {
         compression: Option<crate::Compression>,
         #[cfg(feature = "experimental-http-retry")] retry_policy: Option<RetryPolicy>,
     ) -> Self {
+        let needs_async_runtime = client.requires_async_runtime();
         OtlpHttpClient {
             client: Mutex::new(Some(client)),
             collector_endpoint,
@@ -594,6 +597,7 @@ impl OtlpHttpClient {
                 jitter_ms: 100,
             }),
             resource: ResourceAttributesWithSchema::default(),
+            needs_async_runtime,
         }
     }
 

--- a/opentelemetry-otlp/src/exporter/http/trace.rs
+++ b/opentelemetry-otlp/src/exporter/http/trace.rs
@@ -37,6 +37,10 @@ impl SpanExporter for OtlpHttpClient {
     fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
         self.resource = resource.into();
     }
+
+    fn requires_async_runtime(&self) -> bool {
+        self.needs_async_runtime
+    }
 }
 
 /// Handles partial success returned by OTLP endpoints. We log the rejected spans,

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -42,10 +42,14 @@
 //!         .with_protocol(Protocol::HttpBinary)
 //!         .build()?;
 //!
-//!     // Create a tracer provider with the exporter
+//!     // Create a batch processor and tracer provider
+//!     let processor = opentelemetry_sdk::trace::BatchSpanProcessor::builder(otlp_exporter)
+//!         .build()
+//!         .unwrap();
 //!     let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-//!         .with_batch_exporter(otlp_exporter)
-//!         .build();
+//!         .with_span_processor(processor)
+//!         .build()
+//!         .unwrap();
 //!
 //!     // Set it as the global provider
 //!     global::set_tracer_provider(tracer_provider);
@@ -85,10 +89,14 @@
 //!         .with_tonic()
 //!         .build()?;
 //!
-//!     // Create a tracer provider with the exporter
+//!     // Create a batch processor and tracer provider
+//!     let processor = opentelemetry_sdk::trace::BatchSpanProcessor::builder(otlp_exporter)
+//!         .build()
+//!         .unwrap();
 //!     let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-//!         .with_batch_exporter(otlp_exporter)
-//!         .build();
+//!         .with_span_processor(processor)
+//!         .build()
+//!         .unwrap();
 //!
 //!     // Set it as the global provider
 //!     global::set_tracer_provider(tracer_provider);
@@ -119,9 +127,13 @@
 //!             .with_tonic()
 //!             .build()
 //!             .expect("Failed to create span exporter");
-//!         opentelemetry_sdk::trace::SdkTracerProvider::builder()
-//!             .with_batch_exporter(exporter)
+//!         let processor = opentelemetry_sdk::trace::BatchSpanProcessor::builder(exporter)
 //!             .build()
+//!             .unwrap();
+//!         opentelemetry_sdk::trace::SdkTracerProvider::builder()
+//!             .with_span_processor(processor)
+//!             .build()
+//!             .unwrap()
 //!     });
 //!
 //!     // Set it as the global provider
@@ -580,10 +592,14 @@
 //!     .with_timeout(Duration::from_secs(5))
 //!     .build()
 //!     .expect("Failed to build SpanExporter");
+//! let span_processor = opentelemetry_sdk::trace::BatchSpanProcessor::builder(span_exporter)
+//!     .build()
+//!     .expect("Failed to build BatchSpanProcessor");
 //! let tracer_provider = SdkTracerProvider::builder()
 //!     .with_resource(resource.clone())
-//!     .with_batch_exporter(span_exporter)
-//!     .build();
+//!     .with_span_processor(span_processor)
+//!     .build()
+//!     .unwrap();
 //!
 //! // Metrics
 //! let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
@@ -604,10 +620,14 @@
 //!     .with_timeout(Duration::from_secs(5))
 //!     .build()
 //!     .expect("Failed to build LogExporter");
+//! let log_processor = opentelemetry_sdk::logs::BatchLogProcessor::builder(log_exporter)
+//!     .build()
+//!     .expect("Failed to build BatchLogProcessor");
 //! let logger_provider = SdkLoggerProvider::builder()
 //!     .with_resource(resource)
-//!     .with_batch_exporter(log_exporter)
-//!     .build();
+//!     .with_log_processor(log_processor)
+//!     .build()
+//!     .unwrap();
 //! # }
 //! ```
 #![warn(

--- a/opentelemetry-otlp/tests/integration_test/tests/logs.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs.rs
@@ -32,7 +32,8 @@ fn init_logs(is_simple: bool) -> Result<sdklogs::SdkLoggerProvider> {
     if is_simple {
         logger_provider_builder = logger_provider_builder.with_simple_exporter(exporter)
     } else {
-        logger_provider_builder = logger_provider_builder.with_batch_exporter(exporter)
+        let processor = sdklogs::BatchLogProcessor::builder(exporter).build()?;
+        logger_provider_builder = logger_provider_builder.with_log_processor(processor)
     };
 
     let logger_provider = logger_provider_builder
@@ -41,7 +42,7 @@ fn init_logs(is_simple: bool) -> Result<sdklogs::SdkLoggerProvider> {
                 .with_service_name("logs-integration-test")
                 .build(),
         )
-        .build();
+        .build()?;
 
     Ok(logger_provider)
 }

--- a/opentelemetry-otlp/tests/integration_test/tests/logs_serialize_deserialize.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/logs_serialize_deserialize.rs
@@ -20,15 +20,16 @@ pub async fn test_logs() -> Result<()> {
     test_utils::cleanup_file("./actual/logs.json"); // Ensure logs.json is empty before the test
     let exporter_builder = LogExporter::builder().with_tonic();
     let exporter = exporter_builder.build()?;
+    let processor = opentelemetry_sdk::logs::BatchLogProcessor::builder(exporter).build()?;
     let mut logger_provider_builder = SdkLoggerProvider::builder();
-    logger_provider_builder = logger_provider_builder.with_batch_exporter(exporter);
+    logger_provider_builder = logger_provider_builder.with_log_processor(processor);
     let logger_provider = logger_provider_builder
         .with_resource(
             Resource::builder_empty()
                 .with_service_name("logs-integration-test")
                 .build(),
         )
-        .build();
+        .build()?;
     let layer = layer::OpenTelemetryTracingBridge::new(&logger_provider);
     let subscriber = tracing_subscriber::registry().with(layer);
 

--- a/opentelemetry-otlp/tests/integration_test/tests/traces.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/traces.rs
@@ -3,14 +3,14 @@
 use std::{fs::File, os::unix::fs::MetadataExt};
 
 use integration_test_runner::trace_asserter::{read_spans_from_json, TraceAsserter};
-use opentelemetry_otlp::{ExporterBuildError, SpanExporter};
+use opentelemetry_otlp::SpanExporter;
 
 use anyhow::Result;
 use ctor::dtor;
 use integration_test_runner::test_utils;
 use opentelemetry_sdk::{trace as sdktrace, Resource};
 
-fn init_tracer_provider() -> Result<sdktrace::SdkTracerProvider, ExporterBuildError> {
+fn init_tracer_provider() -> Result<sdktrace::SdkTracerProvider> {
     let exporter_builder = SpanExporter::builder();
     #[cfg(feature = "tonic-client")]
     let exporter_builder = exporter_builder.with_tonic();
@@ -24,14 +24,15 @@ fn init_tracer_provider() -> Result<sdktrace::SdkTracerProvider, ExporterBuildEr
 
     let exporter = exporter_builder.build()?;
 
+    let processor = opentelemetry_sdk::trace::BatchSpanProcessor::builder(exporter).build()?;
     Ok(opentelemetry_sdk::trace::SdkTracerProvider::builder()
-        .with_batch_exporter(exporter)
+        .with_span_processor(processor)
         .with_resource(
             Resource::builder_empty()
                 .with_service_name("basic-otlp-tracing-example")
                 .build(),
         )
-        .build())
+        .build()?)
 }
 
 pub fn assert_traces_results(result: &str, expected: &str) -> Result<()> {

--- a/opentelemetry-otlp/tests/smoke.rs
+++ b/opentelemetry-otlp/tests/smoke.rs
@@ -83,25 +83,28 @@ async fn smoke_tracer() {
         println!("Installing tracer provider...");
         let mut metadata = tonic::metadata::MetadataMap::new();
         metadata.insert("x-header-key", "header-value".parse().unwrap());
+        #[cfg(feature = "gzip-tonic")]
+        let exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_compression(opentelemetry_otlp::Compression::Gzip)
+            .with_endpoint(format!("http://{addr}"))
+            .with_metadata(metadata)
+            .build()
+            .expect("gzip-tonic SpanExporter failed to build");
+        #[cfg(not(feature = "gzip-tonic"))]
+        let exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(format!("http://{}", addr))
+            .with_metadata(metadata)
+            .build()
+            .expect("NON gzip-tonic SpanExporter failed to build");
+        let processor = opentelemetry_sdk::trace::BatchSpanProcessor::builder(exporter)
+            .build()
+            .unwrap();
         let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-            .with_batch_exporter(
-                #[cfg(feature = "gzip-tonic")]
-                opentelemetry_otlp::SpanExporter::builder()
-                    .with_tonic()
-                    .with_compression(opentelemetry_otlp::Compression::Gzip)
-                    .with_endpoint(format!("http://{addr}"))
-                    .with_metadata(metadata)
-                    .build()
-                    .expect("gzip-tonic SpanExporter failed to build"),
-                #[cfg(not(feature = "gzip-tonic"))]
-                opentelemetry_otlp::SpanExporter::builder()
-                    .with_tonic()
-                    .with_endpoint(format!("http://{}", addr))
-                    .with_metadata(metadata)
-                    .build()
-                    .expect("NON gzip-tonic SpanExporter failed to build"),
-            )
-            .build();
+            .with_span_processor(processor)
+            .build()
+            .unwrap();
 
         global::set_tracer_provider(tracer_provider.clone());
 
@@ -200,15 +203,18 @@ async fn partial_success_handling() {
 
     {
         println!("Installing tracer provider for partial success test...");
+        let exporter = opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(format!("http://{}", addr))
+            .build()
+            .expect("SpanExporter failed to build");
+        let processor = opentelemetry_sdk::trace::BatchSpanProcessor::builder(exporter)
+            .build()
+            .unwrap();
         let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-            .with_batch_exporter(
-                opentelemetry_otlp::SpanExporter::builder()
-                    .with_tonic()
-                    .with_endpoint(format!("http://{}", addr))
-                    .build()
-                    .expect("SpanExporter failed to build"),
-            )
-            .build();
+            .with_span_processor(processor)
+            .build()
+            .unwrap();
 
         global::set_tracer_provider(tracer_provider.clone());
         let tracer = global::tracer("partial-success-test");

--- a/opentelemetry-proto/src/transform/logs.rs
+++ b/opentelemetry-proto/src/transform/logs.rs
@@ -257,6 +257,7 @@ mod tests {
         let logger = SdkLoggerProvider::builder()
             .with_log_processor(processor)
             .build()
+            .unwrap()
             .logger("test");
         let mut logrecord = logger.create_log_record();
         logrecord.set_timestamp(now());

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## vNext
 
+- **Breaking** `TracerProviderBuilder::build()` now returns `Result<SdkTracerProvider, ProviderBuildError>`. `LoggerProviderBuilder::build()` now returns `Result<SdkLoggerProvider, ProviderBuildError>`. `BatchSpanProcessorBuilder::build()` and `BatchLogProcessorBuilder::build()` also return `Result`. These changes prevent panics from thread spawn failures during provider construction. Callers of `build()` should add `?` or `.unwrap()` / `.expect()`.
+- **Breaking** Removed `TracerProviderBuilder::with_batch_exporter()` and `LoggerProviderBuilder::with_batch_exporter()`. Build the batch processor explicitly and pass it via `with_span_processor()` / `with_log_processor()`:
+  ```rust
+  let processor = BatchSpanProcessor::builder(exporter).build()?;
+  let provider = SdkTracerProvider::builder()
+      .with_span_processor(processor)
+      .build()?;
+  ```
+- `BatchSpanProcessor::new()` and `BatchLogProcessor::new()` now return `Err(ProviderBuildError::AsyncRuntimeRequired)` if the exporter requires an async runtime (e.g. `reqwest::Client`, `HyperClient`) but the batch processor uses a synchronous OS thread. Previously, this combination would panic at export time with "no reactor running". `SpanExporter` and `LogExporter` gain a new `requires_async_runtime() -> bool` method (default: `false`) to declare this requirement. This check is best-effort: third-party exporters that do not override the method will still return `false`.
 - **Breaking** The SDK `testing` feature is now runtime agnostic. [#3407][3407]
   - `TokioSpanExporter` and `new_tokio_test_exporter` have been renamed to `TestSpanExporter` and `new_test_exporter`.
   - The following transitive dependencies and features have been removed: `tokio/rt`, `tokio/time`, `tokio/macros`, `tokio/rt-multi-thread`, `tokio-stream`, `experimental_async_runtime`

--- a/opentelemetry-sdk/benches/batch_span_processor.rs
+++ b/opentelemetry-sdk/benches/batch_span_processor.rs
@@ -55,7 +55,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                                     .with_max_queue_size(10_000)
                                     .build(),
                             )
-                            .build();
+                            .build()
+                            .unwrap();
                         let mut shared_span_processor = Arc::new(span_processor);
                         let mut handles = Vec::with_capacity(10);
                         for _ in 0..task_num {

--- a/opentelemetry-sdk/benches/context.rs
+++ b/opentelemetry-sdk/benches/context.rs
@@ -157,7 +157,8 @@ fn parent_sampled_tracer(inner_sampler: Sampler) -> (SdkTracerProvider, BoxedTra
     let provider = SdkTracerProvider::builder()
         .with_sampler(Sampler::ParentBased(Box::new(inner_sampler)))
         .with_simple_exporter(NoopExporter)
-        .build();
+        .build()
+        .unwrap();
     let tracer = provider.tracer(module_path!());
     (provider, BoxedTracer::new(Box::new(tracer)))
 }

--- a/opentelemetry-sdk/benches/log.rs
+++ b/opentelemetry-sdk/benches/log.rs
@@ -49,7 +49,8 @@ fn log_benchmark_group<F: Fn(&SdkLogger)>(c: &mut Criterion, name: &str, f: F) {
     group.bench_function("no-context", |b| {
         let provider = SdkLoggerProvider::builder()
             .with_log_processor(NoopProcessor {})
-            .build();
+            .build()
+            .unwrap();
 
         let logger = provider.logger("no-context");
 
@@ -59,14 +60,16 @@ fn log_benchmark_group<F: Fn(&SdkLogger)>(c: &mut Criterion, name: &str, f: F) {
     group.bench_function("with-context", |b| {
         let provider = SdkLoggerProvider::builder()
             .with_log_processor(NoopProcessor {})
-            .build();
+            .build()
+            .unwrap();
 
         let logger = provider.logger("with-context");
 
         // setup tracing as well.
         let tracer_provider = SdkTracerProvider::builder()
             .with_sampler(Sampler::AlwaysOn)
-            .build();
+            .build()
+            .unwrap();
         let tracer = tracer_provider.tracer("bench-tracer");
 
         // Act
@@ -92,7 +95,8 @@ fn logger_creation(c: &mut Criterion) {
     // Provider is created once, outside of the benchmark
     let provider = SdkLoggerProvider::builder()
         .with_log_processor(NoopProcessor {})
-        .build();
+        .build()
+        .unwrap();
 
     c.bench_function("Logger_Creation", |b| {
         b.iter(|| {
@@ -104,7 +108,8 @@ fn logger_creation(c: &mut Criterion) {
 fn logging_comparable_to_appender(c: &mut Criterion) {
     let provider = SdkLoggerProvider::builder()
         .with_log_processor(NoopProcessor {})
-        .build();
+        .build()
+        .unwrap();
     let logger = provider.logger("benchmark");
 
     // This mimics the logic from opentelemetry-tracing-appender closely, but

--- a/opentelemetry-sdk/benches/log_enabled.rs
+++ b/opentelemetry-sdk/benches/log_enabled.rs
@@ -48,7 +48,8 @@ where
 {
     let provider = SdkLoggerProvider::builder()
         .with_log_processor(processor)
-        .build();
+        .build()
+        .unwrap();
     let logger = provider.logger("test_logger");
 
     c.bench_function(name, |b| {

--- a/opentelemetry-sdk/benches/log_exporter.rs
+++ b/opentelemetry-sdk/benches/log_exporter.rs
@@ -117,7 +117,8 @@ fn criterion_benchmark(c: &mut Criterion) {
 fn exporter_with_future(c: &mut Criterion) {
     let provider = SdkLoggerProvider::builder()
         .with_log_processor(ExportingProcessorWithFuture::new(NoOpExporterWithFuture {}))
-        .build();
+        .build()
+        .unwrap();
     let logger = provider.logger("benchmark");
 
     c.bench_function("LogExporterWithFuture", |b| {
@@ -143,7 +144,8 @@ fn exporter_without_future(c: &mut Criterion) {
         .with_log_processor(ExportingProcessorWithoutFuture::new(
             NoOpExporterWithoutFuture {},
         ))
-        .build();
+        .build()
+        .unwrap();
     let logger = provider.logger("benchmark");
 
     c.bench_function("LogExporterWithoutFuture", |b| {

--- a/opentelemetry-sdk/benches/log_processor.rs
+++ b/opentelemetry-sdk/benches/log_processor.rs
@@ -131,7 +131,8 @@ fn criterion_benchmark(c: &mut Criterion) {
 fn log_noop_processor(c: &mut Criterion) {
     let provider = SdkLoggerProvider::builder()
         .with_log_processor(NoopProcessor {})
-        .build();
+        .build()
+        .unwrap();
     let logger = provider.logger("benchmark");
 
     c.bench_function("log_noop_processor", |b| {
@@ -145,7 +146,8 @@ fn log_noop_processor(c: &mut Criterion) {
 fn log_cloning_processor(c: &mut Criterion) {
     let provider = SdkLoggerProvider::builder()
         .with_log_processor(CloningProcessor {})
-        .build();
+        .build()
+        .unwrap();
     let logger = provider.logger("benchmark");
 
     c.bench_function("log_cloning_processor", |b| {
@@ -159,7 +161,8 @@ fn log_cloning_processor(c: &mut Criterion) {
 fn log_cloning_and_send_to_channel_processor(c: &mut Criterion) {
     let provider = SdkLoggerProvider::builder()
         .with_log_processor(SendToChannelProcessor::new())
-        .build();
+        .build()
+        .unwrap();
     let logger = provider.logger("benchmark");
 
     c.bench_function("log_clone_and_send_to_channel_processor", |b| {

--- a/opentelemetry-sdk/benches/span.rs
+++ b/opentelemetry-sdk/benches/span.rs
@@ -167,7 +167,8 @@ fn trace_benchmark_group<F: Fn(&sdktrace::SdkTracer)>(c: &mut Criterion, name: &
         let provider = sdktrace::SdkTracerProvider::builder()
             .with_sampler(sdktrace::Sampler::AlwaysOn)
             .with_simple_exporter(VoidExporter)
-            .build();
+            .build()
+            .unwrap();
         let always_sample = provider.tracer("always-sample");
 
         b.iter(|| f(&always_sample));
@@ -177,7 +178,8 @@ fn trace_benchmark_group<F: Fn(&sdktrace::SdkTracer)>(c: &mut Criterion, name: &
         let provider = sdktrace::SdkTracerProvider::builder()
             .with_sampler(sdktrace::Sampler::AlwaysOff)
             .with_simple_exporter(VoidExporter)
-            .build();
+            .build()
+            .unwrap();
         let never_sample = provider.tracer("never-sample");
         b.iter(|| f(&never_sample));
     });

--- a/opentelemetry-sdk/benches/span_builder.rs
+++ b/opentelemetry-sdk/benches/span_builder.rs
@@ -56,7 +56,8 @@ fn not_sampled_provider() -> (sdktrace::SdkTracerProvider, sdktrace::SdkTracer) 
     let provider = sdktrace::SdkTracerProvider::builder()
         .with_sampler(sdktrace::Sampler::AlwaysOff)
         .with_simple_exporter(NoopExporter)
-        .build();
+        .build()
+        .unwrap();
     let tracer = provider.tracer("not-sampled");
     (provider, tracer)
 }

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -71,7 +71,8 @@ fn trace_benchmark_group<F: Fn(&sdktrace::SdkTracer)>(c: &mut Criterion, name: &
         let provider = sdktrace::SdkTracerProvider::builder()
             .with_sampler(sdktrace::Sampler::AlwaysOn)
             .with_simple_exporter(VoidExporter)
-            .build();
+            .build()
+            .unwrap();
         let always_sample = provider.tracer("always-sample");
 
         b.iter(|| f(&always_sample));
@@ -81,7 +82,8 @@ fn trace_benchmark_group<F: Fn(&sdktrace::SdkTracer)>(c: &mut Criterion, name: &
         let provider = sdktrace::SdkTracerProvider::builder()
             .with_sampler(sdktrace::Sampler::AlwaysOff)
             .with_simple_exporter(VoidExporter)
-            .build();
+            .build()
+            .unwrap();
         let never_sample = provider.tracer("never-sample");
         b.iter(|| f(&never_sample));
     });

--- a/opentelemetry-sdk/benches/tracer_creation.rs
+++ b/opentelemetry-sdk/benches/tracer_creation.rs
@@ -39,7 +39,7 @@ fn get_tracer_with_scope_attrs() -> &'static BoxedTracer {
 fn create_provider() -> sdktrace::SdkTracerProvider {
     // Provider is empty, no exporters, no processors etc.
     // as the goal is measurement of tracer creation time.
-    sdktrace::SdkTracerProvider::builder().build()
+    sdktrace::SdkTracerProvider::builder().build().unwrap()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/opentelemetry-sdk/src/error.rs
+++ b/opentelemetry-sdk/src/error.rs
@@ -43,3 +43,24 @@ pub enum OTelSdkError {
 
 /// A specialized `Result` type for Shutdown operations.
 pub type OTelSdkResult = Result<(), OTelSdkError>;
+
+/// Errors that can occur during provider construction.
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum ProviderBuildError {
+    /// Failed to spawn a background thread for batch processing.
+    #[error("Failed to spawn background thread: {0}")]
+    ThreadSpawnFailed(#[source] std::io::Error),
+
+    /// The exporter requires an async runtime (e.g. Tokio), but the batch
+    /// processor uses a dedicated OS thread with a synchronous executor.
+    ///
+    /// Use a synchronous HTTP client (e.g. `reqwest::blocking::Client`) instead,
+    /// or switch to an async batch processor that runs inside a Tokio runtime.
+    #[error(
+        "Exporter requires an async runtime (e.g. Tokio), but the batch processor uses a \
+         dedicated OS thread with a synchronous executor. Use a synchronous HTTP client \
+         (e.g. reqwest::blocking::Client) instead, or use an async batch processor."
+    )]
+    AsyncRuntimeRequired,
+}

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -22,7 +22,8 @@
 //!     // Create a new trace pipeline that prints to stdout
 //!     let provider = SdkTracerProvider::builder()
 //!         .with_simple_exporter(exporter)
-//!         .build();
+//!         .build()
+//!         .unwrap();
 //!     let tracer = provider.tracer("readme_example");
 //!
 //!     tracer.in_span("doing_work", |cx| {
@@ -196,6 +197,7 @@ pub use resource::Resource;
 
 pub mod error;
 pub use error::ExportError;
+pub use error::ProviderBuildError;
 
 #[cfg(any(feature = "testing", test))]
 #[derive(thiserror::Error, Debug)]

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -15,7 +15,7 @@
 //!   +-----+---------------+   +-----------------------+   +-------------------+
 //! ```
 
-use crate::error::{OTelSdkError, OTelSdkResult};
+use crate::error::{OTelSdkError, OTelSdkResult, ProviderBuildError};
 use crate::logs::log_processor::LogProcessor;
 use crate::{
     logs::{LogBatch, LogExporter, SdkLogRecord},
@@ -121,11 +121,13 @@ type LogsData = Box<(SdkLogRecord, InstrumentationScope)>;
 ///             .with_scheduled_delay(Duration::from_secs(5))
 ///             .build(),
 ///     )
-///     .build();
+///     .build()
+///     .unwrap();
 ///
 /// let provider = SdkLoggerProvider::builder()
 ///     .with_log_processor(processor)
-///     .build();
+///     .build()
+///     .unwrap();
 /// # }
 ///
 pub struct BatchLogProcessor {
@@ -332,10 +334,14 @@ impl LogProcessor for BatchLogProcessor {
 }
 
 impl BatchLogProcessor {
-    pub(crate) fn new<E>(mut exporter: E, config: BatchConfig) -> Self
+    pub(crate) fn new<E>(mut exporter: E, config: BatchConfig) -> Result<Self, ProviderBuildError>
     where
         E: LogExporter + Send + Sync + 'static,
     {
+        if exporter.requires_async_runtime() {
+            return Err(ProviderBuildError::AsyncRuntimeRequired);
+        }
+
         let (logs_sender, logs_receiver) = mpsc::sync_channel::<LogsData>(config.max_queue_size);
         let (message_sender, message_receiver) = mpsc::sync_channel::<BatchMessage>(64); // Is this a reasonable bound?
         let max_queue_size = config.max_queue_size;
@@ -490,10 +496,10 @@ impl BatchLogProcessor {
                     name: "BatchLogProcessor.ThreadStopped"
                 );
             })
-            .expect("Thread spawn failed."); //TODO: Handle thread spawn failure
+            .map_err(ProviderBuildError::ThreadSpawnFailed)?;
 
         // Return batch processor with link to worker
-        BatchLogProcessor {
+        Ok(BatchLogProcessor {
             logs_sender,
             message_sender,
             handle: Mutex::new(Some(handle)),
@@ -503,7 +509,7 @@ impl BatchLogProcessor {
             export_log_message_sent: Arc::new(AtomicBool::new(false)),
             current_batch_size,
             max_export_batch_size,
-        }
+        })
     }
 
     /// Create a new batch processor builder
@@ -570,7 +576,7 @@ where
     }
 
     /// Build a batch processor
-    pub fn build(self) -> BatchLogProcessor {
+    pub fn build(self) -> Result<BatchLogProcessor, ProviderBuildError> {
         BatchLogProcessor::new(self.exporter, self.config)
     }
 }
@@ -859,7 +865,7 @@ mod tests {
         let exporter = MockExporter {
             export_called: Arc::new(AtomicBool::new(false)),
         };
-        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default());
+        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default()).unwrap();
         let scope = opentelemetry::InstrumentationScope::builder("my-crate")
             .with_schema_url("https://opentelemetry.io/schemas/1.17.0")
             .build();
@@ -961,7 +967,7 @@ mod tests {
         let exporter = MockLogExporter {
             resource: Arc::new(Mutex::new(None)),
         };
-        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default());
+        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default()).unwrap();
         let provider = SdkLoggerProvider::builder()
             .with_log_processor(processor)
             .with_resource(
@@ -975,7 +981,8 @@ mod tests {
                     ])
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
 
         provider.force_flush().unwrap();
 
@@ -990,7 +997,7 @@ mod tests {
         let exporter = InMemoryLogExporterBuilder::default()
             .keep_records_on_shutdown()
             .build();
-        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default());
+        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default()).unwrap();
 
         let mut record = SdkLogRecord::new();
         let instrumentation = InstrumentationScope::default();
@@ -1007,7 +1014,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn test_batch_log_processor_shutdown_under_async_runtime_current_flavor_multi_thread() {
         let exporter = InMemoryLogExporterBuilder::default().build();
-        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default());
+        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default()).unwrap();
 
         processor.shutdown().unwrap();
     }
@@ -1015,21 +1022,21 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn test_batch_log_processor_shutdown_with_async_runtime_current_flavor_current_thread() {
         let exporter = InMemoryLogExporterBuilder::default().build();
-        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default());
+        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default()).unwrap();
         processor.shutdown().unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_log_processor_shutdown_with_async_runtime_multi_flavor_multi_thread() {
         let exporter = InMemoryLogExporterBuilder::default().build();
-        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default());
+        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default()).unwrap();
         processor.shutdown().unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_log_processor_shutdown_with_async_runtime_multi_flavor_current_thread() {
         let exporter = InMemoryLogExporterBuilder::default().build();
-        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default());
+        let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default()).unwrap();
         processor.shutdown().unwrap();
     }
 
@@ -1073,7 +1080,7 @@ mod tests {
             .with_scheduled_delay(Duration::from_millis(5))
             .build();
 
-        let processor = BatchLogProcessor::new(exporter, config);
+        let processor = BatchLogProcessor::new(exporter, config).unwrap();
 
         let total_logs_per_thread = 100_000;
         let num_threads = 4;
@@ -1115,6 +1122,30 @@ mod tests {
             logs_dropped > 0,
             "Expected some logs to be dropped under stress, but none were. \
              Consider reducing queue size or increasing thread count/log volume."
+        );
+    }
+
+    #[test]
+    fn test_batch_log_processor_rejects_async_runtime_exporter() {
+        use crate::error::ProviderBuildError;
+
+        #[derive(Debug, Clone)]
+        struct AsyncRequiringLogExporter;
+
+        impl LogExporter for AsyncRequiringLogExporter {
+            async fn export(&self, _batch: LogBatch<'_>) -> OTelSdkResult {
+                Ok(())
+            }
+
+            fn requires_async_runtime(&self) -> bool {
+                true
+            }
+        }
+
+        let result = BatchLogProcessor::builder(AsyncRequiringLogExporter).build();
+        assert!(
+            matches!(result, Err(ProviderBuildError::AsyncRuntimeRequired)),
+            "Expected AsyncRuntimeRequired, got: {result:?}"
         );
     }
 }

--- a/opentelemetry-sdk/src/logs/export.rs
+++ b/opentelemetry-sdk/src/logs/export.rs
@@ -64,6 +64,7 @@ impl<'a> LogBatch<'a> {
 impl LogBatch<'_> {
     /// Returns the number of log records in the batch.
     #[cfg(test)]
+    #[allow(dead_code)]
     pub(crate) fn len(&self) -> usize {
         match &self.data {
             LogBatchData::SliceOfOwnedData(data) => data.len(),
@@ -159,4 +160,16 @@ pub trait LogExporter: Send + Sync + Debug {
     }
     /// Set the resource for the exporter.
     fn set_resource(&mut self, _resource: &Resource) {}
+
+    /// Returns `true` if this exporter requires an async runtime (e.g. Tokio) to be active.
+    ///
+    /// Exporters backed by async HTTP clients (reqwest::Client, HyperClient) return `true`.
+    /// This is used by batch processors to detect invalid combinations at build time.
+    ///
+    /// **Note:** This check is best-effort. Third-party exporters that wrap async HTTP
+    /// clients but do not override this method will return `false` and may panic at
+    /// export time when used with a sync batch processor.
+    fn requires_async_runtime(&self) -> bool {
+        false
+    }
 }

--- a/opentelemetry-sdk/src/logs/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/logs/in_memory_exporter.rs
@@ -27,8 +27,9 @@ use std::time;
 ///    let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
 ///    //Create a LoggerProvider and register the exporter
 ///    let logger_provider = SdkLoggerProvider::builder()
-///        .with_log_processor(BatchLogProcessor::builder(exporter.clone()).build())
-///        .build();
+///        .with_log_processor(BatchLogProcessor::builder(exporter.clone()).build().unwrap())
+///        .build()
+///        .unwrap();
 ///    // Setup Log Appenders and emit logs. (Not shown here)
 ///    logger_provider.force_flush();
 ///    let emitted_logs = exporter.get_emitted_logs().unwrap();
@@ -87,8 +88,9 @@ pub struct LogDataWithResource {
 ///    let exporter: InMemoryLogExporter = InMemoryLogExporterBuilder::default().build();
 ///    //Create a LoggerProvider and register the exporter
 ///    let logger_provider = SdkLoggerProvider::builder()
-///        .with_log_processor(BatchLogProcessor::builder(exporter.clone()).build())
-///        .build();
+///        .with_log_processor(BatchLogProcessor::builder(exporter.clone()).build().unwrap())
+///        .build()
+///        .unwrap();
 ///    // Setup Log Appenders and emit logs. (Not shown here)
 ///    logger_provider.force_flush();
 ///    let emitted_logs = exporter.get_emitted_logs().unwrap();

--- a/opentelemetry-sdk/src/logs/log_processor.rs
+++ b/opentelemetry-sdk/src/logs/log_processor.rs
@@ -205,7 +205,8 @@ pub(crate) mod tests {
         let logger_provider = SdkLoggerProvider::builder()
             .with_log_processor(first_processor)
             .with_log_processor(second_processor)
-            .build();
+            .build()
+            .unwrap();
 
         let logger = logger_provider.logger("test-logger");
         let mut log_record = logger.create_log_record();

--- a/opentelemetry-sdk/src/logs/log_processor_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/logs/log_processor_with_async_runtime.rs
@@ -495,7 +495,8 @@ mod tests {
                     ])
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         assert_eq!(exporter.get_resource().unwrap().into_iter().count(), 5);
     }
 
@@ -519,7 +520,8 @@ mod tests {
                     ])
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
 
         provider.force_flush().unwrap();
 
@@ -678,7 +680,8 @@ mod tests {
         let logger_provider = SdkLoggerProvider::builder()
             .with_log_processor(first_processor)
             .with_log_processor(second_processor)
-            .build();
+            .build()
+            .unwrap();
 
         let logger = logger_provider.logger("test-logger");
         let mut log_record = logger.create_log_record();
@@ -786,7 +789,8 @@ mod tests {
                     ])
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         provider.force_flush().unwrap();
         assert_eq!(exporter.get_resource().unwrap().into_iter().count(), 5);
         let _ = provider.shutdown();

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -1,5 +1,5 @@
-use super::{BatchLogProcessor, LogProcessor, SdkLogger, SimpleLogProcessor};
-use crate::error::{OTelSdkError, OTelSdkResult};
+use super::{LogProcessor, SdkLogger, SimpleLogProcessor};
+use crate::error::{OTelSdkError, OTelSdkResult, ProviderBuildError};
 use crate::logs::LogExporter;
 use crate::Resource;
 use opentelemetry::{otel_debug, otel_info, InstrumentationScope};
@@ -205,29 +205,6 @@ impl LoggerProviderBuilder {
         LoggerProviderBuilder { processors, ..self }
     }
 
-    /// Adds a [BatchLogProcessor] with the configured exporter to the pipeline,
-    /// using the default [super::BatchConfig].
-    ///
-    /// The following environment variables can be used to configure the batching configuration:
-    ///
-    /// * `OTEL_BLRP_SCHEDULE_DELAY` - Corresponds to `with_scheduled_delay`.
-    /// * `OTEL_BLRP_MAX_QUEUE_SIZE` - Corresponds to `with_max_queue_size`.
-    /// * `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE` - Corresponds to `with_max_export_batch_size`.
-    ///
-    /// # Arguments
-    ///
-    /// * `exporter` - The exporter to be used by the `BatchLogProcessor`.
-    ///
-    /// # Returns
-    ///
-    /// A new `LoggerProviderBuilder` instance with the `BatchLogProcessor` added to the pipeline.
-    ///
-    /// Processors are invoked in the order they are added.
-    pub fn with_batch_exporter<T: LogExporter + 'static>(self, exporter: T) -> Self {
-        let batch = BatchLogProcessor::builder(exporter).build();
-        self.with_log_processor(batch)
-    }
-
     /// Adds a custom [LogProcessor] to the pipeline.
     ///
     /// # Arguments
@@ -270,7 +247,8 @@ impl LoggerProviderBuilder {
     ///             .with_attributes([KeyValue::new("deployment.environment.name", "production")])
     ///             .build(),
     ///     )
-    ///     .build();
+    ///     .build()
+    ///     .unwrap();
     /// ```
     ///
     /// *Note*: Calls to this method are additive, each call merges the provided
@@ -288,7 +266,16 @@ impl LoggerProviderBuilder {
     }
 
     /// Create a new provider from this configuration.
-    pub fn build(self) -> SdkLoggerProvider {
+    ///
+    /// # Errors
+    ///
+    /// Currently the provider-level build is infallible. The `Result` return
+    /// type exists so that future validation (e.g. incompatible configuration)
+    /// can be added without a breaking change. Batch log processor construction
+    /// can fail, but that happens in
+    /// [`BatchLogProcessor::builder().build()`](crate::logs::BatchLogProcessor)
+    /// *before* this method is called.
+    pub fn build(self) -> Result<SdkLoggerProvider, ProviderBuildError> {
         let resource = self.resource.unwrap_or(Resource::builder().build());
         let mut processors = self.processors;
         for processor in &mut processors {
@@ -305,7 +292,7 @@ impl LoggerProviderBuilder {
         otel_debug!(
             name: "LoggerProvider.Built",
         );
-        logger_provider
+        Ok(logger_provider)
     }
 }
 
@@ -504,7 +491,8 @@ mod tests {
                 TestProcessorForResource::new(exporter_with_resource.clone());
             let _ = super::SdkLoggerProvider::builder()
                 .with_log_processor(processor_with_resource.clone())
-                .build();
+                .build()
+                .unwrap();
             let service_name = processor_with_resource
                 .resource()
                 .get(&Key::from_static_str(SERVICE_NAME))
@@ -528,7 +516,8 @@ mod tests {
                     .build(),
             )
             .with_log_processor(processor_with_resource.clone())
-            .build();
+            .build()
+            .unwrap();
         assert_resource(
             &processor_with_resource,
             &exporter_with_resource,
@@ -547,7 +536,8 @@ mod tests {
                     TestProcessorForResource::new(exporter_with_resource.clone());
                 let _ = super::SdkLoggerProvider::builder()
                     .with_log_processor(processor_with_resource.clone())
-                    .build();
+                    .build()
+                    .unwrap();
                 let service_name = processor_with_resource
                     .resource()
                     .get(&Key::from_static_str(SERVICE_NAME))
@@ -593,7 +583,8 @@ mod tests {
                             .build(),
                     )
                     .with_log_processor(processor_with_resource.clone())
-                    .build();
+                    .build()
+                    .unwrap();
                 let service_name = processor_with_resource
                     .resource()
                     .get(&Key::from_static_str(SERVICE_NAME))
@@ -633,7 +624,8 @@ mod tests {
         let _ = super::SdkLoggerProvider::builder()
             .with_resource(Resource::empty())
             .with_log_processor(processor_with_resource.clone())
-            .build();
+            .build()
+            .unwrap();
         assert_eq!(processor_with_resource.resource().len(), 0);
     }
 
@@ -644,11 +636,12 @@ mod tests {
 
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         let logger = logger_provider.logger("test-logger");
 
-        let tracer_provider = SdkTracerProvider::builder().build();
+        let tracer_provider = SdkTracerProvider::builder().build().unwrap();
 
         let tracer = tracer_provider.tracer("test-tracer");
 
@@ -709,7 +702,8 @@ mod tests {
         let counter = Arc::new(AtomicU64::new(0));
         let logger_provider = SdkLoggerProvider::builder()
             .with_log_processor(ShutdownTestLogProcessor::new(counter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         let logger1 = logger_provider.logger("test-logger1");
         let logger2 = logger_provider.logger("test-logger2");
@@ -733,7 +727,8 @@ mod tests {
         let counter = Arc::new(AtomicU64::new(0));
         let logger_provider = SdkLoggerProvider::builder()
             .with_log_processor(ShutdownTestLogProcessor::new(counter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         let shutdown_res = logger_provider.shutdown();
         assert!(shutdown_res.is_ok());
@@ -759,7 +754,8 @@ mod tests {
                 shutdown_called.clone(),
                 flush_called.clone(),
             ))
-            .build();
+            .build()
+            .unwrap();
         //set_logger_provider(logger_provider);
         let logger1 = logger_provider.logger("test-logger1");
         let logger2 = logger_provider.logger("test-logger2");
@@ -868,7 +864,8 @@ mod tests {
         let exporter = InMemoryLogExporter::default();
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
         let logger = logger_provider.logger("");
         let mut record = logger.create_log_record();
         record.set_body("Testing empty logger name".into());

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -62,7 +62,8 @@ mod tests {
         let logger_provider = SdkLoggerProvider::builder()
             .with_resource(resource.clone())
             .with_log_processor(SimpleLogProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         // Act
         let logger = logger_provider.logger("test-logger");
@@ -124,7 +125,8 @@ mod tests {
         let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_log_processor(SimpleLogProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         let scope = InstrumentationScope::builder("test_logger")
             .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
@@ -182,7 +184,8 @@ mod tests {
         let logger_provider = SdkLoggerProvider::builder()
             .with_log_processor(EnrichWithBaggageProcessor)
             .with_log_processor(SimpleLogProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         // Act
         let logger = logger_provider.logger("test-logger");
@@ -221,7 +224,8 @@ mod tests {
         let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
 
         // Act
         let logger = logger_provider.logger("test-logger");
@@ -287,7 +291,8 @@ mod tests {
         let processor: ReentrantLogProcessor = ReentrantLogProcessor::new();
         let logger_provider = SdkLoggerProvider::builder()
             .with_log_processor(processor.clone())
-            .build();
+            .build()
+            .unwrap();
         processor.set_logger(logger_provider.logger("processor-logger"));
 
         let logger = logger_provider.logger("test-logger");

--- a/opentelemetry-sdk/src/logs/simple_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/simple_log_processor.rs
@@ -57,7 +57,8 @@ use std::time::Duration;
 /// let exporter = InMemoryLogExporter::default(); // Replace with an actual exporter
 /// let provider = SdkLoggerProvider::builder()
 ///     .with_simple_exporter(exporter)
-///     .build();
+///     .build()
+///     .unwrap();
 /// # }
 /// ```
 ///
@@ -222,7 +223,8 @@ mod tests {
                     ])
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         assert_eq!(exporter.get_resource().unwrap().into_iter().count(), 5);
     }
 
@@ -485,7 +487,8 @@ mod tests {
         let exporter: ReentrantLogExporter = ReentrantLogExporter::new();
         let logger_provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
-            .build();
+            .build()
+            .unwrap();
         exporter.set_logger(logger_provider.logger("processor-logger"));
 
         let logger = logger_provider.logger("test-logger");

--- a/opentelemetry-sdk/src/trace/export.rs
+++ b/opentelemetry-sdk/src/trace/export.rs
@@ -72,6 +72,18 @@ pub trait SpanExporter: Send + Sync + Debug {
 
     /// Set the resource for the exporter.
     fn set_resource(&mut self, _resource: &Resource) {}
+
+    /// Returns `true` if this exporter requires an async runtime (e.g. Tokio) to be active.
+    ///
+    /// Exporters backed by async HTTP clients (reqwest::Client, HyperClient) return `true`.
+    /// This is used by batch processors to detect invalid combinations at build time.
+    ///
+    /// **Note:** This check is best-effort. Third-party exporters that wrap async HTTP
+    /// clients but do not override this method will return `false` and may panic at
+    /// export time when used with a sync batch processor.
+    fn requires_async_runtime(&self) -> bool {
+        false
+    }
 }
 
 /// `SpanData` contains all the information collected by a `Span` and can be used

--- a/opentelemetry-sdk/src/trace/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/trace/in_memory_exporter.rs
@@ -23,8 +23,9 @@ use std::time::Duration;
 ///# async fn main() {
 ///     let exporter = InMemorySpanExporterBuilder::new().build();
 ///     let provider = SdkTracerProvider::builder()
-///         .with_span_processor(BatchSpanProcessor::builder(exporter.clone()).build())
-///         .build();
+///         .with_span_processor(BatchSpanProcessor::builder(exporter.clone()).build().unwrap())
+///         .build()
+///         .unwrap();
 ///
 ///     global::set_tracer_provider(provider.clone());
 ///

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -84,7 +84,8 @@ mod tests {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = SdkTracerProvider::builder()
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
         let tracer = provider.tracer("test_tracer");
 
         #[derive(Debug, PartialEq)]
@@ -169,7 +170,8 @@ mod tests {
     fn span_and_baggage() {
         let provider = SdkTracerProvider::builder()
             .with_span_processor(BaggageInspectingSpanProcessor)
-            .build();
+            .build()
+            .unwrap();
 
         let cx_with_baggage =
             Context::current_with_baggage(vec![KeyValue::new("bag-key", "bag-value")]);
@@ -238,7 +240,8 @@ mod tests {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = SdkTracerProvider::builder()
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         // Act
         let tracer = provider.tracer("test_tracer");
@@ -285,7 +288,8 @@ mod tests {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = SdkTracerProvider::builder()
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         // Act
         let tracer = provider.tracer("test_tracer");
@@ -321,7 +325,8 @@ mod tests {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = SdkTracerProvider::builder()
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         // Act
         let tracer = provider.tracer("test_tracer");
@@ -357,7 +362,8 @@ mod tests {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = SdkTracerProvider::builder()
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         // Act
         let tracer = provider.tracer("test_tracer");
@@ -393,7 +399,8 @@ mod tests {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let provider = SdkTracerProvider::builder()
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         // Act
         let tracer = provider.tracer("test_tracer");
@@ -429,7 +436,8 @@ mod tests {
         let provider = SdkTracerProvider::builder()
             .with_sampler(Sampler::AlwaysOff)
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         let tracer = provider.tracer("test");
         let trace_state = TraceState::from_key_value(vec![("foo", "bar")]).unwrap();
@@ -482,7 +490,8 @@ mod tests {
         let provider = SdkTracerProvider::builder()
             .with_sampler(TestRecordOnlySampler::default())
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
 
         let tracer = provider.tracer("test");
         let trace_state = TraceState::from_key_value(vec![("foo", "bar")]).unwrap();
@@ -513,7 +522,7 @@ mod tests {
 
     #[test]
     fn tracer_attributes() {
-        let provider = SdkTracerProvider::builder().build();
+        let provider = SdkTracerProvider::builder().build().unwrap();
         let scope = InstrumentationScope::builder("basic")
             .with_attributes(vec![KeyValue::new("test_k", "test_v")])
             .build();
@@ -554,7 +563,8 @@ mod tests {
         let span_processor = SimpleSpanProcessor::new(exporter.clone());
         let tracer_provider = SdkTracerProvider::builder()
             .with_span_processor(span_processor)
-            .build();
+            .build()
+            .unwrap();
 
         // Test Tracer creation in 2 ways, both with empty string as tracer name
         let tracer1 = tracer_provider.tracer("");
@@ -572,7 +582,8 @@ mod tests {
         let span_processor = SimpleSpanProcessor::new(exporter.clone());
         let tracer_provider = SdkTracerProvider::builder()
             .with_span_processor(span_processor)
-            .build();
+            .build()
+            .unwrap();
 
         // Act
         let tracer = tracer_provider.tracer("test");

--- a/opentelemetry-sdk/src/trace/provider.rs
+++ b/opentelemetry-sdk/src/trace/provider.rs
@@ -1,5 +1,5 @@
 use super::IdGenerator;
-use crate::error::{OTelSdkError, OTelSdkResult};
+use crate::error::{OTelSdkError, OTelSdkResult, ProviderBuildError};
 /// # Trace Provider SDK
 ///
 /// The `TracerProvider` handles the creation and management of [`Tracer`] instances and coordinates
@@ -65,8 +65,7 @@ use crate::error::{OTelSdkError, OTelSdkResult};
 /// }
 /// ```
 use crate::trace::{
-    BatchSpanProcessor, Config, RandomIdGenerator, Sampler, SdkTracer, SimpleSpanProcessor,
-    SpanLimits,
+    Config, RandomIdGenerator, Sampler, SdkTracer, SimpleSpanProcessor, SpanLimits,
 };
 use crate::Resource;
 use crate::{trace::SpanExporter, trace::SpanProcessor};
@@ -161,7 +160,12 @@ pub struct SdkTracerProvider {
 
 impl Default for SdkTracerProvider {
     fn default() -> Self {
-        SdkTracerProvider::builder().build()
+        // Default builder has no batch processors, so build() is infallible.
+        // ProviderBuildError only arises from batch processor construction,
+        // which happens before build() is called.
+        SdkTracerProvider::builder()
+            .build()
+            .expect("default TracerProvider build is infallible")
     }
 }
 
@@ -320,22 +324,6 @@ impl TracerProviderBuilder {
         self.with_span_processor(simple)
     }
 
-    /// Adds a [BatchSpanProcessor] with the configured exporter to the pipeline.
-    ///
-    /// # Arguments
-    ///
-    /// * `exporter` - The exporter to be used by the BatchSpanProcessor.
-    ///
-    /// # Returns
-    ///
-    /// A new `Builder` instance with the BatchSpanProcessor added to the pipeline.
-    ///
-    /// Processors are invoked in the order they are added.
-    pub fn with_batch_exporter<T: SpanExporter + 'static>(self, exporter: T) -> Self {
-        let batch = BatchSpanProcessor::builder(exporter).build();
-        self.with_span_processor(batch)
-    }
-
     /// Adds a custom [SpanProcessor] to the pipeline.
     ///
     /// # Arguments
@@ -443,7 +431,8 @@ impl TracerProviderBuilder {
     ///             .with_attributes([KeyValue::new("deployment.environment.name", "production")])
     ///             .build(),
     ///     )
-    ///     .build();
+    ///     .build()
+    ///     .expect("Failed to build TracerProvider");
     /// ```
     ///
     /// *Note*: Calls to this method are additive, each call merges the provided
@@ -462,7 +451,16 @@ impl TracerProviderBuilder {
     }
 
     /// Create a new provider from this configuration.
-    pub fn build(self) -> SdkTracerProvider {
+    ///
+    /// # Errors
+    ///
+    /// Currently the provider-level build is infallible. The `Result` return
+    /// type exists so that future validation (e.g. incompatible configuration)
+    /// can be added without a breaking change. Batch processor construction
+    /// can fail, but that happens in
+    /// [`BatchSpanProcessor::builder().build()`](crate::trace::BatchSpanProcessor)
+    /// *before* this method is called.
+    pub fn build(self) -> Result<SdkTracerProvider, ProviderBuildError> {
         let mut config = self.config;
 
         // Now, we can update the config with the resource.
@@ -495,11 +493,11 @@ impl TracerProviderBuilder {
         }
 
         let is_shutdown = AtomicBool::new(false);
-        SdkTracerProvider::new(TracerProviderInner {
+        Ok(SdkTracerProvider::new(TracerProviderInner {
             processors,
             config,
             is_shutdown,
-        })
+        }))
     }
 }
 
@@ -644,7 +642,7 @@ mod tests {
 
         // If users didn't provide a resource and there isn't a env var set. Use default one.
         temp_env::with_var_unset("OTEL_RESOURCE_ATTRIBUTES", || {
-            let default_config_provider = super::SdkTracerProvider::builder().build();
+            let default_config_provider = super::SdkTracerProvider::builder().build().unwrap();
             let service_name = default_config_provider
                 .config()
                 .resource
@@ -666,7 +664,8 @@ mod tests {
                     .with_service_name("test_service")
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         assert_resource(&custom_config_provider, SERVICE_NAME, Some("test_service"));
         assert_eq!(custom_config_provider.config().resource.len(), 1);
 
@@ -675,7 +674,7 @@ mod tests {
             "OTEL_RESOURCE_ATTRIBUTES",
             Some("key1=value1, k2, k3=value2"),
             || {
-                let env_resource_provider = super::SdkTracerProvider::builder().build();
+                let env_resource_provider = super::SdkTracerProvider::builder().build().unwrap();
                 let service_name = env_resource_provider
                     .config()
                     .resource
@@ -708,7 +707,8 @@ mod tests {
                             ])
                             .build(),
                     )
-                    .build();
+                    .build()
+                    .unwrap();
                 let service_name = user_provided_resource_config_provider
                     .config()
                     .resource
@@ -749,7 +749,8 @@ mod tests {
         // If user provided a resource, it takes priority during collision.
         let no_service_name = super::SdkTracerProvider::builder()
             .with_resource(Resource::empty())
-            .build();
+            .build()
+            .unwrap();
 
         assert_eq!(no_service_name.config().resource.len(), 0)
     }
@@ -821,6 +822,7 @@ mod tests {
                     .build(),
             )
             .build()
+            .unwrap()
             .inner
             .config
             .resource

--- a/opentelemetry-sdk/src/trace/runtime_tests.rs
+++ b/opentelemetry-sdk/src/trace/runtime_tests.rs
@@ -53,6 +53,7 @@ fn build_batch_tracer_provider<R: RuntimeChannel>(
     SdkTracerProvider::builder()
         .with_span_processor(processor)
         .build()
+        .unwrap()
 }
 
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
@@ -61,6 +62,7 @@ fn build_simple_tracer_provider(exporter: SpanCountExporter) -> crate::trace::Sd
     SdkTracerProvider::builder()
         .with_simple_exporter(exporter)
         .build()
+        .unwrap()
 }
 
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]

--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -536,7 +536,7 @@ mod tests {
         let exporter = NoopSpanExporter::new();
         let provider_builder =
             crate::trace::SdkTracerProvider::builder().with_simple_exporter(exporter);
-        let provider = provider_builder.build();
+        let provider = provider_builder.build().unwrap();
         let tracer = provider.tracer("opentelemetry-test");
 
         let mut initial_attributes = Vec::new();
@@ -575,7 +575,7 @@ mod tests {
         let exporter = NoopSpanExporter::new();
         let provider_builder =
             crate::trace::SdkTracerProvider::builder().with_simple_exporter(exporter);
-        let provider = provider_builder.build();
+        let provider = provider_builder.build().unwrap();
         let tracer = provider.tracer("opentelemetry-test");
 
         let mut event1 = Event::with_name("test event");
@@ -611,7 +611,7 @@ mod tests {
         let exporter = NoopSpanExporter::new();
         let provider_builder =
             crate::trace::SdkTracerProvider::builder().with_simple_exporter(exporter);
-        let provider = provider_builder.build();
+        let provider = provider_builder.build().unwrap();
         let tracer = provider.tracer("opentelemetry-test");
 
         let mut link = Link::with_context(SpanContext::new(
@@ -643,7 +643,7 @@ mod tests {
         let exporter = NoopSpanExporter::new();
         let provider_builder =
             crate::trace::SdkTracerProvider::builder().with_simple_exporter(exporter);
-        let provider = provider_builder.build();
+        let provider = provider_builder.build().unwrap();
         let tracer = provider.tracer("opentelemetry-test");
 
         let mut links = Vec::new();
@@ -685,7 +685,7 @@ mod tests {
         let exporter = NoopSpanExporter::new();
         let provider_builder =
             crate::trace::SdkTracerProvider::builder().with_simple_exporter(exporter);
-        let provider = provider_builder.build();
+        let provider = provider_builder.build().unwrap();
         let tracer = provider.tracer("opentelemetry-test");
 
         let mut events = Vec::new();
@@ -713,7 +713,8 @@ mod tests {
     fn test_span_exported_data() {
         let provider = crate::trace::SdkTracerProvider::builder()
             .with_simple_exporter(NoopSpanExporter::new())
-            .build();
+            .build()
+            .unwrap();
         let tracer = provider.tracer("test");
 
         let mut span = tracer.start("test_span");

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -34,7 +34,7 @@
 //! [`is_recording`]: opentelemetry::trace::Span::is_recording()
 //! [`TracerProvider`]: opentelemetry::trace::TracerProvider
 
-use crate::error::{OTelSdkError, OTelSdkResult};
+use crate::error::{OTelSdkError, OTelSdkResult, ProviderBuildError};
 use crate::resource::Resource;
 use crate::trace::Span;
 use crate::trace::{SpanData, SpanExporter};
@@ -251,12 +251,14 @@ impl<T: SpanExporter> SpanProcessor for SimpleSpanProcessor<T> {
 ///             .with_scheduled_delay(Duration::from_secs(5)) // Export every 5 seconds.
 ///             .build(),
 ///     )
-///     .build();
+///     .build()
+///     .unwrap();
 ///
 /// // Step 3: Set up a TracerProvider with the configured processor.
 /// let provider = SdkTracerProvider::builder()
 ///     .with_span_processor(batch_processor)
-///     .build();
+///     .build()
+///     .unwrap();
 /// global::set_tracer_provider(provider.clone());
 ///
 /// // Step 4: Create spans and record operations.
@@ -335,10 +337,14 @@ impl BatchSpanProcessor {
         //max_queue_size: usize,
         //scheduled_delay: Duration,
         //shutdown_timeout: Duration,
-    ) -> Self
+    ) -> Result<Self, ProviderBuildError>
     where
         E: SpanExporter + Send + 'static,
     {
+        if exporter.requires_async_runtime() {
+            return Err(ProviderBuildError::AsyncRuntimeRequired);
+        }
+
         let (span_sender, span_receiver) = sync_channel::<SpanData>(config.max_queue_size);
         let (message_sender, message_receiver) = sync_channel::<BatchMessage>(64); // Is this a reasonable bound?
         let max_queue_size = config.max_queue_size;
@@ -451,9 +457,9 @@ impl BatchSpanProcessor {
                     name: "BatchSpanProcessor.ThreadStopped"
                 );
             })
-            .expect("Failed to spawn thread"); //TODO: Handle thread spawn failure
+            .map_err(ProviderBuildError::ThreadSpawnFailed)?;
 
-        Self {
+        Ok(Self {
             span_sender,
             message_sender,
             handle: Mutex::new(Some(handle)),
@@ -463,7 +469,7 @@ impl BatchSpanProcessor {
             export_span_message_sent: Arc::new(AtomicBool::new(false)),
             current_batch_size,
             max_export_batch_size,
-        }
+        })
     }
 
     /// builder
@@ -762,7 +768,7 @@ where
     }
 
     /// Build a new instance of `BatchSpanProcessor`.
-    pub fn build(self) -> BatchSpanProcessor {
+    pub fn build(self) -> Result<BatchSpanProcessor, ProviderBuildError> {
         BatchSpanProcessor::new(self.exporter, self.config)
     }
 }
@@ -1235,7 +1241,7 @@ mod tests {
             .with_max_export_batch_size(10)
             .with_scheduled_delay(Duration::from_secs(5))
             .build();
-        let processor = BatchSpanProcessor::new(exporter, config);
+        let processor = BatchSpanProcessor::new(exporter, config).unwrap();
 
         let test_span = create_test_span("test_span");
         processor.on_end(test_span.clone());
@@ -1257,7 +1263,7 @@ mod tests {
             .with_max_export_batch_size(10)
             .with_scheduled_delay(Duration::from_secs(5))
             .build();
-        let processor = BatchSpanProcessor::new(exporter, config);
+        let processor = BatchSpanProcessor::new(exporter, config).unwrap();
 
         // Create a test span and send it to the processor
         let test_span = create_test_span("force_flush_span");
@@ -1325,7 +1331,7 @@ mod tests {
         let exporter = InMemorySpanExporterBuilder::new()
             .keep_records_on_shutdown()
             .build();
-        let processor = BatchSpanProcessor::new(exporter.clone(), BatchConfig::default());
+        let processor = BatchSpanProcessor::new(exporter.clone(), BatchConfig::default()).unwrap();
 
         let record = create_test_span("test_span");
 
@@ -1376,7 +1382,7 @@ mod tests {
             .with_max_export_batch_size(5)
             .with_scheduled_delay(Duration::from_millis(10))
             .build();
-        let processor = BatchSpanProcessor::new(exporter, config);
+        let processor = BatchSpanProcessor::new(exporter, config).unwrap();
 
         // Rapidly send many more spans than the queue can hold
         let total_spans_to_send = 100;
@@ -1449,7 +1455,7 @@ mod tests {
             max_concurrent_exports: 4,
         };
 
-        let processor = BatchSpanProcessor::new(exporter, config);
+        let processor = BatchSpanProcessor::new(exporter, config).unwrap();
 
         processor.on_end(new_test_export_span_data());
         processor.on_end(new_test_export_span_data());
@@ -1475,7 +1481,7 @@ mod tests {
         let exporter = MockSpanExporter::new();
         let exporter_shared = exporter.exported_spans.clone();
         let config = BatchConfigBuilder::default().build();
-        let processor = BatchSpanProcessor::new(exporter, config);
+        let processor = BatchSpanProcessor::new(exporter, config).unwrap();
 
         // Create a span with attributes
         let mut span_data = create_test_span("attribute_validation");
@@ -1506,7 +1512,7 @@ mod tests {
         let exporter_shared = exporter.exported_spans.clone();
         let resource_shared = exporter.exported_resource.clone();
         let config = BatchConfigBuilder::default().build();
-        let mut processor = BatchSpanProcessor::new(exporter, config);
+        let mut processor = BatchSpanProcessor::new(exporter, config).unwrap();
 
         // Set a resource for the processor
         let resource = Resource::builder_empty()
@@ -1547,7 +1553,7 @@ mod tests {
             .with_max_export_batch_size(3)
             .build();
 
-        let processor = BatchSpanProcessor::new(exporter, config);
+        let processor = BatchSpanProcessor::new(exporter, config).unwrap();
 
         for _ in 0..4 {
             let span = new_test_export_span_data();
@@ -1570,7 +1576,7 @@ mod tests {
             .with_max_export_batch_size(3)
             .build();
 
-        let processor = BatchSpanProcessor::new(exporter, config);
+        let processor = BatchSpanProcessor::new(exporter, config).unwrap();
 
         for _ in 0..4 {
             let span = new_test_export_span_data();
@@ -1594,7 +1600,7 @@ mod tests {
             .build();
 
         // Create the processor with the thread-safe exporter
-        let processor = Arc::new(BatchSpanProcessor::new(exporter, config));
+        let processor = Arc::new(BatchSpanProcessor::new(exporter, config).unwrap());
 
         let mut handles = vec![];
         for _ in 0..10 {
@@ -1615,5 +1621,29 @@ mod tests {
         // Verify exported spans
         let exported_spans = exporter_shared.lock().unwrap();
         assert_eq!(exported_spans.len(), 10);
+    }
+
+    #[test]
+    fn test_batch_span_processor_rejects_async_runtime_exporter() {
+        use crate::error::ProviderBuildError;
+
+        #[derive(Debug)]
+        struct AsyncRequiringExporter;
+
+        impl SpanExporter for AsyncRequiringExporter {
+            async fn export(&self, _batch: Vec<SpanData>) -> OTelSdkResult {
+                Ok(())
+            }
+
+            fn requires_async_runtime(&self) -> bool {
+                true
+            }
+        }
+
+        let result = BatchSpanProcessor::builder(AsyncRequiringExporter).build();
+        assert!(
+            matches!(result, Err(ProviderBuildError::AsyncRuntimeRequired)),
+            "Expected AsyncRuntimeRequired, got: {result:?}"
+        );
     }
 }

--- a/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
@@ -70,10 +70,11 @@ use tokio::sync::RwLock;
 ///         .with_batch_config(BatchConfigBuilder::default().with_max_queue_size(4096).build())
 ///         .build();
 ///
-///     // Then use the `with_batch_exporter` method to have the provider export spans in batches.
+///     // Then use the `with_span_processor` method to have the provider export spans in batches.
 ///     let provider = trace::SdkTracerProvider::builder()
 ///         .with_span_processor(batch)
-///         .build();
+///         .build()
+///         .unwrap();
 ///
 ///     let _ = global::set_tracer_provider(provider);
 /// }

--- a/opentelemetry-sdk/src/trace/tracer.rs
+++ b/opentelemetry-sdk/src/trace/tracer.rs
@@ -310,7 +310,8 @@ mod tests {
         let sampler = TestSampler {};
         let tracer_provider = crate::trace::SdkTracerProvider::builder()
             .with_sampler(sampler)
-            .build();
+            .build()
+            .unwrap();
         let tracer = tracer_provider.tracer("test");
         let trace_state = TraceState::from_key_value(vec![("foo", "bar")]).unwrap();
 
@@ -335,7 +336,8 @@ mod tests {
         let sampler: Box<dyn ShouldSample> = Box::new(TestSampler {});
         let tracer_provider = crate::trace::SdkTracerProvider::builder()
             .with_sampler(sampler)
-            .build();
+            .build()
+            .unwrap();
         let tracer = tracer_provider.tracer("test");
         let trace_state = TraceState::from_key_value(vec![("foo", "bar")]).unwrap();
 
@@ -359,7 +361,8 @@ mod tests {
         let sampler = Sampler::ParentBased(Box::new(Sampler::AlwaysOn));
         let tracer_provider = crate::trace::SdkTracerProvider::builder()
             .with_sampler(sampler)
-            .build();
+            .build()
+            .unwrap();
 
         let context = Context::current_with_span(TestSpan(SpanContext::empty_context()));
         let tracer = tracer_provider.tracer("test");
@@ -373,7 +376,8 @@ mod tests {
         let sampler = Sampler::ParentBased(Box::new(Sampler::AlwaysOn));
         let tracer_provider = crate::trace::SdkTracerProvider::builder()
             .with_sampler(sampler)
-            .build();
+            .build()
+            .unwrap();
         let tracer = tracer_provider.tracer("test");
 
         let _attached = Context::current_with_span(TestSpan(SpanContext::empty_context())).attach();
@@ -403,7 +407,8 @@ mod tests {
         let tracer_provider = crate::trace::SdkTracerProvider::builder()
             .with_sampler(Sampler::AlwaysOn)
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
         let tracer = tracer_provider.tracer("test");
 
         // Create a parent context explicitly
@@ -457,7 +462,8 @@ mod tests {
         let tracer_provider = crate::trace::SdkTracerProvider::builder()
             .with_sampler(Sampler::AlwaysOn)
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
         let tracer = tracer_provider.tracer("test");
 
         // Create a parent span and attach it to the current context
@@ -502,7 +508,8 @@ mod tests {
         let tracer_provider = crate::trace::SdkTracerProvider::builder()
             .with_sampler(Sampler::AlwaysOn)
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
         let tracer = tracer_provider.tracer("test");
 
         // Create a parent context explicitly
@@ -557,7 +564,8 @@ mod tests {
         let tracer_provider = crate::trace::SdkTracerProvider::builder()
             .with_sampler(Sampler::AlwaysOn)
             .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
-            .build();
+            .build()
+            .unwrap();
         let tracer = tracer_provider.tracer("test");
 
         // Create an active context with a specific trace context

--- a/opentelemetry-semantic-conventions/scripts/templates/registry/rust/resource.rs.j2
+++ b/opentelemetry-semantic-conventions/scripts/templates/registry/rust/resource.rs.j2
@@ -21,7 +21,8 @@
 //!
 //! let _tracer = SdkTracerProvider::builder()
 //!     .with_resource(Resource::builder_empty().with_service_name("my-service").build())
-//!     .build();
+//!     .build()
+//!     .unwrap();
 //! ```
 
 {% for attr in ctx | rejectattr("name", "in", params.excluded_attributes) %}

--- a/opentelemetry-semantic-conventions/src/resource.rs
+++ b/opentelemetry-semantic-conventions/src/resource.rs
@@ -20,7 +20,8 @@
 //!
 //! let _tracer = SdkTracerProvider::builder()
 //!     .with_resource(Resource::builder_empty().with_service_name("my-service").build())
-//!     .build();
+//!     .build()
+//!     .unwrap();
 //! ```
 
 #[cfg(feature = "semconv_experimental")]

--- a/opentelemetry-stdout/examples/basic.rs
+++ b/opentelemetry-stdout/examples/basic.rs
@@ -25,7 +25,8 @@ fn init_trace() -> SdkTracerProvider {
     let provider = SdkTracerProvider::builder()
         .with_simple_exporter(exporter)
         .with_resource(RESOURCE.clone())
-        .build();
+        .build()
+        .unwrap();
     global::set_tracer_provider(provider.clone());
     provider
 }
@@ -51,7 +52,8 @@ fn init_logs() -> opentelemetry_sdk::logs::SdkLoggerProvider {
     let provider: SdkLoggerProvider = SdkLoggerProvider::builder()
         .with_simple_exporter(exporter)
         .with_resource(RESOURCE.clone())
-        .build();
+        .build()
+        .unwrap();
     let layer = layer::OpenTelemetryTracingBridge::new(&provider);
     tracing_subscriber::registry().with(layer).init();
     provider

--- a/opentelemetry-stdout/src/lib.rs
+++ b/opentelemetry-stdout/src/lib.rs
@@ -30,6 +30,7 @@
 //!     SdkTracerProvider::builder()
 //!         .with_simple_exporter(exporter)
 //!         .build()
+//!         .unwrap()
 //! }
 //!
 //! fn init_metrics() -> SdkMeterProvider {
@@ -42,6 +43,7 @@
 //!     SdkLoggerProvider::builder()
 //!         .with_simple_exporter(exporter)
 //!         .build()
+//!         .unwrap()
 //! }
 //!
 //! let tracer_provider = init_trace();

--- a/opentelemetry-zipkin/examples/zipkin.rs
+++ b/opentelemetry-zipkin/examples/zipkin.rs
@@ -25,7 +25,8 @@ fn init_traces() -> Result<SdkTracerProvider, ExporterBuildError> {
                 .with_service_name("trace-demo")
                 .build(),
         )
-        .build())
+        .build()
+        .unwrap())
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -38,7 +38,8 @@
 //!                 .with_service_name("trace-demo")
 //!                 .build(),
 //!         )
-//!         .build();
+//!         .build()
+//!         .unwrap();
 //!     global::set_tracer_provider(provider.clone());
 //!
 //!     let tracer = global::tracer("zipkin-tracer");
@@ -76,7 +77,8 @@
 //!
 //!     let batch = BatchSpanProcessor::builder(exporter)
 //!         .with_batch_config(BatchConfigBuilder::default().with_max_queue_size(4096).build())
-//!         .build();
+//!         .build()
+//!         .unwrap();
 //!
 //!     let provider = SdkTracerProvider::builder()
 //!         .with_span_processor(batch)
@@ -85,7 +87,8 @@
 //!                 .with_service_name("runtime-demo")
 //!                 .build(),
 //!         )
-//!         .build();
+//!         .build()
+//!         .unwrap();
 //!
 //!     Ok(())
 //! }
@@ -157,7 +160,7 @@
 //!     }
 //! }
 //!
-//! fn init_traces() -> Result<trace::SdkTracerProvider, ExporterBuildError> {
+//! fn init_traces() -> Result<trace::SdkTracerProvider, Box<dyn Error + Send + Sync + 'static>> {
 //!     let exporter = ZipkinExporter::builder()
 //!         .with_http_client(
 //!             HyperClient(
@@ -173,9 +176,10 @@
 //!         .with_collector_endpoint("http://localhost:9411/api/v2/spans")
 //!         .build()?;
 //!
+//!     let processor = trace::BatchSpanProcessor::builder(exporter).build()?;
 //!     Ok(trace::SdkTracerProvider::builder()
 //!         .with_sampler(Sampler::AlwaysOn)
-//!         .with_batch_exporter(exporter)
+//!         .with_span_processor(processor)
 //!         .with_id_generator(RandomIdGenerator::default())
 //!         .with_max_events_per_span(64)
 //!         .with_max_attributes_per_span(16)
@@ -186,7 +190,7 @@
 //!                 .with_attribute(KeyValue::new("key", "value"))
 //!                 .build()
 //!         )
-//!         .build())
+//!         .build()?)
 //! }
 //!
 //! fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -36,7 +36,7 @@ pub trait LoggerProvider {
     /// use opentelemetry::logs::LoggerProvider;
     /// use opentelemetry_sdk::logs::SdkLoggerProvider;
     ///
-    /// let provider = SdkLoggerProvider::builder().build();
+    /// let provider = SdkLoggerProvider::builder().build().unwrap();
     ///
     /// // logger used in applications/binaries
     /// let logger = provider.logger("my_app");

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -82,7 +82,8 @@ fn main() {
         .with_log_processor(SimpleConcurrentLogProcessor::new(NoopExporter::new(
             enabled,
         )))
-        .build();
+        .build()
+        .unwrap();
 
     // Use the OpenTelemetryTracingBridge to test the throughput of the appender-tracing.
     let layer = layer::OpenTelemetryTracingBridge::new(&provider);

--- a/stress/src/traces.rs
+++ b/stress/src/traces.rs
@@ -25,7 +25,8 @@ lazy_static! {
     static ref PROVIDER: sdktrace::SdkTracerProvider = sdktrace::SdkTracerProvider::builder()
         .with_sampler(sdktrace::Sampler::AlwaysOn)
         .with_span_processor(NoOpSpanProcessor {})
-        .build();
+        .build()
+        .unwrap();
     static ref TRACER: sdktrace::SdkTracer = PROVIDER.tracer("stress");
 }
 


### PR DESCRIPTION
Fixes #2690
Design discussion issue (if applicable) #2673

## Changes

Makes `build()` return `Result` for all SDK provider and batch processor builders, eliminating
two categories of panics at initialization time:

**Thread spawn failures** (`ProviderBuildError::ThreadSpawnFailed`) — `BatchSpanProcessor` and
`BatchLogProcessor` both spawn a background OS thread. On resource-exhausted systems this
`thread::Builder::spawn()` call can fail; previously it would `expect()` and crash the process.

**Async-runtime/processor mismatch** (`ProviderBuildError::AsyncRuntimeRequired`) — The batch
processor runs on a dedicated OS thread using blocking calls (since 0.28). Async HTTP clients
like `reqwest::Client` and `HyperClient` require a Tokio reactor, which isn't available on that
thread — causing a panic at export time with *"there is no reactor running"*. This is a common
pitfall because `reqwest::Client` (async) is the default in many Rust applications.

This PR surfaces that misconfiguration at build time. `SpanExporter` and `LogExporter` gain a
`requires_async_runtime() -> bool` method (default: `false`); OTLP exporters propagate this
flag from their underlying `HttpClient`. The check is best-effort: third-party exporters that
do not override the method continue to return `false` and may still panic at export time.

Build-time detection is preferred over simply documenting "don't use async clients" because:
- The async `reqwest::Client` is what most Rust developers reach for first
- The panic surfaces deep in the export path, often minutes after startup, making it hard to
  diagnose
- Third-party `HttpClient` implementations can opt into the same safety net by overriding
  `requires_async_runtime()`
- A clear `ProviderBuildError::AsyncRuntimeRequired` is better DX than a tokio reactor panic

**Removed `with_batch_exporter()` convenience method** — from both `TracerProviderBuilder` and
`LoggerProviderBuilder`. Users now build the batch processor explicitly and pass it via
`with_span_processor()` / `with_log_processor()`. This eliminates the design tension of having
a fallible operation hidden inside an infallible builder method (see design rationale below).

### API changes (breaking)

| Before | After |
|---|---|
| `TracerProviderBuilder::build() -> SdkTracerProvider` | `-> Result<SdkTracerProvider, ProviderBuildError>` |
| `LoggerProviderBuilder::build() -> SdkLoggerProvider` | `-> Result<SdkLoggerProvider, ProviderBuildError>` |
| `BatchSpanProcessorBuilder::build() -> BatchSpanProcessor` | `-> Result<BatchSpanProcessor, ProviderBuildError>` |
| `BatchLogProcessorBuilder::build() -> BatchLogProcessor` | `-> Result<BatchLogProcessor, ProviderBuildError>` |
| `TracerProviderBuilder::with_batch_exporter()` | **Removed** — use `with_span_processor()` |
| `LoggerProviderBuilder::with_batch_exporter()` | **Removed** — use `with_log_processor()` |

`ProviderBuildError` is `#[non_exhaustive]` to allow future expansion (e.g. detecting additional
invalid client combinations as noted in #2690).

### Design rationale: removing `with_batch_exporter()`

`with_batch_exporter()` was a convenience wrapper that internally constructed a
`BatchSpanProcessor` — a fallible operation (thread spawn, async-runtime validation). This
created a design problem: how should a builder method that returns `Self` report errors?

Three approaches were considered:

1. **Deferred error (`pending_error` field)** — Store the error in the builder and surface it
   at `build()`. This is what `reqwest::ClientBuilder` does. The problem: hidden state, and if
   `with_batch_exporter()` is called twice with two invalid exporters, only the last error is
   reported (the first is silently dropped).

2. **Factory closure (`PendingProcessor` enum)** — Store a closure that captures the exporter
   and defer construction to `build()`. Correct and order-preserving, but novel — no major Rust
   crate uses this pattern — and adds complexity (closure boxing, manual `Debug` impls).

3. **Remove the convenience method entirely** — Require users to build the batch processor
   explicitly via `BatchSpanProcessor::builder(exporter).build()?` and pass it to
   `with_span_processor()`. This follows the `tracing-subscriber` pattern (`.with(layer)` takes
   pre-built layers) and the broader Rust ecosystem consensus: builder setters are infallible,
   `build()` is the single fallible call site.

**Option 3** was chosen because it matches the dominant pattern across the Rust ecosystem
(`tracing-subscriber`, `axum`, `tower`, `tokio`, `rdkafka` — all take pre-built components
rather than wrapping fallible construction in convenience methods). The two-line migration is
straightforward and the explicit processor construction gives users access to `BatchConfigBuilder`
for customization — something `with_batch_exporter()` did not expose.

### Provider `build()` infallibility note

Both `TracerProviderBuilder::build()` and `LoggerProviderBuilder::build()` are currently
infallible at the provider level — the `Result` return type is prophylactic for future
validation. The only errors today come from batch processor construction
(`BatchSpanProcessor::builder().build()` / `BatchLogProcessor::builder().build()`), which
happens *before* the provider `build()` call.

`SdkTracerProvider::Default` uses `.expect()` which is safe because the default builder
has no batch processors.

### Scope

This PR covers both `TracerProvider` and `LoggerProvider` in a single change so the two providers
stay consistent and the breaking change is delivered atomically.

### Migration

```rust
// Before
let provider = SdkTracerProvider::builder()
    .with_batch_exporter(exporter)
    .build();

// After
let processor = BatchSpanProcessor::builder(exporter).build()?;
let provider = SdkTracerProvider::builder()
    .with_span_processor(processor)
    .build()?;
```

```rust
// Before (logs)
let provider = SdkLoggerProvider::builder()
    .with_batch_exporter(exporter)
    .build();

// After (logs)
let processor = BatchLogProcessor::builder(exporter).build()?;
let provider = SdkLoggerProvider::builder()
    .with_log_processor(processor)
    .build()?;
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
