### PR TITLE
fix(prometheus): disable libtest bench harness to fix benchmark CI

### DIFF
--- a/opentelemetry-prometheus/Cargo.toml
+++ b/opentelemetry-prometheus/Cargo.toml
@@ -15,6 +15,9 @@ license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.81.0"
 
+[lib]
+bench = false
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
When opentelemetry-prometheus was restored to the workspace in #3500, the [lib] section with bench = false was not added. This causes criterion-compare-action to fail because cargo bench invokes the default libtest harness for the prometheus crate, which does not understand Criterion-specific flags like --save-baseline.

It has caused CI failure in PR #3473 : https://github.com/open-telemetry/opentelemetry-rust/actions/runs/25944571790/job/76269789635?pr=3473

Every other workspace member already has [lib] bench = false.

Fixes #
Design discussion issue (if applicable) #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
