### PR TITLE
feat(sdk): add otel.sdk.log.created self-observability metric

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -30,8 +30,8 @@
 - Fixed asynchronous counters (`ObservableCounter`, `ObservableUpDownCounter`)
   using delta temporality reporting incorrect deltas when observed attributes
   were recorded in an unsorted key order.
-- Added self-observability metrics `otel.sdk.log.created` and
-  `otel.sdk.processor.log.processed`. Gated behind the
+- Added self-observability metric `otel.sdk.log.created`, counting every log
+  record submitted to the SDK (before any processing). Gated behind the
   `experimental_metrics_bound_instruments` Cargo feature.
 
 ## 0.32.1

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -30,6 +30,9 @@
 - Fixed asynchronous counters (`ObservableCounter`, `ObservableUpDownCounter`)
   using delta temporality reporting incorrect deltas when observed attributes
   were recorded in an unsorted key order.
+- Added self-observability metrics `otel.sdk.log.created` and
+  `otel.sdk.processor.log.processed`. Gated behind the
+  `experimental_metrics_bound_instruments` Cargo feature.
 
 ## 0.32.1
 

--- a/opentelemetry-sdk/src/logs/logger.rs
+++ b/opentelemetry-sdk/src/logs/logger.rs
@@ -15,11 +15,30 @@ use opentelemetry::time::now;
 pub struct SdkLogger {
     scope: InstrumentationScope,
     provider: SdkLoggerProvider,
+
+    // Bound is not strictly needed (no attributes), but the semconv is still
+    // `development` so the metric must be feature-gated; reuse the same
+    // `experimental_metrics_bound_instruments` flag as the other SDK
+    // self-observability metrics for consistency.
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    log_created_counter: opentelemetry::metrics::BoundCounter<u64>,
 }
 
 impl SdkLogger {
     pub(crate) fn new(scope: InstrumentationScope, provider: SdkLoggerProvider) -> Self {
-        SdkLogger { scope, provider }
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        let log_created_counter = opentelemetry::global::meter("otel.sdk")
+            .u64_counter("otel.sdk.log.created")
+            .with_description("The number of logs submitted to enabled SDK Loggers.")
+            .with_unit("{log_record}")
+            .build()
+            .bind(&[]);
+        SdkLogger {
+            scope,
+            provider,
+            #[cfg(feature = "experimental_metrics_bound_instruments")]
+            log_created_counter,
+        }
     }
 }
 
@@ -35,6 +54,10 @@ impl opentelemetry::logs::Logger for SdkLogger {
         if Context::is_current_telemetry_suppressed() {
             return;
         }
+
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        self.log_created_counter.add(1);
+
         let provider = &self.provider;
         let processors = provider.log_processors();
 

--- a/opentelemetry-sdk/src/logs/logger.rs
+++ b/opentelemetry-sdk/src/logs/logger.rs
@@ -29,7 +29,7 @@ impl SdkLogger {
         #[cfg(feature = "experimental_metrics_bound_instruments")]
         let log_created_counter = opentelemetry::global::meter("otel.sdk")
             .u64_counter("otel.sdk.log.created")
-            .with_description("The number of logs submitted to enabled SDK Loggers.")
+            .with_description("The number of log records submitted to the SDK.")
             .with_unit("{log_record}")
             .build()
             .bind(&[]);
@@ -51,10 +51,18 @@ impl opentelemetry::logs::Logger for SdkLogger {
 
     /// Emit a `LogRecord`.
     fn emit(&self, mut record: Self::LogRecord) {
+        // Records emitted while telemetry is suppressed are the SDK's own
+        // internal-operation logs (suppressed to prevent feedback loops). They
+        // are not application intake, so `otel.sdk.log.created` intentionally
+        // excludes them (counting them would create a phantom drop signal
+        // against downstream metrics).
         if Context::is_current_telemetry_suppressed() {
             return;
         }
 
+        // Count every record submitted to the SDK, before any processing, so
+        // this metric is the top of the delivery funnel: records dropped by
+        // downstream processing show up as a gap against downstream metrics.
         #[cfg(feature = "experimental_metrics_bound_instruments")]
         self.log_created_counter.add(1);
 
@@ -90,5 +98,67 @@ impl opentelemetry::logs::Logger for SdkLogger {
             .log_processors()
             .iter()
             .any(|processor| processor.event_enabled(level, target, name))
+    }
+}
+
+#[cfg(all(test, feature = "experimental_metrics_bound_instruments"))]
+mod tests {
+    use crate::logs::SdkLoggerProvider;
+    use crate::metrics::data::{AggregatedMetrics, MetricData};
+    use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+    use opentelemetry::logs::{Logger, LoggerProvider};
+
+    fn sum_log_created(exporter: &InMemoryMetricExporter) -> u64 {
+        let metrics = exporter.get_finished_metrics().unwrap();
+        let mut total = 0u64;
+        for rm in &metrics {
+            for sm in &rm.scope_metrics {
+                for metric in &sm.metrics {
+                    if metric.name == "otel.sdk.log.created" {
+                        if let AggregatedMetrics::U64(MetricData::Sum(sum)) = &metric.data {
+                            for dp in sum.data_points() {
+                                total += dp.value();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        total
+    }
+
+    /// Verifies `otel.sdk.log.created` counts every record submitted to the SDK
+    /// even when no processors are registered, proving the metric is a
+    /// pre-processing intake count (the top of the delivery funnel) rather than
+    /// a post-filter count.
+    ///
+    /// `#[ignore]`d because it calls `global::set_meter_provider()`, which
+    /// mutates process-wide state; CI runs it in isolation via `test.sh`.
+    #[test]
+    #[ignore]
+    fn log_created_counts_intake_without_processors() {
+        let metric_exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(metric_exporter.clone())
+            .build();
+        opentelemetry::global::set_meter_provider(meter_provider.clone());
+
+        // Provider with NO log processors registered.
+        let logger_provider = SdkLoggerProvider::builder().build();
+        let logger = logger_provider.logger("test");
+
+        for _ in 0..10 {
+            logger.emit(logger.create_log_record());
+        }
+
+        meter_provider.force_flush().unwrap();
+
+        assert_eq!(
+            sum_log_created(&metric_exporter),
+            10,
+            "expected 10 records counted at intake regardless of processors"
+        );
+
+        meter_provider.shutdown().unwrap();
     }
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -46,6 +46,7 @@ cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features trace::ru
 
 echo "Running ignored tests for opentelemetry-sdk package (self-diagnostics, requires global MeterProvider)"
 cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features logs::batch_log_processor::tests::self_diagnostics_counter_records_success -- --ignored --exact
+cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features logs::logger::tests::log_created_counts_intake_without_processors -- --ignored --exact
 
 echo "Running ignored tests for opentelemetry-appender-tracing package (global logger tests)"
 cargo test --manifest-path=opentelemetry-appender-tracing/Cargo.toml --all-features layer::tests::tracing_appender_standalone_with_tracing_log -- --ignored --exact


### PR DESCRIPTION
## Changes

Adds the `otel.sdk.log.created` self-observability metric to the Logs SDK.
A `u64` counter is bound once per `SdkLogger` (no attributes) and incremented
on every `emit` call that passes the telemetry-suppression check.

## Merge requirement checklist

* [x] CHANGELOG.md updated
* [x] Unit tests added / N/A
  - Behavioral conformance will be covered by Weaver Live Check
    (in-progress: open-telemetry/opentelemetry-rust-contrib#613).
    SDK control-flow paths (suppression early-return, post-shutdown
    no-op routing) are exercised by existing tests.
* [x] Public API changes added to `CHANGELOG.md` / N/A
* [x] Documentation updated / N/A

## Notes

* Gated behind the `experimental_metrics_bound_instruments` Cargo feature,
  matching the existing `otel.sdk.processor.log.processed` metric. The
  semconv definition is still `stability: development`.
* Cross-SDK alignment: matches the Java/JS/Python pattern of incrementing
  after the per-emit gates and before processor dispatch. Rust's
  telemetry-suppression early-return is SDK-specific; no other reference
  SDK has an equivalent concept.
* Semconv: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/otel/sdk-metrics.md#metric-otelsdklogcreated