### PR TITLE
feat(trace): add allocation-free to_hex() for TraceId and SpanId

### DIFF
--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -253,7 +253,7 @@ pub mod context;
 pub use context::{Context, ContextGuard};
 
 mod trace_context;
-pub use trace_context::{SpanId, TraceFlags, TraceId};
+pub use trace_context::{HexEncode, SpanId, TraceFlags, TraceId};
 
 mod common;
 

--- a/opentelemetry/src/trace_context.rs
+++ b/opentelemetry/src/trace_context.rs
@@ -1,7 +1,63 @@
 use std::fmt;
 use std::hash::Hash;
 use std::num::ParseIntError;
-use std::ops::{BitAnd, BitOr, Not};
+use std::ops::{BitAnd, BitOr, Deref, Not};
+
+/// A stack-allocated buffer holding the lowercase hex encoding of a trace/span ID.
+///
+/// `N` is the number of hex characters (32 for [`TraceId`], 16 for [`SpanId`]).
+/// Obtained from [`TraceId::to_hex`] or [`SpanId::to_hex`].
+///
+/// Derefs to `&str` so it can be used anywhere a string slice is expected
+/// without any heap allocation.
+///
+/// # Example
+/// ```
+/// use opentelemetry::trace::TraceId;
+///
+/// let id = TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap();
+/// let hex: &str = &id.to_hex();   // no allocation
+/// assert_eq!(hex, "4bf92f3577b34da6a3ce929d0e0e4736");
+/// ```
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+pub struct HexEncode<const N: usize>([u8; N]);
+
+impl<const N: usize> HexEncode<N> {
+    /// Return the hex string as a `&str`.
+    pub fn as_str(&self) -> &str {
+        // SAFETY: the buffer is always filled with ASCII hex digits.
+        unsafe { std::str::from_utf8_unchecked(&self.0) }
+    }
+}
+
+impl<const N: usize> Deref for HexEncode<N> {
+    type Target = str;
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<const N: usize> fmt::Display for HexEncode<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl<const N: usize> fmt::Debug for HexEncode<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Write `bytes` as lowercase hex digits into `out`.
+/// `out.len()` must equal `bytes.len() * 2`.
+fn encode_hex_bytes(bytes: &[u8], out: &mut [u8]) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for (i, &b) in bytes.iter().enumerate() {
+        out[2 * i] = HEX[(b >> 4) as usize];
+        out[2 * i + 1] = HEX[(b & 0x0f) as usize];
+    }
+}
 
 /// Flags that can be set on a `SpanContext`.
 ///
@@ -122,6 +178,25 @@ impl TraceId {
     pub fn from_hex(hex: &str) -> Result<Self, ParseIntError> {
         u128::from_str_radix(hex, 16).map(TraceId)
     }
+
+    /// Return the lowercase hex representation as a stack-allocated 32-character buffer.
+    ///
+    /// Unlike `.to_string()` / `format!("{self}")`, this method does **not** allocate on
+    /// the heap. Use it on hot export paths where every allocation counts.
+    ///
+    /// # Example
+    /// ```
+    /// use opentelemetry::trace::TraceId;
+    ///
+    /// let id = TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap();
+    /// let hex = id.to_hex();
+    /// assert_eq!(&*hex, "4bf92f3577b34da6a3ce929d0e0e4736");
+    /// ```
+    pub fn to_hex(&self) -> HexEncode<32> {
+        let mut buf = [0u8; 32];
+        encode_hex_bytes(&self.to_bytes(), &mut buf);
+        HexEncode(buf)
+    }
 }
 
 impl From<u128> for TraceId {
@@ -182,6 +257,25 @@ impl SpanId {
     /// ```
     pub fn from_hex(hex: &str) -> Result<Self, ParseIntError> {
         u64::from_str_radix(hex, 16).map(SpanId)
+    }
+
+    /// Return the lowercase hex representation as a stack-allocated 16-character buffer.
+    ///
+    /// Unlike `.to_string()` / `format!("{self}")`, this method does **not** allocate on
+    /// the heap. Use it on hot export paths where every allocation counts.
+    ///
+    /// # Example
+    /// ```
+    /// use opentelemetry::trace::SpanId;
+    ///
+    /// let id = SpanId::from_hex("00f067aa0ba902b7").unwrap();
+    /// let hex = id.to_hex();
+    /// assert_eq!(&*hex, "00f067aa0ba902b7");
+    /// ```
+    pub fn to_hex(&self) -> HexEncode<16> {
+        let mut buf = [0u8; 16];
+        encode_hex_bytes(&self.to_bytes(), &mut buf);
+        HexEncode(buf)
     }
 }
 

--- a/opentelemetry/src/trace_context.rs
+++ b/opentelemetry/src/trace_context.rs
@@ -348,4 +348,65 @@ mod tests {
             assert_eq!(test_case.0, SpanId::from_bytes(test_case.2));
         }
     }
+
+    #[test]
+    fn test_trace_id_to_hex_matches_display() {
+        for (id, expected, _) in trace_id_test_data() {
+            let hex = id.to_hex();
+            assert_eq!(hex.as_str(), expected);
+            assert_eq!(&*hex, expected);
+            assert_eq!(format!("{}", hex), expected);
+            assert_eq!(format!("{:?}", hex), expected);
+        }
+    }
+
+    #[test]
+    fn test_span_id_to_hex_matches_display() {
+        for (id, expected, _) in span_id_test_data() {
+            let hex = id.to_hex();
+            assert_eq!(hex.as_str(), expected);
+            assert_eq!(&*hex, expected);
+            assert_eq!(format!("{}", hex), expected);
+            assert_eq!(format!("{:?}", hex), expected);
+        }
+    }
+
+    #[test]
+    fn test_to_hex_all_bytes() {
+        // Verify every possible byte value encodes correctly.
+        let mut bytes = [0u8; 16];
+        for i in 0u8..=255 {
+            bytes[i as usize % 16] = i;
+        }
+        let id = TraceId::from_bytes(bytes);
+        let hex = id.to_hex();
+        assert_eq!(hex.as_str(), format!("{}", id));
+        assert_eq!(hex.len(), 32);
+    }
+
+    #[test]
+    fn test_hex_encode_deref_and_clone() {
+        let id = TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap();
+        let hex = id.to_hex();
+        let cloned = hex;
+        assert_eq!(hex.as_str(), cloned.as_str());
+        assert_eq!(hex, cloned);
+        // deref to &str works in string comparisons
+        let s: &str = &hex;
+        assert_eq!(s, "4bf92f3577b34da6a3ce929d0e0e4736");
+    }
+
+    #[test]
+    fn test_span_id_to_hex_invalid() {
+        let hex = SpanId::INVALID.to_hex();
+        assert_eq!(hex.as_str(), "0000000000000000");
+        assert_eq!(hex.len(), 16);
+    }
+
+    #[test]
+    fn test_trace_id_to_hex_invalid() {
+        let hex = TraceId::INVALID.to_hex();
+        assert_eq!(hex.as_str(), "00000000000000000000000000000000");
+        assert_eq!(hex.len(), 32);
+    }
 }


### PR DESCRIPTION
﻿Closes #3544 — adds allocation-free hex encoding methods for `TraceId` and `SpanId`.

## Problem

Exporters that need the hex representation of a trace/span ID today call `.to_string()`, which heap-allocates a `String` on every export event. On hot paths this is two unnecessary allocations per span record.

## Solution

This PR adds:

- **`HexEncode<N>`** — a stack-allocated `[u8; N]` newtype that:
  - implements `Deref<Target = str>`
  - implements `Display` and `Debug`
  - carries zero heap state
- **`TraceId::to_hex() -> HexEncode<32>`** — 32-char lowercase hex, no allocation
- **`SpanId::to_hex() -> HexEncode<16>`** — 16-char lowercase hex, no allocation

`HexEncode` is re-exported from the crate root alongside `TraceId`/`SpanId`.

## Usage

Before:
```rust
let s: String = trace_id.to_string();   // heap allocation
```
After:
```rust
let hex = trace_id.to_hex();   // stack only
write_field(&*hex);             // deref to &str, zero-copy
```

Exporters can switch from `format!("{}", trace_id)` to `trace_id.to_hex()` and eliminate both allocations per record.
