### PR TITLE
chore: update Jaeger to v2

### DIFF
--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -144,7 +144,7 @@
 //! Jaeger natively supports the OTLP protocol, making it easy to send traces directly:
 //!
 //! ```shell
-//! $ docker run -p 16686:16686 -p 4317:4317 -e COLLECTOR_OTLP_ENABLED=true jaegertracing/all-in-one:latest
+//! $ docker run -p 16686:16686 -p 4317:4317 -e COLLECTOR_OTLP_ENABLED=true jaegertracing/jaeger:latest
 //! ```
 //!
 //! After running your application configured with the OTLP exporter, view traces at:

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -144,7 +144,7 @@
 //! Jaeger natively supports the OTLP protocol, making it easy to send traces directly:
 //!
 //! ```shell
-//! $ docker run -p 16686:16686 -p 4317:4317 -e COLLECTOR_OTLP_ENABLED=true jaegertracing/jaeger:latest
+//! $ docker run -p 16686:16686 -p 4317:4317 jaegertracing/jaeger:latest
 //! ```
 //!
 //! After running your application configured with the OTLP exporter, view traces at:


### PR DESCRIPTION
Fixes #
Design discussion issue (if applicable) #

## Changes

The jaegar tracing image has been switched as existing image is eol jaegertracing/jaeger#6321

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
