### PR TITLE
perf: Add trace and logs API benchmarks to opentelemetry crate

### DIFF
--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -69,6 +69,16 @@ name = "context_suppression"
 harness = false
 
 [[bench]]
+name = "trace"
+harness = false
+required-features = ["trace"]
+
+[[bench]]
+name = "logs"
+harness = false
+required-features = ["logs"]
+
+[[bench]]
 name = "baggage"
 harness = false
 

--- a/opentelemetry/benches/attributes.rs
+++ b/opentelemetry/benches/attributes.rs
@@ -12,6 +12,20 @@ RAM: 64.0 GB
 | CreateOtelKeyValueArrayWithMixedValueTypes       |     18.1 ns |
 | CreateOtelKeyValueArrayWithNonStaticValues       |     90.1 ns |
 | CreateTupleKeyValueArray                         |     2.73 ns |
+
+OS: macOS 15
+Hardware: Apple M4 Pro, 14 cores, RAM: 24 GB
+| Test                                             | Average time|
+|--------------------------------------------------|-------------|
+| CreateOTelKey_Static                             |   0.28 ns   |
+| CreateOTelKey_Owned                              |  19.16 ns   |
+| CreateOTelKey_Arc                                |  21.76 ns   |
+| CreateOTelKeyValue                               |   1.30 ns   |
+| CreateTupleKeyValue                              |   0.26 ns   |
+| CreateOtelKeyValueArray                          |   7.41 ns   |
+| CreateOtelKeyValueArrayWithMixedValueTypes       |   5.50 ns   |
+| CreateOtelKeyValueArrayWithNonStaticValues       |  84.94 ns   |
+| CreateTupleKeyValueArray                         |   1.46 ns   |
 */
 
 use criterion::{criterion_group, criterion_main, Criterion};

--- a/opentelemetry/benches/logs.rs
+++ b/opentelemetry/benches/logs.rs
@@ -13,7 +13,9 @@
 */
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use opentelemetry::logs::{AnyValue, LogRecord, Logger, LoggerProvider, NoopLoggerProvider, Severity};
+use opentelemetry::logs::{
+    AnyValue, LogRecord, Logger, LoggerProvider, NoopLoggerProvider, Severity,
+};
 
 // Run this benchmark with:
 // cargo bench --bench logs --features=logs

--- a/opentelemetry/benches/logs.rs
+++ b/opentelemetry/benches/logs.rs
@@ -1,0 +1,83 @@
+/*
+    Benchmark Results:
+    criterion = "0.5.1"
+    OS: macOS 15
+    Hardware: Apple M4 Pro, 14 cores, RAM: 24 GB
+    | Test                                             | Average time|
+    |--------------------------------------------------|-------------|
+    | CreateLogRecord_NoopLogger                       |    0.26 ns  |
+    | CreateLogRecord_NoopLogger_WithAttributes        |    0.26 ns  |
+    | CreateLogRecord_NoopLogger_WithBody              |    1.30 ns  |
+    | CreateLogRecord_NoopLogger_Full                  |    1.30 ns  |
+    | EventEnabled_NoopLogger                          |    0.26 ns  |
+*/
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use opentelemetry::logs::{AnyValue, LogRecord, Logger, LoggerProvider, NoopLoggerProvider, Severity};
+
+// Run this benchmark with:
+// cargo bench --bench logs --features=logs
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let provider = NoopLoggerProvider::new();
+    let logger = provider.logger("bench");
+
+    c.bench_function("CreateLogRecord_NoopLogger", |b| {
+        b.iter(|| {
+            let record = logger.create_log_record();
+            logger.emit(record);
+        });
+    });
+
+    c.bench_function("CreateLogRecord_NoopLogger_WithAttributes", |b| {
+        b.iter(|| {
+            let mut record = logger.create_log_record();
+            record.add_attribute("key1", "value1");
+            record.add_attribute("key2", 123);
+            record.add_attribute("key3", true);
+            record.add_attribute("key4", 123.456);
+            logger.emit(record);
+        });
+    });
+
+    c.bench_function("CreateLogRecord_NoopLogger_WithBody", |b| {
+        b.iter(|| {
+            let mut record = logger.create_log_record();
+            record.set_body(AnyValue::String("This is a log message".into()));
+            record.set_severity_number(Severity::Info);
+            record.set_severity_text("INFO");
+            logger.emit(record);
+        });
+    });
+
+    c.bench_function("CreateLogRecord_NoopLogger_Full", |b| {
+        b.iter(|| {
+            let mut record = logger.create_log_record();
+            record.set_body(AnyValue::String("This is a log message".into()));
+            record.set_severity_number(Severity::Warn);
+            record.set_severity_text("WARN");
+            record.set_event_name("my.event");
+            record.set_target("my_crate::my_module");
+            record.add_attribute("key1", "value1");
+            record.add_attribute("key2", 123);
+            record.add_attribute("key3", true);
+            record.add_attribute("key4", 123.456);
+            logger.emit(record);
+        });
+    });
+
+    c.bench_function("EventEnabled_NoopLogger", |b| {
+        b.iter(|| {
+            black_box(logger.event_enabled(Severity::Info, "my_target", Some("my_event")));
+        });
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/opentelemetry/benches/metrics.rs
+++ b/opentelemetry/benches/metrics.rs
@@ -1,16 +1,15 @@
 /*
     Benchmark Results:
     criterion = "0.5.1"
-    OS: Ubuntu 22.04.4 LTS (5.15.153.1-microsoft-standard-WSL2)
-    Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
-    RAM: 64.0 GB
+    OS: macOS 15
+    Hardware: Apple M4 Pro, 14 cores, RAM: 24 GB
     | Test                                                | Average time|
     |-----------------------------------------------------|-------------|
-    | NoAttributes                                        | 1.1616 ns   |
-    | AddWithInlineStaticAttributes                       | 13.296 ns   |
-    | AddWithStaticArray                                  | 1.1612 ns   |
-    | AddWithDynamicAttributes                            | 110.40 ns   |
-    | AddWithDynamicAttributes_WithStringAllocation       | 77.338 ns   |
+    | NoAttributes                                        |   0.77 ns   |
+    | AddWithInlineStaticAttributes                       |   8.10 ns   |
+    | AddWithStaticArray                                  |   0.77 ns   |
+    | AddWithDynamicAttributes                            |  44.84 ns   |
+    | AddWithDynamicAttributes_WithStringAllocation       |  85.92 ns   |
 */
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};

--- a/opentelemetry/benches/trace.rs
+++ b/opentelemetry/benches/trace.rs
@@ -48,8 +48,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     span_builder(c, &tracer);
 }
 
-fn span_lifecycle(c: &mut Criterion, tracer: &impl Tracer<Span = impl Span + Send + Sync + 'static>) {
-
+fn span_lifecycle(
+    c: &mut Criterion,
+    tracer: &impl Tracer<Span = impl Span + Send + Sync + 'static>,
+) {
     c.bench_function("CreateSpan_NoopTracer", |b| {
         b.iter(|| {
             let mut span = tracer.start("test-span");
@@ -127,7 +129,6 @@ fn span_lifecycle(c: &mut Criterion, tracer: &impl Tracer<Span = impl Span + Sen
 }
 
 fn span_builder(c: &mut Criterion, tracer: &impl Tracer<Span = impl Span + Send + Sync + 'static>) {
-
     c.bench_function("SpanBuilder_Creation", |b| {
         b.iter(|| {
             let span = tracer

--- a/opentelemetry/benches/trace.rs
+++ b/opentelemetry/benches/trace.rs
@@ -1,0 +1,183 @@
+/*
+    Benchmark Results:
+    criterion = "0.5.1"
+    OS: macOS 15
+    Hardware: Apple M4 Pro, 14 cores, RAM: 24 GB
+    | Test                                             | Average time|
+    |--------------------------------------------------|-------------|
+    | CreateSpan_NoopTracer                            |    29.2 ns  |
+    | CreateSpan_NoopTracer_4Attributes                |    29.4 ns  |
+    | CreateSpan_NoopTracer_AddEvent                   |    29.2 ns  |
+    | CreateSpan_NoopTracer_AddLink                    |    29.2 ns  |
+    | CreateSpan_NoopTracer_SetActive                  |    73.3 ns  |
+    | CreateSpan_NoopTracer_WithActiveParent           |   102.9 ns  |
+    | CreateSpan_NoopTracer_InSpan                     |    78.0 ns  |
+    | SpanBuilder_Creation                             |    22.8 ns  |
+    | SpanBuilder_WithAttributes                       |    51.7 ns  |
+    | SpanBuilder_WithLinks                            |    69.0 ns  |
+*/
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use opentelemetry::{
+    global,
+    trace::{
+        noop::NoopTracerProvider, Span, SpanContext, SpanId, SpanKind, TraceFlags, TraceId,
+        TraceState, Tracer,
+    },
+    KeyValue,
+};
+
+// Run this benchmark with:
+// cargo bench --bench trace --features=trace
+
+fn valid_span_context() -> SpanContext {
+    SpanContext::new(
+        TraceId::from(12345u128),
+        SpanId::from(12345u64),
+        TraceFlags::SAMPLED,
+        true,
+        TraceState::default(),
+    )
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    global::set_tracer_provider(NoopTracerProvider::new());
+    let tracer = global::tracer("bench");
+
+    span_lifecycle(c, &tracer);
+    span_builder(c, &tracer);
+}
+
+fn span_lifecycle(c: &mut Criterion, tracer: &impl Tracer<Span = impl Span + Send + Sync + 'static>) {
+
+    c.bench_function("CreateSpan_NoopTracer", |b| {
+        b.iter(|| {
+            let mut span = tracer.start("test-span");
+            span.end();
+        });
+    });
+
+    c.bench_function("CreateSpan_NoopTracer_4Attributes", |b| {
+        b.iter(|| {
+            let mut span = tracer.start("test-span");
+            if span.is_recording() {
+                span.set_attribute(KeyValue::new("key1", false));
+                span.set_attribute(KeyValue::new("key2", "hello"));
+                span.set_attribute(KeyValue::new("key3", 123));
+                span.set_attribute(KeyValue::new("key4", 123.456));
+            }
+            span.end();
+        });
+    });
+
+    c.bench_function("CreateSpan_NoopTracer_AddEvent", |b| {
+        b.iter(|| {
+            let mut span = tracer.start("test-span");
+            if span.is_recording() {
+                span.add_event(
+                    "my-event",
+                    vec![
+                        KeyValue::new("key1", "value1"),
+                        KeyValue::new("key2", "value2"),
+                    ],
+                );
+            }
+            span.end();
+        });
+    });
+
+    c.bench_function("CreateSpan_NoopTracer_AddLink", |b| {
+        let link_context = valid_span_context();
+        b.iter(|| {
+            let mut span = tracer.start("test-span");
+            if span.is_recording() {
+                span.add_link(
+                    link_context.clone(),
+                    vec![
+                        KeyValue::new("key1", "value1"),
+                        KeyValue::new("key2", "value2"),
+                    ],
+                );
+            }
+            span.end();
+        });
+    });
+
+    c.bench_function("CreateSpan_NoopTracer_SetActive", |b| {
+        b.iter(|| {
+            let span = tracer.start("test-span");
+            let _guard = opentelemetry::trace::mark_span_as_active(span);
+        });
+    });
+
+    c.bench_function("CreateSpan_NoopTracer_WithActiveParent", |b| {
+        b.iter(|| {
+            let parent = tracer.start("parent");
+            let _guard = opentelemetry::trace::mark_span_as_active(parent);
+            let mut child = tracer.start("child");
+            child.end();
+        });
+    });
+
+    c.bench_function("CreateSpan_NoopTracer_InSpan", |b| {
+        b.iter(|| {
+            tracer.in_span("test-span", |_cx| {});
+        });
+    });
+}
+
+fn span_builder(c: &mut Criterion, tracer: &impl Tracer<Span = impl Span + Send + Sync + 'static>) {
+
+    c.bench_function("SpanBuilder_Creation", |b| {
+        b.iter(|| {
+            let span = tracer
+                .span_builder("test-span")
+                .with_kind(SpanKind::Client)
+                .start(tracer);
+            black_box(span);
+        });
+    });
+
+    c.bench_function("SpanBuilder_WithAttributes", |b| {
+        b.iter(|| {
+            let span = tracer
+                .span_builder("test-span")
+                .with_kind(SpanKind::Client)
+                .with_attributes(vec![
+                    KeyValue::new("key1", false),
+                    KeyValue::new("key2", "hello"),
+                    KeyValue::new("key3", 123),
+                    KeyValue::new("key4", 123.456),
+                ])
+                .start(tracer);
+            black_box(span);
+        });
+    });
+
+    c.bench_function("SpanBuilder_WithLinks", |b| {
+        let link_context = valid_span_context();
+        b.iter(|| {
+            let span = tracer
+                .span_builder("test-span")
+                .with_links(vec![opentelemetry::trace::Link::new(
+                    link_context.clone(),
+                    vec![
+                        KeyValue::new("key1", "value1"),
+                        KeyValue::new("key2", "value2"),
+                    ],
+                    0,
+                )])
+                .start(tracer);
+            black_box(span);
+        });
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Changes

Add benchmarks for the tracing and logging API noop paths in the `opentelemetry` crate, complementing the existing metrics and attributes benchmarks.

### New: Trace benchmarks (`cargo bench --bench trace`)

| Test | Average time |
|------|-------------|
| CreateSpan_NoopTracer | 29.2 ns |
| CreateSpan_NoopTracer_4Attributes | 29.4 ns |
| CreateSpan_NoopTracer_AddEvent | 29.2 ns |
| CreateSpan_NoopTracer_AddLink | 29.2 ns |
| CreateSpan_NoopTracer_SetActive | 73.3 ns |
| CreateSpan_NoopTracer_WithActiveParent | 102.9 ns |
| CreateSpan_NoopTracer_InSpan | 78.0 ns |
| SpanBuilder_Creation | 22.8 ns |
| SpanBuilder_WithAttributes | 51.7 ns |
| SpanBuilder_WithLinks | 69.0 ns |

### New: Logs benchmarks (`cargo bench --bench logs`)

| Test | Average time |
|------|-------------|
| CreateLogRecord_NoopLogger | 0.26 ns |
| CreateLogRecord_NoopLogger_WithAttributes | 0.26 ns |
| CreateLogRecord_NoopLogger_WithBody | 1.30 ns |
| CreateLogRecord_NoopLogger_Full | 1.30 ns |
| EventEnabled_NoopLogger | 0.26 ns |

### Notes

- Trace benchmarks use `is_recording()` guards around attribute/event/link operations, matching the recommended instrumentation pattern.
- The logs noop path is ~100x faster than the trace noop path, reflecting the trait-based design (compiler eliminates all noop method calls) vs the trace API's dynamic dispatch through the global tracer + Context overhead.
- SpanBuilder benchmarks remain unguarded since attributes/links are allocated before a span exists to check.
- Also refreshes existing metrics and attributes benchmark result headers with numbers from the same machine.
