### PR TITLE
fix(proto): accept empty AnyValue in OTLP/JSON

### DIFF
--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- **Bug fix**: Accept empty `AnyValue` objects in OTLP/JSON payloads instead of rejecting the entire request.
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-proto/src/proto.rs
+++ b/opentelemetry-proto/src/proto.rs
@@ -151,13 +151,10 @@ pub(crate) mod serializers {
                     }
                 }
 
-                if let Some(v) = value {
-                    Ok(Some(v))
-                } else {
-                    Err(de::Error::custom(
-                        "Invalid data for Value, no known keys found",
-                    ))
-                }
+                // An AnyValue with no selected field is valid and considered empty.
+                // Unknown fields are ignored according to the OTLP/JSON specification,
+                // so an empty or unknown-only object has the same representation.
+                Ok(value)
             }
         }
 

--- a/opentelemetry-proto/tests/json_serde.rs
+++ b/opentelemetry-proto/tests/json_serde.rs
@@ -637,6 +637,78 @@ mod json_serde {
         }
     }
 
+    mod empty_any_value {
+        use super::*;
+
+        #[test]
+        fn deserialize_empty_and_unknown_only_values() {
+            for json in [r#"{}"#, r#"{"futureValue":"ignored"}"#] {
+                let actual: AnyValue =
+                    serde_json::from_str(json).expect("empty AnyValue must deserialize");
+                assert_eq!(actual, AnyValue { value: None });
+                assert_eq!(
+                    serde_json::to_string(&actual).expect("empty AnyValue must serialize"),
+                    "{}"
+                );
+            }
+        }
+
+        #[cfg(feature = "trace")]
+        #[test]
+        fn deserialize_empty_span_attribute() {
+            let json = r#"{
+                "resourceSpans": [{
+                    "scopeSpans": [{
+                        "spans": [{
+                            "traceId": "00000000000000000000000000000001",
+                            "spanId": "0000000000000001",
+                            "name": "cloudflare-span",
+                            "attributes": [{"key": "empty", "value": {}}]
+                        }]
+                    }]
+                }]
+            }"#;
+
+            let request: ExportTraceServiceRequest =
+                serde_json::from_str(json).expect("trace request must deserialize");
+            let value = &request.resource_spans[0].scope_spans[0].spans[0].attributes[0]
+                .value
+                .as_ref()
+                .expect("attribute must remain present")
+                .value;
+            assert_eq!(value, &None);
+        }
+
+        #[cfg(feature = "logs")]
+        #[test]
+        fn deserialize_empty_log_field() {
+            let json = r#"{
+                "resourceLogs": [{
+                    "scopeLogs": [{
+                        "logRecords": [{
+                            "body": {
+                                "kvlistValue": {
+                                    "values": [{"key": "value", "value": {}}]
+                                }
+                            }
+                        }]
+                    }]
+                }]
+            }"#;
+
+            let request: ExportLogsServiceRequest =
+                serde_json::from_str(json).expect("logs request must deserialize");
+            let Some(Value::KvlistValue(body)) = request.resource_logs[0].scope_logs[0].log_records
+                [0]
+            .body
+            .as_ref()
+            .and_then(|body| body.value.as_ref()) else {
+                panic!("log body must remain a key-value list");
+            };
+            assert_eq!(body.values[0].value, Some(AnyValue { value: None }));
+        }
+    }
+
     mod key_value {
         use super::*;
 


### PR DESCRIPTION
## Changes

The [`AnyValue` protobuf definition](https://github.com/open-telemetry/opentelemetry-proto/blob/ca839c51f706f5d53bfb46f06c3e90c3af3a52c6/opentelemetry/proto/common/v1/common.proto#L25-L50) explicitly permits its `oneof` to be unset and defines that state as empty. The [OTLP/JSON encoding rules](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding) also require receivers to ignore unknown fields and unmarshal the message as if they were absent.

The custom `AnyValue` visitor introduced in [#1753](https://github.com/open-telemetry/opentelemetry-rust/pull/1753) instead returns an error when it sees no recognized value field. This rejects both `{}` and unknown-only objects and can reject the entire OTLP request.

This occurs in real exporter traffic: [Cloudflare Workers native OpenTelemetry export](https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/) encodes a JavaScript log field containing `null` as an empty OTLP `AnyValue` (`{"key":"value","value":{}}`). A receiver using this decoder currently rejects the whole batch.

Deserialize those objects as the generated empty representation (`AnyValue { value: None }`). This also handles newer value fields safely for receivers that have not learned them yet. Regression coverage includes direct values, span attributes, and nested log fields.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` updated
* [x] No public API changes