### PR TITLE
fix(appender-tracing): always normalize event metadata when `experimental_metadata_attributes` is enabled

### DIFF
--- a/opentelemetry-appender-tracing/CHANGELOG.md
+++ b/opentelemetry-appender-tracing/CHANGELOG.md
@@ -6,6 +6,13 @@
   `OpenTelemetryTracingBridge::builder_with_scope_attributes(..)`.
   [3415](https://github.com/open-telemetry/opentelemetry-rust/issues/3415)
 
+- Fixes [#3543](https://github.com/open-telemetry/opentelemetry-rust/issues/3543):
+  Event metadata is now always normalized when `experimental_metadata_attributes` 
+  is enabled. In particular, when using the feature the underlying OTEL logger
+  will receive the value of `log.target` as its log event `target` for events 
+  generated from the `log` crate (e.g., via `tracing-log`) instead of the static
+  target value `"log"`.
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-appender-tracing/src/layer.rs
+++ b/opentelemetry-appender-tracing/src/layer.rs
@@ -477,7 +477,14 @@ where
         #[cfg_attr(not(feature = "experimental_span_attributes"), allow(unused_variables))]
         ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
+        #[cfg(feature = "experimental_metadata_attributes")]
+        let normalized_meta = event.normalized_metadata();
+        #[cfg(feature = "experimental_metadata_attributes")]
+        let metadata = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+
+        #[cfg(not(feature = "experimental_metadata_attributes"))]
         let metadata = event.metadata();
+
         let severity = severity_of_level(metadata.level());
         let target = metadata.target();
         let name = metadata.name();
@@ -486,15 +493,9 @@ where
             return;
         }
 
-        #[cfg(feature = "experimental_metadata_attributes")]
-        let normalized_meta = event.normalized_metadata();
-
-        #[cfg(feature = "experimental_metadata_attributes")]
-        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
-
         let mut log_record = self.logger.create_log_record();
 
-        log_record.set_target(target);
+        log_record.set_target(target.to_string());
         log_record.set_event_name(name);
         log_record.set_severity_number(severity);
         log_record.set_severity_text(metadata.level().as_str());
@@ -518,7 +519,7 @@ where
 
         let mut visitor = EventVisitor::new(&mut log_record);
         #[cfg(feature = "experimental_metadata_attributes")]
-        visitor.visit_experimental_metadata(meta);
+        visitor.visit_experimental_metadata(metadata);
         // Visit fields.
         event.record(&mut visitor);
 
@@ -1009,13 +1010,21 @@ mod tests {
         // Validate common fields
         assert_eq!(log.instrumentation.name(), "");
         assert_eq!(log.record.severity_number(), Some(Severity::Error));
-        // Target and EventName from Log crate are "log" and "log event" respectively.
         // Validate target
+        #[cfg(feature = "experimental_metadata_attributes")]
+        // Target from Log crate are extracted from the log record.
+        assert_eq!(
+            log.record.target().expect("target is expected").to_string(),
+            "opentelemetry_appender_tracing::layer::tests"
+        );
+        #[cfg(not(feature = "experimental_metadata_attributes"))]
+        // Target from Log crate is "log".
         assert_eq!(
             log.record.target().expect("target is expected").to_string(),
             "log"
         );
         // Validate event name
+        // EventName from Log crate is "log event".
         assert_eq!(
             log.record.event_name().expect("event_name is expected"),
             "log event"


### PR DESCRIPTION
Fixes #3543
~~Design discussion issue (if applicable) #~~

## Changes

Consistently applies `NormalizeEvent` if the `experimental_metadata_attributes` feature is active to ensure that the generated log records that are emitted forward the original `log.target` as the log event target instead of defaulting to `"log"`. 

The change impacts all extracted metadata, not just the target. It also applies to 
- the `severity`, `target` and `name` used to check if `self.logger.event_enabled` (cf. #2668, #2756)
- the `severity` number set on the log record itself
- the severity text set on the log record itself, which is derived from the event metadata `level`

It does **not** affect the behaviour of `EnvFilter`, because of the interaction between `tracing-log` normalizing through `AsTrace` (a _different_ normalization) before calling `enabled` on the dispatcher in `dispatch_record` and the way `EnvFilter` caches `FilterState` and doesn't use `event_enabled` (see also https://github.com/open-telemetry/opentelemetry-rust/issues/3543#issuecomment-4659241874).

Note that this reverts #2799 as the optimization is incompatible with applying normalization before setting the target.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)