### PR TITLE
chore: Fix clippy warnings for Rust 1.95

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/src/trace_asserter.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/trace_asserter.rs
@@ -133,14 +133,8 @@ impl SpanForest {
 
     fn get_root_spans(&self) -> Vec<&SpanTreeNode> {
         self.spans
-            .iter()
-            .filter_map(|(_, span_node)| {
-                if span_node.span.parent_span_id.is_empty() {
-                    Some(span_node)
-                } else {
-                    None
-                }
-            })
+            .values()
+            .filter(|span_node| span_node.span.parent_span_id.is_empty())
             .collect()
     }
 }

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -367,7 +367,7 @@ fn prometheus_exporter_integration() {
                         KeyValue::new(TELEMETRY_SDK_VERSION, "latest"),
                     ]
                     .into_iter()
-                    .chain(tc.custom_resource_attrs.into_iter()),
+                    .chain(tc.custom_resource_attrs),
                 )
                 .build()
         };
@@ -774,7 +774,7 @@ fn duplicate_metrics() {
                     KeyValue::new(TELEMETRY_SDK_VERSION, "latest"),
                 ]
                 .into_iter()
-                .chain(tc.custom_resource_attrs.into_iter()),
+                .chain(tc.custom_resource_attrs),
             )
             .build();
 


### PR DESCRIPTION
Rust 1.95 introduced new clippy lints that cause CI failures.

**Changes:**
- `opentelemetry-otlp/tests/integration_test/src/trace_asserter.rs` — Replace `.iter().filter_map(|(_, v)| ...)` with `.values().filter(|v| ...)` (`clippy::iter_kv_map` + `clippy::unnecessary_filter_map`)
- `opentelemetry-prometheus/tests/integration_test.rs` — Remove redundant `.into_iter()` in `.chain()` calls (`clippy::useless_conversion`)