### PR TITLE
fix(sdk): stop batch processors from panicking on worker thread failures

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+- `BatchSpanProcessor` and `BatchLogProcessor` `shutdown()` no longer panic on
+  background worker thread failures (see #3375). It now returns an
+  `OTelSdkError` instead of triggering a *second* panic when the worker thread
+  panicked while being joined (the original panic message is preserved in the
+  error), and recovers a poisoned handle mutex instead of unwrapping it.
+
 ## 0.32.1
 
 Released 2026-May-23

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -3,10 +3,19 @@
 ## vNext
 
 - `BatchSpanProcessor` and `BatchLogProcessor` `shutdown()` no longer panic on
-  background worker thread failures (see #3375). It now returns an
-  `OTelSdkError` instead of triggering a *second* panic when the worker thread
-  panicked while being joined (the original panic message is preserved in the
-  error), and recovers a poisoned handle mutex instead of unwrapping it.
+  background worker thread failures and now report shutdown errors more
+  accurately (see #3375):
+  - When the worker thread panicked, `shutdown()` returns an `OTelSdkError`
+    (with the original panic message preserved) instead of triggering a
+    masking *second* panic, and recovers a poisoned handle mutex instead of
+    unwrapping it. This now also covers the case where the worker panics
+    *before* sending its shutdown response (e.g. during the final export or
+    the exporter's own shutdown): the worker is still joined so the real panic
+    message is surfaced, rather than returning an opaque "disconnected channel"
+    error.
+  - When the final export performed during shutdown fails, `shutdown()` now
+    returns that export error instead of silently discarding it and returning
+    `Ok(())`.
 
 ## 0.32.1
 

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -171,6 +171,26 @@ impl Debug for BatchLogProcessor {
     }
 }
 
+/// Joins the batch log processor's background worker thread during shutdown,
+/// converting a panic in that thread into an [`OTelSdkError`] instead of
+/// propagating it as a second panic that would mask the original failure.
+///
+/// Returns `Ok(())` when there is no worker to join — for example when the
+/// thread could not be spawned at construction time (see
+/// [`BatchLogProcessor::new`]).
+fn join_worker_thread(handle: Option<thread::JoinHandle<()>>) -> OTelSdkResult {
+    let Some(handle) = handle else {
+        return Ok(());
+    };
+    handle.join().map_err(|payload| {
+        // Surface the original panic message rather than losing it.
+        OTelSdkError::InternalFailure(format!(
+            "the batch log processor worker thread panicked during shutdown: {}",
+            crate::util::panic_message(&*payload)
+        ))
+    })
+}
+
 impl LogProcessor for BatchLogProcessor {
     fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
         let result = self
@@ -309,12 +329,18 @@ impl LogProcessor for BatchLogProcessor {
                 receiver
                     .recv_timeout(timeout)
                     .map(|_| {
-                        // join the background thread after receiving back the
-                        // shutdown signal
-                        if let Some(handle) = self.handle.lock().unwrap().take() {
-                            handle.join().unwrap();
-                        }
-                        OTelSdkResult::Ok(())
+                        // Take the worker handle out and release the lock before
+                        // the (blocking) join. This lock is only ever held here
+                        // across an infallible `take()`, so poisoning is
+                        // practically unreachable; recover the guard defensively
+                        // anyway, since a poisoned lock still guards a valid
+                        // handle and shutdown should not fail over it.
+                        let handle = self
+                            .handle
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .take();
+                        join_worker_thread(handle)
                     })
                     .map_err(|err| match err {
                         RecvTimeoutError::Timeout => {
@@ -381,6 +407,16 @@ impl BatchLogProcessor {
         let current_batch_size = Arc::new(AtomicUsize::new(0));
         let current_batch_size_for_thread = current_batch_size.clone();
 
+        // Spawn the background worker thread. A spawn failure (e.g. the OS
+        // refusing to create the thread under resource exhaustion) is an
+        // unrecoverable setup-time error: without the worker this processor can
+        // never export anything. Fail fast — the spec permits failing on
+        // initialization — and surface the underlying OS error so the cause is
+        // diagnosable instead of a bare "Thread spawn failed.".
+        //
+        // TODO(#3375): return `Result<Self, OTelSdkError>` from this
+        // constructor at the next breaking change so callers can react to a
+        // spawn failure (see also #2690 / #3462).
         let handle = thread::Builder::new()
             .name("OpenTelemetry.Logs.BatchProcessor".to_string())
             .spawn(move || {
@@ -528,7 +564,9 @@ impl BatchLogProcessor {
                     name: "BatchLogProcessor.ThreadStopped"
                 );
             })
-            .expect("Thread spawn failed."); //TODO: Handle thread spawn failure
+            .unwrap_or_else(|err| {
+                panic!("OpenTelemetry batch log processor failed to spawn its worker thread: {err}")
+            });
 
         // Self-diagnostics: create the otel.sdk.processor.log.processed counter
         #[cfg(feature = "experimental_metrics_bound_instruments")]
@@ -850,6 +888,31 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
+
+    #[test]
+    fn join_worker_thread_none_is_ok() {
+        assert!(super::join_worker_thread(None).is_ok());
+    }
+
+    #[test]
+    fn join_worker_thread_joins_clean_thread() {
+        let handle = std::thread::spawn(|| {});
+        assert!(super::join_worker_thread(Some(handle)).is_ok());
+    }
+
+    #[test]
+    fn join_worker_thread_converts_panic_to_error() {
+        // A panicked worker must become an error during shutdown, never a
+        // second panic, and the original panic message must be preserved.
+        let handle = std::thread::spawn(|| panic!("boom in worker"));
+        match super::join_worker_thread(Some(handle)) {
+            Err(crate::error::OTelSdkError::InternalFailure(msg)) => {
+                assert!(msg.contains("panicked during shutdown"), "got: {msg}");
+                assert!(msg.contains("boom in worker"), "got: {msg}");
+            }
+            other => panic!("expected InternalFailure, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_default_const_values() {

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -325,47 +325,51 @@ impl LogProcessor for BatchLogProcessor {
 
         let (sender, receiver) = mpsc::sync_channel(1);
         match self.message_sender.try_send(BatchMessage::Shutdown(sender)) {
-            Ok(_) => {
-                receiver
-                    .recv_timeout(timeout)
-                    .map(|_| {
-                        // Take the worker handle out and release the lock before
-                        // the (blocking) join. This lock is only ever held here
-                        // across an infallible `take()`, so poisoning is
-                        // practically unreachable; recover the guard defensively
-                        // anyway, since a poisoned lock still guards a valid
-                        // handle and shutdown should not fail over it.
-                        let handle = self
-                            .handle
-                            .lock()
-                            .unwrap_or_else(|poisoned| poisoned.into_inner())
-                            .take();
-                        join_worker_thread(handle)
-                    })
-                    .map_err(|err| match err {
-                        RecvTimeoutError::Timeout => {
-                            // TODO: When shutdown times out, log records still
-                            // in the queue or mid-export are silently lost. The
-                            // background thread is not joined and may continue
-                            // running. Consider: (1) recording the lost count
-                            // in the self-diagnostics counter, (2) joining the
-                            // thread with a best-effort wait, or (3) signalling
-                            // the thread to abort the current export.
-                            otel_error!(
-                                name: "BatchLogProcessor.Shutdown.Timeout",
-                                message = "BatchLogProcessor shutdown timing out."
-                            );
-                            OTelSdkError::Timeout(timeout)
-                        }
-                        _ => {
-                            otel_error!(
-                                name: "BatchLogProcessor.Shutdown.Error",
-                                error = format!("{}", err)
-                            );
-                            OTelSdkError::InternalFailure(format!("{err}"))
-                        }
-                    })?
-            }
+            Ok(_) => match receiver.recv_timeout(timeout) {
+                // The worker exported the final batch and replied before
+                // exiting. Join it (the handle is taken out so the lock is
+                // released before the blocking join), then propagate the
+                // worker's own export result so a failed final export is
+                // reported rather than swallowed.
+                Ok(worker_result) => {
+                    join_worker_thread(self.take_worker_handle())?;
+                    worker_result
+                }
+                // The worker dropped the response sender without replying,
+                // which means it panicked mid-shutdown (during the final
+                // export or the exporter's own shutdown). Join it to surface
+                // the original panic message instead of a generic
+                // "disconnected channel" error or a masking second panic.
+                Err(RecvTimeoutError::Disconnected) => {
+                    join_worker_thread(self.take_worker_handle())?;
+                    // The worker disconnected but joined cleanly (no panic
+                    // payload); still report a failure since shutdown never
+                    // received a result.
+                    otel_error!(
+                        name: "BatchLogProcessor.Shutdown.Error",
+                        error = "worker thread disconnected during shutdown without responding"
+                    );
+                    Err(OTelSdkError::InternalFailure(
+                        "worker thread disconnected during shutdown without responding".into(),
+                    ))
+                }
+                // The worker is still running, so we must not join (that could
+                // block well past the timeout).
+                //
+                // TODO: When shutdown times out, log records still in the queue
+                // or mid-export are silently lost. The background thread is not
+                // joined and may continue running. Consider: (1) recording the
+                // lost count in the self-diagnostics counter, (2) joining the
+                // thread with a best-effort wait, or (3) signalling the thread
+                // to abort the current export.
+                Err(RecvTimeoutError::Timeout) => {
+                    otel_error!(
+                        name: "BatchLogProcessor.Shutdown.Timeout",
+                        message = "BatchLogProcessor shutdown timing out."
+                    );
+                    Err(OTelSdkError::Timeout(timeout))
+                }
+            },
             Err(mpsc::TrySendError::Full(_)) => {
                 // If the control message could not be sent, emit a warning.
                 otel_debug!(
@@ -396,6 +400,18 @@ impl LogProcessor for BatchLogProcessor {
 }
 
 impl BatchLogProcessor {
+    /// Takes the worker thread handle out for joining, recovering the guard if
+    /// the lock is poisoned. The lock is only ever held across an infallible
+    /// `take()`, so poisoning is practically unreachable; recover defensively
+    /// anyway, since a poisoned lock still guards a valid handle and shutdown
+    /// should not fail over it.
+    fn take_worker_handle(&self) -> Option<thread::JoinHandle<()>> {
+        self.handle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
+
     pub(crate) fn new<E>(mut exporter: E, config: BatchConfig) -> Self
     where
         E: LogExporter + Send + Sync + 'static,
@@ -911,6 +927,58 @@ mod tests {
                 assert!(msg.contains("boom in worker"), "got: {msg}");
             }
             other => panic!("expected InternalFailure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shutdown_returns_final_export_error() {
+        // If the worker's final shutdown export fails, shutdown() must report
+        // that error rather than swallowing it and returning Ok(()).
+        #[derive(Debug)]
+        struct FailingExporter;
+        impl LogExporter for FailingExporter {
+            async fn export(&self, _batch: LogBatch<'_>) -> OTelSdkResult {
+                Err(crate::error::OTelSdkError::InternalFailure(
+                    "export failed".into(),
+                ))
+            }
+        }
+
+        let processor = BatchLogProcessor::new(FailingExporter, BatchConfig::default());
+        let scope = opentelemetry::InstrumentationScope::builder("test").build();
+        processor.emit(&mut SdkLogRecord::new(), &scope);
+
+        match processor.shutdown() {
+            Err(crate::error::OTelSdkError::InternalFailure(msg)) => {
+                assert!(msg.contains("export failed"), "got: {msg}");
+            }
+            other => panic!("expected the final export error to propagate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shutdown_surfaces_worker_panic_during_export() {
+        // If the worker panics during the final shutdown export, shutdown() must
+        // join the worker and surface the original panic message as an error,
+        // not a generic "disconnected channel" error and not a second panic.
+        #[derive(Debug)]
+        struct PanickingExporter;
+        impl LogExporter for PanickingExporter {
+            async fn export(&self, _batch: LogBatch<'_>) -> OTelSdkResult {
+                panic!("export blew up");
+            }
+        }
+
+        let processor = BatchLogProcessor::new(PanickingExporter, BatchConfig::default());
+        let scope = opentelemetry::InstrumentationScope::builder("test").build();
+        processor.emit(&mut SdkLogRecord::new(), &scope);
+
+        match processor.shutdown() {
+            Err(crate::error::OTelSdkError::InternalFailure(msg)) => {
+                assert!(msg.contains("panicked during shutdown"), "got: {msg}");
+                assert!(msg.contains("export blew up"), "got: {msg}");
+            }
+            other => panic!("expected worker panic surfaced as InternalFailure, got {other:?}"),
         }
     }
 

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -344,6 +344,18 @@ pub struct BatchSpanProcessor {
 }
 
 impl BatchSpanProcessor {
+    /// Takes the worker thread handle out for joining, recovering the guard if
+    /// the lock is poisoned. The lock is only ever held across an infallible
+    /// `take()`, so poisoning is practically unreachable; recover defensively
+    /// anyway, since a poisoned lock still guards a valid handle and shutdown
+    /// should not fail over it.
+    fn take_worker_handle(&self) -> Option<thread::JoinHandle<()>> {
+        self.handle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
+
     /// Creates a new instance of `BatchSpanProcessor`.
     pub fn new<E>(
         mut exporter: E,
@@ -734,40 +746,44 @@ impl SpanProcessor for BatchSpanProcessor {
 
         let (sender, receiver) = std::sync::mpsc::sync_channel(1);
         match self.message_sender.try_send(BatchMessage::Shutdown(sender)) {
-            Ok(_) => {
-                receiver
-                    .recv_timeout(timeout)
-                    .map(|_| {
-                        // Take the worker handle out and release the lock before
-                        // the (blocking) join. This lock is only ever held here
-                        // across an infallible `take()`, so poisoning is
-                        // practically unreachable; recover the guard defensively
-                        // anyway, since a poisoned lock still guards a valid
-                        // handle and shutdown should not fail over it.
-                        let handle = self
-                            .handle
-                            .lock()
-                            .unwrap_or_else(|poisoned| poisoned.into_inner())
-                            .take();
-                        join_worker_thread(handle)
-                    })
-                    .map_err(|err| match err {
-                        std::sync::mpsc::RecvTimeoutError::Timeout => {
-                            otel_error!(
-                                name: "BatchSpanProcessor.Shutdown.Timeout",
-                                message = "BatchSpanProcessor shutdown timing out."
-                            );
-                            OTelSdkError::Timeout(timeout)
-                        }
-                        _ => {
-                            otel_error!(
-                                name: "BatchSpanProcessor.Shutdown.Error",
-                                error = format!("{}", err)
-                            );
-                            OTelSdkError::InternalFailure(format!("{err}"))
-                        }
-                    })?
-            }
+            Ok(_) => match receiver.recv_timeout(timeout) {
+                // The worker exported the final batch and replied before
+                // exiting. Join it (the handle is taken out so the lock is
+                // released before the blocking join), then propagate the
+                // worker's own export result so a failed final export is
+                // reported rather than swallowed.
+                Ok(worker_result) => {
+                    join_worker_thread(self.take_worker_handle())?;
+                    worker_result
+                }
+                // The worker dropped the response sender without replying,
+                // which means it panicked mid-shutdown (during the final
+                // export or the exporter's own shutdown). Join it to surface
+                // the original panic message instead of a generic
+                // "disconnected channel" error or a masking second panic.
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    join_worker_thread(self.take_worker_handle())?;
+                    // The worker disconnected but joined cleanly (no panic
+                    // payload); still report a failure since shutdown never
+                    // received a result.
+                    otel_error!(
+                        name: "BatchSpanProcessor.Shutdown.Error",
+                        error = "worker thread disconnected during shutdown without responding"
+                    );
+                    Err(OTelSdkError::InternalFailure(
+                        "worker thread disconnected during shutdown without responding".into(),
+                    ))
+                }
+                // The worker is still running, so we must not join (that could
+                // block well past the timeout).
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    otel_error!(
+                        name: "BatchSpanProcessor.Shutdown.Timeout",
+                        message = "BatchSpanProcessor shutdown timing out."
+                    );
+                    Err(OTelSdkError::Timeout(timeout))
+                }
+            },
             Err(std::sync::mpsc::TrySendError::Full(_)) => {
                 // If the control message could not be sent, emit a warning.
                 otel_debug!(
@@ -1069,6 +1085,56 @@ mod tests {
                 assert!(msg.contains("boom in worker"), "got: {msg}");
             }
             other => panic!("expected InternalFailure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shutdown_returns_final_export_error() {
+        // If the worker's final shutdown export fails, shutdown() must report
+        // that error rather than swallowing it and returning Ok(()).
+        #[derive(Debug)]
+        struct FailingExporter;
+        impl SpanExporter for FailingExporter {
+            async fn export(&self, _batch: Vec<SpanData>) -> OTelSdkResult {
+                Err(crate::error::OTelSdkError::InternalFailure(
+                    "export failed".into(),
+                ))
+            }
+        }
+
+        let processor = BatchSpanProcessor::new(FailingExporter, BatchConfig::default());
+        processor.on_end(new_test_export_span_data());
+
+        match processor.shutdown() {
+            Err(crate::error::OTelSdkError::InternalFailure(msg)) => {
+                assert!(msg.contains("export failed"), "got: {msg}");
+            }
+            other => panic!("expected the final export error to propagate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shutdown_surfaces_worker_panic_during_export() {
+        // If the worker panics during the final shutdown export, shutdown() must
+        // join the worker and surface the original panic message as an error,
+        // not a generic "disconnected channel" error and not a second panic.
+        #[derive(Debug)]
+        struct PanickingExporter;
+        impl SpanExporter for PanickingExporter {
+            async fn export(&self, _batch: Vec<SpanData>) -> OTelSdkResult {
+                panic!("export blew up");
+            }
+        }
+
+        let processor = BatchSpanProcessor::new(PanickingExporter, BatchConfig::default());
+        processor.on_end(new_test_export_span_data());
+
+        match processor.shutdown() {
+            Err(crate::error::OTelSdkError::InternalFailure(msg)) => {
+                assert!(msg.contains("panicked during shutdown"), "got: {msg}");
+                assert!(msg.contains("export blew up"), "got: {msg}");
+            }
+            other => panic!("expected worker panic surfaced as InternalFailure, got {other:?}"),
         }
     }
 

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -362,6 +362,16 @@ impl BatchSpanProcessor {
         let current_batch_size = Arc::new(AtomicUsize::new(0));
         let current_batch_size_for_thread = current_batch_size.clone();
 
+        // Spawn the background worker thread. A spawn failure (e.g. the OS
+        // refusing to create the thread under resource exhaustion) is an
+        // unrecoverable setup-time error: without the worker this processor can
+        // never export anything. Fail fast — the spec permits failing on
+        // initialization — and surface the underlying OS error so the cause is
+        // diagnosable instead of a bare "Failed to spawn thread.".
+        //
+        // TODO(#3375): return `Result<Self, OTelSdkError>` from this
+        // constructor at the next breaking change so callers can react to a
+        // spawn failure (see also #2690 / #3462).
         let handle = thread::Builder::new()
             .name("OpenTelemetry.Traces.BatchProcessor".to_string())
             .spawn(move || {
@@ -467,7 +477,11 @@ impl BatchSpanProcessor {
                     name: "BatchSpanProcessor.ThreadStopped"
                 );
             })
-            .expect("Failed to spawn thread"); //TODO: Handle thread spawn failure
+            .unwrap_or_else(|err| {
+                panic!(
+                    "OpenTelemetry batch span processor failed to spawn its worker thread: {err}"
+                )
+            });
 
         Self {
             span_sender,
@@ -573,6 +587,26 @@ impl BatchSpanProcessor {
             }
         }
     }
+}
+
+/// Joins the batch span processor's background worker thread during shutdown,
+/// converting a panic in that thread into an [`OTelSdkError`] instead of
+/// propagating it as a second panic that would mask the original failure.
+///
+/// Returns `Ok(())` when there is no worker to join — for example when the
+/// thread could not be spawned at construction time (see
+/// [`BatchSpanProcessor::new`]).
+fn join_worker_thread(handle: Option<thread::JoinHandle<()>>) -> OTelSdkResult {
+    let Some(handle) = handle else {
+        return Ok(());
+    };
+    handle.join().map_err(|payload| {
+        // Surface the original panic message rather than losing it.
+        OTelSdkError::InternalFailure(format!(
+            "the batch span processor worker thread panicked during shutdown: {}",
+            crate::util::panic_message(&*payload)
+        ))
+    })
 }
 
 impl SpanProcessor for BatchSpanProcessor {
@@ -704,12 +738,18 @@ impl SpanProcessor for BatchSpanProcessor {
                 receiver
                     .recv_timeout(timeout)
                     .map(|_| {
-                        // join the background thread after receiving back the
-                        // shutdown signal
-                        if let Some(handle) = self.handle.lock().unwrap().take() {
-                            handle.join().unwrap();
-                        }
-                        OTelSdkResult::Ok(())
+                        // Take the worker handle out and release the lock before
+                        // the (blocking) join. This lock is only ever held here
+                        // across an infallible `take()`, so poisoning is
+                        // practically unreachable; recover the guard defensively
+                        // anyway, since a poisoned lock still guards a valid
+                        // handle and shutdown should not fail over it.
+                        let handle = self
+                            .handle
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .take();
+                        join_worker_thread(handle)
                     })
                     .map_err(|err| match err {
                         std::sync::mpsc::RecvTimeoutError::Timeout => {
@@ -1006,6 +1046,31 @@ mod tests {
     use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status};
     use std::fmt::Debug;
     use std::time::Duration;
+
+    #[test]
+    fn join_worker_thread_none_is_ok() {
+        assert!(super::join_worker_thread(None).is_ok());
+    }
+
+    #[test]
+    fn join_worker_thread_joins_clean_thread() {
+        let handle = std::thread::spawn(|| {});
+        assert!(super::join_worker_thread(Some(handle)).is_ok());
+    }
+
+    #[test]
+    fn join_worker_thread_converts_panic_to_error() {
+        // A panicked worker must become an error during shutdown, never a
+        // second panic, and the original panic message must be preserved.
+        let handle = std::thread::spawn(|| panic!("boom in worker"));
+        match super::join_worker_thread(Some(handle)) {
+            Err(crate::error::OTelSdkError::InternalFailure(msg)) => {
+                assert!(msg.contains("panicked during shutdown"), "got: {msg}");
+                assert!(msg.contains("boom in worker"), "got: {msg}");
+            }
+            other => panic!("expected InternalFailure, got {other:?}"),
+        }
+    }
 
     #[test]
     fn simple_span_processor_on_end_calls_export() {

--- a/opentelemetry-sdk/src/util.rs
+++ b/opentelemetry-sdk/src/util.rs
@@ -7,3 +7,45 @@ pub fn tokio_interval_stream(
 ) -> tokio_stream::wrappers::IntervalStream {
     tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(period))
 }
+
+/// Extracts a human-readable message from a panic payload, such as the value
+/// returned by [`std::thread::JoinHandle::join`] or
+/// [`std::panic::catch_unwind`].
+///
+/// Panic payloads are almost always `&str` (from `panic!("literal")`) or
+/// `String` (from `panic!("{}", ...)`); any other payload type yields a generic
+/// fallback, as its value cannot be rendered without knowing its concrete type.
+#[cfg(any(feature = "trace", feature = "logs"))]
+pub(crate) fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown cause")
+}
+
+#[cfg(all(test, any(feature = "trace", feature = "logs")))]
+mod tests {
+    use super::panic_message;
+    use std::any::Any;
+
+    #[test]
+    fn panic_message_extracts_str_payload() {
+        // `panic!("literal")` produces a `&str` payload.
+        let payload: Box<dyn Any + Send> = Box::new("boom");
+        assert_eq!(panic_message(&*payload), "boom");
+    }
+
+    #[test]
+    fn panic_message_extracts_string_payload() {
+        // `panic!("{}", ...)` produces a `String` payload.
+        let payload: Box<dyn Any + Send> = Box::new(String::from("kaboom"));
+        assert_eq!(panic_message(&*payload), "kaboom");
+    }
+
+    #[test]
+    fn panic_message_falls_back_for_other_payloads() {
+        let payload: Box<dyn Any + Send> = Box::new(42i32);
+        assert_eq!(panic_message(&*payload), "unknown cause");
+    }
+}


### PR DESCRIPTION
Fixes #3375

## Changes

`BatchSpanProcessor` and `BatchLogProcessor` panicked during **shutdown** via `.unwrap()` on thread operations, and the shutdown path also mishandled two non-panic cases. This fixes the shutdown path **without any breaking API change** (signatures are unchanged; `shutdown()` already returns `OTelSdkResult`).

`shutdown_with_timeout` now matches on `recv_timeout` explicitly, with one behavior per outcome:

- **`Ok(result)` — worker exported the final batch and replied:** join the worker, then return the worker's own export result. Previously the result was discarded with `|_|`, so a failed final shutdown export was silently reported as `Ok(())`.
- **`Disconnected` — worker dropped the reply sender without responding (it panicked mid-shutdown, e.g. during the final export or the exporter's own shutdown):** join the worker so the original panic message is surfaced as `OTelSdkError::InternalFailure`, instead of a masking *second* panic or an opaque "disconnected channel" error.
- **`Timeout` — worker still running:** return `OTelSdkError::Timeout` without joining (joining could block past the timeout). The worker-leak / data-loss on this arm is fundamental — the worker is parked in an uninterruptible `block_on(export())` that cannot be cancelled — and is tracked, together with the rest of the export-cancellation class, in #3542.

Supporting changes:

- A poisoned handle mutex is recovered via `into_inner()` rather than `unwrap()`, extracted into a `take_worker_handle()` helper used on both the clean and disconnected arms, and the lock is released before the blocking `join()`.
- The shared `join_worker_thread()` helper (in `util.rs`) converts a worker-thread panic payload into `OTelSdkError::InternalFailure`, preserving the original panic message.
- New tests per processor: `shutdown_returns_final_export_error` (a failing final export propagates) and `shutdown_surfaces_worker_panic_during_export` (a worker panic is surfaced as an error, with no second panic), alongside the existing `join_worker_thread` helper tests.

### Constructor spawn failure: intentionally still fail-fast

The thread-spawn `.expect()` in the constructors is **kept as a panic**, per [review discussion](https://github.com/open-telemetry/opentelemetry-rust/pull/3538#discussion_r3367961873). A spawn failure at construction is an unrecoverable setup-time error — without the worker the processor can never export anything — and the [OTel error-handling spec](https://opentelemetry.io/docs/specs/otel/error-handling/) permits failing fast on initialization. The panic now surfaces the underlying OS error (usually resource exhaustion) instead of a bare `"Thread spawn failed."`.

Returning a `Result` from construction is the preferred long-term fix, but it is a breaking change to the stable Logs/Metrics SDK; it is tracked separately for the OTLP exporter builder / v2.0 via #2690 and #3462.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable) — no public API changes; all signatures unchanged
