### PR TITLE
fix(sdk): deduplicate LogRecord attribute keys

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+- `SdkLogRecord::add_attribute` now deduplicates attribute keys (last-write-wins)
+  so exported log records conform to the OpenTelemetry requirement that
+  attributes form a map of unique keys. Fixes [#3497].
+
 ## 0.32.1
 
 Released 2026-May-23

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,11 +2,22 @@
 
 ## vNext
 
-- `SdkLogRecord::add_attribute` now deduplicates attribute keys (last-write-wins)
-  so exported log records conform to the OpenTelemetry requirement that
-  attributes form a map of unique keys. Deduplication is enabled by default and
-  can be disabled via
-  `LoggerProviderBuilder::with_log_record_attribute_deduplication(false)`.
+- **Breaking behavioral change:** `SdkLogRecord::add_attribute` now deduplicates
+  attribute keys by default (last-write-wins), so exported log records conform to
+  the OpenTelemetry specification requirement that attributes form a map of unique
+  keys. This changes observable output for any code that previously called
+  `add_attribute` with the same key more than once.
+
+  **Migration:** If you relied on the previous push-only behavior (e.g. for
+  performance reasons or because downstream consumers tolerated duplicate keys),
+  opt out via the provider builder:
+
+  ```rust
+  let provider = SdkLoggerProvider::builder()
+      .with_log_record_attribute_deduplication(false)
+      .build();
+  ```
+
   Fixes [#3497].
 
 ## 0.32.1

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 - `SdkLogRecord::add_attribute` now deduplicates attribute keys (last-write-wins)
   so exported log records conform to the OpenTelemetry requirement that
-  attributes form a map of unique keys. Fixes [#3497].
+  attributes form a map of unique keys. Deduplication is enabled by default and
+  can be disabled via
+  `LoggerProviderBuilder::with_log_record_attribute_deduplication(false)`.
+  Fixes [#3497].
 
 ## 0.32.1
 

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -125,6 +125,11 @@ harness = false
 required-features = ["logs"]
 
 [[bench]]
+name = "log_record_attribute_dedup"
+harness = false
+required-features = ["logs"]
+
+[[bench]]
 name = "bound_instruments"
 harness = false
 required-features = ["metrics", "experimental_metrics_custom_reader", "experimental_metrics_bound_instruments", "spec_unstable_metrics_views"]

--- a/opentelemetry-sdk/benches/log_record_attribute_dedup.rs
+++ b/opentelemetry-sdk/benches/log_record_attribute_dedup.rs
@@ -1,0 +1,118 @@
+//! Benchmarks for `SdkLogRecord::add_attribute` deduplication overhead.
+//!
+//! Run with:
+//! `cargo bench --bench log_record_attribute_dedup --features logs`
+//!
+//! Apple M4 Max, macOS 25.3.0 (2026-06-05)
+//!
+//! Results (unique keys — typical case, no duplicates in the batch):
+//! | Scenario                | Dedup ON | Dedup OFF (before) | Overhead |
+//! |-------------------------|----------|--------------------|----------|
+//! | add_1_unique_attribute  | 25.6 ns  | 25.9 ns            |  ~1.0x   |
+//! | add_5_unique_attributes | 129.3 ns | 127.5 ns           |  ~1.0x   |
+//! | add_9_unique_attributes | 292.0 ns | 223.6 ns           |  ~1.3x   |
+//!
+//! Results (repeated key — duplicate writes to the same key):
+//! | Scenario       | Dedup ON | Dedup OFF (before) |
+//! |----------------|----------|--------------------|
+//! | add_5_same_key | 32.1 ns  | 38.5 ns            |
+//!
+//! Note: criterion does not fail CI on regression by itself. These numbers are
+//! reference values for human review in PR #3537 / issue #3497.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use opentelemetry::logs::{AnyValue, LogRecord as _, Logger, LoggerProvider};
+use opentelemetry::Key;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+
+struct BenchLoggers {
+    dedup_on: <SdkLoggerProvider as LoggerProvider>::Logger,
+    dedup_off: <SdkLoggerProvider as LoggerProvider>::Logger,
+}
+
+impl BenchLoggers {
+    fn new() -> Self {
+        let dedup_on = SdkLoggerProvider::builder().build().logger("bench");
+        let dedup_off = SdkLoggerProvider::builder()
+            .with_log_record_attribute_deduplication(false)
+            .build()
+            .logger("bench");
+        Self {
+            dedup_on,
+            dedup_off,
+        }
+    }
+}
+
+fn bench_add_unique_attributes(c: &mut Criterion) {
+    let loggers = BenchLoggers::new();
+    let mut group = c.benchmark_group("LogRecord_AddUniqueAttributes");
+
+    for count in [1usize, 5, 9] {
+        let keys: Vec<Key> = (0..count).map(|i| Key::new(format!("key{i}"))).collect();
+
+        group.bench_with_input(BenchmarkId::new("dedup_on", count), &keys, |b, keys| {
+            b.iter(|| {
+                let mut record = loggers.dedup_on.create_log_record();
+                for (i, key) in keys.iter().enumerate() {
+                    record.add_attribute(key.clone(), AnyValue::Int(i as i64));
+                }
+                black_box(record.attributes_iter().count());
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("dedup_off", count), &keys, |b, keys| {
+            b.iter(|| {
+                let mut record = loggers.dedup_off.create_log_record();
+                for (i, key) in keys.iter().enumerate() {
+                    record.add_attribute(key.clone(), AnyValue::Int(i as i64));
+                }
+                black_box(record.attributes_iter().count());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_add_repeated_key(c: &mut Criterion) {
+    let loggers = BenchLoggers::new();
+    let mut group = c.benchmark_group("LogRecord_AddRepeatedKey");
+    let key = Key::new("key");
+
+    group.bench_function("dedup_on_5_writes", |b| {
+        b.iter(|| {
+            let mut record = loggers.dedup_on.create_log_record();
+            for i in 0..5 {
+                record.add_attribute(key.clone(), AnyValue::Int(i));
+            }
+            black_box(record.attributes_iter().count());
+        });
+    });
+
+    group.bench_function("dedup_off_5_writes", |b| {
+        b.iter(|| {
+            let mut record = loggers.dedup_off.create_log_record();
+            for i in 0..5 {
+                record.add_attribute(key.clone(), AnyValue::Int(i));
+            }
+            black_box(record.attributes_iter().count());
+        });
+    });
+
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    bench_add_unique_attributes(c);
+    bench_add_repeated_key(c);
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(1))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/opentelemetry-sdk/benches/log_record_attribute_dedup.rs
+++ b/opentelemetry-sdk/benches/log_record_attribute_dedup.rs
@@ -3,19 +3,19 @@
 //! Run with:
 //! `cargo bench --bench log_record_attribute_dedup --features logs`
 //!
-//! Apple M4 Max, macOS 25.3.0 (2026-06-05)
+//! Apple M4 Max, macOS 25.3.0 (2026-06-05) — median of 3 independent runs
 //!
 //! Results (unique keys — typical case, no duplicates in the batch):
-//! | Scenario                | Dedup ON | Dedup OFF (before) | Overhead |
-//! |-------------------------|----------|--------------------|----------|
-//! | add_1_unique_attribute  | 25.6 ns  | 25.9 ns            |  ~1.0x   |
-//! | add_5_unique_attributes | 129.3 ns | 127.5 ns           |  ~1.0x   |
-//! | add_9_unique_attributes | 292.0 ns | 223.6 ns           |  ~1.3x   |
+//! | Scenario                | Dedup ON  | Dedup OFF (before) | Overhead |
+//! |-------------------------|-----------|--------------------|----------|
+//! | add_1_unique_attribute  |  25.3 ns  |  25.5 ns           |  ~1.0x   |
+//! | add_5_unique_attributes | 130.7 ns  | 122.9 ns           |  ~1.06x  |
+//! | add_9_unique_attributes | 296.9 ns  | 220.3 ns           |  ~1.35x  |
 //!
 //! Results (repeated key — duplicate writes to the same key):
 //! | Scenario       | Dedup ON | Dedup OFF (before) |
 //! |----------------|----------|--------------------|
-//! | add_5_same_key | 32.1 ns  | 38.5 ns            |
+//! | add_5_same_key | 32.0 ns  | 32.1 ns            |
 //!
 //! Note: criterion does not fail CI on regression by itself. These numbers are
 //! reference values for human review in PR #3537 / issue #3497.

--- a/opentelemetry-sdk/benches/log_record_attribute_dedup.rs
+++ b/opentelemetry-sdk/benches/log_record_attribute_dedup.rs
@@ -8,14 +8,14 @@
 //! Results (unique keys — typical case, no duplicates in the batch):
 //! | Scenario                | Dedup ON  | Dedup OFF          | Overhead |
 //! |-------------------------|-----------|--------------------|----------|
-//! | add_1_unique_attribute  |  41.0 ns  |  42.3 ns           |  ~0.97x  |
-//! | add_5_unique_attributes |  75.7 ns  |  70.8 ns           |  ~1.07x  |
-//! | add_9_unique_attributes | 152.1 ns  | 110.8 ns           |  ~1.37x  |
+//! | add_1_unique_attribute  |  39.7 ns  |  38.7 ns           |  ~1.02x  |
+//! | add_5_unique_attributes |  67.9 ns  |  63.6 ns           |  ~1.07x  |
+//! | add_9_unique_attributes | 150.8 ns  | 102.0 ns           |  ~1.48x  |
 //!
 //! Results (repeated key — duplicate writes to the same key):
 //! | Scenario       | Dedup ON | Dedup OFF          |
 //! |----------------|----------|--------------------|
-//! | add_5_same_key |  54.8 ns |  72.1 ns           |
+//! | add_5_same_key |  53.6 ns |  66.3 ns           |
 //!
 //! Note: criterion does not fail CI on regression by itself. These numbers are
 //! reference values for human review in PR #3537 / issue #3497.

--- a/opentelemetry-sdk/benches/log_record_attribute_dedup.rs
+++ b/opentelemetry-sdk/benches/log_record_attribute_dedup.rs
@@ -6,23 +6,22 @@
 //! Apple M4 Max, macOS 25.3.0 (2026-06-05) — median of 3 independent runs
 //!
 //! Results (unique keys — typical case, no duplicates in the batch):
-//! | Scenario                | Dedup ON  | Dedup OFF (before) | Overhead |
+//! | Scenario                | Dedup ON  | Dedup OFF          | Overhead |
 //! |-------------------------|-----------|--------------------|----------|
-//! | add_1_unique_attribute  |  25.3 ns  |  25.5 ns           |  ~1.0x   |
-//! | add_5_unique_attributes | 130.7 ns  | 122.9 ns           |  ~1.06x  |
-//! | add_9_unique_attributes | 296.9 ns  | 220.3 ns           |  ~1.35x  |
+//! | add_1_unique_attribute  |  41.0 ns  |  42.3 ns           |  ~0.97x  |
+//! | add_5_unique_attributes |  75.7 ns  |  70.8 ns           |  ~1.07x  |
+//! | add_9_unique_attributes | 152.1 ns  | 110.8 ns           |  ~1.37x  |
 //!
 //! Results (repeated key — duplicate writes to the same key):
-//! | Scenario       | Dedup ON | Dedup OFF (before) |
+//! | Scenario       | Dedup ON | Dedup OFF          |
 //! |----------------|----------|--------------------|
-//! | add_5_same_key | 32.0 ns  | 32.1 ns            |
+//! | add_5_same_key |  54.8 ns |  72.1 ns           |
 //!
 //! Note: criterion does not fail CI on regression by itself. These numbers are
 //! reference values for human review in PR #3537 / issue #3497.
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use opentelemetry::logs::{AnyValue, LogRecord as _, Logger, LoggerProvider};
-use opentelemetry::Key;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
 
 struct BenchLoggers {
@@ -44,30 +43,34 @@ impl BenchLoggers {
     }
 }
 
+static KEYS: &[&str] = &[
+    "key0", "key1", "key2", "key3", "key4", "key5", "key6", "key7", "key8",
+];
+
 fn bench_add_unique_attributes(c: &mut Criterion) {
     let loggers = BenchLoggers::new();
     let mut group = c.benchmark_group("LogRecord_AddUniqueAttributes");
 
     for count in [1usize, 5, 9] {
-        let keys: Vec<Key> = (0..count).map(|i| Key::new(format!("key{i}"))).collect();
+        let keys = &KEYS[..count];
 
-        group.bench_with_input(BenchmarkId::new("dedup_on", count), &keys, |b, keys| {
+        group.bench_with_input(BenchmarkId::new("dedup_on", count), keys, |b, keys| {
             b.iter(|| {
                 let mut record = loggers.dedup_on.create_log_record();
-                for (i, key) in keys.iter().enumerate() {
-                    record.add_attribute(key.clone(), AnyValue::Int(i as i64));
+                for (i, &key) in keys.iter().enumerate() {
+                    record.add_attribute(key, AnyValue::Int(i as i64));
                 }
-                black_box(record.attributes_iter().count());
+                black_box(record);
             });
         });
 
-        group.bench_with_input(BenchmarkId::new("dedup_off", count), &keys, |b, keys| {
+        group.bench_with_input(BenchmarkId::new("dedup_off", count), keys, |b, keys| {
             b.iter(|| {
                 let mut record = loggers.dedup_off.create_log_record();
-                for (i, key) in keys.iter().enumerate() {
-                    record.add_attribute(key.clone(), AnyValue::Int(i as i64));
+                for (i, &key) in keys.iter().enumerate() {
+                    record.add_attribute(key, AnyValue::Int(i as i64));
                 }
-                black_box(record.attributes_iter().count());
+                black_box(record);
             });
         });
     }
@@ -78,15 +81,15 @@ fn bench_add_unique_attributes(c: &mut Criterion) {
 fn bench_add_repeated_key(c: &mut Criterion) {
     let loggers = BenchLoggers::new();
     let mut group = c.benchmark_group("LogRecord_AddRepeatedKey");
-    let key = Key::new("key");
+    let key = "key";
 
     group.bench_function("dedup_on_5_writes", |b| {
         b.iter(|| {
             let mut record = loggers.dedup_on.create_log_record();
             for i in 0..5 {
-                record.add_attribute(key.clone(), AnyValue::Int(i));
+                record.add_attribute(key, AnyValue::Int(i));
             }
-            black_box(record.attributes_iter().count());
+            black_box(record);
         });
     });
 
@@ -94,9 +97,9 @@ fn bench_add_repeated_key(c: &mut Criterion) {
         b.iter(|| {
             let mut record = loggers.dedup_off.create_log_record();
             for i in 0..5 {
-                record.add_attribute(key.clone(), AnyValue::Int(i));
+                record.add_attribute(key, AnyValue::Int(i));
             }
-            black_box(record.attributes_iter().count());
+            black_box(record);
         });
     });
 

--- a/opentelemetry-sdk/src/growable_array.rs
+++ b/opentelemetry-sdk/src/growable_array.rs
@@ -80,6 +80,21 @@ impl<
         }
     }
 
+    /// Gets a mutable reference to the value at the specified index.
+    ///
+    /// Returns `None` if the index is out of bounds.
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn get_mut(&mut self, index: usize) -> Option<&mut T> {
+        if index < self.count {
+            Some(&mut self.inline[index])
+        } else if let Some(ref mut overflow) = self.overflow {
+            overflow.get_mut(index - MAX_INLINE_CAPACITY)
+        } else {
+            None
+        }
+    }
+
     /// Returns the number of elements in the `GrowableArray`.
     #[allow(dead_code)]
     #[inline]

--- a/opentelemetry-sdk/src/growable_array.rs
+++ b/opentelemetry-sdk/src/growable_array.rs
@@ -195,6 +195,17 @@ mod tests {
     type KeyValuePair = Option<(Key, AnyValue)>;
 
     #[test]
+    fn test_get_mut() {
+        let mut collection = GrowableArray::<i32>::new();
+        collection.push(1);
+        collection.push(2);
+        *collection.get_mut(0).expect("index 0") = 10;
+        *collection.get_mut(1).expect("index 1") = 20;
+        assert_eq!(collection.get(0), Some(&10));
+        assert_eq!(collection.get(1), Some(&20));
+    }
+
+    #[test]
     fn test_push_and_get() {
         let mut collection = GrowableArray::<i32>::new();
         for i in 0..15 {

--- a/opentelemetry-sdk/src/logs/logger.rs
+++ b/opentelemetry-sdk/src/logs/logger.rs
@@ -27,7 +27,7 @@ impl opentelemetry::logs::Logger for SdkLogger {
     type LogRecord = SdkLogRecord;
 
     fn create_log_record(&self) -> Self::LogRecord {
-        SdkLogRecord::new()
+        SdkLogRecord::with_deduplicate_attributes(self.provider.deduplicate_log_record_attributes())
     }
 
     /// Emit a `LogRecord`.

--- a/opentelemetry-sdk/src/logs/logger.rs
+++ b/opentelemetry-sdk/src/logs/logger.rs
@@ -15,19 +15,26 @@ use opentelemetry::time::now;
 pub struct SdkLogger {
     scope: InstrumentationScope,
     provider: SdkLoggerProvider,
+    deduplicate_log_record_attributes: bool,
 }
 
 impl SdkLogger {
     pub(crate) fn new(scope: InstrumentationScope, provider: SdkLoggerProvider) -> Self {
-        SdkLogger { scope, provider }
+        let deduplicate_log_record_attributes = provider.deduplicate_log_record_attributes();
+        SdkLogger {
+            scope,
+            provider,
+            deduplicate_log_record_attributes,
+        }
     }
 }
 
 impl opentelemetry::logs::Logger for SdkLogger {
     type LogRecord = SdkLogRecord;
 
+    #[inline]
     fn create_log_record(&self) -> Self::LogRecord {
-        SdkLogRecord::with_deduplicate_attributes(self.provider.deduplicate_log_record_attributes())
+        SdkLogRecord::with_deduplicate_attributes(self.deduplicate_log_record_attributes)
     }
 
     /// Emit a `LogRecord`.

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -22,6 +22,7 @@ fn noop_logger_provider() -> &'static SdkLoggerProvider {
         inner: Arc::new(LoggerProviderInner {
             processors: Vec::new(),
             is_shutdown: AtomicBool::new(true),
+            deduplicate_log_record_attributes: true,
         }),
     })
 }
@@ -82,6 +83,10 @@ impl SdkLoggerProvider {
         &self.inner.processors
     }
 
+    pub(crate) fn deduplicate_log_record_attributes(&self) -> bool {
+        self.inner.deduplicate_log_record_attributes
+    }
+
     /// Force flush all remaining logs in log processors and return results.
     pub fn force_flush(&self) -> OTelSdkResult {
         let result: Vec<_> = self
@@ -135,6 +140,7 @@ impl SdkLoggerProvider {
 struct LoggerProviderInner {
     processors: Vec<Box<dyn LogProcessor>>,
     is_shutdown: AtomicBool,
+    deduplicate_log_record_attributes: bool,
 }
 
 impl LoggerProviderInner {
@@ -179,11 +185,22 @@ impl Drop for LoggerProviderInner {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 /// Builder for provider attributes.
 pub struct LoggerProviderBuilder {
     processors: Vec<Box<dyn LogProcessor>>,
     resource: Option<Resource>,
+    deduplicate_log_record_attributes: bool,
+}
+
+impl Default for LoggerProviderBuilder {
+    fn default() -> Self {
+        Self {
+            processors: Vec::new(),
+            resource: None,
+            deduplicate_log_record_attributes: true,
+        }
+    }
 }
 
 impl LoggerProviderBuilder {
@@ -287,6 +304,16 @@ impl LoggerProviderBuilder {
         LoggerProviderBuilder { resource, ..self }
     }
 
+    /// Controls whether log record attribute keys are deduplicated (last-write-wins).
+    ///
+    /// Enabled by default per the OpenTelemetry specification. Set to `false` to
+    /// retain the previous push-only behavior and avoid the lookup cost on
+    /// `add_attribute`.
+    pub fn with_log_record_attribute_deduplication(mut self, enabled: bool) -> Self {
+        self.deduplicate_log_record_attributes = enabled;
+        self
+    }
+
     /// Create a new provider from this configuration.
     pub fn build(self) -> SdkLoggerProvider {
         let resource = self.resource.unwrap_or(Resource::builder().build());
@@ -299,6 +326,7 @@ impl LoggerProviderBuilder {
             inner: Arc::new(LoggerProviderInner {
                 processors,
                 is_shutdown: AtomicBool::new(false),
+                deduplicate_log_record_attributes: self.deduplicate_log_record_attributes,
             }),
         };
 
@@ -793,6 +821,7 @@ mod tests {
                     flush_called.clone(),
                 ))],
                 is_shutdown: AtomicBool::new(false),
+                deduplicate_log_record_attributes: true,
             });
 
             {
@@ -833,6 +862,7 @@ mod tests {
                 flush_called.clone(),
             ))],
             is_shutdown: AtomicBool::new(false),
+            deduplicate_log_record_attributes: true,
         });
 
         // Create a scope to test behavior when providers are dropped

--- a/opentelemetry-sdk/src/logs/logger_provider.rs
+++ b/opentelemetry-sdk/src/logs/logger_provider.rs
@@ -306,9 +306,15 @@ impl LoggerProviderBuilder {
 
     /// Controls whether log record attribute keys are deduplicated (last-write-wins).
     ///
-    /// Enabled by default per the OpenTelemetry specification. Set to `false` to
-    /// retain the previous push-only behavior and avoid the lookup cost on
-    /// `add_attribute`.
+    /// Enabled by default per the OpenTelemetry specification.
+    ///
+    /// Setting this to `false` disables deduplication to avoid lookup overhead on `add_attribute`.
+    ///
+    /// # Warning
+    ///
+    /// Per the OpenTelemetry specification, for many receivers, handling of attributes with
+    /// duplicate keys is unpredictable and it is the user's responsibility to ensure keys are
+    /// not duplicate when deduplication is disabled.
     pub fn with_log_record_attribute_deduplication(mut self, enabled: bool) -> Self {
         self.deduplicate_log_record_attributes = enabled;
         self

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -116,6 +116,29 @@ mod tests {
     }
 
     #[test]
+    fn log_record_attribute_deduplication_disabled_via_builder() {
+        let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
+        let provider = SdkLoggerProvider::builder()
+            .with_log_processor(SimpleLogProcessor::new(exporter.clone()))
+            .with_log_record_attribute_deduplication(false)
+            .build();
+
+        let logger = provider.logger("test-logger");
+        let mut log_record = logger.create_log_record();
+        log_record.add_attribute("key", "first");
+        log_record.add_attribute("key", "second");
+        logger.emit(log_record);
+
+        let exported_logs = exporter
+            .get_emitted_logs()
+            .expect("Logs are expected to be exported.");
+        let log = exported_logs
+            .first()
+            .expect("Atleast one log is expected to be present.");
+        assert_eq!(log.record.attributes_len(), 2);
+    }
+
+    #[test]
     fn logger_attributes() {
         let exporter: InMemoryLogExporter = InMemoryLogExporter::default();
         let provider = SdkLoggerProvider::builder()

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -50,6 +50,10 @@ pub struct SdkLogRecord {
 
     /// Additional attributes associated with this record
     pub(crate) attributes: LogRecordAttributes,
+
+    /// When true, `add_attribute` replaces an existing key (last-write-wins).
+    /// When false, attributes are appended without deduplication.
+    pub(crate) deduplicate_attributes: bool,
 }
 
 impl opentelemetry::logs::LogRecord for SdkLogRecord {
@@ -103,13 +107,15 @@ impl opentelemetry::logs::LogRecord for SdkLogRecord {
     {
         let key = key.into();
         let value = value.into();
-        for i in 0..self.attributes.len() {
-            if let Some((existing_key, existing_value)) =
-                self.attributes.get_mut(i).and_then(|opt| opt.as_mut())
-            {
-                if *existing_key == key {
-                    *existing_value = value;
-                    return;
+        if self.deduplicate_attributes {
+            for i in 0..self.attributes.len() {
+                if let Some((existing_key, existing_value)) =
+                    self.attributes.get_mut(i).and_then(|opt| opt.as_mut())
+                {
+                    if *existing_key == key {
+                        *existing_value = value;
+                        return;
+                    }
                 }
             }
         }
@@ -131,8 +137,15 @@ impl opentelemetry::logs::LogRecord for SdkLogRecord {
 }
 
 impl SdkLogRecord {
-    /// Crate only default constructor
+    /// Crate-only default constructor with attribute deduplication enabled.
+    ///
+    /// Used from `#[cfg(test)]` modules; `clippy --lib` cannot see those call sites.
+    #[allow(dead_code)]
     pub(crate) fn new() -> Self {
+        Self::with_deduplicate_attributes(true)
+    }
+
+    pub(crate) fn with_deduplicate_attributes(deduplicate_attributes: bool) -> Self {
         SdkLogRecord {
             event_name: None,
             target: None,
@@ -143,6 +156,7 @@ impl SdkLogRecord {
             severity_number: None,
             body: None,
             attributes: LogRecordAttributes::default(),
+            deduplicate_attributes,
         }
     }
 
@@ -343,6 +357,18 @@ mod tests {
     }
 
     #[test]
+    fn test_add_attribute_skips_deduplication_when_disabled() {
+        let mut log_record = SdkLogRecord::with_deduplicate_attributes(false);
+        log_record.add_attribute("key", "first");
+        log_record.add_attribute("key", "second");
+        assert_eq!(log_record.attributes_len(), 2);
+        assert!(log_record.attributes_contains(&Key::new("key"), &AnyValue::String("first".into())));
+        assert!(
+            log_record.attributes_contains(&Key::new("key"), &AnyValue::String("second".into()))
+        );
+    }
+
+    #[test]
     fn test_add_attribute_deduplicates_beyond_inline_capacity() {
         let mut log_record = SdkLogRecord::new();
         for i in 0..PREALLOCATED_ATTRIBUTE_CAPACITY {
@@ -387,6 +413,7 @@ mod tests {
             severity_number: Some(Severity::Error),
             body: Some(AnyValue::String("Test body".into())),
             attributes: LogRecordAttributes::new(),
+            deduplicate_attributes: true,
             trace_context: Some(TraceContext {
                 trace_id: TraceId::from(1),
                 span_id: SpanId::from(1),

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -101,7 +101,19 @@ impl opentelemetry::logs::LogRecord for SdkLogRecord {
         K: Into<Key>,
         V: Into<AnyValue>,
     {
-        self.attributes.push(Some((key.into(), value.into())));
+        let key = key.into();
+        let value = value.into();
+        for i in 0..self.attributes.len() {
+            if let Some((existing_key, existing_value)) =
+                self.attributes.get_mut(i).and_then(|opt| opt.as_mut())
+            {
+                if *existing_key == key {
+                    *existing_value = value;
+                    return;
+                }
+            }
+        }
+        self.attributes.push(Some((key, value)));
     }
 
     fn set_trace_context(
@@ -305,6 +317,42 @@ mod tests {
         let key = Key::new("key");
         let value = AnyValue::String("value".into());
         assert!(log_record.attributes_contains(&key, &value));
+    }
+
+    #[test]
+    fn test_add_attribute_deduplicates_last_write_wins() {
+        let mut log_record = SdkLogRecord::new();
+        log_record.add_attribute("key", "first");
+        log_record.add_attribute("key", "second");
+        assert_eq!(log_record.attributes_len(), 1);
+        assert!(
+            log_record.attributes_contains(&Key::new("key"), &AnyValue::String("second".into()))
+        );
+    }
+
+    #[test]
+    fn test_add_attributes_deduplicates_within_batch() {
+        let mut log_record = SdkLogRecord::new();
+        log_record.add_attributes([("key", "first"), ("key", "second")]);
+        log_record.add_attribute(Key::new("other"), AnyValue::Int(1));
+        assert_eq!(log_record.attributes_len(), 2);
+        assert!(
+            log_record.attributes_contains(&Key::new("key"), &AnyValue::String("second".into()))
+        );
+        assert!(log_record.attributes_contains(&Key::new("other"), &AnyValue::Int(1)));
+    }
+
+    #[test]
+    fn test_add_attribute_deduplicates_beyond_inline_capacity() {
+        let mut log_record = SdkLogRecord::new();
+        for i in 0..PREALLOCATED_ATTRIBUTE_CAPACITY {
+            log_record.add_attribute(format!("key{i}"), i as i64);
+        }
+        log_record.add_attribute("key0", "updated");
+        assert_eq!(log_record.attributes_len(), PREALLOCATED_ATTRIBUTE_CAPACITY);
+        assert!(
+            log_record.attributes_contains(&Key::new("key0"), &AnyValue::String("updated".into()))
+        );
     }
 
     #[test]

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -100,6 +100,7 @@ impl opentelemetry::logs::LogRecord for SdkLogRecord {
         }
     }
 
+    #[inline]
     fn add_attribute<K, V>(&mut self, key: K, value: V)
     where
         K: Into<Key>,
@@ -148,6 +149,7 @@ impl SdkLogRecord {
         Self::with_deduplicate_attributes(true)
     }
 
+    #[inline]
     pub(crate) fn with_deduplicate_attributes(deduplicate_attributes: bool) -> Self {
         SdkLogRecord {
             event_name: None,

--- a/opentelemetry-sdk/src/logs/record.rs
+++ b/opentelemetry-sdk/src/logs/record.rs
@@ -105,17 +105,20 @@ impl opentelemetry::logs::LogRecord for SdkLogRecord {
         K: Into<Key>,
         V: Into<AnyValue>,
     {
+        if !self.deduplicate_attributes {
+            self.attributes.push(Some((key.into(), value.into())));
+            return;
+        }
+
         let key = key.into();
         let value = value.into();
-        if self.deduplicate_attributes {
-            for i in 0..self.attributes.len() {
-                if let Some((existing_key, existing_value)) =
-                    self.attributes.get_mut(i).and_then(|opt| opt.as_mut())
-                {
-                    if *existing_key == key {
-                        *existing_value = value;
-                        return;
-                    }
+        for i in 0..self.attributes.len() {
+            if let Some((existing_key, existing_value)) =
+                self.attributes.get_mut(i).and_then(|opt| opt.as_mut())
+            {
+                if *existing_key == key {
+                    *existing_value = value;
+                    return;
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Deduplicate `SdkLogRecord` attribute keys in `add_attribute` using last-write-wins semantics.
- Add `GrowableArray::get_mut` to update existing attribute slots without extra allocations.
- Add unit tests covering inline capacity, batch `add_attributes`, and overflow paths.

Fixes #3497.

## Rationale

The [OpenTelemetry spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute-collections) requires exported attribute collections to contain only unique keys by default. The SDK previously used `Vec::push`, so duplicate keys could reach exporters (e.g. from `tracing` events, span-attribute enrichment, or custom appenders).

Per maintainer feedback on #3497, deduplication is eager at `add_attribute` time (default-on, no builder flag).

## Test plan

- [x] `cargo test -p opentelemetry-sdk --features testing,rt-tokio --lib logs::record::tests`
- [x] `cargo test -p opentelemetry-sdk --features testing,rt-tokio --lib logs::`
- [x] `cargo test -p opentelemetry-appender-tracing --lib`
- [x] `cargo clippy -p opentelemetry-sdk --lib -- -Dwarnings`