### PR TITLE
perf: Do not allocate for scope attributes that collide with reserved ones

### DIFF
--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -422,6 +422,10 @@ fn get_scope_labels(scope: &InstrumentationScope) -> Vec<LabelPair> {
 
     let mut attr_labels = BTreeMap::<String, Vec<String>>::new();
     for kv in scope.attributes() {
+        if matches!(kv.key.as_str(), "name" | "version" | "schema_url") {
+            continue;
+        }
+
         let label_name = utils::sanitize_prom_kv(&format!("{SCOPE_ATTRIBUTE_PREFIX}{}", kv.key));
         if RESERVED_SCOPE_LABELS.contains(&label_name.as_str()) {
             continue;


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-rust/pull/3503#discussion_r3388988776

## Changes

Prevent allocation in `format!` for labels that we know will collide with reserved ones.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
