### PR TITLE
chore(zipkin): deprecate opentelemetry-zipkin crate

### DIFF
--- a/opentelemetry-zipkin/CHANGELOG.md
+++ b/opentelemetry-zipkin/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNext
 
+- **Deprecated**: The `opentelemetry-zipkin` crate is now deprecated. Use the OTLP exporter (`opentelemetry-otlp`) instead. Zipkin supports native OTLP ingestion. This crate will be removed in a future release.
 - `reqwest`'s crypto backend has changed from `ring` to `aws-lc-sys`.
 
 ## 0.31.0

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -16,6 +16,9 @@ edition = "2021"
 rust-version = "1.75.0"
 autobenches = false
 
+[badges]
+maintenance = { status = "deprecated" }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -1,5 +1,9 @@
 # OpenTelemetry Zipkin Exporter
 
+## ⚠️ Deprecation Notice
+
+**This crate is deprecated.** Use the [OTLP exporter](https://crates.io/crates/opentelemetry-otlp) instead. Zipkin supports [native OTLP ingestion](https://zipkin.io/pages/architecture.html). This crate will be removed in a future release.
+
 ![OpenTelemetry — An observability framework for cloud-native software.][splash]
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png

--- a/opentelemetry-zipkin/examples/zipkin.rs
+++ b/opentelemetry-zipkin/examples/zipkin.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use opentelemetry::{
     global::{self},
     trace::{Span, Tracer},

--- a/opentelemetry-zipkin/src/lib.rs
+++ b/opentelemetry-zipkin/src/lib.rs
@@ -1,5 +1,9 @@
 //! # OpenTelemetry Zipkin
 //!
+//! **⚠️ This crate is deprecated.** Use the [OTLP exporter](https://crates.io/crates/opentelemetry-otlp)
+//! instead. Zipkin supports [native OTLP ingestion](https://zipkin.io/pages/architecture.html).
+//! This crate will be removed in a future release.
+//!
 //! Collects OpenTelemetry spans and reports them to a given Zipkin collector
 //! endpoint. See the [Zipkin Docs] for details and deployment information.
 //!
@@ -232,6 +236,11 @@
 //! increased past 1.46, three minor versions prior. Increasing the minimum
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
+#![deprecated(
+    since = "0.32.0",
+    note = "Zipkin exporter is deprecated. Use the OTLP exporter instead. Refer to https://zipkin.io/pages/architecture.html for Zipkin's native OTLP support."
+)]
+#![allow(deprecated)]
 #![warn(
     future_incompatible,
     missing_debug_implementations,


### PR DESCRIPTION
## Summary

Mark the `opentelemetry-zipkin` crate as deprecated. Zipkin supports [native OTLP ingestion](https://zipkin.io/pages/architecture.html), so users should migrate to `opentelemetry-otlp`.

The crate will be removed in a future release.

## Changes

- `Cargo.toml`: Added `[badges] maintenance = { status = "deprecated" }` for crates.io
- `lib.rs`: Added `#![deprecated]` attribute and deprecation warning in docs
- `README.md`: Added deprecation notice at the top
- `CHANGELOG.md`: Added deprecation entry under vNext
- `examples/zipkin.rs`: Added `#![allow(deprecated)]` to suppress warnings in example

Closes #3250
