### PR TITLE
perf(metrics): partition ValueMap into per-thread shards to reduce lock contention

### DIFF
--- a/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/exponential_histogram.rs
@@ -204,6 +204,31 @@ fn scale_change(max_size: i32, bin: i32, start_bin: i32, length: i32) -> u32 {
     count
 }
 
+/// Returns the number of doubling-shrinks (downscale delta) needed so the union bin range
+/// of two bucket sets fits within `max_size` after downscaling.
+/// This is used during merge to avoid allocating huge sparse bucket vectors that's beyond
+/// the "max_size" limit when two histograms at the same scale cover widely different ranges.
+fn scale_change_for_union(max_size: i32, start1: i32, len1: i32, start2: i32, len2: i32) -> u32 {
+    if len1 <= 0 || len2 <= 0 {
+        return 0;
+    }
+    let end1 = start1 + len1 - 1;
+    let end2 = start2 + len2 - 1;
+    let mut low = start1.min(start2);
+    let mut high = end1.max(end2);
+    let mut count = 0u32;
+    while high - low >= max_size {
+        low >>= 1;
+        high >>= 1;
+        count += 1;
+
+        if count > (EXPO_MAX_SCALE - EXPO_MIN_SCALE) as u32 {
+            return count;
+        }
+    }
+    count
+}
+
 // TODO - replace it with LazyLock once it is stable
 static SCALE_FACTORS: OnceLock<[f64; 21]> = OnceLock::new();
 
@@ -265,7 +290,7 @@ fn frexp(x: f64) -> (f64, i32) {
 }
 
 /// A set of buckets in an exponential histogram.
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Clone)]
 struct ExpoBuckets {
     start_bin: i32,
     counts: Vec<u64>,
@@ -373,6 +398,135 @@ where
         let mut current = self.lock().unwrap_or_else(|err| err.into_inner());
         let cloned = replace(current.deref_mut(), ExpoHistogramDataPoint::new(init));
         Mutex::new(cloned)
+    }
+
+    fn merge_to(&self, target: &Self) {
+        let src = self.lock().unwrap_or_else(|err| err.into_inner());
+        // Source is empty: nothing to merge.
+        if src.count == 0 {
+            return;
+        }
+
+        let mut dst = target.lock().unwrap_or_else(|err| err.into_inner());
+        // dest is empty: just copy the src.
+        if dst.count == 0 {
+            *dst = ExpoHistogramDataPoint {
+                max_size: dst.max_size,
+                count: src.count,
+                min: src.min,
+                max: src.max,
+                sum: src.sum,
+                scale: src.scale,
+                pos_buckets: src.pos_buckets.clone(),
+                neg_buckets: src.neg_buckets.clone(),
+                zero_count: src.zero_count,
+            };
+            return;
+        }
+
+        dst.count += src.count;
+        dst.sum += src.sum;
+        dst.zero_count += src.zero_count;
+        if src.min < dst.min {
+            dst.min = src.min;
+        }
+        if src.max > dst.max {
+            dst.max = src.max;
+        }
+
+        // Unify the scales of both sides to smaller scale before merging.
+        let target_scale = src.scale.min(dst.scale);
+
+        if dst.scale > target_scale {
+            let delta = (dst.scale - target_scale) as u32;
+            dst.pos_buckets.downscale(delta);
+            dst.neg_buckets.downscale(delta);
+        }
+        dst.scale = target_scale;
+
+        // Prepare src buckets (cloned) at the common target_scale.
+        let mut src_pos = src.pos_buckets.clone();
+        let mut src_neg = src.neg_buckets.clone();
+        if src.scale > target_scale {
+            let delta = (src.scale - target_scale) as u32;
+            src_pos.downscale(delta);
+            src_neg.downscale(delta);
+        }
+
+        // If the two (now same-scale) bucket ranges are far apart (different start_bin
+        // because the original value ranges were widely different), their union at the
+        // current resolution would exceed max_size. Pre-downscale both so the union fits.
+        let pos_delta = scale_change_for_union(
+            dst.max_size,
+            dst.pos_buckets.start_bin,
+            dst.pos_buckets.counts.len() as i32,
+            src_pos.start_bin,
+            src_pos.counts.len() as i32,
+        );
+        let neg_delta = scale_change_for_union(
+            dst.max_size,
+            dst.neg_buckets.start_bin,
+            dst.neg_buckets.counts.len() as i32,
+            src_neg.start_bin,
+            src_neg.counts.len() as i32,
+        );
+        let delta = pos_delta.max(neg_delta);
+        if delta > 0 {
+            dst.pos_buckets.downscale(delta);
+            dst.neg_buckets.downscale(delta);
+            src_pos.downscale(delta);
+            src_neg.downscale(delta);
+            dst.scale -= delta as i8;
+        }
+
+        merge_expo_buckets(&src_pos, &mut dst.pos_buckets);
+        merge_expo_buckets(&src_neg, &mut dst.neg_buckets);
+
+        // Final safety net (in case alignment after downscale adds an extra bucket).
+        while dst.scale > EXPO_MIN_SCALE
+            && (dst.pos_buckets.counts.len() as i32 > dst.max_size
+                || dst.neg_buckets.counts.len() as i32 > dst.max_size)
+        {
+            dst.pos_buckets.downscale(1);
+            dst.neg_buckets.downscale(1);
+            dst.scale -= 1;
+        }
+    }
+}
+
+/// Merges `src` bucket counts into `dst`, aligning by bin index.
+/// Assumes both have the same scale (no downscaling needed).
+fn merge_expo_buckets(src: &ExpoBuckets, dst: &mut ExpoBuckets) {
+    if src.counts.is_empty() {
+        return;
+    }
+
+    if dst.counts.is_empty() {
+        dst.start_bin = src.start_bin;
+        dst.counts = src.counts.clone();
+        return;
+    }
+
+    // Compute the union bin range
+    let src_end = src.start_bin + src.counts.len() as i32 - 1;
+    let dst_end = dst.start_bin + dst.counts.len() as i32 - 1;
+    let new_start = src.start_bin.min(dst.start_bin);
+    let new_end = src_end.max(dst_end);
+    let new_len = (new_end - new_start + 1) as usize;
+
+    // Shift dst counts to align with new_start
+    let dst_offset = (dst.start_bin - new_start) as usize;
+    if dst_offset > 0 || new_len > dst.counts.len() {
+        let mut new_counts = vec![0u64; new_len];
+        new_counts[dst_offset..dst_offset + dst.counts.len()].copy_from_slice(&dst.counts);
+        dst.counts = new_counts;
+        dst.start_bin = new_start;
+    }
+
+    // Add src counts at their aligned offsets
+    let src_offset = (src.start_bin - new_start) as usize;
+    for (i, &c) in src.counts.iter().enumerate() {
+        dst.counts[src_offset + i] += c;
     }
 }
 
@@ -1695,5 +1849,215 @@ mod tests {
             a.negative_bucket, b.negative_bucket,
             "{test_name}: {message} neg"
         );
+    }
+
+    #[test]
+    fn merge_same_scale() {
+        let cfg = BucketConfig {
+            max_size: 4,
+            max_scale: 20,
+        };
+        // Both source and dest are at the same scale.
+        let a: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        a.update(1.0);
+        a.update(2.0);
+
+        let b: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        b.update(1.0);
+        b.update(4.0);
+
+        let merged: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        a.merge_to(&merged);
+        b.merge_to(&merged);
+
+        let m = merged.lock().unwrap();
+        assert_eq!(m.count, 4);
+        assert_eq!(m.sum, 8.0); // 1+2+1+4
+        assert_eq!(m.min, 1.0);
+        assert_eq!(m.max, 4.0);
+    }
+
+    #[test]
+    fn merge_same_scale_different_start_bin() {
+        // Histogram a records a narrow cluster [1, 2, 3]   (log-span ~1.58)  → ends at scale 0
+        // Histogram b records a wide cluster [1M, 1G, 10G] (log-span ~13.3)  → ends at scale -3
+        //
+        // The two histograms therefore have different scales *and* different start_bin
+        // values after their own recordings. The merge must:
+        //   1. Normalize the finer histogram (A) to the coarser scale (-3)
+        //   2. Detect that even at the common scale the start_bins are still far apart
+        //   3. Perform an additional union downscale (to scale -4) so the merged
+        //      buckets fit in max_size=4.
+        let cfg = BucketConfig {
+            max_size: 4,
+            max_scale: 20,
+        };
+
+        let a: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        a.update(1.0);
+        a.update(2.0);
+        a.update(3.0);
+
+        let b: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        b.update(1_000_000.0); // 1M
+        b.update(1_000_000_000.0); // 1G
+        b.update(10_000_000_000.0); // 10G
+
+        let merged: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        a.merge_to(&merged);
+        b.merge_to(&merged);
+
+        let m = merged.lock().unwrap();
+
+        // Structural invariants that must always hold after any merge
+        assert!(
+            m.pos_buckets.counts.len() as i32 <= m.max_size,
+            "pos bucket len {} > max_size {}",
+            m.pos_buckets.counts.len(),
+            m.max_size
+        );
+        let bucket_total: u64 = m.pos_buckets.counts.iter().sum::<u64>() + m.zero_count;
+        assert_eq!(bucket_total, m.count as u64);
+
+        // Exact results for the given inputs (verified by running the merge)
+        assert_eq!(m.count, 6);
+        assert_eq!(m.min, 1.0);
+        assert_eq!(m.max, 10_000_000_000.0);
+        let expected_sum = 1.0 + 2.0 + 3.0 + 1_000_000.0 + 1_000_000_000.0 + 10_000_000_000.0;
+        assert!((m.sum - expected_sum).abs() < 1.0);
+
+        // After normalizing to -3 and then one extra union downscale we land at -4
+        assert_eq!(m.scale, -4);
+        // The final bucket layout (start_bin + counts) is deterministic for these inputs
+        assert_eq!(m.pos_buckets.start_bin, -1);
+        assert_eq!(m.pos_buckets.counts, vec![1, 2, 2, 1]);
+    }
+
+    #[test]
+    fn merge_different_scales_rescales_buckets() {
+        // Shard A: small values stay at a fine scale.
+        // Shard B: wide-range values force a coarser scale.
+        // After merge, buckets must be rescaled to the coarser scale.
+        let cfg = BucketConfig {
+            max_size: 4,
+            max_scale: 20,
+        };
+
+        let a: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        a.update(1.0);
+        a.update(1.0);
+        let a_scale = a.lock().unwrap().scale;
+
+        let b: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        // Record values that span a wide range to force downscaling.
+        for &v in &[1.0, 2.0, 4.0, 8.0, 16.0] {
+            b.update(v);
+        }
+        let b_scale = b.lock().unwrap().scale;
+
+        // Confirm B is downscaled, B scale < A scale.
+        assert!(
+            b_scale < a_scale,
+            "expected B to be at a coarser scale than A, got a={a_scale} b={b_scale}"
+        );
+
+        let merged: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        a.merge_to(&merged);
+        b.merge_to(&merged);
+
+        let m = merged.lock().unwrap();
+        assert_eq!(m.count, 7); // 2 + 5
+        assert_eq!(m.sum, 1.0 + 1.0 + 1.0 + 2.0 + 4.0 + 8.0 + 16.0);
+        assert_eq!(m.min, 1.0);
+        assert_eq!(m.max, 16.0);
+        // Merged scale should be the coarser of the two.
+        assert_eq!(m.scale, b_scale);
+        // Bucket count must not exceed max_size.
+        assert!(
+            m.pos_buckets.counts.len() as i32 <= m.max_size,
+            "pos buckets {} exceed max_size {}",
+            m.pos_buckets.counts.len(),
+            m.max_size
+        );
+
+        // Total bucket counts must equal count minus zero_count.
+        let total_bucket_count: u64 = m.pos_buckets.counts.iter().sum::<u64>()
+            + m.neg_buckets.counts.iter().sum::<u64>()
+            + m.zero_count;
+        assert_eq!(total_bucket_count, m.count as u64);
+    }
+
+    #[test]
+    fn merge_into_empty_target() {
+        let cfg = BucketConfig {
+            max_size: 4,
+            max_scale: 20,
+        };
+
+        let a: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        a.update(2.0);
+        a.update(8.0);
+
+        let merged: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        a.merge_to(&merged);
+
+        let m = merged.lock().unwrap();
+        let a_inner = a.lock().unwrap();
+        assert_eq!(m.count, a_inner.count);
+        assert_eq!(m.sum, a_inner.sum);
+        assert_eq!(m.scale, a_inner.scale);
+        assert_eq!(m.pos_buckets, a_inner.pos_buckets);
+        assert_eq!(m.neg_buckets, a_inner.neg_buckets);
+    }
+
+    #[test]
+    fn merge_empty_source_is_noop() {
+        let cfg = BucketConfig {
+            max_size: 4,
+            max_scale: 20,
+        };
+
+        let dst: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        dst.update(5.0);
+
+        let empty: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        let before_count = dst.lock().unwrap().count;
+
+        empty.merge_to(&dst);
+
+        let after = dst.lock().unwrap();
+        assert_eq!(after.count, before_count);
+    }
+
+    #[test]
+    fn merge_enforces_max_size() {
+        // Use a very small max_size so that merging two histograms with
+        // non-overlapping bucket ranges forces post-merge downscaling.
+        let cfg = BucketConfig {
+            max_size: 2,
+            max_scale: 20,
+        };
+
+        let a: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        a.update(1.0);
+
+        let b: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        b.update(1024.0);
+
+        let merged: Mutex<ExpoHistogramDataPoint<f64>> = Aggregator::create(&cfg);
+        a.merge_to(&merged);
+        b.merge_to(&merged);
+
+        let m = merged.lock().unwrap();
+        assert_eq!(m.count, 2);
+        assert!(
+            m.pos_buckets.counts.len() as i32 <= m.max_size,
+            "pos buckets {} exceed max_size {}",
+            m.pos_buckets.counts.len(),
+            m.max_size
+        );
+
+        let total: u64 = m.pos_buckets.counts.iter().sum::<u64>() + m.zero_count;
+        assert_eq!(total, m.count as u64);
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -49,6 +49,22 @@ where
         let mut current = self.lock().unwrap_or_else(|err| err.into_inner());
         Mutex::new(replace(current.deref_mut(), Buckets::new(*count)))
     }
+
+    fn merge_to(&self, target: &Self) {
+        let src = self.lock().unwrap_or_else(|err| err.into_inner());
+        let mut dst = target.lock().unwrap_or_else(|err| err.into_inner());
+        dst.count += src.count;
+        dst.total += src.total;
+        if src.min < dst.min {
+            dst.min = src.min;
+        }
+        if src.max > dst.max {
+            dst.max = src.max;
+        }
+        for (i, &c) in src.counts.iter().enumerate() {
+            dst.counts[i] += c;
+        }
+    }
 }
 
 #[derive(Default)]

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -69,6 +69,14 @@ where
             value: T::new_atomic_tracker(self.value.get_and_reset_value()),
         }
     }
+
+    fn merge_to(&self, target: &Self) {
+        target.value.store(self.value.get_value());
+    }
+
+    fn is_order_dependent() -> bool {
+        true
+    }
 }
 
 /// Summarizes a set of measurements as the last one made.
@@ -245,8 +253,8 @@ mod tests {
         bound.call(5);
 
         // While the handle exists, the entry's bound_count is 1.
-        let trackers = last_value.value_map.trackers.read().unwrap();
-        let entry = trackers
+        let shard = last_value.value_map.shards[0].read().unwrap();
+        let entry = shard
             .values()
             .next()
             .expect("entry should exist after bind+call");
@@ -255,12 +263,12 @@ mod tests {
             1,
             "bound_count should reflect a live handle"
         );
-        drop(trackers);
+        drop(shard);
 
         drop(bound);
 
-        let trackers = last_value.value_map.trackers.read().unwrap();
-        let entry = trackers
+        let shard = last_value.value_map.shards[0].read().unwrap();
+        let entry = shard
             .values()
             .next()
             .expect("entry should still exist post-drop");

--- a/opentelemetry-sdk/src/metrics/internal/mod.rs
+++ b/opentelemetry-sdk/src/metrics/internal/mod.rs
@@ -8,12 +8,13 @@ mod sum;
 use core::fmt;
 #[cfg(not(target_has_atomic = "64"))]
 use portable_atomic::{AtomicI64, AtomicU64};
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::ops::{Add, AddAssign, Sub};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 #[cfg(target_has_atomic = "64")]
 use std::sync::atomic::{AtomicI64, AtomicU64};
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
 pub(crate) use aggregate::{AggregateBuilder, AggregateFns, ComputeAggregation, Measure};
 #[cfg(feature = "experimental_metrics_bound_instruments")]
@@ -51,6 +52,16 @@ pub(crate) trait Aggregator {
 
     /// Return current value and reset this instance
     fn clone_and_reset(&self, init: &Self::InitConfig) -> Self;
+
+    /// Read values from self and accumulate into `target`. Self is not modified.
+    fn merge_to(&self, target: &Self);
+
+    /// Whether this aggregator's semantics require all updates for a given
+    /// attribute-set to hit the same tracker instance (e.g. last-value / gauge).
+    /// When true, ValueMap will use a single shard.
+    fn is_order_dependent() -> bool {
+        false
+    }
 }
 
 /// Wraps an aggregator with status tracking for delta collection and bound instruments.
@@ -81,24 +92,66 @@ impl<A: Aggregator> TrackerEntry<A> {
 /// Map from attribute sets to their aggregator tracker entries.
 type TrackerMap<A> = HashMap<Vec<KeyValue>, Arc<TrackerEntry<A>>>;
 
-/// The storage for sums.
+static THREAD_ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+static NUM_SHARDS: OnceLock<usize> = OnceLock::new();
+
+/// Number of shards = min(num_cpu, 64);
+#[inline(always)]
+fn num_shards() -> usize {
+    *NUM_SHARDS.get_or_init(|| {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4)
+            .min(64)
+    })
+}
+
+/// Each thread is assigned a unique shard index. It's saved in a thread-local data,
+/// so subsequent call is just a memory reference.
+fn shard_index() -> usize {
+    thread_local! {
+        static THREAD_SHARD_ID: usize = THREAD_ID_COUNTER.fetch_add(1, Ordering::Relaxed) % num_shards();
+    }
+    THREAD_SHARD_ID.with(|id| *id)
+}
+
+/// Tracks the unique attribute-sets across all shards for exact cardinality enforcement.
+/// Protected by a Mutex, so two threads inserting the same new
+/// attribute-set into different shards only count it once.
+struct CardinalityGuard {
+    count: usize,
+    known_attrs: HashSet<Vec<KeyValue>>,
+}
+
+/// The storage for metric aggregations, sharded to reduce lock contention.
 ///
 /// This structure is parametrized by an `Operation` that indicates how
 /// updates to the underlying value trackers should be performed.
+/// The internal HashMap is partitioned into `num_shards` independent shards,
+/// each protected by its own `RwLock`. Threads select a shard by thread ID,
+/// so concurrent measurements rarely contend on the same lock.
 pub(crate) struct ValueMap<A>
 where
     A: Aggregator,
 {
-    /// Trackers store the values associated with different attribute sets.
-    trackers: RwLock<TrackerMap<A>>,
+    /// Partition the trackers into many shards.
+    /// Different threads will write to different shards to minimize locking contention.
+    shards: Vec<RwLock<TrackerMap<A>>>,
+    /// Number of shards actually in use.
+    /// It equals 1 for order-dependent aggregators (e.g. Assign/gauge), otherwise `num_shards()`.
+    num_shards: usize,
 
-    /// Number of different attribute set stored in the `trackers` map.
-    count: AtomicUsize,
     /// Tracker for values with no attributes attached.
     no_attribute_tracker: Arc<TrackerEntry<A>>,
     /// Configuration for an Aggregator
     config: A::InitConfig,
     cardinality_limit: usize,
+    cardinality: Mutex<CardinalityGuard>,
+    /// Approximate count of unique attribute-sets, used only as a capacity hint by
+    /// `prepare_data`. Updated alongside `CardinalityGuard::count` but read without
+    /// the Mutex.
+    count: AtomicUsize,
 }
 
 impl<A> ValueMap<A>
@@ -110,18 +163,25 @@ where
     }
 
     fn new(config: A::InitConfig, cardinality_limit: usize) -> Self {
+        let n = if A::is_order_dependent() {
+            1
+        } else {
+            num_shards()
+        };
         ValueMap {
-            trackers: RwLock::new(HashMap::with_capacity(1 + cardinality_limit)),
+            shards: (0..n)
+                .map(|_| RwLock::new(HashMap::with_capacity(1 + cardinality_limit)))
+                .collect(),
+            num_shards: n,
             no_attribute_tracker: Arc::new(TrackerEntry::new(&config)),
             count: AtomicUsize::new(0),
             config,
             cardinality_limit,
+            cardinality: Mutex::new(CardinalityGuard {
+                count: 0,
+                known_attrs: HashSet::new(),
+            }),
         }
-    }
-
-    /// Checks whether aggregator has hit cardinality limit for metric streams
-    fn is_under_cardinality_limit(&self) -> bool {
-        self.count.load(Ordering::SeqCst) < self.cardinality_limit
     }
 
     fn measure(&self, value: A::PreComputedValue, attributes: &[KeyValue]) {
@@ -133,7 +193,9 @@ where
             return;
         }
 
-        let Ok(trackers) = self.trackers.read() else {
+        let shard = &self.shards[shard_index() % self.num_shards];
+
+        let Ok(trackers) = shard.read() else {
             return;
         };
 
@@ -155,7 +217,7 @@ where
         // Give up the read lock before acquiring the write lock.
         drop(trackers);
 
-        let Ok(mut trackers) = self.trackers.write() else {
+        let Ok(mut trackers) = shard.write() else {
             return;
         };
 
@@ -164,29 +226,45 @@ where
         if let Some(tracker) = trackers.get(attributes) {
             tracker.aggregator.update(value);
             tracker.has_been_updated.store(true, Ordering::Release);
-        } else if let Some(tracker) = trackers.get(sorted_attrs.as_slice()) {
+            return;
+        }
+        if let Some(tracker) = trackers.get(sorted_attrs.as_slice()) {
             tracker.aggregator.update(value);
             tracker.has_been_updated.store(true, Ordering::Release);
-        } else if self.is_under_cardinality_limit() {
+            return;
+        }
+
+        // Truly new in this shard. Take the Mutex for global cardinality check.
+        let mut guard = self.cardinality.lock().unwrap_or_else(|e| e.into_inner());
+        let is_known = guard.known_attrs.contains(&sorted_attrs);
+        if is_known || guard.count < self.cardinality_limit {
+            if !is_known {
+                guard.known_attrs.insert(sorted_attrs.clone());
+                guard.count += 1;
+                self.count.store(guard.count, Ordering::Relaxed);
+            }
+            drop(guard);
+
             let new_tracker = Arc::new(TrackerEntry::<A>::new(&self.config));
             new_tracker.aggregator.update(value);
             new_tracker.has_been_updated.store(true, Ordering::Release);
-
-            // Insert tracker with the attributes in the provided and sorted orders
             trackers.insert(attributes.to_vec(), new_tracker.clone());
             trackers.insert(sorted_attrs, new_tracker);
-
-            self.count.fetch_add(1, Ordering::SeqCst);
-        } else if let Some(overflow_value) = trackers.get(stream_overflow_attributes().as_slice()) {
-            overflow_value.aggregator.update(value);
-            overflow_value
-                .has_been_updated
-                .store(true, Ordering::Release);
         } else {
-            let new_tracker = TrackerEntry::<A>::new(&self.config);
-            new_tracker.aggregator.update(value);
-            new_tracker.has_been_updated.store(true, Ordering::Release);
-            trackers.insert(stream_overflow_attributes().clone(), Arc::new(new_tracker));
+            drop(guard);
+
+            // It's a new attribute set, and we have hit cardinality limit. Treat it as overflow.
+            if let Some(overflow_value) = trackers.get(stream_overflow_attributes().as_slice()) {
+                overflow_value.aggregator.update(value);
+                overflow_value
+                    .has_been_updated
+                    .store(true, Ordering::Release);
+            } else {
+                let new_tracker = TrackerEntry::<A>::new(&self.config);
+                new_tracker.aggregator.update(value);
+                new_tracker.has_been_updated.store(true, Ordering::Release);
+                trackers.insert(stream_overflow_attributes().clone(), Arc::new(new_tracker));
+            }
         }
     }
 
@@ -217,14 +295,19 @@ where
         self.bind_attrs(attributes, sorted_attrs)
     }
 
+    /// Bound instruments always use shard 0 so the bound tracker has a stable home
+    /// regardless of which thread calls bind(). Unbound measure() calls may create
+    /// duplicate entries in other shards; they are merged during collection.
     #[cfg(feature = "experimental_metrics_bound_instruments")]
     fn bind_attrs(
         &self,
         original: &[KeyValue],
         sorted_attrs: Vec<KeyValue>,
     ) -> Option<Arc<TrackerEntry<A>>> {
+        let shard = &self.shards[0];
+
         // Fast path: read lock lookup using the canonical (sorted) key.
-        if let Ok(trackers) = self.trackers.read() {
+        if let Ok(trackers) = shard.read() {
             if let Some(tracker) = trackers.get(sorted_attrs.as_slice()) {
                 tracker.bound_count.fetch_add(1, Ordering::Relaxed);
                 return Some(Arc::clone(tracker));
@@ -232,7 +315,7 @@ where
         }
 
         // Slow path: write lock, insert if missing.
-        let Ok(mut trackers) = self.trackers.write() else {
+        let Ok(mut trackers) = shard.write() else {
             // Lock poisoned — caller will produce a noop bound handle.
             return None;
         };
@@ -243,7 +326,16 @@ where
             return Some(Arc::clone(tracker));
         }
 
-        if self.is_under_cardinality_limit() {
+        let mut guard = self.cardinality.lock().unwrap_or_else(|e| e.into_inner());
+        let is_known = guard.known_attrs.contains(&sorted_attrs);
+        if is_known || guard.count < self.cardinality_limit {
+            if !is_known {
+                guard.known_attrs.insert(sorted_attrs.clone());
+                guard.count += 1;
+                self.count.store(guard.count, Ordering::Relaxed);
+            }
+            drop(guard);
+
             let new_tracker = Arc::new(TrackerEntry::<A>::new(&self.config));
             new_tracker.bound_count.fetch_add(1, Ordering::Relaxed);
             // Insert with both the original and sorted orderings so subsequent
@@ -253,9 +345,9 @@ where
                 trackers.insert(original.to_vec(), new_tracker.clone());
             }
             trackers.insert(sorted_attrs, new_tracker.clone());
-            self.count.fetch_add(1, Ordering::SeqCst);
             Some(new_tracker)
         } else {
+            drop(guard);
             // Over cardinality limit — bind directly to the overflow tracker so
             // the bound handle keeps its perf contract (no per-call lookup) and
             // its writes land predictably in the overflow bucket. This matches
@@ -287,7 +379,7 @@ where
     where
         MapFn: FnMut(Vec<KeyValue>, &A) -> Res,
     {
-        prepare_data(dest, self.count.load(Ordering::SeqCst));
+        prepare_data(dest, self.count.load(Ordering::Relaxed));
         if self
             .no_attribute_tracker
             .has_been_updated
@@ -296,15 +388,35 @@ where
             dest.push(map_fn(vec![], &self.no_attribute_tracker.aggregator));
         }
 
-        let Ok(trackers) = self.trackers.read() else {
-            return;
-        };
+        // Build a merged map of sorted_attrs -> temporary A across all shards.
+        let mut merged: HashMap<Vec<KeyValue>, A> = HashMap::new();
 
-        let mut seen = HashSet::new();
-        for (attrs, tracker) in trackers.iter() {
-            if seen.insert(Arc::as_ptr(tracker)) {
-                dest.push(map_fn(attrs.clone(), &tracker.aggregator));
+        for shard in &self.shards {
+            let Ok(trackers) = shard.read() else {
+                continue;
+            };
+
+            let mut seen = HashSet::new();
+            for (attrs, tracker) in trackers.iter() {
+                if !seen.insert(Arc::as_ptr(tracker)) {
+                    continue; // skip duplicated attribute-sets within shard
+                }
+                let sorted = sort_and_dedup(attrs);
+                match merged.entry(sorted) {
+                    Entry::Vacant(e) => {
+                        let temp = A::create(&self.config);
+                        tracker.aggregator.merge_to(&temp);
+                        e.insert(temp);
+                    }
+                    Entry::Occupied(e) => {
+                        tracker.aggregator.merge_to(e.get());
+                    }
+                }
             }
+        }
+
+        for (attrs, tracker) in &merged {
+            dest.push(map_fn(attrs.clone(), tracker));
         }
     }
 
@@ -319,7 +431,7 @@ where
     where
         MapFn: FnMut(Vec<KeyValue>, &A) -> Res,
     {
-        prepare_data(dest, self.count.load(Ordering::SeqCst));
+        prepare_data(dest, self.count.load(Ordering::Relaxed));
         if self
             .no_attribute_tracker
             .has_been_updated
@@ -329,46 +441,71 @@ where
         }
 
         let overflow_attrs = stream_overflow_attributes();
-        let mut stale_entries: Vec<Arc<TrackerEntry<A>>> = Vec::new();
+        let mut merged: HashMap<Vec<KeyValue>, A> = HashMap::new();
 
-        {
-            let Ok(trackers) = self.trackers.read() else {
-                return;
-            };
-
+        for shard in &self.shards {
             let mut seen = HashSet::new();
+            let mut stale_pointers: HashSet<*const TrackerEntry<A>> = HashSet::new();
+            // Take a write lock so that no concurrent measure() can update a
+            // tracker between the has_been_updated swap and clone_and_reset().
+            let Ok(mut trackers) = shard.write() else {
+                continue;
+            };
             for (attrs, tracker) in trackers.iter() {
-                if seen.insert(Arc::as_ptr(tracker)) {
-                    if tracker.has_been_updated.swap(false, Ordering::Acquire) {
-                        dest.push(map_fn(attrs.clone(), &tracker.aggregator));
-                    } else if attrs.as_slice() != overflow_attrs.as_slice()
-                        && tracker.bound_count.load(Ordering::Relaxed) == 0
-                    {
-                        // Stale and not bound — candidate for eviction
-                        stale_entries.push(Arc::clone(tracker));
+                if !seen.insert(Arc::as_ptr(tracker)) {
+                    continue; // skip duplicated attribute-sets within a shard.
+                }
+                if tracker.has_been_updated.swap(false, Ordering::Acquire) {
+                    let sorted = sort_and_dedup(attrs);
+                    let cloned = tracker.aggregator.clone_and_reset(&self.config);
+                    match merged.entry(sorted) {
+                        Entry::Vacant(e) => {
+                            e.insert(cloned);
+                        }
+                        Entry::Occupied(e) => {
+                            cloned.merge_to(e.get());
+                        }
+                    }
+                } else if attrs.as_slice() != overflow_attrs.as_slice()
+                    && tracker.bound_count.load(Ordering::Relaxed) == 0
+                {
+                    stale_pointers.insert(Arc::as_ptr(tracker));
+                }
+            }
+            if !stale_pointers.is_empty() {
+                trackers.retain(|_, tracker| !stale_pointers.contains(&Arc::as_ptr(tracker)));
+            }
+        }
+
+        // Rebuild cardinality from the actual shards contents with this locking sequence:
+        //   - read lock on all shards, then,
+        //   - mutex on cardinality
+        // This prevents concurrent inserts (which runs a shard write lock + cardinality mutex) from being forgotten.
+        // Without this, attr-sets inserted between per-shard scans would be lost from known_attrs.
+        // Fast-path measure() (updating existing entries) only needs a read shard lock and isn't blocked.
+        {
+            let shard_read_guards: Vec<_> =
+                self.shards.iter().filter_map(|s| s.read().ok()).collect();
+            let mut guard = self.cardinality.lock().unwrap_or_else(|e| e.into_inner());
+            guard.known_attrs.clear();
+            let mut seen = HashSet::new();
+            for shard_guard in &shard_read_guards {
+                for (attrs, tracker) in shard_guard.iter() {
+                    if !seen.insert(Arc::as_ptr(tracker)) {
+                        continue;
+                    }
+                    let sorted = sort_and_dedup(attrs);
+                    if sorted.as_slice() != overflow_attrs.as_slice() {
+                        guard.known_attrs.insert(sorted);
                     }
                 }
             }
-            // Read lock released here
+            guard.count = guard.known_attrs.len();
+            self.count.store(guard.count, Ordering::Relaxed);
         }
 
-        if !stale_entries.is_empty() {
-            if let Ok(mut trackers) = self.trackers.write() {
-                // Re-check under write lock to avoid TOCTOU race: a measure() or bind() call
-                // between dropping the read lock and acquiring the write lock could have
-                // updated an entry or bound a handle to one we marked as stale.
-                stale_entries.retain(|entry| {
-                    !entry.has_been_updated.load(Ordering::Acquire)
-                        && entry.bound_count.load(Ordering::Acquire) == 0
-                });
-
-                if !stale_entries.is_empty() {
-                    let stale_pointers: HashSet<*const TrackerEntry<A>> =
-                        stale_entries.iter().map(Arc::as_ptr).collect();
-                    trackers.retain(|_, tracker| !stale_pointers.contains(&Arc::as_ptr(tracker)));
-                    self.count.fetch_sub(stale_entries.len(), Ordering::SeqCst);
-                }
-            }
+        for (attrs, tracker) in &merged {
+            dest.push(map_fn(attrs.clone(), tracker));
         }
     }
 
@@ -379,7 +516,7 @@ where
     where
         MapFn: FnMut(Vec<KeyValue>, A) -> Res,
     {
-        prepare_data(dest, self.count.load(Ordering::SeqCst));
+        prepare_data(dest, self.count.load(Ordering::Relaxed));
         if self
             .no_attribute_tracker
             .has_been_updated
@@ -393,24 +530,42 @@ where
             ));
         }
 
-        let old_trackers = {
-            let Ok(mut trackers) = self.trackers.write() else {
-                otel_warn!(name: "MeterProvider.InternalError", message = "Metric collection failed. Report this issue in OpenTelemetry repo.", details ="ValueMap trackers lock poisoned");
-                return;
-            };
-            self.count.store(0, Ordering::SeqCst);
-            std::mem::take(&mut *trackers)
-            // Write lock released here
-        };
+        let mut guard = self.cardinality.lock().unwrap_or_else(|e| e.into_inner());
+        guard.known_attrs.clear();
+        guard.count = 0;
+        drop(guard);
+        self.count.store(0, Ordering::Relaxed);
+        let mut merged: HashMap<Vec<KeyValue>, A> = HashMap::new();
 
-        let mut seen = HashSet::new();
-        for (attrs, tracker) in old_trackers {
-            if seen.insert(Arc::as_ptr(&tracker)) {
-                dest.push(map_fn(
-                    attrs,
-                    tracker.aggregator.clone_and_reset(&self.config),
-                ));
+        for shard in &self.shards {
+            let taken = {
+                let Ok(mut shard_guard) = shard.write() else {
+                    otel_warn!(name: "MeterProvider.InternalError", message = "Metric collection failed. Report this issue in OpenTelemetry repo.", details ="ValueMap shard lock poisoned");
+                    continue;
+                };
+                std::mem::take(&mut *shard_guard)
+                // Write lock released here
+            };
+            let mut seen = HashSet::new();
+            for (attrs, tracker) in taken {
+                if !seen.insert(Arc::as_ptr(&tracker)) {
+                    continue; // skip duplicated attribute-sets within a shard.
+                }
+                // Use sorted order so the same attribute-sets from different shards can be merged.
+                let sorted = sort_and_dedup(&attrs);
+                let cloned = tracker.aggregator.clone_and_reset(&self.config);
+                match merged.entry(sorted) {
+                    Entry::Vacant(e) => {
+                        e.insert(cloned);
+                    }
+                    Entry::Occupied(e) => {
+                        cloned.merge_to(e.get());
+                    }
+                }
             }
+        }
+        for (attrs, tracker) in merged {
+            dest.push(map_fn(attrs, tracker));
         }
     }
 }
@@ -837,6 +992,16 @@ mod tests {
         // keys so no zombie entries remain in the map.
         let value_map = ValueMap::<Assign<i64>>::new((), 10);
 
+        // This function sums HashMap entries across all shards. measure() will update exactly one
+        // shard (determined by the current thread).
+        let total_shard_entries = |value_map: &ValueMap<Assign<i64>>| -> usize {
+            value_map
+                .shards
+                .iter()
+                .map(|shard| shard.read().unwrap().len())
+                .sum()
+        };
+
         // Insert with attributes deliberately in non-sorted order.
         // measure() inserts two keys:
         //   - unsorted: [("b", ...), ("a", ...)]
@@ -844,16 +1009,12 @@ mod tests {
         // both pointing to the same Arc<TrackerEntry>.
         let attrs = vec![KeyValue::new("b", 1_i64), KeyValue::new("a", 2_i64)];
         value_map.measure(1_i64, attrs.as_slice());
-
-        {
-            let trackers = value_map.trackers.read().unwrap();
-            assert_eq!(
-                trackers.len(),
-                2,
-                "should have 2 HashMap keys (unsorted + sorted) for one logical attr-set"
-            );
-        }
-        assert_eq!(value_map.count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            total_shard_entries(&value_map),
+            2,
+            "should have 2 HashMap keys (unsorted + sorted) for one logical attr-set"
+        );
+        assert_eq!(value_map.cardinality.lock().unwrap().count, 1);
 
         // First collect: entry was updated, so it is exported and has_been_updated is reset.
         let mut dest: Vec<Vec<KeyValue>> = Vec::new();
@@ -865,23 +1026,89 @@ mod tests {
         dest.clear();
         value_map.collect_and_reset(&mut dest, |attrs, _| attrs);
         assert_eq!(dest.len(), 0, "stale entry should not be exported");
-
-        {
-            let trackers = value_map.trackers.read().unwrap();
-            assert_eq!(
-                trackers.len(),
-                0,
-                "both HashMap keys (unsorted + sorted) must be evicted for the stale entry"
-            );
-        }
         assert_eq!(
-            value_map.count.load(Ordering::SeqCst),
+            total_shard_entries(&value_map),
+            0,
+            "both HashMap keys (unsorted + sorted) must be evicted for the stale entry"
+        );
+        assert_eq!(
+            value_map.cardinality.lock().unwrap().count,
             0,
             "count should reach 0 after eviction"
         );
     }
 
-    /// When the trackers `RwLock` is poisoned, `bind()` cannot safely insert or
+    #[test]
+    fn assign_uses_single_shard() {
+        let value_map = ValueMap::<Assign<i64>>::new((), 10);
+        assert_eq!(
+            value_map.num_shards, 1,
+            "Assign (order-dependent) should use a single shard"
+        );
+    }
+
+    #[test]
+    fn gauge_last_value_across_threads() {
+        // Verifies that gauge (Assign) preserves last-value semantics when
+        // 10 threads update the same attribute set sequentially.
+        // Thread i waits for threads 0..i-1 to finish before writing,
+        // so thread 9 writes last. The collected value must be thread 9's.
+        use std::sync::{Arc, Barrier};
+
+        const NUM_THREADS: usize = 10;
+        let value_map = Arc::new(ValueMap::<Assign<i64>>::new((), 100));
+        let attrs = vec![KeyValue::new("key", "value")];
+
+        // Chain of barriers: barrier[i] synchronizes thread i and thread i+1.
+        // Thread i writes its value, then waits on barrier[i].
+        // Thread i+1 waits on barrier[i] before writing, ensuring strict ordering.
+        let barriers: Vec<Arc<Barrier>> = (0..NUM_THREADS - 1)
+            .map(|_| Arc::new(Barrier::new(2)))
+            .collect();
+
+        let handles: Vec<_> = (0..NUM_THREADS)
+            .map(|i| {
+                let vm = Arc::clone(&value_map);
+                let attrs = attrs.clone();
+                let prev = if i > 0 {
+                    Some(Arc::clone(&barriers[i - 1]))
+                } else {
+                    None
+                };
+                let next = if i < NUM_THREADS - 1 {
+                    Some(Arc::clone(&barriers[i]))
+                } else {
+                    None
+                };
+                std::thread::spawn(move || {
+                    // Wait for the previous thread to finish its write.
+                    if let Some(b) = prev {
+                        b.wait();
+                    }
+                    vm.measure(i as i64, &attrs);
+                    // Signal the next thread that my write is done.
+                    if let Some(b) = next {
+                        b.wait();
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let mut dest: Vec<(Vec<KeyValue>, i64)> = Vec::new();
+        value_map.collect_readonly(&mut dest, |attrs, aggr| (attrs, aggr.value.get_value()));
+        assert_eq!(dest.len(), 1);
+        assert_eq!(
+            dest[0].1,
+            (NUM_THREADS - 1) as i64,
+            "should report the value from the last thread"
+        );
+    }
+
+    /// When a shard's `RwLock` is poisoned, `bind()` cannot safely insert or
     /// look up entries, so it returns `None` and the caller (Sum/Histogram/etc.)
     /// hands back a `NoopBoundMeasure`. This is a defensive branch that fires
     /// on degenerate states (a thread panicked while holding the write lock)
@@ -889,18 +1116,18 @@ mod tests {
     /// explicitly so the branch keeps coverage.
     #[cfg(feature = "experimental_metrics_bound_instruments")]
     #[test]
-    fn bind_returns_none_when_trackers_lock_is_poisoned() {
+    fn bind_returns_none_when_shard_lock_is_poisoned() {
         let value_map = ValueMap::<Assign<i64>>::new((), 100);
 
-        // Poison the trackers RwLock by panicking inside a write guard.
+        // Poison shard 0's RwLock by panicking inside a write guard.
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard = value_map.trackers.write().unwrap();
+            let _guard = value_map.shards[0].write().unwrap();
             panic!("intentional poison");
         }));
 
         assert!(
-            value_map.trackers.is_poisoned(),
-            "trackers lock must be poisoned for this test to be meaningful"
+            value_map.shards[0].is_poisoned(),
+            "shard 0 lock must be poisoned for this test to be meaningful"
         );
 
         // Empty attrs use the no_attribute_tracker fast path and never touch
@@ -910,9 +1137,7 @@ mod tests {
             "bind(&[]) must succeed even with poisoned lock; uses no_attribute_tracker"
         );
 
-        // Non-empty attrs go through bind_attrs which needs the trackers lock.
-        // The read-lock try succeeds (only writes poison, but read on poisoned
-        // can also fail) — fall through to write lock which fails poisoned.
+        // Non-empty attrs go through bind_attrs which needs shard 0's lock.
         let result = value_map.bind(&[KeyValue::new("k", 1_i64)]);
         assert!(
             result.is_none(),

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -251,18 +251,18 @@ mod tests {
         let bound = Measure::bind(&pre_sum, &attrs);
         bound.call(5);
 
-        let trackers = pre_sum.value_map.trackers.read().unwrap();
-        let entry = trackers
+        let shard = pre_sum.value_map.shards[0].read().unwrap();
+        let entry = shard
             .values()
             .next()
             .expect("entry should exist after bind+call");
         assert_eq!(entry.bound_count.load(Ordering::Relaxed), 1);
-        drop(trackers);
+        drop(shard);
 
         drop(bound);
 
-        let trackers = pre_sum.value_map.trackers.read().unwrap();
-        let entry = trackers
+        let shard = pre_sum.value_map.shards[0].read().unwrap();
+        let entry = shard
             .values()
             .next()
             .expect("entry should still exist post-drop");

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -41,6 +41,10 @@ where
             value: T::new_atomic_tracker(self.value.get_and_reset_value()),
         }
     }
+
+    fn merge_to(&self, target: &Self) {
+        target.value.add(self.value.get_value());
+    }
 }
 
 /// Pre-bound counter handle: writes go directly to a fixed `TrackerEntry` without


### PR DESCRIPTION
Metrics ValueMap is protected by a RwLock. It can be a source of contention under high concurrency. What's more, the cost to update a histogram is even higher because you need to grab a mutex lock after the read lock before you can update a bucket.
There is a previous attempt to shard the ValueMap (https://github.com/open-telemetry/opentelemetry-rust/pull/1564),  but that PR partitions metrics updates based on attribute-sets,  therefore updates to the same attribute-set still land on the same shard, so it's not effective in reducing locking contention when most updates are focused on a small set of attributes.

Fixes #
This PR partitions the single HashMap into shards.  Each thread update different shards based on thread id to minimize locking contention.  If the number of shards >= number of CPUs you won't see locking contentions when updating metrics.

Here are Benchcmark results (metrics_histogram, metrics) with AMD EPYC 9555 CPUs (255 CPU threads).
The numbers in the tables are updates/second in millions.  "shards=16" is this PR with 16 shards, "shards=32" is this PR with 32 shards. 

Counter update throughput (cargo run --release --package stress --bin metrics -- N)
|number of threads | 1 | 2 | 4 | 8 | 16 |
|-- | -- | -- | -- | -- | -- |
|upstream   | 10 | 5.7 | 6.8 | 6 | 5.5|
|shards=16 | 10 | 22 | 32 | 40 | 43|
|shards=32 | 10 | 22 | 31 | 48 | 100|

Histogram update throughput (cargo run --release --package stress --bin metrics_histogram -- N)
|number of threads | 1 | 2 | 4 | 8 | 16 |
|-- | -- | -- | -- | -- | -- |
|upstream| 9.5 | 4.8 | 5.2 | 6 | 5.5 |
|shards=16| 9.5 | 19 | 28 | 40 | 42|
|shards=32 | 9.5 | 19 | 28 | 45 | 84|



## Changes

Two changes are made:
1, Partition ValueMap into shards and let different threads update different shards to minimize locking contention. 
2, Implement merge function for Aggregators, so collector can merge the shards.


## Merge requirement checklist

* [* ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [* ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
