### PR TITLE
fix(proto): accept omitted OTLP JSON collector fields

### DIFF
--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - **Bug fix**: Accept empty `AnyValue` objects in OTLP/JSON payloads instead of rejecting the entire request.
+- **Bug fix**: Accept omitted and proto-named resource fields in OTLP/JSON collector requests.
 
 ## 0.32.0
 

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.logs.v1.rs
@@ -2,6 +2,7 @@
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportLogsServiceRequest {
     /// An array of ResourceLogs.
@@ -10,6 +11,7 @@ pub struct ExportLogsServiceRequest {
     /// data from multiple origins typically batch the data before forwarding further and
     /// in that case this array will contain multiple elements.
     #[prost(message, repeated, tag = "1")]
+    #[cfg_attr(feature = "with-serde", serde(alias = "resource_logs"))]
     pub resource_logs: ::prost::alloc::vec::Vec<
         super::super::super::logs::v1::ResourceLogs,
     >,

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.metrics.v1.rs
@@ -2,6 +2,7 @@
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportMetricsServiceRequest {
     /// An array of ResourceMetrics.
@@ -10,6 +11,7 @@ pub struct ExportMetricsServiceRequest {
     /// data from multiple origins typically batch the data before forwarding further and
     /// in that case this array will contain multiple elements.
     #[prost(message, repeated, tag = "1")]
+    #[cfg_attr(feature = "with-serde", serde(alias = "resource_metrics"))]
     pub resource_metrics: ::prost::alloc::vec::Vec<
         super::super::super::metrics::v1::ResourceMetrics,
     >,

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.profiles.v1development.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.profiles.v1development.rs
@@ -2,6 +2,7 @@
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportProfilesServiceRequest {
     /// An array of ResourceProfiles.
@@ -10,6 +11,7 @@ pub struct ExportProfilesServiceRequest {
     /// data from multiple origins typically batch the data before forwarding further and
     /// in that case this array will contain multiple elements.
     #[prost(message, repeated, tag = "1")]
+    #[cfg_attr(feature = "with-serde", serde(alias = "resource_profiles"))]
     pub resource_profiles: ::prost::alloc::vec::Vec<
         super::super::super::profiles::v1development::ResourceProfiles,
     >,

--- a/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
+++ b/opentelemetry-proto/src/proto/tonic/opentelemetry.proto.collector.trace.v1.rs
@@ -2,6 +2,7 @@
 #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "with-serde", serde(default))]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExportTraceServiceRequest {
     /// An array of ResourceSpans.
@@ -10,6 +11,7 @@ pub struct ExportTraceServiceRequest {
     /// data from multiple origins typically batch the data before forwarding further and
     /// in that case this array will contain multiple elements.
     #[prost(message, repeated, tag = "1")]
+    #[cfg_attr(feature = "with-serde", serde(alias = "resource_spans"))]
     pub resource_spans: ::prost::alloc::vec::Vec<
         super::super::super::trace::v1::ResourceSpans,
     >,

--- a/opentelemetry-proto/tests/grpc_build.rs
+++ b/opentelemetry-proto/tests/grpc_build.rs
@@ -47,6 +47,10 @@ fn build_tonic() {
     // JSON files without those field cannot deserialize
     // we cannot add serde(default) to all generated types because enums cannot be annotated with serde(default)
     for path in [
+        "collector.trace.v1.ExportTraceServiceRequest",
+        "collector.logs.v1.ExportLogsServiceRequest",
+        "collector.metrics.v1.ExportMetricsServiceRequest",
+        "collector.profiles.v1development.ExportProfilesServiceRequest",
         "trace.v1.Span",
         "trace.v1.Span.Link",
         "trace.v1.ScopeSpans",
@@ -74,6 +78,32 @@ fn build_tonic() {
         builder = builder.type_attribute(
             path,
             "#[cfg_attr(feature = \"with-serde\", serde(default))]",
+        )
+    }
+
+    // ProtoJSON parsers accept both the lowerCamelCase JSON name and the original
+    // proto field name. Preserve this for the top-level collector payload fields.
+    for (path, alias) in [
+        (
+            "collector.trace.v1.ExportTraceServiceRequest.resource_spans",
+            "resource_spans",
+        ),
+        (
+            "collector.logs.v1.ExportLogsServiceRequest.resource_logs",
+            "resource_logs",
+        ),
+        (
+            "collector.metrics.v1.ExportMetricsServiceRequest.resource_metrics",
+            "resource_metrics",
+        ),
+        (
+            "collector.profiles.v1development.ExportProfilesServiceRequest.resource_profiles",
+            "resource_profiles",
+        ),
+    ] {
+        builder = builder.field_attribute(
+            path,
+            format!("#[cfg_attr(feature = \"with-serde\", serde(alias = \"{alias}\"))]"),
         )
     }
 

--- a/opentelemetry-proto/tests/json_serde.rs
+++ b/opentelemetry-proto/tests/json_serde.rs
@@ -28,6 +28,16 @@ mod json_serde {
     mod export_trace_service_request {
         use super::*;
 
+        #[test]
+        fn deserialize_omitted_and_proto_name_resource_spans() {
+            let empty: ExportTraceServiceRequest = serde_json::from_str("{}").unwrap();
+            assert!(empty.resource_spans.is_empty());
+
+            let with_proto_name: ExportTraceServiceRequest =
+                serde_json::from_str(r#"{"resource_spans":[{}]}"#).unwrap();
+            assert_eq!(with_proto_name.resource_spans.len(), 1);
+        }
+
         // `ExportTraceServiceRequest` from the OpenTelemetry proto examples
         // see <https://github.com/open-telemetry/opentelemetry-proto/blob/v1.3.2/examples/trace.json>
         mod example {
@@ -866,6 +876,16 @@ mod json_serde {
     mod export_metrics_service_request {
         use super::*;
 
+        #[test]
+        fn deserialize_omitted_and_proto_name_resource_metrics() {
+            let empty: ExportMetricsServiceRequest = serde_json::from_str("{}").unwrap();
+            assert!(empty.resource_metrics.is_empty());
+
+            let with_proto_name: ExportMetricsServiceRequest =
+                serde_json::from_str(r#"{"resource_metrics":[{}]}"#).unwrap();
+            assert_eq!(with_proto_name.resource_metrics.len(), 1);
+        }
+
         // `ExportTraceServiceRequest` from the OpenTelemetry proto examples
         // see <https://github.com/open-telemetry/opentelemetry-proto/blob/v1.3.2/examples/metrics.json>
         mod example {
@@ -1258,6 +1278,16 @@ mod json_serde {
     #[cfg(feature = "logs")]
     mod export_logs_service_request {
         use super::*;
+
+        #[test]
+        fn deserialize_omitted_and_proto_name_resource_logs() {
+            let empty: ExportLogsServiceRequest = serde_json::from_str("{}").unwrap();
+            assert!(empty.resource_logs.is_empty());
+
+            let with_proto_name: ExportLogsServiceRequest =
+                serde_json::from_str(r#"{"resource_logs":[{}]}"#).unwrap();
+            assert_eq!(with_proto_name.resource_logs.len(), 1);
+        }
 
         // `ExportTraceServiceRequest` from the OpenTelemetry proto examples
         // see <https://github.com/open-telemetry/opentelemetry-proto/blob/v1.3.2/examples/logs.json>


### PR DESCRIPTION
Fixes #3678

## Changes

The OTLP collector request schemas define their top-level resource arrays as `repeated` fields for [traces](https://github.com/open-telemetry/opentelemetry-proto/blob/ca839c51f706f5d53bfb46f06c3e90c3af3a52c6/opentelemetry/proto/collector/trace/v1/trace_service.proto#L36-L43), [logs](https://github.com/open-telemetry/opentelemetry-proto/blob/ca839c51f706f5d53bfb46f06c3e90c3af3a52c6/opentelemetry/proto/collector/logs/v1/logs_service.proto#L36-L43), [metrics](https://github.com/open-telemetry/opentelemetry-proto/blob/ca839c51f706f5d53bfb46f06c3e90c3af3a52c6/opentelemetry/proto/collector/metrics/v1/metrics_service.proto#L36-L43), and [profiles](https://github.com/open-telemetry/opentelemetry-proto/blob/ca839c51f706f5d53bfb46f06c3e90c3af3a52c6/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto#L33-L42). The [ProtoJSON mapping](https://protobuf.dev/programming-guides/json/#presence-and-default-values) omits empty repeated fields by default, and the [OTLP specification](https://opentelemetry.io/docs/specs/otlp/#full-success-1) says receivers should respond successfully to empty requests.

The generated collector request types instead require their resource arrays during deserialization. For example, an empty logs request (`{}`) fails with `missing field resourceLogs` instead of producing an empty request.

Add serde defaults for the trace, log, metric, and profile request roots, and configure the generator to preserve them. Omitted resource arrays then decode to empty vectors without changing non-empty lowerCamelCase payloads.

This intentionally does not accept original proto field names such as `resource_logs`: [OTLP/JSON requires lowerCamelCase keys and says original proto field names are invalid](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding).

Regression tests cover omitted resource arrays for all four request types.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` updated
* [x] No public API changes
