### PR TITLE
fix(opentelemetry): resolve clippy byte_char_slices and useless_borrows_in_formatting lints

### DIFF
--- a/opentelemetry-stdout/src/trace/exporter.rs
+++ b/opentelemetry-stdout/src/trace/exporter.rs
@@ -73,10 +73,7 @@ fn print_spans(batch: Vec<SpanData>) {
     for (i, span) in batch.into_iter().enumerate() {
         println!("Span #{i}");
         println!("\tInstrumentation Scope");
-        println!(
-            "\t\tName         : {:?}",
-            span.instrumentation_scope.name()
-        );
+        println!("\t\tName         : {:?}", span.instrumentation_scope.name());
         if let Some(version) = &span.instrumentation_scope.version() {
             println!("\t\tVersion  : {version:?}");
         }

--- a/opentelemetry-stdout/src/trace/exporter.rs
+++ b/opentelemetry-stdout/src/trace/exporter.rs
@@ -75,7 +75,7 @@ fn print_spans(batch: Vec<SpanData>) {
         println!("\tInstrumentation Scope");
         println!(
             "\t\tName         : {:?}",
-            &span.instrumentation_scope.name()
+            span.instrumentation_scope.name()
         );
         if let Some(version) = &span.instrumentation_scope.version() {
             println!("\t\tVersion  : {version:?}");
@@ -94,16 +94,16 @@ fn print_spans(batch: Vec<SpanData>) {
             });
 
         println!();
-        println!("\tName         : {}", &span.name);
-        println!("\tTraceId      : {}", &span.span_context.trace_id());
-        println!("\tSpanId       : {}", &span.span_context.span_id());
-        println!("\tTraceFlags   : {:?}", &span.span_context.trace_flags());
+        println!("\tName         : {}", span.name);
+        println!("\tTraceId      : {}", span.span_context.trace_id());
+        println!("\tSpanId       : {}", span.span_context.span_id());
+        println!("\tTraceFlags   : {:?}", span.span_context.trace_flags());
         if span.parent_span_id == opentelemetry::SpanId::INVALID {
             println!("\tParentSpanId : None (root span)");
         } else {
-            println!("\tParentSpanId : {}", &span.parent_span_id);
+            println!("\tParentSpanId : {}", span.parent_span_id);
         }
-        println!("\tKind         : {:?}", &span.span_kind);
+        println!("\tKind         : {:?}", span.span_kind);
 
         let datetime: DateTime<Utc> = span.start_time.into();
         println!(
@@ -115,7 +115,7 @@ fn print_spans(batch: Vec<SpanData>) {
             "\tEnd time     : {}",
             datetime.format("%Y-%m-%d %H:%M:%S%.6f")
         );
-        println!("\tStatus       : {:?}", &span.status);
+        println!("\tStatus       : {:?}", span.status);
 
         let mut print_header = true;
         for kv in span.attributes.iter() {

--- a/opentelemetry/src/baggage.rs
+++ b/opentelemetry/src/baggage.rs
@@ -30,10 +30,7 @@ const MAX_KEY_VALUE_PAIRS: usize = 64;
 const MAX_LEN_OF_ALL_PAIRS: usize = 8192;
 
 // https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
-const INVALID_ASCII_KEY_CHARS: [u8; 17] = [
-    b'(', b')', b',', b'/', b':', b';', b'<', b'=', b'>', b'?', b'@', b'[', b'\\', b']', b'{',
-    b'}', b'"',
-];
+const INVALID_ASCII_KEY_CHARS: [u8; 17] = *b"(),/:;<=>?@[\\]{}\"";
 
 /// Returns the default baggage, ensuring it is initialized only once.
 #[inline]

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -249,7 +249,7 @@ impl<T> fmt::Debug for HistogramBuilder<'_, T> {
             .field("boundaries", &self.boundaries)
             .field(
                 "kind",
-                &format!("Histogram<{}>", &std::any::type_name::<T>()),
+                &format!("Histogram<{}>", std::any::type_name::<T>()),
             )
             .finish()
     }


### PR DESCRIPTION
Two clippy lints (in the `opentelemetry` crate) started failing CI on stable clippy:

- `clippy::byte_char_slices` in `opentelemetry/src/baggage.rs` — the `INVALID_ASCII_KEY_CHARS: [u8; 17]` byte array is now expressed as a byte string literal `*b"(),/:;<=>?@[\\]{}\""`.
- `clippy::useless_borrows_in_formatting` in `opentelemetry/src/metrics/instruments/mod.rs` — dropped a redundant `&` on `std::any::type_name::<T>()` inside a `format!` argument.

No behavior change; failures were reproducible on `main`.