### PR TITLE
test: move self-observability tests into self_obs modules and auto-discover them in test.sh

### DIFF
--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -1310,222 +1310,228 @@ mod tests {
         );
     }
 
-    /// Verifies that `otel.sdk.processor.log.processed` counter records
-    /// successful log processing when `experimental_metrics_bound_instruments`
-    /// is enabled and a real MeterProvider is set as global before creating
-    /// the processor.
-    ///
-    /// This test is `#[ignore]`d because it calls
-    /// `global::set_meter_provider()` which mutates process-wide state.
-    /// CI runs it in isolation via `test.sh`.
     #[cfg(feature = "experimental_metrics_bound_instruments")]
-    #[test]
-    #[ignore]
-    fn self_diagnostics_counter_records_success() {
-        use crate::metrics::data::{AggregatedMetrics, MetricData};
-        use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+    mod self_obs {
+        use super::*;
 
-        // Setup a real MeterProvider and set it as global BEFORE creating the
-        // BatchLogProcessor, so the processor picks up a real meter.
-        let metric_exporter = InMemoryMetricExporter::default();
-        let meter_provider = SdkMeterProvider::builder()
-            .with_periodic_exporter(metric_exporter.clone())
-            .build();
-        opentelemetry::global::set_meter_provider(meter_provider.clone());
+        /// Verifies that `otel.sdk.processor.log.processed` counter records
+        /// successful log processing when `experimental_metrics_bound_instruments`
+        /// is enabled and a real MeterProvider is set as global before creating
+        /// the processor.
+        ///
+        /// This test is `#[ignore]`d because it calls
+        /// `global::set_meter_provider()` which mutates process-wide state.
+        /// CI runs it in isolation via `test.sh`.
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        #[test]
+        #[ignore]
+        fn self_diagnostics_counter_records_success() {
+            use crate::metrics::data::{AggregatedMetrics, MetricData};
+            use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 
-        let log_exporter = InMemoryLogExporter::default();
-        let config = BatchConfigBuilder::default()
-            .with_max_queue_size(256)
-            .with_max_export_batch_size(64)
-            .with_scheduled_delay(Duration::from_secs(60))
-            .build();
-        let processor = BatchLogProcessor::new(log_exporter, config);
+            // Setup a real MeterProvider and set it as global BEFORE creating the
+            // BatchLogProcessor, so the processor picks up a real meter.
+            let metric_exporter = InMemoryMetricExporter::default();
+            let meter_provider = SdkMeterProvider::builder()
+                .with_periodic_exporter(metric_exporter.clone())
+                .build();
+            opentelemetry::global::set_meter_provider(meter_provider.clone());
 
-        // Emit 10 logs
-        let instrumentation = InstrumentationScope::default();
-        for _ in 0..10 {
-            let mut record = SdkLogRecord::new();
-            processor.emit(&mut record, &instrumentation);
-        }
+            let log_exporter = InMemoryLogExporter::default();
+            let config = BatchConfigBuilder::default()
+                .with_max_queue_size(256)
+                .with_max_export_batch_size(64)
+                .with_scheduled_delay(Duration::from_secs(60))
+                .build();
+            let processor = BatchLogProcessor::new(log_exporter, config);
 
-        // Flush so the batch is submitted to the exporter, which is when the
-        // counter is incremented.
-        processor.force_flush().unwrap();
-
-        // Force a metrics collection
-        meter_provider.force_flush().unwrap();
-
-        // Find the otel.sdk.processor.log.processed metric and sum all data points
-        let metrics = metric_exporter.get_finished_metrics().unwrap();
-        let mut found = false;
-        let mut total_value: u64 = 0;
-        for rm in &metrics {
-            for sm in &rm.scope_metrics {
-                for metric in &sm.metrics {
-                    if metric.name == "otel.sdk.processor.log.processed" {
-                        found = true;
-                        if let AggregatedMetrics::U64(MetricData::Sum(sum)) = &metric.data {
-                            for dp in sum.data_points() {
-                                total_value += dp.value();
-                            }
-                        }
-                    }
-                }
+            // Emit 10 logs
+            let instrumentation = InstrumentationScope::default();
+            for _ in 0..10 {
+                let mut record = SdkLogRecord::new();
+                processor.emit(&mut record, &instrumentation);
             }
-        }
 
-        assert!(found, "otel.sdk.processor.log.processed metric not found");
-        assert_eq!(
-            total_value, 10,
-            "Expected 10 processed logs, got {total_value}"
-        );
+            // Flush so the batch is submitted to the exporter, which is when the
+            // counter is incremented.
+            processor.force_flush().unwrap();
 
-        processor.shutdown().unwrap();
-        meter_provider.shutdown().unwrap();
-    }
+            // Force a metrics collection
+            meter_provider.force_flush().unwrap();
 
-    /// Sums the values of `otel.sdk.processor.log.processed` data points whose
-    /// `error.type` attribute equals `error_type`.
-    #[cfg(feature = "experimental_metrics_bound_instruments")]
-    fn sum_processed_log_records_with_error_type(
-        metric_exporter: &crate::metrics::InMemoryMetricExporter,
-        error_type: &str,
-    ) -> u64 {
-        use crate::metrics::data::{AggregatedMetrics, MetricData};
-
-        let metrics = metric_exporter.get_finished_metrics().unwrap();
-        let mut total: u64 = 0;
-        for rm in &metrics {
-            for sm in &rm.scope_metrics {
-                for metric in &sm.metrics {
-                    if metric.name == "otel.sdk.processor.log.processed" {
-                        if let AggregatedMetrics::U64(MetricData::Sum(sum)) = &metric.data {
-                            for dp in sum.data_points() {
-                                let matches = dp.attributes().any(|kv| {
-                                    kv.key.as_str() == "error.type"
-                                        && kv.value.as_str() == error_type
-                                });
-                                if matches {
-                                    total += dp.value();
+            // Find the otel.sdk.processor.log.processed metric and sum all data points
+            let metrics = metric_exporter.get_finished_metrics().unwrap();
+            let mut found = false;
+            let mut total_value: u64 = 0;
+            for rm in &metrics {
+                for sm in &rm.scope_metrics {
+                    for metric in &sm.metrics {
+                        if metric.name == "otel.sdk.processor.log.processed" {
+                            found = true;
+                            if let AggregatedMetrics::U64(MetricData::Sum(sum)) = &metric.data {
+                                for dp in sum.data_points() {
+                                    total_value += dp.value();
                                 }
                             }
                         }
                     }
                 }
             }
-        }
-        total
-    }
 
-    /// Verifies that `otel.sdk.processor.log.processed` records queue-full drops
-    /// with `error.type = queue_full` when records overflow the queue while the
-    /// worker is blocked exporting.
-    ///
-    /// `#[ignore]`d because it mutates process-wide state via
-    /// `global::set_meter_provider()`. CI runs it in isolation via `test.sh`.
-    #[cfg(feature = "experimental_metrics_bound_instruments")]
-    #[test]
-    #[ignore]
-    fn self_diagnostics_counter_records_queue_full_drops() {
-        use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+            assert!(found, "otel.sdk.processor.log.processed metric not found");
+            assert_eq!(
+                total_value, 10,
+                "Expected 10 processed logs, got {total_value}"
+            );
 
-        let metric_exporter = InMemoryMetricExporter::default();
-        let meter_provider = SdkMeterProvider::builder()
-            .with_periodic_exporter(metric_exporter.clone())
-            .build();
-        opentelemetry::global::set_meter_provider(meter_provider.clone());
-
-        let (started_sender, started_receiver) = mpsc::sync_channel(8);
-        let (release_sender, release_receiver) = mpsc::sync_channel(8);
-        let exported_count = Arc::new(AtomicUsize::new(0));
-        let exporter = BlockingExporter {
-            exported_count: exported_count.clone(),
-            export_started: started_sender,
-            release: Arc::new(Mutex::new(release_receiver)),
-        };
-        let config = BatchConfigBuilder::default()
-            .with_max_queue_size(4)
-            .with_max_export_batch_size(4)
-            .with_scheduled_delay(Duration::from_secs(60))
-            .build();
-        let processor = BatchLogProcessor::new(exporter, config);
-        let instrumentation = InstrumentationScope::default();
-        let emit = || {
-            let mut record = SdkLogRecord::new();
-            processor.emit(&mut record, &instrumentation);
-        };
-
-        // Fill the queue to the export threshold; the worker drains all four
-        // records and blocks inside export().
-        for _ in 0..4 {
-            emit();
-        }
-        started_receiver
-            .recv_timeout(Duration::from_secs(5))
-            .expect("worker should start exporting the first batch");
-
-        // While the worker is blocked, refill the queue (4) and overflow it by
-        // two records, which must be dropped and counted as queue_full.
-        for _ in 0..6 {
-            emit();
+            processor.shutdown().unwrap();
+            meter_provider.shutdown().unwrap();
         }
 
-        // Release the in-flight export and the one triggered by force_flush.
-        release_sender.send(()).unwrap();
-        release_sender.send(()).unwrap();
-        processor.force_flush().unwrap();
+        /// Sums the values of `otel.sdk.processor.log.processed` data points whose
+        /// `error.type` attribute equals `error_type`.
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        fn sum_processed_log_records_with_error_type(
+            metric_exporter: &crate::metrics::InMemoryMetricExporter,
+            error_type: &str,
+        ) -> u64 {
+            use crate::metrics::data::{AggregatedMetrics, MetricData};
 
-        meter_provider.force_flush().unwrap();
-
-        let queue_full = sum_processed_log_records_with_error_type(&metric_exporter, "queue_full");
-        assert_eq!(
-            queue_full, 2,
-            "expected 2 queue_full drops, got {queue_full}"
-        );
-
-        processor.shutdown().unwrap();
-        meter_provider.shutdown().unwrap();
-    }
-
-    /// Verifies that `otel.sdk.processor.log.processed` records post-shutdown
-    /// emits with `error.type = already_shutdown`.
-    ///
-    /// `#[ignore]`d because it mutates process-wide state via
-    /// `global::set_meter_provider()`. CI runs it in isolation via `test.sh`.
-    #[cfg(feature = "experimental_metrics_bound_instruments")]
-    #[test]
-    #[ignore]
-    fn self_diagnostics_counter_records_already_shutdown_drops() {
-        use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
-
-        let metric_exporter = InMemoryMetricExporter::default();
-        let meter_provider = SdkMeterProvider::builder()
-            .with_periodic_exporter(metric_exporter.clone())
-            .build();
-        opentelemetry::global::set_meter_provider(meter_provider.clone());
-
-        let log_exporter = InMemoryLogExporter::default();
-        let processor = BatchLogProcessor::new(log_exporter, BatchConfig::default());
-
-        // Shut the processor down so the worker thread (the only receiver)
-        // disconnects; subsequent emits hit the already_shutdown branch.
-        processor.shutdown().unwrap();
-
-        let instrumentation = InstrumentationScope::default();
-        for _ in 0..7 {
-            let mut record = SdkLogRecord::new();
-            processor.emit(&mut record, &instrumentation);
+            let metrics = metric_exporter.get_finished_metrics().unwrap();
+            let mut total: u64 = 0;
+            for rm in &metrics {
+                for sm in &rm.scope_metrics {
+                    for metric in &sm.metrics {
+                        if metric.name == "otel.sdk.processor.log.processed" {
+                            if let AggregatedMetrics::U64(MetricData::Sum(sum)) = &metric.data {
+                                for dp in sum.data_points() {
+                                    let matches = dp.attributes().any(|kv| {
+                                        kv.key.as_str() == "error.type"
+                                            && kv.value.as_str() == error_type
+                                    });
+                                    if matches {
+                                        total += dp.value();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            total
         }
 
-        meter_provider.force_flush().unwrap();
+        /// Verifies that `otel.sdk.processor.log.processed` records queue-full drops
+        /// with `error.type = queue_full` when records overflow the queue while the
+        /// worker is blocked exporting.
+        ///
+        /// `#[ignore]`d because it mutates process-wide state via
+        /// `global::set_meter_provider()`. CI runs it in isolation via `test.sh`.
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        #[test]
+        #[ignore]
+        fn self_diagnostics_counter_records_queue_full_drops() {
+            use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 
-        let already_shutdown =
-            sum_processed_log_records_with_error_type(&metric_exporter, "already_shutdown");
-        assert_eq!(
-            already_shutdown, 7,
-            "expected 7 already_shutdown drops, got {already_shutdown}"
-        );
+            let metric_exporter = InMemoryMetricExporter::default();
+            let meter_provider = SdkMeterProvider::builder()
+                .with_periodic_exporter(metric_exporter.clone())
+                .build();
+            opentelemetry::global::set_meter_provider(meter_provider.clone());
 
-        meter_provider.shutdown().unwrap();
+            let (started_sender, started_receiver) = mpsc::sync_channel(8);
+            let (release_sender, release_receiver) = mpsc::sync_channel(8);
+            let exported_count = Arc::new(AtomicUsize::new(0));
+            let exporter = BlockingExporter {
+                exported_count: exported_count.clone(),
+                export_started: started_sender,
+                release: Arc::new(Mutex::new(release_receiver)),
+            };
+            let config = BatchConfigBuilder::default()
+                .with_max_queue_size(4)
+                .with_max_export_batch_size(4)
+                .with_scheduled_delay(Duration::from_secs(60))
+                .build();
+            let processor = BatchLogProcessor::new(exporter, config);
+            let instrumentation = InstrumentationScope::default();
+            let emit = || {
+                let mut record = SdkLogRecord::new();
+                processor.emit(&mut record, &instrumentation);
+            };
+
+            // Fill the queue to the export threshold; the worker drains all four
+            // records and blocks inside export().
+            for _ in 0..4 {
+                emit();
+            }
+            started_receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("worker should start exporting the first batch");
+
+            // While the worker is blocked, refill the queue (4) and overflow it by
+            // two records, which must be dropped and counted as queue_full.
+            for _ in 0..6 {
+                emit();
+            }
+
+            // Release the in-flight export and the one triggered by force_flush.
+            release_sender.send(()).unwrap();
+            release_sender.send(()).unwrap();
+            processor.force_flush().unwrap();
+
+            meter_provider.force_flush().unwrap();
+
+            let queue_full =
+                sum_processed_log_records_with_error_type(&metric_exporter, "queue_full");
+            assert_eq!(
+                queue_full, 2,
+                "expected 2 queue_full drops, got {queue_full}"
+            );
+
+            processor.shutdown().unwrap();
+            meter_provider.shutdown().unwrap();
+        }
+
+        /// Verifies that `otel.sdk.processor.log.processed` records post-shutdown
+        /// emits with `error.type = already_shutdown`.
+        ///
+        /// `#[ignore]`d because it mutates process-wide state via
+        /// `global::set_meter_provider()`. CI runs it in isolation via `test.sh`.
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        #[test]
+        #[ignore]
+        fn self_diagnostics_counter_records_already_shutdown_drops() {
+            use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+
+            let metric_exporter = InMemoryMetricExporter::default();
+            let meter_provider = SdkMeterProvider::builder()
+                .with_periodic_exporter(metric_exporter.clone())
+                .build();
+            opentelemetry::global::set_meter_provider(meter_provider.clone());
+
+            let log_exporter = InMemoryLogExporter::default();
+            let processor = BatchLogProcessor::new(log_exporter, BatchConfig::default());
+
+            // Shut the processor down so the worker thread (the only receiver)
+            // disconnects; subsequent emits hit the already_shutdown branch.
+            processor.shutdown().unwrap();
+
+            let instrumentation = InstrumentationScope::default();
+            for _ in 0..7 {
+                let mut record = SdkLogRecord::new();
+                processor.emit(&mut record, &instrumentation);
+            }
+
+            meter_provider.force_flush().unwrap();
+
+            let already_shutdown =
+                sum_processed_log_records_with_error_type(&metric_exporter, "already_shutdown");
+            assert_eq!(
+                already_shutdown, 7,
+                "expected 7 already_shutdown drops, got {already_shutdown}"
+            );
+
+            meter_provider.shutdown().unwrap();
+        }
     }
 }

--- a/opentelemetry-sdk/src/logs/logger.rs
+++ b/opentelemetry-sdk/src/logs/logger.rs
@@ -102,7 +102,7 @@ impl opentelemetry::logs::Logger for SdkLogger {
 }
 
 #[cfg(all(test, feature = "experimental_metrics_bound_instruments"))]
-mod tests {
+mod self_obs {
     use crate::logs::SdkLoggerProvider;
     use crate::metrics::data::{AggregatedMetrics, MetricData};
     use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};

--- a/opentelemetry-sdk/src/logs/simple_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/simple_log_processor.rs
@@ -558,124 +558,131 @@ mod tests {
         logger.emit(log_record);
     }
 
-    /// Sums the values of `otel.sdk.processor.log.processed` data points whose
-    /// `error.type` attribute equals `error_type` (or that have no `error.type`
-    /// attribute when `error_type` is `None`).
     #[cfg(feature = "experimental_metrics_bound_instruments")]
-    fn sum_processed_log_records(
-        metric_exporter: &crate::metrics::InMemoryMetricExporter,
-        error_type: Option<&str>,
-    ) -> u64 {
-        use crate::metrics::data::{AggregatedMetrics, MetricData};
+    mod self_obs {
+        use super::*;
 
-        let metrics = metric_exporter.get_finished_metrics().unwrap();
-        let mut total: u64 = 0;
-        for rm in &metrics {
-            for sm in &rm.scope_metrics {
-                for metric in &sm.metrics {
-                    if metric.name == "otel.sdk.processor.log.processed" {
-                        if let AggregatedMetrics::U64(MetricData::Sum(sum)) = &metric.data {
-                            for dp in sum.data_points() {
-                                let dp_error_type = dp
-                                    .attributes()
-                                    .find(|kv| kv.key.as_str() == "error.type")
-                                    .map(|kv| kv.value.as_str().to_string());
-                                let matches = match error_type {
-                                    Some(expected) => dp_error_type.as_deref() == Some(expected),
-                                    None => dp_error_type.is_none(),
-                                };
-                                if matches {
-                                    total += dp.value();
+        /// Sums the values of `otel.sdk.processor.log.processed` data points whose
+        /// `error.type` attribute equals `error_type` (or that have no `error.type`
+        /// attribute when `error_type` is `None`).
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        fn sum_processed_log_records(
+            metric_exporter: &crate::metrics::InMemoryMetricExporter,
+            error_type: Option<&str>,
+        ) -> u64 {
+            use crate::metrics::data::{AggregatedMetrics, MetricData};
+
+            let metrics = metric_exporter.get_finished_metrics().unwrap();
+            let mut total: u64 = 0;
+            for rm in &metrics {
+                for sm in &rm.scope_metrics {
+                    for metric in &sm.metrics {
+                        if metric.name == "otel.sdk.processor.log.processed" {
+                            if let AggregatedMetrics::U64(MetricData::Sum(sum)) = &metric.data {
+                                for dp in sum.data_points() {
+                                    let dp_error_type = dp
+                                        .attributes()
+                                        .find(|kv| kv.key.as_str() == "error.type")
+                                        .map(|kv| kv.value.as_str().to_string());
+                                    let matches = match error_type {
+                                        Some(expected) => {
+                                            dp_error_type.as_deref() == Some(expected)
+                                        }
+                                        None => dp_error_type.is_none(),
+                                    };
+                                    if matches {
+                                        total += dp.value();
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-        }
-        total
-    }
-
-    /// Verifies that `otel.sdk.processor.log.processed` counts each record the
-    /// SimpleLogProcessor submits to the exporter (with no `error.type`),
-    /// independent of the export outcome.
-    ///
-    /// `#[ignore]`d because it mutates process-wide state via
-    /// `global::set_meter_provider()`. CI runs it in isolation via `test.sh`.
-    #[cfg(feature = "experimental_metrics_bound_instruments")]
-    #[test]
-    #[ignore]
-    fn self_diagnostics_counter_records_success() {
-        use crate::logs::InMemoryLogExporterBuilder;
-        use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
-
-        let metric_exporter = InMemoryMetricExporter::default();
-        let meter_provider = SdkMeterProvider::builder()
-            .with_periodic_exporter(metric_exporter.clone())
-            .build();
-        opentelemetry::global::set_meter_provider(meter_provider.clone());
-
-        let log_exporter = InMemoryLogExporterBuilder::default().build();
-        let processor = SimpleLogProcessor::new(log_exporter);
-
-        let instrumentation = InstrumentationScope::default();
-        for _ in 0..10 {
-            let mut record = SdkLogRecord::new();
-            processor.emit(&mut record, &instrumentation);
+            total
         }
 
-        meter_provider.force_flush().unwrap();
+        /// Verifies that `otel.sdk.processor.log.processed` counts each record the
+        /// SimpleLogProcessor submits to the exporter (with no `error.type`),
+        /// independent of the export outcome.
+        ///
+        /// `#[ignore]`d because it mutates process-wide state via
+        /// `global::set_meter_provider()`. CI runs it in isolation via `test.sh`.
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        #[test]
+        #[ignore]
+        fn self_diagnostics_counter_records_success() {
+            use crate::logs::InMemoryLogExporterBuilder;
+            use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 
-        let processed = sum_processed_log_records(&metric_exporter, None);
-        assert_eq!(processed, 10, "expected 10 processed logs, got {processed}");
+            let metric_exporter = InMemoryMetricExporter::default();
+            let meter_provider = SdkMeterProvider::builder()
+                .with_periodic_exporter(metric_exporter.clone())
+                .build();
+            opentelemetry::global::set_meter_provider(meter_provider.clone());
 
-        meter_provider.shutdown().unwrap();
-    }
+            let log_exporter = InMemoryLogExporterBuilder::default().build();
+            let processor = SimpleLogProcessor::new(log_exporter);
 
-    /// Verifies that `otel.sdk.processor.log.processed` records post-shutdown
-    /// emits with `error.type = already_shutdown`.
-    ///
-    /// `#[ignore]`d because it mutates process-wide state via
-    /// `global::set_meter_provider()`. CI runs it in isolation via `test.sh`.
-    #[cfg(feature = "experimental_metrics_bound_instruments")]
-    #[test]
-    #[ignore]
-    fn self_diagnostics_counter_records_already_shutdown_drops() {
-        use crate::logs::InMemoryLogExporterBuilder;
-        use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+            let instrumentation = InstrumentationScope::default();
+            for _ in 0..10 {
+                let mut record = SdkLogRecord::new();
+                processor.emit(&mut record, &instrumentation);
+            }
 
-        let metric_exporter = InMemoryMetricExporter::default();
-        let meter_provider = SdkMeterProvider::builder()
-            .with_periodic_exporter(metric_exporter.clone())
-            .build();
-        opentelemetry::global::set_meter_provider(meter_provider.clone());
+            meter_provider.force_flush().unwrap();
 
-        let log_exporter = InMemoryLogExporterBuilder::default().build();
-        let processor = SimpleLogProcessor::new(log_exporter);
+            let processed = sum_processed_log_records(&metric_exporter, None);
+            assert_eq!(processed, 10, "expected 10 processed logs, got {processed}");
 
-        // Shut the processor down; subsequent emits hit the already_shutdown branch.
-        processor.shutdown().unwrap();
-
-        let instrumentation = InstrumentationScope::default();
-        for _ in 0..7 {
-            let mut record = SdkLogRecord::new();
-            processor.emit(&mut record, &instrumentation);
+            meter_provider.shutdown().unwrap();
         }
 
-        meter_provider.force_flush().unwrap();
+        /// Verifies that `otel.sdk.processor.log.processed` records post-shutdown
+        /// emits with `error.type = already_shutdown`.
+        ///
+        /// `#[ignore]`d because it mutates process-wide state via
+        /// `global::set_meter_provider()`. CI runs it in isolation via `test.sh`.
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        #[test]
+        #[ignore]
+        fn self_diagnostics_counter_records_already_shutdown_drops() {
+            use crate::logs::InMemoryLogExporterBuilder;
+            use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 
-        let already_shutdown =
-            sum_processed_log_records(&metric_exporter, Some("already_shutdown"));
-        assert_eq!(
-            already_shutdown, 7,
-            "expected 7 already_shutdown drops, got {already_shutdown}"
-        );
-        let success = sum_processed_log_records(&metric_exporter, None);
-        assert_eq!(
-            success, 0,
-            "post-shutdown emits must not be counted as success, got {success}"
-        );
+            let metric_exporter = InMemoryMetricExporter::default();
+            let meter_provider = SdkMeterProvider::builder()
+                .with_periodic_exporter(metric_exporter.clone())
+                .build();
+            opentelemetry::global::set_meter_provider(meter_provider.clone());
 
-        meter_provider.shutdown().unwrap();
+            let log_exporter = InMemoryLogExporterBuilder::default().build();
+            let processor = SimpleLogProcessor::new(log_exporter);
+
+            // Shut the processor down; subsequent emits hit the already_shutdown branch.
+            processor.shutdown().unwrap();
+
+            let instrumentation = InstrumentationScope::default();
+            for _ in 0..7 {
+                let mut record = SdkLogRecord::new();
+                processor.emit(&mut record, &instrumentation);
+            }
+
+            meter_provider.force_flush().unwrap();
+
+            let already_shutdown =
+                sum_processed_log_records(&metric_exporter, Some("already_shutdown"));
+            assert_eq!(
+                already_shutdown, 7,
+                "expected 7 already_shutdown drops, got {already_shutdown}"
+            );
+            let success = sum_processed_log_records(&metric_exporter, None);
+            assert_eq!(
+                success, 0,
+                "post-shutdown emits must not be counted as success, got {success}"
+            );
+
+            meter_provider.shutdown().unwrap();
+        }
     }
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -45,12 +45,19 @@ cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features trace::ru
 cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features trace::runtime_tests::test_set_provider_single_thread_tokio_shutdown -- --ignored --exact
 
 echo "Running ignored tests for opentelemetry-sdk package (self-diagnostics, requires global MeterProvider)"
-cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features logs::batch_log_processor::tests::self_diagnostics_counter_records_success -- --ignored --exact
-cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features logs::batch_log_processor::tests::self_diagnostics_counter_records_queue_full_drops -- --ignored --exact
-cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features logs::batch_log_processor::tests::self_diagnostics_counter_records_already_shutdown_drops -- --ignored --exact
-cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features logs::simple_log_processor::tests::self_diagnostics_counter_records_success -- --ignored --exact
-cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features logs::simple_log_processor::tests::self_diagnostics_counter_records_already_shutdown_drops -- --ignored --exact
-cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features logs::logger::tests::log_created_counts_intake_without_processors -- --ignored --exact
+# Self-observability tests live in `self_obs` modules and each needs its own
+# process (they rely on a set-once global MeterProvider). Discover them by
+# module path so new metrics don't require editing this script.
+self_obs_tests=$(cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features --lib -- --ignored --list 2>/dev/null | sed -n 's/: test$//p' | grep '::self_obs::' || true)
+if [ -z "${self_obs_tests}" ]; then
+  echo "ERROR: no ::self_obs:: tests discovered; the module marker may be broken"
+  exit 1
+fi
+while read -r self_obs_test; do
+  cargo test --manifest-path=opentelemetry-sdk/Cargo.toml --all-features --lib "${self_obs_test}" -- --ignored --exact
+done <<EOF
+${self_obs_tests}
+EOF
 
 echo "Running ignored tests for opentelemetry-appender-tracing package (global logger tests)"
 cargo test --manifest-path=opentelemetry-appender-tracing/Cargo.toml --all-features layer::tests::tracing_appender_standalone_with_tracing_log -- --ignored --exact


### PR DESCRIPTION
Self-observability tests each need their own process (set-once global MeterProvider), so `scripts/test.sh` listed one line per test. Every new metric PR appended to that block, causing repeated merge conflicts.

This moves those tests into `self_obs` modules and replaces the hardcoded list with a discovery loop that finds ignored tests by the `::self_obs::` path marker. New metric tests are picked up automatically.

No behavior change; test infrastructure only.