### PR TITLE
feat(api): add StringValue::from_static_str

### DIFF
--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- **Added** `StringValue::from_static_str` to initialize a constant `StringValue`.
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -259,6 +259,11 @@ impl AsRef<str> for StringValue {
 }
 
 impl StringValue {
+    /// Create a new const `StringValue`.
+    pub const fn from_static_str(value: &'static str) -> Self {
+        StringValue(OtelString::Static(value))
+    }
+
     /// Returns a string slice to this value
     pub fn as_str(&self) -> &str {
         self.0.as_str()

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -261,13 +261,13 @@ impl AsRef<str> for StringValue {
 impl StringValue {
     /// Create a new const `StringValue`.
     ///
-    /// This can be used to create constant labels at compile time:
+    /// This is useful for making static label values:
     /// ```rust
-    /// # use opentelemetry::{StringValue, KeyValue, Key};
-    /// const LABELS: &[KeyValue] = &[KeyValue {
-    ///     key: Key::from_static_str("key"),
-    ///     value: Value::String(StringValue::from_static_str("value")),
-    /// }];
+    /// # use opentelemetry::{StringValue, KeyValue, Key, Value};
+    /// let labels = &[KeyValue::new(
+    ///     Key::from_static_str("key"),
+    ///     Value::String(StringValue::from_static_str("value")),
+    /// )];
     /// ```
     pub const fn from_static_str(value: &'static str) -> Self {
         StringValue(OtelString::Static(value))

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -266,7 +266,7 @@ impl StringValue {
     /// # use opentelemetry::{StringValue, KeyValue, Key, Value};
     /// let labels = &[KeyValue::new(
     ///     Key::from_static_str("key"),
-    ///     Value::String(StringValue::from_static_str("value")),
+    ///     StringValue::from_static_str("value"),
     /// )];
     /// ```
     pub const fn from_static_str(value: &'static str) -> Self {

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -260,6 +260,15 @@ impl AsRef<str> for StringValue {
 
 impl StringValue {
     /// Create a new const `StringValue`.
+    ///
+    /// This can be used to create constant labels at compile time:
+    /// ```rust
+    /// # use opentelemetry::{StringValue, KeyValue};
+    /// const LABELS: &[KeyValue] = &[KeyValue {
+    ///     key: Key::from_static_str("key"),
+    ///     value: Value::String(StringValue::from_static_str("value")),
+    /// }];
+    /// ```
     pub const fn from_static_str(value: &'static str) -> Self {
         StringValue(OtelString::Static(value))
     }

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -263,7 +263,7 @@ impl StringValue {
     ///
     /// This can be used to create constant labels at compile time:
     /// ```rust
-    /// # use opentelemetry::{StringValue, KeyValue};
+    /// # use opentelemetry::{StringValue, KeyValue, Key};
     /// const LABELS: &[KeyValue] = &[KeyValue {
     ///     key: Key::from_static_str("key"),
     ///     value: Value::String(StringValue::from_static_str("value")),


### PR DESCRIPTION
## Changes

Add `StringValue::from_static_str`, make it possible to create a StringValue at compile time.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
