### PR TITLE
feat(sdk): support OTEL_ATTRIBUTE_COUNT_LIMIT env var

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Bound instruments are now available for `Gauge` via the new `BoundGauge<T>`
   type exposed by the `opentelemetry` crate. Requires the
   `experimental_metrics_bound_instruments` feature.
+- Added support for the `OTEL_ATTRIBUTE_COUNT_LIMIT` environment variable,
+  the spec-defined general fallback for the maximum span attribute count. The
+  span-specific `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` continues to take precedence
+  when both are set.
 - Default SDK Resource construction now falls back to `unknown_service` under
   Miri instead of calling `std::env::current_exe()`, avoiding an abort in Miri
   isolation mode while preserving the normal

--- a/opentelemetry-sdk/src/lib.rs
+++ b/opentelemetry-sdk/src/lib.rs
@@ -94,11 +94,17 @@
 //! | `OTEL_TRACES_SAMPLER` | Sampler to use. Valid values: `always_on`, `always_off`, `traceidratio`, `parentbased_always_on`, `parentbased_always_off`, `parentbased_traceidratio`. | `parentbased_always_on` |
 //! | `OTEL_TRACES_SAMPLER_ARG` | Argument for the sampler. Used when `OTEL_TRACES_SAMPLER` is `traceidratio` or `parentbased_traceidratio`. Must be a float between 0.0 and 1.0. | `1.0` |
 //!
+//! ### General Attribute Limits
+//!
+//! | Variable | Description | Default |
+//! |---|---|---|
+//! | `OTEL_ATTRIBUTE_COUNT_LIMIT` | Maximum number of attributes allowed on a span. Acts as the fallback for `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`, which takes precedence when both are set. | `128` |
+//!
 //! ### Trace: Span Limits
 //!
 //! | Variable | Description | Default |
 //! |---|---|---|
-//! | `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` | Maximum number of attributes allowed on a span. | `128` |
+//! | `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` | Maximum number of attributes allowed on a span. Overrides `OTEL_ATTRIBUTE_COUNT_LIMIT` when set. | `128` |
 //! | `OTEL_SPAN_EVENT_COUNT_LIMIT` | Maximum number of events allowed on a span. | `128` |
 //! | `OTEL_SPAN_LINK_COUNT_LIMIT` | Maximum number of links allowed on a span. | `128` |
 //!

--- a/opentelemetry-sdk/src/trace/config.rs
+++ b/opentelemetry-sdk/src/trace/config.rs
@@ -36,6 +36,19 @@ impl Default for Config {
             resource: Cow::Owned(Resource::builder().build()),
         };
 
+        // `OTEL_ATTRIBUTE_COUNT_LIMIT` is the general fallback for the maximum
+        // span attribute count; the span-specific
+        // `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` takes precedence when both are set.
+        // It does not affect the per-event / per-link attribute limits, which
+        // have their own defaults per the spec.
+        // See https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#attribute-limits
+        if let Some(max_attributes) = env::var("OTEL_ATTRIBUTE_COUNT_LIMIT")
+            .ok()
+            .and_then(|count_limit| u32::from_str(&count_limit).ok())
+        {
+            config.span_limits.max_attributes_per_span = max_attributes;
+        }
+
         if let Some(max_attributes_per_span) = env::var("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT")
             .ok()
             .and_then(|count_limit| u32::from_str(&count_limit).ok())
@@ -133,5 +146,69 @@ impl Default for Config {
         }
 
         config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+    use crate::trace::span_limit::{
+        DEFAULT_MAX_ATTRIBUTES_PER_EVENT, DEFAULT_MAX_ATTRIBUTES_PER_LINK,
+        DEFAULT_MAX_ATTRIBUTES_PER_SPAN,
+    };
+
+    #[test]
+    fn otel_attribute_count_limit_sets_span_attribute_limit() {
+        temp_env::with_vars(
+            [
+                ("OTEL_ATTRIBUTE_COUNT_LIMIT", Some("64")),
+                ("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", None::<&str>),
+            ],
+            || {
+                let config = Config::default();
+                assert_eq!(config.span_limits.max_attributes_per_span, 64);
+                // The general limit must not touch the per-event / per-link
+                // attribute limits, which keep their own defaults.
+                assert_eq!(
+                    config.span_limits.max_attributes_per_event,
+                    DEFAULT_MAX_ATTRIBUTES_PER_EVENT
+                );
+                assert_eq!(
+                    config.span_limits.max_attributes_per_link,
+                    DEFAULT_MAX_ATTRIBUTES_PER_LINK
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn span_attribute_count_limit_overrides_general_limit() {
+        temp_env::with_vars(
+            [
+                ("OTEL_ATTRIBUTE_COUNT_LIMIT", Some("64")),
+                ("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", Some("32")),
+            ],
+            || {
+                let config = Config::default();
+                assert_eq!(config.span_limits.max_attributes_per_span, 32);
+            },
+        );
+    }
+
+    #[test]
+    fn default_span_attribute_limit_when_unset() {
+        temp_env::with_vars(
+            [
+                ("OTEL_ATTRIBUTE_COUNT_LIMIT", None::<&str>),
+                ("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", None::<&str>),
+            ],
+            || {
+                let config = Config::default();
+                assert_eq!(
+                    config.span_limits.max_attributes_per_span,
+                    DEFAULT_MAX_ATTRIBUTES_PER_SPAN
+                );
+            },
+        );
     }
 }


### PR DESCRIPTION
Part of #3374

## Problem

`OTEL_ATTRIBUTE_COUNT_LIMIT` is the spec-defined **general fallback** for the maximum span attribute count ([SDK configuration spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#attribute-limits)). The SDK only read the span-specific `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`, so setting the general variable had no effect. This is one of the gaps tracked in #3374.

## Change

In `Config::default()`, read `OTEL_ATTRIBUTE_COUNT_LIMIT` and apply it to `max_attributes_per_span`, then let `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` override it when both are set (per the spec's precedence). Code-based configuration (e.g. `with_max_attributes_per_span`) continues to take precedence over both, since the builder starts from `Config::default()`.

The general limit deliberately does **not** touch the per-event / per-link attribute count limits — those have their own spec defaults (128) and are not governed by `OTEL_ATTRIBUTE_COUNT_LIMIT`.

## Tests

- `otel_attribute_count_limit_sets_span_attribute_limit` — general var applies to span attributes and leaves per-event / per-link limits at their defaults.
- `span_attribute_count_limit_overrides_general_limit` — span-specific var wins when both are set.
- `default_span_attribute_limit_when_unset` — default of 128 when neither is set.

Also documented the variable and its precedence in the crate-level env-var table and added a CHANGELOG entry.

`cargo test -p opentelemetry_sdk --all-features --lib trace::config`, `cargo clippy --all-targets --all-features -- -Dwarnings`, and `cargo fmt --all -- --check` all pass.
