### PR TITLE
feat(stress): add bound counter/histogram stress tests

### DIFF
--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -25,6 +25,20 @@ path = "src/metrics_histogram.rs"
 doc = false
 bench = false
 
+[[bin]] # Bin to run the metrics stress tests for bound Counter
+name = "metrics_counter_bound"
+path = "src/metrics_counter_bound.rs"
+required-features = ["experimental_metrics_bound_instruments"]
+doc = false
+bench = false
+
+[[bin]] # Bin to run the metrics stress tests for bound Histogram
+name = "metrics_histogram_bound"
+path = "src/metrics_histogram_bound.rs"
+required-features = ["experimental_metrics_bound_instruments"]
+doc = false
+bench = false
+
 [[bin]] # Bin to run the metrics overflow stress tests
 name = "metrics_overflow"
 path = "src/metrics_overflow.rs"
@@ -64,6 +78,7 @@ sysinfo = { workspace = true, optional = true }
 
 [features]
 stats = ["sysinfo"]
+experimental_metrics_bound_instruments = ["opentelemetry/experimental_metrics_bound_instruments"]
 
 [lints]
 workspace = true

--- a/stress/src/logs.rs
+++ b/stress/src/logs.rs
@@ -1,9 +1,10 @@
 /*
     Stress test results:
-    Hardware: Apple M4 Pro
-    Total Number of Cores:	14 (10 performance and 4 efficiency)
-    ~27 M/sec
-    ~1.4 B/sec (when disabled)
+    OS: macOS 26.4.1
+    Hardware: Apple M4 Pro, 14 cores (10 performance + 4 efficiency)
+    RAM: 24.0 GB
+    ~27 M /sec
+    ~1.4 B /sec (when disabled)
 */
 use opentelemetry::logs::Severity;
 use opentelemetry::InstrumentationScope;

--- a/stress/src/metrics_counter.rs
+++ b/stress/src/metrics_counter.rs
@@ -7,6 +7,11 @@
 
     Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
     ~20 M /sec
+
+    OS: macOS 26.4.1
+    Hardware: Apple M4 Pro, 14 cores (10 performance + 4 efficiency)
+    RAM: 24.0 GB
+    ~1.65 M /sec
 */
 
 use lazy_static::lazy_static;

--- a/stress/src/metrics_counter_bound.rs
+++ b/stress/src/metrics_counter_bound.rs
@@ -1,0 +1,45 @@
+/*
+    Stress test for bound Counter instrument.
+
+    Run with:
+        cargo run --release --bin metrics_counter_bound \
+            --features experimental_metrics_bound_instruments
+
+    Stress test results:
+    OS: macOS 26.4.1
+    Hardware: Apple M4 Pro, 14 cores (10 performance + 4 efficiency)
+    RAM: 24.0 GB
+    ~13 B /sec
+*/
+
+use lazy_static::lazy_static;
+use opentelemetry::{
+    metrics::{BoundCounter, Counter, MeterProvider as _},
+    KeyValue,
+};
+use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
+
+mod throughput;
+
+lazy_static! {
+    static ref PROVIDER: SdkMeterProvider = SdkMeterProvider::builder()
+        .with_reader(ManualReader::builder().build())
+        .build();
+    static ref COUNTER: Counter<u64> = PROVIDER.meter("test").u64_counter("hello").build();
+    // A single bound counter created once at startup. The hot path simply
+    // calls add(1) on it, exercising the bound-instrument fast path with no
+    // per-call attribute resolution.
+    static ref BOUND_COUNTER: BoundCounter<u64> = COUNTER.bind(&[
+        KeyValue::new("attribute1", "value1"),
+        KeyValue::new("attribute2", "value2"),
+        KeyValue::new("attribute3", "value3"),
+    ]);
+}
+
+fn main() {
+    throughput::test_throughput(test_counter_bound);
+}
+
+fn test_counter_bound() {
+    BOUND_COUNTER.add(1);
+}

--- a/stress/src/metrics_gauge.rs
+++ b/stress/src/metrics_gauge.rs
@@ -4,6 +4,11 @@
     Hardware: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz, 16vCPUs,
     RAM: 64.0 GB
     ~11.5 M/sec
+
+    OS: macOS 26.4.1
+    Hardware: Apple M4 Pro, 14 cores (10 performance + 4 efficiency)
+    RAM: 24.0 GB
+    ~1.6 M /sec
 */
 
 use lazy_static::lazy_static;

--- a/stress/src/metrics_histogram.rs
+++ b/stress/src/metrics_histogram.rs
@@ -7,6 +7,11 @@
 
     Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
     ~12.0 M /sec
+
+    OS: macOS 26.4.1
+    Hardware: Apple M4 Pro, 14 cores (10 performance + 4 efficiency)
+    RAM: 24.0 GB
+    ~1.5 M /sec
 */
 
 use lazy_static::lazy_static;

--- a/stress/src/metrics_histogram_bound.rs
+++ b/stress/src/metrics_histogram_bound.rs
@@ -1,0 +1,45 @@
+/*
+    Stress test for bound Histogram instrument.
+
+    Run with:
+        cargo run --release --bin metrics_histogram_bound \
+            --features experimental_metrics_bound_instruments
+
+    Stress test results:
+    OS: macOS 26.4.1
+    Hardware: Apple M4 Pro, 14 cores (10 performance + 4 efficiency)
+    RAM: 24.0 GB
+    ~11 B /sec
+*/
+
+use lazy_static::lazy_static;
+use opentelemetry::{
+    metrics::{BoundHistogram, Histogram, MeterProvider as _},
+    KeyValue,
+};
+use opentelemetry_sdk::metrics::{ManualReader, SdkMeterProvider};
+
+mod throughput;
+
+lazy_static! {
+    static ref PROVIDER: SdkMeterProvider = SdkMeterProvider::builder()
+        .with_reader(ManualReader::builder().build())
+        .build();
+    static ref HISTOGRAM: Histogram<u64> = PROVIDER.meter("test").u64_histogram("hello").build();
+    // A single bound histogram created once at startup. The hot path simply
+    // calls record() on it, exercising the bound-instrument fast path with no
+    // per-call attribute resolution.
+    static ref BOUND_HISTOGRAM: BoundHistogram<u64> = HISTOGRAM.bind(&[
+        KeyValue::new("attribute1", "value1"),
+        KeyValue::new("attribute2", "value2"),
+        KeyValue::new("attribute3", "value3"),
+    ]);
+}
+
+fn main() {
+    throughput::test_throughput(test_histogram_bound);
+}
+
+fn test_histogram_bound() {
+    BOUND_HISTOGRAM.record(1);
+}

--- a/stress/src/traces.rs
+++ b/stress/src/traces.rs
@@ -7,6 +7,11 @@
 
     Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
     ~10.6 M /sec
+
+    OS: macOS 26.4.1
+    Hardware: Apple M4 Pro, 14 cores (10 performance + 4 efficiency)
+    RAM: 24.0 GB
+    ~5.2 M /sec
 */
 use lazy_static::lazy_static;
 use opentelemetry::{


### PR DESCRIPTION
Adds two new stress test bins for the bound instruments API (gated behind `experimental_metrics_bound_instruments`):

- `metrics_counter_bound` — single `BoundCounter` created at startup; hot loop calls `add(1)`.
- `metrics_histogram_bound` — single `BoundHistogram` created at startup; hot loop calls `record(1)`.

This complements the existing bound-instrument benchmark in [opentelemetry-sdk/benches/bound_instruments.rs](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-sdk/benches/bound_instruments.rs) by exercising the same hot path under sustained multi-threaded load.

Also refreshes the throughput numbers in the headers of all metric/trace/log stress tests with results captured on Apple M4 Pro (macOS 26.4.1, 14 cores), since none of the existing tests had numbers recorded for this hardware.