### PR TITLE
fix(resource): percent-decode attribute values

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## vNext
 
+- `EnvResourceDetector` now percent-decodes attribute keys and values read from
+  `OTEL_RESOURCE_ATTRIBUTES`, matching the W3C Baggage encoding required by the
+  Resource SDK specification. For example,
+  `OTEL_RESOURCE_ATTRIBUTES=key=hello%20world` now yields the value
+  `hello world`. Entries that do not percent-decode to valid UTF-8 are dropped
+  and a warning is logged.
+  ([#857](https://github.com/open-telemetry/opentelemetry-rust/issues/857))
 - Added SDK self-observability metric `otel.sdk.processor.span.processed` for
   `BatchSpanProcessor` and `SimpleSpanProcessor`, feature-gated behind
   `experimental_metrics_bound_instruments`. Spans are counted when the processor

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -15,9 +15,19 @@ opentelemetry = { workspace = true }
 opentelemetry-http = { workspace = true, optional = true }
 futures-channel = { workspace = true, optional = true }
 futures-executor = { workspace = true, optional = true }
-futures-util = { workspace = true, features = ["std", "sink", "async-await-macro"], optional = true }
-percent-encoding = { workspace = true, optional = true }
-rand = { workspace = true, features = ["std", "std_rng", "small_rng", "os_rng", "thread_rng"], optional = true }
+futures-util = { workspace = true, features = [
+  "std",
+  "sink",
+  "async-await-macro",
+], optional = true }
+percent-encoding = { workspace = true }
+rand = { workspace = true, features = [
+  "std",
+  "std_rng",
+  "small_rng",
+  "os_rng",
+  "thread_rng",
+], optional = true }
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
@@ -27,7 +37,9 @@ tokio-stream = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 
 [target.'cfg(not(target_has_atomic = "64"))'.dependencies]
-portable-atomic = { version = "1", default-features = false, features = ["fallback"] }
+portable-atomic = { version = "1", default-features = false, features = [
+  "fallback",
+] }
 
 [package.metadata.docs.rs]
 all-features = true
@@ -44,22 +56,76 @@ pprof = { workspace = true }
 
 [features]
 default = ["trace", "metrics", "logs", "internal-logs"]
-trace = ["opentelemetry/trace", "rand", "percent-encoding", "dep:futures-channel", "dep:futures-executor", "dep:futures-util", "dep:thiserror"]
-jaeger_remote_sampler = ["trace", "opentelemetry-http", "http", "serde", "serde_json", "url", "experimental_async_runtime"]
-logs = ["opentelemetry/logs", "dep:futures-channel", "dep:futures-executor", "dep:futures-util"]
-metrics = ["opentelemetry/metrics", "dep:futures-channel", "dep:futures-executor", "dep:futures-util", "dep:thiserror"]
+trace = [
+  "opentelemetry/trace",
+  "rand",
+  "dep:futures-channel",
+  "dep:futures-executor",
+  "dep:futures-util",
+  "dep:thiserror",
+]
+jaeger_remote_sampler = [
+  "trace",
+  "opentelemetry-http",
+  "http",
+  "serde",
+  "serde_json",
+  "url",
+  "experimental_async_runtime",
+]
+logs = [
+  "opentelemetry/logs",
+  "dep:futures-channel",
+  "dep:futures-executor",
+  "dep:futures-util",
+]
+metrics = [
+  "opentelemetry/metrics",
+  "dep:futures-channel",
+  "dep:futures-executor",
+  "dep:futures-util",
+  "dep:thiserror",
+]
 testing = ["opentelemetry/testing", "trace", "metrics", "logs", "tokio/sync"]
-experimental_async_runtime = ["dep:futures-channel", "dep:futures-executor", "dep:futures-util", "dep:thiserror"]
-rt-tokio = ["tokio/rt", "tokio/time", "tokio-stream", "experimental_async_runtime"]
-rt-tokio-current-thread = ["tokio/rt", "tokio/time", "tokio-stream", "experimental_async_runtime"]
+experimental_async_runtime = [
+  "dep:futures-channel",
+  "dep:futures-executor",
+  "dep:futures-util",
+  "dep:thiserror",
+]
+rt-tokio = [
+  "tokio/rt",
+  "tokio/time",
+  "tokio-stream",
+  "experimental_async_runtime",
+]
+rt-tokio-current-thread = [
+  "tokio/rt",
+  "tokio/time",
+  "tokio-stream",
+  "experimental_async_runtime",
+]
 internal-logs = ["opentelemetry/internal-logs"]
-experimental_metrics_periodicreader_with_async_runtime = ["metrics", "experimental_async_runtime"]
+experimental_metrics_periodicreader_with_async_runtime = [
+  "metrics",
+  "experimental_async_runtime",
+]
 spec_unstable_metrics_views = ["metrics"]
 experimental_metrics_custom_reader = ["metrics"]
-experimental_logs_batch_log_processor_with_async_runtime = ["logs", "experimental_async_runtime"]
-experimental_trace_batch_span_processor_with_async_runtime = ["tokio/sync", "trace", "experimental_async_runtime"]
+experimental_logs_batch_log_processor_with_async_runtime = [
+  "logs",
+  "experimental_async_runtime",
+]
+experimental_trace_batch_span_processor_with_async_runtime = [
+  "tokio/sync",
+  "trace",
+  "experimental_async_runtime",
+]
 experimental_metrics_disable_name_validation = ["metrics"]
-experimental_metrics_bound_instruments = ["metrics", "opentelemetry/experimental_metrics_bound_instruments"]
+experimental_metrics_bound_instruments = [
+  "metrics",
+  "opentelemetry/experimental_metrics_bound_instruments",
+]
 bench_profiling = []
 
 [[bench]]
@@ -117,7 +183,11 @@ required-features = ["testing"]
 [[bench]]
 name = "metric"
 harness = false
-required-features = ["metrics", "spec_unstable_metrics_views", "experimental_metrics_custom_reader"]
+required-features = [
+  "metrics",
+  "spec_unstable_metrics_views",
+  "experimental_metrics_custom_reader",
+]
 
 [[bench]]
 name = "log"
@@ -127,7 +197,12 @@ required-features = ["logs"]
 [[bench]]
 name = "bound_instruments"
 harness = false
-required-features = ["metrics", "experimental_metrics_custom_reader", "experimental_metrics_bound_instruments", "spec_unstable_metrics_views"]
+required-features = [
+  "metrics",
+  "experimental_metrics_custom_reader",
+  "experimental_metrics_bound_instruments",
+  "spec_unstable_metrics_views",
+]
 
 [lib]
 bench = false

--- a/opentelemetry-sdk/src/resource/env.rs
+++ b/opentelemetry-sdk/src/resource/env.rs
@@ -3,7 +3,8 @@
 //! Implementation of `ResourceDetector` to extract a `Resource` from environment
 //! variables.
 use crate::resource::{Resource, ResourceDetector};
-use opentelemetry::{Key, KeyValue, Value};
+use opentelemetry::{otel_warn, Key, KeyValue, Value};
+use percent_encoding::percent_decode_str;
 use std::env;
 
 const OTEL_RESOURCE_ATTRIBUTES: &str = "OTEL_RESOURCE_ATTRIBUTES";
@@ -49,10 +50,26 @@ fn construct_otel_resources(s: String) -> Resource {
                 Some(p) => p,
                 None => return None,
             };
-            let key = parts.0.trim();
-            let value = parts.1.trim();
+            // Trim OWS *before* percent-decoding so that any encoded whitespace
+            // (e.g. `%20`) is preserved. Per the Resource SDK spec, `,` and `=`
+            // in both keys and values MUST be percent-encoded, and other
+            // characters MAY be.
+            let key = percent_decode_str(parts.0.trim()).decode_utf8();
+            let value = percent_decode_str(parts.1.trim()).decode_utf8();
 
-            Some(KeyValue::new(key.to_owned(), value.to_owned()))
+            match (key, value) {
+                (Ok(key), Ok(value)) => {
+                    Some(KeyValue::new(key.into_owned(), value.into_owned()))
+                }
+                _ => {
+                    otel_warn!(
+                        name: "EnvResourceDetector.Detect.InvalidUTF8",
+                        message = "Percent-decoded resource attribute is not valid UTF-8; entry dropped",
+                        entry = entry,
+                    );
+                    None
+                }
+            }
         }))
         .build()
 }
@@ -124,7 +141,7 @@ mod tests {
             [
                 (
                     "OTEL_RESOURCE_ATTRIBUTES",
-                    Some("key=value, k = v , a= x, a=z,base64=SGVsbG8sIFdvcmxkIQ=="),
+                    Some("key=value, k = v , a= x, a=z,base64=SGVsbG8sIFdvcmxkIQ==,encoded=user%20id%3D42%2C%20name%3D%22foo%22,enc%2Ckey%3D=encoded key,bad=%FF"),
                 ),
                 ("IRRELEVANT", Some("20200810")),
             ],
@@ -140,6 +157,11 @@ mod tests {
                             KeyValue::new("a", "x"),
                             KeyValue::new("a", "z"),
                             KeyValue::new("base64", "SGVsbG8sIFdvcmxkIQ=="), // base64('Hello, World!')
+                            // Keys and values are percent-decoded per the Resource SDK spec.
+                            KeyValue::new("encoded", "user id=42, name=\"foo\""),
+                            KeyValue::new("enc,key=", "encoded key"),
+                            // `bad=%FF` is dropped: it does not percent-decode to
+                            // valid UTF-8.
                         ])
                         .build()
                 );


### PR DESCRIPTION
Fixes #857

## Changes

`$OTEL_RESOURCE_ATTRIBUTES` values are now percent-decoded in line with the spec.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
