### PR TITLE
feat(metrics): add BoundGauge under experimental_metrics_bound_instruments

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- Bound instruments are now available for `Gauge` via the new `BoundGauge<T>`
+  type exposed by the `opentelemetry` crate. Requires the
+  `experimental_metrics_bound_instruments` feature.
 - Default SDK Resource construction now falls back to `unknown_service` under
   Miri instead of calling `std::env::current_exe()`, avoiding an abort in Miri
   isolation mode while preserving the normal

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -4437,6 +4437,17 @@ mod tests {
         })
     }
 
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    fn find_overflow_gauge_datapoint<T>(
+        data_points: &[GaugeDataPoint<T>],
+    ) -> Option<&GaugeDataPoint<T>> {
+        data_points.iter().find(|&datapoint| {
+            datapoint.attributes.iter().any(|kv| {
+                kv.key.as_str() == "otel.metric.overflow" && kv.value == Value::Bool(true)
+            })
+        })
+    }
+
     fn find_scope_metric<'a>(
         metrics: &'a [ScopeMetrics],
         name: &'a str,
@@ -6007,5 +6018,382 @@ mod tests {
         assert!(dp.attributes.iter().any(|kv| kv.key.as_str() == "k1"));
         assert!(dp.attributes.iter().any(|kv| kv.key.as_str() == "k2"));
         assert!(!dp.attributes.iter().any(|kv| kv.key.as_str() == "k3"));
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_gauge_cumulative() {
+        let mut test_context = TestContext::new(Temporality::Cumulative);
+        let gauge = test_context.meter().u64_gauge("my_gauge").build();
+        let attrs = vec![KeyValue::new("key1", "bound_value")];
+        let bound = gauge.bind(&attrs);
+
+        bound.record(10);
+        bound.record(20);
+        bound.record(30);
+        test_context.flush_metrics();
+
+        let MetricData::Gauge(gauge_data) = test_context.get_aggregation::<u64>("my_gauge", None)
+        else {
+            unreachable!()
+        };
+
+        assert_eq!(gauge_data.data_points.len(), 1, "Expected one data point");
+        let dp = &gauge_data.data_points[0];
+        assert_eq!(dp.value, 30, "Gauge should report the last recorded value");
+        assert_eq!(dp.attributes, vec![KeyValue::new("key1", "bound_value")]);
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_gauge_delta() {
+        let mut test_context = TestContext::new(Temporality::Delta);
+        let gauge = test_context.meter().u64_gauge("my_gauge").build();
+        let attrs = vec![KeyValue::new("key1", "bound_value")];
+        let bound = gauge.bind(&attrs);
+
+        bound.record(50);
+        bound.record(75);
+        test_context.flush_metrics();
+
+        let MetricData::Gauge(gauge_data) = test_context.get_aggregation::<u64>("my_gauge", None)
+        else {
+            unreachable!()
+        };
+        assert_eq!(gauge_data.data_points.len(), 1);
+        assert_eq!(gauge_data.data_points[0].value, 75);
+
+        // Next cycle: a new record produces the new last value.
+        test_context.reset_metrics();
+        bound.record(25);
+        test_context.flush_metrics();
+
+        let MetricData::Gauge(gauge_data) = test_context.get_aggregation::<u64>("my_gauge", None)
+        else {
+            unreachable!()
+        };
+        assert_eq!(gauge_data.data_points.len(), 1);
+        assert_eq!(
+            gauge_data.data_points[0].value, 25,
+            "Delta gauge should report only the latest value since the last collection"
+        );
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_gauge_matches_unbound() {
+        let mut test_context = TestContext::new(Temporality::Cumulative);
+        let gauge = test_context.meter().u64_gauge("my_gauge").build();
+        let attrs = vec![KeyValue::new("key1", "shared")];
+        let bound = gauge.bind(&attrs);
+
+        // Bound and unbound writes target the same data point. The final
+        // exported value is whichever write happened last.
+        gauge.record(10, &attrs);
+        bound.record(20);
+        gauge.record(30, &attrs);
+        bound.record(40);
+        test_context.flush_metrics();
+
+        let MetricData::Gauge(gauge_data) = test_context.get_aggregation::<u64>("my_gauge", None)
+        else {
+            unreachable!()
+        };
+
+        assert_eq!(
+            gauge_data.data_points.len(),
+            1,
+            "Bound and unbound should share the same data point"
+        );
+        assert_eq!(
+            gauge_data.data_points[0].value, 40,
+            "Last write (via bound) should win"
+        );
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_gauge_delta_no_update_no_export() {
+        let mut test_context = TestContext::new(Temporality::Delta);
+        let gauge = test_context.meter().u64_gauge("my_gauge").build();
+        let attrs = vec![KeyValue::new("key1", "bound_value")];
+        let bound = gauge.bind(&attrs);
+
+        // Cycle 1: record and collect.
+        bound.record(10);
+        test_context.flush_metrics();
+        let MetricData::Gauge(gauge_data) = test_context.get_aggregation::<u64>("my_gauge", None)
+        else {
+            unreachable!()
+        };
+        assert_eq!(gauge_data.data_points.len(), 1);
+        assert_eq!(gauge_data.data_points[0].value, 10);
+
+        // Cycle 2: no record - should export nothing.
+        test_context.reset_metrics();
+        test_context.flush_metrics();
+        let resource_metrics = test_context
+            .exporter
+            .get_finished_metrics()
+            .expect("metrics export should succeed");
+        assert!(
+            resource_metrics.is_empty(),
+            "Bound gauge with no updates should not export"
+        );
+
+        // Cycle 3: record again - handle still alive.
+        test_context.reset_metrics();
+        bound.record(99);
+        test_context.flush_metrics();
+        let MetricData::Gauge(gauge_data) = test_context.get_aggregation::<u64>("my_gauge", None)
+        else {
+            unreachable!()
+        };
+        assert_eq!(gauge_data.data_points.len(), 1);
+        assert_eq!(
+            gauge_data.data_points[0].value, 99,
+            "Bound handle should produce fresh value after quiet cycle"
+        );
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_gauge_at_overflow_attributes_to_overflow_bucket() {
+        let cardinality_limit = 3;
+        let view = move |i: &Instrument| {
+            if i.name() == "my_gauge" {
+                Stream::builder()
+                    .with_name("my_gauge")
+                    .with_cardinality_limit(cardinality_limit)
+                    .build()
+                    .ok()
+            } else {
+                None
+            }
+        };
+        let mut test_context = TestContext::new_with_view(Temporality::Delta, view);
+        let gauge = test_context.meter().u64_gauge("my_gauge").build();
+
+        // Fill to cardinality limit with unbound calls.
+        for v in 0..cardinality_limit {
+            gauge.record(1, &[KeyValue::new("A", v.to_string())]);
+        }
+
+        // bind() at overflow - handle binds directly to the overflow tracker.
+        let overflow_attrs = vec![KeyValue::new("A", "overflow_bind")];
+        let bound = gauge.bind(&overflow_attrs);
+        bound.record(42);
+
+        test_context.flush_metrics();
+        let MetricData::Gauge(gauge_data) = test_context.get_aggregation::<u64>("my_gauge", None)
+        else {
+            unreachable!()
+        };
+
+        assert_eq!(
+            gauge_data.data_points.len(),
+            cardinality_limit + 1,
+            "Expected {} unique + 1 overflow data points",
+            cardinality_limit
+        );
+
+        let overflow_dp = find_overflow_gauge_datapoint(&gauge_data.data_points)
+            .expect("overflow point expected");
+        assert_eq!(
+            overflow_dp.value, 42,
+            "Bound-at-overflow data should go to overflow bucket"
+        );
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_gauge_multiple_handles_same_attrs() {
+        let mut test_context = TestContext::new(Temporality::Delta);
+        let gauge = test_context.meter().u64_gauge("my_gauge").build();
+        let attrs = vec![KeyValue::new("key1", "shared")];
+
+        let bound1 = gauge.bind(&attrs);
+        let bound2 = gauge.bind(&attrs);
+
+        bound1.record(10);
+        bound2.record(20);
+        test_context.flush_metrics();
+
+        let MetricData::Gauge(gauge_data) = test_context.get_aggregation::<u64>("my_gauge", None)
+        else {
+            unreachable!()
+        };
+        assert_eq!(
+            gauge_data.data_points.len(),
+            1,
+            "Multiple handles to same attrs should share data point"
+        );
+        assert_eq!(gauge_data.data_points[0].value, 20);
+
+        // Drop one handle - entry should NOT be evicted while the other handle is alive.
+        drop(bound1);
+        test_context.reset_metrics();
+        test_context.flush_metrics();
+
+        test_context.reset_metrics();
+        bound2.record(5);
+        test_context.flush_metrics();
+
+        let MetricData::Gauge(gauge_data) = test_context.get_aggregation::<u64>("my_gauge", None)
+        else {
+            unreachable!()
+        };
+        assert_eq!(gauge_data.data_points.len(), 1);
+        assert_eq!(
+            gauge_data.data_points[0].value, 5,
+            "Entry should persist while any handle is alive"
+        );
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_gauge_empty_attributes_shares_with_unbound() {
+        let mut test_context = TestContext::new(Temporality::Cumulative);
+        let gauge = test_context.meter().u64_gauge("my_gauge").build();
+        let bound = gauge.bind(&[]);
+
+        // Mix bound and unbound calls with empty attributes - they must share
+        // the same data point. Last write wins.
+        gauge.record(10, &[]);
+        bound.record(20);
+        gauge.record(30, &[]);
+        bound.record(40);
+        test_context.flush_metrics();
+
+        let MetricData::Gauge(gauge_data) = test_context.get_aggregation::<u64>("my_gauge", None)
+        else {
+            unreachable!()
+        };
+
+        assert_eq!(
+            gauge_data.data_points.len(),
+            1,
+            "Bound and unbound with empty attributes must share the same data point"
+        );
+        let dp = &gauge_data.data_points[0];
+        assert!(dp.attributes.is_empty());
+        assert_eq!(dp.value, 40);
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[cfg(feature = "spec_unstable_metrics_views")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_gauge_view_filters_attributes_at_bind_time() {
+        use opentelemetry::Key;
+
+        let exporter = InMemoryMetricExporter::default();
+        let view = |i: &Instrument| {
+            if i.name() == "my_gauge" {
+                Stream::builder()
+                    .with_allowed_attribute_keys(vec![Key::new("k1"), Key::new("k2")])
+                    .build()
+                    .ok()
+            } else {
+                None
+            }
+        };
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .with_view(view)
+            .build();
+        let meter = meter_provider.meter("test");
+        let gauge = meter.u64_gauge("my_gauge").build();
+
+        // bind with k3 included - view should drop it at bind time.
+        let bound = gauge.bind(&[
+            KeyValue::new("k1", "v1"),
+            KeyValue::new("k2", "v2"),
+            KeyValue::new("k3", "v3"),
+        ]);
+        bound.record(10);
+        bound.record(20);
+
+        // Unbound call with a *different* k3 value: after view filtering both
+        // bound and unbound must collapse into the same data point.
+        gauge.record(
+            7,
+            &[
+                KeyValue::new("k1", "v1"),
+                KeyValue::new("k2", "v2"),
+                KeyValue::new("k3", "different"),
+            ],
+        );
+
+        meter_provider.force_flush().unwrap();
+        let resource_metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics are expected to be exported.");
+        let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
+        let data::AggregatedMetrics::U64(MetricData::Gauge(gauge_data)) = &metric.data else {
+            unreachable!()
+        };
+
+        assert_eq!(
+            gauge_data.data_points.len(),
+            1,
+            "view should filter k3, leaving bound+unbound to share the same data point"
+        );
+        assert_eq!(
+            gauge_data.data_points[0].value, 7,
+            "Last write (the unbound record) should win"
+        );
+        let attrs = &gauge_data.data_points[0].attributes;
+        assert_eq!(attrs.len(), 2);
+        assert!(attrs.iter().any(|kv| kv.key.as_str() == "k1"));
+        assert!(attrs.iter().any(|kv| kv.key.as_str() == "k2"));
+        assert!(!attrs.iter().any(|kv| kv.key.as_str() == "k3"));
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_gauge_drop_enables_eviction() {
+        let mut test_context = TestContext::new(Temporality::Delta);
+        let gauge = test_context.meter().u64_gauge("my_gauge").build();
+        let attrs = vec![KeyValue::new("key1", "ephemeral")];
+
+        {
+            let bound = gauge.bind(&attrs);
+            bound.record(100);
+            test_context.flush_metrics();
+
+            let MetricData::Gauge(gauge_data) =
+                test_context.get_aggregation::<u64>("my_gauge", None)
+            else {
+                unreachable!()
+            };
+            assert_eq!(gauge_data.data_points.len(), 1);
+            assert_eq!(gauge_data.data_points[0].value, 100);
+            // bound drops here
+        }
+
+        // Cycle 2: no updates, bound handle dropped - entry becomes stale and evictable.
+        test_context.reset_metrics();
+        test_context.flush_metrics();
+
+        // Cycle 3: the stale entry should have been evicted, so a new unbound
+        // record should be the only data point.
+        test_context.reset_metrics();
+        gauge.record(1, &[KeyValue::new("key1", "new_entry")]);
+        test_context.flush_metrics();
+
+        let MetricData::Gauge(gauge_data) = test_context.get_aggregation::<u64>("my_gauge", None)
+        else {
+            unreachable!()
+        };
+
+        assert_eq!(gauge_data.data_points.len(), 1);
+        let dp = find_gauge_datapoint_with_key_value(&gauge_data.data_points, "key1", "new_entry")
+            .expect("new_entry should be present");
+        assert_eq!(dp.value, 1);
+        assert!(
+            find_gauge_datapoint_with_key_value(&gauge_data.data_points, "key1", "ephemeral")
+                .is_none(),
+            "Dropped bound entry should have been evicted"
+        );
     }
 }

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+- **Added** `BoundGauge<T>` type and `Gauge::bind()` method, extending the
+  experimental bound-instrument API (previously available for `Counter` and
+  `Histogram`) to `Gauge`. Gated behind the
+  `experimental_metrics_bound_instruments` feature flag.
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -2,6 +2,8 @@ use crate::KeyValue;
 use core::fmt;
 use std::sync::Arc;
 
+#[cfg(feature = "experimental_metrics_bound_instruments")]
+use super::BoundSyncInstrument;
 use super::SyncInstrument;
 
 /// An instrument that records independent values
@@ -31,6 +33,41 @@ impl<T> Gauge<T> {
     /// Records an independent value.
     pub fn record(&self, value: T, attributes: &[KeyValue]) {
         self.0.measure(value, attributes)
+    }
+
+    /// Binds this gauge to a fixed set of attributes.
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    pub fn bind(&self, attributes: &[KeyValue]) -> BoundGauge<T> {
+        BoundGauge(Arc::from(self.0.bind(attributes)))
+    }
+}
+
+/// A gauge bound to a fixed set of attributes.
+///
+/// Created by calling [`Gauge::bind`] with an attribute set. All subsequent
+/// [`record`](BoundGauge::record) calls use the pre-resolved attributes, bypassing
+/// per-call attribute lookup for significantly better performance.
+///
+/// `BoundGauge` can be cloned cheaply to share a single bound state across
+/// threads or modules without re-binding. The underlying tracker is reclaimed
+/// when the last clone is dropped.
+#[cfg(feature = "experimental_metrics_bound_instruments")]
+#[derive(Clone)]
+#[must_use = "dropping a BoundGauge immediately is a no-op; store it to benefit from pre-bound attributes"]
+pub struct BoundGauge<T>(Arc<dyn BoundSyncInstrument<T> + Send + Sync>);
+
+#[cfg(feature = "experimental_metrics_bound_instruments")]
+impl<T> fmt::Debug for BoundGauge<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("BoundGauge<{}>", std::any::type_name::<T>()))
+    }
+}
+
+#[cfg(feature = "experimental_metrics_bound_instruments")]
+impl<T> BoundGauge<T> {
+    /// Records an independent value using the pre-bound attributes.
+    pub fn record(&self, value: T) {
+        self.0.measure(value)
     }
 }
 

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -6,7 +6,9 @@ mod instruments;
 mod meter;
 pub mod noop;
 #[cfg(feature = "experimental_metrics_bound_instruments")]
-pub use instruments::{counter::BoundCounter, histogram::BoundHistogram, BoundSyncInstrument};
+pub use instruments::{
+    counter::BoundCounter, gauge::BoundGauge, histogram::BoundHistogram, BoundSyncInstrument,
+};
 pub use instruments::{
     counter::{Counter, ObservableCounter},
     gauge::{Gauge, ObservableGauge},


### PR DESCRIPTION
Adds `BoundGauge<T>` and `Gauge::bind()` to the experimental bound-instrument API, mirroring `BoundCounter` and `BoundHistogram`. The SDK already supports bound gauges end-to-end via the generic `ResolvedMeasures::bind` and `LastValue`'s `BoundLastValueHandle`, so this change is purely additive on the API surface.

Adds 9 SDK tests covering bound semantics for `Gauge`: cumulative, delta, parity with unbound, no-update-no-export, cardinality overflow, multiple handles to the same attribute set, empty-attribute sharing, view attribute filtering at bind time, and drop-enables-eviction.

Part of #3539. `BoundUpDownCounter` will follow in a separate PR.