### PR TITLE
docs: make crate READMEs consistent

### DIFF
--- a/opentelemetry-appender-log/README.md
+++ b/opentelemetry-appender-log/README.md
@@ -12,7 +12,7 @@ This crate contains a [Log Appender](https://github.com/open-telemetry/opentelem
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
-## OpenTelemetry Overview
+## Overview
 
 OpenTelemetry is an Observability framework and toolkit designed to create and
 manage telemetry data such as traces, metrics, and logs. OpenTelemetry is
@@ -27,6 +27,37 @@ can easily instrument your applications or systems, no matter their language,
 infrastructure, or runtime environment. Crucially, the storage and visualization
 of telemetry is intentionally left to other tools.
 
+*[Supported Rust Versions](#supported-rust-versions)*
+
+[Prometheus]: https://prometheus.io
+[Jaeger]: https://www.jaegertracing.io
+
+### What does this crate contain?
+
+This crate provides a [Log Appender](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#log-appender--bridge)
+that forwards log records emitted through the
+[`log`](https://docs.rs/log/latest/log/) crate to the OpenTelemetry Logs
+pipeline. Use this crate when your application (or its dependencies) already
+use `log` and you want those records to be captured, enriched with
+OpenTelemetry context, and exported through an OpenTelemetry exporter.
+
+## Getting started
+
+See [docs](https://docs.rs/opentelemetry-appender-log).
+
 ## Release Notes
 
 You can find the release notes (changelog) [here](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-appender-log/CHANGELOG.md).
+
+## Supported Rust Versions
+
+OpenTelemetry is built against the latest stable release. The minimum supported
+version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+on Rust versions earlier than the minimum supported version.
+
+The current stable Rust compiler and the three most recent minor versions
+before it will always be supported. For example, if the current stable compiler
+version is 1.49, the minimum supported version will not be increased past 1.46,
+three minor versions prior. Increasing the minimum supported compiler version
+is not considered a semver breaking change as long as doing so complies with
+this policy.

--- a/opentelemetry-appender-log/README.md
+++ b/opentelemetry-appender-log/README.md
@@ -52,7 +52,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+version is 1.75.0. The current OpenTelemetry version is NOT guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-appender-tracing/README.md
+++ b/opentelemetry-appender-tracing/README.md
@@ -59,7 +59,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+version is 1.75.0. The current OpenTelemetry version is NOT guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-appender-tracing/README.md
+++ b/opentelemetry-appender-tracing/README.md
@@ -18,7 +18,7 @@ traces.
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
-## OpenTelemetry Overview
+## Overview
 
 OpenTelemetry is an Observability framework and toolkit designed to create and
 manage telemetry data such as traces, metrics, and logs. OpenTelemetry is
@@ -34,6 +34,23 @@ infrastructure, or runtime environment. Crucially, the storage and visualization
 of telemetry is intentionally left to other tools.
 
 *[Supported Rust Versions](#supported-rust-versions)*
+
+### What does this crate contain?
+
+This crate provides a [Log Appender](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#log-appender--bridge)
+that forwards `tracing` events to the OpenTelemetry Logs pipeline. Use this
+crate when your application uses the [`tracing`](https://docs.rs/tracing/) crate
+for structured logging and you want those events to flow through an
+OpenTelemetry exporter.
+
+This is different from
+[tracing-opentelemetry](https://github.com/tokio-rs/tracing-opentelemetry),
+which bridges `tracing` spans and events into OpenTelemetry *traces* rather
+than logs.
+
+## Getting started
+
+See [docs](https://docs.rs/opentelemetry-appender-tracing).
 
 ## Release Notes
 

--- a/opentelemetry-http/README.md
+++ b/opentelemetry-http/README.md
@@ -4,9 +4,10 @@
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png
 
-This crate contains helper implementations for sending HTTP requests. Uses
-include propagating and extracting context over http, exporting telemetry,
-requesting sampling strategies.
+This crate contains helper implementations for sending HTTP requests, used
+by [OpenTelemetry](https://opentelemetry.io/) components. Common uses include
+propagating and extracting context over HTTP, exporting telemetry data over
+HTTP, and requesting sampling strategies from remote endpoints.
 
 [![Crates.io: opentelemetry-http](https://img.shields.io/crates/v/opentelemetry-http.svg)](https://crates.io/crates/opentelemetry-http)
 [![Documentation](https://docs.rs/opentelemetry-http/badge.svg)](https://docs.rs/opentelemetry-http)
@@ -14,7 +15,7 @@ requesting sampling strategies.
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
-## OpenTelemetry Overview
+## Overview
 
 OpenTelemetry is an Observability framework and toolkit designed to create and
 manage telemetry data such as traces, metrics, and logs. OpenTelemetry is
@@ -30,6 +31,37 @@ infrastructure, or runtime environment. Crucially, the storage and visualization
 of telemetry is intentionally left to other tools.
 
 *[Supported Rust Versions](#supported-rust-versions)*
+
+[Prometheus]: https://prometheus.io
+[Jaeger]: https://www.jaegertracing.io
+
+### What does this crate contain?
+
+This crate contains shared HTTP building blocks used across the
+OpenTelemetry Rust ecosystem, including:
+
+- An `HttpClient` trait and adapters for popular HTTP clients such as
+  `reqwest` and `hyper`.
+- Helpers for propagating and extracting OpenTelemetry context (for example
+  W3C TraceContext) over HTTP headers.
+- Utilities used by exporters to send telemetry over HTTP.
+
+This crate is primarily used as a dependency by other OpenTelemetry crates
+(such as [`opentelemetry-otlp`](https://crates.io/crates/opentelemetry-otlp))
+rather than directly by end users.
+
+### Related crates
+
+- **[opentelemetry](https://crates.io/crates/opentelemetry):** The core
+  OpenTelemetry API.
+- **[opentelemetry-sdk](https://crates.io/crates/opentelemetry-sdk):** The
+  OpenTelemetry SDK implementation.
+- **[opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp):** OTLP
+  exporter that uses this crate for HTTP transport.
+
+## Getting started
+
+See [docs](https://docs.rs/opentelemetry-http).
 
 ## Release Notes
 

--- a/opentelemetry-http/README.md
+++ b/opentelemetry-http/README.md
@@ -70,7 +70,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+version is 1.75.0. The current OpenTelemetry version is NOT guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-jaeger-propagator/README.md
+++ b/opentelemetry-jaeger-propagator/README.md
@@ -58,7 +58,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+version is 1.75.0. The current OpenTelemetry version is NOT guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-jaeger-propagator/README.md
+++ b/opentelemetry-jaeger-propagator/README.md
@@ -18,7 +18,7 @@ opentelemetry-otlp crate.
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
-## OpenTelemetry Overview
+## Overview
 
 OpenTelemetry is an Observability framework and toolkit designed to create and
 manage telemetry data such as traces, metrics, and logs. OpenTelemetry is
@@ -34,6 +34,22 @@ infrastructure, or runtime environment. Crucially, the storage and visualization
 of telemetry is intentionally left to other tools.
 
 *[Supported Rust Versions](#supported-rust-versions)*
+
+### What does this crate contain?
+
+This crate provides an implementation of Jaeger's [text-map propagation
+format](https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format)
+for OpenTelemetry, allowing OpenTelemetry-instrumented services to interoperate
+with existing Jaeger-instrumented services during a migration.
+
+This crate only implements *context propagation*. To export telemetry to
+Jaeger, use the
+[opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp) crate
+— Jaeger natively supports OTLP ingestion.
+
+## Getting started
+
+See [docs](https://docs.rs/opentelemetry-jaeger-propagator).
 
 ## Release Notes
 

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -74,7 +74,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+version is 1.75.0. The current OpenTelemetry version is NOT guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-otlp/README.md
+++ b/opentelemetry-otlp/README.md
@@ -35,6 +35,34 @@ of telemetry is intentionally left to other tools.
 [Prometheus]: https://prometheus.io
 [Jaeger]: https://www.jaegertracing.io
 
+### What does this crate contain?
+
+This crate provides an [OTLP
+(OpenTelemetry
+Protocol)](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/README.md)
+exporter that sends telemetry to any OTLP-compatible backend such as the
+[OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)
+or vendor endpoints. Exporters are provided for all three signals - Logs,
+Metrics and Traces - and support both `grpc` and `http` (binary protobuf or
+JSON) transports.
+
+OTLP is the recommended way to export telemetry from OpenTelemetry, as it is
+vendor-neutral and supported by most observability backends.
+
+### Related crates
+
+This crate exports telemetry produced via the OpenTelemetry SDK. It is
+commonly used alongside:
+
+- **[opentelemetry](https://crates.io/crates/opentelemetry):** The core
+  OpenTelemetry API.
+- **[opentelemetry-sdk](https://crates.io/crates/opentelemetry-sdk):** The
+  OpenTelemetry SDK implementation that this exporter plugs into.
+- **[opentelemetry-http](https://crates.io/crates/opentelemetry-http):** HTTP
+  client abstractions used by the HTTP transport in this crate.
+- **[opentelemetry-proto](https://crates.io/crates/opentelemetry-proto):**
+  Generated protobuf types used on the wire.
+
 ## Getting started
 
 See [docs](https://docs.rs/opentelemetry-otlp).

--- a/opentelemetry-prometheus/README.md
+++ b/opentelemetry-prometheus/README.md
@@ -12,7 +12,7 @@
 [![GitHub Actions CI](https://github.com/open-telemetry/opentelemetry-rust/workflows/CI/badge.svg)](https://github.com/open-telemetry/opentelemetry-rust/actions?query=workflow%3ACI+branch%3Amain)
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/rust-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C03GDP0H023)
 
-## OpenTelemetry Overview
+## Overview
 
 OpenTelemetry is an Observability framework and toolkit designed to create and
 manage telemetry data such as traces, metrics, and logs. OpenTelemetry is
@@ -30,6 +30,37 @@ of telemetry is intentionally left to other tools.
 [`Prometheus`]: https://prometheus.io
 [`OpenTelemetry`]: https://crates.io/crates/opentelemetry
 
+*[Supported Rust Versions](#supported-rust-versions)*
+
+### What does this crate contain?
+
+This crate provides an exporter that exposes OpenTelemetry metrics in the
+[Prometheus text
+format](https://prometheus.io/docs/instrumenting/exposition_formats/), so that
+metrics collected via OpenTelemetry can be scraped by a Prometheus server.
+
+For new projects, consider using the
+[opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp) crate
+instead — Prometheus supports [native OTLP
+ingestion](https://prometheus.io/docs/prometheus/latest/feature_flags/#otlp-receiver).
+
+## Getting started
+
+See [docs](https://docs.rs/opentelemetry-prometheus).
+
 ## Release Notes
 
 You can find the release notes (changelog) [here](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-prometheus/CHANGELOG.md).
+
+## Supported Rust Versions
+
+OpenTelemetry is built against the latest stable release. The minimum supported
+version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+on Rust versions earlier than the minimum supported version.
+
+The current stable Rust compiler and the three most recent minor versions
+before it will always be supported. For example, if the current stable compiler
+version is 1.49, the minimum supported version will not be increased past 1.46,
+three minor versions prior. Increasing the minimum supported compiler version
+is not considered a semver breaking change as long as doing so complies with
+this policy.

--- a/opentelemetry-prometheus/README.md
+++ b/opentelemetry-prometheus/README.md
@@ -55,7 +55,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+version is 1.81.0. The current OpenTelemetry version is NOT guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-proto/README.md
+++ b/opentelemetry-proto/README.md
@@ -59,7 +59,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+version is 1.75.0. The current OpenTelemetry version is NOT guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-sdk/README.md
+++ b/opentelemetry-sdk/README.md
@@ -107,7 +107,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+version is 1.75.0. The current OpenTelemetry version is NOT guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-semantic-conventions/README.md
+++ b/opentelemetry-semantic-conventions/README.md
@@ -44,7 +44,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+version is 1.75.0. The current OpenTelemetry version is NOT guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-semantic-conventions/README.md
+++ b/opentelemetry-semantic-conventions/README.md
@@ -1,8 +1,8 @@
+# OpenTelemetry Semantic Conventions
+
 ![OpenTelemetry — An observability framework for cloud-native software.][splash]
 
 [splash]: https://raw.githubusercontent.com/open-telemetry/opentelemetry-rust/main/assets/logo-text.png
-
-# OpenTelemetry Semantic Conventions
 
 Semantic conventions for applications instrumented with [`OpenTelemetry`].
 
@@ -24,6 +24,18 @@ and visualization tools.
 [`opentelemetry`]: https://crates.io/crates/opentelemetry
 
 *[Supported Rust Versions](#supported-rust-versions)*
+
+### What does this crate contain?
+
+This crate contains Rust constants generated from the [OpenTelemetry Semantic
+Conventions](https://github.com/open-telemetry/semantic-conventions)
+specification. It provides standardized attribute keys, metric names and
+resource attributes so that instrumentation produced by different libraries
+remains interoperable across processing and visualization tools.
+
+## Getting started
+
+See [docs](https://docs.rs/opentelemetry-semantic-conventions).
 
 ## Release Notes
 

--- a/opentelemetry-stdout/README.md
+++ b/opentelemetry-stdout/README.md
@@ -36,11 +36,13 @@ of telemetry is intentionally left to other tools.
 
 ### What does this crate contain?
 
-This crate includes exporters that support all three signals - Logs, Metrics,
-and Traces — to standard output. It is intended solely for educational and
-debugging purposes. Please note, this crate is not optimized for performance,
-and the format of the output may change, making it unsuitable for production
-environments
+This crate provides exporters for all three OpenTelemetry signals - Logs,
+Metrics and Traces - that write to standard output in a human-readable format.
+It is intended solely for learning, debugging and local development, where
+inspecting telemetry without setting up a backend is useful.
+
+This crate is not optimized for performance, and the exact output format may
+change between releases, so it should not be used in production.
 
 ## Getting started
 

--- a/opentelemetry-stdout/README.md
+++ b/opentelemetry-stdout/README.md
@@ -55,7 +55,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+version is 1.75.0. The current OpenTelemetry version is NOT guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions

--- a/opentelemetry-zipkin/README.md
+++ b/opentelemetry-zipkin/README.md
@@ -117,7 +117,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build on
+version is 1.75.0. The current OpenTelemetry version is NOT guaranteed to build on
 Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions before

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -136,7 +136,7 @@ You can find the release notes (changelog) [here](https://github.com/open-teleme
 ## Supported Rust Versions
 
 OpenTelemetry is built against the latest stable release. The minimum supported
-version is 1.75.0. The current OpenTelemetry version is not guaranteed to build
+version is 1.75.0. The current OpenTelemetry version is NOT guaranteed to build
 on Rust versions earlier than the minimum supported version.
 
 The current stable Rust compiler and the three most recent minor versions


### PR DESCRIPTION
Revives #3074 to normalize the crate README structure (Overview / What does this crate contain? / Getting started / Release Notes / Supported Rust Versions). Fixes #1306.