### PR TITLE
chore: Prepare for release v0.32.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,16 +60,16 @@ const-hex = "1.14.1"
 lazy_static = "1.4.0"
 num-format = "0.4.4"
 num_cpus = "1.15.0"
-opentelemetry = { path = "opentelemetry", version = "0.31", default-features = false }
-opentelemetry_sdk = { path = "opentelemetry-sdk", version = "0.31", default-features = false }
-opentelemetry-appender-log = { path = "opentelemetry-appender-log", version = "0.31", default-features = false }
-opentelemetry-appender-tracing = { path = "opentelemetry-appender-tracing", version = "0.31.1", default-features = false }
-opentelemetry-http = { path = "opentelemetry-http", version = "0.31", default-features = false }
-opentelemetry-jaeger-propagator = { path = "opentelemetry-jaeger-propagator", version = "0.31", default-features = false }
-opentelemetry-otlp = { path = "opentelemetry-otlp", version = "0.31", default-features = false }
-opentelemetry-proto = { path = "opentelemetry-proto", version = "0.31", default-features = false }
-opentelemetry-semantic-conventions = { path = "opentelemetry-semantic-conventions", version = "0.31", default-features = false }
-opentelemetry-stdout = { path = "opentelemetry-stdout", version = "0.31", default-features = false }
+opentelemetry = { path = "opentelemetry", version = "0.32", default-features = false }
+opentelemetry_sdk = { path = "opentelemetry-sdk", version = "0.32", default-features = false }
+opentelemetry-appender-log = { path = "opentelemetry-appender-log", version = "0.32", default-features = false }
+opentelemetry-appender-tracing = { path = "opentelemetry-appender-tracing", version = "0.32", default-features = false }
+opentelemetry-http = { path = "opentelemetry-http", version = "0.32", default-features = false }
+opentelemetry-jaeger-propagator = { path = "opentelemetry-jaeger-propagator", version = "0.32", default-features = false }
+opentelemetry-otlp = { path = "opentelemetry-otlp", version = "0.32", default-features = false }
+opentelemetry-proto = { path = "opentelemetry-proto", version = "0.32", default-features = false }
+opentelemetry-semantic-conventions = { path = "opentelemetry-semantic-conventions", version = "0.32", default-features = false }
+opentelemetry-stdout = { path = "opentelemetry-stdout", version = "0.32", default-features = false }
 percent-encoding = "2.0"
 rstest = "0.23.0"
 schemars = "1.0"

--- a/docs/release_0.32.md
+++ b/docs/release_0.32.md
@@ -1,0 +1,123 @@
+# Release Notes 0.32
+
+OpenTelemetry Rust 0.32 continues to drive the Logs, Metrics, and Distributed
+Tracing components forward. The Logs and Metrics API and SDK remain stable, with
+no breaking changes in this release. The OTLP Exporters and the Distributed
+Tracing API/SDK remain in pre-stable states (Release-Candidate and Beta
+respectively), and this release introduces a small number of intentional
+breaking changes in those areas to prepare them for stabilization.
+
+For detailed changelogs of individual crates, please refer to their respective
+changelog files. This document serves as a summary of the main changes.
+
+## Key Changes
+
+### Metrics SDK
+
+1. **Bound instruments (experimental)**: Added `Counter::bind()` and
+   `Histogram::bind()` returning pre-bound measurement handles
+   (`BoundCounter<T>`, `BoundHistogram<T>`). Bound instruments resolve the
+   attribute-to-aggregator mapping once at bind time and cache the result,
+   eliminating per-call HashMap lookups on the hot path. Benchmarks show
+   ~28x speedup for counter operations and ~9x for histograms. Gated behind
+   the `experimental_metrics_bound_instruments` feature flag.
+
+2. **Delta collection efficiency**: Delta metrics collection now uses in-place
+   eviction instead of draining the HashMap on every collect cycle. Stale
+   attribute sets that received no measurements since the last collection are
+   evicted.
+
+3. **Stable `Aggregation` API**: `Aggregation` and
+   `StreamBuilder::with_aggregation()` are now stable and no longer require the
+   `spec_unstable_metrics_views` feature flag.
+
+### Logs
+
+1. **Tracing-span attribute enrichment (experimental)**: The
+   `opentelemetry-appender-tracing` crate can now copy attributes from active
+   `tracing` spans onto each emitted log record. ("Span" here refers to
+   `tracing::span!`, not an `opentelemetry::trace::Span`.) Enrichment is
+   disabled by default with zero per-span overhead, and is gated behind the
+   new `experimental_span_attributes` cargo feature.
+
+2. **`spec_unstable_logs_enabled` removed**: The capability (and the backing
+   specification) is now stable and is enabled by default. The feature flag
+   has been removed.
+
+### Distributed Tracing (Beta)
+
+The Distributed Tracing API and SDK remain in beta. This release contains
+intentional breaking changes to clean up the public surface ahead of
+stabilization. In practice, most of these changes affect items that were only
+used by the `tracing-opentelemetry` crate rather than by direct end-users of the
+OpenTelemetry API. End-user impact is expected to be minimal.
+
+- **Breaking** Removed several public fields and methods from `SpanBuilder`
+  (`trace_id`, `span_id`, `end_time`, `status`, `sampling_result`, and their
+  `with_*` counterparts).
+- **Breaking** Moved SDK sampling types (`SamplingDecision`, `SamplingResult`)
+  from `opentelemetry::trace` to `opentelemetry_sdk::trace` — these are SDK
+  implementation details and should be imported from
+  `opentelemetry_sdk::trace`.
+- **Breaking** Removed public hidden methods from `SdkTracer` (`id_generator`,
+  `should_sample`).
+- **Breaking** `SpanExporter` trait methods (`shutdown`, `shutdown_with_timeout`,
+  `force_flush`) now take `&self` instead of `&mut self`, for consistency with
+  `LogExporter` and `PushMetricExporter`. Implementers using interior
+  mutability require no changes.
+- **Breaking** `InMemoryExporterError` has been removed in favor of
+  `OTelSdkError`; a new `JaegerRemoteSamplerBuildError` replaces the last uses
+  of `TraceError`.
+- **Breaking** The SDK `testing` feature is now runtime-agnostic:
+  `TokioSpanExporter` / `new_tokio_test_exporter` are renamed to
+  `TestSpanExporter` / `new_test_exporter`, and several `tokio` transitive
+  dependencies / features are removed.
+
+Other tracing improvements:
+
+- Fix panic when `SpanProcessor::on_end` calls `Context::current()`.
+
+### OTLP Exporters (Release Candidate)
+
+The OTLP Exporters remain in RC. This release introduces breaking changes to
+prepare for stabilization, alongside several quality-of-life improvements:
+
+- **Breaking** Removed `ExportConfig`, `HasExportConfig`, `with_export_config()`,
+  `HasTonicConfig`, `HasHttpConfig`, `TonicConfig`, and `HttpConfig` from the
+  public API. Use the public `WithExportConfig`, `WithTonicConfig`, and
+  `WithHttpConfig` trait methods instead — these remain unchanged.
+- The gRPC/tonic OTLP exporter now returns an error when an `https://` endpoint
+  is configured but no TLS feature (`tls-ring` or `tls-aws-lc`) is enabled,
+  instead of silently sending unencrypted traffic.
+- New `tls-provider-agnostic` feature for environments that bring their own
+  crypto backend (e.g. OpenSSL for FIPS compliance).
+- New `build()` directly on `SpanExporterBuilder`, `MetricExporterBuilder`,
+  and `LogExporterBuilder` (before selecting a transport), auto-selecting the
+  transport based on `OTEL_EXPORTER_OTLP_PROTOCOL` or enabled features.
+- Auth tokens / sensitive server responses no longer leak into export error
+  messages — full details remain available at DEBUG level.
+- Pre-flight transport errors (invalid URL, connect failure, DNS) for
+  `grpc-tonic` are now surfaced at ERROR level instead of requiring DEBUG
+  logging.
+
+### Deprecations
+
+- `opentelemetry-zipkin` is deprecated. Use the OTLP exporter
+  (`opentelemetry-otlp`) — Zipkin supports native OTLP ingestion. The crate
+  will be removed in a future release.
+- `opentelemetry-jaeger-propagator` is deprecated. The Jaeger propagation
+  format is deprecated per the OpenTelemetry specification. Use W3C
+  TraceContext propagation instead. The crate will be removed in a future
+  release.
+
+## Next Release
+
+In the [next release](https://github.com/open-telemetry/opentelemetry-rust/milestone/24),
+the focus will shift to declaring the OTLP Exporters and the Distributed
+Tracing API/SDK stable.
+
+## Acknowledgments
+
+Thank you to everyone who contributed to this milestone. We welcome your
+feedback through GitHub issues or discussions in the [OTel-Rust Slack
+channel](https://cloud-native.slack.com/archives/C03GDP0H023).

--- a/opentelemetry-appender-log/CHANGELOG.md
+++ b/opentelemetry-appender-log/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 - "spec_unstable_logs_enabled" feature flag is removed. The capability (and the
   backing specification) is now stable and is enabled by default.
   [3278](https://github.com/open-telemetry/opentelemetry-rust/pull/3278)

--- a/opentelemetry-appender-log/Cargo.toml
+++ b/opentelemetry-appender-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-appender-log"
-version = "0.31.0"
+version = "0.32.0"
 description = "An OpenTelemetry appender for the log crate"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-log"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-log"

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -35,24 +35,21 @@ Released 2026-May-08
       .build();
   ```
 
+- Remove the `experimental_use_tracing_span_context` since
+  `tracing-opentelemetry` now supports [activating][31901] the OpenTelemetry
+  context for the current tracing span. This fixes [#3190][3190] — the
+  circular dependency introduced by depending on `tracing-opentelemetry`
+  that depends on `opentelemetry`.
+- "spec_unstable_logs_enabled" feature flag is removed. The capability (and the
+  backing specification) is now stable and is enabled by default. [#3278][3278]
+
 [`tracing`]: https://crates.io/crates/tracing
 [tracing-span]: https://docs.rs/tracing/latest/tracing/macro.span.html
+[3190]: https://github.com/open-telemetry/opentelemetry-rust/issues/3190
+[3278]: https://github.com/open-telemetry/opentelemetry-rust/pull/3278
 [3482]: https://github.com/open-telemetry/opentelemetry-rust/pull/3482
 [3505]: https://github.com/open-telemetry/opentelemetry-rust/pull/3505
-
-- Remove the `experimental_use_tracing_span_context` since
-  `tracing-opentelemetry` now supports [activating][31901]  the OpenTelemetry
-  context for the current tracing span.
-  
-  This fixes [3190][3190] the circular dependency introduced by depending on
-  `tracing-opentelemetry` that depends on `opentelemetry`.
-
-[3190]: https://github.com/open-telemetry/opentelemetry-rust/issues/3190
 [31901]: https://github.com/tokio-rs/tracing-opentelemetry/blob/884b00cf438557733bd9cef9456281bea8c4bea1/src/layer.rs#L842
-
-- "spec_unstable_logs_enabled" feature flag is removed. The capability (and the
-  backing specification) is now stable and is enabled by default.
-  [3278](https://github.com/open-telemetry/opentelemetry-rust/pull/3278)
 
 ## 0.31.1
 

--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 - **Add tracing span attribute enrichment (experimental).** When enabled,
   attributes attached to active [`tracing`] spans are copied onto each emitted
   log record. "Span" here refers to a [`tracing::span!`][tracing-span] from the
   [`tracing`] crate (the appender's source), **not** an OpenTelemetry span.
+  [#3482][3482], [#3505][3505]
 
   Gated behind the new **`experimental_span_attributes`** cargo feature. As
   with all `experimental_*` features in this repo, the API may change without
@@ -32,6 +37,8 @@
 
 [`tracing`]: https://crates.io/crates/tracing
 [tracing-span]: https://docs.rs/tracing/latest/tracing/macro.span.html
+[3482]: https://github.com/open-telemetry/opentelemetry-rust/pull/3482
+[3505]: https://github.com/open-telemetry/opentelemetry-rust/pull/3505
 
 - Remove the `experimental_use_tracing_span_context` since
   `tracing-opentelemetry` now supports [activating][31901]  the OpenTelemetry

--- a/opentelemetry-appender-tracing/Cargo.toml
+++ b/opentelemetry-appender-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-appender-tracing"
-version = "0.31.1"
+version = "0.32.0"
 edition = "2021"
 description = "An OpenTelemetry log appender for the tracing crate"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-appender-tracing"

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 - `reqwest`'s crypto backend has changed from `ring` to `aws-lc-sys`.
 
 ## 0.31.0

--- a/opentelemetry-http/Cargo.toml
+++ b/opentelemetry-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 description = "Helper implementations for sending HTTP requests. Uses include propagating and extracting context over http, exporting telemetry, requesting sampling strategies."
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-http"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-http"

--- a/opentelemetry-jaeger-propagator/CHANGELOG.md
+++ b/opentelemetry-jaeger-propagator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 - **Deprecated**: The `opentelemetry-jaeger-propagator` crate is now deprecated. The Jaeger propagation format is deprecated per the OpenTelemetry specification. Use W3C TraceContext propagation instead. This crate will be removed in a future release.
 
 ## 0.31.0

--- a/opentelemetry-jaeger-propagator/Cargo.toml
+++ b/opentelemetry-jaeger-propagator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-jaeger-propagator"
-version = "0.31.0"
+version = "0.32.0"
 description = "Jaeger propagator for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger-propagator"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger-propagator"

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 - Add `tls-provider-agnostic` feature flag for environments that require a custom crypto backend (e.g., OpenSSL for FIPS compliance). Enables TLS code paths without bundling `ring` or `aws-lc-rs`.
 - Add `build()` directly on `SpanExporterBuilder`, `MetricExporterBuilder`, and `LogExporterBuilder`
   (before selecting a transport), which auto-selects the transport based on the

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.32.0"
 description = "Exporter for the OpenTelemetry Collector"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp"

--- a/opentelemetry-prometheus/CHANGELOG.md
+++ b/opentelemetry-prometheus/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 - Un-deprecate `opentelemetry-prometheus` and remove stale discontinuation notices. [#3288](https://github.com/open-telemetry/opentelemetry-rust/issues/3288)
 - Set MSRV to 1.81.0 to match the `prometheus` dependency requirement.
 

--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-prometheus"
-version = "0.31.1"
+version = "0.32.0"
 description = "Prometheus exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-prometheus"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-prometheus"

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 - Update proto definitions to v1.10.0.
 - Updated `schemars` dependency to version 1.0.0.
 - **Bug fix**: `InstrumentationScope` version and attributes are now preserved when logs have a target set. Previously, setting a log target would discard the scope's version and attributes. ([#3276](https://github.com/open-telemetry/opentelemetry-rust/issues/3276))

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 description = "Protobuf generated files and transformations."
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto"

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -60,9 +60,12 @@ Released 2026-May-08
   - Updated `SpanProcessor::on_end` documentation to clarify that `Context::current()` returns the parent context, not the span's context
 - Fix `traceparent` headers with unknown flags (e.g. W3C random-trace-id flag `0x02`) being incorrectly rejected. Unknown flags are now accepted and zeroed out as required by the W3C trace-context spec. [#3435][3435]
 - **Breaking** `InMemoryExporterError` has been removed and replaced by `OTelSdkError`, and a new `JaegerRemoteSamplerBuildError` introduced to replace last uses of `TraceError`. [#3458][3458]
+- "spec_unstable_logs_enabled" feature flag is removed. The capability (and the
+  backing specification) is now stable and is enabled by default. [#3278][3278]
 
 [3227]: https://github.com/open-telemetry/opentelemetry-rust/pull/3227
 [3277]: https://github.com/open-telemetry/opentelemetry-rust/pull/3277
+[3278]: https://github.com/open-telemetry/opentelemetry-rust/pull/3278
 [3312]: https://github.com/open-telemetry/opentelemetry-rust/pull/3312
 [3248]: https://github.com/open-telemetry/opentelemetry-rust/pull/3248
 [3262]: https://github.com/open-telemetry/opentelemetry-rust/pull/3262
@@ -70,10 +73,6 @@ Released 2026-May-08
 [3435]: https://github.com/open-telemetry/opentelemetry-rust/issues/3435
 [3458]: https://github.com/open-telemetry/opentelemetry-rust/pull/3458
 [3506]: https://github.com/open-telemetry/opentelemetry-rust/pull/3506
-
-- "spec_unstable_logs_enabled" feature flag is removed. The capability (and the
-  backing specification) is now stable and is enabled by default.
-  [3278](https://github.com/open-telemetry/opentelemetry-rust/pull/3278)
 
 ## 0.31.0
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 - `SimpleSpanProcessor` now suppresses telemetry during export, preventing
   telemetry-induced-telemetry feedback loops. This aligns with the existing
   behavior in `BatchSpanProcessor` and `SimpleLogProcessor`.
@@ -48,7 +52,7 @@
   - `SamplingDecision`, `SamplingResult`
   - These types are SDK implementation details and should be imported from `opentelemetry_sdk::trace` instead.
 - `StreamBuilder::build()` now rejects `usize::MAX` as a cardinality limit
-  with a validation error.
+  with a validation error. [#3506][3506]
 - Fix Histogram boundaries being ignored in the presence of views [#3312][3312]
 - `TracerProviderBuilder::with_sampler` allows to pass boxed instance of `ShouldSample` [#3313][3313]
 - Fix ObservableCounter and ObservableUpDownCounter now correctly report only data points from the current measurement cycle, removing stale attribute combinations that are no longer observed. [#3248][3248]
@@ -65,6 +69,7 @@
 [3407]: https://github.com/open-telemetry/opentelemetry-rust/pull/3407
 [3435]: https://github.com/open-telemetry/opentelemetry-rust/issues/3435
 [3458]: https://github.com/open-telemetry/opentelemetry-rust/pull/3458
+[3506]: https://github.com/open-telemetry/opentelemetry-rust/pull/3506
 
 - "spec_unstable_logs_enabled" feature flag is removed. The capability (and the
   backing specification) is now stable and is enabled by default.

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.0"
 description = "The SDK for the OpenTelemetry metrics collection and distributed tracing framework"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk"

--- a/opentelemetry-semantic-conventions/CHANGELOG.md
+++ b/opentelemetry-semantic-conventions/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 ## 0.31.0
 
 Released 2025-Sep-25

--- a/opentelemetry-semantic-conventions/Cargo.toml
+++ b/opentelemetry-semantic-conventions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
+version = "0.32.0"
 description = "Semantic conventions for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-semantic-conventions"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-semantic-conventions"

--- a/opentelemetry-stdout/CHANGELOG.md
+++ b/opentelemetry-stdout/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 - ExponentialHistogram supported in stdout
 
 ## 0.31.0

--- a/opentelemetry-stdout/Cargo.toml
+++ b/opentelemetry-stdout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-stdout"
-version = "0.31.0"
+version = "0.32.0"
 description = "An OpenTelemetry exporter for stdout"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-stdout"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-stdout"

--- a/opentelemetry-zipkin/CHANGELOG.md
+++ b/opentelemetry-zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 - **Deprecated**: The `opentelemetry-zipkin` crate is now deprecated. Use the OTLP exporter (`opentelemetry-otlp`) instead. Zipkin supports native OTLP ingestion. This crate will be removed in a future release.
 - `reqwest`'s crypto backend has changed from `ring` to `aws-lc-sys`.
 

--- a/opentelemetry-zipkin/Cargo.toml
+++ b/opentelemetry-zipkin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-zipkin"
-version = "0.31.0"
+version = "0.32.0"
 description = "Zipkin exporter for OpenTelemetry"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-zipkin"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-zipkin"

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.0
+
+Released 2026-May-08
+
 - **Added** `BoundCounter<T>` and `BoundHistogram<T>` types that cache resolved
   aggregator references for a fixed attribute set. Created via `Counter::bind()`
   and `Histogram::bind()`, bound instruments bypass per-call attribute lookup,

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 description = "OpenTelemetry API for Rust"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry"


### PR DESCRIPTION
Bumps all crates to 0.32.0, rolls each `vNext` into a dated `## 0.32.0` section, and adds release notes at `docs/release_0.32.md`.