### PR TITLE
feat: support OTLP retry for sync exporters & stabilise feature flags 

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -10,14 +10,24 @@
   async-runtime processors.
   The default `RetryPolicy` performs no retries (preserving existing behaviour).
   To enable retries, configure a policy via `.with_retry_policy(RetryPolicy::recommended())`
-  which provides exponential backoff with 3 attempts.
+  which provides exponential backoff with up to 3 retries (4 attempts total).
   **Migration**: Remove the experimental retry feature flags from your `Cargo.toml`.
   If you were relying on them to enable retry, configure a policy explicitly instead:
   ```rust
+  // HTTP
   use opentelemetry_otlp::{WithHttpConfig, RetryPolicy};
 
   let exporter = opentelemetry_otlp::SpanExporter::builder()
       .with_http()
+      .with_retry_policy(RetryPolicy::recommended())
+      .build()?;
+  ```
+  ```rust
+  // gRPC (tonic)
+  use opentelemetry_otlp::{WithTonicConfig, RetryPolicy};
+
+  let exporter = opentelemetry_otlp::SpanExporter::builder()
+      .with_tonic()
       .with_retry_policy(RetryPolicy::recommended())
       .build()?;
   ```

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## vNext
 
+- **Breaking** Removed experimental retry feature flags (`grpc-tonic-with-retry`,
+  `http-proto-with-retry`, `http-json-with-retry`). Retry support is now always
+  included for both gRPC and HTTP exporters and works with all processor types,
+  including the default `BatchSpanProcessor`, `BatchLogProcessor`, and
+  `PeriodicReader` (which use a dedicated OS thread), as well as the experimental
+  async-runtime processors.
+  The default `RetryPolicy` performs no retries (preserving existing behaviour).
+  To enable retries, configure a policy via `.with_retry_policy(RetryPolicy::recommended())`
+  which provides exponential backoff with 3 attempts.
+  **Migration**: Remove the experimental retry feature flags from your `Cargo.toml`.
+  If you were relying on them to enable retry, configure a policy explicitly instead:
+  ```rust
+  use opentelemetry_otlp::{WithHttpConfig, RetryPolicy};
+
+  let exporter = opentelemetry_otlp::SpanExporter::builder()
+      .with_http()
+      .with_retry_policy(RetryPolicy::recommended())
+      .build()?;
+  ```
+  [#3621](https://github.com/open-telemetry/opentelemetry-rust/pull/3621)
 - Add support for INSECURE environment variables for gRPC (env-var-only, no builder method, per spec):
   `OTEL_EXPORTER_OTLP_INSECURE` (generic), `OTEL_EXPORTER_OTLP_TRACES_INSECURE`,
   `OTEL_EXPORTER_OTLP_METRICS_INSECURE`, `OTEL_EXPORTER_OTLP_LOGS_INSECURE`.

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { workspace = true, features = ["sync", "rt", "time"], optional = true }
 
 reqwest = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
-httpdate = { version = "1.0.3" }
+httpdate = { version = "1.0.3", optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 thiserror = { workspace = true }
 serde_json = { workspace = true, optional = true }
@@ -52,6 +52,7 @@ zstd = { version = "0.13", optional = true }
 tokio-stream = { workspace = true, features = ["net"] }
 opentelemetry_sdk = { workspace = true, features = ["trace", "testing"], default-features = false }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+futures-executor = { workspace = true }
 futures-util = { workspace = true }
 temp-env = { workspace = true }
 tonic = { workspace = true, features = ["router", "server"] }
@@ -74,9 +75,6 @@ grpc-tonic = ["tonic", "tonic-types", "prost", "http", "tokio", "opentelemetry-p
 gzip-tonic = ["tonic/gzip"]
 zstd-tonic = ["tonic/zstd"]
 
-# grpc with retry support
-
-
 # http compression
 gzip-http = ["flate2"]
 zstd-http = ["zstd"]
@@ -91,12 +89,9 @@ tls-roots = ["tonic/tls-native-roots"]
 tls-webpki-roots = ["tonic/tls-webpki-roots"]
 
 # http binary
-http-proto = ["prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "http", "trace", "metrics"]
+http-proto = ["prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "http", "httpdate", "trace", "metrics"]
 
-# http with retry support.
-
-
-http-json = ["serde_json", "prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "opentelemetry-proto/with-serde", "http", "trace", "metrics"]
+http-json = ["serde_json", "prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "opentelemetry-proto/with-serde", "http", "httpdate", "trace", "metrics"]
 
 #
 # HTTP clients

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -35,11 +35,11 @@ opentelemetry-proto = { workspace = true, default-features = false }
 prost = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }
 tonic-types = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["sync", "rt"], optional = true }
+tokio = { workspace = true, features = ["sync", "rt", "time"], optional = true }
 
 reqwest = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
-httpdate = { version = "1.0.3", optional = true }
+httpdate = { version = "1.0.3" }
 serde = { workspace = true, features = ["derive"], optional = true }
 thiserror = { workspace = true }
 serde_json = { workspace = true, optional = true }
@@ -75,7 +75,7 @@ gzip-tonic = ["tonic/gzip"]
 zstd-tonic = ["tonic/zstd"]
 
 # grpc with retry support
-experimental-grpc-retry = ["grpc-tonic", "opentelemetry_sdk/experimental_async_runtime", "opentelemetry_sdk/rt-tokio"]
+
 
 # http compression
 gzip-http = ["flate2"]
@@ -94,7 +94,7 @@ tls-webpki-roots = ["tonic/tls-webpki-roots"]
 http-proto = ["prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "http", "trace", "metrics"]
 
 # http with retry support.
-experimental-http-retry = ["opentelemetry_sdk/experimental_async_runtime", "opentelemetry_sdk/rt-tokio", "tokio", "httpdate"]
+
 
 http-json = ["serde_json", "prost", "opentelemetry-http", "opentelemetry-proto/gen-tonic-messages", "opentelemetry-proto/with-serde", "http", "trace", "metrics"]
 
@@ -109,8 +109,8 @@ reqwest-blocking-client = ["reqwest/blocking", "opentelemetry-http/reqwest-block
 # Async HTTP clients. Do not enable these for the default SDK
 # processors/readers; they require an export path that is driven by a Tokio
 # runtime, such as the experimental async-runtime processors/readers.
-reqwest-client = ["reqwest", "opentelemetry-http/reqwest"]
-hyper-client = ["opentelemetry-http/hyper"]
+reqwest-client = ["reqwest", "opentelemetry-http/reqwest", "tokio"]
+hyper-client = ["opentelemetry-http/hyper", "tokio"]
 
 # TLS options for reqwest-based HTTP clients, both blocking and async. Combine
 # these with either reqwest-blocking-client or reqwest-client.

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -48,11 +48,7 @@ impl HttpExportError {
     }
 
     /// Create a new HttpExportError with retry-after header
-    pub(crate) fn with_retry_after(
-        status_code: u16,
-        retry_after: String,
-        message: String,
-    ) -> Self {
+    pub(crate) fn with_retry_after(status_code: u16, retry_after: String, message: String) -> Self {
         Self {
             status_code,
             retry_after: Some(retry_after),
@@ -382,8 +378,9 @@ impl OtlpHttpClient {
     /// Shared HTTP export logic used by all exporters with retry support.
     ///
     /// Uses the configured retry policy with the exporter timeout as the deadline.
-    /// Delays between retries use `std::thread::sleep`, which is safe because the
-    /// SDK's batch processors call exporters from a dedicated OS thread.
+    /// Delays between retries adapt to the calling context: cooperative
+    /// `tokio::time::sleep` inside a Tokio runtime, or `std::thread::sleep`
+    /// on bare OS threads (the SDK's default batch processors).
     async fn export_http_with_retry<F, T>(
         &self,
         data: T,
@@ -411,13 +408,8 @@ impl OtlpHttpClient {
             classify_http_export_error,
             operation_name,
             || async {
-                self.export_http_once(
-                    &retry_data,
-                    content_type,
-                    content_encoding,
-                    operation_name,
-                )
-                .await
+                self.export_http_once(&retry_data, content_type, content_encoding, operation_name)
+                    .await
             },
         )
         .await
@@ -1025,7 +1017,7 @@ mod tests {
                 client: None,
                 headers: Some(initial_headers),
                 compression: None,
-                
+
                 retry_policy: None,
             },
             exporter_config: crate::exporter::ExportConfig::default(),
@@ -1094,7 +1086,6 @@ mod tests {
                 crate::Protocol::HttpBinary,
                 std::time::Duration::from_secs(10),
                 Some(crate::Compression::Gzip),
-                
                 None,
             );
 
@@ -1127,7 +1118,6 @@ mod tests {
                 crate::Protocol::HttpBinary,
                 std::time::Duration::from_secs(10),
                 Some(crate::Compression::Zstd),
-                
                 None,
             );
 
@@ -1158,7 +1148,6 @@ mod tests {
                 crate::Protocol::HttpBinary,
                 std::time::Duration::from_secs(10),
                 None, // No compression
-                
                 None,
             );
 
@@ -1181,7 +1170,6 @@ mod tests {
                 crate::Protocol::HttpBinary,
                 std::time::Duration::from_secs(10),
                 Some(crate::Compression::Gzip),
-                
                 None,
             );
 
@@ -1205,7 +1193,6 @@ mod tests {
                 crate::Protocol::HttpBinary,
                 std::time::Duration::from_secs(10),
                 Some(crate::Compression::Zstd),
-                
                 None,
             );
 
@@ -1269,7 +1256,6 @@ mod tests {
                 protocol,
                 std::time::Duration::from_secs(10),
                 compression,
-                
                 None,
             )
         }
@@ -1509,7 +1495,6 @@ mod tests {
             ));
         }
 
-        
         #[test]
         fn test_with_retry_policy() {
             use super::super::HttpExporterBuilder;

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -25,29 +25,23 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-#[cfg(feature = "experimental-http-retry")]
 use crate::retry::{RetryErrorType, RetryPolicy};
-#[cfg(feature = "experimental-http-retry")]
 use crate::retry_classification::http::classify_http_error;
 
 // Shared HTTP retry functionality
 /// HTTP-specific error wrapper for retry classification
 #[derive(Debug)]
 pub(crate) struct HttpExportError {
-    #[cfg(feature = "experimental-http-retry")]
     pub status_code: u16,
-    #[cfg(feature = "experimental-http-retry")]
     pub retry_after: Option<String>,
     pub message: String,
 }
 
 impl HttpExportError {
     /// Create a new HttpExportError without retry-after header
-    pub(crate) fn new(_status_code: u16, message: String) -> Self {
+    pub(crate) fn new(status_code: u16, message: String) -> Self {
         Self {
-            #[cfg(feature = "experimental-http-retry")]
-            status_code: _status_code,
-            #[cfg(feature = "experimental-http-retry")]
+            status_code,
             retry_after: None,
             message,
         }
@@ -55,21 +49,18 @@ impl HttpExportError {
 
     /// Create a new HttpExportError with retry-after header
     pub(crate) fn with_retry_after(
-        _status_code: u16,
-        _retry_after: String,
+        status_code: u16,
+        retry_after: String,
         message: String,
     ) -> Self {
         Self {
-            #[cfg(feature = "experimental-http-retry")]
-            status_code: _status_code,
-            #[cfg(feature = "experimental-http-retry")]
-            retry_after: Some(_retry_after),
+            status_code,
+            retry_after: Some(retry_after),
             message,
         }
     }
 }
 
-#[cfg(feature = "experimental-http-retry")]
 /// Classify HTTP export errors for retry decisions
 pub(crate) fn classify_http_export_error(error: &HttpExportError) -> RetryErrorType {
     classify_http_error(error.status_code, error.retry_after.as_deref())
@@ -116,7 +107,6 @@ pub(crate) struct HttpConfig {
     compression: Option<crate::Compression>,
 
     /// The retry policy to use for HTTP requests.
-    #[cfg(feature = "experimental-http-retry")]
     retry_policy: Option<RetryPolicy>,
 }
 
@@ -296,7 +286,6 @@ impl HttpExporterBuilder {
             protocol,
             timeout,
             compression,
-            #[cfg(feature = "experimental-http-retry")]
             self.http_config.retry_policy.take(),
         ))
     }
@@ -381,9 +370,8 @@ pub(crate) struct OtlpHttpClient {
     collector_endpoint: Uri,
     headers: Arc<HashMap<HeaderName, HeaderValue>>,
     protocol: Protocol,
-    _timeout: Duration,
+    timeout: Duration,
     compression: Option<crate::Compression>,
-    #[cfg(feature = "experimental-http-retry")]
     retry_policy: RetryPolicy,
     #[allow(dead_code)]
     // <allow dead> would be removed once we support set_resource for metrics and traces.
@@ -391,7 +379,11 @@ pub(crate) struct OtlpHttpClient {
 }
 
 impl OtlpHttpClient {
-    /// Shared HTTP export logic used by all exporters with retry support
+    /// Shared HTTP export logic used by all exporters with retry support.
+    ///
+    /// Uses the configured retry policy with the exporter timeout as the deadline.
+    /// Delays between retries use `std::thread::sleep`, which is safe because the
+    /// SDK's batch processors call exporters from a dedicated OS thread.
     async fn export_http_with_retry<F, T>(
         &self,
         data: T,
@@ -401,68 +393,37 @@ impl OtlpHttpClient {
     where
         F: Fn(&Self, T) -> Result<(Vec<u8>, &'static str, Option<&'static str>), String>,
     {
-        #[cfg(feature = "experimental-http-retry")]
-        {
-            use crate::retry::retry_with_backoff;
+        use crate::retry::retry_with_backoff;
 
-            // Build request body once before retry loop
-            let (body, content_type, content_encoding) = build_body_fn(self, data)
-                .map_err(opentelemetry_sdk::error::OTelSdkError::InternalFailure)?;
+        // Build request body once before retry loop
+        let (body, content_type, content_encoding) = build_body_fn(self, data)
+            .map_err(opentelemetry_sdk::error::OTelSdkError::InternalFailure)?;
 
-            let retry_data = Arc::new(HttpRetryData {
-                body,
-                headers: self.headers.clone(),
-                endpoint: self.collector_endpoint.to_string(),
-            });
+        let retry_data = Arc::new(HttpRetryData {
+            body,
+            headers: self.headers.clone(),
+            endpoint: self.collector_endpoint.to_string(),
+        });
 
-            // Select runtime based on HTTP client feature - if we're using
-            // one without Tokio, we don't need or want the Tokio async blocking
-            // behaviour.
-            #[cfg(feature = "reqwest-blocking-client")]
-            let runtime = opentelemetry_sdk::runtime::NoAsync;
-
-            #[cfg(not(feature = "reqwest-blocking-client"))]
-            let runtime = opentelemetry_sdk::runtime::Tokio;
-
-            let response_body = retry_with_backoff(
-                runtime,
-                self.retry_policy.clone(),
-                classify_http_export_error,
-                operation_name,
-                || async {
-                    self.export_http_once(
-                        &retry_data,
-                        content_type,
-                        content_encoding,
-                        operation_name,
-                    )
-                    .await
-                },
-            )
-            .await
-            .map_err(|e| opentelemetry_sdk::error::OTelSdkError::InternalFailure(e.message))?;
-
-            Ok(response_body)
-        }
-
-        #[cfg(not(feature = "experimental-http-retry"))]
-        {
-            let (body, content_type, content_encoding) = build_body_fn(self, data)
-                .map_err(opentelemetry_sdk::error::OTelSdkError::InternalFailure)?;
-
-            let retry_data = HttpRetryData {
-                body,
-                headers: self.headers.clone(),
-                endpoint: self.collector_endpoint.to_string(),
-            };
-
-            let response_body = self
-                .export_http_once(&retry_data, content_type, content_encoding, operation_name)
+        let response_body = retry_with_backoff(
+            &self.retry_policy,
+            self.timeout,
+            classify_http_export_error,
+            operation_name,
+            || async {
+                self.export_http_once(
+                    &retry_data,
+                    content_type,
+                    content_encoding,
+                    operation_name,
+                )
                 .await
-                .map_err(|e| opentelemetry_sdk::error::OTelSdkError::InternalFailure(e.message))?;
+            },
+        )
+        .await
+        .map_err(|e| opentelemetry_sdk::error::OTelSdkError::InternalFailure(e.message))?;
 
-            Ok(response_body)
-        }
+        Ok(response_body)
     }
 
     /// Single HTTP export attempt - shared between retry and no-retry paths
@@ -592,22 +553,16 @@ impl OtlpHttpClient {
         protocol: Protocol,
         timeout: Duration,
         compression: Option<crate::Compression>,
-        #[cfg(feature = "experimental-http-retry")] retry_policy: Option<RetryPolicy>,
+        retry_policy: Option<RetryPolicy>,
     ) -> Self {
         OtlpHttpClient {
             client: Mutex::new(Some(client)),
             collector_endpoint,
             headers: Arc::new(headers),
             protocol,
-            _timeout: timeout,
+            timeout,
             compression,
-            #[cfg(feature = "experimental-http-retry")]
-            retry_policy: retry_policy.unwrap_or(RetryPolicy {
-                max_retries: 3,
-                initial_delay_ms: 100,
-                max_delay_ms: 1600,
-                jitter_ms: 100,
-            }),
+            retry_policy: retry_policy.unwrap_or_default(),
             resource: ResourceAttributesWithSchema::default(),
         }
     }
@@ -795,7 +750,6 @@ pub trait WithHttpConfig {
     fn with_compression(self, compression: crate::Compression) -> Self;
 
     /// Set the retry policy for HTTP requests.
-    #[cfg(feature = "experimental-http-retry")]
     fn with_retry_policy(self, policy: RetryPolicy) -> Self;
 }
 
@@ -822,7 +776,6 @@ impl<B: HasHttpConfig> WithHttpConfig for B {
         self
     }
 
-    #[cfg(feature = "experimental-http-retry")]
     fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
         self.http_client_config().retry_policy = Some(policy);
         self
@@ -1072,7 +1025,7 @@ mod tests {
                 client: None,
                 headers: Some(initial_headers),
                 compression: None,
-                #[cfg(feature = "experimental-http-retry")]
+                
                 retry_policy: None,
             },
             exporter_config: crate::exporter::ExportConfig::default(),
@@ -1141,7 +1094,7 @@ mod tests {
                 crate::Protocol::HttpBinary,
                 std::time::Duration::from_secs(10),
                 Some(crate::Compression::Gzip),
-                #[cfg(feature = "experimental-http-retry")]
+                
                 None,
             );
 
@@ -1174,7 +1127,7 @@ mod tests {
                 crate::Protocol::HttpBinary,
                 std::time::Duration::from_secs(10),
                 Some(crate::Compression::Zstd),
-                #[cfg(feature = "experimental-http-retry")]
+                
                 None,
             );
 
@@ -1205,7 +1158,7 @@ mod tests {
                 crate::Protocol::HttpBinary,
                 std::time::Duration::from_secs(10),
                 None, // No compression
-                #[cfg(feature = "experimental-http-retry")]
+                
                 None,
             );
 
@@ -1228,7 +1181,7 @@ mod tests {
                 crate::Protocol::HttpBinary,
                 std::time::Duration::from_secs(10),
                 Some(crate::Compression::Gzip),
-                #[cfg(feature = "experimental-http-retry")]
+                
                 None,
             );
 
@@ -1252,7 +1205,7 @@ mod tests {
                 crate::Protocol::HttpBinary,
                 std::time::Duration::from_secs(10),
                 Some(crate::Compression::Zstd),
-                #[cfg(feature = "experimental-http-retry")]
+                
                 None,
             );
 
@@ -1316,7 +1269,7 @@ mod tests {
                 protocol,
                 std::time::Duration::from_secs(10),
                 compression,
-                #[cfg(feature = "experimental-http-retry")]
+                
                 None,
             )
         }
@@ -1556,7 +1509,7 @@ mod tests {
             ));
         }
 
-        #[cfg(feature = "experimental-http-retry")]
+        
         #[test]
         fn test_with_retry_policy() {
             use super::super::HttpExporterBuilder;
@@ -1580,19 +1533,19 @@ mod tests {
             assert_eq!(retry_policy.jitter_ms, 50);
         }
 
-        #[cfg(all(feature = "http-proto", feature = "experimental-http-retry"))]
+        #[cfg(feature = "http-proto")]
         #[test]
         fn test_default_retry_policy_when_none_configured() {
             let client = create_test_client(crate::Protocol::HttpBinary, None);
 
-            // Verify default values are used
-            assert_eq!(client.retry_policy.max_retries, 3);
+            // Verify default values are used (default = no retry)
+            assert_eq!(client.retry_policy.max_retries, 0);
             assert_eq!(client.retry_policy.initial_delay_ms, 100);
             assert_eq!(client.retry_policy.max_delay_ms, 1600);
             assert_eq!(client.retry_policy.jitter_ms, 100);
         }
 
-        #[cfg(all(feature = "http-proto", feature = "experimental-http-retry"))]
+        #[cfg(feature = "http-proto")]
         #[test]
         fn test_custom_retry_policy_used() {
             use crate::retry::RetryPolicy;

--- a/opentelemetry-otlp/src/exporter/tonic/logs.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/logs.rs
@@ -14,12 +14,11 @@ use opentelemetry_proto::transform::logs::tonic::group_logs_by_resource_and_scop
 use super::BoxInterceptor;
 
 use crate::retry::RetryPolicy;
-#[cfg(feature = "experimental-grpc-retry")]
-use opentelemetry_sdk::runtime::Tokio;
 
 pub(crate) struct TonicLogsClient {
     inner: Mutex<Option<ClientInner>>,
     retry_policy: RetryPolicy,
+    timeout: std::time::Duration,
     #[allow(dead_code)]
     // <allow dead> would be removed once we support set_resource for metrics.
     resource: opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema,
@@ -42,6 +41,7 @@ impl TonicLogsClient {
         interceptor: BoxInterceptor,
         compression: Option<CompressionEncoding>,
         retry_policy: Option<RetryPolicy>,
+        timeout: std::time::Duration,
     ) -> Self {
         let mut client = LogsServiceClient::new(channel);
         if let Some(compression) = compression {
@@ -57,12 +57,8 @@ impl TonicLogsClient {
                 client,
                 interceptor,
             })),
-            retry_policy: retry_policy.unwrap_or(RetryPolicy {
-                max_retries: 3,
-                initial_delay_ms: 100,
-                max_delay_ms: 1600,
-                jitter_ms: 100,
-            }),
+            retry_policy: retry_policy.unwrap_or_default(),
+            timeout,
             resource: Default::default(),
         }
     }
@@ -73,11 +69,8 @@ impl LogExporter for TonicLogsClient {
         let batch = Arc::new(batch);
 
         match super::tonic_retry_with_backoff(
-            #[cfg(feature = "experimental-grpc-retry")]
-            Tokio,
-            #[cfg(not(feature = "experimental-grpc-retry"))]
-            (),
-            self.retry_policy.clone(),
+            &self.retry_policy,
+            self.timeout,
             crate::retry_classification::grpc::classify_tonic_status,
             "TonicLogsClient.Export",
             || async {

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -13,12 +13,11 @@ use super::BoxInterceptor;
 use crate::metric::MetricsClient;
 
 use crate::retry::RetryPolicy;
-#[cfg(feature = "experimental-grpc-retry")]
-use opentelemetry_sdk::runtime::Tokio;
 
 pub(crate) struct TonicMetricsClient {
     inner: Mutex<Option<ClientInner>>,
     retry_policy: RetryPolicy,
+    timeout: std::time::Duration,
 }
 
 struct ClientInner {
@@ -38,6 +37,7 @@ impl TonicMetricsClient {
         interceptor: BoxInterceptor,
         compression: Option<CompressionEncoding>,
         retry_policy: Option<RetryPolicy>,
+        timeout: std::time::Duration,
     ) -> Self {
         let mut client = MetricsServiceClient::new(channel);
         if let Some(compression) = compression {
@@ -53,12 +53,8 @@ impl TonicMetricsClient {
                 client,
                 interceptor,
             })),
-            retry_policy: retry_policy.unwrap_or(RetryPolicy {
-                max_retries: 3,
-                initial_delay_ms: 100,
-                max_delay_ms: 1600,
-                jitter_ms: 100,
-            }),
+            retry_policy: retry_policy.unwrap_or_default(),
+            timeout,
         }
     }
 }
@@ -66,11 +62,8 @@ impl TonicMetricsClient {
 impl MetricsClient for TonicMetricsClient {
     async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
         match super::tonic_retry_with_backoff(
-            #[cfg(feature = "experimental-grpc-retry")]
-            Tokio,
-            #[cfg(not(feature = "experimental-grpc-retry"))]
-            (),
-            self.retry_policy.clone(),
+            &self.retry_policy,
+            self.timeout,
             crate::retry_classification::grpc::classify_tonic_status,
             "TonicMetricsClient.Export",
             || async {

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -173,7 +173,7 @@ impl Default for TonicExporterBuilder {
 
 impl TonicExporterBuilder {
     // This is for clippy to work with only the grpc-tonic feature enabled
-    #[allow(unused)]
+    #[allow(unused, clippy::type_complexity)]
     fn build_channel(
         self,
         signal_endpoint_var: &str,
@@ -262,13 +262,7 @@ impl TonicExporterBuilder {
 
         // If a custom channel was provided, use that channel instead of creating one
         if let Some(channel) = self.tonic_config.channel {
-            return Ok((
-                channel,
-                interceptor,
-                compression,
-                retry_policy,
-                timeout,
-            ));
+            return Ok((channel, interceptor, compression, retry_policy, timeout));
         }
 
         let config = self.exporter_config;
@@ -332,13 +326,7 @@ impl TonicExporterBuilder {
         let channel = endpoint.timeout(timeout).connect_lazy();
 
         otel_debug!(name: "TonicChannelBuilt", endpoint = endpoint_clone, timeout_in_millisecs = timeout.as_millis(), compression = format!("{:?}", compression), headers = format!("{:?}", headers_for_logging));
-        Ok((
-            channel,
-            interceptor,
-            compression,
-            retry_policy,
-            timeout,
-        ))
+        Ok((channel, interceptor, compression, retry_policy, timeout))
     }
 
     fn resolve_endpoint(default_endpoint_var: &str, provided_endpoint: Option<String>) -> String {
@@ -410,7 +398,8 @@ impl TonicExporterBuilder {
             crate::metric::OTEL_EXPORTER_OTLP_METRICS_INSECURE,
         )?;
 
-        let client = TonicMetricsClient::new(channel, interceptor, compression, retry_policy, timeout);
+        let client =
+            TonicMetricsClient::new(channel, interceptor, compression, retry_policy, timeout);
 
         Ok(MetricExporter::from_tonic(client, temporality))
     }
@@ -431,7 +420,8 @@ impl TonicExporterBuilder {
             crate::span::OTEL_EXPORTER_OTLP_TRACES_INSECURE,
         )?;
 
-        let client = TonicTracesClient::new(channel, interceptor, compression, retry_policy, timeout);
+        let client =
+            TonicTracesClient::new(channel, interceptor, compression, retry_policy, timeout);
 
         Ok(crate::SpanExporter::from_tonic(client))
     }
@@ -439,9 +429,9 @@ impl TonicExporterBuilder {
 
 /// Retries a tonic export operation with exponential backoff.
 ///
-/// Uses `std::thread::sleep` for delays between retries. This is safe because
-/// tonic exporters are called from the SDK's dedicated export thread via
-/// `futures_executor::block_on`.
+/// Delays between retries adapt to the calling context: cooperative
+/// `tokio::time::sleep` inside a Tokio runtime, or `std::thread::sleep`
+/// on bare OS threads.
 #[cfg(all(
     feature = "grpc-tonic",
     any(feature = "trace", feature = "metrics", feature = "logs")

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -22,17 +22,11 @@ use crate::exporter::Compression;
 use crate::{exporter::ExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS};
 
 #[cfg(all(
-    feature = "experimental-grpc-retry",
+    feature = "grpc-tonic",
     any(feature = "trace", feature = "metrics", feature = "logs")
 ))]
 use crate::retry::retry_with_backoff;
-#[cfg(feature = "grpc-tonic")]
 use crate::retry::RetryPolicy;
-#[cfg(all(
-    feature = "experimental-grpc-retry",
-    any(feature = "trace", feature = "metrics", feature = "logs")
-))]
-use opentelemetry_sdk::runtime::Runtime;
 #[cfg(all(
     feature = "grpc-tonic",
     any(feature = "trace", feature = "metrics", feature = "logs")
@@ -69,7 +63,6 @@ pub(crate) struct TonicConfig {
     pub(crate) channel: Option<tonic::transport::Channel>,
     pub(crate) interceptor: Option<BoxInterceptor>,
     /// The retry policy to use for gRPC requests.
-    #[cfg(feature = "experimental-grpc-retry")]
     pub(crate) retry_policy: Option<RetryPolicy>,
 }
 
@@ -168,7 +161,6 @@ impl Default for TonicExporterBuilder {
                 compression: None,
                 channel: Option::default(),
                 interceptor: Option::default(),
-                #[cfg(feature = "experimental-grpc-retry")]
                 retry_policy: None,
             },
             exporter_config: ExportConfig {
@@ -196,6 +188,7 @@ impl TonicExporterBuilder {
             BoxInterceptor,
             Option<CompressionEncoding>,
             Option<RetryPolicy>,
+            std::time::Duration,
         ),
         ExporterBuildError,
     > {
@@ -262,8 +255,10 @@ impl TonicExporterBuilder {
         };
 
         // Get retry policy before consuming self
-        #[cfg(feature = "experimental-grpc-retry")]
         let retry_policy = self.tonic_config.retry_policy.clone();
+
+        // Resolve timeout early so it's available for both custom-channel and built-channel paths
+        let timeout = resolve_timeout(signal_timeout_var, self.exporter_config.timeout.as_ref());
 
         // If a custom channel was provided, use that channel instead of creating one
         if let Some(channel) = self.tonic_config.channel {
@@ -271,10 +266,8 @@ impl TonicExporterBuilder {
                 channel,
                 interceptor,
                 compression,
-                #[cfg(feature = "experimental-grpc-retry")]
                 retry_policy,
-                #[cfg(not(feature = "experimental-grpc-retry"))]
-                None,
+                timeout,
             ));
         }
 
@@ -312,8 +305,6 @@ impl TonicExporterBuilder {
                 ),
             });
         }
-        let timeout = resolve_timeout(signal_timeout_var, config.timeout.as_ref());
-
         #[cfg(any(
             feature = "tls",
             feature = "tls-ring",
@@ -345,10 +336,8 @@ impl TonicExporterBuilder {
             channel,
             interceptor,
             compression,
-            #[cfg(feature = "experimental-grpc-retry")]
             retry_policy,
-            #[cfg(not(feature = "experimental-grpc-retry"))]
-            None,
+            timeout,
         ))
     }
 
@@ -387,7 +376,7 @@ impl TonicExporterBuilder {
 
         otel_debug!(name: "LogsTonicChannelBuilding");
 
-        let (channel, interceptor, compression, retry_policy) = self.build_channel(
+        let (channel, interceptor, compression, retry_policy, timeout) = self.build_channel(
             crate::logs::OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
             crate::logs::OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
             crate::logs::OTEL_EXPORTER_OTLP_LOGS_COMPRESSION,
@@ -396,7 +385,7 @@ impl TonicExporterBuilder {
             crate::logs::OTEL_EXPORTER_OTLP_LOGS_INSECURE,
         )?;
 
-        let client = TonicLogsClient::new(channel, interceptor, compression, retry_policy);
+        let client = TonicLogsClient::new(channel, interceptor, compression, retry_policy, timeout);
 
         Ok(crate::logs::LogExporter::from_tonic(client))
     }
@@ -412,7 +401,7 @@ impl TonicExporterBuilder {
 
         otel_debug!(name: "MetricsTonicChannelBuilding");
 
-        let (channel, interceptor, compression, retry_policy) = self.build_channel(
+        let (channel, interceptor, compression, retry_policy, timeout) = self.build_channel(
             crate::metric::OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
             crate::metric::OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
             crate::metric::OTEL_EXPORTER_OTLP_METRICS_COMPRESSION,
@@ -421,7 +410,7 @@ impl TonicExporterBuilder {
             crate::metric::OTEL_EXPORTER_OTLP_METRICS_INSECURE,
         )?;
 
-        let client = TonicMetricsClient::new(channel, interceptor, compression, retry_policy);
+        let client = TonicMetricsClient::new(channel, interceptor, compression, retry_policy, timeout);
 
         Ok(MetricExporter::from_tonic(client, temporality))
     }
@@ -433,7 +422,7 @@ impl TonicExporterBuilder {
 
         otel_debug!(name: "TracesTonicChannelBuilding");
 
-        let (channel, interceptor, compression, retry_policy) = self.build_channel(
+        let (channel, interceptor, compression, retry_policy, timeout) = self.build_channel(
             crate::span::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
             crate::span::OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
             crate::span::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
@@ -442,53 +431,33 @@ impl TonicExporterBuilder {
             crate::span::OTEL_EXPORTER_OTLP_TRACES_INSECURE,
         )?;
 
-        let client = TonicTracesClient::new(channel, interceptor, compression, retry_policy);
+        let client = TonicTracesClient::new(channel, interceptor, compression, retry_policy, timeout);
 
         Ok(crate::SpanExporter::from_tonic(client))
     }
 }
 
-/// Wrapper for retry functionality in tonic exporters.
-/// Provides a unified call path that either uses retry_with_backoff when experimental-grpc-retry
-/// feature is enabled, or executes the operation once when it's not.
+/// Retries a tonic export operation with exponential backoff.
+///
+/// Uses `std::thread::sleep` for delays between retries. This is safe because
+/// tonic exporters are called from the SDK's dedicated export thread via
+/// `futures_executor::block_on`.
 #[cfg(all(
     feature = "grpc-tonic",
-    feature = "experimental-grpc-retry",
     any(feature = "trace", feature = "metrics", feature = "logs")
 ))]
-async fn tonic_retry_with_backoff<R, F, Fut, T>(
-    runtime: R,
-    policy: RetryPolicy,
+async fn tonic_retry_with_backoff<F, Fut, T>(
+    policy: &RetryPolicy,
+    timeout: std::time::Duration,
     classify_fn: fn(&tonic::Status) -> crate::retry::RetryErrorType,
     operation_name: &'static str,
     operation: F,
 ) -> Result<T, tonic::Status>
 where
-    R: Runtime,
     F: Fn() -> Fut,
     Fut: Future<Output = Result<T, tonic::Status>>,
 {
-    retry_with_backoff(runtime, policy, classify_fn, operation_name, operation).await
-}
-
-/// Provides a unified call path when experimental-grpc-retry is not enabled - just executes the operation once.
-#[cfg(all(
-    feature = "grpc-tonic",
-    not(feature = "experimental-grpc-retry"),
-    any(feature = "trace", feature = "metrics", feature = "logs")
-))]
-async fn tonic_retry_with_backoff<F, Fut, T>(
-    _runtime: (),
-    _policy: RetryPolicy,
-    _classify_fn: fn(&tonic::Status) -> crate::retry::RetryErrorType,
-    _operation_name: &'static str,
-    operation: F,
-) -> Result<T, tonic::Status>
-where
-    F: Fn() -> Fut,
-    Fut: Future<Output = Result<T, tonic::Status>>,
-{
-    operation().await
+    retry_with_backoff(policy, timeout, classify_fn, operation_name, operation).await
 }
 
 #[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
@@ -784,7 +753,6 @@ pub trait WithTonicConfig {
         I: tonic::service::Interceptor + Clone + Send + Sync + 'static;
 
     /// Set the retry policy for gRPC requests.
-    #[cfg(feature = "experimental-grpc-retry")]
     fn with_retry_policy(self, policy: RetryPolicy) -> Self;
 }
 
@@ -833,7 +801,6 @@ impl<B: HasTonicConfig> WithTonicConfig for B {
         self
     }
 
-    #[cfg(feature = "experimental-grpc-retry")]
     fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
         self.tonic_config().retry_policy = Some(policy);
         self
@@ -1127,7 +1094,6 @@ mod tests {
         });
     }
 
-    #[cfg(feature = "experimental-grpc-retry")]
     #[test]
     fn test_with_retry_policy() {
         use crate::retry::RetryPolicy;
@@ -1150,7 +1116,6 @@ mod tests {
         assert_eq!(retry_policy.jitter_ms, 50);
     }
 
-    #[cfg(feature = "experimental-grpc-retry")]
     #[test]
     fn test_default_retry_policy_when_none_configured() {
         // This test requires us to create a tonic client, but we can't easily do that without

--- a/opentelemetry-otlp/src/exporter/tonic/trace.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/trace.rs
@@ -16,12 +16,11 @@ use tonic::{codegen::CompressionEncoding, service::Interceptor, transport::Chann
 use super::BoxInterceptor;
 
 use crate::retry::RetryPolicy;
-#[cfg(feature = "experimental-grpc-retry")]
-use opentelemetry_sdk::runtime::Tokio;
 
 pub(crate) struct TonicTracesClient {
     inner: Mutex<Option<ClientInner>>,
     retry_policy: RetryPolicy,
+    timeout: std::time::Duration,
     #[allow(dead_code)]
     // <allow dead> would be removed once we support set_resource for metrics.
     resource: opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema,
@@ -44,6 +43,7 @@ impl TonicTracesClient {
         interceptor: BoxInterceptor,
         compression: Option<CompressionEncoding>,
         retry_policy: Option<RetryPolicy>,
+        timeout: std::time::Duration,
     ) -> Self {
         let mut client = TraceServiceClient::new(channel);
         if let Some(compression) = compression {
@@ -59,12 +59,8 @@ impl TonicTracesClient {
                 client,
                 interceptor,
             })),
-            retry_policy: retry_policy.unwrap_or(RetryPolicy {
-                max_retries: 3,
-                initial_delay_ms: 100,
-                max_delay_ms: 1600,
-                jitter_ms: 100,
-            }),
+            retry_policy: retry_policy.unwrap_or_default(),
+            timeout,
             resource: Default::default(),
         }
     }
@@ -75,11 +71,8 @@ impl SpanExporter for TonicTracesClient {
         let batch = Arc::new(batch);
 
         match super::tonic_retry_with_backoff(
-            #[cfg(feature = "experimental-grpc-retry")]
-            Tokio,
-            #[cfg(not(feature = "experimental-grpc-retry"))]
-            (),
-            self.retry_policy.clone(),
+            &self.retry_policy,
+            self.timeout,
             crate::retry_classification::grpc::classify_tonic_status,
             "TonicTracesClient.Export",
             || async {

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -299,12 +299,10 @@
 //!   `rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned())`, then pass it
 //!   via `with_http_client()`.
 //!
-//! The following feature flags enable experimental retry support:
-//!
-//! * `experimental-grpc-retry`: Enable automatic retry with exponential backoff for gRPC exports.
-//!   Requires a Tokio runtime (`rt-tokio` SDK feature is enabled transitively).
-//! * `experimental-http-retry`: Enable automatic retry with exponential backoff for HTTP exports.
-//!   Requires a Tokio runtime (`rt-tokio` SDK feature is enabled transitively).
+//! Retry with exponential backoff is always enabled for both gRPC and HTTP exports.
+//! Failed exports are automatically retried according to the configured retry policy,
+//! with proper classification of retryable vs non-retryable errors and support for
+//! server-provided throttling hints (HTTP Retry-After, gRPC RetryInfo).
 //!
 //! # Full Configuration Reference
 //!
@@ -448,11 +446,11 @@
 //!
 //! ### gRPC retry policy
 //!
-//! Requires the `experimental-grpc-retry` feature. When enabled, failed exports are retried
-//! with exponential backoff and jitter. Without this feature, failed exports are not retried.
+//! Failed exports are retried with exponential backoff and jitter. The retry policy
+//! can be customized:
 //!
 //! ```no_run
-//! # #[cfg(all(feature = "trace", feature = "experimental-grpc-retry"))]
+//! # #[cfg(all(feature = "trace", feature = "grpc-tonic"))]
 //! # {
 //! use opentelemetry_otlp::{WithTonicConfig, RetryPolicy};
 //!
@@ -550,11 +548,11 @@
 //!
 //! ### HTTP retry policy
 //!
-//! Requires the `experimental-http-retry` feature. When enabled, failed exports are retried
-//! with exponential backoff and jitter. Without this feature, failed exports are not retried.
+//! Failed exports are retried with exponential backoff and jitter. The retry policy
+//! can be customized:
 //!
 //! ```no_run
-//! # #[cfg(all(feature = "trace", feature = "experimental-http-retry"))]
+//! # #[cfg(feature = "trace")]
 //! # {
 //! use opentelemetry_otlp::{WithHttpConfig, RetryPolicy};
 //!
@@ -655,11 +653,11 @@ mod metric;
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 mod span;
 
-#[cfg(any(feature = "grpc-tonic", feature = "experimental-http-retry"))]
+#[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
 pub mod retry_classification;
 
 /// Retry logic for exporting telemetry data.
-#[cfg(any(feature = "grpc-tonic", feature = "experimental-http-retry"))]
+#[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
 pub mod retry;
 
 pub use crate::exporter::Compression;
@@ -705,10 +703,7 @@ pub use crate::exporter::{
     OTEL_EXPORTER_OTLP_TIMEOUT, OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT,
 };
 
-#[cfg(any(
-    feature = "experimental-http-retry",
-    feature = "experimental-grpc-retry"
-))]
+#[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
 pub use retry::RetryPolicy;
 
 /// Type to indicate the builder does not have a client set.

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -552,7 +552,7 @@
 //! can be customized:
 //!
 //! ```no_run
-//! # #[cfg(feature = "trace")]
+//! # #[cfg(all(feature = "trace", feature = "http-proto"))]
 //! # {
 //! use opentelemetry_otlp::{WithHttpConfig, RetryPolicy};
 //!

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -115,6 +115,12 @@ fn generate_jitter(max_jitter: u64) -> u64 {
 /// A time budget (deadline) bounds the total retry duration. If the budget is exhausted,
 /// the function returns the last error without further retries.
 ///
+/// **Note:** The deadline governs whether to start another retry and caps inter-retry
+/// sleep durations, but it does not cancel an in-flight export operation. On dedicated
+/// threads (the SDK's default batch processors), individual export calls do not have a
+/// timeout today, so a single slow export can exceed the deadline. This is an existing
+/// limitation.
+///
 /// # Arguments
 ///
 /// * `policy` - The retry policy configuration.

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -9,8 +9,9 @@
 //! server-provided throttling hints.
 
 use opentelemetry::{otel_debug, otel_info, otel_warn};
+use std::collections::hash_map::DefaultHasher;
 use std::future::Future;
-use std::hash::{DefaultHasher, Hasher};
+use std::hash::Hasher;
 use std::time::{Duration, Instant, SystemTime};
 
 /// Sleeps for the given duration, using `tokio::time::sleep` if running inside
@@ -410,7 +411,7 @@ mod tests {
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
         // Should have waited ~50ms (the server delay), not 1000ms (the default)
         assert!(elapsed >= Duration::from_millis(50));
-        assert!(elapsed < Duration::from_millis(200));
+        assert!(elapsed < Duration::from_millis(500));
     }
 
     #[tokio::test]

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -14,10 +14,15 @@ use std::future::Future;
 use std::hash::Hasher;
 use std::time::{Duration, Instant, SystemTime};
 
-/// Sleeps for the given duration, using `tokio::time::sleep` if running inside
-/// a Tokio runtime (cooperative, won't block other tasks), or falling back to
-/// `std::thread::sleep` when on a bare OS thread (e.g. the SDK's default
-/// batch-processor export thread).
+/// Sleeps for the given duration.
+///
+/// Uses `tokio::time::sleep` when the `tokio` feature is enabled and a Tokio
+/// runtime is present (cooperative, won't block the reactor); otherwise falls
+/// back to `std::thread::sleep`.
+///
+/// Note: `tokio` is not a default feature, so default builds
+/// (`reqwest-blocking-client`) always use `std::thread::sleep`. It is pulled in
+/// by `grpc-tonic`, `reqwest-client`, and `hyper-client`.
 async fn sleep_for(duration: Duration) {
     #[cfg(feature = "tokio")]
     {

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -176,11 +176,9 @@ where
                         let delay_ms = std::cmp::min(delay + jitter, policy.max_delay_ms);
                         let sleep_duration = Duration::from_millis(delay_ms);
 
-                        // Don't sleep longer than the remaining budget
+                        // If the backoff delay would consume all remaining budget, fail now
                         let remaining = deadline.saturating_sub(start.elapsed());
-                        let actual_sleep = sleep_duration.min(remaining);
-
-                        if actual_sleep.is_zero() {
+                        if sleep_duration >= remaining {
                             otel_warn!(name: "Export.Failed.DeadlineExceeded",
                                 operation = operation_name,
                                 retries = attempt,
@@ -192,10 +190,10 @@ where
                         otel_debug!(name: "Export.InProgress.Retrying",
                             operation = operation_name,
                             attempt = attempt,
-                            delay_ms = actual_sleep.as_millis(),
+                            delay_ms = sleep_duration.as_millis(),
                             message = "OTLP export failed with retryable error - retrying"
                         );
-                        sleep_for(actual_sleep).await;
+                        sleep_for(sleep_duration).await;
                         delay = std::cmp::min(delay * 2, policy.max_delay_ms);
                     }
                     RetryErrorType::Throttled(server_delay) if attempt < policy.max_retries => {
@@ -203,11 +201,9 @@ where
                         // Cap server-provided delay to prevent excessive blocking
                         let capped_delay = server_delay.min(MAX_THROTTLE_DURATION);
 
-                        // Further constrain to remaining time budget
+                        // If the throttle delay would consume all remaining budget, fail now
                         let remaining = deadline.saturating_sub(start.elapsed());
-                        let actual_sleep = capped_delay.min(remaining);
-
-                        if actual_sleep.is_zero() {
+                        if capped_delay >= remaining {
                             otel_warn!(name: "Export.Failed.DeadlineExceeded",
                                 operation = operation_name,
                                 retries = attempt,
@@ -219,11 +215,11 @@ where
                         otel_info!(name: "Export.InProgress.Throttled",
                             operation = operation_name,
                             attempt = attempt,
-                            delay_ms = actual_sleep.as_millis(),
+                            delay_ms = capped_delay.as_millis(),
                             server_requested_ms = server_delay.as_millis(),
                             message = "OTLP export throttled by OTLP endpoint - delaying and retrying"
                         );
-                        sleep_for(actual_sleep).await;
+                        sleep_for(capped_delay).await;
                         // Don't update exponential backoff delay since server provided specific timing
                     }
                     _ => {
@@ -481,6 +477,113 @@ mod tests {
         let elapsed = start.elapsed();
         assert!(result.is_err());
         // Should be capped by the deadline, not sleep for 120s or even 30s
+        assert!(elapsed < Duration::from_millis(500));
+    }
+
+    // Tests exercising the dedicated-thread (std::thread::sleep) path.
+    // These use futures_executor::block_on with no Tokio runtime present.
+
+    #[test]
+    fn test_retry_succeeds_after_retries_no_tokio() {
+        let policy = RetryPolicy {
+            max_retries: 3,
+            initial_delay_ms: 10,
+            max_delay_ms: 100,
+            jitter_ms: 5,
+        };
+        let deadline = Duration::from_secs(10);
+        let attempts = AtomicUsize::new(0);
+
+        let start = Instant::now();
+        let result = futures_executor::block_on(retry_with_backoff(
+            &policy,
+            deadline,
+            |_: &&str| RetryErrorType::Retryable,
+            "test_operation",
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move {
+                    if attempt < 2 {
+                        Err("error")
+                    } else {
+                        Ok("success")
+                    }
+                })
+            },
+        ));
+
+        let elapsed = start.elapsed();
+        assert_eq!(result, Ok("success"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        // Should have slept at least ~10ms for each of 2 retries
+        assert!(elapsed >= Duration::from_millis(20));
+    }
+
+    #[test]
+    fn test_retry_deadline_exceeded_no_tokio() {
+        let policy = RetryPolicy {
+            max_retries: 100,
+            initial_delay_ms: 50,
+            max_delay_ms: 200,
+            jitter_ms: 0,
+        };
+        let deadline = Duration::from_millis(120);
+        let attempts = AtomicUsize::new(0);
+
+        let start = Instant::now();
+        let result = futures_executor::block_on(retry_with_backoff(
+            &policy,
+            deadline,
+            |_: &()| RetryErrorType::Retryable,
+            "test_operation",
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async { Err::<(), _>(()) })
+            },
+        ));
+
+        let elapsed = start.elapsed();
+        assert!(result.is_err());
+        // Should have stopped before exhausting 100 retries due to deadline
+        assert!(attempts.load(Ordering::SeqCst) < 10);
+        // Shouldn't have taken much longer than the deadline
+        assert!(elapsed < Duration::from_millis(300));
+    }
+
+    #[test]
+    fn test_retry_throttled_uses_server_delay_no_tokio() {
+        let policy = RetryPolicy {
+            max_retries: 2,
+            initial_delay_ms: 1000,
+            max_delay_ms: 5000,
+            jitter_ms: 0,
+        };
+        let deadline = Duration::from_secs(10);
+        let attempts = AtomicUsize::new(0);
+
+        let start = Instant::now();
+        let result = futures_executor::block_on(retry_with_backoff(
+            &policy,
+            deadline,
+            |_: &()| RetryErrorType::Throttled(Duration::from_millis(50)),
+            "test_operation",
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move {
+                    if attempt < 1 {
+                        Err(())
+                    } else {
+                        Ok("success")
+                    }
+                })
+            },
+        ));
+
+        let elapsed = start.elapsed();
+        assert_eq!(result, Ok("success"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        // Should have waited ~50ms (the server delay), not 1000ms (the default)
+        assert!(elapsed >= Duration::from_millis(50));
         assert!(elapsed < Duration::from_millis(500));
     }
 }

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -7,38 +7,26 @@
 //! specified retry policy, using exponential backoff and jitter to determine the delay between
 //! retries. The function uses error classification to determine retry behavior and can honor
 //! server-provided throttling hints.
-#[cfg(any(
-    feature = "experimental-grpc-retry",
-    feature = "experimental-http-retry"
-))]
-use opentelemetry::{otel_debug, otel_info};
 
-#[cfg(any(
-    feature = "experimental-grpc-retry",
-    feature = "experimental-http-retry"
-))]
-use opentelemetry::otel_warn;
-#[cfg(any(
-    feature = "experimental-grpc-retry",
-    feature = "experimental-http-retry"
-))]
-use opentelemetry_sdk::runtime::Runtime;
-#[cfg(any(
-    feature = "experimental-grpc-retry",
-    feature = "experimental-http-retry"
-))]
+use opentelemetry::{otel_debug, otel_info, otel_warn};
 use std::future::Future;
-#[cfg(any(
-    feature = "experimental-grpc-retry",
-    feature = "experimental-http-retry"
-))]
 use std::hash::{DefaultHasher, Hasher};
-use std::time::Duration;
-#[cfg(any(
-    feature = "experimental-grpc-retry",
-    feature = "experimental-http-retry"
-))]
-use std::time::SystemTime;
+use std::time::{Duration, Instant, SystemTime};
+
+/// Sleeps for the given duration, using `tokio::time::sleep` if running inside
+/// a Tokio runtime (cooperative, won't block other tasks), or falling back to
+/// `std::thread::sleep` when on a bare OS thread (e.g. the SDK's default
+/// batch-processor export thread).
+async fn sleep_for(duration: Duration) {
+    #[cfg(feature = "tokio")]
+    {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::time::sleep(duration).await;
+            return;
+        }
+    }
+    std::thread::sleep(duration);
+}
 
 /// Classification of errors for retry purposes.
 #[derive(Debug, Clone, PartialEq)]
@@ -65,11 +53,38 @@ pub struct RetryPolicy {
     pub jitter_ms: u64,
 }
 
+impl Default for RetryPolicy {
+    /// Default retry policy performs no retries (single attempt only).
+    /// Use `RetryPolicy::recommended()` or configure explicitly to enable retry.
+    fn default() -> Self {
+        Self {
+            max_retries: 0,
+            initial_delay_ms: 100,
+            max_delay_ms: 1600,
+            jitter_ms: 100,
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// Recommended retry policy per the OTLP spec: 3 retries with exponential
+    /// backoff (100ms initial, 1600ms max, 100ms jitter).
+    pub fn recommended() -> Self {
+        Self {
+            max_retries: 3,
+            initial_delay_ms: 100,
+            max_delay_ms: 1600,
+            jitter_ms: 100,
+        }
+    }
+}
+
+/// Maximum duration a server-provided throttle delay (Retry-After / RetryInfo) is allowed
+/// to block the export thread. Any server-provided delay exceeding this cap is truncated.
+/// This prevents a misbehaving server from stalling the export pipeline indefinitely.
+const MAX_THROTTLE_DURATION: Duration = Duration::from_secs(30);
+
 // Generates a random jitter value up to max_jitter
-#[cfg(any(
-    feature = "experimental-grpc-retry",
-    feature = "experimental-http-retry"
-))]
 fn generate_jitter(max_jitter: u64) -> u64 {
     let nanos = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -83,13 +98,21 @@ fn generate_jitter(max_jitter: u64) -> u64 {
 
 /// Retries the given operation with exponential backoff, jitter, and error classification.
 ///
-/// This function provides sophisticated retry behavior by classifying errors
-/// and honoring server-provided throttling hints (e.g., HTTP Retry-After, gRPC RetryInfo).
+/// This function provides retry behavior by classifying errors and honoring server-provided
+/// throttling hints (e.g., HTTP Retry-After, gRPC RetryInfo).
+///
+/// Delays between retries adapt to the calling context: when running inside a Tokio
+/// runtime (gRPC/async HTTP exporters), `tokio::time::sleep` is used cooperatively;
+/// on a bare OS thread (the SDK's default batch processors), `std::thread::sleep`
+/// is used instead.
+///
+/// A time budget (deadline) bounds the total retry duration. If the budget is exhausted,
+/// the function returns the last error without further retries.
 ///
 /// # Arguments
 ///
-/// * `runtime` - The async runtime to use for delays.
 /// * `policy` - The retry policy configuration.
+/// * `deadline` - Maximum total time allowed for all retry attempts combined.
 /// * `error_classifier` - Function to classify errors for retry decisions.
 /// * `operation_name` - The name of the operation being retried.
 /// * `operation` - The operation to be retried.
@@ -98,69 +121,104 @@ fn generate_jitter(max_jitter: u64) -> u64 {
 ///
 /// A `Result` containing the operation's result or an error if max retries are reached
 /// or a non-retryable error occurs.
-#[cfg(any(
-    feature = "experimental-grpc-retry",
-    feature = "experimental-http-retry"
-))]
-pub async fn retry_with_backoff<R, F, Fut, T, E, C>(
-    runtime: R,
-    policy: RetryPolicy,
+pub async fn retry_with_backoff<F, Fut, T, E, C>(
+    policy: &RetryPolicy,
+    deadline: Duration,
     error_classifier: C,
     operation_name: &str,
     mut operation: F,
 ) -> Result<T, E>
 where
-    R: Runtime,
     F: FnMut() -> Fut,
     E: std::fmt::Debug,
     Fut: Future<Output = Result<T, E>>,
     C: Fn(&E) -> RetryErrorType,
 {
+    let start = Instant::now();
     let mut attempt = 0;
     let mut delay = policy.initial_delay_ms;
 
     loop {
         match operation().await {
-            Ok(result) => return Ok(result), // Return the result if the operation succeeds
+            Ok(result) => return Ok(result),
             Err(err) => {
-                // Classify the error
+                // Check time budget before deciding to retry
+                let elapsed = start.elapsed();
+                if elapsed >= deadline {
+                    otel_warn!(name: "Export.Failed.DeadlineExceeded",
+                        operation = operation_name,
+                        retries = attempt,
+                        elapsed_ms = elapsed.as_millis(),
+                        message = "OTLP export deadline exceeded - telemetry data will be lost"
+                    );
+                    return Err(err);
+                }
+
                 let error_type = error_classifier(&err);
 
                 match error_type {
                     RetryErrorType::NonRetryable => {
                         otel_warn!(name: "Export.Failed.NonRetryable",
                             operation = operation_name,
-                            message = "OTLP export failed with non-retryable error - telemetry data will be lost");
+                            message = "OTLP export failed with non-retryable error - telemetry data will be lost"
+                        );
                         return Err(err);
                     }
                     RetryErrorType::Retryable if attempt < policy.max_retries => {
                         attempt += 1;
-                        // Use exponential backoff with jitter
                         let jitter = generate_jitter(policy.jitter_ms);
-                        let delay_with_jitter = std::cmp::min(delay + jitter, policy.max_delay_ms);
+                        let delay_ms = std::cmp::min(delay + jitter, policy.max_delay_ms);
+                        let sleep_duration = Duration::from_millis(delay_ms);
+
+                        // Don't sleep longer than the remaining budget
+                        let remaining = deadline.saturating_sub(start.elapsed());
+                        let actual_sleep = sleep_duration.min(remaining);
+
+                        if actual_sleep.is_zero() {
+                            otel_warn!(name: "Export.Failed.DeadlineExceeded",
+                                operation = operation_name,
+                                retries = attempt,
+                                message = "OTLP export deadline exceeded during backoff - telemetry data will be lost"
+                            );
+                            return Err(err);
+                        }
+
                         otel_debug!(name: "Export.InProgress.Retrying",
                             operation = operation_name,
                             attempt = attempt,
-                            delay_ms = delay_with_jitter,
-                            jitter_ms = jitter,
+                            delay_ms = actual_sleep.as_millis(),
                             message = "OTLP export failed with retryable error - retrying"
                         );
-                        runtime
-                            .delay(Duration::from_millis(delay_with_jitter))
-                            .await;
-                        delay = std::cmp::min(delay * 2, policy.max_delay_ms); // Exponential backoff
+                        sleep_for(actual_sleep).await;
+                        delay = std::cmp::min(delay * 2, policy.max_delay_ms);
                     }
                     RetryErrorType::Throttled(server_delay) if attempt < policy.max_retries => {
                         attempt += 1;
-                        // Use server-specified delay (overrides exponential backoff)
+                        // Cap server-provided delay to prevent excessive blocking
+                        let capped_delay = server_delay.min(MAX_THROTTLE_DURATION);
+
+                        // Further constrain to remaining time budget
+                        let remaining = deadline.saturating_sub(start.elapsed());
+                        let actual_sleep = capped_delay.min(remaining);
+
+                        if actual_sleep.is_zero() {
+                            otel_warn!(name: "Export.Failed.DeadlineExceeded",
+                                operation = operation_name,
+                                retries = attempt,
+                                message = "OTLP export deadline exceeded during throttle - telemetry data will be lost"
+                            );
+                            return Err(err);
+                        }
+
                         otel_info!(name: "Export.InProgress.Throttled",
                             operation = operation_name,
                             attempt = attempt,
-                            delay_ms = server_delay.as_millis(),
+                            delay_ms = actual_sleep.as_millis(),
+                            server_requested_ms = server_delay.as_millis(),
                             message = "OTLP export throttled by OTLP endpoint - delaying and retrying"
                         );
-                        runtime.delay(server_delay).await;
-                        // Don't update exponential backoff delay for next attempt since server provided specific timing
+                        sleep_for(actual_sleep).await;
+                        // Don't update exponential backoff delay since server provided specific timing
                     }
                     _ => {
                         // Max retries reached
@@ -177,159 +235,36 @@ where
     }
 }
 
-/// No-op retry function for when experimental_async_runtime is not enabled.
-/// This function will execute the operation exactly once without any retries.
-#[cfg(not(any(
-    feature = "experimental-grpc-retry",
-    feature = "experimental-http-retry"
-)))]
-pub async fn retry_with_backoff<R, F, Fut, T, E, C>(
-    _runtime: R,
-    _policy: RetryPolicy,
-    _error_classifier: C,
-    _operation_name: &str,
-    mut operation: F,
-) -> Result<T, E>
-where
-    F: FnMut() -> Fut,
-    Fut: std::future::Future<Output = Result<T, E>>,
-{
-    // Without experimental_async_runtime, we just execute once without retries
-    operation().await
-}
-
-#[cfg(all(test, feature = "experimental-grpc-retry"))]
+#[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry_sdk::runtime::Tokio;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::time::Duration;
-    use tokio::time::timeout;
 
-    // Test to ensure generate_jitter returns a value within the expected range
-    #[tokio::test]
-    async fn test_generate_jitter() {
+    #[test]
+    fn test_generate_jitter() {
         let max_jitter = 100;
         let jitter = generate_jitter(max_jitter);
         assert!(jitter <= max_jitter);
     }
 
-    // Test to ensure retry_with_exponential_backoff succeeds on the first attempt
-    #[tokio::test]
-    async fn test_retry_with_exponential_backoff_success() {
-        let runtime = Tokio;
-        let policy = RetryPolicy {
-            max_retries: 3,
-            initial_delay_ms: 100,
-            max_delay_ms: 1600,
-            jitter_ms: 100,
-        };
-
-        let result = retry_with_backoff(
-            runtime,
-            policy,
-            |_: &()| RetryErrorType::Retryable,
-            "test_operation",
-            || Box::pin(async { Ok::<_, ()>("success") }),
-        )
-        .await;
-
-        assert_eq!(result, Ok("success"));
+    #[test]
+    fn test_default_retry_policy() {
+        let policy = RetryPolicy::default();
+        assert_eq!(policy.max_retries, 0);
+        assert_eq!(policy.initial_delay_ms, 100);
+        assert_eq!(policy.max_delay_ms, 1600);
+        assert_eq!(policy.jitter_ms, 100);
     }
 
-    // Test to ensure retry_with_exponential_backoff retries the operation and eventually succeeds
-    #[tokio::test]
-    async fn test_retry_with_exponential_backoff_retries() {
-        let runtime = Tokio;
-        let policy = RetryPolicy {
-            max_retries: 3,
-            initial_delay_ms: 100,
-            max_delay_ms: 1600,
-            jitter_ms: 100,
-        };
-
-        let attempts = AtomicUsize::new(0);
-
-        let result = retry_with_backoff(
-            runtime,
-            policy,
-            |_: &&str| RetryErrorType::Retryable,
-            "test_operation",
-            || {
-                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-                Box::pin(async move {
-                    if attempt < 2 {
-                        Err::<&str, &str>("error") // Fail the first two attempts
-                    } else {
-                        Ok::<&str, &str>("success") // Succeed on the third attempt
-                    }
-                })
-            },
-        )
-        .await;
-
-        assert_eq!(result, Ok("success"));
-        assert_eq!(attempts.load(Ordering::SeqCst), 3); // Ensure there were 3 attempts
+    #[test]
+    fn test_recommended_retry_policy() {
+        let policy = RetryPolicy::recommended();
+        assert_eq!(policy.max_retries, 3);
+        assert_eq!(policy.initial_delay_ms, 100);
+        assert_eq!(policy.max_delay_ms, 1600);
+        assert_eq!(policy.jitter_ms, 100);
     }
 
-    // Test to ensure retry_with_exponential_backoff fails after max retries
-    #[tokio::test]
-    async fn test_retry_with_exponential_backoff_failure() {
-        let runtime = Tokio;
-        let policy = RetryPolicy {
-            max_retries: 3,
-            initial_delay_ms: 100,
-            max_delay_ms: 1600,
-            jitter_ms: 100,
-        };
-
-        let attempts = AtomicUsize::new(0);
-
-        let result = retry_with_backoff(
-            runtime,
-            policy,
-            |_: &&str| RetryErrorType::Retryable,
-            "test_operation",
-            || {
-                attempts.fetch_add(1, Ordering::SeqCst);
-                Box::pin(async { Err::<(), _>("error") }) // Always fail
-            },
-        )
-        .await;
-
-        assert_eq!(result, Err("error"));
-        assert_eq!(attempts.load(Ordering::SeqCst), 4); // Ensure there were 4 attempts (initial + 3 retries)
-    }
-
-    // Test to ensure retry_with_exponential_backoff respects the timeout
-    #[tokio::test]
-    async fn test_retry_with_exponential_backoff_timeout() {
-        let runtime = Tokio;
-        let policy = RetryPolicy {
-            max_retries: 12, // Increase the number of retries
-            initial_delay_ms: 100,
-            max_delay_ms: 1600,
-            jitter_ms: 100,
-        };
-
-        let result = timeout(
-            Duration::from_secs(1),
-            retry_with_backoff(
-                runtime,
-                policy,
-                |_: &&str| RetryErrorType::Retryable,
-                "test_operation",
-                || {
-                    Box::pin(async { Err::<(), _>("error") }) // Always fail
-                },
-            ),
-        )
-        .await;
-
-        assert!(result.is_err()); // Ensure the operation times out
-    }
-
-    // Tests for error classification (Phase 1)
     #[test]
     fn test_retry_error_type_equality() {
         assert_eq!(RetryErrorType::NonRetryable, RetryErrorType::NonRetryable);
@@ -341,156 +276,205 @@ mod tests {
         assert_ne!(RetryErrorType::Retryable, RetryErrorType::NonRetryable);
     }
 
-    // Tests for enhanced retry function (Phase 3)
     #[tokio::test]
-    async fn test_retry_with_throttling_non_retryable_error() {
-        let runtime = Tokio;
-        let policy = RetryPolicy {
-            max_retries: 3,
-            initial_delay_ms: 100,
-            max_delay_ms: 1600,
-            jitter_ms: 100,
-        };
+    async fn test_retry_success_on_first_attempt() {
+        let policy = RetryPolicy::default();
+        let deadline = Duration::from_secs(10);
 
-        let attempts = AtomicUsize::new(0);
-
-        // Classifier that returns non-retryable
-        let classifier = |_: &()| RetryErrorType::NonRetryable;
-
-        let result = retry_with_backoff(runtime, policy, classifier, "test_operation", || {
-            attempts.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async { Err::<(), _>(()) }) // Always fail
-        })
-        .await;
-
-        assert!(result.is_err());
-        assert_eq!(attempts.load(Ordering::SeqCst), 1); // Should only try once
-    }
-
-    #[tokio::test]
-    async fn test_retry_with_throttling_retryable_error() {
-        let runtime = Tokio;
-        let policy = RetryPolicy {
-            max_retries: 2,
-            initial_delay_ms: 10, // Short delay for test
-            max_delay_ms: 100,
-            jitter_ms: 5,
-        };
-
-        let attempts = AtomicUsize::new(0);
-
-        // Classifier that returns retryable
-        let classifier = |_: &()| RetryErrorType::Retryable;
-
-        let result = retry_with_backoff(runtime, policy, classifier, "test_operation", || {
-            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async move {
-                if attempt < 1 {
-                    Err::<&str, ()>(()) // Fail first attempt
-                } else {
-                    Ok("success") // Succeed on retry
-                }
-            })
-        })
+        let result = retry_with_backoff(
+            &policy,
+            deadline,
+            |_: &()| RetryErrorType::Retryable,
+            "test_operation",
+            || Box::pin(async { Ok::<_, ()>("success") }),
+        )
         .await;
 
         assert_eq!(result, Ok("success"));
-        assert_eq!(attempts.load(Ordering::SeqCst), 2); // Should try twice
     }
 
     #[tokio::test]
-    async fn test_retry_with_throttling_throttled_error() {
-        let runtime = Tokio;
-        let policy = RetryPolicy {
-            max_retries: 2,
-            initial_delay_ms: 100,
-            max_delay_ms: 1600,
-            jitter_ms: 100,
-        };
-
-        let attempts = AtomicUsize::new(0);
-
-        // Classifier that returns throttled with short delay
-        let classifier = |_: &()| RetryErrorType::Throttled(Duration::from_millis(10));
-
-        let start_time = std::time::Instant::now();
-
-        let result = retry_with_backoff(runtime, policy, classifier, "test_operation", || {
-            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async move {
-                if attempt < 1 {
-                    Err::<&str, ()>(()) // Fail first attempt (will be throttled)
-                } else {
-                    Ok("success") // Succeed on retry
-                }
-            })
-        })
-        .await;
-
-        let elapsed = start_time.elapsed();
-
-        assert_eq!(result, Ok("success"));
-        assert_eq!(attempts.load(Ordering::SeqCst), 2); // Should try twice
-        assert!(elapsed >= Duration::from_millis(10)); // Should have waited for throttle delay
-    }
-
-    #[tokio::test]
-    async fn test_retry_with_throttling_max_attempts_exceeded() {
-        let runtime = Tokio;
-        let policy = RetryPolicy {
-            max_retries: 1, // Only 1 retry
-            initial_delay_ms: 10,
-            max_delay_ms: 100,
-            jitter_ms: 5,
-        };
-
-        let attempts = AtomicUsize::new(0);
-
-        // Classifier that returns retryable
-        let classifier = |_: &()| RetryErrorType::Retryable;
-
-        let result = retry_with_backoff(runtime, policy, classifier, "test_operation", || {
-            attempts.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async { Err::<(), _>(()) }) // Always fail
-        })
-        .await;
-
-        assert!(result.is_err());
-        assert_eq!(attempts.load(Ordering::SeqCst), 2); // Initial attempt + 1 retry
-    }
-
-    #[tokio::test]
-    async fn test_retry_with_throttling_mixed_error_types() {
-        let runtime = Tokio;
+    async fn test_retry_succeeds_after_retries() {
         let policy = RetryPolicy {
             max_retries: 3,
             initial_delay_ms: 10,
             max_delay_ms: 100,
             jitter_ms: 5,
         };
-
+        let deadline = Duration::from_secs(10);
         let attempts = AtomicUsize::new(0);
 
-        // Classifier that returns different types based on attempt number
-        let classifier = |err: &usize| match *err {
-            0 => RetryErrorType::Retryable,
-            1 => RetryErrorType::Throttled(Duration::from_millis(10)),
-            _ => RetryErrorType::Retryable,
-        };
-
-        let result = retry_with_backoff(runtime, policy, classifier, "test_operation", || {
-            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
-            Box::pin(async move {
-                if attempt < 2 {
-                    Err(attempt) // Return attempt number as error
-                } else {
-                    Ok("success") // Succeed on third attempt
-                }
-            })
-        })
+        let result = retry_with_backoff(
+            &policy,
+            deadline,
+            |_: &&str| RetryErrorType::Retryable,
+            "test_operation",
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move {
+                    if attempt < 2 {
+                        Err("error")
+                    } else {
+                        Ok("success")
+                    }
+                })
+            },
+        )
         .await;
 
         assert_eq!(result, Ok("success"));
-        assert_eq!(attempts.load(Ordering::SeqCst), 3); // Should try three times
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_retry_fails_after_max_retries() {
+        let policy = RetryPolicy {
+            max_retries: 3,
+            initial_delay_ms: 10,
+            max_delay_ms: 100,
+            jitter_ms: 5,
+        };
+        let deadline = Duration::from_secs(10);
+        let attempts = AtomicUsize::new(0);
+
+        let result = retry_with_backoff(
+            &policy,
+            deadline,
+            |_: &&str| RetryErrorType::Retryable,
+            "test_operation",
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async { Err::<(), _>("error") })
+            },
+        )
+        .await;
+
+        assert_eq!(result, Err("error"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 4); // initial + 3 retries
+    }
+
+    #[tokio::test]
+    async fn test_retry_non_retryable_stops_immediately() {
+        let policy = RetryPolicy::default();
+        let deadline = Duration::from_secs(10);
+        let attempts = AtomicUsize::new(0);
+
+        let result = retry_with_backoff(
+            &policy,
+            deadline,
+            |_: &()| RetryErrorType::NonRetryable,
+            "test_operation",
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async { Err::<(), _>(()) })
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_retry_throttled_uses_server_delay() {
+        let policy = RetryPolicy {
+            max_retries: 2,
+            initial_delay_ms: 1000, // high default delay
+            max_delay_ms: 5000,
+            jitter_ms: 0,
+        };
+        let deadline = Duration::from_secs(10);
+        let attempts = AtomicUsize::new(0);
+
+        let start = Instant::now();
+        let result = retry_with_backoff(
+            &policy,
+            deadline,
+            |_: &()| RetryErrorType::Throttled(Duration::from_millis(50)),
+            "test_operation",
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move {
+                    if attempt < 1 {
+                        Err(())
+                    } else {
+                        Ok("success")
+                    }
+                })
+            },
+        )
+        .await;
+
+        let elapsed = start.elapsed();
+        assert_eq!(result, Ok("success"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        // Should have waited ~50ms (the server delay), not 1000ms (the default)
+        assert!(elapsed >= Duration::from_millis(50));
+        assert!(elapsed < Duration::from_millis(200));
+    }
+
+    #[tokio::test]
+    async fn test_retry_deadline_exceeded() {
+        let policy = RetryPolicy {
+            max_retries: 100, // many retries allowed
+            initial_delay_ms: 50,
+            max_delay_ms: 200,
+            jitter_ms: 0,
+        };
+        // Very short deadline
+        let deadline = Duration::from_millis(120);
+        let attempts = AtomicUsize::new(0);
+
+        let start = Instant::now();
+        let result = retry_with_backoff(
+            &policy,
+            deadline,
+            |_: &()| RetryErrorType::Retryable,
+            "test_operation",
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async { Err::<(), _>(()) })
+            },
+        )
+        .await;
+
+        let elapsed = start.elapsed();
+        assert!(result.is_err());
+        // Should have stopped before exhausting 100 retries due to deadline
+        assert!(attempts.load(Ordering::SeqCst) < 10);
+        // Shouldn't have taken much longer than the deadline
+        assert!(elapsed < Duration::from_millis(300));
+    }
+
+    #[tokio::test]
+    async fn test_retry_throttle_capped_at_max() {
+        let policy = RetryPolicy {
+            max_retries: 2,
+            initial_delay_ms: 10,
+            max_delay_ms: 100,
+            jitter_ms: 0,
+        };
+        let attempts = AtomicUsize::new(0);
+
+        let start = Instant::now();
+        // Server requests 120s delay (exceeds MAX_THROTTLE_DURATION of 30s)
+        // But deadline is short so we don't wait 30s in tests
+        let short_deadline = Duration::from_millis(200);
+        let result = retry_with_backoff(
+            &policy,
+            short_deadline,
+            |_: &()| RetryErrorType::Throttled(Duration::from_secs(120)),
+            "test_operation",
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async { Err::<(), _>(()) })
+            },
+        )
+        .await;
+
+        let elapsed = start.elapsed();
+        assert!(result.is_err());
+        // Should be capped by the deadline, not sleep for 120s or even 30s
+        assert!(elapsed < Duration::from_millis(500));
     }
 }

--- a/opentelemetry-otlp/src/retry_classification.rs
+++ b/opentelemetry-otlp/src/retry_classification.rs
@@ -65,7 +65,8 @@ pub mod http {
             return Some(Duration::from_secs(capped_seconds));
         }
 
-        // Try parsing as HTTP date
+        // Try parsing as HTTP date (requires httpdate crate)
+        #[cfg(feature = "httpdate")]
         if let Ok(delay_seconds) = parse_http_date_to_delay(retry_after) {
             // Cap at 10 minutes. TODO - what's sensible here?
             let capped_seconds = delay_seconds.min(600);
@@ -76,6 +77,7 @@ pub mod http {
     }
 
     /// Parses HTTP date format and returns delay in seconds from now.
+    #[cfg(feature = "httpdate")]
     fn parse_http_date_to_delay(date_str: &str) -> Result<u64, ()> {
         use std::time::SystemTime;
 
@@ -221,7 +223,7 @@ mod tests {
         }
 
         #[test]
-
+        #[cfg(feature = "httpdate")]
         fn test_http_429_with_retry_after_valid_date() {
             use std::time::SystemTime;
 
@@ -243,14 +245,14 @@ mod tests {
         }
 
         #[test]
-
+        #[cfg(feature = "httpdate")]
         fn test_http_429_with_retry_after_invalid_date() {
             let result = classify_http_error(429, Some("Not a valid date"));
             assert_eq!(result, RetryErrorType::Retryable); // Falls back to retryable
         }
 
         #[test]
-
+        #[cfg(feature = "httpdate")]
         fn test_http_429_with_retry_after_malformed_date() {
             let result = classify_http_error(429, Some("Sun, 99 Nov 9999 99:99:99 GMT"));
             assert_eq!(result, RetryErrorType::Retryable); // Falls back to retryable

--- a/opentelemetry-otlp/src/retry_classification.rs
+++ b/opentelemetry-otlp/src/retry_classification.rs
@@ -163,7 +163,7 @@ pub mod grpc {
 #[cfg(test)]
 mod tests {
     // Tests for HTTP error classification
-    
+
     mod http_tests {
         use crate::retry::RetryErrorType;
         use crate::retry_classification::http::*;
@@ -221,7 +221,7 @@ mod tests {
         }
 
         #[test]
-        
+
         fn test_http_429_with_retry_after_valid_date() {
             use std::time::SystemTime;
 
@@ -243,14 +243,14 @@ mod tests {
         }
 
         #[test]
-        
+
         fn test_http_429_with_retry_after_invalid_date() {
             let result = classify_http_error(429, Some("Not a valid date"));
             assert_eq!(result, RetryErrorType::Retryable); // Falls back to retryable
         }
 
         #[test]
-        
+
         fn test_http_429_with_retry_after_malformed_date() {
             let result = classify_http_error(429, Some("Sun, 99 Nov 9999 99:99:99 GMT"));
             assert_eq!(result, RetryErrorType::Retryable); // Falls back to retryable

--- a/opentelemetry-otlp/src/retry_classification.rs
+++ b/opentelemetry-otlp/src/retry_classification.rs
@@ -13,7 +13,6 @@ use tonic;
 use tonic_types::StatusExt;
 
 /// HTTP-specific error classification with Retry-After header support.
-#[cfg(feature = "experimental-http-retry")]
 pub mod http {
     use super::*;
     use std::time::Duration;
@@ -164,7 +163,7 @@ pub mod grpc {
 #[cfg(test)]
 mod tests {
     // Tests for HTTP error classification
-    #[cfg(feature = "experimental-http-retry")]
+    
     mod http_tests {
         use crate::retry::RetryErrorType;
         use crate::retry_classification::http::*;
@@ -222,7 +221,7 @@ mod tests {
         }
 
         #[test]
-        #[cfg(feature = "experimental-http-retry")]
+        
         fn test_http_429_with_retry_after_valid_date() {
             use std::time::SystemTime;
 
@@ -244,14 +243,14 @@ mod tests {
         }
 
         #[test]
-        #[cfg(feature = "experimental-http-retry")]
+        
         fn test_http_429_with_retry_after_invalid_date() {
             let result = classify_http_error(429, Some("Not a valid date"));
             assert_eq!(result, RetryErrorType::Retryable); // Falls back to retryable
         }
 
         #[test]
-        #[cfg(feature = "experimental-http-retry")]
+        
         fn test_http_429_with_retry_after_malformed_date() {
             let result = classify_http_error(429, Some("Sun, 99 Nov 9999 99:99:99 GMT"));
             assert_eq!(result, RetryErrorType::Retryable); // Falls back to retryable


### PR DESCRIPTION
Retry with exponential backoff is a spec MUST for OTLP exporters, but until now it only worked behind `experimental-grpc-retry` / `experimental-http-retry` feature flags. Those flags existed because the retry implementation depended on the SDK's experimental `Runtime` trait just to sleep between attempts.

This PR removes that dependency entirely:

- Replaces `Runtime::delay()` with a small internal `sleep_for()` helper that uses `tokio::time::sleep` when inside a Tokio runtime, or `std::thread::sleep` on bare OS threads
- Adds a time budget (deadline = exporter timeout) to cap total retry duration
- Caps server-provided throttle delays (Retry-After / RetryInfo) at 30s
- Removes the `experimental-grpc-retry` and `experimental-http-retry` feature flags

The default `RetryPolicy` has `max_retries: 0` (no retry), so this is not a behaviour change out of the box. Users opt in with `.with_retry_policy(RetryPolicy::recommended())` or a custom policy. We can flip the default in a couple versions, but for now we're aiming to hit the feature requirements of the OTLP exporters with a safe change.

The adaptive sleep means both paths work correctly:
- Default batch processors (dedicated OS thread, no Tokio reactor) → `std::thread::sleep`
- Async processors / gRPC with tonic (Tokio runtime present) → cooperative `tokio::time::sleep`

This is overall a simplification - no new public traits, feature flags, or deps, net loss of about 150 LoC. 


Relates to #3061

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
