### PR TITLE
feat(sdk): enable minimal-dependency SDK build

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+- Made `futures-channel`, `futures-executor`, `futures-util`, and `thiserror`
+  optional, enabling a minimal SDK build. With `default-features = false`, the
+  SDK's only dependency is the `opentelemetry` API crate.
+  ([#3593](https://github.com/open-telemetry/opentelemetry-rust/pull/3593))
 - Bound instruments are now available for `Gauge` and `UpDownCounter` via the
   new `BoundGauge<T>` and `BoundUpDownCounter<T>` types exposed by the
   `opentelemetry` crate. Requires the `experimental_metrics_bound_instruments`

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -20,7 +20,7 @@ percent-encoding = { workspace = true, optional = true }
 rand = { workspace = true, features = ["std", "std_rng", "small_rng", "os_rng", "thread_rng"], optional = true }
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
 serde_json = { workspace = true, optional = true }
-thiserror = { workspace = true }
+thiserror = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 tokio = { workspace = true, default-features = false, optional = true }
 tokio-stream = { workspace = true, optional = true }
@@ -44,12 +44,12 @@ pprof = { workspace = true }
 
 [features]
 default = ["trace", "metrics", "logs", "internal-logs"]
-trace = ["opentelemetry/trace", "rand", "percent-encoding", "dep:futures-channel", "dep:futures-executor", "dep:futures-util"]
+trace = ["opentelemetry/trace", "rand", "percent-encoding", "dep:futures-channel", "dep:futures-executor", "dep:futures-util", "dep:thiserror"]
 jaeger_remote_sampler = ["trace", "opentelemetry-http", "http", "serde", "serde_json", "url", "experimental_async_runtime"]
 logs = ["opentelemetry/logs", "dep:futures-channel", "dep:futures-executor", "dep:futures-util"]
-metrics = ["opentelemetry/metrics", "dep:futures-channel", "dep:futures-executor", "dep:futures-util"]
+metrics = ["opentelemetry/metrics", "dep:futures-channel", "dep:futures-executor", "dep:futures-util", "dep:thiserror"]
 testing = ["opentelemetry/testing", "trace", "metrics", "logs", "tokio/sync"]
-experimental_async_runtime = ["dep:futures-channel", "dep:futures-executor", "dep:futures-util"]
+experimental_async_runtime = ["dep:futures-channel", "dep:futures-executor", "dep:futures-util", "dep:thiserror"]
 rt-tokio = ["tokio/rt", "tokio/time", "tokio-stream", "experimental_async_runtime"]
 rt-tokio-current-thread = ["tokio/rt", "tokio/time", "tokio-stream", "experimental_async_runtime"]
 internal-logs = ["opentelemetry/internal-logs"]

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -13,9 +13,9 @@ autobenches = false
 [dependencies]
 opentelemetry = { workspace = true }
 opentelemetry-http = { workspace = true, optional = true }
-futures-channel = { workspace = true }
-futures-executor = { workspace = true }
-futures-util = { workspace = true, features = ["std", "sink", "async-await-macro"] }
+futures-channel = { workspace = true, optional = true }
+futures-executor = { workspace = true, optional = true }
+futures-util = { workspace = true, features = ["std", "sink", "async-await-macro"], optional = true }
 percent-encoding = { workspace = true, optional = true }
 rand = { workspace = true, features = ["std", "std_rng", "small_rng", "os_rng", "thread_rng"], optional = true }
 serde = { workspace = true, features = ["derive", "rc"], optional = true }
@@ -44,12 +44,12 @@ pprof = { workspace = true }
 
 [features]
 default = ["trace", "metrics", "logs", "internal-logs"]
-trace = ["opentelemetry/trace", "rand", "percent-encoding"]
+trace = ["opentelemetry/trace", "rand", "percent-encoding", "dep:futures-channel", "dep:futures-executor", "dep:futures-util"]
 jaeger_remote_sampler = ["trace", "opentelemetry-http", "http", "serde", "serde_json", "url", "experimental_async_runtime"]
-logs = ["opentelemetry/logs"]
-metrics = ["opentelemetry/metrics"]
+logs = ["opentelemetry/logs", "dep:futures-channel", "dep:futures-executor", "dep:futures-util"]
+metrics = ["opentelemetry/metrics", "dep:futures-channel", "dep:futures-executor", "dep:futures-util"]
 testing = ["opentelemetry/testing", "trace", "metrics", "logs", "tokio/sync"]
-experimental_async_runtime = []
+experimental_async_runtime = ["dep:futures-channel", "dep:futures-executor", "dep:futures-util"]
 rt-tokio = ["tokio/rt", "tokio/time", "tokio-stream", "experimental_async_runtime"]
 rt-tokio-current-thread = ["tokio/rt", "tokio/time", "tokio-stream", "experimental_async_runtime"]
 internal-logs = ["opentelemetry/internal-logs"]

--- a/opentelemetry-sdk/src/error.rs
+++ b/opentelemetry-sdk/src/error.rs
@@ -1,8 +1,6 @@
 //! Wrapper for error from trace, logs and metrics part of open telemetry.
 
-use std::{result::Result, time::Duration};
-
-use thiserror::Error;
+use std::{fmt, result::Result, time::Duration};
 
 /// Trait for errors returned by exporters
 pub trait ExportError: std::error::Error + Send + Sync + 'static {
@@ -10,7 +8,7 @@ pub trait ExportError: std::error::Error + Send + Sync + 'static {
     fn exporter_name(&self) -> &'static str;
 }
 
-#[derive(Error, Debug)]
+#[derive(Debug)]
 /// Errors that can occur during SDK operations export(), force_flush() and shutdown().
 pub enum OTelSdkError {
     /// Shutdown has already been invoked.
@@ -20,7 +18,6 @@ pub enum OTelSdkError {
     /// invoking `shutdown` earlier than intended. Users should review their
     /// code to identify unintended or duplicate shutdown calls and ensure it is
     /// only triggered once at the correct place.
-    #[error("Shutdown already invoked")]
     AlreadyShutdown,
 
     /// Operation timed out before completing.
@@ -28,7 +25,6 @@ pub enum OTelSdkError {
     /// This does not necessarily indicate a failure—operation may still be
     /// complete. If this occurs frequently, consider increasing the timeout
     /// duration to allow more time for completion.
-    #[error("Operation timed out after {0:?}")]
     Timeout(Duration),
 
     /// Operation failed due to an internal error.
@@ -37,9 +33,22 @@ pub enum OTelSdkError {
     /// be used to make programmatic decisions. It is implementation-specific
     /// and subject to change without notice. Consumers of this error should not
     /// rely on its content beyond logging.
-    #[error("Operation failed: {0}")]
     InternalFailure(String),
 }
+
+impl fmt::Display for OTelSdkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OTelSdkError::AlreadyShutdown => write!(f, "Shutdown already invoked"),
+            OTelSdkError::Timeout(duration) => {
+                write!(f, "Operation timed out after {duration:?}")
+            }
+            OTelSdkError::InternalFailure(reason) => write!(f, "Operation failed: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for OTelSdkError {}
 
 #[cfg(any(feature = "testing", test))]
 impl<T> From<std::sync::PoisonError<T>> for OTelSdkError {
@@ -50,3 +59,24 @@ impl<T> From<std::sync::PoisonError<T>> for OTelSdkError {
 
 /// A specialized `Result` type for Shutdown operations.
 pub type OTelSdkResult = Result<(), OTelSdkError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_matches_variants() {
+        assert_eq!(
+            OTelSdkError::AlreadyShutdown.to_string(),
+            "Shutdown already invoked"
+        );
+        assert_eq!(
+            OTelSdkError::Timeout(Duration::from_secs(5)).to_string(),
+            "Operation timed out after 5s"
+        );
+        assert_eq!(
+            OTelSdkError::InternalFailure("db unreachable".into()).to_string(),
+            "Operation failed: db unreachable"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #3592

## Changes

Make `futures-channel`, `futures-executor`, `futures-util`, and `thiserror` optional so the SDK can build without them. They're now enabled only by the features that use them.

With this change, building the SDK with `default-features = false` leaves `opentelemetry` (the API crate) as the only dependency. That lets projects like otel-arrow use resource detection without dragging in the whole SDK. Default builds and the public API are unchanged. Verified using: `cargo hack --each-feature check`.

Below shows how the tree changed with each commit:

**original**

```
cargo tree -p opentelemetry_sdk --no-default-features -e no-dev
opentelemetry_sdk v0.32.1 (/Users/matt/Repos/otel/opentelemetry-rust/opentelemetry-sdk)
├── futures-channel v0.3.32
│   └── futures-core v0.3.32
├── futures-executor v0.3.32
│   ├── futures-core v0.3.32
│   ├── futures-task v0.3.32
│   └── futures-util v0.3.32
│       ├── futures-core v0.3.32
│       ├── futures-macro v0.3.32 (proc-macro)
│       │   ├── proc-macro2 v1.0.106
│       │   │   └── unicode-ident v1.0.24
│       │   ├── quote v1.0.45
│       │   │   └── proc-macro2 v1.0.106 (*)
│       │   └── syn v2.0.117
│       │       ├── proc-macro2 v1.0.106 (*)
│       │       ├── quote v1.0.45 (*)
│       │       └── unicode-ident v1.0.24
│       ├── futures-sink v0.3.32
│       ├── futures-task v0.3.32
│       ├── pin-project-lite v0.2.17
│       └── slab v0.4.12
├── futures-util v0.3.32 (*)
├── opentelemetry v0.32.0 (/Users/matt/Repos/otel/opentelemetry-rust/opentelemetry)
└── thiserror v2.0.18
    └── thiserror-impl v2.0.18 (proc-macro)
        ├── proc-macro2 v1.0.106 (*)
        ├── quote v1.0.45 (*)
        └── syn v2.0.117 (*)
```

**futures optional (452e1721052fd2cc28d09fd27d6d50ed06ed3019)**

```
cargo tree -p opentelemetry_sdk --no-default-features -e no-dev
opentelemetry_sdk v0.32.1 (/Users/matt/Repos/otel/opentelemetry-rust/opentelemetry-sdk)
├── opentelemetry v0.32.0 (/Users/matt/Repos/otel/opentelemetry-rust/opentelemetry)
└── thiserror v2.0.18
    └── thiserror-impl v2.0.18 (proc-macro)
        ├── proc-macro2 v1.0.106
        │   └── unicode-ident v1.0.24
        ├── quote v1.0.45
        │   └── proc-macro2 v1.0.106 (*)
        └── syn v2.0.117
            ├── proc-macro2 v1.0.106 (*)
            ├── quote v1.0.45 (*)
            └── unicode-ident v1.0.24

```

**thiserror optional (2ff57b520c4ab7f9c401ac5c433275db569dbdb4)**

```
cargo tree -p opentelemetry_sdk --no-default-features -e no-dev
opentelemetry_sdk v0.32.1 (/Users/matt/Repos/otel/opentelemetry-rust/opentelemetry-sdk)
└── opentelemetry v0.32.0 (/Users/matt/Repos/otel/opentelemetry-rust/opentelemetry)
```

## Merge requirement checklist

* [x] [[CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md)](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)