### PR TITLE
fix(sdk): suppress telemetry in SimpleSpanProcessor during export

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- `SimpleSpanProcessor` now suppresses telemetry during export, preventing
+  telemetry-induced-telemetry feedback loops. This aligns with the existing
+  behavior in `BatchSpanProcessor` and `SimpleLogProcessor`.
 - Removed `SimpleConcurrentLogProcessor` and the `experimental_logs_concurrent_log_processor`
   feature flag. The use cases it was designed for (ETW/user_events exporters) are
   better served by modeling those exporters as processors directly.

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -172,6 +172,7 @@ impl<T: SpanExporter> SpanProcessor for SimpleSpanProcessor<T> {
             return;
         }
 
+        let _suppress_guard = Context::enter_telemetry_suppressed_scope();
         let result = self
             .exporter
             .lock()


### PR DESCRIPTION
## Summary

Add telemetry suppression guard in `SimpleSpanProcessor::on_end` to prevent telemetry-induced-telemetry feedback loops during export.

`BatchSpanProcessor` and `SimpleLogProcessor` already suppress telemetry during their export paths. `SimpleSpanProcessor` was the only processor missing this guard, meaning that if used with an HTTP-based exporter, the export call could generate telemetry that feeds back into the pipeline.

This was made possible by #3262 which fixed the `ContextGuard::drop` panic that previously prevented safe `Context::current()` access during `on_end`.

## Changes

One-line fix: added `let _suppress_guard = Context::enter_telemetry_suppressed_scope();` before the export call in `SimpleSpanProcessor::on_end`.

Closes #2883