### PR TITLE
ci: align codeql-action steps to v4.37.3 to fix version mismatch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
         submodules: true
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       with:
         languages: rust
 
@@ -43,4 +43,4 @@ jobs:
       uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3


### PR DESCRIPTION
## Motivation

CodeQL Analysis has been failing on `main` (and consequently on every open PR) since 2026-08-05 with:

```
We were unable to automatically build your code. Please replace the call to the autobuild action with your custom build steps. Loaded a configuration file for version '4.36.2', but running version '4.37.3'
```

The three `github/codeql-action` steps had drifted to three different versions because Dependabot bumped them in separate PRs (#3580, #3613, #3615): `init` was pinned to v4.36.2, `autobuild` to v4.37.3, and `analyze` to v4.37.4. `init` writes a config for its version, and `autobuild`/`analyze` refuse to run against a config from a different version, breaking the job.

## Changes

Align all three `codeql-action` steps to the same pinned SHA `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` (v4.37.3). This mirrors the same fix already applied in `opentelemetry-rust-contrib`.

- `init`: v4.36.2 → v4.37.3
- `autobuild`: already v4.37.3 (unchanged)
- `analyze`: v4.37.4 → v4.37.3