### PR TITLE
feat(ci): add CI Doctor canary + clippy auto-fix workflows

### DIFF
--- a/.github/scripts/ci-doctor-report.sh
+++ b/.github/scripts/ci-doctor-report.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# ci-doctor-report.sh — open, close, or leave alone a "CI Doctor" tracking issue
+# based on the outcome of a scheduled hygiene check.
+#
+# The script is idempotent:
+#   * If the check FAILED and no open issue with the signature exists → create one.
+#   * If the check FAILED and an open issue exists → do nothing (avoid comment spam).
+#   * If the check PASSED and an open issue with the signature exists → close it.
+#   * If the check PASSED and no issue exists → do nothing.
+#
+# Dedupe key is a hidden HTML comment embedded in the issue body:
+#   <!-- ci-doctor:signature=<signature> -->
+#
+# Required env: GH_TOKEN (with issues:write on the repo).
+#
+# Required flags:
+#   --signature <slug>            stable dedupe key, e.g. "clippy-stable"
+#   --title "<text>"              issue title used when creating
+#   --status pass|fail            outcome of the check
+#   --command "<text>"            failing command, shown in body
+#   --log <path>                  path to the captured log
+#   --run-url <url>               link back to the GitHub Actions run
+#   --label <name>                label to apply / filter by
+#   --toolchain <name>            optional, informational only
+
+set -euo pipefail
+
+SIGNATURE=""
+TITLE=""
+STATUS=""
+COMMAND=""
+LOG_PATH=""
+RUN_URL=""
+LABEL=""
+TOOLCHAIN=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --signature) SIGNATURE="$2"; shift 2 ;;
+        --title) TITLE="$2"; shift 2 ;;
+        --status) STATUS="$2"; shift 2 ;;
+        --command) COMMAND="$2"; shift 2 ;;
+        --log) LOG_PATH="$2"; shift 2 ;;
+        --run-url) RUN_URL="$2"; shift 2 ;;
+        --label) LABEL="$2"; shift 2 ;;
+        --toolchain) TOOLCHAIN="$2"; shift 2 ;;
+        *) echo "unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+: "${SIGNATURE:?--signature is required}"
+: "${STATUS:?--status is required}"
+: "${LABEL:?--label is required}"
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+    echo "GH_TOKEN must be set" >&2
+    exit 2
+fi
+
+MARKER="<!-- ci-doctor:signature=${SIGNATURE} -->"
+
+# Ensure the label exists (idempotent).
+gh label create "${LABEL}" \
+    --description "Tracking issue opened by CI Doctor" \
+    --color "d93f0b" \
+    --force >/dev/null
+
+# Find any existing open issue for this signature.
+# The MARKER is embedded in the issue body when we create it; gh's default
+# search covers title+body, so plain-text search on the marker is enough.
+EXISTING_NUMBER="$(gh issue list \
+    --state open \
+    --label "${LABEL}" \
+    --search "${MARKER}" \
+    --json number \
+    --jq '.[0].number // empty')"
+
+case "${STATUS}" in
+    pass|success)
+        if [[ -n "${EXISTING_NUMBER}" ]]; then
+            echo "Check ${SIGNATURE} passed — closing issue #${EXISTING_NUMBER}."
+            gh issue comment "${EXISTING_NUMBER}" \
+                --body "Resolved: the \`${SIGNATURE}\` check passed in run ${RUN_URL} on $(date -u +%Y-%m-%dT%H:%M:%SZ). Closing."
+            gh issue close "${EXISTING_NUMBER}" --reason completed
+        else
+            echo "Check ${SIGNATURE} passed and no tracking issue exists — nothing to do."
+        fi
+        ;;
+    fail|failure)
+        if [[ -n "${EXISTING_NUMBER}" ]]; then
+            echo "Check ${SIGNATURE} still failing — tracking issue #${EXISTING_NUMBER} already open. No-op."
+            exit 0
+        fi
+
+        # Build the issue body. Trim the log to keep the issue readable.
+        BODY_FILE="$(mktemp)"
+        {
+            echo "${MARKER}"
+            echo
+            echo "The scheduled **CI Doctor** run detected a failure on \`main\`."
+            echo
+            if [[ -n "${TOOLCHAIN}" ]]; then
+                echo "- **Check:** \`${SIGNATURE}\` (toolchain: \`${TOOLCHAIN}\`)"
+            else
+                echo "- **Check:** \`${SIGNATURE}\`"
+            fi
+            echo "- **Run:** ${RUN_URL}"
+            echo "- **Command:**"
+            echo
+            echo '  ```'
+            echo "  ${COMMAND}"
+            echo '  ```'
+            echo
+            echo "### Trimmed log"
+            echo
+            echo '```'
+            if [[ -n "${LOG_PATH}" && -f "${LOG_PATH}" ]]; then
+                # First and last 80 lines, since clippy/cargo-deny output can be long.
+                LINE_COUNT="$(wc -l <"${LOG_PATH}" | tr -d ' ')"
+                if [[ "${LINE_COUNT}" -le 200 ]]; then
+                    cat "${LOG_PATH}"
+                else
+                    head -n 80 "${LOG_PATH}"
+                    echo
+                    echo "… [$(( LINE_COUNT - 160 )) lines omitted] …"
+                    echo
+                    tail -n 80 "${LOG_PATH}"
+                fi
+            else
+                echo "(no log captured)"
+            fi
+            echo '```'
+            echo
+            echo "---"
+            echo
+            echo "This issue was opened automatically. It will be closed on the next successful"
+            echo "run of the same check. To suppress CI Doctor entirely, set the repo variable"
+            echo "\`CI_DOCTOR_ENABLED=false\`."
+        } >"${BODY_FILE}"
+
+        echo "Opening tracking issue for ${SIGNATURE}."
+        gh issue create \
+            --title "${TITLE}" \
+            --label "${LABEL}" \
+            --body-file "${BODY_FILE}"
+        rm -f "${BODY_FILE}"
+        ;;
+    *)
+        echo "Unknown --status value: ${STATUS}" >&2
+        exit 2
+        ;;
+esac

--- a/.github/workflows/ci-doctor-autofix.yml
+++ b/.github/workflows/ci-doctor-autofix.yml
@@ -1,0 +1,184 @@
+# CI Doctor — Tier 2 (auto-fix)
+#
+# Runs after the canary. Attempts `cargo clippy --fix` for the machine-
+# applicable clippy lints on the stable toolchain. If the resulting tree
+# is clean-clippy + tests pass, opens (or updates) a PR titled
+# "chore(ci-hygiene): apply clippy suggestions". If the fix does not
+# resolve all lints, no PR is opened — the tracking issue from Tier 1
+# will still track the problem for a human.
+#
+# Only stable is auto-fixed. Beta lints may not be stabilized in their
+# final form, so we do not want to churn code chasing them.
+#
+# Note: PRs opened via GITHUB_TOKEN do not trigger downstream workflow
+# runs. Reviewers must close-and-reopen the PR to force CI. Provide a
+# repo secret `CI_DOCTOR_TOKEN` (a fine-grained PAT or GitHub App
+# installation token with contents:write and pull_requests:write) to
+# have the bot's PR trigger CI automatically.
+name: CI Doctor Autofix
+env:
+  CI: true
+permissions:
+  contents: read
+on:
+  schedule:
+    # 30 minutes after the canary run so we work off the same daily view.
+    - cron: '30 6 * * *'
+  workflow_dispatch: {}
+concurrency:
+  group: ci-doctor-autofix
+  cancel-in-progress: false
+jobs:
+  clippy-autofix:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-rust' && vars.CI_DOCTOR_ENABLED != 'false' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+          # Full history so we can force-push the autofix branch cleanly.
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2.81.3
+        with:
+          tool: cargo-hack
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Refresh dependency graph
+        run: cargo update
+      - name: Confirm main is failing on clippy
+        id: precheck
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          cargo clippy --workspace --all-targets --all-features -- -Dwarnings 2>&1 | tee /tmp/precheck.log
+      - name: Nothing to fix
+        if: steps.precheck.outcome == 'success'
+        run: |
+          echo "clippy already clean on main — nothing to auto-fix."
+          exit 0
+      - name: Attempt cargo clippy --fix
+        if: steps.precheck.outcome == 'failure'
+        run: |
+          set -o pipefail
+          # --fix requires a clean-ish tree; --allow-dirty + --allow-no-vcs cover the
+          # case where cargo update touched Cargo.lock. Do not fail the step if
+          # unfixable lints remain — we detect that in the verify step below.
+          cargo clippy \
+            --workspace --all-targets --all-features \
+            --fix --allow-dirty --allow-staged --allow-no-vcs \
+            -- -Dwarnings 2>&1 | tee /tmp/autofix.log || true
+          cargo fmt --all
+      - name: Detect changes
+        if: steps.precheck.outcome == 'failure'
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat
+          fi
+      - name: No auto-fixable lints
+        if: steps.precheck.outcome == 'failure' && steps.diff.outputs.changed != 'true'
+        run: |
+          echo "clippy failed but no machine-applicable fixes were produced."
+          echo "The Tier 1 tracking issue will still record this failure."
+          exit 0
+      - name: Verify — clippy clean after fix
+        if: steps.precheck.outcome == 'failure' && steps.diff.outputs.changed == 'true'
+        id: verify_clippy
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          cargo clippy --workspace --all-targets --all-features -- -Dwarnings 2>&1 | tee /tmp/verify.log
+      - name: Verify — tests still pass
+        if: steps.precheck.outcome == 'failure' && steps.diff.outputs.changed == 'true' && steps.verify_clippy.outcome == 'success'
+        id: verify_tests
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          cargo test --workspace --all-features --lib 2>&1 | tee /tmp/tests.log
+      - name: Bail out if verification failed
+        if: >-
+          steps.precheck.outcome == 'failure' &&
+          steps.diff.outputs.changed == 'true' &&
+          (steps.verify_clippy.outcome != 'success' || steps.verify_tests.outcome != 'success')
+        run: |
+          echo "Auto-fix produced changes but verification failed."
+          echo "clippy outcome: ${{ steps.verify_clippy.outcome }}"
+          echo "tests outcome: ${{ steps.verify_tests.outcome }}"
+          echo "Not opening a PR. The Tier 1 tracking issue will still record the underlying failure."
+          exit 0
+      - name: Commit and force-push autofix branch
+        if: >-
+          steps.precheck.outcome == 'failure' &&
+          steps.diff.outputs.changed == 'true' &&
+          steps.verify_clippy.outcome == 'success' &&
+          steps.verify_tests.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.CI_DOCTOR_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B ci-doctor/clippy-fix
+          git add -A
+          RUST_VERSION="$(rustc --version | awk '{print $2}')"
+          git commit -m "chore(ci-hygiene): apply clippy suggestions from Rust ${RUST_VERSION}"
+          # Push using the token so the follow-up PR can be created by the same identity.
+          REMOTE_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force "${REMOTE_URL}" HEAD:ci-doctor/clippy-fix
+      - name: Open or update the auto-fix PR
+        if: >-
+          steps.precheck.outcome == 'failure' &&
+          steps.diff.outputs.changed == 'true' &&
+          steps.verify_clippy.outcome == 'success' &&
+          steps.verify_tests.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.CI_DOCTOR_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          RUST_VERSION="$(rustc --version | awk '{print $2}')"
+          BODY_FILE="$(mktemp)"
+          {
+            echo "Applied by the **CI Doctor autofix** workflow after \`cargo clippy --fix\` on stable Rust \`${RUST_VERSION}\`."
+            echo
+            echo "- **Command:** \`cargo clippy --workspace --all-targets --all-features --fix -- -Dwarnings\`"
+            echo "- **Verification:** clippy + \`cargo test --workspace --all-features --lib\` both passed on the fixed tree."
+            echo "- **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo
+            echo "### Changed files"
+            echo
+            echo '```'
+            git diff --stat HEAD^ HEAD || true
+            echo '```'
+            echo
+            echo "> This PR was opened automatically. **Please review before merging.**"
+            echo "> If the fix is wrong or scope has drifted, close this PR — the bot will not"
+            echo "> reopen it unless the underlying failure recurs. To disable the bot entirely,"
+            echo "> set the repo variable \`CI_DOCTOR_ENABLED=false\`."
+          } >"${BODY_FILE}"
+
+          if gh pr view ci-doctor/clippy-fix --json state --jq .state >/dev/null 2>&1; then
+            echo "Existing PR found — updating body."
+            gh pr edit ci-doctor/clippy-fix --body-file "${BODY_FILE}"
+          else
+            echo "Opening new PR."
+            gh pr create \
+              --base main \
+              --head ci-doctor/clippy-fix \
+              --title "chore(ci-hygiene): apply clippy suggestions from Rust ${RUST_VERSION}" \
+              --label ci-hygiene \
+              --body-file "${BODY_FILE}"
+          fi
+          rm -f "${BODY_FILE}"

--- a/.github/workflows/ci-doctor.yml
+++ b/.github/workflows/ci-doctor.yml
@@ -1,0 +1,165 @@
+# CI Doctor — Tier 1 (canary)
+#
+# Runs the checks most likely to break `main` unexpectedly (new stable
+# clippy lints, new RUSTSEC advisories, MSRV drift under a fresh
+# dependency resolve) once a day on a schedule.
+#
+# On failure, a tracking issue is opened (or updated) with a stable
+# signature so that repeat runs do not spam. Passing checks auto-close
+# any matching open issue.
+#
+# See `.github/scripts/ci-doctor-report.sh` for the reporter details.
+#
+# Kill switch: set the repository variable `CI_DOCTOR_ENABLED=false`
+# to skip all jobs without editing this file.
+name: CI Doctor
+env:
+  CI: true
+permissions:
+  contents: read
+  issues: write
+on:
+  schedule:
+    # Every day at 06:00 UTC. Chosen to be well before EU business hours
+    # so a tracking issue exists by the time contributors open PRs.
+    - cron: '0 6 * * *'
+  workflow_dispatch: {}
+concurrency:
+  group: ci-doctor
+  cancel-in-progress: false
+jobs:
+  clippy:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-rust' && vars.CI_DOCTOR_ENABLED != 'false' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2.81.3
+        with:
+          tool: cargo-hack
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Refresh dependency graph (mirror PR CI without a lockfile)
+        run: cargo update
+      - name: Clippy (workspace, all features)
+        id: check
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          cargo clippy --workspace --all-targets --all-features -- -Dwarnings 2>&1 | tee /tmp/check.log
+      - name: Report outcome
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash .github/scripts/ci-doctor-report.sh \
+            --signature clippy-stable \
+            --title "[CI Doctor] clippy failing on stable Rust" \
+            --status "${{ steps.check.outcome }}" \
+            --command "cargo clippy --workspace --all-targets --all-features -- -Dwarnings" \
+            --log /tmp/check.log \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --label ci-hygiene \
+            --toolchain stable
+      - name: Surface failure to the workflow
+        if: steps.check.outcome == 'failure'
+        run: exit 1
+
+  cargo-deny:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-rust' && vars.CI_DOCTOR_ENABLED != 'false' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2.81.3
+        with:
+          tool: cargo-deny
+      - name: cargo-deny (advisories, fresh DB)
+        id: check
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          # `cargo deny fetch` refreshes the advisory database so we exercise the same view
+          # PR CI sees on any given day.
+          cargo deny fetch 2>&1 | tee -a /tmp/check.log
+          cargo deny check advisories 2>&1 | tee -a /tmp/check.log
+      - name: Report outcome
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash .github/scripts/ci-doctor-report.sh \
+            --signature cargo-deny-advisories \
+            --title "[CI Doctor] cargo-deny advisories failing on main" \
+            --status "${{ steps.check.outcome }}" \
+            --command "cargo deny check advisories" \
+            --log /tmp/check.log \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --label ci-hygiene
+      - name: Surface failure to the workflow
+        if: steps.check.outcome == 'failure'
+        run: exit 1
+
+  msrv:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-rust' && vars.CI_DOCTOR_ENABLED != 'false' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2.81.3
+        with:
+          tool: cargo-msrv
+      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Refresh dependency graph (mirror PR CI without a lockfile)
+        run: cargo update
+      - name: MSRV verify
+        id: check
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          bash ./scripts/msrv.sh 2>&1 | tee /tmp/check.log
+      - name: Report outcome
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash .github/scripts/ci-doctor-report.sh \
+            --signature msrv \
+            --title "[CI Doctor] MSRV verification failing on main" \
+            --status "${{ steps.check.outcome }}" \
+            --command "bash ./scripts/msrv.sh (after cargo update)" \
+            --log /tmp/check.log \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --label ci-hygiene
+      - name: Surface failure to the workflow
+        if: steps.check.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
Adds two scheduled workflows plus one helper script to catch and repair the CI failures that today only surface when a contributor opens an unrelated PR — new stable clippy releases, new RUSTSEC advisories, and MSRV drift under a fresh dependency resolve. Motivated by the clippy 1.97 fallout seen in #3593 / #3594.

**Tier 1 — `.github/workflows/ci-doctor.yml` (canary)**
Runs daily on `main` (and on `workflow_dispatch`). Three jobs, all on stable, all with a fresh `cargo update` first:
- `clippy` — `cargo clippy --workspace --all-targets --all-features -- -Dwarnings`
- `cargo-deny` — `cargo deny fetch` + `cargo deny check advisories`
- `msrv` — `scripts/msrv.sh`

On failure the reporter opens (or leaves alone) a labeled tracking issue with a stable signature so repeat runs do not spam. On the next passing run the issue is auto-closed. This alone converts "surprise red PR" into "known open tracking issue".

**Tier 2 — `.github/workflows/ci-doctor-autofix.yml`**
Runs 30 minutes after the canary. Attempts `cargo clippy --fix` on stable, runs `cargo fmt --all`, and only opens a PR if the fixed tree passes both `cargo clippy … -Dwarnings` and `cargo test --workspace --all-features --lib`. Partial fixes are refused — the Tier 1 tracking issue is enough for those. The PR uses branch `ci-doctor/clippy-fix` (force-pushed on each run) and is titled `chore(ci-hygiene): apply clippy suggestions from Rust <version>`.

**Reporter — `.github/scripts/ci-doctor-report.sh`**
Idempotent bash script used by Tier 1. Dedupes by hidden `<!-- ci-doctor:signature=<key> -->` marker in the issue body. Auto-creates the `ci-hygiene` label if missing.

**Guardrails**
- Both workflows are no-ops on forks (`github.repository ==` guard).
- Kill switch: repo variable `CI_DOCTOR_ENABLED=false`.
- Optional secret `CI_DOCTOR_TOKEN` (a bot PAT or GitHub App installation token) — when set, autofix opens the PR under that identity so its own CI runs; without it, the default `GITHUB_TOKEN` opens the PR but CI must be manually kicked (close-and-reopen or empty commit).
- No workflow calls `gh pr merge` or `gh pr review --approve`. Bot PRs need normal review + CLA.

**Local checks done**
- `actionlint` clean on both workflow YAMLs.
- `shellcheck` clean on the reporter.
- Reporter branching logic exercised with a stubbed `gh` — all four cases (fail/pass × issue exists / does not exist) call the right sub-commands and produce a well-formed issue body.

**Not yet exercised end-to-end** — these will only be validated on the first real run:
- GitHub search-based dedupe of the tracking issue.
- `cargo clippy --fix` behavior on a GH runner.
- The autofix push + `gh pr create` flow.
- Whether the autofix PR triggers downstream CI (see the `CI_DOCTOR_TOKEN` note above).

Suggested shakedown after merge: manually `workflow_dispatch` both workflows once and observe, then iterate with follow-up PRs if anything misbehaves.
