### PR TITLE
fix(sdk): skip current_exe() under Miri in default service.name fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,24 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
       run: bash ./scripts/test.sh
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        submodules: true
+    - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+      with:
+        toolchain: nightly
+        components: miri
+    - name: Miri smoke test
+      run: cargo +nightly miri test --manifest-path=opentelemetry-sdk/Cargo.toml --no-default-features --features metrics --test miri_smoke
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
       run: bash ./scripts/test.sh
+  # Targeted Miri regression check for SDK default resource construction.
+  # Broader Miri support and CI policy are tracked in #3554.
   miri:
     runs-on: ubuntu-latest
     steps:

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+- Default SDK Resource construction now falls back to `unknown_service` under
+  Miri instead of calling `std::env::current_exe()`, avoiding an abort in Miri
+  isolation mode while preserving the normal
+  `unknown_service:<process.executable.name>` fallback outside Miri.
+
 ## 0.32.1
 
 Released 2026-May-23

--- a/opentelemetry-sdk/src/resource/env.rs
+++ b/opentelemetry-sdk/src/resource/env.rs
@@ -72,6 +72,24 @@ fn construct_otel_resources(s: String) -> Resource {
 #[derive(Debug)]
 pub struct SdkProvidedResourceDetector;
 
+fn default_service_name() -> Value {
+    // Fallback to unknown_service:<process.executable.name> per spec.
+    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#sdk-provided-resource-attributes
+    if cfg!(miri) {
+        return "unknown_service".into();
+    }
+
+    env::current_exe()
+        .ok()
+        .and_then(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| format!("unknown_service:{}", name))
+        })
+        .unwrap_or_else(|| "unknown_service".to_string())
+        .into()
+}
+
 impl ResourceDetector for SdkProvidedResourceDetector {
     fn detect(&self) -> Resource {
         Resource::builder_empty()
@@ -86,19 +104,7 @@ impl ResourceDetector for SdkProvidedResourceDetector {
                             .detect()
                             .get(&Key::new(super::SERVICE_NAME))
                     })
-                    .unwrap_or_else(|| {
-                        // Fallback to unknown_service:<process.executable.name> per spec
-                        // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#sdk-provided-resource-attributes
-                        env::current_exe()
-                            .ok()
-                            .and_then(|path| {
-                                path.file_name()
-                                    .and_then(|name| name.to_str())
-                                    .map(|name| format!("unknown_service:{}", name))
-                            })
-                            .unwrap_or_else(|| "unknown_service".to_string())
-                            .into()
-                    }),
+                    .unwrap_or_else(default_service_name),
             )])
             .build()
     }
@@ -155,11 +161,15 @@ mod tests {
             .map(|v| v.to_string())
             .unwrap();
 
-        assert!(
-            service_name.starts_with("unknown_service:opentelemetry_sdk-"),
-            "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
-            service_name
-        );
+        if cfg!(miri) {
+            assert_eq!(service_name, "unknown_service");
+        } else {
+            assert!(
+                service_name.starts_with("unknown_service:opentelemetry_sdk-"),
+                "Expected service name to start with 'unknown_service:opentelemetry_sdk-', got: {}",
+                service_name
+            );
+        }
 
         temp_env::with_var(OTEL_SERVICE_NAME, Some("test service"), || {
             let with_service = SdkProvidedResourceDetector.detect();

--- a/opentelemetry-sdk/tests/miri_smoke.rs
+++ b/opentelemetry-sdk/tests/miri_smoke.rs
@@ -1,0 +1,6 @@
+#[cfg(feature = "metrics")]
+#[test]
+fn default_meter_provider_builds() {
+    let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder().build();
+    drop(provider);
+}

--- a/opentelemetry-sdk/tests/miri_smoke.rs
+++ b/opentelemetry-sdk/tests/miri_smoke.rs
@@ -1,3 +1,5 @@
+// Targeted Miri regression check for SDK default resource construction.
+// This does not imply general opentelemetry-rust Miri support; see #3554.
 #[cfg(feature = "metrics")]
 #[test]
 fn default_meter_provider_builds() {


### PR DESCRIPTION
Fixes #3523.

`std::env::current_exe()` aborts under Miri isolation instead of returning Err, so the existing .ok() fallback in `SdkProvidedResourceDetector` was unreachable, causing any test that constructed a default SDK provider to abort under Miri.

Extract the fallback into default_service_name() and short-circuit to "unknown_service" when `cfg!(miri)` is set, preserving the normal `unknown_service:<process.executable.name>` behaviour outside Miri.

Also adds a targeted Miri smoke test (tests/miri_smoke.rs) and a minimal CI job that runs only that test under nightly Miri.

Design discussion issue (if applicable) #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
