### PR TITLE
feat(api): accept quoted-key fields in otel logging macros

### DIFF
--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- `otel_info!`, `otel_warn!`, `otel_debug!`, and `otel_error!` macros now accept quoted-key fields
+  (e.g. `"otel.component.type" = "value"`) for dotted attribute names.
 - **Added** `BoundGauge<T>` type and `Gauge::bind()` method, extending the
   experimental bound-instrument API (previously available for `Counter` and
   `Histogram`) to `Gauge`. Gated behind the

--- a/opentelemetry/src/global/internal_logging.rs
+++ b/opentelemetry/src/global/internal_logging.rs
@@ -39,7 +39,7 @@ macro_rules! otel_info {
             let _ = $name; // Compiler will optimize this out as it's unused.
         }
     };
-    (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
+    (name: $name:expr, $($key:tt = $value:expr),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             $crate::_private::info!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, $($key = $value),+);
@@ -90,7 +90,7 @@ macro_rules! otel_warn {
             let _ = $name; // Compiler will optimize this out as it's unused.
         }
     };
-    (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
+    (name: $name:expr, $($key:tt = $value:expr),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             $crate::_private::warn!(name: $name,
@@ -147,7 +147,7 @@ macro_rules! otel_debug {
             let _ = $name; // Compiler will optimize this out as it's unused.
         }
     };
-    (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
+    (name: $name:expr, $($key:tt = $value:expr),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             $crate::_private::debug!(name: $name, target: env!("CARGO_PKG_NAME"), name = $name, $($key = $value),+);
@@ -198,7 +198,7 @@ macro_rules! otel_error {
             let _ = $name; // Compiler will optimize this out as it's unused.
         }
     };
-    (name: $name:expr, $($key:ident = $value:expr),+ $(,)?) => {
+    (name: $name:expr, $($key:tt = $value:expr),+ $(,)?) => {
         #[cfg(feature = "internal-logs")]
         {
             $crate::_private::error!(name: $name,


### PR DESCRIPTION
Changes `$key:ident` to `$key:tt` in the `otel_info!`, `otel_warn!`, `otel_debug!`, and `otel_error!` macro arms. This allows dotted attribute names like `"otel.component.type" = "value"` which are required by SDK self-observability semantic conventions ([open-telemetry/semantic-conventions#3723](https://github.com/open-telemetry/semantic-conventions/pull/3723)).

Existing callers using plain ident keys continue to work unchanged — `tt` matches both identifiers and string literals. The `#[cfg(test)]` print branch also works: `stringify!` on a string-literal tt produces the quoted form (e.g. `"otel.component.type"=value`), which is still readable debug output.

Once this lands, the shutdown-event POC ([#3552](https://github.com/open-telemetry/opentelemetry-rust/pull/3552)) can switch from `opentelemetry::_private::info!` to the public `otel_info!` macro.