### PR TITLE
feat(appender-tracing): stabilize span attribute propagation

### DIFF
--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -11,26 +11,26 @@
 
   Enrichment is **disabled by default** (no per-span overhead) and must be
   opted into at runtime via a single builder method that accepts a
-  [`SpanAttributes`] value:
+  [`TracingSpanAttributes`] value:
 
   ```rust
-  use opentelemetry_appender_tracing::layer::SpanAttributes;
+  use opentelemetry_appender_tracing::layer::TracingSpanAttributes;
 
   // Copy all tracing-span attributes onto log records:
   let layer = OpenTelemetryTracingBridge::builder(&provider)
-      .with_span_attributes(SpanAttributes::all())
+      .with_span_attributes(TracingSpanAttributes::all())
       .build();
 
   // Or copy only an allowlist of attributes:
   let layer = OpenTelemetryTracingBridge::builder(&provider)
-      .with_span_attributes(SpanAttributes::allowlist(["session.id"]))
+      .with_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
       .build();
   ```
 
   Migration from the experimental feature: drop the
   `experimental_span_attributes` feature from `Cargo.toml`, and add
-  `.with_span_attributes(SpanAttributes::all())` to the builder (or use
-  `SpanAttributes::allowlist(keys)` to restrict which span attributes are
+  `.with_span_attributes(TracingSpanAttributes::all())` to the builder (or use
+  `TracingSpanAttributes::allowlist(keys)` to restrict which span attributes are
   copied).
 
 [`tracing`]: https://crates.io/crates/tracing

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -10,32 +10,28 @@
   active `tracing` spans are copied onto each emitted log record.
 
   Enrichment is **disabled by default** (no per-span overhead) and must be
-  opted into at runtime via two new builder methods:
+  opted into at runtime via a single builder method that accepts a
+  [`SpanAttributes`] value:
 
   ```rust
+  use opentelemetry_appender_tracing::layer::SpanAttributes;
+
   // Copy all tracing-span attributes onto log records:
   let layer = OpenTelemetryTracingBridge::builder(&provider)
-      .enable_span_attributes(true)
+      .with_span_attributes(SpanAttributes::all())
       .build();
 
-  // Or restrict to an allowlist (must also call enable_span_attributes(true)):
+  // Or copy only an allowlist of attributes:
   let layer = OpenTelemetryTracingBridge::builder(&provider)
-      .enable_span_attributes(true)
-      .with_span_attribute_allowlist(["session.id"])
+      .with_span_attributes(SpanAttributes::allowlist(["session.id"]))
       .build();
   ```
 
-  `enable_span_attributes` and `with_span_attribute_allowlist` are independent:
-  - `enable_span_attributes(bool)` toggles enrichment on or off.
-  - `with_span_attribute_allowlist(keys)` configures the filter, but only
-    takes effect when enrichment is also enabled. Calling it without also
-    calling `enable_span_attributes(true)` is a no-op (a warning is emitted
-    via `otel_warn!` from `build()`).
-
   Migration from the experimental feature: drop the
-  `experimental_span_attributes` feature from `Cargo.toml`, and add an
-  explicit `.enable_span_attributes(true)` call on the builder. Existing
-  `with_span_attribute_allowlist(keys)` calls are preserved as-is.
+  `experimental_span_attributes` feature from `Cargo.toml`, and add
+  `.with_span_attributes(SpanAttributes::all())` to the builder (or use
+  `SpanAttributes::allowlist(keys)` to restrict which span attributes are
+  copied).
 
 [`tracing`]: https://crates.io/crates/tracing
 [tracing-span]: https://docs.rs/tracing/latest/tracing/macro.span.html

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 ## vNext
 
-- **Stabilize tracing span attribute enrichment.** The
-  `experimental_span_attributes` cargo feature has been removed; the capability
-  is now part of the stable API surface. "Span" here refers to a
-  [`tracing::span!`][tracing-span] from the [`tracing`] crate (the appender's
-  source), **not** an OpenTelemetry span. When enabled, attributes attached to
-  active `tracing` spans are copied onto each emitted log record.
+- **Add tracing span attribute enrichment.** When enabled, attributes attached
+  to active [`tracing`] spans are copied onto each emitted log record. "Span"
+  here refers to a [`tracing::span!`][tracing-span] from the [`tracing`] crate
+  (the appender's source), **not** an OpenTelemetry span.
 
   Enrichment is **disabled by default** (no per-span overhead) and must be
   opted into at runtime via a single builder method that accepts a
@@ -26,12 +24,6 @@
       .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
       .build();
   ```
-
-  Migration from the experimental feature: drop the
-  `experimental_span_attributes` feature from `Cargo.toml`, and add
-  `.with_tracing_span_attributes(TracingSpanAttributes::all())` to the builder (or use
-  `TracingSpanAttributes::allowlist(keys)` to restrict which span attributes are
-  copied).
 
 [`tracing`]: https://crates.io/crates/tracing
 [tracing-span]: https://docs.rs/tracing/latest/tracing/macro.span.html

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -5,25 +5,26 @@
 - **Stabilize span attribute propagation.** The `experimental_span_attributes`
   cargo feature has been removed; the capability is now part of the stable API
   surface. Propagation is **disabled by default** (no per-span overhead) and
-  must be opted into at runtime via the new builder method
-  `OpenTelemetryTracingBridgeBuilder::with_span_attributes`:
+  must be opted into at runtime via either of two new builder methods:
 
   ```rust
   // Copy all span attributes onto log records:
   let layer = OpenTelemetryTracingBridge::builder(&provider)
-      .with_span_attributes(std::iter::empty::<&str>())
+      .enable_span_attributes(true)
       .build();
 
-  // Or restrict to an allowlist:
+  // Or restrict to an allowlist (implicitly enables propagation):
   let layer = OpenTelemetryTracingBridge::builder(&provider)
-      .with_span_attributes(["session.id"])
+      .with_span_attribute_allowlist(["session.id"])
       .build();
   ```
 
   Migration from the experimental feature: drop the
-  `experimental_span_attributes` feature from `Cargo.toml`, and replace
-  `with_span_attribute_allowlist(keys)` with `with_span_attributes(keys)`. To
-  preserve the previous "copy everything" default, pass an empty iterator.
+  `experimental_span_attributes` feature from `Cargo.toml`. Existing users of
+  `with_span_attribute_allowlist(keys)` need no code change beyond that. Users
+  who previously enabled the feature without configuring an allowlist (relying
+  on the "copy all" default behavior) must now explicitly call
+  `enable_span_attributes(true)`.
 
 - Remove the `experimental_use_tracing_span_context` since
   `tracing-opentelemetry` now supports [activating][31901]  the OpenTelemetry

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -18,18 +18,18 @@
 
   // Copy all tracing-span attributes onto log records:
   let layer = OpenTelemetryTracingBridge::builder(&provider)
-      .with_span_attributes(TracingSpanAttributes::all())
+      .with_tracing_span_attributes(TracingSpanAttributes::all())
       .build();
 
   // Or copy only an allowlist of attributes:
   let layer = OpenTelemetryTracingBridge::builder(&provider)
-      .with_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
+      .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
       .build();
   ```
 
   Migration from the experimental feature: drop the
   `experimental_span_attributes` feature from `Cargo.toml`, and add
-  `.with_span_attributes(TracingSpanAttributes::all())` to the builder (or use
+  `.with_tracing_span_attributes(TracingSpanAttributes::all())` to the builder (or use
   `TracingSpanAttributes::allowlist(keys)` to restrict which span attributes are
   copied).
 

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -5,7 +5,7 @@
 - **Stabilize span attribute propagation.** The `experimental_span_attributes`
   cargo feature has been removed; the capability is now part of the stable API
   surface. Propagation is **disabled by default** (no per-span overhead) and
-  must be opted into at runtime via either of two new builder methods:
+  must be opted into at runtime via two new builder methods:
 
   ```rust
   // Copy all span attributes onto log records:
@@ -13,18 +13,24 @@
       .enable_span_attributes(true)
       .build();
 
-  // Or restrict to an allowlist (implicitly enables propagation):
+  // Or restrict to an allowlist (must also call enable_span_attributes(true)):
   let layer = OpenTelemetryTracingBridge::builder(&provider)
+      .enable_span_attributes(true)
       .with_span_attribute_allowlist(["session.id"])
       .build();
   ```
 
+  `enable_span_attributes` and `with_span_attribute_allowlist` are independent:
+  - `enable_span_attributes(bool)` toggles propagation on or off.
+  - `with_span_attribute_allowlist(keys)` configures the filter, but only
+    takes effect when propagation is also enabled. Calling it without also
+    calling `enable_span_attributes(true)` is a no-op (a warning is emitted
+    via `otel_warn!` from `build()`).
+
   Migration from the experimental feature: drop the
-  `experimental_span_attributes` feature from `Cargo.toml`. Existing users of
-  `with_span_attribute_allowlist(keys)` need no code change beyond that. Users
-  who previously enabled the feature without configuring an allowlist (relying
-  on the "copy all" default behavior) must now explicitly call
-  `enable_span_attributes(true)`.
+  `experimental_span_attributes` feature from `Cargo.toml`, and add an
+  explicit `.enable_span_attributes(true)` call on the builder. Existing
+  `with_span_attribute_allowlist(keys)` calls are preserved as-is.
 
 - Remove the `experimental_use_tracing_span_context` since
   `tracing-opentelemetry` now supports [activating][31901]  the OpenTelemetry

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## vNext
 
-- **Stabilize span attribute propagation.** The `experimental_span_attributes`
-  cargo feature has been removed; the capability is now part of the stable API
-  surface. Propagation is **disabled by default** (no per-span overhead) and
-  must be opted into at runtime via two new builder methods:
+- **Stabilize tracing span attribute enrichment.** The
+  `experimental_span_attributes` cargo feature has been removed; the capability
+  is now part of the stable API surface. "Span" here refers to a
+  [`tracing::span!`][tracing-span] from the [`tracing`] crate (the appender's
+  source), **not** an OpenTelemetry span. When enabled, attributes attached to
+  active `tracing` spans are copied onto each emitted log record.
+
+  Enrichment is **disabled by default** (no per-span overhead) and must be
+  opted into at runtime via two new builder methods:
 
   ```rust
-  // Copy all span attributes onto log records:
+  // Copy all tracing-span attributes onto log records:
   let layer = OpenTelemetryTracingBridge::builder(&provider)
       .enable_span_attributes(true)
       .build();
@@ -21,9 +26,9 @@
   ```
 
   `enable_span_attributes` and `with_span_attribute_allowlist` are independent:
-  - `enable_span_attributes(bool)` toggles propagation on or off.
+  - `enable_span_attributes(bool)` toggles enrichment on or off.
   - `with_span_attribute_allowlist(keys)` configures the filter, but only
-    takes effect when propagation is also enabled. Calling it without also
+    takes effect when enrichment is also enabled. Calling it without also
     calling `enable_span_attributes(true)` is a no-op (a warning is emitted
     via `otel_warn!` from `build()`).
 
@@ -31,6 +36,9 @@
   `experimental_span_attributes` feature from `Cargo.toml`, and add an
   explicit `.enable_span_attributes(true)` call on the builder. Existing
   `with_span_attribute_allowlist(keys)` calls are preserved as-is.
+
+[`tracing`]: https://crates.io/crates/tracing
+[tracing-span]: https://docs.rs/tracing/latest/tracing/macro.span.html
 
 - Remove the `experimental_use_tracing_span_context` since
   `tracing-opentelemetry` now supports [activating][31901]  the OpenTelemetry

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,10 +2,28 @@
 
 ## vNext
 
-- New *experimental* feature to enrich log records with attributes from active
-  tracing spans (`experimental_span_attributes`). Use
-  `OpenTelemetryTracingBridge::builder()` with `with_span_attribute_allowlist`
-  to control which span attributes are copied to log records.
+- **Stabilize span attribute propagation.** The `experimental_span_attributes`
+  cargo feature has been removed; the capability is now part of the stable API
+  surface. Propagation is **disabled by default** (no per-span overhead) and
+  must be opted into at runtime via the new builder method
+  `OpenTelemetryTracingBridgeBuilder::with_span_attributes`:
+
+  ```rust
+  // Copy all span attributes onto log records:
+  let layer = OpenTelemetryTracingBridge::builder(&provider)
+      .with_span_attributes(std::iter::empty::<&str>())
+      .build();
+
+  // Or restrict to an allowlist:
+  let layer = OpenTelemetryTracingBridge::builder(&provider)
+      .with_span_attributes(["session.id"])
+      .build();
+  ```
+
+  Migration from the experimental feature: drop the
+  `experimental_span_attributes` feature from `Cargo.toml`, and replace
+  `with_span_attribute_allowlist(keys)` with `with_span_attributes(keys)`. To
+  preserve the previous "copy everything" default, pass an empty iterator.
 
 - Remove the `experimental_use_tracing_span_context` since
   `tracing-opentelemetry` now supports [activating][31901]  the OpenTelemetry

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -34,7 +34,6 @@ pprof = { workspace = true }
 [features]
 default = []
 experimental_metadata_attributes = ["dep:tracing-log"]
-experimental_span_attributes = []
 bench_profiling = []
 
 [[bench]]

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -34,7 +34,6 @@ pprof = { workspace = true }
 [features]
 default = []
 experimental_metadata_attributes = ["dep:tracing-log"]
-internal-logs = ["opentelemetry/internal-logs"]
 bench_profiling = []
 
 [[bench]]

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -34,6 +34,7 @@ pprof = { workspace = true }
 [features]
 default = []
 experimental_metadata_attributes = ["dep:tracing-log"]
+internal-logs = ["opentelemetry/internal-logs"]
 bench_profiling = []
 
 [[bench]]

--- a/opentelemetry-appender-tracing/benches/logs.rs
+++ b/opentelemetry-appender-tracing/benches/logs.rs
@@ -14,13 +14,14 @@
 
     Hardware: Apple M4 Pro
     Total Number of Cores:	14 (10 performance and 4 efficiency)
+    rustc 1.95.0 (59807616e 2026-04-14)
     | Test                        | Average time|
     |-----------------------------|-------------|
-    | log_no_subscriber           | 285 ps      |
-    | noop_layer_disabled         | 8 ns       |
-    | noop_layer_enabled          | 14 ns       |
-    | ot_layer_disabled           | 12 ns       |
-    | ot_layer_enabled            | 130 ns      |
+    | log_no_subscriber           | 262 ps      |
+    | noop_layer_disabled         |   4 ns      |
+    | noop_layer_enabled          |  12 ns      |
+    | ot_layer_disabled           |   7 ns      |
+    | ot_layer_enabled            | 122 ns      |
 */
 
 use criterion::{criterion_group, criterion_main, Criterion};

--- a/opentelemetry-appender-tracing/benches/span-attributes.rs
+++ b/opentelemetry-appender-tracing/benches/span-attributes.rs
@@ -9,7 +9,7 @@
 //
 // Attribute counts are chosen to stay within the SDK's inline-array optimisation
 // threshold (5 attributes). With span-attribute propagation enabled (via
-// `OpenTelemetryTracingBridgeBuilder::with_span_attributes`), span attributes
+// `OpenTelemetryTracingBridgeBuilder::enable_span_attributes`), span attributes
 // are copied onto the log record, so total = log attrs + span attrs.
 //
 // Log + span benchmarks (showing incremental cost of span attributes on logging):
@@ -69,7 +69,7 @@ fn benchmark_span_attributes(c: &mut Criterion, num_attributes: usize) {
         .build();
 
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(std::iter::empty::<&str>())
+        .enable_span_attributes(true)
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -133,7 +133,7 @@ fn benchmark_nested_spans(c: &mut Criterion, depth: usize) {
         .build();
 
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(std::iter::empty::<&str>())
+        .enable_span_attributes(true)
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -252,7 +252,7 @@ fn make_provider() -> SdkLoggerProvider {
 fn benchmark_log_1_attr_no_span(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(std::iter::empty::<&str>())
+        .enable_span_attributes(true)
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -276,7 +276,7 @@ fn benchmark_log_1_attr_no_span(c: &mut Criterion) {
 fn benchmark_log_1_attr_in_span_2_attr(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(std::iter::empty::<&str>())
+        .enable_span_attributes(true)
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -303,7 +303,7 @@ fn benchmark_log_1_attr_in_span_2_attr(c: &mut Criterion) {
 fn benchmark_log_1_attr_in_nested_spans_2plus2_attr(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(std::iter::empty::<&str>())
+        .enable_span_attributes(true)
         .build();
     let subscriber = Registry::default().with(ot_layer);
 

--- a/opentelemetry-appender-tracing/benches/span-attributes.rs
+++ b/opentelemetry-appender-tracing/benches/span-attributes.rs
@@ -1,6 +1,6 @@
 /*
 // Run this benchmark with:
-// cargo bench --bench span-attributes --features experimental_span_attributes
+// cargo bench --bench span-attributes
 // The benchmark results:
 // Hardware: Mac M4 Pro
 // Total Number of Cores: 14 (10 performance and 4 efficiency)
@@ -8,8 +8,9 @@
 // cargo 1.93.0 (083ac5135 2025-12-15)
 //
 // Attribute counts are chosen to stay within the SDK's inline-array optimisation
-// threshold (5 attributes). With `experimental_span_attributes` enabled, span
-// attributes are copied onto the log record, so total = log attrs + span attrs.
+// threshold (5 attributes). With span-attribute propagation enabled (via
+// `OpenTelemetryTracingBridgeBuilder::with_span_attributes`), span attributes
+// are copied onto the log record, so total = log attrs + span attrs.
 //
 // Log + span benchmarks (showing incremental cost of span attributes on logging):
 // | Test                                      | Total attrs | Average time | Increment vs baseline        |
@@ -67,7 +68,9 @@ fn benchmark_span_attributes(c: &mut Criterion, num_attributes: usize) {
         .with_log_processor(NoopProcessor)
         .build();
 
-    let ot_layer = tracing_layer::OpenTelemetryTracingBridge::new(&provider);
+    let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
+        .with_span_attributes(std::iter::empty::<&str>())
+        .build();
     let subscriber = Registry::default().with(ot_layer);
 
     tracing::subscriber::with_default(subscriber, || {
@@ -129,7 +132,9 @@ fn benchmark_nested_spans(c: &mut Criterion, depth: usize) {
         .with_log_processor(NoopProcessor)
         .build();
 
-    let ot_layer = tracing_layer::OpenTelemetryTracingBridge::new(&provider);
+    let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
+        .with_span_attributes(std::iter::empty::<&str>())
+        .build();
     let subscriber = Registry::default().with(ot_layer);
 
     tracing::subscriber::with_default(subscriber, || {
@@ -246,7 +251,9 @@ fn make_provider() -> SdkLoggerProvider {
 /// 5-attribute inline-array optimisation threshold.
 fn benchmark_log_1_attr_no_span(c: &mut Criterion) {
     let provider = make_provider();
-    let ot_layer = tracing_layer::OpenTelemetryTracingBridge::new(&provider);
+    let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
+        .with_span_attributes(std::iter::empty::<&str>())
+        .build();
     let subscriber = Registry::default().with(ot_layer);
 
     tracing::subscriber::with_default(subscriber, || {
@@ -264,11 +271,13 @@ fn benchmark_log_1_attr_no_span(c: &mut Criterion) {
 
 /// Emit an error log with 1 attribute while inside a span that carries 2 attributes
 /// (total = 3 attrs on the log record, within the SDK's 5-attr inline threshold).
-/// With `experimental_span_attributes` the 2 span attributes are propagated onto the
+/// With span-attribute propagation enabled, the 2 span attributes are propagated onto the
 /// log record, so the delta vs `log_1_attr_no_span` shows the pure span-attribute cost.
 fn benchmark_log_1_attr_in_span_2_attr(c: &mut Criterion) {
     let provider = make_provider();
-    let ot_layer = tracing_layer::OpenTelemetryTracingBridge::new(&provider);
+    let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
+        .with_span_attributes(std::iter::empty::<&str>())
+        .build();
     let subscriber = Registry::default().with(ot_layer);
 
     tracing::subscriber::with_default(subscriber, || {
@@ -293,7 +302,9 @@ fn benchmark_log_1_attr_in_span_2_attr(c: &mut Criterion) {
 /// two spans) vs the same total number of span attributes on a single span.
 fn benchmark_log_1_attr_in_nested_spans_2plus2_attr(c: &mut Criterion) {
     let provider = make_provider();
-    let ot_layer = tracing_layer::OpenTelemetryTracingBridge::new(&provider);
+    let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
+        .with_span_attributes(std::iter::empty::<&str>())
+        .build();
     let subscriber = Registry::default().with(ot_layer);
 
     tracing::subscriber::with_default(subscriber, || {

--- a/opentelemetry-appender-tracing/benches/span-attributes.rs
+++ b/opentelemetry-appender-tracing/benches/span-attributes.rs
@@ -9,7 +9,7 @@
 //
 // Attribute counts are chosen to stay within the SDK's inline-array optimisation
 // threshold (5 attributes). With tracing-span attribute enrichment enabled (via
-// `OpenTelemetryTracingBridgeBuilder::with_span_attributes`), tracing-span
+// `OpenTelemetryTracingBridgeBuilder::with_tracing_span_attributes`), tracing-span
 // attributes are copied onto the log record, so total = log attrs + span attrs.
 //
 // Log + span benchmarks (showing incremental cost of span attributes on logging):
@@ -70,7 +70,7 @@ fn benchmark_span_attributes(c: &mut Criterion, num_attributes: usize) {
         .build();
 
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(TracingSpanAttributes::all())
+        .with_tracing_span_attributes(TracingSpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -134,7 +134,7 @@ fn benchmark_nested_spans(c: &mut Criterion, depth: usize) {
         .build();
 
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(TracingSpanAttributes::all())
+        .with_tracing_span_attributes(TracingSpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -253,7 +253,7 @@ fn make_provider() -> SdkLoggerProvider {
 fn benchmark_log_1_attr_no_span(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(TracingSpanAttributes::all())
+        .with_tracing_span_attributes(TracingSpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -277,7 +277,7 @@ fn benchmark_log_1_attr_no_span(c: &mut Criterion) {
 fn benchmark_log_1_attr_in_span_2_attr(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(TracingSpanAttributes::all())
+        .with_tracing_span_attributes(TracingSpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -304,7 +304,7 @@ fn benchmark_log_1_attr_in_span_2_attr(c: &mut Criterion) {
 fn benchmark_log_1_attr_in_nested_spans_2plus2_attr(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(TracingSpanAttributes::all())
+        .with_tracing_span_attributes(TracingSpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 

--- a/opentelemetry-appender-tracing/benches/span-attributes.rs
+++ b/opentelemetry-appender-tracing/benches/span-attributes.rs
@@ -8,9 +8,9 @@
 // cargo 1.93.0 (083ac5135 2025-12-15)
 //
 // Attribute counts are chosen to stay within the SDK's inline-array optimisation
-// threshold (5 attributes). With span-attribute propagation enabled (via
-// `OpenTelemetryTracingBridgeBuilder::enable_span_attributes`), span attributes
-// are copied onto the log record, so total = log attrs + span attrs.
+// threshold (5 attributes). With tracing-span attribute enrichment enabled (via
+// `OpenTelemetryTracingBridgeBuilder::enable_span_attributes`), tracing-span
+// attributes are copied onto the log record, so total = log attrs + span attrs.
 //
 // Log + span benchmarks (showing incremental cost of span attributes on logging):
 // | Test                                      | Total attrs | Average time | Increment vs baseline        |
@@ -271,7 +271,7 @@ fn benchmark_log_1_attr_no_span(c: &mut Criterion) {
 
 /// Emit an error log with 1 attribute while inside a span that carries 2 attributes
 /// (total = 3 attrs on the log record, within the SDK's 5-attr inline threshold).
-/// With span-attribute propagation enabled, the 2 span attributes are propagated onto the
+/// With tracing-span attribute enrichment enabled, the 2 span attributes are copied onto the
 /// log record, so the delta vs `log_1_attr_no_span` shows the pure span-attribute cost.
 fn benchmark_log_1_attr_in_span_2_attr(c: &mut Criterion) {
     let provider = make_provider();

--- a/opentelemetry-appender-tracing/benches/span-attributes.rs
+++ b/opentelemetry-appender-tracing/benches/span-attributes.rs
@@ -33,7 +33,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::InstrumentationScope;
 use opentelemetry_appender_tracing::layer as tracing_layer;
-use opentelemetry_appender_tracing::layer::SpanAttributes;
+use opentelemetry_appender_tracing::layer::TracingSpanAttributes;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::logs::{LogProcessor, SdkLogRecord, SdkLoggerProvider};
 use opentelemetry_sdk::Resource;
@@ -70,7 +70,7 @@ fn benchmark_span_attributes(c: &mut Criterion, num_attributes: usize) {
         .build();
 
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(SpanAttributes::all())
+        .with_span_attributes(TracingSpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -134,7 +134,7 @@ fn benchmark_nested_spans(c: &mut Criterion, depth: usize) {
         .build();
 
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(SpanAttributes::all())
+        .with_span_attributes(TracingSpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -253,7 +253,7 @@ fn make_provider() -> SdkLoggerProvider {
 fn benchmark_log_1_attr_no_span(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(SpanAttributes::all())
+        .with_span_attributes(TracingSpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -277,7 +277,7 @@ fn benchmark_log_1_attr_no_span(c: &mut Criterion) {
 fn benchmark_log_1_attr_in_span_2_attr(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(SpanAttributes::all())
+        .with_span_attributes(TracingSpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -304,7 +304,7 @@ fn benchmark_log_1_attr_in_span_2_attr(c: &mut Criterion) {
 fn benchmark_log_1_attr_in_nested_spans_2plus2_attr(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .with_span_attributes(SpanAttributes::all())
+        .with_span_attributes(TracingSpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 

--- a/opentelemetry-appender-tracing/benches/span-attributes.rs
+++ b/opentelemetry-appender-tracing/benches/span-attributes.rs
@@ -4,8 +4,8 @@
 // The benchmark results:
 // Hardware: Mac M4 Pro
 // Total Number of Cores: 14 (10 performance and 4 efficiency)
-// rustc 1.93.0 (254b59607 2026-01-19)
-// cargo 1.93.0 (083ac5135 2025-12-15)
+// rustc 1.95.0 (59807616e 2026-04-14)
+// cargo 1.95.0 (f2d3ce0bd 2026-03-21)
 //
 // Attribute counts are chosen to stay within the SDK's inline-array optimisation
 // threshold (5 attributes). With tracing-span attribute enrichment enabled (via
@@ -15,18 +15,18 @@
 // Log + span benchmarks (showing incremental cost of span attributes on logging):
 // | Test                                      | Total attrs | Average time | Increment vs baseline        |
 // |-------------------------------------------|-------------|--------------|------------------------------|
-// | log_1_attr_no_span                        | 1           | 81 ns        | -                            |
-// | log_1_attr_in_span_2_attr                 | 3           | 325 ns       | +244 ns                      |
-// | log_1_attr_in_nested_spans_2plus2_attr    | 5           | 570 ns       | +489 ns (+245 ns vs 1 span)  |
+// | log_1_attr_no_span                        | 1           |  85 ns       | -                            |
+// | log_1_attr_in_span_2_attr                 | 3           | 382 ns       | +297 ns                      |
+// | log_1_attr_in_nested_spans_2plus2_attr    | 5           | 590 ns       | +505 ns (+208 ns vs 1 span)  |
 //
 // Span-only benchmarks (no log emission, kept for reference):
 // | Test                  | Average time | Increment |
 // |-----------------------|--------------|-----------|
-// | span_4_attributes     | 175 ns       | -         |
-// | span_8_attributes     | 272 ns       | +97 ns    |
-// | nested_spans_1_levels | 183 ns       | -         |
-// | nested_spans_2_levels | 385 ns       | +202 ns   |
-// | nested_spans_3_levels | 583 ns       | +198 ns   |
+// | span_4_attributes     | 194 ns       | -         |
+// | span_8_attributes     | 314 ns       | +120 ns   |
+// | nested_spans_1_levels | 194 ns       | -         |
+// | nested_spans_2_levels | 413 ns       | +219 ns   |
+// | nested_spans_3_levels | 630 ns       | +217 ns   |
 
 */
 

--- a/opentelemetry-appender-tracing/benches/span-attributes.rs
+++ b/opentelemetry-appender-tracing/benches/span-attributes.rs
@@ -9,7 +9,7 @@
 //
 // Attribute counts are chosen to stay within the SDK's inline-array optimisation
 // threshold (5 attributes). With tracing-span attribute enrichment enabled (via
-// `OpenTelemetryTracingBridgeBuilder::enable_span_attributes`), tracing-span
+// `OpenTelemetryTracingBridgeBuilder::with_span_attributes`), tracing-span
 // attributes are copied onto the log record, so total = log attrs + span attrs.
 //
 // Log + span benchmarks (showing incremental cost of span attributes on logging):
@@ -33,6 +33,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use opentelemetry::InstrumentationScope;
 use opentelemetry_appender_tracing::layer as tracing_layer;
+use opentelemetry_appender_tracing::layer::SpanAttributes;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::logs::{LogProcessor, SdkLogRecord, SdkLoggerProvider};
 use opentelemetry_sdk::Resource;
@@ -69,7 +70,7 @@ fn benchmark_span_attributes(c: &mut Criterion, num_attributes: usize) {
         .build();
 
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .enable_span_attributes(true)
+        .with_span_attributes(SpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -133,7 +134,7 @@ fn benchmark_nested_spans(c: &mut Criterion, depth: usize) {
         .build();
 
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .enable_span_attributes(true)
+        .with_span_attributes(SpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -252,7 +253,7 @@ fn make_provider() -> SdkLoggerProvider {
 fn benchmark_log_1_attr_no_span(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .enable_span_attributes(true)
+        .with_span_attributes(SpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -276,7 +277,7 @@ fn benchmark_log_1_attr_no_span(c: &mut Criterion) {
 fn benchmark_log_1_attr_in_span_2_attr(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .enable_span_attributes(true)
+        .with_span_attributes(SpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 
@@ -303,7 +304,7 @@ fn benchmark_log_1_attr_in_span_2_attr(c: &mut Criterion) {
 fn benchmark_log_1_attr_in_nested_spans_2plus2_attr(c: &mut Criterion) {
     let provider = make_provider();
     let ot_layer = tracing_layer::OpenTelemetryTracingBridge::builder(&provider)
-        .enable_span_attributes(true)
+        .with_span_attributes(SpanAttributes::all())
         .build();
     let subscriber = Registry::default().with(ot_layer);
 

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -311,34 +311,34 @@ struct StoredSpanAttributes {
 ///
 /// [`tracing`]: https://crates.io/crates/tracing
 /// [`tracing::span!`]: https://docs.rs/tracing/latest/tracing/macro.span.html
-pub struct SpanAttributes(SpanAttributesInner);
+pub struct TracingSpanAttributes(TracingSpanAttributesInner);
 
-enum SpanAttributesInner {
+enum TracingSpanAttributesInner {
     All,
     Allowlist(HashSet<Cow<'static, str>>),
 }
 
-impl SpanAttributes {
+impl TracingSpanAttributes {
     /// Copy **all** tracing-span attributes onto log records.
     pub fn all() -> Self {
-        Self(SpanAttributesInner::All)
+        Self(TracingSpanAttributesInner::All)
     }
 
     /// Copy only the tracing-span attributes whose keys are in the given
     /// allowlist.
     pub fn allowlist(keys: impl IntoIterator<Item = impl Into<Cow<'static, str>>>) -> Self {
-        Self(SpanAttributesInner::Allowlist(
+        Self(TracingSpanAttributesInner::Allowlist(
             keys.into_iter().map(Into::into).collect(),
         ))
     }
 }
 
-impl std::fmt::Debug for SpanAttributes {
+impl std::fmt::Debug for TracingSpanAttributes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.0 {
-            SpanAttributesInner::All => f.write_str("SpanAttributes::all()"),
-            SpanAttributesInner::Allowlist(set) => {
-                f.debug_tuple("SpanAttributes::allowlist").field(set).finish()
+            TracingSpanAttributesInner::All => f.write_str("TracingSpanAttributes::all()"),
+            TracingSpanAttributesInner::Allowlist(set) => {
+                f.debug_tuple("TracingSpanAttributes::allowlist").field(set).finish()
             }
         }
     }
@@ -404,8 +404,8 @@ where
     /// By default, enrichment is **disabled** and no per-span work is
     /// performed.
     ///
-    /// Use [`SpanAttributes::all()`] to copy every tracing-span attribute, or
-    /// [`SpanAttributes::allowlist(keys)`](SpanAttributes::allowlist) to copy
+    /// Use [`TracingSpanAttributes::all()`] to copy every tracing-span attribute, or
+    /// [`TracingSpanAttributes::allowlist(keys)`](TracingSpanAttributes::allowlist) to copy
     /// only named attributes.
     ///
     /// Calling this method multiple times replaces any prior configuration —
@@ -413,10 +413,10 @@ where
     ///
     /// [`tracing`]: https://crates.io/crates/tracing
     /// [`tracing::span!`]: https://docs.rs/tracing/latest/tracing/macro.span.html
-    pub fn with_span_attributes(mut self, span_attributes: SpanAttributes) -> Self {
+    pub fn with_span_attributes(mut self, span_attributes: TracingSpanAttributes) -> Self {
         self.span_attributes = Some(match span_attributes.0 {
-            SpanAttributesInner::All => HashSet::new(),
-            SpanAttributesInner::Allowlist(set) => set,
+            TracingSpanAttributesInner::All => HashSet::new(),
+            TracingSpanAttributesInner::Allowlist(set) => set,
         });
         self
     }
@@ -574,7 +574,7 @@ const fn severity_of_level(level: &Level) -> Severity {
 #[cfg(test)]
 mod tests {
     use crate::layer;
-    use crate::layer::SpanAttributes;
+    use crate::layer::TracingSpanAttributes;
     use opentelemetry::logs::Severity;
     use opentelemetry::trace::TracerProvider;
     use opentelemetry::trace::{TraceContextExt, TraceFlags, Tracer};
@@ -1190,7 +1190,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(SpanAttributes::all())
+            .with_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1241,7 +1241,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(SpanAttributes::all())
+            .with_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1302,7 +1302,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(SpanAttributes::all())
+            .with_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1414,7 +1414,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(SpanAttributes::all())
+            .with_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1478,7 +1478,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(SpanAttributes::allowlist(["session.id"]))
+            .with_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1514,7 +1514,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(SpanAttributes::allowlist(["session.id"]))
+            .with_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1552,7 +1552,7 @@ mod tests {
 
     #[test]
     fn tracing_appender_span_attributes_all_copies_all() {
-        // `SpanAttributes::all()` enables enrichment and copies all
+        // `TracingSpanAttributes::all()` enables enrichment and copies all
         // tracing-span attributes (no filtering).
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
@@ -1560,7 +1560,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(SpanAttributes::all())
+            .with_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1597,7 +1597,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(SpanAttributes::allowlist(["session.id"]))
+            .with_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,6 +1,6 @@
 use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    otel_warn, Key,
+    Key,
 };
 use std::borrow::Cow;
 use std::collections::HashSet;
@@ -300,6 +300,50 @@ struct StoredSpanAttributes {
     attributes: Vec<(Key, AnyValue)>,
 }
 
+/// Configures which attributes from active [`tracing`] spans are copied onto
+/// each emitted log record.
+///
+/// "Span" here refers to a [`tracing::span!`] from the [`tracing`] crate,
+/// **not** an `opentelemetry::trace::Span`.
+///
+/// Pass this to [`OpenTelemetryTracingBridgeBuilder::with_span_attributes`] to
+/// enable tracing-span attribute enrichment.
+///
+/// [`tracing`]: https://crates.io/crates/tracing
+/// [`tracing::span!`]: https://docs.rs/tracing/latest/tracing/macro.span.html
+pub struct SpanAttributes(SpanAttributesInner);
+
+enum SpanAttributesInner {
+    All,
+    Allowlist(HashSet<Cow<'static, str>>),
+}
+
+impl SpanAttributes {
+    /// Copy **all** tracing-span attributes onto log records.
+    pub fn all() -> Self {
+        Self(SpanAttributesInner::All)
+    }
+
+    /// Copy only the tracing-span attributes whose keys are in the given
+    /// allowlist.
+    pub fn allowlist(keys: impl IntoIterator<Item = impl Into<Cow<'static, str>>>) -> Self {
+        Self(SpanAttributesInner::Allowlist(
+            keys.into_iter().map(Into::into).collect(),
+        ))
+    }
+}
+
+impl std::fmt::Debug for SpanAttributes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            SpanAttributesInner::All => f.write_str("SpanAttributes::all()"),
+            SpanAttributesInner::Allowlist(set) => {
+                f.debug_tuple("SpanAttributes::allowlist").field(set).finish()
+            }
+        }
+    }
+}
+
 pub struct OpenTelemetryTracingBridge<P, L>
 where
     P: LoggerProvider<Logger = L> + Send + Sync,
@@ -333,8 +377,7 @@ where
             // See https://github.com/open-telemetry/semantic-conventions/issues/1550
             logger: provider.logger(""),
             _phantom: Default::default(),
-            span_attributes_enabled: false,
-            span_attribute_allowlist: None,
+            span_attributes: None,
         }
     }
 }
@@ -346,8 +389,7 @@ where
 {
     logger: L,
     _phantom: std::marker::PhantomData<P>,
-    span_attributes_enabled: bool,
-    span_attribute_allowlist: Option<HashSet<Cow<'static, str>>>,
+    span_attributes: Option<HashSet<Cow<'static, str>>>,
 }
 
 impl<P, L> OpenTelemetryTracingBridgeBuilder<P, L>
@@ -355,70 +397,35 @@ where
     P: LoggerProvider<Logger = L> + Send + Sync,
     L: Logger + Send + Sync,
 {
-    /// Enable (or disable) copying attributes from active [`tracing`] spans
-    /// (i.e. spans created with [`tracing::span!`] or one of its level-specific
-    /// macros — **not** `opentelemetry::trace::Span`) onto each emitted log
-    /// record.
+    /// Enable copying attributes from active [`tracing`] spans onto each
+    /// emitted log record. ("Span" here means a [`tracing::span!`] from the
+    /// [`tracing`] crate, **not** an `opentelemetry::trace::Span`.)
     ///
     /// By default, enrichment is **disabled** and no per-span work is
     /// performed.
     ///
-    /// `with_span_attribute_allowlist` only takes effect if enrichment is
-    /// also explicitly enabled via this method. Calling
-    /// `with_span_attribute_allowlist` without also calling
-    /// `enable_span_attributes(true)` is a no-op (a warning is emitted via
-    /// `otel_warn!` from `build()`).
+    /// Use [`SpanAttributes::all()`] to copy every tracing-span attribute, or
+    /// [`SpanAttributes::allowlist(keys)`](SpanAttributes::allowlist) to copy
+    /// only named attributes.
+    ///
+    /// Calling this method multiple times replaces any prior configuration —
+    /// the last call wins.
     ///
     /// [`tracing`]: https://crates.io/crates/tracing
     /// [`tracing::span!`]: https://docs.rs/tracing/latest/tracing/macro.span.html
-    pub fn enable_span_attributes(mut self, enable: bool) -> Self {
-        self.span_attributes_enabled = enable;
-        self
-    }
-
-    /// Restrict the set of [`tracing`]-span attributes that are copied onto
-    /// log records to the given allowlist. ("Span" here means a
-    /// [`tracing::span!`] from the [`tracing`] crate, not an
-    /// `opentelemetry::trace::Span`.)
-    ///
-    /// This method only takes effect when enrichment is also enabled via
-    /// [`Self::enable_span_attributes`]`(true)`. Calling this method alone has
-    /// no runtime effect — `build()` will emit an `otel_warn!` in that case.
-    ///
-    /// Calling this method multiple times replaces any prior allowlist — the
-    /// last call wins.
-    ///
-    /// [`tracing`]: https://crates.io/crates/tracing
-    /// [`tracing::span!`]: https://docs.rs/tracing/latest/tracing/macro.span.html
-    pub fn with_span_attribute_allowlist(
-        mut self,
-        keys: impl IntoIterator<Item = impl Into<Cow<'static, str>>>,
-    ) -> Self {
-        self.span_attribute_allowlist = Some(keys.into_iter().map(Into::into).collect());
+    pub fn with_span_attributes(mut self, span_attributes: SpanAttributes) -> Self {
+        self.span_attributes = Some(match span_attributes.0 {
+            SpanAttributesInner::All => HashSet::new(),
+            SpanAttributesInner::Allowlist(set) => set,
+        });
         self
     }
 
     pub fn build(self) -> OpenTelemetryTracingBridge<P, L> {
-        let span_attributes = if self.span_attributes_enabled {
-            // Enabled. If an allowlist was configured, use it; otherwise an
-            // empty set indicates "copy all" at runtime.
-            Some(self.span_attribute_allowlist.unwrap_or_default())
-        } else {
-            // Disabled. Warn if the user configured an allowlist that won't
-            // take effect.
-            if self.span_attribute_allowlist.is_some() {
-                otel_warn!(
-                    name: "OpenTelemetryTracingBridge.AllowlistWithoutEnable",
-                    message = "with_span_attribute_allowlist was called but enable_span_attributes(true) was not; the allowlist will have no effect. Call enable_span_attributes(true) to opt into tracing-span attribute enrichment."
-                );
-            }
-            None
-        };
-
         OpenTelemetryTracingBridge {
             logger: self.logger,
             _phantom: self._phantom,
-            span_attributes,
+            span_attributes: self.span_attributes,
         }
     }
 }
@@ -567,6 +574,7 @@ const fn severity_of_level(level: &Level) -> Severity {
 #[cfg(test)]
 mod tests {
     use crate::layer;
+    use crate::layer::SpanAttributes;
     use opentelemetry::logs::Severity;
     use opentelemetry::trace::TracerProvider;
     use opentelemetry::trace::{TraceContextExt, TraceFlags, Tracer};
@@ -1132,9 +1140,8 @@ mod tests {
 
     #[test]
     fn tracing_appender_span_attributes_disabled_by_default() {
-        // When neither `enable_span_attributes` nor `with_span_attribute_allowlist`
-        // is called on the builder, tracing-span attributes must NOT be copied
-        // onto log records.
+        // When `with_span_attributes` is not called on the builder, tracing-span
+        // attributes must NOT be copied onto log records.
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
@@ -1183,7 +1190,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .enable_span_attributes(true)
+            .with_span_attributes(SpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1234,7 +1241,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .enable_span_attributes(true)
+            .with_span_attributes(SpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1295,7 +1302,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .enable_span_attributes(true)
+            .with_span_attributes(SpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1407,7 +1414,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .enable_span_attributes(true)
+            .with_span_attributes(SpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1471,8 +1478,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .enable_span_attributes(true)
-            .with_span_attribute_allowlist(["session.id"])
+            .with_span_attributes(SpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1508,8 +1514,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .enable_span_attributes(true)
-            .with_span_attribute_allowlist(["session.id"])
+            .with_span_attributes(SpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1546,16 +1551,16 @@ mod tests {
     }
 
     #[test]
-    fn tracing_appender_enable_span_attributes_copies_all() {
-        // `enable_span_attributes(true)` (without an allowlist) enables
-        // enrichment and copies all tracing-span attributes (no filtering).
+    fn tracing_appender_span_attributes_all_copies_all() {
+        // `SpanAttributes::all()` enables enrichment and copies all
+        // tracing-span attributes (no filtering).
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .enable_span_attributes(true)
+            .with_span_attributes(SpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1592,8 +1597,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .enable_span_attributes(true)
-            .with_span_attribute_allowlist(["session.id"])
+            .with_span_attributes(SpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1624,78 +1628,5 @@ mod tests {
             .record
             .attributes_iter()
             .any(|(k, _)| k == &Key::new("ignored")));
-    }
-
-    #[test]
-    fn tracing_appender_allowlist_alone_is_no_op() {
-        // `with_span_attribute_allowlist` without `enable_span_attributes(true)`
-        // is a no-op (a warning is emitted via otel_warn! from build()).
-        let exporter = InMemoryLogExporter::default();
-        let provider = SdkLoggerProvider::builder()
-            .with_simple_exporter(exporter.clone())
-            .build();
-
-        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attribute_allowlist(["session.id"])
-            .build()
-            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
-                meta.is_span() || *meta.level() <= tracing::Level::ERROR
-            }));
-        let subscriber = tracing_subscriber::registry().with(layer);
-        let _guard = tracing::subscriber::set_default(subscriber);
-
-        let span = tracing::info_span!("test_span", session.id = "abc");
-        let _enter = span.enter();
-        tracing::error!("test message");
-
-        provider.force_flush().unwrap();
-        let logs = exporter.get_emitted_logs().unwrap();
-        assert_eq!(logs.len(), 1);
-        let log = &logs[0];
-
-        // Allowlist alone does not enable enrichment — session.id must not appear.
-        assert!(!log
-            .record
-            .attributes_iter()
-            .any(|(k, _)| k == &Key::new("session.id")));
-    }
-
-    #[test]
-    fn tracing_appender_enable_then_allowlist_order_independent() {
-        // Order of enable_span_attributes(true) and with_span_attribute_allowlist
-        // does not matter — both produce the same enabled-with-filter state.
-        let exporter = InMemoryLogExporter::default();
-        let provider = SdkLoggerProvider::builder()
-            .with_simple_exporter(exporter.clone())
-            .build();
-
-        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attribute_allowlist(["session.id"])
-            .enable_span_attributes(true)
-            .build()
-            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
-                meta.is_span() || *meta.level() <= tracing::Level::ERROR
-            }));
-        let subscriber = tracing_subscriber::registry().with(layer);
-        let _guard = tracing::subscriber::set_default(subscriber);
-
-        let span = tracing::info_span!("test_span", session.id = "abc", other = "v");
-        let _enter = span.enter();
-        tracing::error!("test message");
-
-        provider.force_flush().unwrap();
-        let logs = exporter.get_emitted_logs().unwrap();
-        assert_eq!(logs.len(), 1);
-        let log = &logs[0];
-
-        assert!(attributes_contains(
-            &log.record,
-            &Key::new("session.id"),
-            &AnyValue::String("abc".into())
-        ));
-        assert!(!log
-            .record
-            .attributes_iter()
-            .any(|(k, _)| k == &Key::new("other")));
     }
 }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1,6 +1,6 @@
 use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
-    Key,
+    otel_warn, Key,
 };
 use std::borrow::Cow;
 use std::collections::HashSet;
@@ -332,7 +332,8 @@ where
             // See https://github.com/open-telemetry/semantic-conventions/issues/1550
             logger: provider.logger(""),
             _phantom: Default::default(),
-            span_attributes: None,
+            span_attributes_enabled: false,
+            span_attribute_allowlist: None,
         }
     }
 }
@@ -344,7 +345,8 @@ where
 {
     logger: L,
     _phantom: std::marker::PhantomData<P>,
-    span_attributes: Option<HashSet<Cow<'static, str>>>,
+    span_attributes_enabled: bool,
+    span_attribute_allowlist: Option<HashSet<Cow<'static, str>>>,
 }
 
 impl<P, L> OpenTelemetryTracingBridgeBuilder<P, L>
@@ -358,41 +360,54 @@ where
     /// By default, span attribute propagation is **disabled** and no per-span
     /// work is performed.
     ///
-    /// - `enable_span_attributes(true)` enables propagation. If no allowlist
-    ///   has been configured (via [`Self::with_span_attribute_allowlist`]),
-    ///   **all** span attributes are copied. If an allowlist has already been
-    ///   configured, it is preserved.
-    /// - `enable_span_attributes(false)` disables propagation entirely and
-    ///   clears any previously configured allowlist.
+    /// `with_span_attribute_allowlist` only takes effect if propagation is
+    /// also explicitly enabled via this method. Calling
+    /// `with_span_attribute_allowlist` without also calling
+    /// `enable_span_attributes(true)` is a no-op (a warning is emitted via
+    /// `otel_warn!` from `build()`).
     pub fn enable_span_attributes(mut self, enable: bool) -> Self {
-        if !enable {
-            self.span_attributes = None;
-        } else if self.span_attributes.is_none() {
-            self.span_attributes = Some(HashSet::new());
-        }
-        // else: already enabled (with or without allowlist) — preserve.
+        self.span_attributes_enabled = enable;
         self
     }
 
     /// Restrict the set of span attributes that are copied onto log records to
     /// the given allowlist.
     ///
-    /// Calling this method implicitly enables span attribute propagation, even
-    /// if [`Self::enable_span_attributes`] was not called. Calling it multiple
-    /// times replaces any previously configured allowlist — the last call wins.
+    /// This method only takes effect when propagation is also enabled via
+    /// [`Self::enable_span_attributes`]`(true)`. Calling this method alone has
+    /// no runtime effect — `build()` will emit an `otel_warn!` in that case.
+    ///
+    /// Calling this method multiple times replaces any prior allowlist — the
+    /// last call wins.
     pub fn with_span_attribute_allowlist(
         mut self,
         keys: impl IntoIterator<Item = impl Into<Cow<'static, str>>>,
     ) -> Self {
-        self.span_attributes = Some(keys.into_iter().map(Into::into).collect());
+        self.span_attribute_allowlist = Some(keys.into_iter().map(Into::into).collect());
         self
     }
 
     pub fn build(self) -> OpenTelemetryTracingBridge<P, L> {
+        let span_attributes = if self.span_attributes_enabled {
+            // Enabled. If an allowlist was configured, use it; otherwise an
+            // empty set indicates "copy all" at runtime.
+            Some(self.span_attribute_allowlist.unwrap_or_default())
+        } else {
+            // Disabled. Warn if the user configured an allowlist that won't
+            // take effect.
+            if self.span_attribute_allowlist.is_some() {
+                otel_warn!(
+                    name: "OpenTelemetryTracingBridge.AllowlistWithoutEnable",
+                    message = "with_span_attribute_allowlist was called but enable_span_attributes(true) was not; the allowlist will have no effect. Call enable_span_attributes(true) to opt into span attribute propagation."
+                );
+            }
+            None
+        };
+
         OpenTelemetryTracingBridge {
             logger: self.logger,
             _phantom: self._phantom,
-            span_attributes: self.span_attributes,
+            span_attributes,
         }
     }
 }
@@ -1445,6 +1460,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+            .enable_span_attributes(true)
             .with_span_attribute_allowlist(["session.id"])
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
@@ -1481,6 +1497,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+            .enable_span_attributes(true)
             .with_span_attribute_allowlist(["session.id"])
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
@@ -1564,6 +1581,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+            .enable_span_attributes(true)
             .with_span_attribute_allowlist(["session.id"])
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
@@ -1598,9 +1616,9 @@ mod tests {
     }
 
     #[test]
-    fn tracing_appender_enable_false_clears_allowlist() {
-        // `enable_span_attributes(false)` after an allowlist was set must
-        // disable propagation entirely (and clear the allowlist).
+    fn tracing_appender_allowlist_alone_is_no_op() {
+        // `with_span_attribute_allowlist` without `enable_span_attributes(true)`
+        // is a no-op (a warning is emitted via otel_warn! from build()).
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
@@ -1608,7 +1626,6 @@ mod tests {
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
             .with_span_attribute_allowlist(["session.id"])
-            .enable_span_attributes(false)
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1625,8 +1642,7 @@ mod tests {
         assert_eq!(logs.len(), 1);
         let log = &logs[0];
 
-        // session.id was on the allowlist, but enable_span_attributes(false)
-        // disabled propagation entirely.
+        // Allowlist alone does not enable propagation — session.id must not appear.
         assert!(!log
             .record
             .attributes_iter()
@@ -1634,9 +1650,9 @@ mod tests {
     }
 
     #[test]
-    fn tracing_appender_enable_true_preserves_allowlist() {
-        // `enable_span_attributes(true)` after `with_span_attribute_allowlist`
-        // must NOT clobber the allowlist.
+    fn tracing_appender_enable_then_allowlist_order_independent() {
+        // Order of enable_span_attributes(true) and with_span_attribute_allowlist
+        // does not matter — both produce the same enabled-with-filter state.
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -1622,4 +1622,49 @@ mod tests {
             .attributes_iter()
             .any(|(k, _)| k == &Key::new("ignored")));
     }
+
+    #[test]
+    fn tracing_appender_empty_allowlist_copies_nothing() {
+        // An empty allowlist means "allow nothing" — enrichment is enabled
+        // but no span attributes match, so none are copied.
+        let exporter = InMemoryLogExporter::default();
+        let provider = SdkLoggerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+
+        let empty: Vec<&str> = vec![];
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+            .with_tracing_span_attributes(TracingSpanAttributes::allowlist(empty))
+            .build()
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }));
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = tracing::info_span!("test_span", user_id = 123, session.id = "abc");
+        let _enter = span.enter();
+        tracing::error!(event_attr = "val", "test message");
+
+        provider.force_flush().unwrap();
+        let logs = exporter.get_emitted_logs().unwrap();
+        assert_eq!(logs.len(), 1);
+        let log = &logs[0];
+
+        // Event attribute is still recorded.
+        assert!(attributes_contains(
+            &log.record,
+            &Key::new("event_attr"),
+            &AnyValue::String("val".into())
+        ));
+        // No span attributes should appear — empty allowlist means nothing passes.
+        assert!(!log
+            .record
+            .attributes_iter()
+            .any(|(k, _)| k == &Key::new("user_id")));
+        assert!(!log
+            .record
+            .attributes_iter()
+            .any(|(k, _)| k == &Key::new("session.id")));
+    }
 }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -307,10 +307,11 @@ where
 {
     logger: L,
     _phantom: std::marker::PhantomData<P>, // P is not used.
-    // Span-attribute propagation configuration:
+    // Tracing-span attribute enrichment configuration:
     // - `None` => disabled (default). No per-span work, no scope walk.
-    // - `Some(set)` => enabled. If `set` is empty, all span attributes are
-    //   copied; otherwise only attributes whose keys are in `set`.
+    // - `Some(set)` => enabled. If `set` is empty, all tracing-span attributes
+    //   are copied onto log records; otherwise only attributes whose keys are
+    //   in `set`.
     span_attributes: Option<HashSet<Cow<'static, str>>>,
 }
 
@@ -354,31 +355,41 @@ where
     P: LoggerProvider<Logger = L> + Send + Sync,
     L: Logger + Send + Sync,
 {
-    /// Enable (or disable) copying attributes from active tracing spans onto
-    /// each emitted log record.
+    /// Enable (or disable) copying attributes from active [`tracing`] spans
+    /// (i.e. spans created with [`tracing::span!`] or one of its level-specific
+    /// macros — **not** `opentelemetry::trace::Span`) onto each emitted log
+    /// record.
     ///
-    /// By default, span attribute propagation is **disabled** and no per-span
-    /// work is performed.
+    /// By default, enrichment is **disabled** and no per-span work is
+    /// performed.
     ///
-    /// `with_span_attribute_allowlist` only takes effect if propagation is
+    /// `with_span_attribute_allowlist` only takes effect if enrichment is
     /// also explicitly enabled via this method. Calling
     /// `with_span_attribute_allowlist` without also calling
     /// `enable_span_attributes(true)` is a no-op (a warning is emitted via
     /// `otel_warn!` from `build()`).
+    ///
+    /// [`tracing`]: https://crates.io/crates/tracing
+    /// [`tracing::span!`]: https://docs.rs/tracing/latest/tracing/macro.span.html
     pub fn enable_span_attributes(mut self, enable: bool) -> Self {
         self.span_attributes_enabled = enable;
         self
     }
 
-    /// Restrict the set of span attributes that are copied onto log records to
-    /// the given allowlist.
+    /// Restrict the set of [`tracing`]-span attributes that are copied onto
+    /// log records to the given allowlist. ("Span" here means a
+    /// [`tracing::span!`] from the [`tracing`] crate, not an
+    /// `opentelemetry::trace::Span`.)
     ///
-    /// This method only takes effect when propagation is also enabled via
+    /// This method only takes effect when enrichment is also enabled via
     /// [`Self::enable_span_attributes`]`(true)`. Calling this method alone has
     /// no runtime effect — `build()` will emit an `otel_warn!` in that case.
     ///
     /// Calling this method multiple times replaces any prior allowlist — the
     /// last call wins.
+    ///
+    /// [`tracing`]: https://crates.io/crates/tracing
+    /// [`tracing::span!`]: https://docs.rs/tracing/latest/tracing/macro.span.html
     pub fn with_span_attribute_allowlist(
         mut self,
         keys: impl IntoIterator<Item = impl Into<Cow<'static, str>>>,
@@ -398,7 +409,7 @@ where
             if self.span_attribute_allowlist.is_some() {
                 otel_warn!(
                     name: "OpenTelemetryTracingBridge.AllowlistWithoutEnable",
-                    message = "with_span_attribute_allowlist was called but enable_span_attributes(true) was not; the allowlist will have no effect. Call enable_span_attributes(true) to opt into span attribute propagation."
+                    message = "with_span_attribute_allowlist was called but enable_span_attributes(true) was not; the allowlist will have no effect. Call enable_span_attributes(true) to opt into tracing-span attribute enrichment."
                 );
             }
             None
@@ -441,7 +452,7 @@ where
         log_record.set_severity_number(severity);
         log_record.set_severity_text(metadata.level().as_str());
 
-        // Extract span attributes if span-attribute propagation is enabled.
+        // Extract tracing-span attributes if enrichment is enabled.
         if self.span_attributes.is_some() {
             // Collect attributes from all parent spans (root to leaf), including current span
             if let Some(scope) = ctx.event_scope(event) {
@@ -473,8 +484,8 @@ where
         id: &tracing::span::Id,
         ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
-        // Skip entirely when span-attribute propagation is disabled to avoid
-        // any per-span overhead.
+        // Skip entirely when tracing-span attribute enrichment is disabled to
+        // avoid any per-span overhead.
         let Some(allowlist) = self.span_attributes.as_ref() else {
             return;
         };
@@ -1122,8 +1133,8 @@ mod tests {
     #[test]
     fn tracing_appender_span_attributes_disabled_by_default() {
         // When neither `enable_span_attributes` nor `with_span_attribute_allowlist`
-        // is called on the builder, span attributes must NOT be propagated onto
-        // log records.
+        // is called on the builder, tracing-span attributes must NOT be copied
+        // onto log records.
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
@@ -1537,7 +1548,7 @@ mod tests {
     #[test]
     fn tracing_appender_enable_span_attributes_copies_all() {
         // `enable_span_attributes(true)` (without an allowlist) enables
-        // propagation and copies all span attributes (no filtering).
+        // enrichment and copies all tracing-span attributes (no filtering).
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
@@ -1642,7 +1653,7 @@ mod tests {
         assert_eq!(logs.len(), 1);
         let log = &logs[0];
 
-        // Allowlist alone does not enable propagation — session.id must not appear.
+        // Allowlist alone does not enable enrichment — session.id must not appear.
         assert!(!log
             .record
             .attributes_iter()

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -353,10 +353,9 @@ where
     _phantom: std::marker::PhantomData<P>, // P is not used.
     // Tracing-span attribute enrichment configuration:
     // - `None` => disabled (default). No per-span work, no scope walk.
-    // - `Some(set)` => enabled. If `set` is empty, all tracing-span attributes
-    //   are copied onto log records; otherwise only attributes whose keys are
-    //   in `set`.
-    span_attributes: Option<HashSet<Cow<'static, str>>>,
+    // - `Some(All)` => copy all tracing-span attributes onto log records.
+    // - `Some(Allowlist(set))` => copy only attributes whose keys are in `set`.
+    span_attributes: Option<TracingSpanAttributesInner>,
 }
 
 impl<P, L> OpenTelemetryTracingBridge<P, L>
@@ -389,7 +388,7 @@ where
 {
     logger: L,
     _phantom: std::marker::PhantomData<P>,
-    span_attributes: Option<HashSet<Cow<'static, str>>>,
+    span_attributes: Option<TracingSpanAttributesInner>,
 }
 
 impl<P, L> OpenTelemetryTracingBridgeBuilder<P, L>
@@ -414,10 +413,7 @@ where
     /// [`tracing`]: https://crates.io/crates/tracing
     /// [`tracing::span!`]: https://docs.rs/tracing/latest/tracing/macro.span.html
     pub fn with_tracing_span_attributes(mut self, span_attributes: TracingSpanAttributes) -> Self {
-        self.span_attributes = Some(match span_attributes.0 {
-            TracingSpanAttributesInner::All => HashSet::new(),
-            TracingSpanAttributesInner::Allowlist(set) => set,
-        });
+        self.span_attributes = Some(span_attributes.0);
         self
     }
 
@@ -493,14 +489,12 @@ where
     ) {
         // Skip entirely when tracing-span attribute enrichment is disabled to
         // avoid any per-span overhead.
-        let Some(allowlist) = self.span_attributes.as_ref() else {
+        let Some(config) = self.span_attributes.as_ref() else {
             return;
         };
-        // Empty allowlist = "copy all" (no filter).
-        let allowlist = if allowlist.is_empty() {
-            None
-        } else {
-            Some(allowlist)
+        let allowlist = match config {
+            TracingSpanAttributesInner::All => None,
+            TracingSpanAttributesInner::Allowlist(set) => Some(set),
         };
 
         let span = ctx.span(id).expect("Span not found; this is a bug");
@@ -526,13 +520,12 @@ where
         values: &tracing::span::Record<'_>,
         ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
-        let Some(allowlist) = self.span_attributes.as_ref() else {
+        let Some(config) = self.span_attributes.as_ref() else {
             return;
         };
-        let allowlist = if allowlist.is_empty() {
-            None
-        } else {
-            Some(allowlist)
+        let allowlist = match config {
+            TracingSpanAttributesInner::All => None,
+            TracingSpanAttributesInner::Allowlist(set) => Some(set),
         };
 
         let span = ctx.span(id).expect("Span not found; this is a bug");

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -2,9 +2,7 @@ use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
     Key,
 };
-#[cfg(feature = "experimental_span_attributes")]
 use std::borrow::Cow;
-#[cfg(feature = "experimental_span_attributes")]
 use std::collections::HashSet;
 use tracing_core::Level;
 #[cfg(feature = "experimental_metadata_attributes")]
@@ -185,13 +183,11 @@ impl<LR: LogRecord> tracing::field::Visit for EventVisitor<'_, LR> {
 /// Visitor to extract fields from a tracing span.
 /// Takes a mutable reference to a Vec to append fields to, and an optional
 /// allowlist to include only named attributes.
-#[cfg(feature = "experimental_span_attributes")]
 struct SpanFieldVisitor<'a> {
     attributes: &'a mut Vec<(Key, AnyValue)>,
     allowlist: Option<&'a HashSet<Cow<'static, str>>>,
 }
 
-#[cfg(feature = "experimental_span_attributes")]
 impl SpanFieldVisitor<'_> {
     #[inline]
     fn allowed(&self, field: &tracing::field::Field) -> bool {
@@ -200,7 +196,6 @@ impl SpanFieldVisitor<'_> {
     }
 }
 
-#[cfg(feature = "experimental_span_attributes")]
 impl tracing::field::Visit for SpanFieldVisitor<'_> {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         if self.allowed(field) {
@@ -300,7 +295,6 @@ impl tracing::field::Visit for SpanFieldVisitor<'_> {
 /// Similar to how `tracing_subscriber::fmt::FormattedFields` stores formatted
 /// field data directly in span extensions - the Registry's internal locking
 /// provides the necessary synchronization.
-#[cfg(feature = "experimental_span_attributes")]
 #[derive(Debug)]
 struct StoredSpanAttributes {
     attributes: Vec<(Key, AnyValue)>,
@@ -313,8 +307,11 @@ where
 {
     logger: L,
     _phantom: std::marker::PhantomData<P>, // P is not used.
-    #[cfg(feature = "experimental_span_attributes")]
-    span_attribute_allowlist: Option<HashSet<Cow<'static, str>>>,
+    // Span-attribute propagation configuration:
+    // - `None` => disabled (default). No per-span work, no scope walk.
+    // - `Some(set)` => enabled. If `set` is empty, all span attributes are
+    //   copied; otherwise only attributes whose keys are in `set`.
+    span_attributes: Option<HashSet<Cow<'static, str>>>,
 }
 
 impl<P, L> OpenTelemetryTracingBridge<P, L>
@@ -335,8 +332,7 @@ where
             // See https://github.com/open-telemetry/semantic-conventions/issues/1550
             logger: provider.logger(""),
             _phantom: Default::default(),
-            #[cfg(feature = "experimental_span_attributes")]
-            span_attribute_allowlist: None,
+            span_attributes: None,
         }
     }
 }
@@ -348,8 +344,7 @@ where
 {
     logger: L,
     _phantom: std::marker::PhantomData<P>,
-    #[cfg(feature = "experimental_span_attributes")]
-    span_attribute_allowlist: Option<HashSet<Cow<'static, str>>>,
+    span_attributes: Option<HashSet<Cow<'static, str>>>,
 }
 
 impl<P, L> OpenTelemetryTracingBridgeBuilder<P, L>
@@ -357,14 +352,24 @@ where
     P: LoggerProvider<Logger = L> + Send + Sync,
     L: Logger + Send + Sync,
 {
-    /// Only copy span attributes whose keys are in the given allowlist to log
-    /// records. When no allowlist is set, all span attributes are copied.
-    #[cfg(feature = "experimental_span_attributes")]
-    pub fn with_span_attribute_allowlist(
+    /// Enable copying attributes from active tracing spans onto each emitted
+    /// log record.
+    ///
+    /// - Pass an empty iterator (e.g. `[]` or `std::iter::empty::<&str>()`)
+    ///   to copy **all** span attributes.
+    /// - Pass one or more keys to copy only attributes whose names appear in
+    ///   the given allowlist.
+    ///
+    /// If this method is not called, span attribute propagation is disabled
+    /// (the default), and no per-span work is performed.
+    ///
+    /// Calling this method multiple times replaces any prior configuration —
+    /// the last call wins.
+    pub fn with_span_attributes(
         mut self,
-        keys: impl IntoIterator<Item = impl Into<Cow<'static, str>>>,
+        allowlist: impl IntoIterator<Item = impl Into<Cow<'static, str>>>,
     ) -> Self {
-        self.span_attribute_allowlist = Some(keys.into_iter().map(Into::into).collect());
+        self.span_attributes = Some(allowlist.into_iter().map(Into::into).collect());
         self
     }
 
@@ -372,9 +377,7 @@ where
         OpenTelemetryTracingBridge {
             logger: self.logger,
             _phantom: self._phantom,
-            #[cfg(feature = "experimental_span_attributes")]
-            // Treat empty allowlist as not set - disable the feature flag instead.
-            span_attribute_allowlist: self.span_attribute_allowlist.filter(|s| !s.is_empty()),
+            span_attributes: self.span_attributes,
         }
     }
 }
@@ -385,7 +388,6 @@ where
     P: LoggerProvider<Logger = L> + Send + Sync + 'static,
     L: Logger + Send + Sync + 'static,
 {
-    #[allow(unused_variables)]
     fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
         let metadata = event.metadata();
         let severity = severity_of_level(metadata.level());
@@ -409,9 +411,8 @@ where
         log_record.set_severity_number(severity);
         log_record.set_severity_text(metadata.level().as_str());
 
-        // Extract span attributes if feature is enabled
-        #[cfg(feature = "experimental_span_attributes")]
-        {
+        // Extract span attributes if span-attribute propagation is enabled.
+        if self.span_attributes.is_some() {
             // Collect attributes from all parent spans (root to leaf), including current span
             if let Some(scope) = ctx.event_scope(event) {
                 for span_ref in scope.from_root() {
@@ -435,18 +436,30 @@ where
         //emit record
         self.logger.emit(log_record);
     }
-    #[cfg(feature = "experimental_span_attributes")]
+
     fn on_new_span(
         &self,
         attrs: &tracing::span::Attributes<'_>,
         id: &tracing::span::Id,
         ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
+        // Skip entirely when span-attribute propagation is disabled to avoid
+        // any per-span overhead.
+        let Some(allowlist) = self.span_attributes.as_ref() else {
+            return;
+        };
+        // Empty allowlist = "copy all" (no filter).
+        let allowlist = if allowlist.is_empty() {
+            None
+        } else {
+            Some(allowlist)
+        };
+
         let span = ctx.span(id).expect("Span not found; this is a bug");
         let mut fields = Vec::with_capacity(attrs.fields().len());
         let mut visitor = SpanFieldVisitor {
             attributes: &mut fields,
-            allowlist: self.span_attribute_allowlist.as_ref(),
+            allowlist,
         };
         attrs.record(&mut visitor);
 
@@ -459,13 +472,21 @@ where
         }
     }
 
-    #[cfg(feature = "experimental_span_attributes")]
     fn on_record(
         &self,
         id: &tracing::span::Id,
         values: &tracing::span::Record<'_>,
         ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
+        let Some(allowlist) = self.span_attributes.as_ref() else {
+            return;
+        };
+        let allowlist = if allowlist.is_empty() {
+            None
+        } else {
+            Some(allowlist)
+        };
+
         let span = ctx.span(id).expect("Span not found; this is a bug");
         let mut extensions = span.extensions_mut();
 
@@ -473,7 +494,7 @@ where
             // Append to existing attributes - extensions_mut() gives us mutable access
             let mut visitor = SpanFieldVisitor {
                 attributes: &mut stored.attributes,
-                allowlist: self.span_attribute_allowlist.as_ref(),
+                allowlist,
             };
             values.record(&mut visitor);
         } else {
@@ -481,7 +502,7 @@ where
             let mut fields = Vec::with_capacity(values.len());
             let mut visitor = SpanFieldVisitor {
                 attributes: &mut fields,
-                allowlist: self.span_attribute_allowlist.as_ref(),
+                allowlist,
             };
             values.record(&mut visitor);
             if !fields.is_empty() {
@@ -1069,9 +1090,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "experimental_span_attributes")]
-    fn tracing_appender_span_context_enrichment_enabled() {
-        // Arrange
+    fn tracing_appender_span_attributes_disabled_by_default() {
+        // When `with_span_attributes` is not called on the builder, span attributes
+        // must NOT be propagated onto log records.
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
@@ -1079,12 +1100,55 @@ mod tests {
 
         let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
             tracing_subscriber::filter::filter_fn(|meta| {
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }),
+        );
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = tracing::info_span!("test_span", user_id = 123, endpoint = "/api/users");
+        let _enter = span.enter();
+        tracing::error!(status = 200, "test message");
+
+        provider.force_flush().unwrap();
+        let logs = exporter.get_emitted_logs().unwrap();
+        assert_eq!(logs.len(), 1);
+        let log = &logs[0];
+
+        // Event attribute is still recorded.
+        assert!(attributes_contains(
+            &log.record,
+            &Key::new("status"),
+            &AnyValue::Int(200)
+        ));
+        // Span attributes must not appear on the log record.
+        assert!(!log
+            .record
+            .attributes_iter()
+            .any(|(k, _)| k == &Key::new("user_id")));
+        assert!(!log
+            .record
+            .attributes_iter()
+            .any(|(k, _)| k == &Key::new("endpoint")));
+    }
+
+    #[test]
+    fn tracing_appender_span_context_enrichment_enabled() {
+        // Arrange
+        let exporter = InMemoryLogExporter::default();
+        let provider = SdkLoggerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+            .with_span_attributes(std::iter::empty::<&str>())
+            .build()
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
                 // but only allow ERROR events to prevent internal otel_info! events from leaking
                 // in when internal-logs feature is enabled and tests run in parallel.
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
-            }),
-        );
+            }));
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1120,7 +1184,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "experimental_span_attributes")]
     fn tracing_appender_nested_spans_collect_all_parent_attributes() {
         // Arrange
         let exporter = InMemoryLogExporter::default();
@@ -1128,14 +1191,15 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
-            tracing_subscriber::filter::filter_fn(|meta| {
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+            .with_span_attributes(std::iter::empty::<&str>())
+            .build()
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
                 // but only allow ERROR events to prevent internal otel_info! events from leaking
                 // in when internal-logs feature is enabled and tests run in parallel.
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
-            }),
-        );
+            }));
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1181,7 +1245,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "experimental_span_attributes")]
     fn tracing_appender_span_context_with_various_types() {
         // Arrange
         let exporter = InMemoryLogExporter::default();
@@ -1189,14 +1252,15 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
-            tracing_subscriber::filter::filter_fn(|meta| {
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+            .with_span_attributes(std::iter::empty::<&str>())
+            .build()
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
                 // but only allow ERROR events to prevent internal otel_info! events from leaking
                 // in when internal-logs feature is enabled and tests run in parallel.
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
-            }),
-        );
+            }));
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1290,7 +1354,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "experimental_span_attributes")]
     fn tracing_appender_span_record_after_creation() {
         // This test verifies that span fields recorded AFTER span creation
         // are captured via the on_record implementation.
@@ -1301,14 +1364,15 @@ mod tests {
             .with_simple_exporter(exporter.clone())
             .build();
 
-        let layer = layer::OpenTelemetryTracingBridge::new(&provider).with_filter(
-            tracing_subscriber::filter::filter_fn(|meta| {
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+            .with_span_attributes(std::iter::empty::<&str>())
+            .build()
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
                 // but only allow ERROR events to prevent internal otel_info! events from leaking
                 // in when internal-logs feature is enabled and tests run in parallel.
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
-            }),
-        );
+            }));
         let subscriber = tracing_subscriber::registry().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
@@ -1358,7 +1422,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "experimental_span_attributes")]
     fn tracing_appender_span_attribute_allowlist_includes_only_named() {
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
@@ -1366,7 +1429,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attribute_allowlist(["session.id"])
+            .with_span_attributes(["session.id"])
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1395,7 +1458,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "experimental_span_attributes")]
     fn tracing_appender_span_attribute_allowlist_nested_spans() {
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
@@ -1403,7 +1465,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attribute_allowlist(["session.id"])
+            .with_span_attributes(["session.id"])
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1440,17 +1502,16 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "experimental_span_attributes")]
-    fn tracing_appender_span_attribute_allowlist_empty_treated_as_none() {
-        // Empty allowlist is normalized to None in build(), so all span
-        // attributes are copied (same as default behavior).
+    fn tracing_appender_span_attributes_empty_iterator_copies_all() {
+        // An empty iterator passed to `with_span_attributes` enables propagation
+        // and copies all span attributes (no filtering).
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attribute_allowlist(std::iter::empty::<&str>())
+            .with_span_attributes(std::iter::empty::<&str>())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1480,7 +1541,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "experimental_span_attributes")]
     fn tracing_appender_span_attribute_allowlist_with_on_record() {
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
@@ -1488,7 +1548,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attribute_allowlist(["session.id"])
+            .with_span_attributes(["session.id"])
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -352,24 +352,39 @@ where
     P: LoggerProvider<Logger = L> + Send + Sync,
     L: Logger + Send + Sync,
 {
-    /// Enable copying attributes from active tracing spans onto each emitted
-    /// log record.
+    /// Enable (or disable) copying attributes from active tracing spans onto
+    /// each emitted log record.
     ///
-    /// - Pass an empty iterator (e.g. `[]` or `std::iter::empty::<&str>()`)
-    ///   to copy **all** span attributes.
-    /// - Pass one or more keys to copy only attributes whose names appear in
-    ///   the given allowlist.
+    /// By default, span attribute propagation is **disabled** and no per-span
+    /// work is performed.
     ///
-    /// If this method is not called, span attribute propagation is disabled
-    /// (the default), and no per-span work is performed.
+    /// - `enable_span_attributes(true)` enables propagation. If no allowlist
+    ///   has been configured (via [`Self::with_span_attribute_allowlist`]),
+    ///   **all** span attributes are copied. If an allowlist has already been
+    ///   configured, it is preserved.
+    /// - `enable_span_attributes(false)` disables propagation entirely and
+    ///   clears any previously configured allowlist.
+    pub fn enable_span_attributes(mut self, enable: bool) -> Self {
+        if !enable {
+            self.span_attributes = None;
+        } else if self.span_attributes.is_none() {
+            self.span_attributes = Some(HashSet::new());
+        }
+        // else: already enabled (with or without allowlist) — preserve.
+        self
+    }
+
+    /// Restrict the set of span attributes that are copied onto log records to
+    /// the given allowlist.
     ///
-    /// Calling this method multiple times replaces any prior configuration —
-    /// the last call wins.
-    pub fn with_span_attributes(
+    /// Calling this method implicitly enables span attribute propagation, even
+    /// if [`Self::enable_span_attributes`] was not called. Calling it multiple
+    /// times replaces any previously configured allowlist — the last call wins.
+    pub fn with_span_attribute_allowlist(
         mut self,
-        allowlist: impl IntoIterator<Item = impl Into<Cow<'static, str>>>,
+        keys: impl IntoIterator<Item = impl Into<Cow<'static, str>>>,
     ) -> Self {
-        self.span_attributes = Some(allowlist.into_iter().map(Into::into).collect());
+        self.span_attributes = Some(keys.into_iter().map(Into::into).collect());
         self
     }
 
@@ -1091,8 +1106,9 @@ mod tests {
 
     #[test]
     fn tracing_appender_span_attributes_disabled_by_default() {
-        // When `with_span_attributes` is not called on the builder, span attributes
-        // must NOT be propagated onto log records.
+        // When neither `enable_span_attributes` nor `with_span_attribute_allowlist`
+        // is called on the builder, span attributes must NOT be propagated onto
+        // log records.
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
@@ -1141,7 +1157,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(std::iter::empty::<&str>())
+            .enable_span_attributes(true)
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1192,7 +1208,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(std::iter::empty::<&str>())
+            .enable_span_attributes(true)
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1253,7 +1269,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(std::iter::empty::<&str>())
+            .enable_span_attributes(true)
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1365,7 +1381,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(std::iter::empty::<&str>())
+            .enable_span_attributes(true)
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1429,7 +1445,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(["session.id"])
+            .with_span_attribute_allowlist(["session.id"])
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1465,7 +1481,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(["session.id"])
+            .with_span_attribute_allowlist(["session.id"])
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1502,16 +1518,16 @@ mod tests {
     }
 
     #[test]
-    fn tracing_appender_span_attributes_empty_iterator_copies_all() {
-        // An empty iterator passed to `with_span_attributes` enables propagation
-        // and copies all span attributes (no filtering).
+    fn tracing_appender_enable_span_attributes_copies_all() {
+        // `enable_span_attributes(true)` (without an allowlist) enables
+        // propagation and copies all span attributes (no filtering).
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
             .with_simple_exporter(exporter.clone())
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(std::iter::empty::<&str>())
+            .enable_span_attributes(true)
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1548,7 +1564,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(["session.id"])
+            .with_span_attribute_allowlist(["session.id"])
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1579,5 +1595,80 @@ mod tests {
             .record
             .attributes_iter()
             .any(|(k, _)| k == &Key::new("ignored")));
+    }
+
+    #[test]
+    fn tracing_appender_enable_false_clears_allowlist() {
+        // `enable_span_attributes(false)` after an allowlist was set must
+        // disable propagation entirely (and clear the allowlist).
+        let exporter = InMemoryLogExporter::default();
+        let provider = SdkLoggerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+            .with_span_attribute_allowlist(["session.id"])
+            .enable_span_attributes(false)
+            .build()
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }));
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = tracing::info_span!("test_span", session.id = "abc");
+        let _enter = span.enter();
+        tracing::error!("test message");
+
+        provider.force_flush().unwrap();
+        let logs = exporter.get_emitted_logs().unwrap();
+        assert_eq!(logs.len(), 1);
+        let log = &logs[0];
+
+        // session.id was on the allowlist, but enable_span_attributes(false)
+        // disabled propagation entirely.
+        assert!(!log
+            .record
+            .attributes_iter()
+            .any(|(k, _)| k == &Key::new("session.id")));
+    }
+
+    #[test]
+    fn tracing_appender_enable_true_preserves_allowlist() {
+        // `enable_span_attributes(true)` after `with_span_attribute_allowlist`
+        // must NOT clobber the allowlist.
+        let exporter = InMemoryLogExporter::default();
+        let provider = SdkLoggerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+
+        let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
+            .with_span_attribute_allowlist(["session.id"])
+            .enable_span_attributes(true)
+            .build()
+            .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
+                meta.is_span() || *meta.level() <= tracing::Level::ERROR
+            }));
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = tracing::info_span!("test_span", session.id = "abc", other = "v");
+        let _enter = span.enter();
+        tracing::error!("test message");
+
+        provider.force_flush().unwrap();
+        let logs = exporter.get_emitted_logs().unwrap();
+        assert_eq!(logs.len(), 1);
+        let log = &logs[0];
+
+        assert!(attributes_contains(
+            &log.record,
+            &Key::new("session.id"),
+            &AnyValue::String("abc".into())
+        ));
+        assert!(!log
+            .record
+            .attributes_iter()
+            .any(|(k, _)| k == &Key::new("other")));
     }
 }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -337,9 +337,10 @@ impl std::fmt::Debug for TracingSpanAttributes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.0 {
             TracingSpanAttributesInner::All => f.write_str("TracingSpanAttributes::all()"),
-            TracingSpanAttributesInner::Allowlist(set) => {
-                f.debug_tuple("TracingSpanAttributes::allowlist").field(set).finish()
-            }
+            TracingSpanAttributesInner::Allowlist(set) => f
+                .debug_tuple("TracingSpanAttributes::allowlist")
+                .field(set)
+                .finish(),
         }
     }
 }

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -306,7 +306,7 @@ struct StoredSpanAttributes {
 /// "Span" here refers to a [`tracing::span!`] from the [`tracing`] crate,
 /// **not** an `opentelemetry::trace::Span`.
 ///
-/// Pass this to [`OpenTelemetryTracingBridgeBuilder::with_span_attributes`] to
+/// Pass this to [`OpenTelemetryTracingBridgeBuilder::with_tracing_span_attributes`] to
 /// enable tracing-span attribute enrichment.
 ///
 /// [`tracing`]: https://crates.io/crates/tracing
@@ -413,7 +413,7 @@ where
     ///
     /// [`tracing`]: https://crates.io/crates/tracing
     /// [`tracing::span!`]: https://docs.rs/tracing/latest/tracing/macro.span.html
-    pub fn with_span_attributes(mut self, span_attributes: TracingSpanAttributes) -> Self {
+    pub fn with_tracing_span_attributes(mut self, span_attributes: TracingSpanAttributes) -> Self {
         self.span_attributes = Some(match span_attributes.0 {
             TracingSpanAttributesInner::All => HashSet::new(),
             TracingSpanAttributesInner::Allowlist(set) => set,
@@ -1140,7 +1140,7 @@ mod tests {
 
     #[test]
     fn tracing_appender_span_attributes_disabled_by_default() {
-        // When `with_span_attributes` is not called on the builder, tracing-span
+        // When `with_tracing_span_attributes` is not called on the builder, tracing-span
         // attributes must NOT be copied onto log records.
         let exporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()
@@ -1190,7 +1190,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(TracingSpanAttributes::all())
+            .with_tracing_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1241,7 +1241,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(TracingSpanAttributes::all())
+            .with_tracing_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1302,7 +1302,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(TracingSpanAttributes::all())
+            .with_tracing_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1414,7 +1414,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(TracingSpanAttributes::all())
+            .with_tracing_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 // Allow spans at any level (needed for on_new_span to store span attributes),
@@ -1478,7 +1478,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
+            .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1514,7 +1514,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
+            .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1560,7 +1560,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(TracingSpanAttributes::all())
+            .with_tracing_span_attributes(TracingSpanAttributes::all())
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR
@@ -1597,7 +1597,7 @@ mod tests {
             .build();
 
         let layer = layer::OpenTelemetryTracingBridge::builder(&provider)
-            .with_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
+            .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
             .build()
             .with_filter(tracing_subscriber::filter::filter_fn(|meta| {
                 meta.is_span() || *meta.level() <= tracing::Level::ERROR

--- a/opentelemetry-appender-tracing/src/lib.rs
+++ b/opentelemetry-appender-tracing/src/lib.rs
@@ -123,20 +123,47 @@
 //!
 //! In future, additional types may be supported.
 //!
-//! > **Note:** This crate does not support `tracing` Spans. One may use [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/) to
-//! > convert `tracing` spans into OpenTelemetry spans. This is a third-party crate
-//! > that is not maintained by the OpenTelemetry project.
-//! > `tracing-opentelemetry`:
-//! > - Converts `tracing` spans into OpenTelemetry spans  
-//! > - Converts `tracing` events into OpenTelemetry `SpanEvents` rather than logs
-//! >   Depending on the outcome of the
-//! >   [discussion](https://github.com/open-telemetry/opentelemetry-rust/issues/1571),
-//! >   the OpenTelemetry project may provide direct support to map `tracing`
-//! >   spans to OpenTelemetry in the future.
+//! ## Tracing Span Attribute Enrichment
+//!
+//! By default, only the fields on the `tracing` event itself are captured. Optionally,
+//! attributes from active [`tracing::span!`](https://docs.rs/tracing/latest/tracing/macro.span.html)
+//! scopes can be copied onto each emitted log record. **"Span" here refers to a `tracing` span,
+//! not an `opentelemetry::trace::Span`.**
+//!
+//! Enrichment is **disabled by default** (zero per-span overhead) and must be opted into
+//! via the builder:
+//!
+//! ```rust
+//! # use opentelemetry_sdk::logs::SdkLoggerProvider;
+//! # use opentelemetry_stdout::LogExporter;
+//! # let exporter = LogExporter::default();
+//! # let provider = SdkLoggerProvider::builder().with_simple_exporter(exporter).build();
+//! use opentelemetry_appender_tracing::layer::{OpenTelemetryTracingBridge, TracingSpanAttributes};
+//!
+//! // Copy ALL tracing-span attributes onto log records:
+//! let layer = OpenTelemetryTracingBridge::builder(&provider)
+//!     .with_tracing_span_attributes(TracingSpanAttributes::all())
+//!     .build();
+//!
+//! // Or copy only specific attributes:
+//! let layer = OpenTelemetryTracingBridge::builder(&provider)
+//!     .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
+//!     .build();
+//! ```
+//!
+//! When enrichment is enabled, attributes from all ancestor spans (root to leaf)
+//! are collected and added to the log record before the event's own fields.
+//!
+//! > **Note:** This crate does not convert `tracing` spans into OpenTelemetry spans.
+//! > Use [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/)
+//! > for that. The span enrichment feature here only *reads* tracing-span fields to
+//! > copy them onto log records — it does not create or manage OpenTelemetry spans.
 //!
 //! ## Feature Flags
 //!
-//! `experimental_metadata_attributes`: TODO
+//! - `experimental_metadata_attributes`: Adds source code metadata (`code.filepath`,
+//!   `code.filename`, `code.namespace`, `code.lineno`) as log record attributes.
+//!   This is experimental and may change in future releases.
 //!
 //!
 //! ## Limitations


### PR DESCRIPTION
Implements the API shape discussed in #3481.

Note: throughout this PR, **"span" refers to a [`tracing::span!`](https://docs.rs/tracing/latest/tracing/macro.span.html) from the `tracing` crate** (the source the appender consumes), **not** an `opentelemetry::trace::Span`.

## Changes

- **Removes the `experimental_span_attributes` cargo feature.** Tracing-span attribute *enrichment* (copying attributes from active `tracing` spans onto each emitted log record) is now part of the stable API surface of `opentelemetry-appender-tracing`. Note: the experimental feature was never released, so this is effectively a new feature.
- **Disabled by default.** Users who don't enable enrichment pay no per-span overhead (`on_new_span` / `on_record` / scope walk all return early).
- **Single builder method with a value type** to configure runtime behavior:

  ```rust
  use opentelemetry_appender_tracing::layer::TracingSpanAttributes;

  // Copy all tracing-span attributes onto log records:
  let layer = OpenTelemetryTracingBridge::builder(&provider)
      .with_tracing_span_attributes(TracingSpanAttributes::all())
      .build();

  // Or restrict to an allowlist:
  let layer = OpenTelemetryTracingBridge::builder(&provider)
      .with_tracing_span_attributes(TracingSpanAttributes::allowlist(["session.id"]))
      .build();
  ```

  One setter means no invalid combinations are expressible — no runtime warnings or extra feature plumbing needed.

## Terminology

The PR uses **"enrichment"** rather than "propagation". Propagation is already an overloaded term in OpenTelemetry (W3C TraceContext, baggage, etc.), and "enrichment" matches the term used by the Java and .NET SDKs for this exact pattern.

## Tests

All existing tests have been updated. Tests cover:

- `tracing_appender_span_attributes_disabled_by_default` — enrichment off by default.
- `tracing_appender_span_attributes_all_copies_all` — `TracingSpanAttributes::all()` copies all span attributes.
- `tracing_appender_span_attribute_allowlist_includes_only_named` — `TracingSpanAttributes::allowlist(...)` filters correctly.
- `tracing_appender_span_attribute_allowlist_nested_spans` — allowlist filtering across nested spans.
- `tracing_appender_span_attribute_allowlist_with_on_record` — allowlist with late-recorded fields.
- `tracing_appender_empty_allowlist_copies_nothing` — empty allowlist means "allow nothing".

## Out of Scope

- `span.name` propagation (#3466) is intentionally not part of this PR. Discussion continues separately.
- `experimental_metadata_attributes` cargo feature is unchanged; that's a separate stabilization decision.

## Refs

- Design discussion: #3481
- Tracking issue: #3376
- Original feature: #3282, #3387, #3314

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (adds `TracingSpanAttributes` type and `with_tracing_span_attributes` builder method, removes `experimental_span_attributes` feature)
