### PR TITLE
fix(sdk): count batch items before enqueue to fix flush/shutdown race

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -6,6 +6,12 @@
   new `BoundGauge<T>` and `BoundUpDownCounter<T>` types exposed by the
   `opentelemetry` crate. Requires the `experimental_metrics_bound_instruments`
   feature.
+- Fixed a race in `BatchSpanProcessor` and `BatchLogProcessor` where a
+  span/log enqueued just before `force_flush()` or `shutdown()` could be
+  missed by the flush and dropped at shutdown: the pending-item counter is
+  now incremented before enqueueing (and reverted if the queue is full), so
+  the worker's counter snapshot can no longer under-count items already in
+  the queue (#3453).
 - Default SDK Resource construction now falls back to `unknown_service` under
   Miri instead of calling `std::env::current_exe()`, avoiding an abort in Miri
   isolation mode while preserving the normal

--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -173,6 +173,11 @@ impl Debug for BatchLogProcessor {
 
 impl LogProcessor for BatchLogProcessor {
     fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+        // Count the log record before enqueueing it so that a concurrent
+        // force_flush()/shutdown() drain never observes an
+        // enqueued-but-uncounted record and misses it (issue #3453). If the
+        // send fails, the increment is reverted in the error arms below.
+        let previous_batch_size = self.current_batch_size.fetch_add(1, Ordering::AcqRel);
         let result = self
             .logs_sender
             .try_send(Box::new((record.clone(), instrumentation.clone())));
@@ -185,11 +190,9 @@ impl LogProcessor for BatchLogProcessor {
                 self.processed_success.add(1);
 
                 // Successfully sent the log record to the data channel.
-                // Increment the current batch size and check if it has reached
-                // the max export batch size.
-                if self.current_batch_size.fetch_add(1, Ordering::AcqRel) + 1
-                    >= self.max_export_batch_size
-                {
+                // Check if the current batch size has reached the max export
+                // batch size.
+                if previous_batch_size + 1 >= self.max_export_batch_size {
                     // Check if the a control message for exporting logs is
                     // already sent to the worker thread. If not, send a control
                     // message to export logs. `export_log_message_sent` is set
@@ -225,6 +228,8 @@ impl LogProcessor for BatchLogProcessor {
                 }
             }
             Err(mpsc::TrySendError::Full(_)) => {
+                // The record never entered the channel; revert the increment.
+                self.current_batch_size.fetch_sub(1, Ordering::AcqRel);
                 // Record queue-full drop in self-diagnostics
                 #[cfg(feature = "experimental_metrics_bound_instruments")]
                 self.processed_queue_full.add(1);
@@ -237,6 +242,8 @@ impl LogProcessor for BatchLogProcessor {
                 }
             }
             Err(mpsc::TrySendError::Disconnected(_)) => {
+                // The record never entered the channel; revert the increment.
+                self.current_batch_size.fetch_sub(1, Ordering::AcqRel);
                 // Record after-shutdown drop in self-diagnostics
                 #[cfg(feature = "experimental_metrics_bound_instruments")]
                 self.processed_after_shutdown.add(1);
@@ -848,6 +855,7 @@ mod tests {
     use opentelemetry::InstrumentationScope;
     use opentelemetry::KeyValue;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::mpsc;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -1117,6 +1125,90 @@ mod tests {
         let exporter = InMemoryLogExporterBuilder::default().build();
         let processor = BatchLogProcessor::new(exporter.clone(), BatchConfig::default());
         processor.shutdown().unwrap();
+    }
+
+    #[derive(Debug)]
+    struct BlockingExporter {
+        exported_count: Arc<AtomicUsize>,
+        export_started: mpsc::SyncSender<()>,
+        release: Arc<Mutex<mpsc::Receiver<()>>>,
+    }
+
+    impl LogExporter for BlockingExporter {
+        async fn export(&self, batch: LogBatch<'_>) -> OTelSdkResult {
+            let _ = self.export_started.try_send(());
+            // Block until the test releases the export.
+            let _ = self.release.lock().unwrap().recv();
+            self.exported_count.fetch_add(batch.len(), Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_batch_log_processor_emit_reverts_count_when_queue_full() {
+        let (started_sender, started_receiver) = mpsc::sync_channel(8);
+        let (release_sender, release_receiver) = mpsc::sync_channel(8);
+        let exported_count = Arc::new(AtomicUsize::new(0));
+        let exporter = BlockingExporter {
+            exported_count: exported_count.clone(),
+            export_started: started_sender,
+            release: Arc::new(Mutex::new(release_receiver)),
+        };
+        let config = BatchConfigBuilder::default()
+            .with_max_queue_size(4)
+            .with_max_export_batch_size(4)
+            .with_scheduled_delay(Duration::from_secs(60))
+            .build();
+        let processor = BatchLogProcessor::new(exporter, config);
+        let instrumentation = InstrumentationScope::default();
+        let emit = || {
+            let mut record = SdkLogRecord::new();
+            record.set_body("test log".into());
+            processor.emit(&mut record, &instrumentation);
+        };
+
+        // Fill the queue to the export threshold; the worker drains all four
+        // records and blocks inside export().
+        for _ in 0..4 {
+            emit();
+        }
+        started_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("worker should start exporting the first batch");
+
+        // While the worker is blocked, refill the queue and overflow it by
+        // two records, which must be dropped and their counts reverted.
+        for _ in 0..6 {
+            emit();
+        }
+
+        assert_eq!(processor.dropped_logs_count.load(Ordering::Relaxed), 2);
+        // 4 records in-flight in the blocked export (not yet subtracted)
+        // plus 4 records queued. Without the queue-full revert this would
+        // read 10.
+        assert_eq!(
+            processor.current_batch_size.load(Ordering::Relaxed),
+            8,
+            "dropped logs must not remain counted as pending"
+        );
+
+        // Release the in-flight export and the one triggered by force_flush.
+        release_sender.send(()).unwrap();
+        release_sender.send(()).unwrap();
+        let flush_result = processor.force_flush();
+        assert!(flush_result.is_ok(), "force flush failed unexpectedly");
+
+        assert_eq!(
+            exported_count.load(Ordering::SeqCst),
+            8,
+            "all logs that entered the queue must be exported"
+        );
+        assert_eq!(
+            processor.current_batch_size.load(Ordering::Relaxed),
+            0,
+            "counter should settle to zero; a leftover value indicates the \
+             queue-full path did not revert its increment"
+        );
     }
 
     /// A slow exporter that counts the number of logs received.

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -1524,7 +1524,7 @@ mod tests {
 
         let processor = BatchSpanProcessor::new(exporter, config);
 
-        let total_spans_per_thread = 100_000;
+        let total_spans_per_thread = 10_000;
         let num_threads = 4;
         let total_spans_to_emit = total_spans_per_thread * num_threads;
 

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -583,17 +583,20 @@ impl SpanProcessor for BatchSpanProcessor {
 
     /// Handles span end.
     fn on_end(&self, span: SpanData) {
+        // Count the span before enqueueing it so that a concurrent
+        // force_flush()/shutdown() drain never observes an
+        // enqueued-but-uncounted span and misses it (issue #3453). If the
+        // send fails, the increment is reverted in the error arms below.
+        let previous_batch_size = self.current_batch_size.fetch_add(1, Ordering::AcqRel);
         let result = self.span_sender.try_send(span);
 
         // match for result and handle each separately
         match result {
             Ok(_) => {
                 // Successfully sent the span to the data channel.
-                // Increment the current batch size and check if it has reached
-                // the max export batch size.
-                if self.current_batch_size.fetch_add(1, Ordering::AcqRel) + 1
-                    >= self.max_export_batch_size
-                {
+                // Check if the current batch size has reached the max export
+                // batch size.
+                if previous_batch_size + 1 >= self.max_export_batch_size {
                     // Check if the a control message for exporting spans is
                     // already sent to the worker thread. If not, send a control
                     // message to export spans. `export_span_message_sent` is set
@@ -630,6 +633,8 @@ impl SpanProcessor for BatchSpanProcessor {
                 }
             }
             Err(std::sync::mpsc::TrySendError::Full(_)) => {
+                // The span never entered the channel; revert the increment.
+                self.current_batch_size.fetch_sub(1, Ordering::AcqRel);
                 // Increment dropped spans count. The first time we have to drop
                 // a span, emit a warning.
                 if self.dropped_spans_count.fetch_add(1, Ordering::Relaxed) == 0 {
@@ -638,6 +643,8 @@ impl SpanProcessor for BatchSpanProcessor {
                 }
             }
             Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
+                // The span never entered the channel; revert the increment.
+                self.current_batch_size.fetch_sub(1, Ordering::AcqRel);
                 // Given background thread is the only receiver, and it's
                 // disconnected, it indicates the thread is shutdown
                 otel_warn!(
@@ -1332,6 +1339,216 @@ mod tests {
         assert!(
             receiver.try_recv().is_ok(),
             "one span should remain queued for a later export cycle"
+        );
+    }
+
+    #[test]
+    fn batchspanprocessor_drain_handles_counted_but_not_yet_enqueued_spans() {
+        // Since on_end() increments `current_batch_size` before enqueueing
+        // (issue #3453), a concurrent drain can observe a counter that is
+        // higher than the channel depth. The drain must export what is
+        // available, keep the surplus count intact (no underflow), and pick
+        // the late span up on a later cycle.
+        let exporter = MockSpanExporter::new();
+        let exported_spans = exporter.exported_spans.clone();
+        let (sender, receiver) = std::sync::mpsc::sync_channel(4);
+        // Two spans counted, but only one has landed in the channel so far.
+        let current_batch_size = AtomicUsize::new(2);
+        let config = BatchConfigBuilder::default()
+            .with_max_queue_size(4)
+            .with_max_export_batch_size(4)
+            .build();
+        let mut spans = Vec::with_capacity(config.max_export_batch_size);
+        let mut last_export_time = Instant::now();
+
+        sender.send(create_test_span("landed")).unwrap();
+
+        let result = BatchSpanProcessor::get_spans_and_export(
+            &receiver,
+            &exporter,
+            &mut spans,
+            &mut last_export_time,
+            &current_batch_size,
+            &config,
+        );
+
+        assert!(result.is_ok(), "export should succeed");
+        assert_eq!(
+            exported_spans.lock().unwrap().len(),
+            1,
+            "only the span that landed in the channel can be exported"
+        );
+        assert_eq!(
+            current_batch_size.load(Ordering::Relaxed),
+            1,
+            "the count of the not-yet-enqueued span must survive the drain"
+        );
+
+        // The late span lands; a later drain cycle must export it and settle
+        // the counter back to zero.
+        sender.send(create_test_span("late")).unwrap();
+        let result = BatchSpanProcessor::get_spans_and_export(
+            &receiver,
+            &exporter,
+            &mut spans,
+            &mut last_export_time,
+            &current_batch_size,
+            &config,
+        );
+
+        assert!(result.is_ok(), "export should succeed");
+        assert_eq!(
+            exported_spans.lock().unwrap().len(),
+            2,
+            "the late span should be exported on the next cycle"
+        );
+        assert_eq!(
+            current_batch_size.load(Ordering::Relaxed),
+            0,
+            "counter should settle to zero once everything is exported"
+        );
+    }
+
+    #[derive(Debug)]
+    struct BlockingExporter {
+        exported_count: Arc<AtomicUsize>,
+        export_started: std::sync::mpsc::SyncSender<()>,
+        release: Arc<Mutex<std::sync::mpsc::Receiver<()>>>,
+    }
+
+    impl SpanExporter for BlockingExporter {
+        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+            let _ = self.export_started.try_send(());
+            // Block until the test releases the export.
+            let _ = self.release.lock().unwrap().recv();
+            self.exported_count.fetch_add(batch.len(), Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn batchspanprocessor_on_end_reverts_count_when_queue_full() {
+        let (started_sender, started_receiver) = std::sync::mpsc::sync_channel(8);
+        let (release_sender, release_receiver) = std::sync::mpsc::sync_channel(8);
+        let exported_count = Arc::new(AtomicUsize::new(0));
+        let exporter = BlockingExporter {
+            exported_count: exported_count.clone(),
+            export_started: started_sender,
+            release: Arc::new(Mutex::new(release_receiver)),
+        };
+        let config = BatchConfigBuilder::default()
+            .with_max_queue_size(4)
+            .with_max_export_batch_size(4)
+            .with_scheduled_delay(Duration::from_secs(60))
+            .build();
+        let processor = BatchSpanProcessor::new(exporter, config);
+
+        // Fill the queue to the export threshold; the worker drains all four
+        // spans and blocks inside export().
+        for _ in 0..4 {
+            processor.on_end(create_test_span("first_batch"));
+        }
+        started_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("worker should start exporting the first batch");
+
+        // While the worker is blocked, refill the queue and overflow it by
+        // two spans, which must be dropped and their counts reverted.
+        for _ in 0..4 {
+            processor.on_end(create_test_span("second_batch"));
+        }
+        for _ in 0..2 {
+            processor.on_end(create_test_span("overflow"));
+        }
+
+        assert_eq!(processor.dropped_spans_count.load(Ordering::Relaxed), 2);
+        // 4 spans in-flight in the blocked export (not yet subtracted) plus
+        // 4 spans queued. Without the queue-full revert this would read 10.
+        assert_eq!(
+            processor.current_batch_size.load(Ordering::Relaxed),
+            8,
+            "dropped spans must not remain counted as pending"
+        );
+
+        // Release the in-flight export and the one triggered by force_flush.
+        release_sender.send(()).unwrap();
+        release_sender.send(()).unwrap();
+        let flush_result = processor.force_flush();
+        assert!(flush_result.is_ok(), "force flush failed unexpectedly");
+
+        assert_eq!(
+            exported_count.load(Ordering::SeqCst),
+            8,
+            "all spans that entered the queue must be exported"
+        );
+        assert_eq!(
+            processor.current_batch_size.load(Ordering::Relaxed),
+            0,
+            "counter should settle to zero; a leftover value indicates the \
+             queue-full path did not revert its increment"
+        );
+    }
+
+    /// A slow exporter that counts the number of spans received.
+    /// Used for stress testing the BatchSpanProcessor.
+    #[derive(Debug)]
+    struct CountingSpanExporter {
+        count: Arc<AtomicUsize>,
+    }
+
+    impl SpanExporter for CountingSpanExporter {
+        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+            self.count.fetch_add(batch.len(), Ordering::SeqCst);
+            // Simulate slow export to cause queue buildup and drops
+            std::thread::sleep(Duration::from_millis(20));
+            Ok(())
+        }
+    }
+
+    /// Stress test that verifies all spans are accounted for.
+    /// With multiple threads pushing spans faster than the exporter can
+    /// handle, some spans will inevitably be dropped. This test validates:
+    /// total_spans_sent == spans_received_by_exporter + spans_dropped
+    #[test]
+    fn batchspanprocessor_all_spans_accounted_for() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let exporter = CountingSpanExporter {
+            count: count.clone(),
+        };
+
+        let config = BatchConfigBuilder::default()
+            .with_max_queue_size(2048)
+            .with_max_export_batch_size(512)
+            .with_scheduled_delay(Duration::from_millis(5))
+            .build();
+
+        let processor = BatchSpanProcessor::new(exporter, config);
+
+        let total_spans_per_thread = 100_000;
+        let num_threads = 4;
+        let total_spans_to_emit = total_spans_per_thread * num_threads;
+
+        std::thread::scope(|s| {
+            for _ in 0..num_threads {
+                s.spawn(|| {
+                    for _ in 0..total_spans_per_thread {
+                        processor.on_end(create_test_span("stress test span"));
+                    }
+                });
+            }
+        });
+
+        // Shutdown the processor to ensure all buffered spans are flushed
+        processor.shutdown().unwrap();
+
+        let spans_received = count.load(Ordering::SeqCst);
+        let spans_dropped = processor.dropped_spans_count.load(Ordering::SeqCst);
+
+        // The invariant: every span is either received or dropped
+        assert_eq!(
+            spans_received + spans_dropped,
+            total_spans_to_emit,
+            "Spans unaccounted for! Received: {spans_received}, Dropped: {spans_dropped}, Total emitted: {total_spans_to_emit}"
         );
     }
 


### PR DESCRIPTION
Fixes #3453

## Problem

In the thread-based `BatchSpanProcessor` and `BatchLogProcessor`, the producer (`on_end()` / `emit()`) does `try_send(item)` into the data channel **first** and only then `current_batch_size.fetch_add(1)`. The worker uses a snapshot of `current_batch_size` (`load(Acquire)`) as the drain *target* for `force_flush()` / `shutdown()`.

If a flush/shutdown drain snapshots the counter in the window **between** a successful `try_send` and the `fetch_add`, it under-counts: the worker drains nothing (or too little) and returns success. As a result:

- `force_flush()` can return before an already-enqueued item is exported.
- `shutdown()` can miss an already-enqueued item and then exit, dropping it.

## Fix

Increment `current_batch_size` **before** enqueueing, and revert it (`fetch_sub`) when the send fails (`Full` or `Disconnected`). Producer-side only; the drain logic is untouched.

This flips the counter's invariant from "may under-count the channel" (lossy) to **"counter is always ≥ channel depth"** (an upper bound). A flush/shutdown drain can therefore no longer under-count items already in the queue.

## Why the drain logic doesn't need to change

The drain already tolerates a *transient over-count* (an item counted but not yet enqueued), thanks to the #3441 fix:

- `batch_limit = max_export_batch_size.min(target - total_exported)`
- break out of the loop on an empty chunk
- `fetch_sub` only the count actually exported

So when the worker snapshots a `target` that includes a not-yet-enqueued item, it exports what's in the channel, breaks on the empty chunk, and leaves that item's `+1` in the counter to be drained on a later cycle. No underflow, no spin. **#3441's drain logic and its regression test are left unchanged.**

### Race interleavings considered

1. **Original bug** (sent but not counted) — eliminated by construction (count precedes send).
2. **Symmetric race** (counted but not yet sent) during a flush — drain exports what's present, breaks on empty chunk, the phantom `+1` survives and is drained next cycle. The item wasn't "enqueued before the flush" in any happens-before sense, so missing it is within contract.
3. **Shutdown** — if `try_send` Ok happens-before the `shutdown()` call, the `fetch_add` (sequenced-before the send) is visible to the worker via the mutex-backed control channel → item is both counted and in the channel → exported.
4. **Queue full / disconnected** — `fetch_add` then send fails then `fetch_sub`: transient over-count of 1, handled like case 2; dropped-count accounting unchanged.

## Tests

- `batchspanprocessor_drain_handles_counted_but_not_yet_enqueued_spans` — drives the drain helper with counter=2 / channel depth=1, asserts 1 exported, counter stays at 1 (no underflow), and the late item is exported on the next cycle.
- `batchspanprocessor_on_end_reverts_count_when_queue_full` / `test_batch_log_processor_emit_reverts_count_when_queue_full` — overflow the queue while the exporter is blocked, assert dropped items don't remain counted as pending and the counter settles to 0 after flush. (Verified these fail without the queue-full revert.)
- `batchspanprocessor_all_spans_accounted_for` — spans analog of the existing logs stress test (4 threads × 100k), asserting `received + dropped == emitted`.

`cargo test -p opentelemetry_sdk --all-features --lib`, `cargo clippy --all-targets --all-features -- -Dwarnings`, and `cargo fmt --all -- --check` all pass.
