### PR TITLE
feat(metrics): add BoundUpDownCounter under experimental_metrics_bound_instruments

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -258,10 +258,12 @@ on every call. For hot paths that repeatedly emit measurements with the *same*
 attribute set, this per-call lookup can be avoided by pre-binding the
 attributes once and reusing the resulting bound handle.
 
-Bound instruments are currently supported on `Counter` and `Histogram` via the
-`bind` method, which returns a `BoundCounter<T>` or `BoundHistogram<T>`
-respectively. Subsequent `add` / `record` calls on the bound handle skip
-attribute resolution and write directly to the pre-resolved tracker.
+Bound instruments are supported on all sync instruments — `Counter`,
+`UpDownCounter`, `Histogram`, and `Gauge` — via the `bind` method, which
+returns a `BoundCounter<T>`, `BoundUpDownCounter<T>`, `BoundHistogram<T>`, or
+`BoundGauge<T>` respectively. Subsequent `add` / `record` calls on the bound
+handle skip attribute resolution and write directly to the pre-resolved
+tracker.
 
 :heavy_check_mark: Use bound instruments on hot paths where the same attribute
 set is used repeatedly, and store the bound handle for reuse.
@@ -285,17 +287,20 @@ tcp_packets.add(1);
 udp_packets.add(1);
 ```
 
-`BoundCounter` and `BoundHistogram` are cheap to clone, so a single bound
-handle can be shared across threads or modules without re-binding. Dropping
-the last clone makes the underlying tracker eligible for cleanup.
+`BoundCounter`, `BoundUpDownCounter`, `BoundHistogram`, and `BoundGauge` are
+cheap to clone, so a single bound handle can be shared across threads or
+modules without re-binding. Dropping the last clone makes the underlying
+tracker eligible for cleanup.
 
 For reference, the SDK's `bound_instruments` benchmark on an Apple M4 Max with
 3 attributes (`method`, `status`, `path`) reports:
 
-| Operation              | Unbound   | Bound     | Speedup |
-| ---------------------- | --------- | --------- | ------- |
-| `Counter::add`         | ~50 ns    | ~1.8 ns   | ~28x    |
-| `Histogram::record`    | ~58 ns    | ~6.5 ns   | ~9x     |
+| Operation                | Unbound   | Bound     | Speedup |
+| ------------------------ | --------- | --------- | ------- |
+| `Counter::add`           | ~50 ns    | ~1.9 ns   | ~26x    |
+| `UpDownCounter::add`     | ~53 ns    | ~1.9 ns   | ~28x    |
+| `Gauge::record`          | ~53 ns    | ~1.3 ns   | ~42x    |
+| `Histogram::record`      | ~60 ns    | ~6.6 ns   | ~9x     |
 
 The exact win depends on attribute count, contention, and the cost of the
 lookup being skipped (more attributes make the unbound path more expensive,

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## vNext
 
-- Bound instruments are now available for `Gauge` via the new `BoundGauge<T>`
-  type exposed by the `opentelemetry` crate. Requires the
-  `experimental_metrics_bound_instruments` feature.
+- Bound instruments are now available for `Gauge` and `UpDownCounter` via the
+  new `BoundGauge<T>` and `BoundUpDownCounter<T>` types exposed by the
+  `opentelemetry` crate. Requires the `experimental_metrics_bound_instruments`
+  feature.
 - Default SDK Resource construction now falls back to `unknown_service` under
   Miri instead of calling `std::env::current_exe()`, avoiding an abort in Miri
   isolation mode while preserving the normal

--- a/opentelemetry-sdk/benches/bound_instruments.rs
+++ b/opentelemetry-sdk/benches/bound_instruments.rs
@@ -9,12 +9,16 @@ use opentelemetry_sdk::metrics::{Instrument, ManualReader, SdkMeterProvider, Str
 //
 // Results (3 attributes: method, status, path):
 // Counter_Unbound_Delta              time:   [50.20 ns]
-// Counter_Bound_Delta                time:   [ 1.80 ns]  ~28x faster
+// Counter_Bound_Delta                time:   [ 1.92 ns]  ~26x faster
 // Counter_Bound_With_View_Delta      time:   [ 1.82 ns]  view filter applied at bind, not on hot path
 // Counter_Bound_AtOverflow_Delta     time:   [ 1.82 ns]  bind() at cardinality limit binds directly to the overflow
 //                                                        tracker — perf parity with a normal bind, no per-call resolution
-// Histogram_Unbound_Delta            time:   [58.64 ns]
-// Histogram_Bound_Delta              time:   [ 6.50 ns]  ~9.0x faster
+// UpDownCounter_Unbound_Cumulative   time:   [53.08 ns]  UpDownCounter always uses Cumulative regardless of reader pref
+// UpDownCounter_Bound_Cumulative     time:   [ 1.91 ns]  ~28x faster
+// Gauge_Unbound_Delta                time:   [52.82 ns]
+// Gauge_Bound_Delta                  time:   [ 1.27 ns]  ~42x faster (LastValue store is cheaper than atomic add)
+// Histogram_Unbound_Delta            time:   [60.15 ns]
+// Histogram_Bound_Delta              time:   [ 6.61 ns]  ~9.1x faster
 // Histogram_Bound_AtOverflow_Delta   time:   [ 6.58 ns]  perf parity with a normal bind
 // Counter_Bound_Multithread/2        time:   [21.59 µs]  (100 adds/thread)
 // Counter_Bound_Multithread/4        time:   [37.21 µs]  (100 adds/thread)
@@ -127,6 +131,46 @@ fn bench_bound_instruments(c: &mut Criterion) {
         });
     }
 
+    // UpDownCounter: Unbound vs Bound (always Cumulative regardless of reader pref)
+    {
+        let provider = create_provider(Temporality::Cumulative);
+        let meter = provider.meter("bench");
+        let updown = meter.i64_up_down_counter("unbound_updown").build();
+        group.bench_function("UpDownCounter_Unbound_Cumulative", |b| {
+            b.iter(|| updown.add(1, &attrs));
+        });
+    }
+
+    {
+        let provider = create_provider(Temporality::Cumulative);
+        let meter = provider.meter("bench");
+        let updown = meter.i64_up_down_counter("bound_updown").build();
+        let bound = updown.bind(&attrs);
+        group.bench_function("UpDownCounter_Bound_Cumulative", |b| {
+            b.iter(|| bound.add(1));
+        });
+    }
+
+    // Gauge: Unbound vs Bound (Delta)
+    {
+        let provider = create_provider(Temporality::Delta);
+        let meter = provider.meter("bench");
+        let gauge = meter.u64_gauge("unbound_gauge").build();
+        group.bench_function("Gauge_Unbound_Delta", |b| {
+            b.iter(|| gauge.record(1, &attrs));
+        });
+    }
+
+    {
+        let provider = create_provider(Temporality::Delta);
+        let meter = provider.meter("bench");
+        let gauge = meter.u64_gauge("bound_gauge").build();
+        let bound = gauge.bind(&attrs);
+        group.bench_function("Gauge_Bound_Delta", |b| {
+            b.iter(|| bound.record(1));
+        });
+    }
+
     // Histogram: Unbound vs Bound (Delta)
     {
         let provider = create_provider(Temporality::Delta);
@@ -192,6 +236,76 @@ fn bench_bound_instruments(c: &mut Criterion) {
                         s.spawn(|| {
                             for _ in 0..100 {
                                 bound.add(1);
+                            }
+                        });
+                    }
+                });
+            });
+        });
+    }
+
+    // Multi-threaded bound up-down counter (atomic add on i64)
+    for num_threads in [2, 4, 8] {
+        let provider = create_provider(Temporality::Cumulative);
+        let meter = provider.meter("bench");
+        let updown = meter.i64_up_down_counter("mt_bound_updown").build();
+        let bound = updown.bind(&attrs);
+
+        group.bench_function(
+            format!("UpDownCounter_Bound_Multithread/{num_threads}"),
+            |b| {
+                b.iter(|| {
+                    std::thread::scope(|s| {
+                        for _ in 0..num_threads {
+                            s.spawn(|| {
+                                for _ in 0..100 {
+                                    bound.add(1);
+                                }
+                            });
+                        }
+                    });
+                });
+            },
+        );
+    }
+
+    // Multi-threaded bound histogram (Mutex<Buckets> — expected to show
+    // contention quickly relative to atomic-based instruments).
+    for num_threads in [2, 4, 8] {
+        let provider = create_provider(Temporality::Delta);
+        let meter = provider.meter("bench");
+        let histogram = meter.f64_histogram("mt_bound_hist").build();
+        let bound = histogram.bind(&attrs);
+
+        group.bench_function(format!("Histogram_Bound_Multithread/{num_threads}"), |b| {
+            b.iter(|| {
+                std::thread::scope(|s| {
+                    for _ in 0..num_threads {
+                        s.spawn(|| {
+                            for _ in 0..100 {
+                                bound.record(1.5);
+                            }
+                        });
+                    }
+                });
+            });
+        });
+    }
+
+    // Multi-threaded bound gauge (LastValue: atomic store, no read-modify-write)
+    for num_threads in [2, 4, 8] {
+        let provider = create_provider(Temporality::Delta);
+        let meter = provider.meter("bench");
+        let gauge = meter.u64_gauge("mt_bound_gauge").build();
+        let bound = gauge.bind(&attrs);
+
+        group.bench_function(format!("Gauge_Bound_Multithread/{num_threads}"), |b| {
+            b.iter(|| {
+                std::thread::scope(|s| {
+                    for _ in 0..num_threads {
+                        s.spawn(|| {
+                            for _ in 0..100 {
+                                bound.record(1);
                             }
                         });
                     }

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -6396,4 +6396,275 @@ mod tests {
             "Dropped bound entry should have been evicted"
         );
     }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_updown_counter_cumulative() {
+        let mut test_context = TestContext::new(Temporality::Cumulative);
+        let counter = test_context.i64_up_down_counter("test", "my_updown", None);
+        let attrs = vec![KeyValue::new("key1", "bound_value")];
+        let bound = counter.bind(&attrs);
+
+        // UpDownCounter supports both positive and negative values.
+        bound.add(50);
+        bound.add(-20);
+        bound.add(30);
+        test_context.flush_metrics();
+
+        let MetricData::Sum(sum) = test_context.get_aggregation::<i64>("my_updown", None) else {
+            unreachable!()
+        };
+
+        assert_eq!(sum.data_points.len(), 1, "Expected one data point");
+        assert!(
+            !sum.is_monotonic,
+            "UpDownCounter must not produce monotonic Sums"
+        );
+        assert_eq!(sum.temporality, Temporality::Cumulative);
+        assert_eq!(sum.data_points[0].value, 60);
+        assert_eq!(
+            sum.data_points[0].attributes,
+            vec![KeyValue::new("key1", "bound_value")]
+        );
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_updown_counter_always_cumulative_even_when_delta_requested() {
+        // UpDownCounter always uses Cumulative temporality regardless of the
+        // reader's preference. Confirm the bound API observes the same rule.
+        let mut test_context = TestContext::new(Temporality::Delta);
+        let counter = test_context.i64_up_down_counter("test", "my_updown", None);
+        let attrs = vec![KeyValue::new("key1", "bound_value")];
+        let bound = counter.bind(&attrs);
+
+        bound.add(50);
+        bound.add(-10);
+        test_context.flush_metrics();
+
+        let MetricData::Sum(sum) = test_context.get_aggregation::<i64>("my_updown", None) else {
+            unreachable!()
+        };
+        assert_eq!(
+            sum.temporality,
+            Temporality::Cumulative,
+            "UpDownCounter must produce Cumulative regardless of reader preference"
+        );
+        assert!(!sum.is_monotonic);
+        assert_eq!(sum.data_points.len(), 1);
+        assert_eq!(sum.data_points[0].value, 40);
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_updown_counter_matches_unbound() {
+        let mut test_context = TestContext::new(Temporality::Cumulative);
+        let counter = test_context.i64_up_down_counter("test", "my_updown", None);
+        let attrs = vec![KeyValue::new("key1", "shared")];
+        let bound = counter.bind(&attrs);
+
+        // Mix bound and unbound additions to the same attribute set.
+        counter.add(10, &attrs);
+        bound.add(-20);
+        counter.add(30, &attrs);
+        bound.add(40);
+        test_context.flush_metrics();
+
+        let MetricData::Sum(sum) = test_context.get_aggregation::<i64>("my_updown", None) else {
+            unreachable!()
+        };
+
+        assert_eq!(
+            sum.data_points.len(),
+            1,
+            "Bound and unbound should share the same data point"
+        );
+        assert!(!sum.is_monotonic);
+        assert_eq!(sum.data_points[0].value, 60);
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_updown_counter_at_overflow_attributes_to_overflow_bucket() {
+        let cardinality_limit = 3;
+        let view = move |i: &Instrument| {
+            if i.name() == "my_updown" {
+                Stream::builder()
+                    .with_name("my_updown")
+                    .with_cardinality_limit(cardinality_limit)
+                    .build()
+                    .ok()
+            } else {
+                None
+            }
+        };
+        let mut test_context = TestContext::new_with_view(Temporality::Cumulative, view);
+        let counter = test_context.i64_up_down_counter("test", "my_updown", None);
+
+        // Fill to cardinality limit with unbound calls.
+        for v in 0..cardinality_limit {
+            counter.add(1, &[KeyValue::new("A", v.to_string())]);
+        }
+
+        // bind() at overflow - handle binds directly to the overflow tracker.
+        let overflow_attrs = vec![KeyValue::new("A", "overflow_bind")];
+        let bound = counter.bind(&overflow_attrs);
+        bound.add(42);
+        bound.add(-2);
+
+        test_context.flush_metrics();
+        let MetricData::Sum(sum) = test_context.get_aggregation::<i64>("my_updown", None) else {
+            unreachable!()
+        };
+
+        assert_eq!(
+            sum.data_points.len(),
+            cardinality_limit + 1,
+            "Expected {} unique + 1 overflow data points",
+            cardinality_limit
+        );
+
+        let overflow_dp =
+            find_overflow_sum_datapoint(&sum.data_points).expect("overflow point expected");
+        assert_eq!(
+            overflow_dp.value, 40,
+            "Bound-at-overflow data should go to overflow bucket"
+        );
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_updown_counter_multiple_handles_same_attrs() {
+        let mut test_context = TestContext::new(Temporality::Cumulative);
+        let counter = test_context.i64_up_down_counter("test", "my_updown", None);
+        let attrs = vec![KeyValue::new("key1", "shared")];
+
+        let bound1 = counter.bind(&attrs);
+        let bound2 = counter.bind(&attrs);
+
+        bound1.add(10);
+        bound2.add(-3);
+        test_context.flush_metrics();
+
+        let MetricData::Sum(sum) = test_context.get_aggregation::<i64>("my_updown", None) else {
+            unreachable!()
+        };
+        assert_eq!(
+            sum.data_points.len(),
+            1,
+            "Multiple handles to same attrs should share data point"
+        );
+        assert_eq!(sum.data_points[0].value, 7);
+
+        // Drop one handle. Cumulative state still includes its contributions
+        // and the surviving handle continues to write to the same tracker.
+        drop(bound1);
+        test_context.reset_metrics();
+        bound2.add(-5);
+        test_context.flush_metrics();
+
+        let MetricData::Sum(sum) = test_context.get_aggregation::<i64>("my_updown", None) else {
+            unreachable!()
+        };
+        assert_eq!(sum.data_points.len(), 1);
+        assert_eq!(
+            sum.data_points[0].value, 2,
+            "Cumulative tracker should retain prior bound contributions"
+        );
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_updown_counter_empty_attributes_shares_with_unbound() {
+        let mut test_context = TestContext::new(Temporality::Cumulative);
+        let counter = test_context.i64_up_down_counter("test", "my_updown", None);
+        let bound = counter.bind(&[]);
+
+        // Mix bound and unbound calls with empty attributes - they must share
+        // the same data point (both route to no_attribute_tracker).
+        counter.add(10, &[]);
+        bound.add(-3);
+        counter.add(30, &[]);
+        bound.add(-2);
+        test_context.flush_metrics();
+
+        let MetricData::Sum(sum) = test_context.get_aggregation::<i64>("my_updown", None) else {
+            unreachable!()
+        };
+
+        assert_eq!(
+            sum.data_points.len(),
+            1,
+            "Bound and unbound with empty attributes must share the same data point"
+        );
+        assert!(sum.data_points[0].attributes.is_empty());
+        assert_eq!(sum.data_points[0].value, 35);
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[cfg(feature = "spec_unstable_metrics_views")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn bound_updown_counter_view_filters_attributes_at_bind_time() {
+        use opentelemetry::Key;
+
+        let exporter = InMemoryMetricExporter::default();
+        let view = |i: &Instrument| {
+            if i.name() == "my_updown" {
+                Stream::builder()
+                    .with_allowed_attribute_keys(vec![Key::new("k1"), Key::new("k2")])
+                    .build()
+                    .ok()
+            } else {
+                None
+            }
+        };
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .with_view(view)
+            .build();
+        let meter = meter_provider.meter("test");
+        let counter = meter.i64_up_down_counter("my_updown").build();
+
+        // bind with k3 included - view should drop it at bind time.
+        let bound = counter.bind(&[
+            KeyValue::new("k1", "v1"),
+            KeyValue::new("k2", "v2"),
+            KeyValue::new("k3", "v3"),
+        ]);
+        bound.add(10);
+        bound.add(-3);
+
+        // unbound call with a *different* k3 value: after view filtering both
+        // bound and unbound must collapse into the same data point.
+        counter.add(
+            7,
+            &[
+                KeyValue::new("k1", "v1"),
+                KeyValue::new("k2", "v2"),
+                KeyValue::new("k3", "different"),
+            ],
+        );
+
+        meter_provider.force_flush().unwrap();
+        let resource_metrics = exporter
+            .get_finished_metrics()
+            .expect("metrics are expected to be exported.");
+        let metric = &resource_metrics[0].scope_metrics[0].metrics[0];
+        let data::AggregatedMetrics::I64(MetricData::Sum(sum)) = &metric.data else {
+            unreachable!()
+        };
+
+        assert_eq!(
+            sum.data_points.len(),
+            1,
+            "view should filter k3, leaving bound+unbound to aggregate together"
+        );
+        assert!(!sum.is_monotonic);
+        assert_eq!(sum.data_points[0].value, 14);
+        let attrs = &sum.data_points[0].attributes;
+        assert_eq!(attrs.len(), 2);
+        assert!(attrs.iter().any(|kv| kv.key.as_str() == "k1"));
+        assert!(attrs.iter().any(|kv| kv.key.as_str() == "k2"));
+        assert!(!attrs.iter().any(|kv| kv.key.as_str() == "k3"));
+    }
 }

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## vNext
 
-- **Added** `BoundGauge<T>` type and `Gauge::bind()` method, extending the
-  experimental bound-instrument API (previously available for `Counter` and
-  `Histogram`) to `Gauge`. Gated behind the
+- **Added** `BoundGauge<T>` and `BoundUpDownCounter<T>` types (and the
+  corresponding `Gauge::bind()` / `UpDownCounter::bind()` methods), completing
+  the experimental bound-instrument API across all sync instruments
+  (`Counter`, `UpDownCounter`, `Histogram`, `Gauge`). Gated behind the
   `experimental_metrics_bound_instruments` feature flag.
 
 ## 0.32.0

--- a/opentelemetry/src/metrics/instruments/counter.rs
+++ b/opentelemetry/src/metrics/instruments/counter.rs
@@ -36,6 +36,9 @@ impl<T> Counter<T> {
     }
 
     /// Binds this counter to a fixed set of attributes.
+    ///
+    /// Corresponds to the `Bind` capability in the OpenTelemetry spec (status:
+    /// Development as of spec 1.57.0).
     #[cfg(feature = "experimental_metrics_bound_instruments")]
     pub fn bind(&self, attributes: &[KeyValue]) -> BoundCounter<T> {
         BoundCounter(Arc::from(self.0.bind(attributes)))

--- a/opentelemetry/src/metrics/instruments/gauge.rs
+++ b/opentelemetry/src/metrics/instruments/gauge.rs
@@ -36,6 +36,9 @@ impl<T> Gauge<T> {
     }
 
     /// Binds this gauge to a fixed set of attributes.
+    ///
+    /// Corresponds to the `Bind` capability in the OpenTelemetry spec (status:
+    /// Development as of spec 1.57.0).
     #[cfg(feature = "experimental_metrics_bound_instruments")]
     pub fn bind(&self, attributes: &[KeyValue]) -> BoundGauge<T> {
         BoundGauge(Arc::from(self.0.bind(attributes)))

--- a/opentelemetry/src/metrics/instruments/histogram.rs
+++ b/opentelemetry/src/metrics/instruments/histogram.rs
@@ -36,6 +36,9 @@ impl<T> Histogram<T> {
     }
 
     /// Binds this histogram to a fixed set of attributes.
+    ///
+    /// Corresponds to the `Bind` capability in the OpenTelemetry spec (status:
+    /// Development as of spec 1.57.0).
     #[cfg(feature = "experimental_metrics_bound_instruments")]
     pub fn bind(&self, attributes: &[KeyValue]) -> BoundHistogram<T> {
         BoundHistogram(Arc::from(self.0.bind(attributes)))

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -46,7 +46,8 @@ pub trait SyncInstrument<T>: Send + Sync {
 }
 
 /// A pre-bound synchronous instrument that records measurements without attributes.
-/// Created by calling `bind()` on a `Counter` or `Histogram` with a fixed attribute set.
+/// Created by calling `bind()` on a `Counter`, `UpDownCounter`, `Histogram`,
+/// or `Gauge` with a fixed attribute set.
 #[cfg(feature = "experimental_metrics_bound_instruments")]
 pub trait BoundSyncInstrument<T>: Send + Sync {
     /// Records a measurement. The attributes were fixed at bind time.

--- a/opentelemetry/src/metrics/instruments/up_down_counter.rs
+++ b/opentelemetry/src/metrics/instruments/up_down_counter.rs
@@ -2,6 +2,8 @@ use crate::KeyValue;
 use core::fmt;
 use std::sync::Arc;
 
+#[cfg(feature = "experimental_metrics_bound_instruments")]
+use super::BoundSyncInstrument;
 use super::SyncInstrument;
 
 /// An instrument that records increasing or decreasing values.
@@ -34,6 +36,47 @@ impl<T> UpDownCounter<T> {
     /// Records an increment or decrement to the counter.
     pub fn add(&self, value: T, attributes: &[KeyValue]) {
         self.0.measure(value, attributes)
+    }
+
+    /// Binds this up-down counter to a fixed set of attributes.
+    ///
+    /// Corresponds to the `Bind` capability in the OpenTelemetry spec (status:
+    /// Development as of spec 1.57.0).
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    pub fn bind(&self, attributes: &[KeyValue]) -> BoundUpDownCounter<T> {
+        BoundUpDownCounter(Arc::from(self.0.bind(attributes)))
+    }
+}
+
+/// An up-down counter bound to a fixed set of attributes.
+///
+/// Created by calling [`UpDownCounter::bind`] with an attribute set. All subsequent
+/// [`add`](BoundUpDownCounter::add) calls use the pre-resolved attributes, bypassing
+/// per-call attribute lookup for significantly better performance.
+///
+/// `BoundUpDownCounter` can be cloned cheaply to share a single bound state across
+/// threads or modules without re-binding. The underlying tracker is reclaimed
+/// when the last clone is dropped.
+#[cfg(feature = "experimental_metrics_bound_instruments")]
+#[derive(Clone)]
+#[must_use = "dropping a BoundUpDownCounter immediately is a no-op; store it to benefit from pre-bound attributes"]
+pub struct BoundUpDownCounter<T>(Arc<dyn BoundSyncInstrument<T> + Send + Sync>);
+
+#[cfg(feature = "experimental_metrics_bound_instruments")]
+impl<T> fmt::Debug for BoundUpDownCounter<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "BoundUpDownCounter<{}>",
+            std::any::type_name::<T>()
+        ))
+    }
+}
+
+#[cfg(feature = "experimental_metrics_bound_instruments")]
+impl<T> BoundUpDownCounter<T> {
+    /// Records an increment or decrement using the pre-bound attributes.
+    pub fn add(&self, value: T) {
+        self.0.measure(value)
     }
 }
 

--- a/opentelemetry/src/metrics/mod.rs
+++ b/opentelemetry/src/metrics/mod.rs
@@ -7,7 +7,8 @@ mod meter;
 pub mod noop;
 #[cfg(feature = "experimental_metrics_bound_instruments")]
 pub use instruments::{
-    counter::BoundCounter, gauge::BoundGauge, histogram::BoundHistogram, BoundSyncInstrument,
+    counter::BoundCounter, gauge::BoundGauge, histogram::BoundHistogram,
+    up_down_counter::BoundUpDownCounter, BoundSyncInstrument,
 };
 pub use instruments::{
     counter::{Counter, ObservableCounter},


### PR DESCRIPTION
Adds `BoundUpDownCounter<T>` and `UpDownCounter::bind()` to the experimental bound-instrument API, completing the set across all sync instruments (`Counter`, `UpDownCounter`, `Histogram`, `Gauge`). The SDK already supports bound up-down counters end-to-end via the generic `ResolvedMeasures::bind` and `Sum`'s `BoundSumHandle`, so this change is purely additive on the API surface.

Also extends the bound-instrument benchmark (`opentelemetry-sdk/benches/bound_instruments.rs`) with new cases for `UpDownCounter` and `Gauge` (unbound and bound), and updates the bench header with measured numbers from an Apple M4 Max. Updates `docs/metrics.md` to state that all four sync instruments support `bind()` and to include the full 4-row perf table.

Adds 7 SDK tests covering bound semantics for `UpDownCounter`: cumulative, "always cumulative even when delta is requested", parity with unbound, cardinality overflow, multiple handles to the same attribute set, empty-attribute sharing, and view attribute filtering at bind time. Tests confirm `!sum.is_monotonic` and exercise both positive and negative deltas.

Closes #3539. Part of #1374.