### PR TITLE
feat(sdk): relax instrument name validation; remove experimental_metrics_disable_name_validation feature

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## vNext
 
+- **Relaxed instrument name validation** to accept the expanded character set
+  defined by the OpenTelemetry specification. The allowed character set now
+  includes `:`, `\`, `(`, `)`, `%`, `*`, `#`, and space (with space restricted
+  to non-leading, non-trailing positions), and the first character is no
+  longer required to be alphabetic. This enables names shaped like Windows
+  performance counters (`\Processor(_Total)\% Processor Time`,
+  `\.NET CLR Memory(*)\# Bytes in all Heaps`) to be used directly without
+  workarounds. ASCII, case-insensitivity, and the 255-character maximum are
+  unchanged. See
+  [opentelemetry-specification#5092](https://github.com/open-telemetry/opentelemetry-specification/pull/5092).
+- **Removed** the `experimental_metrics_disable_name_validation` Cargo feature.
+  With the relaxed validation rules above, the use cases this feature was
+  introduced for (notably Windows performance counter names) are now supported
+  by the default validation. Consumers that previously enabled this feature
+  should drop it from their Cargo.toml.
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -58,7 +58,6 @@ spec_unstable_metrics_views = ["metrics"]
 experimental_metrics_custom_reader = ["metrics"]
 experimental_logs_batch_log_processor_with_async_runtime = ["logs", "experimental_async_runtime"]
 experimental_trace_batch_span_processor_with_async_runtime = ["tokio/sync", "trace", "experimental_async_runtime"]
-experimental_metrics_disable_name_validation = ["metrics"]
 experimental_metrics_bound_instruments = ["metrics", "opentelemetry/experimental_metrics_bound_instruments"]
 bench_profiling = []
 

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -489,7 +489,10 @@ mod tests {
             // Still invalid: characters outside the allowlist
             ("\\allow\\$$slash /sec", INSTRUMENT_NAME_INVALID_CHAR),
             ("Total $ Count", INSTRUMENT_NAME_INVALID_CHAR),
-            ("\\test\\UsagePercent(Total) > 80%", INSTRUMENT_NAME_INVALID_CHAR),
+            (
+                "\\test\\UsagePercent(Total) > 80%",
+                INSTRUMENT_NAME_INVALID_CHAR,
+            ),
         ];
 
         for (name, expected_error) in stream_name_test_cases {

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -12,8 +12,8 @@ use crate::metrics::internal::BoundMeasure;
 use crate::metrics::{aggregation::Aggregation, internal::Measure};
 
 use super::meter::{
-    INSTRUMENT_NAME_EMPTY, INSTRUMENT_NAME_FIRST_ALPHABETIC, INSTRUMENT_NAME_INVALID_CHAR,
-    INSTRUMENT_NAME_LENGTH, INSTRUMENT_UNIT_INVALID_CHAR, INSTRUMENT_UNIT_LENGTH,
+    INSTRUMENT_NAME_EMPTY, INSTRUMENT_NAME_INVALID_CHAR, INSTRUMENT_NAME_LENGTH,
+    INSTRUMENT_UNIT_INVALID_CHAR, INSTRUMENT_UNIT_LENGTH,
 };
 
 use super::Temporality;
@@ -231,12 +231,14 @@ impl StreamBuilder {
                 return Err(INSTRUMENT_NAME_LENGTH.into());
             }
 
-            if name.starts_with(|c: char| !c.is_ascii_alphabetic()) {
-                return Err(INSTRUMENT_NAME_FIRST_ALPHABETIC.into());
+            // First and last character must not be a space.
+            if name.starts_with(' ') || name.ends_with(' ') {
+                return Err(INSTRUMENT_NAME_INVALID_CHAR.into());
             }
 
             if name.contains(|c: char| {
-                !c.is_ascii_alphanumeric()
+                c != ' '
+                    && !c.is_ascii_alphanumeric()
                     && !super::meter::INSTRUMENT_NAME_ALLOWED_NON_ALPHANUMERIC_CHARS.contains(&c)
             }) {
                 return Err(INSTRUMENT_NAME_INVALID_CHAR.into());
@@ -445,32 +447,49 @@ impl<T: Copy + Send + Sync + 'static> AsyncInstrument<T> for Observable<T> {
 mod tests {
     use super::StreamBuilder;
     use crate::metrics::meter::{
-        INSTRUMENT_NAME_EMPTY, INSTRUMENT_NAME_FIRST_ALPHABETIC, INSTRUMENT_NAME_INVALID_CHAR,
-        INSTRUMENT_NAME_LENGTH, INSTRUMENT_UNIT_INVALID_CHAR, INSTRUMENT_UNIT_LENGTH,
+        INSTRUMENT_NAME_EMPTY, INSTRUMENT_NAME_INVALID_CHAR, INSTRUMENT_NAME_LENGTH,
+        INSTRUMENT_UNIT_INVALID_CHAR, INSTRUMENT_UNIT_LENGTH,
     };
 
     #[test]
     fn stream_name_validation() {
         // (name, expected error)
         let stream_name_test_cases = vec![
+            // Standard names
             ("validateName", ""),
-            ("_startWithNoneAlphabet", INSTRUMENT_NAME_FIRST_ALPHABETIC),
-            ("utf8char锈", INSTRUMENT_NAME_INVALID_CHAR),
             ("a".repeat(255).leak(), ""),
-            ("a".repeat(256).leak(), INSTRUMENT_NAME_LENGTH),
-            ("invalid name", INSTRUMENT_NAME_INVALID_CHAR),
             ("allow/slash", ""),
             ("allow_under_score", ""),
             ("allow.dots.ok", ""),
+            // Empty / length / non-ASCII
             ("", INSTRUMENT_NAME_EMPTY),
-            ("\\allow\\slash /sec", INSTRUMENT_NAME_FIRST_ALPHABETIC),
-            ("\\allow\\$$slash /sec", INSTRUMENT_NAME_FIRST_ALPHABETIC),
+            ("a".repeat(256).leak(), INSTRUMENT_NAME_LENGTH),
+            ("utf8char锈", INSTRUMENT_NAME_INVALID_CHAR),
+            // Newly valid: leading non-alphabetic characters and new chars
+            ("_startWithUnderscore", ""),
+            ("-startWithDash", ""),
+            ("1startWithDigit", ""),
+            (":startWithColon", ""),
+            ("\\startWithBackslash", ""),
+            ("with:colon", ""),
+            ("with\\backslash", ""),
+            ("with(parens)", ""),
+            ("with%percent", ""),
+            ("with*asterisk", ""),
+            ("with#hash", ""),
+            // Newly valid: space in middle and Windows perf counter shapes
+            ("invalid name", ""),
+            ("\\Processor(_Total)\\% Processor Time", ""),
+            ("\\.NET CLR Memory(*)\\# Bytes in all Heaps", ""),
+            ("\\allow\\slash /sec", ""),
+            ("/not / allowed but now is", ""),
+            // Still invalid: leading / trailing space
+            (" leadingSpace", INSTRUMENT_NAME_INVALID_CHAR),
+            ("trailingSpace ", INSTRUMENT_NAME_INVALID_CHAR),
+            // Still invalid: characters outside the allowlist
+            ("\\allow\\$$slash /sec", INSTRUMENT_NAME_INVALID_CHAR),
             ("Total $ Count", INSTRUMENT_NAME_INVALID_CHAR),
-            (
-                "\\test\\UsagePercent(Total) > 80%",
-                INSTRUMENT_NAME_FIRST_ALPHABETIC,
-            ),
-            ("/not / allowed", INSTRUMENT_NAME_FIRST_ALPHABETIC),
+            ("\\test\\UsagePercent(Total) > 80%", INSTRUMENT_NAME_INVALID_CHAR),
         ];
 
         for (name, expected_error) in stream_name_test_cases {

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -24,16 +24,16 @@ use super::noop::NoopSyncInstrument;
 pub(crate) const INSTRUMENT_NAME_MAX_LENGTH: usize = 255;
 // maximum length of instrument unit name
 pub(crate) const INSTRUMENT_UNIT_NAME_MAX_LENGTH: usize = 63;
-// Characters allowed in instrument name
-pub(crate) const INSTRUMENT_NAME_ALLOWED_NON_ALPHANUMERIC_CHARS: [char; 4] = ['_', '.', '-', '/'];
+// Non-alphanumeric characters allowed in instrument name (in addition to ASCII
+// alphanumeric). Space is also allowed but is treated separately because it is
+// only permitted in non-leading, non-trailing positions.
+pub(crate) const INSTRUMENT_NAME_ALLOWED_NON_ALPHANUMERIC_CHARS: [char; 11] =
+    ['_', '.', '-', '/', ':', '\\', '(', ')', '%', '*', '#'];
 
 // name validation error strings
 pub(crate) const INSTRUMENT_NAME_EMPTY: &str = "name must be non-empty";
 pub(crate) const INSTRUMENT_NAME_LENGTH: &str = "name must be less than 256 characters";
-pub(crate) const INSTRUMENT_NAME_INVALID_CHAR: &str =
-    "characters in name must be ASCII and belong to the alphanumeric characters, '_', '.', '-' and '/'";
-pub(crate) const INSTRUMENT_NAME_FIRST_ALPHABETIC: &str =
-    "name must start with an alphabetic character";
+pub(crate) const INSTRUMENT_NAME_INVALID_CHAR: &str = "characters in name must be ASCII alphanumeric or one of '_', '.', '-', '/', ':', '\\', '(', ')', '%', '*', '#', or space; first and last characters must not be a space";
 
 // unit validation error strings
 pub(crate) const INSTRUMENT_UNIT_LENGTH: &str = "unit must be less than 64 characters";
@@ -574,13 +574,6 @@ fn validate_bucket_boundaries(boundaries: &[f64]) -> MetricResult<()> {
     Ok(())
 }
 
-#[cfg(feature = "experimental_metrics_disable_name_validation")]
-fn validate_instrument_name(_name: &str) -> MetricResult<()> {
-    // No name restrictions when name validation is disabled
-    Ok(())
-}
-
-#[cfg(not(feature = "experimental_metrics_disable_name_validation"))]
 fn validate_instrument_name(name: &str) -> MetricResult<()> {
     if name.is_empty() {
         return Err(MetricError::InvalidInstrumentConfiguration(
@@ -593,13 +586,27 @@ fn validate_instrument_name(name: &str) -> MetricResult<()> {
         ));
     }
 
-    if name.starts_with(|c: char| !c.is_ascii_alphabetic()) {
+    // First character must not be a space.
+    if name.starts_with(' ') {
         return Err(MetricError::InvalidInstrumentConfiguration(
-            INSTRUMENT_NAME_FIRST_ALPHABETIC,
+            INSTRUMENT_NAME_INVALID_CHAR,
         ));
     }
+
+    // Last character must not be a space.
+    if name.ends_with(' ') {
+        return Err(MetricError::InvalidInstrumentConfiguration(
+            INSTRUMENT_NAME_INVALID_CHAR,
+        ));
+    }
+
+    // Every character must be ASCII alphanumeric, one of the allowed
+    // non-alphanumeric characters, or a space (space allowed in middle only;
+    // leading/trailing already rejected above).
     if name.contains(|c: char| {
-        !c.is_ascii_alphanumeric() && !INSTRUMENT_NAME_ALLOWED_NON_ALPHANUMERIC_CHARS.contains(&c)
+        c != ' '
+            && !c.is_ascii_alphanumeric()
+            && !INSTRUMENT_NAME_ALLOWED_NON_ALPHANUMERIC_CHARS.contains(&c)
     }) {
         return Err(MetricError::InvalidInstrumentConfiguration(
             INSTRUMENT_NAME_INVALID_CHAR,
@@ -688,80 +695,82 @@ mod tests {
 
     use super::{
         validate_instrument_name, validate_instrument_unit, INSTRUMENT_NAME_EMPTY,
-        INSTRUMENT_NAME_FIRST_ALPHABETIC, INSTRUMENT_NAME_INVALID_CHAR, INSTRUMENT_NAME_LENGTH,
-        INSTRUMENT_UNIT_INVALID_CHAR, INSTRUMENT_UNIT_LENGTH,
+        INSTRUMENT_NAME_INVALID_CHAR, INSTRUMENT_NAME_LENGTH, INSTRUMENT_UNIT_INVALID_CHAR,
+        INSTRUMENT_UNIT_LENGTH,
     };
 
     #[test]
-    #[cfg(not(feature = "experimental_metrics_disable_name_validation"))]
     fn instrument_name_validation() {
         // (name, expected error)
         let instrument_name_test_cases = vec![
+            // Standard names
             ("validateName", ""),
-            ("_startWithNoneAlphabet", INSTRUMENT_NAME_FIRST_ALPHABETIC),
-            ("utf8char锈", INSTRUMENT_NAME_INVALID_CHAR),
             ("a".repeat(255).leak(), ""),
-            ("a".repeat(256).leak(), INSTRUMENT_NAME_LENGTH),
-            ("invalid name", INSTRUMENT_NAME_INVALID_CHAR),
             ("allow/slash", ""),
             ("allow_under_score", ""),
             ("allow.dots.ok", ""),
+            // Empty / length / non-ASCII
             ("", INSTRUMENT_NAME_EMPTY),
-            ("\\allow\\slash /sec", INSTRUMENT_NAME_FIRST_ALPHABETIC),
-            ("\\allow\\$$slash /sec", INSTRUMENT_NAME_FIRST_ALPHABETIC),
-            ("Total $ Count", INSTRUMENT_NAME_INVALID_CHAR),
-            (
-                "\\test\\UsagePercent(Total) > 80%",
-                INSTRUMENT_NAME_FIRST_ALPHABETIC,
-            ),
-            ("/not / allowed", INSTRUMENT_NAME_FIRST_ALPHABETIC),
-        ];
-        for (name, expected_error) in instrument_name_test_cases {
-            let assert = |result: Result<_, MetricError>| {
-                if expected_error.is_empty() {
-                    assert!(result.is_ok());
-                } else {
-                    assert!(matches!(
-                        result.unwrap_err(),
-                        MetricError::InvalidInstrumentConfiguration(msg) if msg == expected_error
-                    ));
-                }
-            };
-
-            assert(validate_instrument_name(name).map(|_| ()));
-        }
-    }
-
-    #[test]
-    #[cfg(feature = "experimental_metrics_disable_name_validation")]
-    fn instrument_name_validation_disabled() {
-        // (name, expected error)
-        let instrument_name_test_cases = vec![
-            ("validateName", ""),
-            ("_startWithNoneAlphabet", ""),
-            ("utf8char锈", ""),
-            ("a".repeat(255).leak(), ""),
-            ("a".repeat(256).leak(), ""),
+            ("a".repeat(256).leak(), INSTRUMENT_NAME_LENGTH),
+            ("utf8char锈", INSTRUMENT_NAME_INVALID_CHAR),
+            // Newly valid: leading non-alphabetic characters
+            ("_startWithUnderscore", ""),
+            ("-startWithDash", ""),
+            (".startWithDot", ""),
+            ("1startWithDigit", ""),
+            (":startWithColon", ""),
+            ("\\startWithBackslash", ""),
+            ("(startWithParen", ""),
+            ("%startWithPercent", ""),
+            ("*startWithAsterisk", ""),
+            ("#startWithHash", ""),
+            // Newly valid: ':', '\', '(', ')', '%', '*', '#'
+            ("with:colon", ""),
+            ("with\\backslash", ""),
+            ("with(parens)", ""),
+            ("with%percent", ""),
+            ("with*asterisk", ""),
+            ("with#hash", ""),
+            // Newly valid: space in middle
             ("invalid name", ""),
-            ("allow/slash", ""),
-            ("allow_under_score", ""),
-            ("allow.dots.ok", ""),
-            ("", ""),
+            ("name with multiple words", ""),
+            ("name with  consecutive  spaces", ""),
+            // Newly valid: real-world Windows performance counter shapes
+            ("\\Processor(_Total)\\% Processor Time", ""),
+            ("\\Memory\\Available Bytes", ""),
+            ("\\.NET CLR Memory(*)\\# Bytes in all Heaps", ""),
+            ("\\.NET CLR Memory(_Global_)\\# Gen 0 Collections", ""),
+            ("\\test\\UsagePercent(Total) 80%", ""),
             ("\\allow\\slash /sec", ""),
-            ("\\allow\\$$slash /sec", ""),
-            ("Total $ Count", ""),
-            ("\\test\\UsagePercent(Total) > 80%", ""),
-            ("/not / allowed", ""),
+            ("/not / allowed but now is", ""),
+            // Still invalid: leading / trailing space
+            (" leadingSpace", INSTRUMENT_NAME_INVALID_CHAR),
+            ("trailingSpace ", INSTRUMENT_NAME_INVALID_CHAR),
+            (" ", INSTRUMENT_NAME_INVALID_CHAR),
+            ("   ", INSTRUMENT_NAME_INVALID_CHAR),
+            // Still invalid: characters outside the allowlist
+            ("\\allow\\$$slash /sec", INSTRUMENT_NAME_INVALID_CHAR),
+            ("Total $ Count", INSTRUMENT_NAME_INVALID_CHAR),
+            ("\\test\\UsagePercent(Total) > 80%", INSTRUMENT_NAME_INVALID_CHAR),
+            ("name\twith\ttab", INSTRUMENT_NAME_INVALID_CHAR),
+            ("name\nwith\nnewline", INSTRUMENT_NAME_INVALID_CHAR),
+            ("name+with+plus", INSTRUMENT_NAME_INVALID_CHAR),
+            ("name[with[bracket", INSTRUMENT_NAME_INVALID_CHAR),
+            ("name;with;semicolon", INSTRUMENT_NAME_INVALID_CHAR),
+            ("name=with=equals", INSTRUMENT_NAME_INVALID_CHAR),
         ];
         for (name, expected_error) in instrument_name_test_cases {
             let assert = |result: Result<_, MetricError>| {
                 if expected_error.is_empty() {
-                    assert!(result.is_ok());
+                    assert!(
+                        result.is_ok(),
+                        "expected {name:?} to be valid, but got error: {result:?}"
+                    );
                 } else {
                     assert!(matches!(
                         result.unwrap_err(),
                         MetricError::InvalidInstrumentConfiguration(msg) if msg == expected_error
-                    ));
+                    ), "expected {name:?} to fail with {expected_error:?}");
                 }
             };
 

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -751,7 +751,10 @@ mod tests {
             // Still invalid: characters outside the allowlist
             ("\\allow\\$$slash /sec", INSTRUMENT_NAME_INVALID_CHAR),
             ("Total $ Count", INSTRUMENT_NAME_INVALID_CHAR),
-            ("\\test\\UsagePercent(Total) > 80%", INSTRUMENT_NAME_INVALID_CHAR),
+            (
+                "\\test\\UsagePercent(Total) > 80%",
+                INSTRUMENT_NAME_INVALID_CHAR,
+            ),
             ("name\twith\ttab", INSTRUMENT_NAME_INVALID_CHAR),
             ("name\nwith\nnewline", INSTRUMENT_NAME_INVALID_CHAR),
             ("name+with+plus", INSTRUMENT_NAME_INVALID_CHAR),
@@ -767,10 +770,13 @@ mod tests {
                         "expected {name:?} to be valid, but got error: {result:?}"
                     );
                 } else {
-                    assert!(matches!(
-                        result.unwrap_err(),
-                        MetricError::InvalidInstrumentConfiguration(msg) if msg == expected_error
-                    ), "expected {name:?} to fail with {expected_error:?}");
+                    assert!(
+                        matches!(
+                            result.unwrap_err(),
+                            MetricError::InvalidInstrumentConfiguration(msg) if msg == expected_error
+                        ),
+                        "expected {name:?} to fail with {expected_error:?}"
+                    );
                 }
             };
 

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -150,15 +150,15 @@ mod tests {
     // be able to make progress!
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[cfg(not(feature = "experimental_metrics_disable_name_validation"))]
     async fn invalid_instrument_config_noops() {
         // Run this test with stdout enabled to see output.
         // cargo test invalid_instrument_config_noops --features=testing,spec_unstable_metrics_views -- --nocapture
         let invalid_instrument_names = vec![
-            "_startWithNoneAlphabet",
             "utf8char锈",
             "a".repeat(256).leak(),
-            "invalid name",
+            " leadingSpace",
+            "trailingSpace ",
+            "name+with+plus",
         ];
         for name in invalid_instrument_names {
             let test_context = TestContext::new(Temporality::Cumulative);
@@ -204,97 +204,6 @@ mod tests {
             test_context.check_no_metrics();
         }
 
-        let invalid_bucket_boundaries = vec![
-            vec![1.0, 1.0],                          // duplicate boundaries
-            vec![1.0, 2.0, 3.0, 2.0],                // duplicate non consequent boundaries
-            vec![1.0, 2.0, 3.0, 4.0, 2.5],           // unsorted boundaries
-            vec![1.0, 2.0, 3.0, f64::INFINITY, 4.0], // boundaries with positive infinity
-            vec![1.0, 2.0, 3.0, f64::NAN],           // boundaries with NaNs
-            vec![f64::NEG_INFINITY, 2.0, 3.0],       // boundaries with negative infinity
-        ];
-        for bucket_boundaries in invalid_bucket_boundaries {
-            let test_context = TestContext::new(Temporality::Cumulative);
-            let histogram = test_context
-                .meter()
-                .f64_histogram("test")
-                .with_boundaries(bucket_boundaries)
-                .build();
-            histogram.record(1.9, &[]);
-            test_context.flush_metrics();
-
-            // As bucket boundaries provided via advisory params are invalid,
-            // no metrics should be exported
-            test_context.check_no_metrics();
-        }
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[cfg(feature = "experimental_metrics_disable_name_validation")]
-    async fn valid_instrument_config_with_feature_experimental_metrics_disable_name_validation() {
-        // Run this test with stdout enabled to see output.
-        // cargo test valid_instrument_config_with_feature_experimental_metrics_disable_name_validation --all-features -- --nocapture
-        let invalid_instrument_names = vec![
-            "_startWithNoneAlphabet",
-            "utf8char锈",
-            "",
-            "a".repeat(256).leak(),
-            "\\allow\\slash /sec",
-            "\\allow\\$$slash /sec",
-            "Total $ Count",
-            "\\test\\UsagePercent(Total) > 80%",
-            "invalid name",
-        ];
-        for name in invalid_instrument_names {
-            let test_context = TestContext::new(Temporality::Cumulative);
-            let counter = test_context.meter().u64_counter(name).build();
-            counter.add(1, &[]);
-
-            let up_down_counter = test_context.meter().i64_up_down_counter(name).build();
-            up_down_counter.add(1, &[]);
-
-            let gauge = test_context.meter().f64_gauge(name).build();
-            gauge.record(1.9, &[]);
-
-            let histogram = test_context.meter().f64_histogram(name).build();
-            histogram.record(1.0, &[]);
-
-            let _observable_counter = test_context
-                .meter()
-                .u64_observable_counter(name)
-                .with_callback(move |observer| {
-                    observer.observe(1, &[]);
-                })
-                .build();
-
-            let _observable_gauge = test_context
-                .meter()
-                .f64_observable_gauge(name)
-                .with_callback(move |observer| {
-                    observer.observe(1.0, &[]);
-                })
-                .build();
-
-            let _observable_up_down_counter = test_context
-                .meter()
-                .i64_observable_up_down_counter(name)
-                .with_callback(move |observer| {
-                    observer.observe(1, &[]);
-                })
-                .build();
-
-            test_context.flush_metrics();
-
-            // As instrument name are valid because of the feature flag, metrics should be exported
-            let resource_metrics = test_context
-                .exporter
-                .get_finished_metrics()
-                .expect("metrics expected to be exported");
-
-            assert!(!resource_metrics.is_empty(), "metrics should be exported");
-        }
-
-        // Ensuring that the Histograms with invalid bucket boundaries are not exported
-        // when using the feature flag
         let invalid_bucket_boundaries = vec![
             vec![1.0, 1.0],                          // duplicate boundaries
             vec![1.0, 2.0, 3.0, 2.0],                // duplicate non consequent boundaries


### PR DESCRIPTION
**Draft** — depends on [opentelemetry-specification#5092](https://github.com/open-telemetry/opentelemetry-specification/pull/5092). Will be ready for review once the spec PR is merged.

**Description**

Relaxes the SDK instrument-name validation to match the proposed expanded character set in [opentelemetry-specification#5092](https://github.com/open-telemetry/opentelemetry-specification/pull/5092):

- Adds `:`, `\`, `(`, `)`, `%`, `*`, `#`, and space to the allowed character set.
- Drops the requirement that the first character be alphabetic.
- Space is restricted to non-leading and non-trailing positions.
- ASCII-only, the 255-byte maximum, and the `name must be non-empty` rule are unchanged.

This enables Windows performance counter style names (e.g. `\Processor(_Total)\% Processor Time`, `\.NET CLR Memory(*)\# Bytes in all Heaps`) to be used directly as instrument names without workarounds.

**Removes the `experimental_metrics_disable_name_validation` Cargo feature** (introduced in #2538 specifically for these use cases). With the relaxed validation, the workaround is no longer needed and the feature can be retired.

**Backwards compatibility**

Strict superset of the existing rule. Every name valid under the old validator remains valid; some previously-rejected names are now accepted. Consumers that enabled `experimental_metrics_disable_name_validation` should drop the feature from their `Cargo.toml`.
