### PR TITLE
fix(proto): deserialize `{}` as an empty AnyValue in with-serde

### DIFF
--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- **Bug fix**: `with-serde` now deserializes `{}` as an empty `AnyValue` (`value: None`). Proto3 JSON encodes a message with no fields set as `{}` — the unset `oneof` the proto documents as a valid "empty" `AnyValue` — and it is what the serializer itself emits for `AnyValue { value: None }`, as well as what the OpenTelemetry Collector's file exporter writes for body-less log records. Previously this failed with "Invalid data for Value, no known keys found"; objects containing only unknown keys still fail. ([#3598](https://github.com/open-telemetry/opentelemetry-rust/issues/3598))
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## vNext
 
-- **Bug fix**: `with-serde` now deserializes `{}` as an empty `AnyValue` (`value: None`). Proto3 JSON encodes a message with no fields set as `{}` — the unset `oneof` the proto documents as a valid "empty" `AnyValue` — and it is what the serializer itself emits for `AnyValue { value: None }`, as well as what the OpenTelemetry Collector's file exporter writes for body-less log records. Previously this failed with "Invalid data for Value, no known keys found"; objects containing only unknown keys still fail. ([#3598](https://github.com/open-telemetry/opentelemetry-rust/issues/3598))
+- **Bug fix**: `with-serde` now deserializes `{}` as an empty `AnyValue` (`value: None`). Previously this failed with "Invalid data for Value, no known keys found". ([#3598](https://github.com/open-telemetry/opentelemetry-rust/issues/3598))
 
 ## 0.32.0
 

--- a/opentelemetry-proto/src/proto.rs
+++ b/opentelemetry-proto/src/proto.rs
@@ -110,8 +110,10 @@ pub(crate) mod serializers {
                 V: de::MapAccess<'de>,
             {
                 let mut value: Option<any_value::Value> = None;
+                let mut saw_key = false;
 
                 while let Some(key) = map.next_key::<String>()? {
+                    saw_key = true;
                     let key_str = key.as_str();
                     match key_str {
                         "stringValue" => {
@@ -153,6 +155,18 @@ pub(crate) mod serializers {
 
                 if let Some(v) = value {
                     Ok(Some(v))
+                } else if !saw_key {
+                    // An empty JSON object is proto3 JSON's encoding of a
+                    // message with no fields set — for `AnyValue`, the unset
+                    // oneof ("It is valid for all values to be unspecified in
+                    // which case this AnyValue is considered to be 'empty'").
+                    // It is also what this module's own serializer emits for
+                    // `AnyValue { value: None }` (the `flatten` of an unset
+                    // oneof serializes no fields), and what real producers
+                    // emit on the wire: the OpenTelemetry Collector's file
+                    // exporter writes `"body": {}` for body-less event
+                    // records.
+                    Ok(None)
                 } else {
                     Err(de::Error::custom(
                         "Invalid data for Value, no known keys found",

--- a/opentelemetry-proto/tests/json_serde.rs
+++ b/opentelemetry-proto/tests/json_serde.rs
@@ -473,6 +473,32 @@ mod json_serde {
         use super::*;
 
         #[test]
+        fn empty() {
+            // proto3 JSON encodes a message with no fields set as `{}` —
+            // for `AnyValue` that is the unset oneof, which the proto
+            // itself documents as valid ("It is valid for all values to
+            // be unspecified in which case this AnyValue is considered
+            // to be 'empty'"). Real producers emit it on the wire (the
+            // Collector's file exporter writes `"body": {}` for
+            // body-less event records), and it is also exactly what
+            // this crate's own serializer produces for
+            // `AnyValue { value: None }` — which previously failed to
+            // deserialize back ("Invalid data for Value, no known keys
+            // found").
+            let value = AnyValue { value: None };
+            // language=json
+            let json = r#"{}"#;
+            assert_eq!(
+                serde_json::to_string(&value).expect("serialization succeeds"),
+                json
+            );
+            assert_eq!(
+                serde_json::from_str::<AnyValue>(json).expect("deserialization succeeds"),
+                value
+            );
+        }
+
+        #[test]
         fn string() {
             let value = Value::StringValue(String::from("my.service"));
             // language=json


### PR DESCRIPTION
Fixes #3598

## Changes

`with-serde`'s `ValueVisitor` (`deserialize_from_value`) rejected **every** `AnyValue` object that produced no known-key value — conflating two cases:

- an object with **only unknown keys** → still an error (unchanged), and
- an object with **no keys at all** (`{}`) → proto3 JSON's encoding of a message with no fields set, which for `AnyValue` is the unset `oneof` the proto itself documents as valid (*"It is valid for all values to be unspecified in which case this AnyValue is considered to be 'empty'"*).

The empty object is not hypothetical wire data: the OpenTelemetry Collector's file exporter emits `"body": {}` for body-less log records (e.g. the event records the current `opentelemetry-demo` produces), and it is also **exactly what this crate's own serializer emits** for `AnyValue { value: None }` (the `serde(flatten)` of an unset oneof serializes no fields) — so the serializer's output previously failed to round-trip through its own deserializer.

The fix tracks whether the visitor saw any key: a genuinely empty object deserializes to the unset value (`Ok(None)`); unknown-keys-only objects keep the existing `"Invalid data for Value, no known keys found"` error. New regression test (`json_serde::value::empty`) covers serialize + deserialize of the empty `AnyValue`; it fails without the `proto.rs` change.

Found via a real Collector capture in a downstream OTLP/JSON ingest path; evidence trail: https://github.com/jensholdgaard/ourios/issues/549.

**Disclosure**: this fix was developed with AI assistance (Claude, driving a coding session under my direction); I've reviewed and verified the change, the mutation check (test fails without the patch), and the test run (`cargo test -p opentelemetry-proto --features gen-tonic-messages,logs,trace,metrics,zpages,with-serde` — all pass except `grpc_build`, which requires a local `protoc` and was not run in my environment; no generated files are touched by this PR).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable) — no public API change (behavioral fix inside the existing deserializer)
