### PR TITLE
chore(prometheus): restore crate to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ members = [
     "stress",
 ]
 resolver = "2"
-# Avoid applying patch to force use of workspace members for this
-# not actively maintained crate
-exclude = ["opentelemetry-prometheus"]
 
 [profile.bench]
 # https://doc.rust-lang.org/cargo/reference/profiles.html#debug

--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- Un-deprecate `opentelemetry-prometheus` and remove stale discontinuation notices. [#3288](https://github.com/open-telemetry/opentelemetry-rust/issues/3288)
+- Set MSRV to 1.81.0 to match the `prometheus` dependency requirement.
+
 ## v0.31.1
 
 - Remove `protobuf` dependency from `prometheus`

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "opentelemetry-prometheus"
 version = "0.31.1"
-description = "Prometheus exporter for OpenTelemetry (This crate is discontinued and is no longer maintained)"
+description = "Prometheus exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-prometheus"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-prometheus"
 readme = "README.md"
@@ -13,25 +13,25 @@ categories = [
 keywords = ["opentelemetry", "prometheus", "metrics", "async"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.81.0"
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-once_cell = { version = "1.13" }
-opentelemetry = { version = "0.31", default-features = false, features = ["metrics", "internal-logs"] }
-opentelemetry_sdk = { version = "0.31", default-features = false, features = ["metrics", "experimental_metrics_custom_reader"] }
+once_cell = { workspace = true }
+opentelemetry = { workspace = true, features = ["metrics", "internal-logs"] }
+opentelemetry_sdk = { workspace = true, features = ["metrics", "experimental_metrics_custom_reader"] }
 prometheus = { version = "0.14", default-features = false }
-tracing = { version = ">=0.1.40", default-features = false, optional = true } # optional for opentelemetry internal logging
+tracing = { workspace = true, optional = true } # optional for opentelemetry internal logging
 
 [dev-dependencies]
-opentelemetry-semantic-conventions = { version = "0.31" }
-http-body-util = { version = "0.1" }
-hyper = { version = "1.3", features = ["full"] }
-hyper-util = { version = "0.1", features = ["full"] }
-tokio = { version = "1", features = ["full"] }
+opentelemetry-semantic-conventions = { workspace = true }
+http-body-util = { workspace = true }
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = ["internal-logs"]

--- a/opentelemetry-prometheus/README.md
+++ b/opentelemetry-prometheus/README.md
@@ -4,21 +4,7 @@
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png
 
-[`Prometheus`] integration for applications instrumented with [`OpenTelemetry`]. 
-
-**Warning: This crate is no longer recommended for use.**
-
-Development of the Prometheus exporter has been discontinued. See the related
-[issue](https://github.com/open-telemetry/opentelemetry-rust/issues/2451). This
-crate depends on the unmaintained `protobuf` crate and has unresolved security
-vulnerabilities. Version 0.29 will be the final release.
-
-For Prometheus integration, we strongly recommend using the [OTLP] exporter
-instead. Prometheus [natively supports
-OTLP](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver),
-providing a more stable and actively maintained solution.
-
-[OTLP]: https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/
+[`Prometheus`] integration for applications instrumented with [`OpenTelemetry`].
 
 [![Crates.io: opentelemetry-prometheus](https://img.shields.io/crates/v/opentelemetry-prometheus.svg)](https://crates.io/crates/opentelemetry-prometheus)
 [![Documentation](https://docs.rs/opentelemetry-prometheus/badge.svg)](https://docs.rs/opentelemetry-prometheus)

--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -1,19 +1,6 @@
 //! An OpenTelemetry exporter for [Prometheus] metrics.
 //!
-//! <div class="warning">
-//! <strong>Warning: This crate is no longer recommended for use.</strong><br><br>
-//! Development of the Prometheus exporter has been discontinued. See the related
-//! [issue](https://github.com/open-telemetry/opentelemetry-rust/issues/2451).
-//! This crate depends on the unmaintained `protobuf` crate and has unresolved
-//! security vulnerabilities. Version 0.29 will be the final release.
-//!
-//! For Prometheus integration, we strongly recommend using the [OTLP] exporter instead.
-//! Prometheus [natively supports OTLP](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver),
-//! providing a more stable and actively maintained solution.
-//! </div>
-//!
 //! [Prometheus]: https://prometheus.io
-//! [OTLP]: https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/
 //!
 //! ```
 //! use opentelemetry::{metrics::MeterProvider, KeyValue};
@@ -96,11 +83,7 @@
     unreachable_pub,
     unused
 )]
-#![cfg_attr(
-    docsrs,
-    feature(doc_cfg),
-    deny(rustdoc::broken_intra_doc_links)
-)]
+#![cfg_attr(docsrs, feature(doc_cfg), deny(rustdoc::broken_intra_doc_links))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo.svg"
 )]


### PR DESCRIPTION
## Changes

Un-deprecates `opentelemetry-prometheus` by removing stale unsupported/discontinued notices and restoring the crate to the workspace. Sets the crate MSRV to 1.81.0 to match the `prometheus` dependency requirement.

Fixes #3288

## Validation

- `cargo metadata --no-deps --format-version 1`
- `cargo +1.81.0 check -p opentelemetry-prometheus --all-targets --all-features`
- `cargo +nightly shear --expand`
- `cargo clippy -p opentelemetry-prometheus --all-targets --all-features -- -Dwarnings`
- `cargo test -p opentelemetry-prometheus --all-features --lib`