### PR TITLE
docs: Improve getting-started example discoverability

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,78 +1,68 @@
 # Examples
 
-This directory contains some examples that should help you get start crates from `opentelemetry-rust`.
+This directory contains runnable examples for the `opentelemetry-rust` crates.
 
-## logs-basic
+## Getting Started
 
-This example uses following crates from this repo:
+If you are new to OpenTelemetry Rust, start with one of the **Getting Started**
+examples below. Each one focuses on a single signal, uses a stdout exporter,
+and can be run with `cargo run` so you can immediately see telemetry on your
+console:
 
-- opentelemetry(log)
-- opentelemetry-appender-tracing
-- opentelemetry-stdout
+| Signal  | Example                                       | What it shows                                              |
+|---------|-----------------------------------------------|------------------------------------------------------------|
+| Logs    | [logs-basic](./logs-basic/README.md)          | Bridging the `tracing` crate to OpenTelemetry              |
+| Metrics | [metrics-basic](./metrics-basic/README.md)    | Counter, UpDownCounter, Histogram, Gauge and observables   |
+| Traces  | [tracing-grpc](./tracing-grpc/README.md)      | A trace propagated across a gRPC client and server         |
 
-Check this example if you want to understand *how to instrument logs using opentelemetry*.
+For OTLP - the recommended exporter for production - see the
+[opentelemetry-otlp examples](../opentelemetry-otlp/examples), in particular
+[basic-otlp](../opentelemetry-otlp/examples/basic-otlp/README.md) (gRPC) and
+[basic-otlp-http](../opentelemetry-otlp/examples/basic-otlp-http/README.md).
 
-## logs-advanced
+## All examples
 
-This example uses following crates from this repo:
+### logs-basic
 
-- opentelemetry(log)
-- opentelemetry-appender-tracing
-- opentelemetry-stdout
+Uses: `opentelemetry`, `opentelemetry-appender-tracing`, `opentelemetry-stdout`.
 
-This builds on top of the logs-basic,
-and shows how to implement and compose `LogProcessor`s..
+The recommended starting point for OpenTelemetry **logging** in Rust. Shows how
+to bridge logs emitted via the [`tracing`](https://docs.rs/tracing) crate to
+OpenTelemetry using the `opentelemetry-appender-tracing` appender.
 
-## metrics-basic
+### logs-advanced
 
-This example uses following crates from this repo:
+Uses: `opentelemetry`, `opentelemetry-appender-tracing`, `opentelemetry-stdout`.
 
-- opentelemetry(metrics)
-- opentelemetry-stdout
+Builds on top of `logs-basic` and shows how to implement and compose custom
+`LogProcessor`s.
 
-Check this example if you want to understand *how to instrument metrics using opentelemetry*.
+### metrics-basic
 
-## metrics-advanced
+Uses: `opentelemetry`, `opentelemetry-stdout`.
 
-This example uses following crates from this repo:
+The recommended starting point for OpenTelemetry **metrics** in Rust.
+Demonstrates every instrument type (`Counter`, `UpDownCounter`, `Histogram`,
+`Gauge`, and their observable counterparts).
 
-- opentelemetry(metrics)
-- opentelemetry-stdout
+### metrics-advanced
 
-This builds on top of the metrics-basic,
-and shows advanced features in Metrics SDK like using Views.
+Uses: `opentelemetry`, `opentelemetry-stdout`.
 
-## tracing-grpc
+Builds on top of `metrics-basic` and shows advanced features of the Metrics
+SDK such as Views.
 
-This example uses following crates from this repo:
+### tracing-grpc
 
-- opentelemetry(tracing)
-- opentelemetry-stdout
+Uses: `opentelemetry`, `opentelemetry-stdout`, `tonic`, `tokio`.
 
-The application is built using `tokio`.
+The recommended starting point for OpenTelemetry **tracing** in Rust. Shows
+how to create spans and propagate/restore trace context across a gRPC
+client/server boundary so the two sides share a single trace.
 
-Check this example if you want to understand *how to create spans and
-propagate/restore context in OpenTelemetry* in a gRPC client-server application.
+### tracing-http-propagator
 
-## tracing-http-propagator
+Uses: `opentelemetry`, `opentelemetry-http`, `opentelemetry-stdout`.
 
-This example uses following crates from this repo:
-
-- opentelemetry(tracing)
-- opentelemetry-http
-- opentelemetry-stdout
-
-Check this example if you want to understand *how to create spans and
-propagate/restore context in OpenTelemetry* in an HTTP client-server
-application.
-
-## tracing-jaeger
-
-This example uses following crates from this repo:
-
-- opentelemetry(tracing)
-- opentelemetry-otlp
-
-The application is built using `tokio`.
-
-Check this example if you want to understand *how to use OTLP Exporter to export traces to Jaeger*.
+Same idea as `tracing-grpc`, but propagating trace context over HTTP headers
+instead of gRPC metadata.

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -34,7 +34,12 @@
 //! # }
 //! ```
 //!
-//! See the [examples](https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples) directory for different integration patterns.
+//! For a runnable getting-started example, see
+//! [`examples/tracing-grpc`](https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples/tracing-grpc),
+//! which demonstrates creating spans and propagating trace context across a
+//! gRPC client and server. See the
+//! [examples](https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples)
+//! directory for additional integration patterns.
 //!
 //! See the [`trace`] module docs for more information on creating and managing
 //! spans.
@@ -52,6 +57,10 @@
 //!    (e.g., counters, histograms).
 //! 3. **Record Measurements:** Use the instruments to record measurement values
 //!    along with optional attributes.
+//!
+//! For a runnable getting-started example, see
+//! [`examples/metrics-basic`](https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples/metrics-basic),
+//! which exercises every instrument type.
 //!
 //! ## How Metrics work in OpenTelemetry
 //! In OpenTelemetry, raw measurements recorded using instruments are
@@ -129,11 +138,6 @@
 //! .build();
 //! ```
 //!
-//! See the
-//! [examples](https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples/metrics-basic)
-//! directory that show a runnable example with all type of instruments.
-//!
-//!
 //! See the [`metrics`] module docs for more information on creating and
 //! managing instruments.
 //!
@@ -151,6 +155,10 @@
 //!  and
 //!  [`opentelemetry-appender-tracing`](https://crates.io/crates/opentelemetry-appender-tracing)
 //!  crates.
+//!
+//! For a runnable getting-started example, see
+//! [`examples/logs-basic`](https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples/logs-basic),
+//! which uses the `tracing` appender to bridge logs to OpenTelemetry.
 //!
 //! # Crate Feature Flags
 //!


### PR DESCRIPTION
Follow-up to #3299 / #3477 addressing [@scottgerring's review feedback](https://github.com/open-telemetry/opentelemetry-rust/pull/3477#pullrequestreview-3402041739):

> Couple things we might try to increase discoverability but not blocking:
> - Updating `examples/README.md` which feels like its now under-selling these
> - Linking more prominently to them from the docs.rs docs?

Changes:

- **`examples/README.md`**: New top-of-page **Getting Started** section with a signal/example/description table calling out `logs-basic`, `metrics-basic`, and `tracing-grpc` as the recommended entry points, plus a pointer to the OTLP examples for production. The full per-example list is kept below as an "All examples" reference, with the redundant "this example uses following crates" boilerplate replaced by a single `Uses:` line and a real one-sentence description of what each example shows.
- **`opentelemetry/src/lib.rs`** (docs.rs landing page):
  - *Tracing* section: replaced the vague "see examples directory" with an explicit pointer to `examples/tracing-grpc` (kept the broader examples link too).
  - *Metrics* section: promoted the existing `examples/metrics-basic` link to right after the 3-step intro; removed the duplicate at the bottom.
  - *Logs* section: added a `examples/logs-basic` link (was previously missing entirely).

Also drops a stale `tracing-jaeger` entry from `examples/README.md` - the directory no longer exists.

No code changes. `cargo doc --no-deps --all-features` passes with `-D warnings`.

Towards #3254.