### PR TITLE
chore: Remove doc_auto_cfg feature (merged into doc_cfg in Rust 1.92.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The Rust [OpenTelemetry](https://opentelemetry.io/) implementation.
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![Documentation](https://docs.rs/opentelemetry/badge.svg)](https://docs.rs/opentelemetry)
 [![codecov](https://codecov.io/gh/open-telemetry/opentelemetry-rust/branch/main/graph/badge.svg)](https://codecov.io/gh/open-telemetry/opentelemetry-rust)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-dashboard-blue)](https://open-telemetry.github.io/opentelemetry-rust/dev/bench/)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/open-telemetry/opentelemetry-rust/badge)](https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-rust)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10394/badge)](https://www.bestpractices.dev/projects/10394)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)

--- a/opentelemetry-jaeger-propagator/src/lib.rs
+++ b/opentelemetry-jaeger-propagator/src/lib.rs
@@ -28,11 +28,7 @@
     unreachable_pub,
     unused
 )]
-#![cfg_attr(
-    docsrs,
-    feature(doc_cfg),
-    deny(rustdoc::broken_intra_doc_links)
-)]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]

--- a/opentelemetry-jaeger-propagator/src/lib.rs
+++ b/opentelemetry-jaeger-propagator/src/lib.rs
@@ -30,7 +30,7 @@
 )]
 #![cfg_attr(
     docsrs,
-    feature(doc_cfg, doc_auto_cfg),
+    feature(doc_cfg),
     deny(rustdoc::broken_intra_doc_links)
 )]
 #![doc(

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -623,11 +623,7 @@
     unused
 )]
 #![allow(elided_lifetimes_in_paths)]
-#![cfg_attr(
-    docsrs,
-    feature(doc_cfg),
-    deny(rustdoc::broken_intra_doc_links)
-)]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![cfg_attr(test, deny(warnings))]
 
 mod exporter;

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -625,7 +625,7 @@
 #![allow(elided_lifetimes_in_paths)]
 #![cfg_attr(
     docsrs,
-    feature(doc_cfg, doc_auto_cfg),
+    feature(doc_cfg),
     deny(rustdoc::broken_intra_doc_links)
 )]
 #![cfg_attr(test, deny(warnings))]

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -98,7 +98,7 @@
 )]
 #![cfg_attr(
     docsrs,
-    feature(doc_cfg, doc_auto_cfg),
+    feature(doc_cfg),
     deny(rustdoc::broken_intra_doc_links)
 )]
 #![doc(

--- a/opentelemetry-proto/src/lib.rs
+++ b/opentelemetry-proto/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! This crate contains generated files from [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto)
 //! repository and transformation between types from generated files and types defined in [opentelemetry](https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry)
 //!

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -156,11 +156,7 @@
     unused
 )]
 #![allow(clippy::needless_doctest_main)]
-#![cfg_attr(
-    docsrs,
-    feature(doc_cfg),
-    deny(rustdoc::broken_intra_doc_links)
-)]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -158,7 +158,7 @@
 #![allow(clippy::needless_doctest_main)]
 #![cfg_attr(
     docsrs,
-    feature(doc_cfg, doc_auto_cfg),
+    feature(doc_cfg),
     deny(rustdoc::broken_intra_doc_links)
 )]
 #![doc(

--- a/opentelemetry-stdout/src/lib.rs
+++ b/opentelemetry-stdout/src/lib.rs
@@ -55,7 +55,7 @@
 #![warn(missing_debug_implementations, missing_docs)]
 #![cfg_attr(
     docsrs,
-    feature(doc_cfg, doc_auto_cfg),
+    feature(doc_cfg),
     deny(rustdoc::broken_intra_doc_links)
 )]
 

--- a/opentelemetry-stdout/src/lib.rs
+++ b/opentelemetry-stdout/src/lib.rs
@@ -53,11 +53,7 @@
 //! # }
 //! ```
 #![warn(missing_debug_implementations, missing_docs)]
-#![cfg_attr(
-    docsrs,
-    feature(doc_cfg),
-    deny(rustdoc::broken_intra_doc_links)
-)]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 
 #[cfg(feature = "metrics")]
 mod metrics;

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -241,11 +241,7 @@
     unreachable_pub,
     unused
 )]
-#![cfg_attr(
-    docsrs,
-    feature(doc_cfg),
-    deny(rustdoc::broken_intra_doc_links)
-)]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -243,7 +243,7 @@
 )]
 #![cfg_attr(
     docsrs,
-    feature(doc_cfg, doc_auto_cfg),
+    feature(doc_cfg),
     deny(rustdoc::broken_intra_doc_links)
 )]
 #![doc(

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -232,7 +232,7 @@
 #![allow(clippy::needless_doctest_main)]
 #![cfg_attr(
     docsrs,
-    feature(doc_cfg, doc_auto_cfg),
+    feature(doc_cfg),
     deny(rustdoc::broken_intra_doc_links)
 )]
 #![doc(

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -230,11 +230,7 @@
     unused
 )]
 #![allow(clippy::needless_doctest_main)]
-#![cfg_attr(
-    docsrs,
-    feature(doc_cfg),
-    deny(rustdoc::broken_intra_doc_links)
-)]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]


### PR DESCRIPTION
The doc_auto_cfg feature was removed in Rust 1.92.0 and merged into doc_cfg. This causes docs.rs builds to fail on nightly. Removes doc_auto_cfg from all 8 crates, keeping only feature(doc_cfg).

Fixes #3490