### PR TITLE
fix(proto): accept null AnyValue fields in OTLP JSON

### DIFF
--- a/opentelemetry-proto/CHANGELOG.md
+++ b/opentelemetry-proto/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - **Bug fix**: Accept empty `AnyValue` objects in OTLP/JSON payloads instead of rejecting the entire request.
+- **Bug fix**: Accept `null` fields in OTLP/JSON `AnyValue` objects as unset.
 
 ## 0.32.0
 

--- a/opentelemetry-proto/src/proto.rs
+++ b/opentelemetry-proto/src/proto.rs
@@ -4,7 +4,7 @@
 #[cfg(all(feature = "with-serde", feature = "gen-tonic-messages"))]
 pub(crate) mod serializers {
     use crate::tonic::common::v1::any_value::{self, Value};
-    use crate::tonic::common::v1::AnyValue;
+    use crate::tonic::common::v1::{AnyValue, ArrayValue, KeyValueList};
     use serde::de::{self, MapAccess, Visitor};
     use serde::ser::{SerializeMap, SerializeSeq, SerializeStruct};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -115,34 +115,41 @@ pub(crate) mod serializers {
                     let key_str = key.as_str();
                     match key_str {
                         "stringValue" => {
-                            let s = map.next_value()?;
-                            value = Some(any_value::Value::StringValue(s));
+                            if let Some(s) = map.next_value::<Option<String>>()? {
+                                value = Some(any_value::Value::StringValue(s));
+                            }
                         }
                         "boolValue" => {
-                            let b = map.next_value()?;
-                            value = Some(any_value::Value::BoolValue(b));
+                            if let Some(b) = map.next_value::<Option<bool>>()? {
+                                value = Some(any_value::Value::BoolValue(b));
+                            }
                         }
                         "intValue" => {
-                            let int_value = map.next_value::<StringOrInt>()?.get_int::<V>()?;
-                            value = Some(any_value::Value::IntValue(int_value));
+                            if let Some(int_value) = map.next_value::<Option<StringOrInt>>()? {
+                                value = Some(any_value::Value::IntValue(int_value.get_int::<V>()?));
+                            }
                         }
                         "doubleValue" => {
-                            let d = map.next_value()?;
-                            value = Some(any_value::Value::DoubleValue(d));
+                            if let Some(d) = map.next_value::<Option<f64>>()? {
+                                value = Some(any_value::Value::DoubleValue(d));
+                            }
                         }
                         "arrayValue" => {
-                            let a = map.next_value()?;
-                            value = Some(any_value::Value::ArrayValue(a));
+                            if let Some(a) = map.next_value::<Option<ArrayValue>>()? {
+                                value = Some(any_value::Value::ArrayValue(a));
+                            }
                         }
                         "kvlistValue" => {
-                            let kv = map.next_value()?;
-                            value = Some(any_value::Value::KvlistValue(kv));
+                            if let Some(kv) = map.next_value::<Option<KeyValueList>>()? {
+                                value = Some(any_value::Value::KvlistValue(kv));
+                            }
                         }
                         "bytesValue" => {
-                            let base64: String = map.next_value()?;
-                            let decoded = base64::decode(base64.as_bytes())
-                                .map_err(|e| de::Error::custom(e))?;
-                            value = Some(any_value::Value::BytesValue(decoded));
+                            if let Some(base64) = map.next_value::<Option<String>>()? {
+                                let decoded = base64::decode(base64.as_bytes())
+                                    .map_err(|e| de::Error::custom(e))?;
+                                value = Some(any_value::Value::BytesValue(decoded));
+                            }
                         }
                         _ => {
                             //skip unknown keys, and handle error later.

--- a/opentelemetry-proto/tests/json_serde.rs
+++ b/opentelemetry-proto/tests/json_serde.rs
@@ -653,6 +653,24 @@ mod json_serde {
             }
         }
 
+        #[test]
+        fn deserialize_null_values_as_unset() {
+            for field in [
+                "stringValue",
+                "boolValue",
+                "intValue",
+                "doubleValue",
+                "arrayValue",
+                "kvlistValue",
+                "bytesValue",
+            ] {
+                let json = format!(r#"{{"{field}":null}}"#);
+                let actual: AnyValue =
+                    serde_json::from_str(&json).expect("null AnyValue field must deserialize");
+                assert_eq!(actual.value, None, "field: {field}");
+            }
+        }
+
         #[cfg(feature = "trace")]
         #[test]
         fn deserialize_empty_span_attribute() {


### PR DESCRIPTION
Fixes #3677

## Changes

The [ProtoJSON mapping](https://protobuf.dev/programming-guides/json/#null-values) requires parsers to accept `null` for any field and leave that field unset. The [`AnyValue` protobuf definition](https://github.com/open-telemetry/opentelemetry-proto/blob/ca839c51f706f5d53bfb46f06c3e90c3af3a52c6/opentelemetry/proto/common/v1/common.proto#L25-L50) permits its `oneof` to remain unset.

The custom `AnyValue` visitor introduced in [#1753](https://github.com/open-telemetry/opentelemetry-rust/pull/1753) deserializes recognized fields directly into their concrete type. As a result, `{"intValue":null}` fails with `data did not match any variant of untagged enum StringOrInt` instead of producing an empty `AnyValue`. This happens before the empty-value handling fixed in [#3595](https://github.com/open-telemetry/opentelemetry-rust/pull/3595), so it is a separate pre-existing case.

This occurs in real exporter traffic: the Vercel AI SDK can emit [`doubleValue: null` for non-finite token attributes](https://github.com/vercel/ai/issues/6546), and PostHog independently encountered whole-request failures in `opentelemetry-proto` and [merged a receiver-side workaround](https://github.com/PostHog/posthog/pull/54414) that removes null-valued `AnyValue` fields before deserialization.

Deserialize each recognized field through `Option`, treating `null` as unset while preserving normal validation for non-null values. Regression coverage includes every `AnyValue` variant.

This was also tested through an OTLP receiver's JSON ingest path: upstream `main` rejected `{"intValue":null}` with the `StringOrInt` error; with this change it decodes as an unset value, while a fractional `intValue` remains rejected.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` updated
* [x] No public API changes
