### PR TITLE
fix(opentelemetry): test with `--no-default-features` & fix OOB panic

### DIFF
--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -9,6 +9,8 @@
   the experimental bound-instrument API across all sync instruments
   (`Counter`, `UpDownCounter`, `Histogram`, `Gauge`). Gated behind the
   `experimental_metrics_bound_instruments` feature flag.
+- **Fixed** Out-of-bounds array index in `ContextStack::pop_id` when the `trace`
+  feature is disabled.
 
 ## 0.32.0
 

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -42,7 +42,8 @@ internal-logs = ["tracing"]
 experimental_metrics_bound_instruments = ["metrics"]
 
 [dev-dependencies]
-opentelemetry_sdk = { path = "../opentelemetry-sdk"} # for documentation tests
+# for documentation tests
+opentelemetry_sdk = { path = "../opentelemetry-sdk", default-features = false }
 criterion = { workspace = true }
 rand = { workspace = true, features = ["os_rng", "thread_rng"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -590,6 +590,8 @@ impl ContextStack {
             );
             #[cfg(feature = "trace")]
             return None;
+            #[cfg(not(feature = "trace"))]
+            return;
         }
         let len: u16 = self.stack.len() as u16;
         // Are we at the top of the [`ContextStack`]?
@@ -615,6 +617,8 @@ impl ContextStack {
             }
             #[cfg(feature = "trace")]
             return None;
+            #[cfg(not(feature = "trace"))]
+            return;
         } else {
             // This is an out of order pop.
             if pos >= len {
@@ -627,6 +631,8 @@ impl ContextStack {
                 );
                 #[cfg(feature = "trace")]
                 return None;
+                #[cfg(not(feature = "trace"))]
+                return;
             }
             // Clear out the entry at the given id and extract its span
             #[cfg(feature = "trace")]
@@ -657,7 +663,9 @@ impl Default for ContextStack {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "futures")]
     use std::time::Duration;
+    #[cfg(feature = "futures")]
     use tokio::time::sleep;
 
     #[derive(Debug, PartialEq)]
@@ -918,6 +926,7 @@ mod tests {
     /// Tests that:
     /// 1. Parent context values are properly propagated to async operations
     /// 2. Values added during async operations do not affect parent context
+    #[cfg(feature = "futures")]
     #[tokio::test]
     async fn test_async_context_propagation() {
         // A nested async operation we'll use to test propagation
@@ -1003,6 +1012,7 @@ mod tests {
     /// Tests that unnatural parent->child relationships in nested async
     /// operations behave properly.
     ///
+    #[cfg(feature = "futures")]
     #[tokio::test]
     async fn test_out_of_order_context_detachment_futures() {
         // This function returns a future, but doesn't await it
@@ -1141,6 +1151,7 @@ mod tests {
         assert!(!Context::is_current_telemetry_suppressed());
     }
 
+    #[cfg(feature = "futures")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_async_suppression() {
         async fn nested_operation() {

--- a/opentelemetry/src/lib.rs
+++ b/opentelemetry/src/lib.rs
@@ -113,6 +113,8 @@
 //!
 //! ## Example Usage
 //! ```
+//! # #[cfg(feature = "metrics")]
+//! # {
 //! use opentelemetry::{global, KeyValue};
 //!
 //! // Get a meter from a provider.
@@ -136,6 +138,7 @@
 //!     )
 //! })
 //! .build();
+//! # }
 //! ```
 //!
 //! See the [`metrics`] module docs for more information on creating and

--- a/opentelemetry/src/logs/logger.rs
+++ b/opentelemetry/src/logs/logger.rs
@@ -31,7 +31,7 @@ pub trait LoggerProvider {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// use opentelemetry::InstrumentationScope;
     /// use opentelemetry::logs::LoggerProvider;
     /// use opentelemetry_sdk::logs::SdkLoggerProvider;

--- a/opentelemetry/src/metrics/meter.rs
+++ b/opentelemetry/src/metrics/meter.rs
@@ -40,7 +40,7 @@ pub trait MeterProvider {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// use std::sync::Arc;
     /// use opentelemetry::InstrumentationScope;
     /// use opentelemetry::metrics::MeterProvider;

--- a/opentelemetry/src/propagation/composite.rs
+++ b/opentelemetry/src/propagation/composite.rs
@@ -21,7 +21,7 @@ use std::collections::HashSet;
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use opentelemetry::{
 ///     baggage::BaggageExt,
 ///     propagation::{TextMapPropagator, TextMapCompositePropagator},

--- a/opentelemetry/src/trace_context.rs
+++ b/opentelemetry/src/trace_context.rs
@@ -112,12 +112,15 @@ impl TraceId {
     /// # Examples
     ///
     /// ```
+    /// # #[cfg(feature = "trace")]
+    /// # {
     /// use opentelemetry::trace::TraceId;
     ///
     /// assert!(TraceId::from_hex("42").is_ok());
     /// assert!(TraceId::from_hex("58406520a006649127e371903a2de979").is_ok());
     ///
     /// assert!(TraceId::from_hex("not_hex").is_err());
+    /// # }
     /// ```
     pub fn from_hex(hex: &str) -> Result<Self, ParseIntError> {
         u128::from_str_radix(hex, 16).map(TraceId)
@@ -173,12 +176,15 @@ impl SpanId {
     /// # Examples
     ///
     /// ```
+    /// # #[cfg(feature = "trace")]
+    /// # {
     /// use opentelemetry::trace::SpanId;
     ///
     /// assert!(SpanId::from_hex("42").is_ok());
     /// assert!(SpanId::from_hex("58406520a0066491").is_ok());
     ///
     /// assert!(SpanId::from_hex("not_hex").is_err());
+    /// # }
     /// ```
     pub fn from_hex(hex: &str) -> Result<Self, ParseIntError> {
         u64::from_str_radix(hex, 16).map(SpanId)


### PR DESCRIPTION
Cargo's feature unification (rfcs#3692) means that opentelemetry_sdk implicitly enables the default features of opentelemetry, so `--no-default-features` actually builds with default features enabled.

This masked a bug introduced in 7087f65c when building without `trace`. Prefer ignoring a few doctests to silently reducing test coverage for non-default feature combinations via feature unification.

Fixes: 7087f65c00a1fed22f29bbc67b0dffb38b30d73c
Fixes: 627f252d23ef3e2ee598855dd19ec63a28fcc794

I found this while packaging a few otel crates for Debian; our CI pipeline runs the tests for each feature from crates.io, so feature unification doesn't happen in our environment.

## Changes

Mostly trivial disabling tests to fix the tests with various feature combinations.

I'd like to flag that **I don't fully understand** the high-level purpose & semantics of `pop_id`; I believe the changes that I've made here align with the semantics of the function when `trace` is enabled, but I'd appreciate a careful review of that part of the PR.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] ~~Unit tests added/updated (if applicable)~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
