### PR TITLE
docs: add continuous benchmark dashboard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![Documentation](https://docs.rs/opentelemetry/badge.svg)](https://docs.rs/opentelemetry)
 [![codecov](https://codecov.io/gh/open-telemetry/opentelemetry-rust/branch/main/graph/badge.svg)](https://codecov.io/gh/open-telemetry/opentelemetry-rust)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-dashboard-blue)](https://open-telemetry.github.io/opentelemetry-rust/dev/bench/)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/open-telemetry/opentelemetry-rust/badge)](https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-rust)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10394/badge)](https://www.bestpractices.dev/projects/10394)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)


### PR DESCRIPTION
Adds a badge in the README header linking to the continuous benchmark dashboard at https://open-telemetry.github.io/opentelemetry-rust/dev/bench/.

The dashboard is already documented in CONTRIBUTING.md ("Testing and Benchmarking" section), but surfacing it as a badge in the README makes it more discoverable for users and contributors interested in tracking performance over time.

## Changes

- README.md: add a Benchmarks badge alongside the existing CI / codecov / scorecard badges.