### PR TITLE
chore: prepare opentelemetry_sdk 0.32.1 release

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## 0.32.1
+
+Released 2026-May-23
+
 - `BaggagePropagator` now enforces the W3C Baggage maximum header length
   (8192 bytes) and maximum list-member count (64) when extracting an inbound
   `baggage` header. Headers exceeding 8192 bytes are dropped at the

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry_sdk"
-version = "0.32.0"
+version = "0.32.1"
 description = "The SDK for the OpenTelemetry metrics collection and distributed tracing framework"
 homepage = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk"
 repository = "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk"


### PR DESCRIPTION
## Changes

  - Bump `opentelemetry_sdk` from 0.32.0 to 0.32.1.
  - Move current SDK changelog entries under a new 0.32.1 release section.

  ## Notes

  This is a patch release for `opentelemetry_sdk` only. The crate continues to depend on `opentelemetry = ^0.32`, so no `opentelemetry` crate release is needed.



## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
