### PR TITLE
fix(prometheus-exporter): Concatenate metric attributes with Scope during collisions

### DIFF
--- a/opentelemetry-prometheus/src/lib.rs
+++ b/opentelemetry-prometheus/src/lib.rs
@@ -377,28 +377,64 @@ impl prometheus::core::Collector for Collector {
 /// It sanitizes invalid characters and handles duplicate keys (due to
 /// sanitization) by sorting and concatenating the values following the spec.
 fn get_attrs(kvs: &mut dyn Iterator<Item = (&Key, &Value)>, extra: &[LabelPair]) -> Vec<LabelPair> {
-    let mut keys_map = BTreeMap::<String, Vec<String>>::new();
+    let mut keys_map = BTreeMap::<String, Vec<(String, String)>>::new();
+    let mut extra_keys_map = BTreeMap::<String, Vec<(String, String)>>::new();
+    let mut extra_key_order = Vec::with_capacity(extra.len());
+
+    for label in extra {
+        let key = label.name().to_string();
+        if !extra_keys_map.contains_key(&key) {
+            extra_key_order.push(key.clone());
+        }
+        extra_keys_map
+            .entry(key.clone())
+            .and_modify(|values| values.push((key.clone(), label.value().to_string())))
+            .or_insert_with(|| vec![(key, label.value().to_string())]);
+    }
+
     for (key, value) in kvs {
-        let key = utils::sanitize_prom_kv(key.as_str());
-        keys_map
-            .entry(key)
-            .and_modify(|v| v.push(value.to_string()))
-            .or_insert_with(|| vec![value.to_string()]);
+        let original_key = key.as_str().to_string();
+        let sanitized_key = utils::sanitize_prom_kv(key.as_str());
+
+        if let Some(values) = extra_keys_map.get_mut(&sanitized_key) {
+            values.push((original_key, value.to_string()));
+        } else {
+            keys_map
+                .entry(sanitized_key)
+                .and_modify(|values| values.push((original_key.clone(), value.to_string())))
+                .or_insert_with(|| vec![(original_key, value.to_string())]);
+        }
     }
 
     let mut res = Vec::with_capacity(keys_map.len() + extra.len());
 
     for (key, mut values) in keys_map.into_iter() {
-        values.sort_unstable();
+        values.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
 
         let mut lp = LabelPair::default();
         lp.set_name(key);
-        lp.set_value(values.join(";"));
+        lp.set_value(
+            values
+                .into_iter()
+                .map(|(_, value)| value)
+                .collect::<Vec<_>>()
+                .join(";"),
+        );
         res.push(lp);
     }
 
-    if !extra.is_empty() {
-        res.extend(&mut extra.iter().cloned());
+    for key in extra_key_order {
+        if let Some(mut values) = extra_keys_map.remove(&key) {
+            values.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+            res.push(label_pair(
+                key,
+                values
+                    .into_iter()
+                    .map(|(_, value)| value)
+                    .collect::<Vec<_>>()
+                    .join(";"),
+            ));
+        }
     }
 
     res

--- a/opentelemetry-prometheus/tests/integration_test.rs
+++ b/opentelemetry-prometheus/tests/integration_test.rs
@@ -55,6 +55,39 @@ fn scope_info_labels_are_added_to_metric_points() {
 }
 
 #[test]
+fn scope_info_labels_do_not_collide_with_metric_attributes() {
+    let registry = prometheus::Registry::new();
+    let exporter = ExporterBuilder::default()
+        .with_registry(registry.clone())
+        .build()
+        .unwrap();
+    let provider = SdkMeterProvider::builder().with_reader(exporter).build();
+
+    let scope = InstrumentationScope::builder("scope-test")
+        .with_version("v1.2.3")
+        .with_schema_url("https://opentelemetry.io/schemas/1.0.0")
+        .build();
+    let meter = provider.meter_with_scope(scope);
+
+    let counter = meter.u64_counter("scope.counter").build();
+    counter.add(
+        1,
+        &[
+            KeyValue::new("metric.attr", "metric-value"),
+            KeyValue::new("otel_scope_name", "metric-scope-name"),
+            KeyValue::new("otel_scope_version", "metric-scope-version"),
+            KeyValue::new("otel_scope_schema_url", "metric-scope-schema-url"),
+        ],
+    );
+
+    let output = gather_and_encode(registry);
+
+    assert!(output.contains(
+        r#"scope_counter_total{metric_attr="metric-value",otel_scope_name="scope-test;metric-scope-name",otel_scope_version="v1.2.3;metric-scope-version",otel_scope_schema_url="https://opentelemetry.io/schemas/1.0.0;metric-scope-schema-url"} 1"#
+    ));
+}
+
+#[test]
 fn scope_info_labels_can_be_disabled() {
     let registry = prometheus::Registry::new();
     let exporter = ExporterBuilder::default()


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-rust/pull/3503#discussion_r3389029168

## Changes

Small change so `extra` labels always have preference over metric attributes in `get_attributes`. From my understanding, this will make sure Scope Name/Version/SchemaURL and attributes will always superseed metric attributes

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
