### PR TITLE
feat(trace): Span::record_error: Emit `exception.stacktrace`

### DIFF
--- a/opentelemetry-sdk/src/trace/span.rs
+++ b/opentelemetry-sdk/src/trace/span.rs
@@ -390,6 +390,47 @@ mod tests {
     }
 
     #[test]
+    fn record_error_with_source_chain_emits_stacktrace() {
+        /// An error that wraps a `source`, so `record_error` produces an
+        /// `exception.stacktrace` attribute from the error chain.
+        #[derive(Debug)]
+        struct SourcedError {
+            message: &'static str,
+            source: std::io::Error,
+        }
+
+        impl std::fmt::Display for SourcedError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.message)
+            }
+        }
+
+        impl std::error::Error for SourcedError {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.source)
+            }
+        }
+
+        let mut span = create_span();
+        let err = SourcedError {
+            message: "outer error",
+            source: std::io::Error::other("inner error"),
+        };
+        span.record_error(&err);
+        span.with_data(|data| {
+            let event = data.events.iter().next().expect("no event");
+            assert_eq!(event.name, "exception");
+            assert_eq!(
+                event.attributes,
+                vec![
+                    KeyValue::new("exception.stacktrace", "outer error\ninner error"),
+                    KeyValue::new("exception.message", err.to_string()),
+                ]
+            );
+        });
+    }
+
+    #[test]
     fn set_attribute() {
         let mut span = create_span();
         let attributes = KeyValue::new("k", "v");

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -9,6 +9,12 @@
   the experimental bound-instrument API across all sync instruments
   (`Counter`, `UpDownCounter`, `Histogram`, `Gauge`). Gated behind the
   `experimental_metrics_bound_instruments` feature flag.
+- `opentelemetry::trace::Span::record_error` now sets the
+  [`exception.stacktrace`][exception.stacktrace] attribute to the messages of
+  the errors in the `std::error::Error::source` chain ([#3570][3570]).
+
+[3570]: https://github.com/open-telemetry/opentelemetry-rust/pull/3570
+[exception.stacktrace]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/exception/#exception-stacktrace
 
 ## 0.32.0
 

--- a/opentelemetry/src/trace/span.rs
+++ b/opentelemetry/src/trace/span.rs
@@ -71,7 +71,12 @@ pub trait Span {
     /// If this span is not being recorded then this method does nothing.
     fn record_error(&mut self, err: &dyn Error) {
         if self.is_recording() {
-            let attributes = vec![KeyValue::new("exception.message", err.to_string())];
+            let message = err.to_string();
+            let mut attributes = Vec::with_capacity(2);
+            if let Some(stacktrace) = format_error_sources(err, &message) {
+                attributes.push(KeyValue::new("exception.stacktrace", stacktrace));
+            }
+            attributes.push(KeyValue::new("exception.message", message));
             self.add_event("exception", attributes);
         }
     }
@@ -317,13 +322,139 @@ impl Status {
     }
 }
 
+/// Format [`Error::source`]s into an 'error source chain' for use in the `exception.stacktrace`
+/// field of an exception event.
+///
+/// See: <https://opentelemetry.io/docs/specs/semconv/registry/attributes/exception/#exception-stacktrace>
+///
+/// Error messages are output one per line, like this:
+///
+/// ```text
+/// My error message
+/// IO Error (123)
+/// Inner-most error message
+/// ```
+fn format_error_sources(error: &dyn Error, message: &str) -> Option<String> {
+    error.source().map(|source| {
+        let mut stacktrace = message.to_owned();
+
+        for source in SourceIter::new(source) {
+            stacktrace.push('\n');
+            stacktrace.push_str(&source.to_string());
+        }
+
+        stacktrace
+    })
+}
+
+/// [`Iterator`] over [`std::error::Error::source`] chains.
+///
+/// See: <https://github.com/rust-lang/rust/issues/58520>
+struct SourceIter<'a> {
+    current: Option<&'a (dyn Error + 'static)>,
+}
+
+impl<'a> SourceIter<'a> {
+    /// Create a new iterator over the error and its sources.
+    ///
+    /// The first value returned by the iterator is the given `error`.
+    fn new(error: &'a (dyn Error + 'static)) -> Self {
+        Self {
+            current: Some(error),
+        }
+    }
+}
+
+impl<'a> Iterator for SourceIter<'a> {
+    type Item = &'a (dyn Error + 'static);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.current;
+        self.current = self.current.and_then(Error::source);
+        current
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt;
 
     #[test]
     fn status_order() {
         assert!(Status::Ok > Status::error(""));
         assert!(Status::error("") > Status::Unset);
+    }
+
+    /// A simple error that optionally wraps a `source`, for testing
+    /// [`format_error_sources`].
+    #[derive(Debug)]
+    struct TestError {
+        message: &'static str,
+        source: Option<Box<TestError>>,
+    }
+
+    impl TestError {
+        fn new(message: &'static str) -> Self {
+            Self {
+                message,
+                source: None,
+            }
+        }
+
+        fn with_source(message: &'static str, source: TestError) -> Self {
+            Self {
+                message,
+                source: Some(Box::new(source)),
+            }
+        }
+    }
+
+    impl fmt::Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.message)
+        }
+    }
+
+    impl Error for TestError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            self.source
+                .as_ref()
+                .map(|source| source.as_ref() as &(dyn Error + 'static))
+        }
+    }
+
+    #[test]
+    fn format_error_sources_without_source() {
+        let error = TestError::new("top-level error");
+        assert_eq!(
+            format_error_sources(&error, &error.to_string()),
+            None,
+            "an error with no source should not produce a stacktrace"
+        );
+    }
+
+    #[test]
+    fn format_error_sources_with_single_source() {
+        let error = TestError::with_source("top-level error", TestError::new("inner error"));
+        assert_eq!(
+            format_error_sources(&error, &error.to_string()).as_deref(),
+            Some("top-level error\ninner error"),
+        );
+    }
+
+    #[test]
+    fn format_error_sources_with_chain() {
+        let error = TestError::with_source(
+            "top-level error",
+            TestError::with_source(
+                "middle error",
+                TestError::with_source("inner error", TestError::new("root cause")),
+            ),
+        );
+        assert_eq!(
+            format_error_sources(&error, &error.to_string()).as_deref(),
+            Some("top-level error\nmiddle error\ninner error\nroot cause"),
+        );
     }
 }


### PR DESCRIPTION
## Changes

Rust's `std::error::Error`s expose a chain of sources with the `Error::source` method. Let's use those to emit an `exception.stacktrace` attribute in accordance with the OpenTelemetry Semantic Conventions.

See: <https://opentelemetry.io/docs/specs/semconv/registry/attributes/exception/#exception-stacktrace>

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
