### PR TITLE
fix(.gitattributes): use merge=union for CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
Normally, adding a new entry to a CHANGELOG.md will cause conflicts with every other open PR. This `.gitattributes` entry tells Git to keep both sides -- perfect for a changelog where multiple entries can be added in the same place by different authors, helping us keep review-round-trips down.