### PR TITLE
chore(jaeger): deprecate opentelemetry-jaeger-propagator crate

### DIFF
--- a/opentelemetry-jaeger-propagator/CHANGELOG.md
+++ b/opentelemetry-jaeger-propagator/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- **Deprecated**: The `opentelemetry-jaeger-propagator` crate is now deprecated. The Jaeger propagation format is deprecated per the OpenTelemetry specification. Use W3C TraceContext propagation instead. This crate will be removed in a future release.
+
 ## 0.31.0
 
 Released 2025-Sep-25

--- a/opentelemetry-jaeger-propagator/Cargo.toml
+++ b/opentelemetry-jaeger-propagator/Cargo.toml
@@ -16,6 +16,9 @@ edition = "2021"
 rust-version = "1.75.0"
 autobenches = false
 
+[badges]
+maintenance = { status = "deprecated" }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/opentelemetry-jaeger-propagator/README.md
+++ b/opentelemetry-jaeger-propagator/README.md
@@ -1,5 +1,9 @@
 # OpenTelemetry Jaeger Propagator
 
+## ⚠️ Deprecation Notice
+
+**This crate is deprecated.** The Jaeger propagation format is deprecated per the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/pull/4827). Use W3C TraceContext propagation instead. See the [Jaeger SDK migration guide](https://www.jaegertracing.io/sdk-migration/#propagation-format) for details. This crate will be removed in a future release.
+
 ![OpenTelemetry — An observability framework for cloud-native software.][splash]
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png

--- a/opentelemetry-jaeger-propagator/src/lib.rs
+++ b/opentelemetry-jaeger-propagator/src/lib.rs
@@ -1,3 +1,9 @@
+//! **⚠️ This crate is deprecated.** The Jaeger propagation format is deprecated
+//! per the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/pull/4827).
+//! Use W3C TraceContext propagation instead. See the
+//! [Jaeger SDK migration guide](https://www.jaegertracing.io/sdk-migration/#propagation-format)
+//! for details. This crate will be removed in a future release.
+//!
 //! *[Supported Rust Versions](#supported-rust-versions)*
 //!
 //! [Jaeger Docs]: https://www.jaegertracing.io/docs/
@@ -19,6 +25,11 @@
 //! increased past 1.46, three minor versions prior. Increasing the minimum
 //! supported compiler version is not considered a semver breaking change as
 //! long as doing so complies with this policy.
+#![deprecated(
+    since = "0.32.0",
+    note = "Jaeger propagation format is deprecated. Use W3C TraceContext propagation instead. See https://www.jaegertracing.io/sdk-migration/#propagation-format"
+)]
+#![allow(deprecated)]
 #![warn(
     future_incompatible,
     missing_debug_implementations,


### PR DESCRIPTION
## Summary

Mark the `opentelemetry-jaeger-propagator` crate as deprecated. The Jaeger propagation format is deprecated per the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/pull/4827). Users should migrate to W3C TraceContext propagation. See the [Jaeger SDK migration guide](https://www.jaegertracing.io/sdk-migration/#propagation-format) for details.

The crate will be removed in a future release.

## Changes

- `Cargo.toml`: Added `[badges] maintenance = { status = "deprecated" }` for crates.io
- `lib.rs`: Added `#![deprecated]` attribute and deprecation warning in docs
- `README.md`: Added deprecation notice at the top
- `CHANGELOG.md`: Added deprecation entry under vNext

Closes #3303
