### PR TITLE
feat(sdk): add otel.sdk.processor.log.processed self-diagnostics metric

### DIFF
--- a/docs/design/observability.md
+++ b/docs/design/observability.md
@@ -1,0 +1,101 @@
+# SDK Self-Diagnostics via Metrics
+
+Status:
+[Development](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/document-status.md)
+
+The OpenTelemetry Rust SDK can emit metrics about its own internal state,
+following the [semantic conventions for SDK metrics](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/otel/sdk-metrics.md).
+
+## Implemented Metrics
+
+### `otel.sdk.processor.log.processed`
+
+- **Instrument**: `Counter<u64>`
+- **Unit**: `{log_record}`
+- **Description**: The number of log records for which processing has finished,
+  either successful or failed.
+- **Component**: `BatchLogProcessor`
+
+**Attributes:**
+
+| Attribute | Value |
+|-----------|-------|
+| `otel.component.type` | `batching_log_processor` |
+| `otel.component.name` | `batching_log_processor/{id}` (auto-assigned) |
+| `error.type` | `queue_full` when dropped due to full queue; `already_shutdown` when emitted after shutdown. Absent on success. |
+
+The counter is incremented on every `emit()` call: once for successful
+enqueue, once with `error.type=queue_full` when dropped due to a full queue,
+and once with `error.type=already_shutdown` when emitted after the processor
+has been shut down.
+
+## Feature Gate
+
+Self-diagnostics metrics require the `experimental_metrics_bound_instruments`
+feature on `opentelemetry_sdk`. This feature is not enabled by default.
+
+Without bound instruments, every `Counter::add()` call would need to resolve
+attributes to the internal aggregation state — roughly 50 ns per call on the
+`emit()` hot path. With bound instruments, attributes are resolved once at
+construction and subsequent `add()` calls are a single atomic increment at
+~1.8 ns. Since `emit()` is called for every log record in the application,
+this overhead matters. Bound instruments are what make self-diagnostics
+practical without measurable performance impact.
+
+## Provider Initialization Order
+
+The `BatchLogProcessor` obtains a `Meter` from the global `MeterProvider`
+during construction. Rust's `global::meter()` returns a snapshot — it does
+**not** retroactively upgrade if the global provider changes later.
+
+For self-diagnostics to produce real data, the global `MeterProvider` must be
+set **before** creating the `LoggerProvider` (and its `BatchLogProcessor`).
+The recommended setup order is:
+
+```rust
+// 1. MeterProvider first. Optionally set up a throwaway thread-local fmt
+//    subscriber so that any internal logs emitted during MeterProvider
+//    construction still appear on stdout. This is not required — without it
+//    those few startup-time debug messages are simply lost.
+let meter_provider = {
+    let _guard = tracing::subscriber::set_default(
+        tracing_subscriber::fmt().with_env_filter("info").finish(),
+    );
+    let mp = init_metrics();
+    global::set_meter_provider(mp.clone());
+    mp
+}; // _guard drops here, removing the throwaway subscriber
+
+// 2. LoggerProvider second (BatchLogProcessor picks up the real meter)
+let logger_provider = init_logs();
+
+// 3. Full tracing subscriber (fmt + OTel bridge)
+tracing_subscriber::registry()
+    .with(OpenTelemetryTracingBridge::new(&logger_provider))
+    .with(fmt::layer())
+    .init();
+
+// 4. TracerProvider last (init logs captured by OTel pipeline)
+let tracer_provider = init_traces();
+global::set_tracer_provider(tracer_provider.clone());
+```
+
+See the OTLP examples (`basic-otlp`, `basic-otlp-http`) for the full pattern
+including a temporary thread-local `fmt` subscriber during MeterProvider setup.
+
+If the `MeterProvider` is set after the `LoggerProvider`, the counter will be
+backed by a no-op meter and silently produce nothing. This is harmless but
+means no self-diagnostics data.
+
+## TODO
+
+- Emit `otel.sdk.processor.log.queue.size` (current queue depth).
+- Emit `otel.sdk.processor.log.queue.capacity` (configured max queue size).
+- Emit `otel.sdk.exporter.log.exported` from log exporters.
+- Add self-diagnostics to `BatchSpanProcessor`.
+- Add self-diagnostics to `SimpleLogProcessor`.
+- Record logs lost when `shutdown_with_timeout` times out (the background
+  thread may still hold unfinished exports and queued records).
+- Long-term: `global::meter()` currently returns a snapshot that does not
+  reflect later calls to `set_meter_provider()`. Investigate whether the
+  global meter can be made to pick up provider changes after the fact.

--- a/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp-http/src/main.rs
@@ -67,6 +67,27 @@ fn init_metrics() -> SdkMeterProvider {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    // Setup MeterProvider first so that SDK components (e.g., BatchLogProcessor)
+    // that obtain a Meter from the global MeterProvider during their
+    // initialization will get a functional meter for self-diagnostics.
+    // A temporary thread-local fmt subscriber is used to capture any logs
+    // emitted during MeterProvider initialization to stdout.
+    //
+    // Set the global meter provider using a clone of the meter_provider.
+    // Setting global meter provider is required if other parts of the application
+    // uses global::meter() or global::meter_with_version() to get a meter.
+    // Cloning simply creates a new reference to the same meter provider. It is
+    // important to hold on to the meter_provider here, so as to invoke
+    // shutdown on it when application ends.
+    let meter_provider = {
+        let _guard = tracing::subscriber::set_default(
+            tracing_subscriber::fmt().with_env_filter("info").finish(),
+        );
+        let meter_provider = init_metrics();
+        global::set_meter_provider(meter_provider.clone());
+        meter_provider
+    };
+
     let logger_provider = init_logs();
 
     // Create a new OpenTelemetryTracingBridge using the above LoggerProvider.
@@ -119,15 +140,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // shutdown on it when application ends.
     global::set_tracer_provider(tracer_provider.clone());
 
-    let meter_provider = init_metrics();
-    // Set the global meter provider using a clone of the meter_provider.
-    // Setting global meter provider is required if other parts of the application
-    // uses global::meter() or global::meter_with_version() to get a meter.
-    // Cloning simply creates a new reference to the same meter provider. It is
-    // important to hold on to the meter_provider here, so as to invoke
-    // shutdown on it when application ends.
-    global::set_meter_provider(meter_provider.clone());
-
     let common_scope_attributes = vec![KeyValue::new("scope-key", "scope-value")];
     let scope = InstrumentationScope::builder("basic")
         .with_version("1.0")
@@ -166,18 +178,21 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     info!(target: "my-target", "hello from {}. My price is {}", "apple", 1.99);
 
-    // Collect all shutdown errors
+    // Collect all shutdown errors.
+    // Shutdown order: tracer first, then logger, then meter.
+    // MeterProvider is shut down last because the LoggerProvider's
+    // BatchLogProcessor may emit self-diagnostic metrics during its shutdown.
     let mut shutdown_errors = Vec::new();
     if let Err(e) = tracer_provider.shutdown() {
         shutdown_errors.push(format!("tracer provider: {e}"));
     }
 
-    if let Err(e) = meter_provider.shutdown() {
-        shutdown_errors.push(format!("meter provider: {e}"));
-    }
-
     if let Err(e) = logger_provider.shutdown() {
         shutdown_errors.push(format!("logger provider: {e}"));
+    }
+
+    if let Err(e) = meter_provider.shutdown() {
+        shutdown_errors.push(format!("meter provider: {e}"));
     }
 
     // Return an error if any shutdown failed

--- a/opentelemetry-otlp/examples/basic-otlp/src/main.rs
+++ b/opentelemetry-otlp/examples/basic-otlp/src/main.rs
@@ -58,6 +58,27 @@ fn init_logs() -> SdkLoggerProvider {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    // Setup MeterProvider first so that SDK components (e.g., BatchLogProcessor)
+    // that obtain a Meter from the global MeterProvider during their
+    // initialization will get a functional meter for self-diagnostics.
+    // A temporary thread-local fmt subscriber is used to capture any logs
+    // emitted during MeterProvider initialization to stdout.
+    //
+    // Set the global meter provider using a clone of the meter_provider.
+    // Setting global meter provider is required if other parts of the application
+    // uses global::meter() or global::meter_with_version() to get a meter.
+    // Cloning simply creates a new reference to the same meter provider. It is
+    // important to hold on to the meter_provider here, so as to invoke
+    // shutdown on it when application ends.
+    let meter_provider = {
+        let _guard = tracing::subscriber::set_default(
+            tracing_subscriber::fmt().with_env_filter("info").finish(),
+        );
+        let meter_provider = init_metrics();
+        global::set_meter_provider(meter_provider.clone());
+        meter_provider
+    };
+
     let logger_provider = init_logs();
 
     // Create a new OpenTelemetryTracingBridge using the above LoggerProvider.
@@ -110,15 +131,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // shutdown on it when application ends.
     global::set_tracer_provider(tracer_provider.clone());
 
-    let meter_provider = init_metrics();
-    // Set the global meter provider using a clone of the meter_provider.
-    // Setting global meter provider is required if other parts of the application
-    // uses global::meter() or global::meter_with_version() to get a meter.
-    // Cloning simply creates a new reference to the same meter provider. It is
-    // important to hold on to the meter_provider here, so as to invoke
-    // shutdown on it when application ends.
-    global::set_meter_provider(meter_provider.clone());
-
     let common_scope_attributes = vec![KeyValue::new("scope-key", "scope-value")];
     let scope = InstrumentationScope::builder("basic")
         .with_version("1.0")
@@ -156,18 +168,21 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
     info!(name: "my-event", target: "my-target", "hello from {}. My price is {}", "apple", 1.99);
 
-    // Collect all shutdown errors
+    // Collect all shutdown errors.
+    // Shutdown order: tracer first, then logger, then meter.
+    // MeterProvider is shut down last because the LoggerProvider's
+    // BatchLogProcessor may emit self-diagnostic metrics during its shutdown.
     let mut shutdown_errors = Vec::new();
     if let Err(e) = tracer_provider.shutdown() {
         shutdown_errors.push(format!("tracer provider: {e}"));
     }
 
-    if let Err(e) = meter_provider.shutdown() {
-        shutdown_errors.push(format!("meter provider: {e}"));
-    }
-
     if let Err(e) = logger_provider.shutdown() {
         shutdown_errors.push(format!("logger provider: {e}"));
+    }
+
+    if let Err(e) = meter_provider.shutdown() {
+        shutdown_errors.push(format!("meter provider: {e}"));
     }
 
     // Return an error if any shutdown failed

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -25,6 +25,9 @@ use std::sync::mpsc::{self, RecvTimeoutError, SyncSender};
 
 use opentelemetry::{otel_debug, otel_error, otel_warn, Context, InstrumentationScope};
 
+#[cfg(feature = "experimental_metrics_bound_instruments")]
+use opentelemetry::KeyValue;
+
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::{cmp::min, env, sync::Mutex};
 use std::{
@@ -142,6 +145,17 @@ pub struct BatchLogProcessor {
 
     // Track the maximum queue size that was configured for this processor
     max_queue_size: usize,
+
+    // Self-diagnostics: otel.sdk.processor.log.processed counter.
+    // Gated behind experimental_metrics_bound_instruments so the hot-path
+    // `add` is a single atomic increment (~1.8 ns) with no per-call
+    // attribute resolution.
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    processed_success: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    processed_queue_full: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    processed_after_shutdown: opentelemetry::metrics::BoundCounter<u64>,
 }
 
 impl Debug for BatchLogProcessor {
@@ -161,6 +175,10 @@ impl LogProcessor for BatchLogProcessor {
         // match for result and handle each separately
         match result {
             Ok(_) => {
+                // Record successful processing in self-diagnostics
+                #[cfg(feature = "experimental_metrics_bound_instruments")]
+                self.processed_success.add(1);
+
                 // Successfully sent the log record to the data channel.
                 // Increment the current batch size and check if it has reached
                 // the max export batch size.
@@ -202,6 +220,10 @@ impl LogProcessor for BatchLogProcessor {
                 }
             }
             Err(mpsc::TrySendError::Full(_)) => {
+                // Record queue-full drop in self-diagnostics
+                #[cfg(feature = "experimental_metrics_bound_instruments")]
+                self.processed_queue_full.add(1);
+
                 // Increment dropped logs count. The first time we have to drop
                 // a log, emit a warning.
                 if self.dropped_logs_count.fetch_add(1, Ordering::Relaxed) == 0 {
@@ -210,6 +232,10 @@ impl LogProcessor for BatchLogProcessor {
                 }
             }
             Err(mpsc::TrySendError::Disconnected(_)) => {
+                // Record after-shutdown drop in self-diagnostics
+                #[cfg(feature = "experimental_metrics_bound_instruments")]
+                self.processed_after_shutdown.add(1);
+
                 // The following `otel_warn!` may cause an infinite feedback loop of
                 // 'telemetry-induced-telemetry', potentially causing a stack overflow
                 let _guard = Context::enter_telemetry_suppressed_scope();
@@ -287,6 +313,13 @@ impl LogProcessor for BatchLogProcessor {
                     })
                     .map_err(|err| match err {
                         RecvTimeoutError::Timeout => {
+                            // TODO: When shutdown times out, log records still
+                            // in the queue or mid-export are silently lost. The
+                            // background thread is not joined and may continue
+                            // running. Consider: (1) recording the lost count
+                            // in the self-diagnostics counter, (2) joining the
+                            // thread with a best-effort wait, or (3) signalling
+                            // the thread to abort the current export.
                             otel_error!(
                                 name: "BatchLogProcessor.Shutdown.Timeout",
                                 message = "BatchLogProcessor shutdown timing out."
@@ -492,6 +525,48 @@ impl BatchLogProcessor {
             })
             .expect("Thread spawn failed."); //TODO: Handle thread spawn failure
 
+        // Self-diagnostics: create the otel.sdk.processor.log.processed counter
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        let (processed_success, processed_queue_full, processed_after_shutdown) = {
+            static INSTANCE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+            let instance_id = INSTANCE_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let component_name = format!("batching_log_processor/{instance_id}");
+
+            let meter = opentelemetry::global::meter("otel.sdk");
+            let counter = meter
+                .u64_counter("otel.sdk.processor.log.processed")
+                .with_description(
+                    "The number of log records for which the processing has finished, \
+                     either successful or failed.",
+                )
+                .with_unit("{log_record}")
+                .build();
+
+            // Attribute values follow the OTel semantic conventions for SDK metrics:
+            // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/otel/sdk-metrics.md#metric-otelsdkprocessorlogprocessed
+            // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/otel.md#otel-component-attributes
+            let success_attrs = [
+                KeyValue::new("otel.component.type", "batching_log_processor"),
+                KeyValue::new("otel.component.name", component_name.clone()),
+            ];
+            let queue_full_attrs = [
+                KeyValue::new("error.type", "queue_full"),
+                KeyValue::new("otel.component.type", "batching_log_processor"),
+                KeyValue::new("otel.component.name", component_name.clone()),
+            ];
+            let after_shutdown_attrs = [
+                KeyValue::new("error.type", "already_shutdown"),
+                KeyValue::new("otel.component.type", "batching_log_processor"),
+                KeyValue::new("otel.component.name", component_name),
+            ];
+
+            (
+                counter.bind(&success_attrs),
+                counter.bind(&queue_full_attrs),
+                counter.bind(&after_shutdown_attrs),
+            )
+        };
+
         // Return batch processor with link to worker
         BatchLogProcessor {
             logs_sender,
@@ -503,6 +578,12 @@ impl BatchLogProcessor {
             export_log_message_sent: Arc::new(AtomicBool::new(false)),
             current_batch_size,
             max_export_batch_size,
+            #[cfg(feature = "experimental_metrics_bound_instruments")]
+            processed_success,
+            #[cfg(feature = "experimental_metrics_bound_instruments")]
+            processed_queue_full,
+            #[cfg(feature = "experimental_metrics_bound_instruments")]
+            processed_after_shutdown,
         }
     }
 
@@ -1116,5 +1197,75 @@ mod tests {
             "Expected some logs to be dropped under stress, but none were. \
              Consider reducing queue size or increasing thread count/log volume."
         );
+    }
+
+    /// Verifies that `otel.sdk.processor.log.processed` counter records
+    /// successful log processing when `experimental_metrics_bound_instruments`
+    /// is enabled and a real MeterProvider is set as global before creating
+    /// the processor.
+    ///
+    /// This test is `#[ignore]`d because it calls
+    /// `global::set_meter_provider()` which mutates process-wide state.
+    /// CI runs it in isolation via `test.sh`.
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[test]
+    #[ignore]
+    fn self_diagnostics_counter_records_success() {
+        use crate::metrics::data::{AggregatedMetrics, MetricData};
+        use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+
+        // Setup a real MeterProvider and set it as global BEFORE creating the
+        // BatchLogProcessor, so the processor picks up a real meter.
+        let metric_exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(metric_exporter.clone())
+            .build();
+        opentelemetry::global::set_meter_provider(meter_provider.clone());
+
+        let log_exporter = InMemoryLogExporter::default();
+        let config = BatchConfigBuilder::default()
+            .with_max_queue_size(256)
+            .with_max_export_batch_size(64)
+            .with_scheduled_delay(Duration::from_secs(60))
+            .build();
+        let processor = BatchLogProcessor::new(log_exporter, config);
+
+        // Emit 10 logs
+        let instrumentation = InstrumentationScope::default();
+        for _ in 0..10 {
+            let mut record = SdkLogRecord::new();
+            processor.emit(&mut record, &instrumentation);
+        }
+
+        // Force a metrics collection
+        meter_provider.force_flush().unwrap();
+
+        // Find the otel.sdk.processor.log.processed metric and sum all data points
+        let metrics = metric_exporter.get_finished_metrics().unwrap();
+        let mut found = false;
+        let mut total_value: u64 = 0;
+        for rm in &metrics {
+            for sm in &rm.scope_metrics {
+                for metric in &sm.metrics {
+                    if metric.name == "otel.sdk.processor.log.processed" {
+                        found = true;
+                        if let AggregatedMetrics::U64(MetricData::Sum(sum)) = &metric.data {
+                            for dp in sum.data_points() {
+                                total_value += dp.value();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        assert!(found, "otel.sdk.processor.log.processed metric not found");
+        assert_eq!(
+            total_value, 10,
+            "Expected 10 processed logs, got {total_value}"
+        );
+
+        processor.shutdown().unwrap();
+        meter_provider.shutdown().unwrap();
     }
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -30,6 +30,9 @@ cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features trace::ru
 cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features trace::runtime_tests::test_set_provider_single_thread_tokio -- --ignored --exact
 cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features trace::runtime_tests::test_set_provider_single_thread_tokio_shutdown -- --ignored --exact
 
+echo "Running ignored tests for opentelemetry-sdk package (self-diagnostics, requires global MeterProvider)"
+cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features logs::batch_log_processor::tests::self_diagnostics_counter_records_success -- --ignored --exact
+
 echo "Running ignored tests for opentelemetry-appender-tracing package (global logger tests)"
 cargo test --manifest-path=opentelemetry-appender-tracing/Cargo.toml --all-features layer::tests::tracing_appender_standalone_with_tracing_log -- --ignored --exact
 cargo test --manifest-path=opentelemetry-appender-tracing/Cargo.toml --all-features layer::tests::tracing_appender_inside_tracing_context_with_tracing_log -- --ignored --exact


### PR DESCRIPTION
Adds the `otel.sdk.processor.log.processed` counter to `BatchLogProcessor`, following the [OTel SDK metrics semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/otel/sdk-metrics.md#metric-otelsdkprocessorlogprocessed).

Gated behind the existing `experimental_metrics_bound_instruments` feature flag — bound instruments make this practical on the hot path (~1.8 ns per emit vs ~50 ns with unbound).

**Changes:**
- `BatchLogProcessor` emits a counter on every `emit()` call with three attribute variants: success, `queue_full`, and `already_shutdown`
- OTLP examples reordered to set up MeterProvider first (so the processor gets a real meter)
- Shutdown order corrected to tracer → logger → meter
- Design doc added at `docs/design/observability.md`
- Ignored test added (runs in isolation in CI via `test.sh`)

**Ordering requirement:** `global::set_meter_provider()` must be called before creating the `LoggerProvider`. Rust's `global::meter()` returns a snapshot, not a delegate. See the design doc for details.
