### PR TITLE
feat: add context event observer API

### DIFF
--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -6,6 +6,15 @@
   specification allows. `from_str`, `from_key_value` and `insert` now keep at most
   32, dropping members from the end of the list as the specification prescribes, so
   neither a parsed nor a locally built `tracestate` can exceed the limit.
+- **Added** experimental support for a global context event observer. A
+  `ContextObserver` can be registered via `GlobalContextObserver::set` to be
+  notified of context transitions through the `on_context_enter` and
+  `on_context_exit` callbacks. This feature is primarily intended to publish a
+  different view of the current context (the `ObserverContextView`) through
+  alternative channels that let external readers (e.g. an eBPF profiler) track
+  the current context. See the associated
+  [OTEP](https://github.com/open-telemetry/opentelemetry-specification/pull/4947).
+  Gated behind the `experimental_context_observer` feature flag.
 - `otel_info!`, `otel_warn!`, `otel_debug!`, and `otel_error!` macros now accept quoted-key fields
   (e.g. `"otel.component.type" = "value"`) for dotted attribute names.
 - **Added** `BoundGauge<T>` and `BoundUpDownCounter<T>` types (and the

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -40,6 +40,7 @@ testing = ["trace"]
 logs = []
 internal-logs = ["tracing"]
 experimental_metrics_bound_instruments = ["metrics"]
+experimental_context_observer = []
 
 [dev-dependencies]
 opentelemetry_sdk = { path = "../opentelemetry-sdk"} # for documentation tests

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -19,12 +19,17 @@ use std::fmt;
 use std::hash::{BuildHasherDefault, Hasher};
 use std::marker::PhantomData;
 use std::sync::Arc;
+#[cfg(feature = "experimental_context_observer")]
+use std::sync::OnceLock;
 
 #[cfg(feature = "futures")]
 mod future_ext;
 
 #[cfg(feature = "futures")]
 pub use future_ext::{FutureExt, WithContext};
+
+#[cfg(feature = "experimental_context_observer")]
+pub use context_observer::*;
 
 thread_local! {
     static CURRENT_CONTEXT: RefCell<ContextStack> = RefCell::new(ContextStack::default());
@@ -98,7 +103,25 @@ pub struct Context {
     pub(crate) span: Option<Arc<SynchronizedSpan>>,
     entries: Option<Arc<EntryMap>>,
     suppress_telemetry: bool,
+    /// A context's observer view of this [Context].
+    ///
+    /// The main application for observers is to share information from the current context with
+    /// external readers (e.g. a full host eBPF profiler). In that case, the observer will attach
+    /// and detach some data on context events using its own mechanism. The shared data has no
+    /// reason to match our internal representation ([Context]).
+    ///
+    /// [observer_state] makes it possible to store the observer's view of the context alongside a
+    /// [Context] value, such that it can be attached and detached on context events.
+    #[cfg(feature = "experimental_context_observer")]
+    observer_cx_view: OnceLock<Arc<dyn ObserverContextView>>,
 }
+
+/// A context's observer view of a [Context]. This is basically an arbitrary data structure.
+///
+/// The `Any` supertrait lets an observer recover the concrete type it stored in the
+/// `observer_cx_view` slot (via trait upcasting to `&dyn Any` and `downcast_ref`).
+#[cfg(feature = "experimental_context_observer")]
+pub trait ObserverContextView: Any + Send + Sync {}
 
 type EntryMap = HashMap<TypeId, Arc<dyn Any + Sync + Send>, BuildHasherDefault<IdHasher>>;
 
@@ -264,6 +287,8 @@ impl Context {
             #[cfg(feature = "trace")]
             span: self.span.clone(),
             suppress_telemetry: self.suppress_telemetry,
+            #[cfg(feature = "experimental_context_observer")]
+            observer_cx_view: OnceLock::new(),
         }
     }
 
@@ -363,6 +388,8 @@ impl Context {
             #[cfg(feature = "trace")]
             span: self.span.clone(),
             suppress_telemetry: true,
+            #[cfg(feature = "experimental_context_observer")]
+            observer_cx_view: OnceLock::new(),
         }
     }
 
@@ -426,12 +453,21 @@ impl Context {
         Self::map_current(|cx| cx.is_telemetry_suppressed())
     }
 
+    /// Returns the observer's view of this context, if any.
+    #[cfg(feature = "experimental_context_observer")]
+    #[inline]
+    pub fn observer_cx_view(&self) -> &OnceLock<Arc<dyn ObserverContextView>> {
+        &self.observer_cx_view
+    }
+
     #[cfg(feature = "trace")]
     pub(crate) fn current_with_synchronized_span(value: SynchronizedSpan) -> Self {
         Self::map_current(|cx| Context {
             span: Some(Arc::new(value)),
             entries: cx.entries.clone(),
             suppress_telemetry: cx.suppress_telemetry,
+            #[cfg(feature = "experimental_context_observer")]
+            observer_cx_view: OnceLock::new(),
         })
     }
 
@@ -441,6 +477,8 @@ impl Context {
             span: Some(Arc::new(value)),
             entries: self.entries.clone(),
             suppress_telemetry: self.suppress_telemetry,
+            #[cfg(feature = "experimental_context_observer")]
+            observer_cx_view: OnceLock::new(),
         }
     }
 }
@@ -557,6 +595,11 @@ impl ContextStack {
         // top of the [`ContextStack`] as the `current_cx`.
         let next_id = self.stack.len() + 1;
         if next_id < ContextStack::MAX_POS.into() {
+            #[cfg(feature = "experimental_context_observer")]
+            if let Some(observer) = GlobalContextObserver::get() {
+                observer.on_context_enter(&self.current_cx, &cx);
+            }
+
             let current_cx = std::mem::replace(&mut self.current_cx, cx);
             self.stack.push(Some(current_cx));
             next_id as u16
@@ -602,6 +645,11 @@ impl ContextStack {
             // empty context is always at the bottom of the stack if the
             // [`ContextStack`] is not empty.
             if let Some(Some(next_cx)) = self.stack.pop() {
+                #[cfg(feature = "experimental_context_observer")]
+                if let Some(observer) = GlobalContextObserver::get() {
+                    observer.on_context_exit(&self.current_cx, &next_cx);
+                }
+
                 // Extract and return only the span to avoid cloning the entire Context
                 #[cfg(feature = "trace")]
                 {
@@ -650,6 +698,51 @@ impl Default for ContextStack {
             current_cx: Context::default(),
             stack: Vec::with_capacity(ContextStack::INITIAL_CAPACITY),
             _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(feature = "experimental_context_observer")]
+mod context_observer {
+    use super::*;
+
+    /// An observer trait for monitoring context transitions.
+    ///
+    /// Implementors of this trait can observe when a context is entered or exited,
+    /// allowing for custom logic to be executed during context switches.
+    pub trait ContextObserver {
+        /// Called when a context is entered, allowing observers to react to the transition
+        /// from one context (`from`) to another (`to`).
+        fn on_context_enter(&self, from: &Context, to: &Context);
+
+        /// Called when a context is exited, allowing observers to react to the transition
+        /// from one context (`from`) to another (`to`).
+        fn on_context_exit(&self, from: &Context, to: &Context);
+    }
+
+    static GLOBAL_CONTEXT_OBSERVER: OnceLock<Arc<dyn ContextObserver + Send + Sync>> =
+        OnceLock::new();
+
+    /// A global observer for context transitions.
+    ///
+    /// This struct provides static methods to set and get a global context observer.
+    #[allow(missing_debug_implementations)]
+    pub struct GlobalContextObserver;
+
+    impl GlobalContextObserver {
+        /// Sets the global context observer, logging a warning if it was already set.
+        pub fn set(observer: Arc<dyn ContextObserver + Send + Sync>) {
+            if GLOBAL_CONTEXT_OBSERVER.set(observer).is_err() {
+                otel_warn!(
+                    name: "GlobalContextObserver.SetFailed",
+                    message = "Global context observer was already set. Ignoring new observer."
+                );
+            }
+        }
+
+        /// Returns the global context observer.
+        pub(super) fn get<'a>() -> Option<&'a Arc<dyn ContextObserver + Send + Sync>> {
+            GLOBAL_CONTEXT_OBSERVER.get()
         }
     }
 }

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -709,6 +709,23 @@ mod context_observer {
     /// to be published through an alternative channel, but in essence it is arbitrary data computed
     /// from the context.
     ///
+    /// # Refcell already borrowed panic
+    ///
+    /// [crate::context] maintains thread-local, internal state in a `RefCell`. This is
+    /// implementation detail leaks when the `experimental_context_observer` feature is enabled:
+    /// [Self::on_context_enter] and [Self::on_context_exit] are called from a point where the cell
+    /// is currently borrowed. If a [ContextObserver] implementation calls back into a
+    /// cell-borrowing function from the Context API, typically `Context::current()`, this will
+    /// result in a `Refcell already borrowed` panic.
+    /// 
+    /// As general hygiene, with respect to the [Context] API, it is strongly advised to only use
+    /// simple getters and setters on the `from` and `to` context objects provided to the observer.
+    /// Do not call `Context::current()`, nor try to manually attach or detach context objects from
+    /// an observer.
+    ///
+    /// If you get Refcell-related panics within the [crate::context] module, this is the most
+    /// likely cause.
+    ///
     /// # Example
     ///
     /// ```
@@ -752,8 +769,6 @@ mod context_observer {
     ///         assert_eq!(view.correlation_id, 42);
     ///     }
     /// }
-    ///
-
     /// # }
     /// ```
     pub trait ContextObserver {

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -723,7 +723,7 @@ mod context_observer {
     /// A global observer for context transitions.
     ///
     /// This struct provides static methods to set and get a global context observer.
-    #[allow(missing_debug_implementations)]
+    #[derive(Debug)]
     pub struct GlobalContextObserver;
 
     impl GlobalContextObserver {

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -717,7 +717,7 @@ mod context_observer {
     /// is currently borrowed. If a [ContextObserver] implementation calls back into a
     /// cell-borrowing function from the Context API, typically `Context::current()`, this will
     /// result in a `Refcell already borrowed` panic.
-    /// 
+    ///
     /// As general hygiene, with respect to the [Context] API, it is strongly advised to only use
     /// simple getters and setters on the `from` and `to` context objects provided to the observer.
     /// Do not call `Context::current()`, nor try to manually attach or detach context objects from

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -1282,3 +1282,133 @@ mod tests {
         assert!(!Context::is_current_telemetry_suppressed());
     }
 }
+
+#[cfg(all(test, feature = "experimental_context_observer"))]
+mod observer_tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::sync::Arc;
+
+    #[derive(Debug, PartialEq)]
+    struct V(u64);
+
+    #[derive(Debug, PartialEq, Clone)]
+    enum Event {
+        Enter { from: Option<u64>, to: Option<u64> },
+        Exit { from: Option<u64>, to: Option<u64> },
+    }
+
+    thread_local! {
+        static EVENTS: RefCell<Vec<Event>> = const { RefCell::new(Vec::new()) };
+    }
+
+    fn value_of(cx: &Context) -> Option<u64> {
+        cx.get::<V>().map(|v| v.0)
+    }
+
+    // Records every transition into a thread-local buffer. As the observer is a process-global
+    // singleton, recording per-thread keeps each test's assertions isolated from context
+    // activity happening on other test threads.
+    struct RecordingObserver;
+
+    impl ContextObserver for RecordingObserver {
+        fn on_context_enter(&self, from: &Context, to: &Context) {
+            EVENTS.with(|e| {
+                e.borrow_mut().push(Event::Enter {
+                    from: value_of(from),
+                    to: value_of(to),
+                })
+            });
+        }
+
+        fn on_context_exit(&self, from: &Context, to: &Context) {
+            EVENTS.with(|e| {
+                e.borrow_mut().push(Event::Exit {
+                    from: value_of(from),
+                    to: value_of(to),
+                })
+            });
+        }
+    }
+
+    // Establishes a clean base context on the current thread and clears any previously
+    // recorded events, so the assertions below only see transitions this test triggers.
+    fn setup() -> ContextGuard {
+        // Idempotent across tests: only the first call installs the observer, but every test
+        // uses the same `RecordingObserver`, so a lost race is harmless.
+        GlobalContextObserver::set(Arc::new(RecordingObserver));
+        let guard = Context::new().attach();
+        EVENTS.with(|e| e.borrow_mut().clear());
+        guard
+    }
+
+    #[test]
+    fn global_observer_records_enter_and_exit() {
+        let _clean = setup();
+
+        {
+            let _g = Context::current().with_value(V(1)).attach();
+            // Entering fires immediately: from the clean base (no value) to `V(1)`.
+            EVENTS.with(|e| {
+                assert_eq!(
+                    *e.borrow(),
+                    vec![Event::Enter {
+                        from: None,
+                        to: Some(1)
+                    }]
+                )
+            });
+        }
+
+        // Dropping the guard restores the base and fires the matching exit event.
+        EVENTS.with(|e| {
+            assert_eq!(
+                *e.borrow(),
+                vec![
+                    Event::Enter {
+                        from: None,
+                        to: Some(1)
+                    },
+                    Event::Exit {
+                        from: Some(1),
+                        to: None
+                    }
+                ]
+            )
+        });
+    }
+
+    #[test]
+    fn global_observer_records_nested_transitions() {
+        let _clean = setup();
+
+        let g1 = Context::current().with_value(V(1)).attach();
+        let g2 = Context::current().with_value(V(2)).attach();
+        drop(g2);
+        drop(g1);
+
+        EVENTS.with(|e| {
+            assert_eq!(
+                *e.borrow(),
+                vec![
+                    Event::Enter {
+                        from: None,
+                        to: Some(1)
+                    },
+                    Event::Enter {
+                        from: Some(1),
+                        to: Some(2)
+                    },
+                    Event::Exit {
+                        from: Some(2),
+                        to: Some(1)
+                    },
+                    Event::Exit {
+                        from: Some(1),
+                        to: None
+                    },
+                ]
+            )
+        });
+    }
+}

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -711,8 +711,8 @@ mod context_observer {
     ///
     /// # Refcell already borrowed panic
     ///
-    /// [crate::context] maintains thread-local, internal state in a `RefCell`. This is
-    /// implementation detail leaks when the `experimental_context_observer` feature is enabled:
+    /// [crate::context] maintains thread-local, internal state in a `RefCell`. This implementation
+    /// detail leaks when the `experimental_context_observer` feature is enabled:
     /// [Self::on_context_enter] and [Self::on_context_exit] are called from a point where the cell
     /// is currently borrowed. If a [ContextObserver] implementation calls back into a
     /// cell-borrowing function from the Context API, typically `Context::current()`, this will
@@ -808,38 +808,16 @@ mod context_observer {
     }
 
     /// A context's observer view of a [Context]. This is an arbitrary data structure. See
-    /// [ContextObserver]'s documentation for an example usage.
-    ///
-    /// ```
-    /// # #[cfg(feature = "experimental_context_observer")]
-    /// # {
-    /// use opentelemetry::context::ObserverContextView;
-    /// use std::any::Any;
-    /// use std::sync::Arc;
-    ///
-    /// struct MyView {
-    ///     correlation_id: u64,
-    /// }
-    ///
-    /// impl ObserverContextView for MyView {
-    ///     fn as_any(&self) -> &dyn Any {
-    ///         self
-    ///     }
-    /// }
-    ///
-    /// let view: Arc<dyn ObserverContextView> = Arc::new(MyView { correlation_id: 42 });
-    /// let my_view = view.as_any().downcast_ref::<MyView>().unwrap();
-    /// assert_eq!(my_view.correlation_id, 42);
-    /// # }
-    /// ```
-    ///
-    /// The [`as_any`](ObserverContextView::as_any) method is required because this crate's MSRV is
-    /// below the Rust version (1.86) that stabilized trait upcasting; without it, callers on the
-    /// minimum supported compiler couldn't upcast `&dyn ObserverContextView` to `&dyn Any` to perform
-    /// the downcast themselves.
+    /// [ContextObserver]'s documentation for examples.
     #[cfg(feature = "experimental_context_observer")]
     pub trait ObserverContextView: Any + Send + Sync {
         /// Returns this view as a `&dyn Any`, enabling downcasting back to the concrete type.
+        ///
+        /// This method is required because this crate's MSRV is below the Rust version (1.86) that
+        /// stabilized trait upcasting. Without it, callers below 1.86 couldn't upcast `&dyn
+        /// ObserverContextView` to `&dyn Any` to perform the downcast themselves.
+        ///
+        /// This is a work-around for the absence of trait upcasting before Rust 1.86.
         ///
         /// Implementors should simply return `self`:
         ///

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -786,8 +786,9 @@ mod context_observer {
 
     /// An observer trait for monitoring context transitions.
     ///
-    /// Implementors of this trait can observe when a context is entered or exited,
-    /// allowing for custom logic to be executed during context switches.
+    /// Implementors of this trait can observe when a context is entered or exited, allowing for
+    /// custom logic to be executed during context switches. Implementors can cache context-specific
+    /// computed state in [Context::observer_cx_view].
     pub trait ContextObserver {
         /// Called when a context is entered, allowing observers to react to the transition
         /// from one context (`from`) to another (`to`).
@@ -1364,7 +1365,7 @@ mod tests {
 #[cfg(all(test, feature = "experimental_context_observer"))]
 mod observer_tests {
     use super::*;
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
     use std::sync::Arc;
 
     #[derive(Debug, PartialEq)]
@@ -1384,22 +1385,37 @@ mod observer_tests {
         cx.get::<V>().map(|v| v.0)
     }
 
-    // Records every transition into a thread-local buffer. As the observer is a process-global
-    // singleton, recording per-thread keeps each test's assertions isolated from context
-    // activity happening on other test threads.
+    // When enabled, on each transition it records the event into a thread-local buffer, and on
+    // enter it also installs an observer view on the entered context and bumps the thread-local
+    // `VIEWS_CREATED` counter. See `observer_installs_and_reuses_view`.
+    //
+    // The observer is a process-global singleton, so its callbacks fire for context activity on
+    // *every* thread across the whole test binary once installed. To keep that cheap and isolated,
+    // all of its work is gated behind the per-thread `ENABLE_TEST_OBSERVER` switch: threads that
+    // didn't opt in (via `setup()`) get an inert observer.
     struct RecordingObserver;
 
     impl ContextObserver for RecordingObserver {
         fn on_context_enter(&self, from: &Context, to: &Context) {
+            if !ENABLE_TEST_OBSERVER.with(Cell::get) {
+                return;
+            }
+
             EVENTS.with(|e| {
                 e.borrow_mut().push(Event::Enter {
                     from: value_of(from),
                     to: value_of(to),
                 })
             });
+
+            install_or_reuse_view(to);
         }
 
         fn on_context_exit(&self, from: &Context, to: &Context) {
+            if !ENABLE_TEST_OBSERVER.with(Cell::get) {
+                return;
+            }
+
             EVENTS.with(|e| {
                 e.borrow_mut().push(Event::Exit {
                     from: value_of(from),
@@ -1409,20 +1425,70 @@ mod observer_tests {
         }
     }
 
-    // Establishes a clean base context on the current thread and clears any previously
-    // recorded events, so the assertions below only see transitions this test triggers.
-    fn setup() -> ContextGuard {
+    thread_local! {
+        // Master switch for the observer per thread. Enabled for the duration of a test that cares,
+        // and left false everywhere else, so we don't slow down tests unrelated to the observer.
+        // See `setup`.
+        static ENABLE_TEST_OBSERVER: Cell<bool> = const { Cell::new(false) };
+        // Counts how many distinct views the observer created on the current thread.
+        static VIEWS_CREATED: Cell<u64> = const { Cell::new(0) };
+    }
+
+    // On context enter, install the observer's view if this context doesn't have one yet, or reuse
+    // the existing one otherwise. The view is the context's `V` value (or 0 for a value-less
+    // context).
+    fn install_or_reuse_view(cx: &Context) {
+        if cx.observer_cx_view().get().is_some() {
+            // Already initialized (e.g. a clone of an already-observed context): reuse it.
+            return;
+        }
+
+        let correlation_id = value_of(cx).unwrap_or(0);
+
+        cx.observer_cx_view()
+            .set(Arc::new(MyView { correlation_id }))
+            .unwrap_or_else(|_| unreachable!("view was empty, just checked above"));
+        VIEWS_CREATED.with(|c| c.set(c.get() + 1));
+    }
+
+    // Recovers the correlation id stored in a context's observer view, if any.
+    fn view_id(cx: &Context) -> Option<u64> {
+        cx.observer_cx_view()
+            .get()
+            .and_then(|v| v.as_any().downcast_ref::<MyView>())
+            .map(|v| v.correlation_id)
+    }
+
+    // Holds the base context guard and disables the observer on this thread when dropped. The
+    // struct's own `Drop` runs before its fields, so the flag is cleared before the base context is
+    // popped, which is thus not observed (symmetrically to `setup`, which installs the base context
+    // before registering/enabling the observer).
+    struct ObserverTestGuard {
+        _cx: ContextGuard,
+    }
+
+    impl Drop for ObserverTestGuard {
+        fn drop(&mut self) {
+            ENABLE_TEST_OBSERVER.with(|e| e.set(false));
+        }
+    }
+
+    // Enables the observer on this thread, establishes a clean base context, and clears any
+    // previously recorded events, so the assertions below only see transitions this test
+    // triggers. Dropping the returned guard disables the observer again.
+    fn setup_observer() -> ObserverTestGuard {
         // Idempotent across tests: only the first call installs the observer, but every test
         // uses the same `RecordingObserver`, so a lost race is harmless.
         GlobalContextObserver::set(Arc::new(RecordingObserver));
+        ENABLE_TEST_OBSERVER.with(|e| e.set(true));
         let guard = Context::new().attach();
         EVENTS.with(|e| e.borrow_mut().clear());
-        guard
+        ObserverTestGuard { _cx: guard }
     }
 
     #[test]
     fn global_observer_records_enter_and_exit() {
-        let _clean = setup();
+        let _clean = setup_observer();
 
         {
             let _g = Context::current().with_value(V(1)).attach();
@@ -1438,7 +1504,7 @@ mod observer_tests {
             });
         }
 
-        // Dropping the guard restores the base and fires the matching exit event.
+        // Dropping the (context) guard restores the base and fires the matching exit event.
         EVENTS.with(|e| {
             assert_eq!(
                 *e.borrow(),
@@ -1458,7 +1524,7 @@ mod observer_tests {
 
     #[test]
     fn global_observer_records_nested_transitions() {
-        let _clean = setup();
+        let _clean = setup_observer();
 
         let g1 = Context::current().with_value(V(1)).attach();
         let g2 = Context::current().with_value(V(2)).attach();
@@ -1522,5 +1588,41 @@ mod observer_tests {
 
         // Downcasting to an unrelated type fails gracefully rather than misbehaving.
         assert!(view.as_any().downcast_ref::<V>().is_none());
+    }
+
+    // A realistic use of the observer view: the global observer installs its own view on each
+    // context the first time that context is entered, and reuses it on re-entry. The
+    // thread-local counter checks that exactly one view is created per distinct context.
+    #[test]
+    fn observer_installs_and_reuses_view() {
+        let _clean = setup_observer();
+
+        // Reset the counter for the work below.
+        VIEWS_CREATED.with(|c| c.set(0));
+
+        // Entering two distinct contexts installs a fresh view for each, derived from its value.
+        let g1 = Context::current().with_value(V(1)).attach();
+        assert_eq!(view_id(&Context::current()), Some(1));
+
+        let g2 = Context::current().with_value(V(2)).attach();
+        assert_eq!(view_id(&Context::current()), Some(2));
+
+        assert_eq!(VIEWS_CREATED.with(Cell::get), 2);
+
+        // Re-entering an already-observed context must reuse its view, not create a new one.
+        // `Context::current()` clones the current context, carrying along its already-set view.
+        let observed = Context::current();
+        let g3 = observed.attach();
+
+        assert_eq!(view_id(&Context::current()), Some(2));
+        assert_eq!(
+            VIEWS_CREATED.with(Cell::get),
+            2,
+            "re-entering an observed context must not create a new view"
+        );
+
+        drop(g3);
+        drop(g2);
+        drop(g1);
     }
 }

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -8,44 +8,6 @@
 //!
 //! - [`Context`]: An immutable, execution-scoped collection of values.
 //!
-//! # Observer Views
-//!
-//! When the `experimental_context_observer` feature is enabled, an arbitrary observer-owned view
-//! can be attached to a [`Context`] via [`Context::observer_cx_view`]. The view is type-erased to
-//! `Arc<dyn ObserverContextView>`, and its concrete type is recovered through
-//! [`ObserverContextView::as_any`]:
-//!
-//! ```
-//! # #[cfg(feature = "experimental_context_observer")]
-//! # {
-//! use opentelemetry::Context;
-//! use opentelemetry::context::ObserverContextView;
-//! use std::any::Any;
-//! use std::sync::Arc;
-//!
-//! // An observer's own view of the context, carrying arbitrary data.
-//! struct MyView {
-//!     correlation_id: u64,
-//! }
-//!
-//! impl ObserverContextView for MyView {
-//!     fn as_any(&self) -> &dyn Any {
-//!         self
-//!     }
-//! }
-//!
-//! // Attach the view to a context.
-//! let cx = Context::new();
-//! cx.observer_cx_view()
-//!     .set(Arc::new(MyView { correlation_id: 42 }))
-//!     .unwrap_or_else(|_| unreachable!("view was just created and is empty"));
-//!
-//! // Later, recover the concrete type from the stored view.
-//! let view = cx.observer_cx_view().get().expect("view was set above");
-//! let my_view = view.as_any().downcast_ref::<MyView>().expect("view is a `MyView`");
-//! assert_eq!(my_view.correlation_id, 42);
-//! # }
-//! ```
 
 use crate::otel_warn;
 #[cfg(feature = "trace")]
@@ -151,54 +113,7 @@ pub struct Context {
     /// [observer_state] makes it possible to store the observer's view of the context alongside a
     /// [Context] value, such that it can be attached and detached on context events.
     #[cfg(feature = "experimental_context_observer")]
-    observer_cx_view: OnceLock<Arc<dyn ObserverContextView>>,
-}
-
-/// A context's observer view of a [Context]. This is an arbitrary data structure.
-///
-/// A view is stored and retrieved as a type-erased `Arc<dyn ObserverContextView>` (see
-/// [`Context::observer_cx_view`]). To recover the original concrete type from a stored view, use
-/// [`ObserverContextView::as_any`] together with [`Any::downcast_ref`]:
-///
-/// ```
-/// # #[cfg(feature = "experimental_context_observer")]
-/// # {
-/// use opentelemetry::context::ObserverContextView;
-/// use std::any::Any;
-/// use std::sync::Arc;
-///
-/// struct MyView {
-///     correlation_id: u64,
-/// }
-///
-/// impl ObserverContextView for MyView {
-///     fn as_any(&self) -> &dyn Any {
-///         self
-///     }
-/// }
-///
-/// let view: Arc<dyn ObserverContextView> = Arc::new(MyView { correlation_id: 42 });
-/// let my_view = view.as_any().downcast_ref::<MyView>().unwrap();
-/// assert_eq!(my_view.correlation_id, 42);
-/// # }
-/// ```
-///
-/// The [`as_any`](ObserverContextView::as_any) method is required because this crate's MSRV is
-/// below the Rust version (1.86) that stabilized trait upcasting; without it, callers on the
-/// minimum supported compiler couldn't upcast `&dyn ObserverContextView` to `&dyn Any` to perform
-/// the downcast themselves.
-#[cfg(feature = "experimental_context_observer")]
-pub trait ObserverContextView: Any + Send + Sync {
-    /// Returns this view as a `&dyn Any`, enabling downcasting back to the concrete type.
-    ///
-    /// Implementors should simply return `self`:
-    ///
-    /// ```ignore
-    /// fn as_any(&self) -> &dyn std::any::Any {
-    ///     self
-    /// }
-    /// ```
-    fn as_any(&self) -> &dyn Any;
+    observer_view: OnceLock<Arc<dyn ObserverContextView>>,
 }
 
 type EntryMap = HashMap<TypeId, Arc<dyn Any + Sync + Send>, BuildHasherDefault<IdHasher>>;
@@ -366,7 +281,7 @@ impl Context {
             span: self.span.clone(),
             suppress_telemetry: self.suppress_telemetry,
             #[cfg(feature = "experimental_context_observer")]
-            observer_cx_view: OnceLock::new(),
+            observer_view: OnceLock::new(),
         }
     }
 
@@ -467,7 +382,7 @@ impl Context {
             span: self.span.clone(),
             suppress_telemetry: true,
             #[cfg(feature = "experimental_context_observer")]
-            observer_cx_view: OnceLock::new(),
+            observer_view: OnceLock::new(),
         }
     }
 
@@ -534,8 +449,8 @@ impl Context {
     /// Returns the observer's view of this context, if any.
     #[cfg(feature = "experimental_context_observer")]
     #[inline]
-    pub fn observer_cx_view(&self) -> &OnceLock<Arc<dyn ObserverContextView>> {
-        &self.observer_cx_view
+    pub fn observer_view(&self) -> &OnceLock<Arc<dyn ObserverContextView>> {
+        &self.observer_view
     }
 
     #[cfg(feature = "trace")]
@@ -545,7 +460,7 @@ impl Context {
             entries: cx.entries.clone(),
             suppress_telemetry: cx.suppress_telemetry,
             #[cfg(feature = "experimental_context_observer")]
-            observer_cx_view: OnceLock::new(),
+            observer_view: OnceLock::new(),
         })
     }
 
@@ -556,7 +471,7 @@ impl Context {
             entries: self.entries.clone(),
             suppress_telemetry: self.suppress_telemetry,
             #[cfg(feature = "experimental_context_observer")]
-            observer_cx_view: OnceLock::new(),
+            observer_view: OnceLock::new(),
         }
     }
 }
@@ -787,8 +702,60 @@ mod context_observer {
     /// An observer trait for monitoring context transitions.
     ///
     /// Implementors of this trait can observe when a context is entered or exited, allowing for
-    /// custom logic to be executed during context switches. Implementors can cache context-specific
-    /// computed state in [Context::observer_cx_view].
+    /// custom logic to be executed during context switches.
+    ///
+    /// An observer-specific view can be attached to a [`Context`] via
+    /// [`Context::observer_view`]. A view is usually a different representation of the context
+    /// to be published through an alternative channel, but in essence it is arbitrary data computed
+    /// from the context.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[cfg(feature = "experimental_context_observer")]
+    /// # {
+    /// use opentelemetry::Context;
+    /// use opentelemetry::context::{ContextObserver, ObserverContextView};
+    /// use std::any::Any;
+    /// use std::sync::Arc;
+    ///
+    /// // An observer's own view of the context, carrying arbitrary data.
+    /// struct MyView {
+    ///     correlation_id: u64,
+    /// }
+    ///
+    /// impl ObserverContextView for MyView {
+    ///     fn as_any(&self) -> &dyn Any {
+    ///         self
+    ///     }
+    /// }
+    ///
+    /// struct Observer;
+    ///
+    /// # fn do_something(view: &MyView) { }
+    ///
+    /// impl ContextObserver for Observer {
+    ///     fn on_context_enter(&self, from: &Context, to: &Context) {
+    ///         let view = to.observer_view()
+    ///             .get_or_init(|| Arc::new(MyView { correlation_id: 42 }));
+    ///         do_something(view.as_any().downcast_ref::<MyView>().unwrap());
+    ///     }
+    ///
+    ///     fn on_context_exit(&self, from: &Context, to: &Context) {
+    ///         let view = to
+    ///             .observer_view()
+    ///             .get()
+    ///             .unwrap()
+    ///             .as_any()
+    ///             .downcast_ref::<MyView>()
+    ///             .unwrap();
+    ///         assert_eq!(view.correlation_id, 42);
+    ///     }
+    /// }
+    ///
+
+    /// # }
+    /// ```
     pub trait ContextObserver {
         /// Called when a context is entered, allowing observers to react to the transition
         /// from one context (`from`) to another (`to`).
@@ -823,6 +790,50 @@ mod context_observer {
         pub(super) fn get<'a>() -> Option<&'a Arc<dyn ContextObserver + Send + Sync>> {
             GLOBAL_CONTEXT_OBSERVER.get()
         }
+    }
+
+    /// A context's observer view of a [Context]. This is an arbitrary data structure. See
+    /// [ContextObserver]'s documentation for an example usage.
+    ///
+    /// ```
+    /// # #[cfg(feature = "experimental_context_observer")]
+    /// # {
+    /// use opentelemetry::context::ObserverContextView;
+    /// use std::any::Any;
+    /// use std::sync::Arc;
+    ///
+    /// struct MyView {
+    ///     correlation_id: u64,
+    /// }
+    ///
+    /// impl ObserverContextView for MyView {
+    ///     fn as_any(&self) -> &dyn Any {
+    ///         self
+    ///     }
+    /// }
+    ///
+    /// let view: Arc<dyn ObserverContextView> = Arc::new(MyView { correlation_id: 42 });
+    /// let my_view = view.as_any().downcast_ref::<MyView>().unwrap();
+    /// assert_eq!(my_view.correlation_id, 42);
+    /// # }
+    /// ```
+    ///
+    /// The [`as_any`](ObserverContextView::as_any) method is required because this crate's MSRV is
+    /// below the Rust version (1.86) that stabilized trait upcasting; without it, callers on the
+    /// minimum supported compiler couldn't upcast `&dyn ObserverContextView` to `&dyn Any` to perform
+    /// the downcast themselves.
+    #[cfg(feature = "experimental_context_observer")]
+    pub trait ObserverContextView: Any + Send + Sync {
+        /// Returns this view as a `&dyn Any`, enabling downcasting back to the concrete type.
+        ///
+        /// Implementors should simply return `self`:
+        ///
+        /// ```ignore
+        /// fn as_any(&self) -> &dyn std::any::Any {
+        ///     self
+        /// }
+        /// ```
+        fn as_any(&self) -> &dyn Any;
     }
 }
 
@@ -1438,14 +1449,14 @@ mod observer_tests {
     // the existing one otherwise. The view is the context's `V` value (or 0 for a value-less
     // context).
     fn install_or_reuse_view(cx: &Context) {
-        if cx.observer_cx_view().get().is_some() {
+        if cx.observer_view().get().is_some() {
             // Already initialized (e.g. a clone of an already-observed context): reuse it.
             return;
         }
 
         let correlation_id = value_of(cx).unwrap_or(0);
 
-        cx.observer_cx_view()
+        cx.observer_view()
             .set(Arc::new(MyView { correlation_id }))
             .unwrap_or_else(|_| unreachable!("view was empty, just checked above"));
         VIEWS_CREATED.with(|c| c.set(c.get() + 1));
@@ -1453,7 +1464,7 @@ mod observer_tests {
 
     // Recovers the correlation id stored in a context's observer view, if any.
     fn view_id(cx: &Context) -> Option<u64> {
-        cx.observer_cx_view()
+        cx.observer_view()
             .get()
             .and_then(|v| v.as_any().downcast_ref::<MyView>())
             .map(|v| v.correlation_id)
@@ -1573,13 +1584,13 @@ mod observer_tests {
         let cx = Context::new();
 
         // Attaching the view stores it type-erased as `Arc<dyn ObserverContextView>`.
-        cx.observer_cx_view()
+        cx.observer_view()
             .set(Arc::new(MyView { correlation_id: 7 }))
             .unwrap_or_else(|_| unreachable!("view was just created and is empty"));
 
         // `as_any` lets us recover the concrete type on our low MSRV, where trait upcasting to
         // `dyn Any` is not available.
-        let view = cx.observer_cx_view().get().expect("view was set above");
+        let view = cx.observer_view().get().expect("view was set above");
         let my_view = view
             .as_any()
             .downcast_ref::<MyView>()

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -8,6 +8,44 @@
 //!
 //! - [`Context`]: An immutable, execution-scoped collection of values.
 //!
+//! # Observer Views
+//!
+//! When the `experimental_context_observer` feature is enabled, an arbitrary observer-owned view
+//! can be attached to a [`Context`] via [`Context::observer_cx_view`]. The view is type-erased to
+//! `Arc<dyn ObserverContextView>`, and its concrete type is recovered through
+//! [`ObserverContextView::as_any`]:
+//!
+//! ```
+//! # #[cfg(feature = "experimental_context_observer")]
+//! # {
+//! use opentelemetry::Context;
+//! use opentelemetry::context::ObserverContextView;
+//! use std::any::Any;
+//! use std::sync::Arc;
+//!
+//! // An observer's own view of the context, carrying arbitrary data.
+//! struct MyView {
+//!     correlation_id: u64,
+//! }
+//!
+//! impl ObserverContextView for MyView {
+//!     fn as_any(&self) -> &dyn Any {
+//!         self
+//!     }
+//! }
+//!
+//! // Attach the view to a context.
+//! let cx = Context::new();
+//! cx.observer_cx_view()
+//!     .set(Arc::new(MyView { correlation_id: 42 }))
+//!     .unwrap_or_else(|_| unreachable!("view was just created and is empty"));
+//!
+//! // Later, recover the concrete type from the stored view.
+//! let view = cx.observer_cx_view().get().expect("view was set above");
+//! let my_view = view.as_any().downcast_ref::<MyView>().expect("view is a `MyView`");
+//! assert_eq!(my_view.correlation_id, 42);
+//! # }
+//! ```
 
 use crate::otel_warn;
 #[cfg(feature = "trace")]
@@ -117,8 +155,51 @@ pub struct Context {
 }
 
 /// A context's observer view of a [Context]. This is an arbitrary data structure.
+///
+/// A view is stored and retrieved as a type-erased `Arc<dyn ObserverContextView>` (see
+/// [`Context::observer_cx_view`]). To recover the original concrete type from a stored view, use
+/// [`ObserverContextView::as_any`] together with [`Any::downcast_ref`]:
+///
+/// ```
+/// # #[cfg(feature = "experimental_context_observer")]
+/// # {
+/// use opentelemetry::context::ObserverContextView;
+/// use std::any::Any;
+/// use std::sync::Arc;
+///
+/// struct MyView {
+///     correlation_id: u64,
+/// }
+///
+/// impl ObserverContextView for MyView {
+///     fn as_any(&self) -> &dyn Any {
+///         self
+///     }
+/// }
+///
+/// let view: Arc<dyn ObserverContextView> = Arc::new(MyView { correlation_id: 42 });
+/// let my_view = view.as_any().downcast_ref::<MyView>().unwrap();
+/// assert_eq!(my_view.correlation_id, 42);
+/// # }
+/// ```
+///
+/// The [`as_any`](ObserverContextView::as_any) method is required because this crate's MSRV is
+/// below the Rust version (1.86) that stabilized trait upcasting; without it, callers on the
+/// minimum supported compiler couldn't upcast `&dyn ObserverContextView` to `&dyn Any` to perform
+/// the downcast themselves.
 #[cfg(feature = "experimental_context_observer")]
-pub trait ObserverContextView: Any + Send + Sync {}
+pub trait ObserverContextView: Any + Send + Sync {
+    /// Returns this view as a `&dyn Any`, enabling downcasting back to the concrete type.
+    ///
+    /// Implementors should simply return `self`:
+    ///
+    /// ```ignore
+    /// fn as_any(&self) -> &dyn std::any::Any {
+    ///     self
+    /// }
+    /// ```
+    fn as_any(&self) -> &dyn Any;
+}
 
 type EntryMap = HashMap<TypeId, Arc<dyn Any + Sync + Send>, BuildHasherDefault<IdHasher>>;
 
@@ -1407,5 +1488,39 @@ mod observer_tests {
                 ]
             )
         });
+    }
+
+    // An observer view carrying arbitrary data, unrelated to the internal `Context`
+    // representation.
+    struct MyView {
+        correlation_id: u64,
+    }
+
+    impl ObserverContextView for MyView {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    #[test]
+    fn observer_view_roundtrips_through_as_any() {
+        let cx = Context::new();
+
+        // Attaching the view stores it type-erased as `Arc<dyn ObserverContextView>`.
+        cx.observer_cx_view()
+            .set(Arc::new(MyView { correlation_id: 7 }))
+            .unwrap_or_else(|_| unreachable!("view was just created and is empty"));
+
+        // `as_any` lets us recover the concrete type on our low MSRV, where trait upcasting to
+        // `dyn Any` is not available.
+        let view = cx.observer_cx_view().get().expect("view was set above");
+        let my_view = view
+            .as_any()
+            .downcast_ref::<MyView>()
+            .expect("view is a `MyView`");
+        assert_eq!(my_view.correlation_id, 7);
+
+        // Downcasting to an unrelated type fails gracefully rather than misbehaving.
+        assert!(view.as_any().downcast_ref::<V>().is_none());
     }
 }

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -113,7 +113,7 @@ pub struct Context {
     /// [observer_view] makes it possible to store the observer's view of the context alongside a
     /// [Context] value, such that it can be attached and detached on context events.
     #[cfg(feature = "experimental_context_observer")]
-    observer_view: OnceLock<Arc<dyn ObserverContextView>>,
+    observer_view: Option<Arc<dyn ObserverContextView>>,
 }
 
 type EntryMap = HashMap<TypeId, Arc<dyn Any + Sync + Send>, BuildHasherDefault<IdHasher>>;
@@ -275,14 +275,16 @@ impl Context {
             entries.insert(TypeId::of::<T>(), Arc::new(value));
             Some(Arc::new(entries))
         };
+
         Context {
             entries,
             #[cfg(feature = "trace")]
             span: self.span.clone(),
             suppress_telemetry: self.suppress_telemetry,
             #[cfg(feature = "experimental_context_observer")]
-            observer_view: OnceLock::new(),
+            observer_view: None,
         }
+        .with_observer_view()
     }
 
     /// Replaces the current context on this thread with this context.
@@ -382,8 +384,9 @@ impl Context {
             span: self.span.clone(),
             suppress_telemetry: true,
             #[cfg(feature = "experimental_context_observer")]
-            observer_view: OnceLock::new(),
+            observer_view: None,
         }
+        .with_observer_view()
     }
 
     /// Enters a scope where telemetry is suppressed.
@@ -446,21 +449,41 @@ impl Context {
         Self::map_current(|cx| cx.is_telemetry_suppressed())
     }
 
+    // Initialize `self.observer_view` for a newly created context using the current context
+    // observer, if set.
+    #[cfg(feature = "experimental_context_observer")]
+    fn with_observer_view(mut self) -> Self {
+        if let Some(observer) = GlobalContextObserver::get() {
+            self.observer_view = observer.make_view(&self);
+        }
+
+        self
+    }
+
+    // No-op when the experimental_context_observer feature is not enabled.
+    #[cfg(not(feature = "experimental_context_observer"))]
+    const fn with_observer_view(self) -> Self {
+        self
+    }
+
     /// Returns the observer's view of this context, if any.
     #[cfg(feature = "experimental_context_observer")]
     #[inline]
-    pub fn observer_view(&self) -> &OnceLock<Arc<dyn ObserverContextView>> {
+    pub fn observer_view(&self) -> &Option<Arc<dyn ObserverContextView>> {
         &self.observer_view
     }
 
     #[cfg(feature = "trace")]
     pub(crate) fn current_with_synchronized_span(value: SynchronizedSpan) -> Self {
-        Self::map_current(|cx| Context {
-            span: Some(Arc::new(value)),
-            entries: cx.entries.clone(),
-            suppress_telemetry: cx.suppress_telemetry,
-            #[cfg(feature = "experimental_context_observer")]
-            observer_view: OnceLock::new(),
+        Self::map_current(|cx| {
+            Context {
+                span: Some(Arc::new(value)),
+                entries: cx.entries.clone(),
+                suppress_telemetry: cx.suppress_telemetry,
+                #[cfg(feature = "experimental_context_observer")]
+                observer_view: None,
+            }
+            .with_observer_view()
         })
     }
 
@@ -471,8 +494,9 @@ impl Context {
             entries: self.entries.clone(),
             suppress_telemetry: self.suppress_telemetry,
             #[cfg(feature = "experimental_context_observer")]
-            observer_view: OnceLock::new(),
+            observer_view: None,
         }
+        .with_observer_view()
     }
 }
 
@@ -753,20 +777,22 @@ mod context_observer {
     ///
     /// impl ContextObserver for Observer {
     ///     fn on_context_enter(&self, from: &Context, to: &Context) {
-    ///         let view = to.observer_view()
-    ///             .get_or_init(|| Arc::new(MyView { correlation_id: 42 }));
+    ///         let view = to.observer_view().unwrap();
     ///         do_something(view.as_any().downcast_ref::<MyView>().unwrap());
     ///     }
     ///
     ///     fn on_context_exit(&self, from: &Context, to: &Context) {
     ///         let view = to
     ///             .observer_view()
-    ///             .get()
     ///             .unwrap()
     ///             .as_any()
     ///             .downcast_ref::<MyView>()
     ///             .unwrap();
     ///         assert_eq!(view.correlation_id, 42);
+    ///     }
+    ///
+    ///     fn make_view(&self, ctx: &Context) -> Option<Arc<dyn ObserverContextView>> {
+    ///         Some(Arc::new(MyView { correlation_id: 42 }))
     ///     }
     /// }
     /// # }
@@ -779,6 +805,14 @@ mod context_observer {
         /// Called when a context is exited, allowing observers to react to the transition
         /// from one context (`from`) to another (`to`).
         fn on_context_exit(&self, from: &Context, to: &Context);
+
+        /// Derive a fresh view for a newly created context. The provided `ctx` has an unitialized
+        /// view sets to `None`.
+        ///
+        /// The default implementation returns `None` for observers that don't use the view.
+        fn make_view(&self, _ctx: &Context) -> Option<Arc<dyn ObserverContextView>> {
+            None
+        }
     }
 
     static GLOBAL_CONTEXT_OBSERVER: OnceLock<Arc<dyn ContextObserver + Send + Sync>> =
@@ -1411,8 +1445,6 @@ mod observer_tests {
                     to: value_of(to),
                 })
             });
-
-            install_or_reuse_view(to);
         }
 
         fn on_context_exit(&self, from: &Context, to: &Context) {
@@ -1427,6 +1459,15 @@ mod observer_tests {
                 })
             });
         }
+
+        // On context enter, install the observer's view if this context doesn't have one yet, or reuse
+        // the existing one otherwise. The view is the context's `V` value (or 0 for a value-less
+        // context).
+        fn make_view(&self, cx: &Context) -> Option<Arc<dyn ObserverContextView>> {
+            let correlation_id = value_of(cx).unwrap_or(0);
+            VIEWS_CREATED.with(|c| c.set(c.get() + 1));
+            Some(Arc::new(MyView { correlation_id }))
+        }
     }
 
     thread_local! {
@@ -1438,27 +1479,10 @@ mod observer_tests {
         static VIEWS_CREATED: Cell<u64> = const { Cell::new(0) };
     }
 
-    // On context enter, install the observer's view if this context doesn't have one yet, or reuse
-    // the existing one otherwise. The view is the context's `V` value (or 0 for a value-less
-    // context).
-    fn install_or_reuse_view(cx: &Context) {
-        if cx.observer_view().get().is_some() {
-            // Already initialized (e.g. a clone of an already-observed context): reuse it.
-            return;
-        }
-
-        let correlation_id = value_of(cx).unwrap_or(0);
-
-        cx.observer_view()
-            .set(Arc::new(MyView { correlation_id }))
-            .unwrap_or_else(|_| unreachable!("view was empty, just checked above"));
-        VIEWS_CREATED.with(|c| c.set(c.get() + 1));
-    }
-
     // Recovers the correlation id stored in a context's observer view, if any.
     fn view_id(cx: &Context) -> Option<u64> {
         cx.observer_view()
-            .get()
+            .as_ref()
             .and_then(|v| v.as_any().downcast_ref::<MyView>())
             .map(|v| v.correlation_id)
     }
@@ -1570,28 +1594,6 @@ mod observer_tests {
         fn as_any(&self) -> &dyn Any {
             self
         }
-    }
-
-    #[test]
-    fn observer_view_roundtrips_through_as_any() {
-        let cx = Context::new();
-
-        // Attaching the view stores it type-erased as `Arc<dyn ObserverContextView>`.
-        cx.observer_view()
-            .set(Arc::new(MyView { correlation_id: 7 }))
-            .unwrap_or_else(|_| unreachable!("view was just created and is empty"));
-
-        // `as_any` lets us recover the concrete type on our low MSRV, where trait upcasting to
-        // `dyn Any` is not available.
-        let view = cx.observer_view().get().expect("view was set above");
-        let my_view = view
-            .as_any()
-            .downcast_ref::<MyView>()
-            .expect("view is a `MyView`");
-        assert_eq!(my_view.correlation_id, 7);
-
-        // Downcasting to an unrelated type fails gracefully rather than misbehaving.
-        assert!(view.as_any().downcast_ref::<V>().is_none());
     }
 
     // A realistic use of the observer view: the global observer installs its own view on each

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -116,10 +116,7 @@ pub struct Context {
     observer_cx_view: OnceLock<Arc<dyn ObserverContextView>>,
 }
 
-/// A context's observer view of a [Context]. This is basically an arbitrary data structure.
-///
-/// The `Any` supertrait lets an observer recover the concrete type it stored in the
-/// `observer_cx_view` slot (via trait upcasting to `&dyn Any` and `downcast_ref`).
+/// A context's observer view of a [Context]. This is an arbitrary data structure.
 #[cfg(feature = "experimental_context_observer")]
 pub trait ObserverContextView: Any + Send + Sync {}
 

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -110,7 +110,7 @@ pub struct Context {
     /// and detach some data on context events using its own mechanism. The shared data has no
     /// reason to match our internal representation ([Context]).
     ///
-    /// [observer_state] makes it possible to store the observer's view of the context alongside a
+    /// [observer_view] makes it possible to store the observer's view of the context alongside a
     /// [Context] value, such that it can be attached and detached on context events.
     #[cfg(feature = "experimental_context_observer")]
     observer_view: OnceLock<Arc<dyn ObserverContextView>>,

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -777,13 +777,14 @@ mod context_observer {
     ///
     /// impl ContextObserver for Observer {
     ///     fn on_context_enter(&self, from: &Context, to: &Context) {
-    ///         let view = to.observer_view().unwrap();
+    ///         let view = to.observer_view().as_ref().unwrap();
     ///         do_something(view.as_any().downcast_ref::<MyView>().unwrap());
     ///     }
     ///
     ///     fn on_context_exit(&self, from: &Context, to: &Context) {
     ///         let view = to
     ///             .observer_view()
+    ///             .as_ref()
     ///             .unwrap()
     ///             .as_any()
     ///             .downcast_ref::<MyView>()


### PR DESCRIPTION
## Motivation

[OTEP: Thread Context: Sharing Thread-Level Information with external readers](https://github.com/open-telemetry/opentelemetry-specification/pull/4947) is on the verge of being merged as an official OTEP. This proposal defines a protocol for an instrumented application to publish thread-level context somewhere that is discoverable by an external, potentially out-of-process reader (typically the eBPF profiler).

In order to properly implement this, any telemetry crate building upon opentelemetry-rust needs to be notified about context switches. This PR adds such a capability/API in a very simple way, currently gated behind an experimental feature.

## Changes

Add an API for downstream crates to subscribe to context switch events through the `ContextObserver` trait. The initial implementation is minimal and has only two events, `on_context_enter` and `on_context_exit`. We currently only allow one global observer.

Additionally, for any implementation of the OTEP mentioned above to be remotely performant, we'll also need to store alongside opentelemetry-rust's `Context` the `ThreadContextRecord` view of this context defined in the OTEP, which bears similar information but in a different shape. This PR adds a generic free-form field to `Context`, the observer's context view, which represents an immutable, set-once view of the associated context for the observer.

The view is behind a `OnceLock` so that:

- there's an obvious `Default` implementation
- the lifecycle design questions are entirely offloaded to the observer. Whether to initialize the view immediately or at first `on_context_enter`, etc.

An alternative would be to have an `Option<_>`, but that would need to be initialized at context creation, which would need an additional context event (e.g. `on_context_created` or `make_view`). Another possibility would be to require `Default` on `ObserverContextView`, but that would make it not object-safe which is out of the question.

All in all the lock is simple, minimize changes to this repo, doesn't prevent future optimization (having more events for optimized view creations, like when deriving a context from an existing one). To only price is the lock's additional size, (I suppose at most a usize).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
