### PR TITLE
feat(sdk): add flight recorder log processor

### DIFF
--- a/examples/logs-flight-recorder/Cargo.toml
+++ b/examples/logs-flight-recorder/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "logs-flight-recorder"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+rust-version = "1.75.0"
+publish = false
+autobenches = false
+
+[[bin]]
+name = "logs-flight-recorder"
+path = "src/main.rs"
+bench = false
+
+[dependencies]
+http-body-util = { workspace = true }
+hyper = { workspace = true, features = ["full"] }
+hyper-util = { workspace = true, features = ["full"] }
+opentelemetry = { workspace = true, features = ["logs"] }
+opentelemetry-appender-tracing = { workspace = true }
+opentelemetry-otlp = { workspace = true, features = ["http-proto", "logs", "reqwest-blocking-client"] }
+opentelemetry_sdk = { workspace = true, features = ["experimental_logs_flight_recorder", "logs"] }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true, features = ["std"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "registry", "std"] }
+url = { workspace = true }
+
+[dev-dependencies]
+opentelemetry-proto = { workspace = true, features = ["gen-tonic-messages", "logs"] }
+prost = { workspace = true }
+
+[lints]
+workspace = true

--- a/examples/logs-flight-recorder/README.md
+++ b/examples/logs-flight-recorder/README.md
@@ -94,6 +94,18 @@ if result.is_err() {
 }
 ```
 
+`trigger()` waits for the wrapped processor's `force_flush` and is appropriate
+when completion must be observed before continuing. `handoff()` only submits the
+snapshot to the wrapped processor. It avoids waiting for exporter completion,
+but remains synchronous around recorder locks and delegate `emit` calls. Both
+operations are serialized with other triggers. Because `handoff()` does not
+pre-flush a bounded delegate queue, the application must account for records
+already queued when sizing that queue. It also does not preserve submission
+order between records already on the delegate's normal path and the older
+snapshot: consumers should use record timestamps for ordering. `trigger()`
+pre-flushes normal-path records before replay, but those newer records can
+therefore still arrive before the older snapshot.
+
 When wrapping a batch processor, its queue should have at least as many free
 slots as the maximum snapshot from one scope. This example configures both
 limits to the same record count. Estimated byte limits provide the primary
@@ -191,6 +203,8 @@ configurable.
 - Each operation scope has its own ring buffer.
 - Triggering drains that scope and switches it to passthrough so subsequent
   records follow the normal path.
+- `handoff` submits a snapshot without flushing; `trigger` additionally
+  pre-flushes and flushes after replay.
 - Dropping or discarding an untriggered scope loses its buffered records.
 - Logs without an attached scope follow the normal path.
 - Independently spawned tasks must explicitly use the same scope's

--- a/examples/logs-flight-recorder/README.md
+++ b/examples/logs-flight-recorder/README.md
@@ -1,0 +1,140 @@
+# OpenTelemetry Logs Flight Recorder
+
+The flight recorder keeps recent logs in memory and exports them only when an
+application-defined trigger fires. It is useful when detailed logs are valuable
+during failures but are unlikely to be useful for successful operations.
+
+Applications can continue producing detailed diagnostic logs without paying the
+storage and ingestion cost for every record. Routine logs remain in a bounded
+ring buffer and are overwritten as newer records arrive. When an error, timeout,
+or other suspicious condition occurs, the application triggers the recorder and
+exports the recent context leading up to that condition.
+
+This is an experimental prototype enabled by the
+`experimental_logs_flight_recorder` feature.
+
+## How it works
+
+The `FlightRecorderLogProcessor` wraps another `LogProcessor`, such as a
+`BatchLogProcessor`:
+
+```text
+application logs
+      |
+      v
+FlightRecorderLogProcessor
+  bounded in-memory ring buffer
+      |
+      | only after a trigger
+      v
+BatchLogProcessor
+      |
+      v
+OTLP exporter
+```
+
+Creating the processor also returns a cloneable `FlightRecorderTrigger`. The
+handle can be passed to application logic, request handlers, health monitors, or
+controllers that know when the retained logs should be exported.
+
+```rust
+use opentelemetry_sdk::logs::{
+    BatchConfigBuilder, BatchLogProcessor, FlightRecorderLogProcessor,
+    SdkLoggerProvider,
+};
+
+const MAX_RECORDS: usize = 1_024;
+
+let batch_processor = BatchLogProcessor::builder(exporter)
+    .with_batch_config(
+        BatchConfigBuilder::default()
+            .with_max_queue_size(MAX_RECORDS)
+            .build(),
+    )
+    .build();
+
+let (flight_recorder, trigger) =
+    FlightRecorderLogProcessor::builder(batch_processor)
+        .with_max_records(MAX_RECORDS)
+        .build();
+
+let logger_provider = SdkLoggerProvider::builder()
+    .with_log_processor(flight_recorder)
+    .build();
+
+// Application code decides when the retained context is valuable.
+if operation_failed {
+    trigger.trigger()?;
+}
+```
+
+When wrapping a batch processor, its queue should have at least as many free
+slots as the maximum flight-recorder snapshot. This example configures both
+limits to the same record count.
+
+## Running the demo
+
+The demo is a small Hyper application that exports triggered logs to an OTLP
+HTTP endpoint. Start an OpenTelemetry Collector or another OTLP-compatible
+backend, then run:
+
+```shell
+OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://localhost:4318/v1/logs \
+cargo run -p logs-flight-recorder
+```
+
+The server listens on `127.0.0.1:3000` by default.
+
+A successful request generates logs but does not export them:
+
+```shell
+curl "http://127.0.0.1:3000/work?result=ok&logs=5&request_id=successful"
+```
+
+A failing request records its own logs and triggers the current snapshot:
+
+```shell
+curl "http://127.0.0.1:3000/work?result=error&logs=5&request_id=failing"
+```
+
+The exported snapshot can include logs from the earlier successful request.
+This is expected because the prototype uses one application-wide buffer rather
+than a separate buffer for each request. Every demo log includes a
+`request_id` attribute so interleaved requests can be distinguished.
+
+Configuration:
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `FLIGHT_RECORDER_LISTEN_ADDR` | `127.0.0.1:3000` | Demo HTTP listen address |
+| `FLIGHT_RECORDER_MAX_RECORDS` | `64` | Maximum retained log records |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | OTLP exporter default | OTLP logs endpoint |
+
+## Trigger ideas
+
+The trigger is deliberately independent of any Rust web framework. Applications
+can invoke it when:
+
+- a request or background job fails;
+- an operation exceeds a latency threshold;
+- a circuit breaker opens;
+- a health check detects degradation;
+- business logic encounters an unexpected state.
+
+High-severity logs that must always be delivered can use a separate processor.
+The flight recorder can then retain verbose contextual logs for selective
+export.
+
+## Prototype semantics and limitations
+
+- Capacity is based on record count, not estimated encoded bytes.
+- The oldest records are overwritten when the buffer is full.
+- Triggering drains the current snapshot. Logs arriving during replay are kept
+  for the next trigger.
+- `force_flush` also triggers and exports the current snapshot.
+- Untriggered records are discarded during shutdown.
+- Snapshot handoff is at-most-once and best-effort because the wrapped
+  `LogProcessor::emit` API cannot report whether each record was accepted.
+- The buffer is application-wide per processor instance. Per-request or
+  operation-scoped buffers are not implemented.
+

--- a/examples/logs-flight-recorder/README.md
+++ b/examples/logs-flight-recorder/README.md
@@ -55,7 +55,7 @@ use opentelemetry_sdk::logs::{
 };
 use opentelemetry::logs::Severity;
 
-const MAX_RECORDS: usize = 1_024;
+const MAX_RECORDS: usize = 256;
 
 let batch_processor = BatchLogProcessor::builder(exporter)
     .with_batch_config(
@@ -68,7 +68,10 @@ let batch_processor = BatchLogProcessor::builder(exporter)
 let (flight_recorder, recorder) =
     ScopedFlightRecorderLogProcessor::builder(batch_processor)
         .with_max_records_per_scope(MAX_RECORDS)
-        .with_max_active_scopes(1_024)
+        .with_max_active_scopes(128)
+        .with_max_buffer_size_bytes_per_scope(256 * 1024)
+        .with_max_total_buffer_size_bytes(16 * 1024 * 1024)
+        .with_max_record_size_bytes(64 * 1024)
         .with_max_buffered_severity(Severity::Info4)
         .build();
 
@@ -92,8 +95,9 @@ if result.is_err() {
 
 When wrapping a batch processor, its queue should have at least as many free
 slots as the maximum snapshot from one scope. This example configures both
-limits to the same record count. The active-scope limit bounds total memory
-usage under high request concurrency.
+limits to the same record count. Estimated byte limits provide the primary
+memory bounds: each scope defaults to 256 KiB, all scopes share a 16 MiB
+aggregate budget, and records estimated above 64 KiB bypass buffering.
 
 ## Running the demo
 
@@ -148,7 +152,10 @@ Configuration:
 | --- | --- | --- |
 | `FLIGHT_RECORDER_LISTEN_ADDR` | `127.0.0.1:3000` | Demo HTTP listen address |
 | `FLIGHT_RECORDER_MAX_RECORDS` | `64` | Maximum retained records per request |
-| `FLIGHT_RECORDER_MAX_ACTIVE_SCOPES` | `1024` | Maximum concurrent request scopes |
+| `FLIGHT_RECORDER_MAX_ACTIVE_SCOPES` | `128` | Maximum concurrent request scopes |
+| `FLIGHT_RECORDER_MAX_BUFFER_BYTES_PER_SCOPE` | `262144` | Maximum estimated retained bytes per request |
+| `FLIGHT_RECORDER_MAX_TOTAL_BUFFER_BYTES` | `16777216` | Aggregate estimated retained bytes across requests |
+| `FLIGHT_RECORDER_MAX_RECORD_BYTES` | `65536` | Records above this estimated size bypass buffering |
 | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | OTLP exporter default | OTLP logs endpoint |
 
 ## Trigger ideas
@@ -169,7 +176,10 @@ configurable.
 
 ## Prototype semantics and limitations
 
-- Capacity is based on record count, not estimated encoded bytes.
+- Capacity is bounded by both record count and a conservative in-memory size
+  estimate. This is not the serialized OTLP size.
+- When the aggregate scoped byte budget is exhausted, new low-severity records
+  bypass buffering and follow the normal export path.
 - INFO and lower-severity records are buffered by default; WARN and higher
   records bypass the buffer.
 - The oldest records are overwritten when the buffer is full.

--- a/examples/logs-flight-recorder/README.md
+++ b/examples/logs-flight-recorder/README.md
@@ -106,6 +106,27 @@ snapshot: consumers should use record timestamps for ordering. `trigger()`
 pre-flushes normal-path records before replay, but those newer records can
 therefore still arrive before the older snapshot.
 
+For the common `Result` workflow, `record_on_error` manages the scope
+automatically:
+
+```rust
+let result = recorder
+    .record_on_error(async {
+        run_operation().await
+    })
+    .await;
+```
+
+An `Ok` result discards the snapshot. An `Err` result hands it off and returns
+`ScopedFlightRecorderOperationError::Operation`; admission and handoff failures
+have separate variants that preserve the original operation error. This helper
+uses handoff rather than flush-completing `trigger()` so it remains independent
+of runtime-specific flush or blocking APIs. Handoff submits the snapshot but
+does not confirm OTLP export completion; short-lived applications must still
+flush or shut down their logger provider before exiting. The delegate's `emit`
+implementation can still block, and cancelling the helper discards the
+in-progress snapshot.
+
 When wrapping a batch processor, its queue should have at least as many free
 slots as the maximum snapshot from one scope. This example configures both
 limits to the same record count. Estimated byte limits provide the primary

--- a/examples/logs-flight-recorder/README.md
+++ b/examples/logs-flight-recorder/README.md
@@ -171,6 +171,21 @@ Configuration:
 | `FLIGHT_RECORDER_MAX_RECORD_BYTES` | `65536` | Records above this estimated size bypass buffering |
 | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | OTLP exporter default | OTLP logs endpoint |
 
+## Self-observability
+
+When `experimental_metrics_bound_instruments` is also enabled, recorder
+instances emit SDK metrics through the global meter provider:
+
+- `otel.sdk.processor.log.flight_recorder.records` counts buffered, evicted,
+  replayed, oversized, and capacity-overflow records using the `action`
+  attribute.
+- `otel.sdk.processor.log.flight_recorder.events` counts scope admission,
+  rejection, discard, trigger, and handoff events.
+
+Both experimental, recorder-specific metrics include the conventional
+`otel.component.type` and a unique `otel.component.name` used by other SDK
+processor metrics.
+
 ## Trigger ideas
 
 Scopes are deliberately independent of any Rust web framework. Applications

--- a/examples/logs-flight-recorder/README.md
+++ b/examples/logs-flight-recorder/README.md
@@ -51,7 +51,7 @@ boundary.
 ```rust
 use opentelemetry_sdk::logs::{
     BatchConfigBuilder, BatchLogProcessor, ScopedFlightRecorderLogProcessor,
-    SdkLoggerProvider,
+    ScopedFlightRecorderOverflowPolicy, SdkLoggerProvider,
 };
 use opentelemetry::logs::Severity;
 
@@ -72,6 +72,7 @@ let (flight_recorder, recorder) =
         .with_max_buffer_size_bytes_per_scope(256 * 1024)
         .with_max_total_buffer_size_bytes(16 * 1024 * 1024)
         .with_max_record_size_bytes(64 * 1024)
+        .with_overflow_policy(ScopedFlightRecorderOverflowPolicy::Drop)
         .with_max_buffered_severity(Severity::Info4)
         .build();
 
@@ -79,7 +80,7 @@ let logger_provider = SdkLoggerProvider::builder()
     .with_log_processor(flight_recorder)
     .build();
 
-let operation = recorder.try_start().expect("scope capacity available");
+let operation = recorder.try_start()?;
 let result = operation
     .with_context(async {
         run_operation().await
@@ -179,7 +180,11 @@ configurable.
 - Capacity is bounded by both record count and a conservative in-memory size
   estimate. This is not the serialized OTLP size.
 - When the aggregate scoped byte budget is exhausted, new low-severity records
-  bypass buffering and follow the normal export path.
+  are dropped by default, preserving the expected ingestion-cost bound. Set
+  `ScopedFlightRecorderOverflowPolicy::Export` to send them through the wrapped
+  processor instead.
+- Scope admission reports whether the active-scope limit was reached, the
+  processor was shut down, or an internal registry failure occurred.
 - INFO and lower-severity records are buffered by default; WARN and higher
   records bypass the buffer.
 - The oldest records are overwritten when the buffer is full.

--- a/examples/logs-flight-recorder/README.md
+++ b/examples/logs-flight-recorder/README.md
@@ -13,18 +13,28 @@ exports the recent context leading up to that condition.
 This is an experimental prototype enabled by the
 `experimental_logs_flight_recorder` feature.
 
-## How it works
+The SDK prototype provides two variants:
 
-The `FlightRecorderLogProcessor` wraps another `LogProcessor`, such as a
+- `FlightRecorderLogProcessor` maintains one application-wide buffer.
+- `ScopedFlightRecorderLogProcessor` maintains an isolated buffer for each
+  explicitly created operation scope.
+
+The demo uses scoped recording to model concurrent HTTP requests without
+coupling the SDK API to a particular Rust web framework.
+
+## How scoped recording works
+
+The `ScopedFlightRecorderLogProcessor` wraps another `LogProcessor`, such as a
 `BatchLogProcessor`:
 
 ```text
 application logs
       |
       v
-FlightRecorderLogProcessor
-  INFO and lower: bounded ring buffer
+ScopedFlightRecorderLogProcessor
+  INFO and lower with context: per-operation ring buffer
   WARN and higher: direct path
+  logs without a scope: direct path
       |
       | only after a trigger
       v
@@ -34,13 +44,13 @@ BatchLogProcessor
 OTLP exporter
 ```
 
-Creating the processor also returns a cloneable `FlightRecorderTrigger`. The
-handle can be passed to application logic, request handlers, health monitors, or
-controllers that know when the retained logs should be exported.
+Creating the processor also returns a cloneable `ScopedFlightRecorder` handle.
+Applications use it to create a scope at a request, job, RPC, or message
+boundary.
 
 ```rust
 use opentelemetry_sdk::logs::{
-    BatchConfigBuilder, BatchLogProcessor, FlightRecorderLogProcessor,
+    BatchConfigBuilder, BatchLogProcessor, ScopedFlightRecorderLogProcessor,
     SdkLoggerProvider,
 };
 use opentelemetry::logs::Severity;
@@ -55,9 +65,10 @@ let batch_processor = BatchLogProcessor::builder(exporter)
     )
     .build();
 
-let (flight_recorder, trigger) =
-    FlightRecorderLogProcessor::builder(batch_processor)
-        .with_max_records(MAX_RECORDS)
+let (flight_recorder, recorder) =
+    ScopedFlightRecorderLogProcessor::builder(batch_processor)
+        .with_max_records_per_scope(MAX_RECORDS)
+        .with_max_active_scopes(1_024)
         .with_max_buffered_severity(Severity::Info4)
         .build();
 
@@ -65,15 +76,24 @@ let logger_provider = SdkLoggerProvider::builder()
     .with_log_processor(flight_recorder)
     .build();
 
-// Application code decides when the retained context is valuable.
-if operation_failed {
-    trigger.trigger()?;
+let operation = recorder.try_start().expect("scope capacity available");
+let result = operation
+    .with_context(async {
+        run_operation().await
+    })
+    .await;
+
+if result.is_err() {
+    operation.trigger()?;
+} else {
+    operation.discard();
 }
 ```
 
 When wrapping a batch processor, its queue should have at least as many free
-slots as the maximum flight-recorder snapshot. This example configures both
-limits to the same record count.
+slots as the maximum snapshot from one scope. This example configures both
+limits to the same record count. The active-scope limit bounds total memory
+usage under high request concurrency.
 
 ## Running the demo
 
@@ -88,14 +108,16 @@ cargo run -p logs-flight-recorder
 
 The server listens on `127.0.0.1:3000` by default.
 
-A successful request generates logs but does not export them:
+A successful request generates scoped INFO logs and discards them when the
+request completes:
 
 ```shell
 curl "http://127.0.0.1:3000/work?result=ok&logs=5&request_id=successful"
 ```
 
-A warning request demonstrates the normal export path. Its INFO records remain
-buffered, while its WARN record is handed directly to the batch processor:
+A warning request demonstrates the normal export path. Its INFO records are
+discarded with the successful scope, while its WARN record is handed directly
+to the batch processor:
 
 ```shell
 curl "http://127.0.0.1:3000/work?result=warn&logs=5&request_id=warning"
@@ -107,23 +129,32 @@ A failing request records its own logs and triggers the current snapshot:
 curl "http://127.0.0.1:3000/work?result=error&logs=5&request_id=failing"
 ```
 
-The exported snapshot can include logs from the earlier successful request.
-This is expected because the prototype uses one application-wide buffer rather
-than a separate buffer for each request. Every demo log includes a
-`request_id` attribute so interleaved requests can be distinguished.
+Only the failing request's buffered INFO records are exported. Logs from
+successful or concurrently executing requests remain isolated in their own
+scopes.
+
+Use `delay_ms` to make concurrent request isolation easy to observe:
+
+```shell
+curl "http://127.0.0.1:3000/work?result=ok&logs=5&delay_ms=200&request_id=slow-success" &
+curl "http://127.0.0.1:3000/work?result=error&logs=2&request_id=failure"
+```
+
+The failure snapshot contains only records with `request_id=failure`.
 
 Configuration:
 
 | Environment variable | Default | Description |
 | --- | --- | --- |
 | `FLIGHT_RECORDER_LISTEN_ADDR` | `127.0.0.1:3000` | Demo HTTP listen address |
-| `FLIGHT_RECORDER_MAX_RECORDS` | `64` | Maximum retained log records |
+| `FLIGHT_RECORDER_MAX_RECORDS` | `64` | Maximum retained records per request |
+| `FLIGHT_RECORDER_MAX_ACTIVE_SCOPES` | `1024` | Maximum concurrent request scopes |
 | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | OTLP exporter default | OTLP logs endpoint |
 
 ## Trigger ideas
 
-The trigger is deliberately independent of any Rust web framework. Applications
-can invoke it when:
+Scopes are deliberately independent of any Rust web framework. Applications
+can create and trigger them around:
 
 - a request or background job fails;
 - an operation exceeds a latency threshold;
@@ -142,11 +173,16 @@ configurable.
 - INFO and lower-severity records are buffered by default; WARN and higher
   records bypass the buffer.
 - The oldest records are overwritten when the buffer is full.
-- Triggering drains the current snapshot. Logs arriving during replay are kept
-  for the next trigger.
-- `force_flush` also triggers and exports the current snapshot.
+- Each operation scope has its own ring buffer.
+- Triggering drains that scope and switches it to passthrough so subsequent
+  records follow the normal path.
+- Dropping or discarding an untriggered scope loses its buffered records.
+- Logs without an attached scope follow the normal path.
+- Independently spawned tasks must explicitly use the same scope's
+  `with_context` wrapper.
+- `force_flush` triggers and exports all currently active scoped snapshots.
 - Untriggered records are discarded during shutdown.
 - Snapshot handoff is at-most-once and best-effort because the wrapped
   `LogProcessor::emit` API cannot report whether each record was accepted.
-- The buffer is application-wide per processor instance. Per-request or
-  operation-scoped buffers are not implemented.
+- The global `FlightRecorderLogProcessor` remains available when one shared
+  application-wide history is preferred.

--- a/examples/logs-flight-recorder/README.md
+++ b/examples/logs-flight-recorder/README.md
@@ -23,7 +23,8 @@ application logs
       |
       v
 FlightRecorderLogProcessor
-  bounded in-memory ring buffer
+  INFO and lower: bounded ring buffer
+  WARN and higher: direct path
       |
       | only after a trigger
       v
@@ -42,6 +43,7 @@ use opentelemetry_sdk::logs::{
     BatchConfigBuilder, BatchLogProcessor, FlightRecorderLogProcessor,
     SdkLoggerProvider,
 };
+use opentelemetry::logs::Severity;
 
 const MAX_RECORDS: usize = 1_024;
 
@@ -56,6 +58,7 @@ let batch_processor = BatchLogProcessor::builder(exporter)
 let (flight_recorder, trigger) =
     FlightRecorderLogProcessor::builder(batch_processor)
         .with_max_records(MAX_RECORDS)
+        .with_max_buffered_severity(Severity::Info4)
         .build();
 
 let logger_provider = SdkLoggerProvider::builder()
@@ -91,6 +94,13 @@ A successful request generates logs but does not export them:
 curl "http://127.0.0.1:3000/work?result=ok&logs=5&request_id=successful"
 ```
 
+A warning request demonstrates the normal export path. Its INFO records remain
+buffered, while its WARN record is handed directly to the batch processor:
+
+```shell
+curl "http://127.0.0.1:3000/work?result=warn&logs=5&request_id=warning"
+```
+
 A failing request records its own logs and triggers the current snapshot:
 
 ```shell
@@ -121,13 +131,16 @@ can invoke it when:
 - a health check detects degradation;
 - business logic encounters an unexpected state.
 
-High-severity logs that must always be delivered can use a separate processor.
-The flight recorder can then retain verbose contextual logs for selective
-export.
+By default, the flight recorder buffers the TRACE, DEBUG, and INFO severity
+ranges. WARN, ERROR, and FATAL records bypass the ring buffer and follow the
+wrapped processor's normal export path. The maximum buffered severity is
+configurable.
 
 ## Prototype semantics and limitations
 
 - Capacity is based on record count, not estimated encoded bytes.
+- INFO and lower-severity records are buffered by default; WARN and higher
+  records bypass the buffer.
 - The oldest records are overwritten when the buffer is full.
 - Triggering drains the current snapshot. Logs arriving during replay are kept
   for the next trigger.
@@ -137,4 +150,3 @@ export.
   `LogProcessor::emit` API cannot report whether each record was accepted.
 - The buffer is application-wide per processor instance. Per-request or
   operation-scoped buffers are not implemented.
-

--- a/examples/logs-flight-recorder/README.md
+++ b/examples/logs-flight-recorder/README.md
@@ -207,6 +207,17 @@ Both experimental, recorder-specific metrics include the conventional
 `otel.component.type` and a unique `otel.component.name` used by other SDK
 processor metrics.
 
+## Benchmarks
+
+The SDK includes Criterion coverage for global buffered/bypass emits and the
+combined scoped context-propagation plus buffered-emit path:
+
+```shell
+cargo bench -p opentelemetry_sdk \
+  --features experimental_logs_flight_recorder \
+  --bench flight_recorder
+```
+
 ## Trigger ideas
 
 Scopes are deliberately independent of any Rust web framework. Applications

--- a/examples/logs-flight-recorder/src/main.rs
+++ b/examples/logs-flight-recorder/src/main.rs
@@ -8,7 +8,7 @@ use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{LogExporter, Protocol, WithExportConfig};
 use opentelemetry_sdk::logs::{
     BatchConfigBuilder, BatchLogProcessor, ScopedFlightRecorder, ScopedFlightRecorderLogProcessor,
-    SdkLoggerProvider,
+    ScopedFlightRecorderOperationError, SdkLoggerProvider,
 };
 use opentelemetry_sdk::Resource;
 use std::convert::Infallible;
@@ -176,15 +176,9 @@ async fn handle_request(
         Outcome::Warn => "warn",
         Outcome::Error => "error",
     };
-    let recording_scope = match state.recorder.try_start() {
-        Ok(scope) => scope,
-        Err(err) => {
-            return Ok(response(StatusCode::SERVICE_UNAVAILABLE, err.to_string()));
-        }
-    };
-
-    recording_scope
-        .with_context(async {
+    let recorded = state
+        .recorder
+        .record_on_error(async {
             for step in 1..=work.log_count {
                 info!(
                     target: "flight_recorder_demo",
@@ -216,42 +210,50 @@ async fn handle_request(
                     "request failed; triggering the flight recorder"
                 );
             }
+
+            if work.outcome == Outcome::Error {
+                Err("request failed")
+            } else {
+                Ok(())
+            }
         })
         .await;
 
-    if work.outcome == Outcome::Ok {
-        recording_scope.discard();
-        return Ok(response(
+    match recorded {
+        Ok(()) if work.outcome == Outcome::Ok => Ok(response(
             StatusCode::OK,
             format!(
                 "request {} completed; scoped logs discarded",
                 work.request_id
             ),
-        ));
-    }
-
-    if work.outcome == Outcome::Warn {
-        recording_scope.discard();
-        return Ok(response(
+        )),
+        Ok(()) => Ok(response(
             StatusCode::OK,
             format!(
                 "request {} completed; warning followed the normal export path",
                 work.request_id
             ),
-        ));
-    }
-
-    match tokio::task::block_in_place(|| recording_scope.trigger()) {
-        Ok(()) => Ok(response(
+        )),
+        Err(ScopedFlightRecorderOperationError::Operation(_)) => Ok(response(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!(
-                "request {} failed; flight recorder snapshot exported",
+                "request {} failed; flight recorder snapshot handed off",
                 work.request_id
             ),
         )),
-        Err(err) => Ok(response(
+        Err(ScopedFlightRecorderOperationError::Start(err)) => {
+            Ok(response(StatusCode::SERVICE_UNAVAILABLE, err.to_string()))
+        }
+        Err(ScopedFlightRecorderOperationError::Handoff { handoff, .. }) => Ok(response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("request {} failed; trigger failed: {err}", work.request_id),
+            format!(
+                "request {} failed; snapshot handoff failed: {handoff}",
+                work.request_id
+            ),
+        )),
+        Err(_) => Ok(response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("request {} failed", work.request_id),
         )),
     }
 }

--- a/examples/logs-flight-recorder/src/main.rs
+++ b/examples/logs-flight-recorder/src/main.rs
@@ -3,6 +3,7 @@ use hyper::body::{Bytes, Incoming};
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::{TokioExecutor, TokioIo};
+use opentelemetry::logs::Severity;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{LogExporter, Protocol, WithExportConfig};
 use opentelemetry_sdk::logs::{
@@ -17,7 +18,7 @@ use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
@@ -37,6 +38,7 @@ struct AppState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Outcome {
     Ok,
+    Warn,
     Error,
 }
 
@@ -63,6 +65,7 @@ fn init_logs(
         .build();
     let (flight_recorder, trigger) = FlightRecorderLogProcessor::builder(batch_processor)
         .with_max_records(max_records)
+        .with_max_buffered_severity(Severity::Info4)
         .build();
     let provider = SdkLoggerProvider::builder()
         .with_resource(
@@ -100,8 +103,9 @@ fn parse_work_request(
             "result" => {
                 outcome = match value.as_ref() {
                     "ok" => Outcome::Ok,
+                    "warn" => Outcome::Warn,
                     "error" => Outcome::Error,
-                    _ => return Err("result must be 'ok' or 'error'"),
+                    _ => return Err("result must be 'ok', 'warn', or 'error'"),
                 };
             }
             "logs" => {
@@ -146,6 +150,7 @@ async fn handle_request(
     };
     let outcome = match work.outcome {
         Outcome::Ok => "ok",
+        Outcome::Warn => "warn",
         Outcome::Error => "error",
     };
 
@@ -165,6 +170,23 @@ async fn handle_request(
             StatusCode::OK,
             format!(
                 "request {} completed; logs remain in the flight recorder",
+                work.request_id
+            ),
+        ));
+    }
+
+    if work.outcome == Outcome::Warn {
+        warn!(
+            target: "flight_recorder_demo",
+            event_kind = "warning",
+            request_id = work.request_id.as_str(),
+            outcome,
+            "request completed with a warning; bypassing the flight recorder"
+        );
+        return Ok(response(
+            StatusCode::OK,
+            format!(
+                "request {} completed; warning followed the normal export path",
                 work.request_id
             ),
         ));
@@ -224,7 +246,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     });
     let listener = TcpListener::bind(listen_addr).await?;
     eprintln!("flight recorder demo listening on http://{listen_addr}");
-    eprintln!("try: /work?result=ok&logs=5 and /work?result=error&logs=5");
+    eprintln!("try: /work?result=ok|warn|error&logs=5");
 
     loop {
         tokio::select! {

--- a/examples/logs-flight-recorder/src/main.rs
+++ b/examples/logs-flight-recorder/src/main.rs
@@ -1,0 +1,257 @@
+use http_body_util::{combinators::BoxBody, BodyExt, Full};
+use hyper::body::{Bytes, Incoming};
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry_otlp::{LogExporter, Protocol, WithExportConfig};
+use opentelemetry_sdk::logs::{
+    BatchConfigBuilder, BatchLogProcessor, FlightRecorderLogProcessor, FlightRecorderTrigger,
+    SdkLoggerProvider,
+};
+use opentelemetry_sdk::Resource;
+use std::convert::Infallible;
+use std::env;
+use std::error::Error;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tracing::{error, info};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer};
+use url::form_urlencoded;
+
+const DEFAULT_LISTEN_ADDR: &str = "127.0.0.1:3000";
+const DEFAULT_MAX_RECORDS: usize = 64;
+const MAX_LOGS_PER_REQUEST: usize = 100;
+
+type HttpBody = BoxBody<Bytes, Infallible>;
+
+struct AppState {
+    trigger: FlightRecorderTrigger,
+    next_request_id: AtomicU64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Outcome {
+    Ok,
+    Error,
+}
+
+struct WorkRequest {
+    outcome: Outcome,
+    log_count: usize,
+    request_id: String,
+}
+
+fn init_logs(
+    max_records: usize,
+) -> Result<(SdkLoggerProvider, FlightRecorderTrigger), Box<dyn Error>> {
+    let exporter = LogExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .build()?;
+    let batch_processor = BatchLogProcessor::builder(exporter)
+        .with_batch_config(
+            BatchConfigBuilder::default()
+                .with_max_queue_size(max_records)
+                .with_max_export_batch_size(max_records)
+                .build(),
+        )
+        .build();
+    let (flight_recorder, trigger) = FlightRecorderLogProcessor::builder(batch_processor)
+        .with_max_records(max_records)
+        .build();
+    let provider = SdkLoggerProvider::builder()
+        .with_resource(
+            Resource::builder_empty()
+                .with_service_name("logs-flight-recorder")
+                .build(),
+        )
+        .with_log_processor(flight_recorder)
+        .build();
+
+    Ok((provider, trigger))
+}
+
+fn response(status: StatusCode, body: impl Into<Bytes>) -> Response<HttpBody> {
+    let mut response = Response::new(
+        Full::new(body.into())
+            .map_err(|never| match never {})
+            .boxed(),
+    );
+    *response.status_mut() = status;
+    response
+}
+
+fn parse_work_request(
+    request: &Request<Incoming>,
+    default_request_id: u64,
+) -> Result<WorkRequest, &'static str> {
+    let mut outcome = Outcome::Ok;
+    let mut log_count = 5;
+    let mut request_id = default_request_id.to_string();
+
+    for (key, value) in form_urlencoded::parse(request.uri().query().unwrap_or_default().as_bytes())
+    {
+        match key.as_ref() {
+            "result" => {
+                outcome = match value.as_ref() {
+                    "ok" => Outcome::Ok,
+                    "error" => Outcome::Error,
+                    _ => return Err("result must be 'ok' or 'error'"),
+                };
+            }
+            "logs" => {
+                log_count = value
+                    .parse()
+                    .map_err(|_| "logs must be an integer between 1 and 100")?;
+                if !(1..=MAX_LOGS_PER_REQUEST).contains(&log_count) {
+                    return Err("logs must be an integer between 1 and 100");
+                }
+            }
+            "request_id" => request_id = value.into_owned(),
+            _ => {}
+        }
+    }
+
+    if request_id.is_empty() {
+        return Err("request_id must not be empty");
+    }
+
+    Ok(WorkRequest {
+        outcome,
+        log_count,
+        request_id,
+    })
+}
+
+async fn handle_request(
+    request: Request<Incoming>,
+    state: Arc<AppState>,
+) -> Result<Response<HttpBody>, Infallible> {
+    if request.method() == Method::GET && request.uri().path() == "/health" {
+        return Ok(response(StatusCode::OK, "healthy"));
+    }
+    if request.method() != Method::GET || request.uri().path() != "/work" {
+        return Ok(response(StatusCode::NOT_FOUND, "not found"));
+    }
+
+    let request_number = state.next_request_id.fetch_add(1, Ordering::Relaxed);
+    let work = match parse_work_request(&request, request_number) {
+        Ok(work) => work,
+        Err(message) => return Ok(response(StatusCode::BAD_REQUEST, message)),
+    };
+    let outcome = match work.outcome {
+        Outcome::Ok => "ok",
+        Outcome::Error => "error",
+    };
+
+    for step in 1..=work.log_count {
+        info!(
+            target: "flight_recorder_demo",
+            event_kind = "work",
+            request_id = work.request_id.as_str(),
+            outcome,
+            step,
+            "processing request"
+        );
+    }
+
+    if work.outcome == Outcome::Ok {
+        return Ok(response(
+            StatusCode::OK,
+            format!(
+                "request {} completed; logs remain in the flight recorder",
+                work.request_id
+            ),
+        ));
+    }
+
+    error!(
+        target: "flight_recorder_demo",
+        event_kind = "failure",
+        request_id = work.request_id.as_str(),
+        outcome,
+        "request failed; triggering the flight recorder"
+    );
+    match tokio::task::block_in_place(|| state.trigger.trigger()) {
+        Ok(()) => Ok(response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!(
+                "request {} failed; flight recorder snapshot exported",
+                work.request_id
+            ),
+        )),
+        Err(err) => Ok(response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("request {} failed; trigger failed: {err}", work.request_id),
+        )),
+    }
+}
+
+fn parse_env<T>(name: &str, default: T) -> Result<T, Box<dyn Error>>
+where
+    T: std::str::FromStr,
+    T::Err: Error + 'static,
+{
+    match env::var(name) {
+        Ok(value) => Ok(value.parse()?),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let listen_addr: SocketAddr =
+        parse_env("FLIGHT_RECORDER_LISTEN_ADDR", DEFAULT_LISTEN_ADDR.parse()?)?;
+    let max_records = parse_env("FLIGHT_RECORDER_MAX_RECORDS", DEFAULT_MAX_RECORDS)?;
+    if max_records == 0 {
+        return Err("FLIGHT_RECORDER_MAX_RECORDS must be greater than zero".into());
+    }
+
+    let (logger_provider, trigger) = init_logs(max_records)?;
+    let otel_layer = OpenTelemetryTracingBridge::new(&logger_provider)
+        .with_filter(EnvFilter::new("off").add_directive("flight_recorder_demo=info".parse()?));
+    tracing_subscriber::registry().with(otel_layer).try_init()?;
+
+    let state = Arc::new(AppState {
+        trigger,
+        next_request_id: AtomicU64::new(1),
+    });
+    let listener = TcpListener::bind(listen_addr).await?;
+    eprintln!("flight recorder demo listening on http://{listen_addr}");
+    eprintln!("try: /work?result=ok&logs=5 and /work?result=error&logs=5");
+
+    loop {
+        tokio::select! {
+            accepted = listener.accept() => {
+                let (stream, _) = accepted?;
+                let state = state.clone();
+                tokio::spawn(async move {
+                    if let Err(err) = hyper_util::server::conn::auto::Builder::new(
+                        TokioExecutor::new(),
+                    )
+                    .serve_connection(
+                        TokioIo::new(stream),
+                        service_fn(move |request| handle_request(request, state.clone())),
+                    )
+                    .await
+                    {
+                        eprintln!("connection error: {err}");
+                    }
+                });
+            }
+            signal = tokio::signal::ctrl_c() => {
+                signal?;
+                break;
+            }
+        }
+    }
+
+    logger_provider.shutdown()?;
+    Ok(())
+}

--- a/examples/logs-flight-recorder/src/main.rs
+++ b/examples/logs-flight-recorder/src/main.rs
@@ -26,7 +26,10 @@ use url::form_urlencoded;
 
 const DEFAULT_LISTEN_ADDR: &str = "127.0.0.1:3000";
 const DEFAULT_MAX_RECORDS: usize = 64;
-const DEFAULT_MAX_ACTIVE_SCOPES: usize = 1_024;
+const DEFAULT_MAX_ACTIVE_SCOPES: usize = 128;
+const DEFAULT_MAX_BUFFER_BYTES_PER_SCOPE: usize = 256 * 1024;
+const DEFAULT_MAX_TOTAL_BUFFER_BYTES: usize = 16 * 1024 * 1024;
+const DEFAULT_MAX_RECORD_BYTES: usize = 64 * 1024;
 const MAX_LOGS_PER_REQUEST: usize = 100;
 
 type HttpBody = BoxBody<Bytes, Infallible>;
@@ -53,6 +56,9 @@ struct WorkRequest {
 fn init_logs(
     max_records: usize,
     max_active_scopes: usize,
+    max_buffer_bytes_per_scope: usize,
+    max_total_buffer_bytes: usize,
+    max_record_bytes: usize,
 ) -> Result<(SdkLoggerProvider, ScopedFlightRecorder), Box<dyn Error>> {
     let exporter = LogExporter::builder()
         .with_http()
@@ -69,6 +75,9 @@ fn init_logs(
     let (flight_recorder, recorder) = ScopedFlightRecorderLogProcessor::builder(batch_processor)
         .with_max_records_per_scope(max_records)
         .with_max_active_scopes(max_active_scopes)
+        .with_max_buffer_size_bytes_per_scope(max_buffer_bytes_per_scope)
+        .with_max_total_buffer_size_bytes(max_total_buffer_bytes)
+        .with_max_record_size_bytes(max_record_bytes)
         .with_max_buffered_severity(Severity::Info4)
         .build();
     let provider = SdkLoggerProvider::builder()
@@ -277,8 +286,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
     if max_active_scopes == 0 {
         return Err("FLIGHT_RECORDER_MAX_ACTIVE_SCOPES must be greater than zero".into());
     }
+    let max_buffer_bytes_per_scope = parse_env(
+        "FLIGHT_RECORDER_MAX_BUFFER_BYTES_PER_SCOPE",
+        DEFAULT_MAX_BUFFER_BYTES_PER_SCOPE,
+    )?;
+    let max_total_buffer_bytes = parse_env(
+        "FLIGHT_RECORDER_MAX_TOTAL_BUFFER_BYTES",
+        DEFAULT_MAX_TOTAL_BUFFER_BYTES,
+    )?;
+    let max_record_bytes = parse_env("FLIGHT_RECORDER_MAX_RECORD_BYTES", DEFAULT_MAX_RECORD_BYTES)?;
+    if max_buffer_bytes_per_scope == 0 || max_total_buffer_bytes == 0 || max_record_bytes == 0 {
+        return Err("flight recorder byte limits must be greater than zero".into());
+    }
 
-    let (logger_provider, recorder) = init_logs(max_records, max_active_scopes)?;
+    let (logger_provider, recorder) = init_logs(
+        max_records,
+        max_active_scopes,
+        max_buffer_bytes_per_scope,
+        max_total_buffer_bytes,
+        max_record_bytes,
+    )?;
     let otel_layer = OpenTelemetryTracingBridge::new(&logger_provider)
         .with_filter(EnvFilter::new("off").add_directive("flight_recorder_demo=info".parse()?));
     tracing_subscriber::registry().with(otel_layer).try_init()?;

--- a/examples/logs-flight-recorder/src/main.rs
+++ b/examples/logs-flight-recorder/src/main.rs
@@ -177,12 +177,9 @@ async fn handle_request(
         Outcome::Error => "error",
     };
     let recording_scope = match state.recorder.try_start() {
-        Some(scope) => scope,
-        None => {
-            return Ok(response(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "flight recorder active-scope limit reached",
-            ));
+        Ok(scope) => scope,
+        Err(err) => {
+            return Ok(response(StatusCode::SERVICE_UNAVAILABLE, err.to_string()));
         }
     };
 

--- a/examples/logs-flight-recorder/src/main.rs
+++ b/examples/logs-flight-recorder/src/main.rs
@@ -7,7 +7,7 @@ use opentelemetry::logs::Severity;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::{LogExporter, Protocol, WithExportConfig};
 use opentelemetry_sdk::logs::{
-    BatchConfigBuilder, BatchLogProcessor, FlightRecorderLogProcessor, FlightRecorderTrigger,
+    BatchConfigBuilder, BatchLogProcessor, ScopedFlightRecorder, ScopedFlightRecorderLogProcessor,
     SdkLoggerProvider,
 };
 use opentelemetry_sdk::Resource;
@@ -26,12 +26,13 @@ use url::form_urlencoded;
 
 const DEFAULT_LISTEN_ADDR: &str = "127.0.0.1:3000";
 const DEFAULT_MAX_RECORDS: usize = 64;
+const DEFAULT_MAX_ACTIVE_SCOPES: usize = 1_024;
 const MAX_LOGS_PER_REQUEST: usize = 100;
 
 type HttpBody = BoxBody<Bytes, Infallible>;
 
 struct AppState {
-    trigger: FlightRecorderTrigger,
+    recorder: ScopedFlightRecorder,
     next_request_id: AtomicU64,
 }
 
@@ -45,12 +46,14 @@ enum Outcome {
 struct WorkRequest {
     outcome: Outcome,
     log_count: usize,
+    delay_ms: u64,
     request_id: String,
 }
 
 fn init_logs(
     max_records: usize,
-) -> Result<(SdkLoggerProvider, FlightRecorderTrigger), Box<dyn Error>> {
+    max_active_scopes: usize,
+) -> Result<(SdkLoggerProvider, ScopedFlightRecorder), Box<dyn Error>> {
     let exporter = LogExporter::builder()
         .with_http()
         .with_protocol(Protocol::HttpBinary)
@@ -63,8 +66,9 @@ fn init_logs(
                 .build(),
         )
         .build();
-    let (flight_recorder, trigger) = FlightRecorderLogProcessor::builder(batch_processor)
-        .with_max_records(max_records)
+    let (flight_recorder, recorder) = ScopedFlightRecorderLogProcessor::builder(batch_processor)
+        .with_max_records_per_scope(max_records)
+        .with_max_active_scopes(max_active_scopes)
         .with_max_buffered_severity(Severity::Info4)
         .build();
     let provider = SdkLoggerProvider::builder()
@@ -76,7 +80,7 @@ fn init_logs(
         .with_log_processor(flight_recorder)
         .build();
 
-    Ok((provider, trigger))
+    Ok((provider, recorder))
 }
 
 fn response(status: StatusCode, body: impl Into<Bytes>) -> Response<HttpBody> {
@@ -95,6 +99,7 @@ fn parse_work_request(
 ) -> Result<WorkRequest, &'static str> {
     let mut outcome = Outcome::Ok;
     let mut log_count = 5;
+    let mut delay_ms = 0;
     let mut request_id = default_request_id.to_string();
 
     for (key, value) in form_urlencoded::parse(request.uri().query().unwrap_or_default().as_bytes())
@@ -116,6 +121,14 @@ fn parse_work_request(
                     return Err("logs must be an integer between 1 and 100");
                 }
             }
+            "delay_ms" => {
+                delay_ms = value
+                    .parse()
+                    .map_err(|_| "delay_ms must be an integer between 0 and 1000")?;
+                if delay_ms > 1_000 {
+                    return Err("delay_ms must be an integer between 0 and 1000");
+                }
+            }
             "request_id" => request_id = value.into_owned(),
             _ => {}
         }
@@ -128,6 +141,7 @@ fn parse_work_request(
     Ok(WorkRequest {
         outcome,
         log_count,
+        delay_ms,
         request_id,
     })
 }
@@ -153,36 +167,65 @@ async fn handle_request(
         Outcome::Warn => "warn",
         Outcome::Error => "error",
     };
+    let recording_scope = match state.recorder.try_start() {
+        Some(scope) => scope,
+        None => {
+            return Ok(response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "flight recorder active-scope limit reached",
+            ));
+        }
+    };
 
-    for step in 1..=work.log_count {
-        info!(
-            target: "flight_recorder_demo",
-            event_kind = "work",
-            request_id = work.request_id.as_str(),
-            outcome,
-            step,
-            "processing request"
-        );
-    }
+    recording_scope
+        .with_context(async {
+            for step in 1..=work.log_count {
+                info!(
+                    target: "flight_recorder_demo",
+                    event_kind = "work",
+                    request_id = work.request_id.as_str(),
+                    outcome,
+                    step,
+                    "processing request"
+                );
+                if work.delay_ms > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(work.delay_ms)).await;
+                }
+            }
+
+            if work.outcome == Outcome::Warn {
+                warn!(
+                    target: "flight_recorder_demo",
+                    event_kind = "warning",
+                    request_id = work.request_id.as_str(),
+                    outcome,
+                    "request completed with a warning; bypassing the flight recorder"
+                );
+            } else if work.outcome == Outcome::Error {
+                error!(
+                    target: "flight_recorder_demo",
+                    event_kind = "failure",
+                    request_id = work.request_id.as_str(),
+                    outcome,
+                    "request failed; triggering the flight recorder"
+                );
+            }
+        })
+        .await;
 
     if work.outcome == Outcome::Ok {
+        recording_scope.discard();
         return Ok(response(
             StatusCode::OK,
             format!(
-                "request {} completed; logs remain in the flight recorder",
+                "request {} completed; scoped logs discarded",
                 work.request_id
             ),
         ));
     }
 
     if work.outcome == Outcome::Warn {
-        warn!(
-            target: "flight_recorder_demo",
-            event_kind = "warning",
-            request_id = work.request_id.as_str(),
-            outcome,
-            "request completed with a warning; bypassing the flight recorder"
-        );
+        recording_scope.discard();
         return Ok(response(
             StatusCode::OK,
             format!(
@@ -192,14 +235,7 @@ async fn handle_request(
         ));
     }
 
-    error!(
-        target: "flight_recorder_demo",
-        event_kind = "failure",
-        request_id = work.request_id.as_str(),
-        outcome,
-        "request failed; triggering the flight recorder"
-    );
-    match tokio::task::block_in_place(|| state.trigger.trigger()) {
+    match tokio::task::block_in_place(|| recording_scope.trigger()) {
         Ok(()) => Ok(response(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!(
@@ -234,19 +270,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
     if max_records == 0 {
         return Err("FLIGHT_RECORDER_MAX_RECORDS must be greater than zero".into());
     }
+    let max_active_scopes = parse_env(
+        "FLIGHT_RECORDER_MAX_ACTIVE_SCOPES",
+        DEFAULT_MAX_ACTIVE_SCOPES,
+    )?;
+    if max_active_scopes == 0 {
+        return Err("FLIGHT_RECORDER_MAX_ACTIVE_SCOPES must be greater than zero".into());
+    }
 
-    let (logger_provider, trigger) = init_logs(max_records)?;
+    let (logger_provider, recorder) = init_logs(max_records, max_active_scopes)?;
     let otel_layer = OpenTelemetryTracingBridge::new(&logger_provider)
         .with_filter(EnvFilter::new("off").add_directive("flight_recorder_demo=info".parse()?));
     tracing_subscriber::registry().with(otel_layer).try_init()?;
 
     let state = Arc::new(AppState {
-        trigger,
+        recorder,
         next_request_id: AtomicU64::new(1),
     });
     let listener = TcpListener::bind(listen_addr).await?;
     eprintln!("flight recorder demo listening on http://{listen_addr}");
-    eprintln!("try: /work?result=ok|warn|error&logs=5");
+    eprintln!("try: /work?result=ok|warn|error&logs=5&delay_ms=0");
 
     loop {
         tokio::select! {

--- a/examples/logs-flight-recorder/tests/flight_recorder.rs
+++ b/examples/logs-flight-recorder/tests/flight_recorder.rs
@@ -1,0 +1,313 @@
+use http_body_util::{BodyExt, Full};
+use hyper::body::{Bytes, Incoming};
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use opentelemetry_proto::tonic::collector::logs::v1::{
+    ExportLogsServiceRequest, ExportLogsServiceResponse,
+};
+use opentelemetry_proto::tonic::common::v1::any_value::Value;
+use opentelemetry_proto::tonic::logs::v1::LogRecord;
+use prost::Message;
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+async fn collect_otlp_request(
+    request: Request<Incoming>,
+    requests: Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
+) -> Result<Response<Full<Bytes>>, Infallible> {
+    if request.method() != Method::POST || request.uri().path() != "/v1/logs" {
+        return Ok(Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Full::new(Bytes::new()))
+            .unwrap());
+    }
+    assert_eq!(
+        request
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("application/x-protobuf")
+    );
+
+    let body = request.into_body().collect().await.unwrap().to_bytes();
+    requests
+        .lock()
+        .unwrap()
+        .push(ExportLogsServiceRequest::decode(body).unwrap());
+    let response = ExportLogsServiceResponse::default().encode_to_vec();
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/x-protobuf")
+        .body(Full::new(Bytes::from(response)))
+        .unwrap())
+}
+
+async fn start_fake_collector() -> (
+    SocketAddr,
+    Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let stored_requests = requests.clone();
+    let task = tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            let requests = stored_requests.clone();
+            tokio::spawn(async move {
+                hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+                    .serve_connection(
+                        TokioIo::new(stream),
+                        service_fn(move |request| collect_otlp_request(request, requests.clone())),
+                    )
+                    .await
+                    .unwrap();
+            });
+        }
+    });
+    (address, requests, task)
+}
+
+async fn get_without_timeout(address: SocketAddr, path: &str) -> u16 {
+    let mut stream = TcpStream::connect(address).await.unwrap();
+    stream
+        .write_all(
+            format!("GET {path} HTTP/1.1\r\nHost: {address}\r\nConnection: close\r\n\r\n")
+                .as_bytes(),
+        )
+        .await
+        .unwrap();
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).await.unwrap();
+    let status_line = std::str::from_utf8(&response)
+        .unwrap()
+        .lines()
+        .next()
+        .unwrap();
+    status_line
+        .split_whitespace()
+        .nth(1)
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+async fn get(address: SocketAddr, path: &str) -> u16 {
+    tokio::time::timeout(Duration::from_secs(2), get_without_timeout(address, path))
+        .await
+        .expect("HTTP request timed out")
+}
+
+async fn wait_until_ready(address: SocketAddr) {
+    for _ in 0..100 {
+        if tokio::time::timeout(Duration::from_millis(100), TcpStream::connect(address))
+            .await
+            .is_ok_and(|result| result.is_ok())
+            && get(address, "/health").await == 200
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("demo application did not become ready");
+}
+
+fn all_log_records(requests: &[ExportLogsServiceRequest]) -> Vec<&LogRecord> {
+    requests
+        .iter()
+        .flat_map(|request| &request.resource_logs)
+        .flat_map(|resource| &resource.scope_logs)
+        .flat_map(|scope| &scope.log_records)
+        .collect()
+}
+
+fn string_attribute<'a>(record: &'a LogRecord, key: &str) -> Option<&'a str> {
+    record
+        .attributes
+        .iter()
+        .find(|attribute| attribute.key == key)
+        .and_then(|attribute| attribute.value.as_ref())
+        .and_then(|value| value.value.as_ref())
+        .and_then(|value| match value {
+            Value::StringValue(value) => Some(value.as_str()),
+            _ => None,
+        })
+}
+
+fn int_attribute(record: &LogRecord, key: &str) -> Option<i64> {
+    record
+        .attributes
+        .iter()
+        .find(|attribute| attribute.key == key)
+        .and_then(|attribute| attribute.value.as_ref())
+        .and_then(|value| value.value.as_ref())
+        .and_then(|value| match value {
+            Value::IntValue(value) => Some(*value),
+            _ => None,
+        })
+}
+
+fn string_body(record: &LogRecord) -> Option<&str> {
+    record
+        .body
+        .as_ref()
+        .and_then(|body| body.value.as_ref())
+        .and_then(|value| match value {
+            Value::StringValue(value) => Some(value.as_str()),
+            _ => None,
+        })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn exports_only_the_triggered_bounded_snapshot_to_otlp() {
+    let (collector_address, requests, collector_task) = start_fake_collector().await;
+    let app_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let app_address = app_listener.local_addr().unwrap();
+    drop(app_listener);
+
+    let child = Command::new(env!("CARGO_BIN_EXE_logs-flight-recorder"))
+        .env("FLIGHT_RECORDER_LISTEN_ADDR", app_address.to_string())
+        .env("FLIGHT_RECORDER_MAX_RECORDS", "5")
+        .env(
+            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+            format!("http://{collector_address}/v1/logs"),
+        )
+        .env("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "http/protobuf")
+        .env_remove("OTEL_EXPORTER_OTLP_LOGS_COMPRESSION")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let _child = ChildGuard(child);
+    wait_until_ready(app_address).await;
+
+    assert_eq!(
+        get(app_address, "/work?result=ok&logs=4&request_id=successful").await,
+        200
+    );
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(requests.lock().unwrap().is_empty());
+
+    assert_eq!(
+        get(app_address, "/work?result=error&logs=2&request_id=failing").await,
+        500
+    );
+
+    let records = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let records = {
+                let requests = requests.lock().unwrap();
+                all_log_records(&requests)
+                    .into_iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+            };
+            if records.len() >= 5 {
+                break records;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("collector did not receive the expected logs");
+    assert_eq!(records.len(), 5);
+
+    let identities = records
+        .iter()
+        .map(|record| {
+            assert!(matches!(
+                string_body(record),
+                Some("processing request" | "request failed; triggering the flight recorder")
+            ));
+            (
+                string_attribute(record, "request_id").unwrap().to_string(),
+                string_attribute(record, "event_kind").unwrap().to_string(),
+                int_attribute(record, "step"),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        identities,
+        [
+            ("successful".into(), "work".into(), Some(3)),
+            ("successful".into(), "work".into(), Some(4)),
+            ("failing".into(), "work".into(), Some(1)),
+            ("failing".into(), "work".into(), Some(2)),
+            ("failing".into(), "failure".into(), None),
+        ]
+    );
+
+    assert_eq!(
+        get(
+            app_address,
+            "/work?result=ok&logs=1&request_id=after-trigger"
+        )
+        .await,
+        200
+    );
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(all_log_records(&requests.lock().unwrap()).len(), 5);
+
+    assert_eq!(
+        get(
+            app_address,
+            "/work?result=error&logs=1&request_id=second-failure"
+        )
+        .await,
+        500
+    );
+    let records = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let records = {
+                let requests = requests.lock().unwrap();
+                all_log_records(&requests)
+                    .into_iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+            };
+            if records.len() >= 8 {
+                break records;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("collector did not receive the second snapshot");
+    assert_eq!(records.len(), 8);
+    let second_snapshot = records[5..]
+        .iter()
+        .map(|record| {
+            (
+                string_attribute(record, "request_id").unwrap(),
+                string_attribute(record, "event_kind").unwrap(),
+                int_attribute(record, "step"),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        second_snapshot,
+        [
+            ("after-trigger", "work", Some(1)),
+            ("second-failure", "work", Some(1)),
+            ("second-failure", "failure", None),
+        ]
+    );
+
+    collector_task.abort();
+}

--- a/examples/logs-flight-recorder/tests/flight_recorder.rs
+++ b/examples/logs-flight-recorder/tests/flight_recorder.rs
@@ -198,7 +198,7 @@ async fn wait_for_records(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn routes_high_severity_logs_and_exports_triggered_snapshots_to_otlp() {
+async fn isolates_concurrent_scopes_and_exports_triggered_snapshots_to_otlp() {
     let (collector_address, requests, collector_task) = start_fake_collector().await;
     let app_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let app_address = app_listener.local_addr().unwrap();
@@ -221,13 +221,6 @@ async fn routes_high_severity_logs_and_exports_triggered_snapshots_to_otlp() {
     wait_until_ready(app_address).await;
 
     assert_eq!(
-        get(app_address, "/work?result=ok&logs=4&request_id=successful").await,
-        200
-    );
-    tokio::time::sleep(Duration::from_millis(200)).await;
-    assert!(requests.lock().unwrap().is_empty());
-
-    assert_eq!(
         get(app_address, "/work?result=warn&logs=1&request_id=warning").await,
         200
     );
@@ -241,13 +234,23 @@ async fn routes_high_severity_logs_and_exports_triggered_snapshots_to_otlp() {
         Some("request completed with a warning; bypassing the flight recorder")
     );
 
+    let successful_request = tokio::spawn(get(
+        app_address,
+        "/work?result=ok&logs=4&delay_ms=75&request_id=successful",
+    ));
+    tokio::time::sleep(Duration::from_millis(50)).await;
     assert_eq!(
-        get(app_address, "/work?result=error&logs=2&request_id=failing").await,
+        get(
+            app_address,
+            "/work?result=error&logs=2&delay_ms=10&request_id=failing",
+        )
+        .await,
         500
     );
+    assert_eq!(successful_request.await.unwrap(), 200);
 
-    let records = wait_for_records(&requests, 7).await;
-    assert_eq!(records.len(), 7);
+    let records = wait_for_records(&requests, 4).await;
+    assert_eq!(records.len(), 4);
 
     let identities = records
         .iter()
@@ -272,9 +275,6 @@ async fn routes_high_severity_logs_and_exports_triggered_snapshots_to_otlp() {
         [
             ("warning".into(), "warning".into(), None),
             ("failing".into(), "failure".into(), None),
-            ("successful".into(), "work".into(), Some(3)),
-            ("successful".into(), "work".into(), Some(4)),
-            ("warning".into(), "work".into(), Some(1)),
             ("failing".into(), "work".into(), Some(1)),
             ("failing".into(), "work".into(), Some(2)),
         ]
@@ -283,29 +283,26 @@ async fn routes_high_severity_logs_and_exports_triggered_snapshots_to_otlp() {
     assert!(records[2..]
         .iter()
         .all(|record| record.severity_number == 9));
+    assert!(records.iter().all(|record| {
+        string_attribute(record, "request_id") != Some("successful")
+            && !(string_attribute(record, "request_id") == Some("warning")
+                && string_attribute(record, "event_kind") == Some("work"))
+    }));
 
-    assert_eq!(
-        get(
-            app_address,
-            "/work?result=ok&logs=1&request_id=after-trigger"
-        )
-        .await,
-        200
-    );
     tokio::time::sleep(Duration::from_millis(200)).await;
-    assert_eq!(all_log_records(&requests.lock().unwrap()).len(), 7);
+    assert_eq!(all_log_records(&requests.lock().unwrap()).len(), 4);
 
     assert_eq!(
         get(
             app_address,
-            "/work?result=error&logs=1&request_id=second-failure"
+            "/work?result=error&logs=1&request_id=second-failure",
         )
         .await,
         500
     );
-    let records = wait_for_records(&requests, 10).await;
-    assert_eq!(records.len(), 10);
-    let second_snapshot = records[7..]
+    let records = wait_for_records(&requests, 6).await;
+    assert_eq!(records.len(), 6);
+    let second_snapshot = records[4..]
         .iter()
         .map(|record| {
             (
@@ -319,7 +316,6 @@ async fn routes_high_severity_logs_and_exports_triggered_snapshots_to_otlp() {
         second_snapshot,
         [
             ("second-failure", "failure", None),
-            ("after-trigger", "work", Some(1)),
             ("second-failure", "work", Some(1)),
         ]
     );

--- a/examples/logs-flight-recorder/tests/flight_recorder.rs
+++ b/examples/logs-flight-recorder/tests/flight_recorder.rs
@@ -174,8 +174,31 @@ fn string_body(record: &LogRecord) -> Option<&str> {
         })
 }
 
+async fn wait_for_records(
+    requests: &Mutex<Vec<ExportLogsServiceRequest>>,
+    expected_count: usize,
+) -> Vec<LogRecord> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let records = {
+                let requests = requests.lock().unwrap();
+                all_log_records(&requests)
+                    .into_iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+            };
+            if records.len() >= expected_count {
+                break records;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("collector did not receive the expected logs")
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn exports_only_the_triggered_bounded_snapshot_to_otlp() {
+async fn routes_high_severity_logs_and_exports_triggered_snapshots_to_otlp() {
     let (collector_address, requests, collector_task) = start_fake_collector().await;
     let app_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let app_address = app_listener.local_addr().unwrap();
@@ -205,35 +228,37 @@ async fn exports_only_the_triggered_bounded_snapshot_to_otlp() {
     assert!(requests.lock().unwrap().is_empty());
 
     assert_eq!(
+        get(app_address, "/work?result=warn&logs=1&request_id=warning").await,
+        200
+    );
+    let records = wait_for_records(&requests, 1).await;
+    assert_eq!(records.len(), 1);
+    assert_eq!(string_attribute(&records[0], "request_id"), Some("warning"));
+    assert_eq!(string_attribute(&records[0], "event_kind"), Some("warning"));
+    assert_eq!(records[0].severity_number, 13);
+    assert_eq!(
+        string_body(&records[0]),
+        Some("request completed with a warning; bypassing the flight recorder")
+    );
+
+    assert_eq!(
         get(app_address, "/work?result=error&logs=2&request_id=failing").await,
         500
     );
 
-    let records = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let records = {
-                let requests = requests.lock().unwrap();
-                all_log_records(&requests)
-                    .into_iter()
-                    .cloned()
-                    .collect::<Vec<_>>()
-            };
-            if records.len() >= 5 {
-                break records;
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-    })
-    .await
-    .expect("collector did not receive the expected logs");
-    assert_eq!(records.len(), 5);
+    let records = wait_for_records(&requests, 7).await;
+    assert_eq!(records.len(), 7);
 
     let identities = records
         .iter()
         .map(|record| {
             assert!(matches!(
                 string_body(record),
-                Some("processing request" | "request failed; triggering the flight recorder")
+                Some(
+                    "processing request"
+                        | "request completed with a warning; bypassing the flight recorder"
+                        | "request failed; triggering the flight recorder"
+                )
             ));
             (
                 string_attribute(record, "request_id").unwrap().to_string(),
@@ -245,13 +270,19 @@ async fn exports_only_the_triggered_bounded_snapshot_to_otlp() {
     assert_eq!(
         identities,
         [
+            ("warning".into(), "warning".into(), None),
+            ("failing".into(), "failure".into(), None),
             ("successful".into(), "work".into(), Some(3)),
             ("successful".into(), "work".into(), Some(4)),
+            ("warning".into(), "work".into(), Some(1)),
             ("failing".into(), "work".into(), Some(1)),
             ("failing".into(), "work".into(), Some(2)),
-            ("failing".into(), "failure".into(), None),
         ]
     );
+    assert_eq!(records[1].severity_number, 17);
+    assert!(records[2..]
+        .iter()
+        .all(|record| record.severity_number == 9));
 
     assert_eq!(
         get(
@@ -262,7 +293,7 @@ async fn exports_only_the_triggered_bounded_snapshot_to_otlp() {
         200
     );
     tokio::time::sleep(Duration::from_millis(200)).await;
-    assert_eq!(all_log_records(&requests.lock().unwrap()).len(), 5);
+    assert_eq!(all_log_records(&requests.lock().unwrap()).len(), 7);
 
     assert_eq!(
         get(
@@ -272,25 +303,9 @@ async fn exports_only_the_triggered_bounded_snapshot_to_otlp() {
         .await,
         500
     );
-    let records = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let records = {
-                let requests = requests.lock().unwrap();
-                all_log_records(&requests)
-                    .into_iter()
-                    .cloned()
-                    .collect::<Vec<_>>()
-            };
-            if records.len() >= 8 {
-                break records;
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-    })
-    .await
-    .expect("collector did not receive the second snapshot");
-    assert_eq!(records.len(), 8);
-    let second_snapshot = records[5..]
+    let records = wait_for_records(&requests, 10).await;
+    assert_eq!(records.len(), 10);
+    let second_snapshot = records[7..]
         .iter()
         .map(|record| {
             (
@@ -303,9 +318,9 @@ async fn exports_only_the_triggered_bounded_snapshot_to_otlp() {
     assert_eq!(
         second_snapshot,
         [
+            ("second-failure", "failure", None),
             ("after-trigger", "work", Some(1)),
             ("second-failure", "work", Some(1)),
-            ("second-failure", "failure", None),
         ]
     );
 

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@
   behind `experimental_logs_flight_recorder`. It retains a configurable number
   of recent log records in a bounded ring buffer and exports the current
   snapshot through a wrapped processor when its cloneable trigger is invoked.
+  By default, WARN and higher-severity records bypass the recorder and follow
+  the wrapped processor's normal export path.
 - Added SDK self-observability metrics, feature-gated behind
   `experimental_metrics_bound_instruments`: `otel.sdk.log.created` counts log
   records submitted to the SDK; `otel.sdk.processor.log.processed` and

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+- Added an experimental global flight-recorder log processor, feature-gated
+  behind `experimental_logs_flight_recorder`. It retains a configurable number
+  of recent log records in a bounded ring buffer and exports the current
+  snapshot through a wrapped processor when its cloneable trigger is invoked.
 - Added SDK self-observability metrics, feature-gated behind
   `experimental_metrics_bound_instruments`: `otel.sdk.log.created` counts log
   records submitted to the SDK; `otel.sdk.processor.log.processed` and

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -20,6 +20,8 @@
   eviction, overflow, replay, scope admission, discard, trigger, and handoff
   activity. A `record_on_error` helper manages the common fallible-operation
   workflow by discarding successful scopes and handing off failed ones.
+  Criterion benchmarks and concurrent emit/trigger/discard/shutdown stress
+  tests cover the recorder hot paths.
 - Added SDK self-observability metrics, feature-gated behind
   `experimental_metrics_bound_instruments`: `otel.sdk.log.created` counts log
   records submitted to the SDK; `otel.sdk.processor.log.processed` and

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -14,6 +14,8 @@
   record-count limits. Scope admission returns explicit errors, and records
   that cannot be buffered are dropped by default rather than unexpectedly
   increasing export volume; an opt-in export overflow policy is available.
+  Trigger handles also provide a handoff-only operation when callers do not
+  need to wait for delegate flush completion.
 - Added SDK self-observability metrics, feature-gated behind
   `experimental_metrics_bound_instruments`: `otel.sdk.log.created` counts log
   records submitted to the SDK; `otel.sdk.processor.log.processed` and

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -15,7 +15,10 @@
   that cannot be buffered are dropped by default rather than unexpectedly
   increasing export volume; an opt-in export overflow policy is available.
   Trigger handles also provide a handoff-only operation when callers do not
-  need to wait for delegate flush completion.
+  need to wait for delegate flush completion. With
+  `experimental_metrics_bound_instruments`, SDK metrics report buffering,
+  eviction, overflow, replay, scope admission, discard, trigger, and handoff
+  activity.
 - Added SDK self-observability metrics, feature-gated behind
   `experimental_metrics_bound_instruments`: `otel.sdk.log.created` counts log
   records submitted to the SDK; `otel.sdk.processor.log.processed` and

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -9,7 +9,9 @@
   By default, WARN and higher-severity records bypass the recorder and follow
   the wrapped processor's normal export path. An operation-scoped variant uses
   OpenTelemetry context propagation to isolate buffers for concurrent requests,
-  jobs, or other logical operations.
+  jobs, or other logical operations. Configurable per-record, per-buffer, and
+  aggregate scoped byte limits bound estimated retained memory in addition to
+  record-count limits.
 - Added SDK self-observability metrics, feature-gated behind
   `experimental_metrics_bound_instruments`: `otel.sdk.log.created` counts log
   records submitted to the SDK; `otel.sdk.processor.log.processed` and

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -11,7 +11,9 @@
   OpenTelemetry context propagation to isolate buffers for concurrent requests,
   jobs, or other logical operations. Configurable per-record, per-buffer, and
   aggregate scoped byte limits bound estimated retained memory in addition to
-  record-count limits.
+  record-count limits. Scope admission returns explicit errors, and records
+  that cannot be buffered are dropped by default rather than unexpectedly
+  increasing export volume; an opt-in export overflow policy is available.
 - Added SDK self-observability metrics, feature-gated behind
   `experimental_metrics_bound_instruments`: `otel.sdk.log.created` counts log
   records submitted to the SDK; `otel.sdk.processor.log.processed` and

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -7,7 +7,9 @@
   of recent log records in a bounded ring buffer and exports the current
   snapshot through a wrapped processor when its cloneable trigger is invoked.
   By default, WARN and higher-severity records bypass the recorder and follow
-  the wrapped processor's normal export path.
+  the wrapped processor's normal export path. An operation-scoped variant uses
+  OpenTelemetry context propagation to isolate buffers for concurrent requests,
+  jobs, or other logical operations.
 - Added SDK self-observability metrics, feature-gated behind
   `experimental_metrics_bound_instruments`: `otel.sdk.log.created` counts log
   records submitted to the SDK; `otel.sdk.processor.log.processed` and

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -18,7 +18,8 @@
   need to wait for delegate flush completion. With
   `experimental_metrics_bound_instruments`, SDK metrics report buffering,
   eviction, overflow, replay, scope admission, discard, trigger, and handoff
-  activity.
+  activity. A `record_on_error` helper manages the common fallible-operation
+  workflow by discarding successful scopes and handing off failed ones.
 - Added SDK self-observability metrics, feature-gated behind
   `experimental_metrics_bound_instruments`: `otel.sdk.log.created` counts log
   records submitted to the SDK; `otel.sdk.processor.log.processed` and

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -57,6 +57,7 @@ experimental_metrics_periodicreader_with_async_runtime = ["metrics", "experiment
 spec_unstable_metrics_views = ["metrics"]
 experimental_metrics_custom_reader = ["metrics"]
 experimental_logs_batch_log_processor_with_async_runtime = ["logs", "experimental_async_runtime"]
+experimental_logs_flight_recorder = ["logs"]
 experimental_trace_batch_span_processor_with_async_runtime = ["tokio/sync", "trace", "experimental_async_runtime"]
 experimental_metrics_disable_name_validation = ["metrics"]
 experimental_metrics_bound_instruments = ["metrics", "opentelemetry/experimental_metrics_bound_instruments"]

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -99,6 +99,11 @@ name = "log_processor"
 harness = false
 
 [[bench]]
+name = "flight_recorder"
+harness = false
+required-features = ["experimental_logs_flight_recorder"]
+
+[[bench]]
 name = "log_enabled"
 harness = false
 

--- a/opentelemetry-sdk/benches/flight_recorder.rs
+++ b/opentelemetry-sdk/benches/flight_recorder.rs
@@ -1,0 +1,60 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use opentelemetry::logs::{LogRecord, Logger, LoggerProvider, Severity};
+use opentelemetry::InstrumentationScope;
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::logs::{
+    FlightRecorderLogProcessor, LogProcessor, ScopedFlightRecorderLogProcessor, SdkLogRecord,
+    SdkLogger, SdkLoggerProvider,
+};
+use std::time::Duration;
+
+#[derive(Debug)]
+struct NoopProcessor;
+
+impl LogProcessor for NoopProcessor {
+    fn emit(&self, _record: &mut SdkLogRecord, _scope: &InstrumentationScope) {}
+
+    fn force_flush(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+        Ok(())
+    }
+}
+
+fn record(logger: &SdkLogger, severity: Severity) -> SdkLogRecord {
+    let mut record = logger.create_log_record();
+    record.set_severity_number(severity);
+    record.set_body("flight recorder benchmark".into());
+    record.add_attribute("request.id", "benchmark");
+    record
+}
+
+fn benchmark(c: &mut Criterion) {
+    let instrumentation = InstrumentationScope::builder("benchmark").build();
+    let provider = SdkLoggerProvider::builder().build();
+    let logger = provider.logger("benchmark");
+    let (global, _trigger) = FlightRecorderLogProcessor::builder(NoopProcessor).build();
+    c.bench_function("flight_recorder/global_buffered_emit", |b| {
+        b.iter(|| global.emit(&mut record(&logger, Severity::Info), &instrumentation));
+    });
+
+    let (global, _trigger) = FlightRecorderLogProcessor::builder(NoopProcessor).build();
+    c.bench_function("flight_recorder/global_bypass_emit", |b| {
+        b.iter(|| global.emit(&mut record(&logger, Severity::Warn), &instrumentation));
+    });
+
+    let (scoped, recorder) = ScopedFlightRecorderLogProcessor::builder(NoopProcessor).build();
+    let scope = recorder.try_start().unwrap();
+    c.bench_function("flight_recorder/scoped_context_and_buffered_emit", |b| {
+        b.iter(|| {
+            futures_executor::block_on(scope.with_context(async {
+                scoped.emit(&mut record(&logger, Severity::Info), &instrumentation);
+            }));
+        });
+    });
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/opentelemetry-sdk/src/logs/flight_recorder.rs
+++ b/opentelemetry-sdk/src/logs/flight_recorder.rs
@@ -1,0 +1,99 @@
+use crate::logs::SdkLogRecord;
+use opentelemetry::logs::AnyValue;
+use opentelemetry::{Array, InstrumentationScope, KeyValue, Value};
+use std::mem::size_of;
+
+/// Conservatively estimates retained in-memory size, not serialized OTLP size.
+pub(crate) fn estimated_log_size(
+    record: &SdkLogRecord,
+    instrumentation: &InstrumentationScope,
+) -> usize {
+    let mut size = size_of::<SdkLogRecord>().saturating_add(size_of::<InstrumentationScope>());
+    size = size.saturating_add(record.event_name().map_or(0, str::len));
+    size = size.saturating_add(record.target().map_or(0, |target| target.len()));
+    size = size.saturating_add(record.severity_text().map_or(0, str::len));
+    size = size.saturating_add(record.body().map_or(0, estimated_any_value_size));
+    size = record.attributes_iter().fold(size, |size, (key, value)| {
+        size.saturating_add(key.as_str().len())
+            .saturating_add(estimated_any_value_size(value))
+    });
+    size = size.saturating_add(instrumentation.name().len());
+    size = size.saturating_add(instrumentation.version().map_or(0, str::len));
+    size = size.saturating_add(instrumentation.schema_url().map_or(0, str::len));
+    size = instrumentation.attributes().fold(size, |size, value| {
+        size.saturating_add(estimated_key_value_size(value))
+    });
+    size
+}
+
+fn estimated_any_value_size(value: &AnyValue) -> usize {
+    size_of::<AnyValue>().saturating_add(match value {
+        AnyValue::Int(_) | AnyValue::Double(_) | AnyValue::Boolean(_) => 0,
+        AnyValue::String(value) => value.as_str().len(),
+        AnyValue::Bytes(value) => value.len(),
+        AnyValue::ListAny(values) => values.iter().fold(0usize, |size, value| {
+            size.saturating_add(estimated_any_value_size(value))
+        }),
+        AnyValue::Map(values) => values.iter().fold(0usize, |size, (key, value)| {
+            size.saturating_add(key.as_str().len())
+                .saturating_add(estimated_any_value_size(value))
+        }),
+        _ => 0,
+    })
+}
+
+fn estimated_key_value_size(key_value: &KeyValue) -> usize {
+    size_of::<KeyValue>()
+        .saturating_add(key_value.key.as_str().len())
+        .saturating_add(match &key_value.value {
+            Value::Bool(_) | Value::I64(_) | Value::F64(_) => 0,
+            Value::String(value) => value.as_str().len(),
+            Value::Array(Array::Bool(values)) => size_of::<bool>().saturating_mul(values.len()),
+            Value::Array(Array::I64(values)) => size_of::<i64>().saturating_mul(values.len()),
+            Value::Array(Array::F64(values)) => size_of::<f64>().saturating_mul(values.len()),
+            Value::Array(Array::String(values)) => values.iter().fold(0usize, |size, value| {
+                size.saturating_add(value.as_str().len())
+            }),
+            _ => 0,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::logs::LogRecord;
+    use opentelemetry::KeyValue;
+
+    #[test]
+    fn nested_values_increase_estimated_size() {
+        let instrumentation = InstrumentationScope::builder("test").build();
+        let empty = SdkLogRecord::new();
+        let mut populated = SdkLogRecord::new();
+        populated.set_body(AnyValue::Map(Box::new(
+            [(
+                "nested".into(),
+                AnyValue::ListAny(Box::new(vec!["value".into()])),
+            )]
+            .into(),
+        )));
+        populated.add_attribute("attribute", "value");
+
+        assert!(
+            estimated_log_size(&populated, &instrumentation)
+                > estimated_log_size(&empty, &instrumentation)
+        );
+    }
+
+    #[test]
+    fn instrumentation_scope_content_is_counted() {
+        let record = SdkLogRecord::new();
+        let empty = InstrumentationScope::builder("test").build();
+        let populated = InstrumentationScope::builder("test")
+            .with_version("1.0")
+            .with_schema_url("https://example.com/schema")
+            .with_attributes([KeyValue::new("scope.attribute", "value")])
+            .build();
+
+        assert!(estimated_log_size(&record, &populated) > estimated_log_size(&record, &empty));
+    }
+}

--- a/opentelemetry-sdk/src/logs/flight_recorder.rs
+++ b/opentelemetry-sdk/src/logs/flight_recorder.rs
@@ -4,14 +4,161 @@ use opentelemetry::logs::Severity;
 use opentelemetry::{Array, InstrumentationScope, KeyValue, Value};
 use std::collections::VecDeque;
 use std::mem::size_of;
+#[cfg(feature = "experimental_metrics_bound_instruments")]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, MutexGuard, TryLockError};
 use std::time::{Duration, Instant};
 
 pub(crate) type BufferedLog = (SdkLogRecord, InstrumentationScope, usize);
 
+#[derive(Clone, Copy)]
 pub(crate) struct EvictionPlan {
     pub(crate) count: usize,
     pub(crate) bytes: usize,
+}
+
+pub(crate) struct FlightRecorderMetrics {
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    buffered: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    evicted: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    replayed: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    oversized_dropped: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    oversized_exported: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    capacity_dropped: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    capacity_exported: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    scopes_admitted: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    scopes_rejected: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    scopes_discarded: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    triggered: opentelemetry::metrics::BoundCounter<u64>,
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    handed_off: opentelemetry::metrics::BoundCounter<u64>,
+}
+
+impl FlightRecorderMetrics {
+    pub(crate) fn new(component_type: &'static str) -> Self {
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        {
+            static INSTANCE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+            let instance_id = INSTANCE_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let component_name = format!("{component_type}/{instance_id}");
+            let meter = opentelemetry::global::meter("otel.sdk");
+            let records = meter
+                .u64_counter("otel.sdk.processor.log.flight_recorder.records")
+                .with_description("The number of log records handled by a flight recorder.")
+                .with_unit("{log_record}")
+                .build();
+            let events = meter
+                .u64_counter("otel.sdk.processor.log.flight_recorder.events")
+                .with_description("The number of flight-recorder lifecycle events.")
+                .with_unit("{event}")
+                .build();
+            let bind = |counter: &opentelemetry::metrics::Counter<u64>, action| {
+                counter.bind(&[
+                    KeyValue::new("action", action),
+                    KeyValue::new("otel.component.type", component_type),
+                    KeyValue::new("otel.component.name", component_name.clone()),
+                ])
+            };
+
+            Self {
+                buffered: bind(&records, "buffered"),
+                evicted: bind(&records, "evicted"),
+                replayed: bind(&records, "replayed"),
+                oversized_dropped: bind(&records, "oversized_dropped"),
+                oversized_exported: bind(&records, "oversized_exported"),
+                capacity_dropped: bind(&records, "capacity_dropped"),
+                capacity_exported: bind(&records, "capacity_exported"),
+                scopes_admitted: bind(&events, "scope_admitted"),
+                scopes_rejected: bind(&events, "scope_rejected"),
+                scopes_discarded: bind(&events, "scope_discarded"),
+                triggered: bind(&events, "triggered"),
+                handed_off: bind(&events, "handed_off"),
+            }
+        }
+        #[cfg(not(feature = "experimental_metrics_bound_instruments"))]
+        {
+            let _ = component_type;
+            Self {}
+        }
+    }
+
+    pub(crate) fn buffered(&self, count: usize) {
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        self.buffered.add(u64::try_from(count).unwrap_or(u64::MAX));
+        #[cfg(not(feature = "experimental_metrics_bound_instruments"))]
+        let _ = count;
+    }
+
+    pub(crate) fn evicted(&self, count: usize) {
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        self.evicted.add(u64::try_from(count).unwrap_or(u64::MAX));
+        #[cfg(not(feature = "experimental_metrics_bound_instruments"))]
+        let _ = count;
+    }
+
+    pub(crate) fn replayed(&self, count: usize) {
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        self.replayed.add(u64::try_from(count).unwrap_or(u64::MAX));
+        #[cfg(not(feature = "experimental_metrics_bound_instruments"))]
+        let _ = count;
+    }
+
+    pub(crate) fn oversized(&self, exported: bool) {
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        if exported {
+            self.oversized_exported.add(1);
+        } else {
+            self.oversized_dropped.add(1);
+        }
+        #[cfg(not(feature = "experimental_metrics_bound_instruments"))]
+        let _ = exported;
+    }
+
+    pub(crate) fn capacity_overflow(&self, exported: bool) {
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        if exported {
+            self.capacity_exported.add(1);
+        } else {
+            self.capacity_dropped.add(1);
+        }
+        #[cfg(not(feature = "experimental_metrics_bound_instruments"))]
+        let _ = exported;
+    }
+
+    pub(crate) fn scope_admitted(&self) {
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        self.scopes_admitted.add(1);
+    }
+
+    pub(crate) fn scope_rejected(&self) {
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        self.scopes_rejected.add(1);
+    }
+
+    pub(crate) fn scope_discarded(&self) {
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        self.scopes_discarded.add(1);
+    }
+
+    pub(crate) fn triggered(&self) {
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        self.triggered.add(1);
+    }
+
+    pub(crate) fn handed_off(&self) {
+        #[cfg(feature = "experimental_metrics_bound_instruments")]
+        self.handed_off.add(1);
+    }
 }
 
 pub(crate) struct LogBuffer {
@@ -48,6 +195,10 @@ impl LogBuffer {
         plan
     }
 
+    pub(crate) fn can_fit(&self, size: usize) -> bool {
+        size <= self.max_size_bytes
+    }
+
     pub(crate) fn insert(&mut self, log: BufferedLog, plan: EvictionPlan) {
         for _ in 0..plan.count {
             self.records.pop_front();
@@ -56,11 +207,10 @@ impl LogBuffer {
         self.records.push_back(log);
     }
 
-    pub(crate) fn push_overwriting(&mut self, log: BufferedLog) -> usize {
+    pub(crate) fn push_overwriting(&mut self, log: BufferedLog) -> EvictionPlan {
         let plan = self.plan_insertion(log.2);
-        let evicted_bytes = plan.bytes;
         self.insert(log, plan);
-        evicted_bytes
+        plan
     }
 
     pub(crate) fn take(&mut self) -> VecDeque<BufferedLog> {

--- a/opentelemetry-sdk/src/logs/flight_recorder.rs
+++ b/opentelemetry-sdk/src/logs/flight_recorder.rs
@@ -1,7 +1,111 @@
 use crate::logs::SdkLogRecord;
 use opentelemetry::logs::AnyValue;
+use opentelemetry::logs::Severity;
 use opentelemetry::{Array, InstrumentationScope, KeyValue, Value};
+use std::collections::VecDeque;
 use std::mem::size_of;
+use std::sync::{Mutex, MutexGuard, TryLockError};
+use std::time::{Duration, Instant};
+
+pub(crate) type BufferedLog = (SdkLogRecord, InstrumentationScope, usize);
+
+pub(crate) struct EvictionPlan {
+    pub(crate) count: usize,
+    pub(crate) bytes: usize,
+}
+
+pub(crate) struct LogBuffer {
+    records: VecDeque<BufferedLog>,
+    size_bytes: usize,
+    max_records: usize,
+    max_size_bytes: usize,
+}
+
+impl LogBuffer {
+    pub(crate) fn new(max_records: usize, max_size_bytes: usize) -> Self {
+        Self {
+            records: VecDeque::new(),
+            size_bytes: 0,
+            max_records,
+            max_size_bytes,
+        }
+    }
+
+    pub(crate) fn plan_insertion(&self, size: usize) -> EvictionPlan {
+        let mut remaining_records = self.records.len();
+        let mut remaining_bytes = self.size_bytes;
+        let mut plan = EvictionPlan { count: 0, bytes: 0 };
+        for (_, _, record_size) in &self.records {
+            if remaining_records < self.max_records && size <= self.max_size_bytes - remaining_bytes
+            {
+                break;
+            }
+            remaining_records -= 1;
+            remaining_bytes -= record_size;
+            plan.count += 1;
+            plan.bytes += record_size;
+        }
+        plan
+    }
+
+    pub(crate) fn insert(&mut self, log: BufferedLog, plan: EvictionPlan) {
+        for _ in 0..plan.count {
+            self.records.pop_front();
+        }
+        self.size_bytes = self.size_bytes - plan.bytes + log.2;
+        self.records.push_back(log);
+    }
+
+    pub(crate) fn push_overwriting(&mut self, log: BufferedLog) -> usize {
+        let plan = self.plan_insertion(log.2);
+        let evicted_bytes = plan.bytes;
+        self.insert(log, plan);
+        evicted_bytes
+    }
+
+    pub(crate) fn take(&mut self) -> VecDeque<BufferedLog> {
+        self.size_bytes = 0;
+        std::mem::take(&mut self.records)
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.records.clear();
+        self.size_bytes = 0;
+    }
+}
+
+pub(crate) fn should_buffer(record: &SdkLogRecord, max_severity: Severity) -> bool {
+    record
+        .severity_number()
+        .map_or(true, |severity| severity <= max_severity)
+}
+
+pub(crate) enum TimedLockError {
+    Poisoned,
+    Timeout,
+}
+
+pub(crate) fn lock_with_timeout<T>(
+    lock: &Mutex<T>,
+    timeout: Duration,
+) -> Result<MutexGuard<'_, T>, TimedLockError> {
+    let start = Instant::now();
+    loop {
+        match lock.try_lock() {
+            Ok(guard) => return Ok(guard),
+            Err(TryLockError::Poisoned(_)) => return Err(TimedLockError::Poisoned),
+            Err(TryLockError::WouldBlock) => {
+                let Some(remaining) = timeout.checked_sub(start.elapsed()) else {
+                    return Err(TimedLockError::Timeout);
+                };
+                if remaining.is_zero() {
+                    return Err(TimedLockError::Timeout);
+                }
+                std::thread::sleep(remaining.min(Duration::from_millis(1)));
+            }
+        }
+    }
+}
 
 /// Conservatively estimates retained in-memory size, not serialized OTLP size.
 pub(crate) fn estimated_log_size(

--- a/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
@@ -1,4 +1,5 @@
 use crate::error::{OTelSdkError, OTelSdkResult};
+use crate::logs::flight_recorder::estimated_log_size;
 use crate::logs::{LogProcessor, SdkLogRecord};
 use crate::Resource;
 use opentelemetry::logs::Severity;
@@ -8,10 +9,12 @@ use std::fmt::{self, Debug, Formatter};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock, TryLockError};
 use std::time::{Duration, Instant};
 
-const DEFAULT_MAX_RECORDS: usize = 2_048;
+const DEFAULT_MAX_RECORDS: usize = 1_024;
+const DEFAULT_MAX_BUFFER_SIZE_BYTES: usize = 4 * 1024 * 1024;
+const DEFAULT_MAX_RECORD_SIZE_BYTES: usize = 64 * 1024;
 const DEFAULT_MAX_BUFFERED_SEVERITY: Severity = Severity::Info4;
 
-type BufferedLog = (SdkLogRecord, InstrumentationScope);
+type BufferedLog = (SdkLogRecord, InstrumentationScope, usize);
 
 /// A log processor that retains recent logs until explicitly triggered.
 ///
@@ -57,6 +60,8 @@ impl<P: LogProcessor> FlightRecorderLogProcessor<P> {
         FlightRecorderLogProcessorBuilder {
             delegate,
             max_records: DEFAULT_MAX_RECORDS,
+            max_buffer_size_bytes: DEFAULT_MAX_BUFFER_SIZE_BYTES,
+            max_record_size_bytes: DEFAULT_MAX_RECORD_SIZE_BYTES,
             max_buffered_severity: DEFAULT_MAX_BUFFERED_SEVERITY,
         }
     }
@@ -67,6 +72,8 @@ impl<P: LogProcessor> FlightRecorderLogProcessor<P> {
 pub struct FlightRecorderLogProcessorBuilder<P: LogProcessor> {
     delegate: P,
     max_records: usize,
+    max_buffer_size_bytes: usize,
+    max_record_size_bytes: usize,
     max_buffered_severity: Severity,
 }
 
@@ -78,6 +85,21 @@ impl<P: LogProcessor + 'static> FlightRecorderLogProcessorBuilder<P> {
     /// [`build`](Self::build) panics if `max_records` is zero.
     pub fn with_max_records(mut self, max_records: usize) -> Self {
         self.max_records = max_records;
+        self
+    }
+
+    /// Sets the maximum estimated memory retained by the ring buffer.
+    pub fn with_max_buffer_size_bytes(mut self, max_buffer_size_bytes: usize) -> Self {
+        self.max_buffer_size_bytes = max_buffer_size_bytes;
+        self
+    }
+
+    /// Sets the maximum estimated size of an individual buffered record.
+    ///
+    /// Larger records bypass the recorder and follow the wrapped processor's
+    /// normal path.
+    pub fn with_max_record_size_bytes(mut self, max_record_size_bytes: usize) -> Self {
+        self.max_record_size_bytes = max_record_size_bytes;
         self
     }
 
@@ -101,15 +123,26 @@ impl<P: LogProcessor + 'static> FlightRecorderLogProcessorBuilder<P> {
             self.max_records > 0,
             "flight recorder max_records must be greater than zero"
         );
+        assert!(
+            self.max_buffer_size_bytes > 0,
+            "flight recorder max_buffer_size_bytes must be greater than zero"
+        );
+        assert!(
+            self.max_record_size_bytes > 0,
+            "flight recorder max_record_size_bytes must be greater than zero"
+        );
 
         let shared = Arc::new(Shared {
             delegate: RwLock::new(self.delegate),
             state: Mutex::new(State {
                 records: VecDeque::new(),
+                buffer_size_bytes: 0,
                 is_shutdown: false,
             }),
             trigger_lock: Mutex::new(()),
             max_records: self.max_records,
+            max_buffer_size_bytes: self.max_buffer_size_bytes,
+            max_record_size_bytes: self.max_record_size_bytes,
             max_buffered_severity: self.max_buffered_severity,
         });
         let trigger = FlightRecorderTrigger {
@@ -154,11 +187,14 @@ struct Shared<P: LogProcessor> {
     state: Mutex<State>,
     trigger_lock: Mutex<()>,
     max_records: usize,
+    max_buffer_size_bytes: usize,
+    max_record_size_bytes: usize,
     max_buffered_severity: Severity,
 }
 
 struct State {
     records: VecDeque<BufferedLog>,
+    buffer_size_bytes: usize,
     is_shutdown: bool,
 }
 
@@ -186,13 +222,14 @@ impl<P: LogProcessor> Shared<P> {
             if state.is_shutdown {
                 return Err(OTelSdkError::AlreadyShutdown);
             }
+            state.buffer_size_bytes = 0;
             std::mem::take(&mut state.records)
         };
 
         if snapshot.is_empty() {
             return Ok(());
         }
-        for (mut record, instrumentation) in snapshot {
+        for (mut record, instrumentation, _) in snapshot {
             delegate.emit(&mut record, &instrumentation);
         }
         delegate.force_flush()
@@ -267,7 +304,25 @@ impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
             return;
         }
 
-        let buffered_log = (record.clone(), instrumentation.clone());
+        let estimated_size = estimated_log_size(record, instrumentation);
+        if estimated_size > self.shared.max_record_size_bytes
+            || estimated_size > self.shared.max_buffer_size_bytes
+        {
+            let delegate = match self.shared.delegate.read() {
+                Ok(delegate) => delegate,
+                Err(err) => {
+                    otel_warn!(
+                        name: "FlightRecorderLogProcessor.DelegateLockFailed",
+                        error = format!("{err}")
+                    );
+                    return;
+                }
+            };
+            delegate.emit(record, instrumentation);
+            return;
+        }
+
+        let buffered_log = (record.clone(), instrumentation.clone(), estimated_size);
         let mut state = match self.shared.state.lock() {
             Ok(state) => state,
             Err(err) => {
@@ -287,9 +342,16 @@ impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
             return;
         }
 
-        if state.records.len() == self.shared.max_records {
-            state.records.pop_front();
+        while state.records.len() == self.shared.max_records
+            || estimated_size > self.shared.max_buffer_size_bytes - state.buffer_size_bytes
+        {
+            if let Some((_, _, evicted_size)) = state.records.pop_front() {
+                state.buffer_size_bytes -= evicted_size;
+            } else {
+                break;
+            }
         }
+        state.buffer_size_bytes += estimated_size;
         state.records.push_back(buffered_log);
     }
 
@@ -312,6 +374,7 @@ impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
             }
             state.is_shutdown = true;
             state.records.clear();
+            state.buffer_size_bytes = 0;
         }
 
         let remaining = timeout.saturating_sub(start.elapsed());
@@ -393,7 +456,7 @@ mod tests {
             self.records
                 .lock()
                 .unwrap()
-                .push((record.clone(), instrumentation.clone()));
+                .push((record.clone(), instrumentation.clone(), 0));
         }
 
         fn force_flush(&self) -> OTelSdkResult {
@@ -432,7 +495,7 @@ mod tests {
             self.records
                 .lock()
                 .unwrap()
-                .push((record.clone(), instrumentation.clone()));
+                .push((record.clone(), instrumentation.clone(), 0));
         }
 
         fn force_flush(&self) -> OTelSdkResult {
@@ -462,7 +525,7 @@ mod tests {
             .lock()
             .unwrap()
             .iter()
-            .map(|(record, _)| match record.body() {
+            .map(|(record, _, _)| match record.body() {
                 Some(AnyValue::String(value)) => value.to_string(),
                 body => panic!("unexpected body: {body:?}"),
             })
@@ -498,6 +561,39 @@ mod tests {
         trigger.trigger().unwrap();
 
         assert_eq!(bodies(&delegate), ["two", "three"]);
+    }
+
+    #[test]
+    fn byte_capacity_overwrites_oldest_records() {
+        let delegate = TestProcessor::new(true);
+        let scope = InstrumentationScope::builder("test").build();
+        let estimated_size = estimated_log_size(&record("one"), &scope);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_buffer_size_bytes(estimated_size * 2)
+            .build();
+
+        processor.emit(&mut record("one"), &scope);
+        processor.emit(&mut record("two"), &scope);
+        processor.emit(&mut record("six"), &scope);
+        trigger.trigger().unwrap();
+
+        assert_eq!(bodies(&delegate), ["two", "six"]);
+    }
+
+    #[test]
+    fn oversized_records_bypass_the_buffer() {
+        let delegate = TestProcessor::new(true);
+        let scope = InstrumentationScope::builder("test").build();
+        let estimated_size = estimated_log_size(&record("oversized"), &scope);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_record_size_bytes(estimated_size - 1)
+            .build();
+
+        processor.emit(&mut record("oversized"), &scope);
+
+        assert_eq!(bodies(&delegate), ["oversized"]);
+        trigger.trigger().unwrap();
+        assert_eq!(bodies(&delegate), ["oversized"]);
     }
 
     #[test]

--- a/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
@@ -2,7 +2,8 @@ use crate::error::{OTelSdkError, OTelSdkResult};
 #[cfg(test)]
 use crate::logs::flight_recorder::BufferedLog;
 use crate::logs::flight_recorder::{
-    estimated_log_size, lock_with_timeout, should_buffer, LogBuffer, TimedLockError,
+    estimated_log_size, lock_with_timeout, should_buffer, FlightRecorderMetrics, LogBuffer,
+    TimedLockError,
 };
 use crate::logs::{LogProcessor, SdkLogRecord};
 use crate::Resource;
@@ -144,6 +145,7 @@ impl<P: LogProcessor + 'static> FlightRecorderLogProcessorBuilder<P> {
             max_buffer_size_bytes: self.max_buffer_size_bytes,
             max_record_size_bytes: self.max_record_size_bytes,
             max_buffered_severity: self.max_buffered_severity,
+            metrics: FlightRecorderMetrics::new("flight_recorder_log_processor"),
         });
         let trigger = FlightRecorderTrigger {
             inner: shared.clone(),
@@ -201,6 +203,7 @@ struct Shared<P: LogProcessor> {
     max_buffer_size_bytes: usize,
     max_record_size_bytes: usize,
     max_buffered_severity: Severity,
+    metrics: FlightRecorderMetrics,
 }
 
 struct State {
@@ -240,6 +243,7 @@ impl<P: LogProcessor> Shared<P> {
         if snapshot.is_empty() {
             return Ok(());
         }
+        self.metrics.replayed(snapshot.len());
         for (mut record, instrumentation, _) in snapshot {
             delegate.emit(&mut record, &instrumentation);
         }
@@ -253,11 +257,15 @@ impl<P: LogProcessor> Shared<P> {
 
 impl<P: LogProcessor> TriggerFlightRecorder for Shared<P> {
     fn handoff(&self) -> OTelSdkResult {
-        self.replay_snapshot(false)
+        self.replay_snapshot(false)?;
+        self.metrics.handed_off();
+        Ok(())
     }
 
     fn trigger(&self) -> OTelSdkResult {
-        self.replay_snapshot(true)
+        self.replay_snapshot(true)?;
+        self.metrics.triggered();
+        Ok(())
     }
 }
 
@@ -300,6 +308,7 @@ impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
         if estimated_size > self.shared.max_record_size_bytes
             || estimated_size > self.shared.max_buffer_size_bytes
         {
+            self.shared.metrics.oversized(true);
             let delegate = match self.shared.delegate.read() {
                 Ok(delegate) => delegate,
                 Err(err) => {
@@ -334,11 +343,15 @@ impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
             return;
         }
 
-        state.buffer.push_overwriting(buffered_log);
+        let evicted = state.buffer.push_overwriting(buffered_log);
+        self.shared.metrics.buffered(1);
+        self.shared.metrics.evicted(evicted.count);
     }
 
     fn force_flush(&self) -> OTelSdkResult {
-        self.shared.replay_snapshot(true)
+        self.shared.replay_snapshot(true)?;
+        self.shared.metrics.triggered();
+        Ok(())
     }
 
     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
@@ -827,5 +840,67 @@ mod tests {
         let _ = FlightRecorderLogProcessor::builder(delegate)
             .with_max_records(0)
             .build();
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[test]
+    #[ignore]
+    fn self_diagnostics_report_buffer_eviction_replay_and_trigger() {
+        use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+
+        let metric_exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(metric_exporter.clone())
+            .build();
+        opentelemetry::global::set_meter_provider(meter_provider.clone());
+
+        let delegate = TestProcessor::new(true);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate)
+            .with_max_records(1)
+            .build();
+        let scope = InstrumentationScope::builder("test").build();
+        processor.emit(&mut record("one"), &scope);
+        processor.emit(&mut record("two"), &scope);
+        trigger.trigger().unwrap();
+        meter_provider.force_flush().unwrap();
+
+        assert_eq!(diagnostic_action_total(&metric_exporter, "buffered"), 2);
+        assert_eq!(diagnostic_action_total(&metric_exporter, "evicted"), 1);
+        assert_eq!(diagnostic_action_total(&metric_exporter, "replayed"), 1);
+        assert_eq!(diagnostic_action_total(&metric_exporter, "triggered"), 1);
+
+        meter_provider.shutdown().unwrap();
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    fn diagnostic_action_total(
+        exporter: &crate::metrics::InMemoryMetricExporter,
+        action: &str,
+    ) -> u64 {
+        use crate::metrics::data::{AggregatedMetrics, MetricData};
+
+        exporter
+            .get_finished_metrics()
+            .unwrap()
+            .iter()
+            .flat_map(|resource| &resource.scope_metrics)
+            .flat_map(|scope| &scope.metrics)
+            .filter(|metric| {
+                metric
+                    .name
+                    .starts_with("otel.sdk.processor.log.flight_recorder.")
+            })
+            .filter_map(|metric| match &metric.data {
+                AggregatedMetrics::U64(MetricData::Sum(sum)) => Some(sum),
+                _ => None,
+            })
+            .flat_map(|sum| sum.data_points())
+            .filter(|point| {
+                point.attributes().any(|attribute| {
+                    attribute.key.as_str() == "action" && attribute.value.as_str() == action
+                })
+            })
+            .map(|point| point.value())
+            .sum()
     }
 }

--- a/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
@@ -1,20 +1,21 @@
 use crate::error::{OTelSdkError, OTelSdkResult};
-use crate::logs::flight_recorder::estimated_log_size;
+#[cfg(test)]
+use crate::logs::flight_recorder::BufferedLog;
+use crate::logs::flight_recorder::{
+    estimated_log_size, lock_with_timeout, should_buffer, LogBuffer, TimedLockError,
+};
 use crate::logs::{LogProcessor, SdkLogRecord};
 use crate::Resource;
 use opentelemetry::logs::Severity;
 use opentelemetry::{otel_warn, InstrumentationScope};
-use std::collections::VecDeque;
 use std::fmt::{self, Debug, Formatter};
-use std::sync::{Arc, Mutex, MutexGuard, RwLock, TryLockError};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 const DEFAULT_MAX_RECORDS: usize = 1_024;
 const DEFAULT_MAX_BUFFER_SIZE_BYTES: usize = 4 * 1024 * 1024;
 const DEFAULT_MAX_RECORD_SIZE_BYTES: usize = 64 * 1024;
 const DEFAULT_MAX_BUFFERED_SEVERITY: Severity = Severity::Info4;
-
-type BufferedLog = (SdkLogRecord, InstrumentationScope, usize);
 
 /// A log processor that retains recent logs until explicitly triggered.
 ///
@@ -135,8 +136,7 @@ impl<P: LogProcessor + 'static> FlightRecorderLogProcessorBuilder<P> {
         let shared = Arc::new(Shared {
             delegate: RwLock::new(self.delegate),
             state: Mutex::new(State {
-                records: VecDeque::new(),
-                buffer_size_bytes: 0,
+                buffer: LogBuffer::new(self.max_records, self.max_buffer_size_bytes),
                 is_shutdown: false,
             }),
             trigger_lock: Mutex::new(()),
@@ -193,8 +193,7 @@ struct Shared<P: LogProcessor> {
 }
 
 struct State {
-    records: VecDeque<BufferedLog>,
-    buffer_size_bytes: usize,
+    buffer: LogBuffer,
     is_shutdown: bool,
 }
 
@@ -222,8 +221,7 @@ impl<P: LogProcessor> Shared<P> {
             if state.is_shutdown {
                 return Err(OTelSdkError::AlreadyShutdown);
             }
-            state.buffer_size_bytes = 0;
-            std::mem::take(&mut state.records)
+            state.buffer.take()
         };
 
         if snapshot.is_empty() {
@@ -233,30 +231,6 @@ impl<P: LogProcessor> Shared<P> {
             delegate.emit(&mut record, &instrumentation);
         }
         delegate.force_flush()
-    }
-
-    fn lock_trigger_with_timeout(
-        &self,
-        timeout: Duration,
-    ) -> Result<MutexGuard<'_, ()>, OTelSdkError> {
-        let start = Instant::now();
-        loop {
-            match self.trigger_lock.try_lock() {
-                Ok(guard) => return Ok(guard),
-                Err(TryLockError::Poisoned(err)) => {
-                    return Err(mutex_error("trigger", err));
-                }
-                Err(TryLockError::WouldBlock) => {
-                    let Some(remaining) = timeout.checked_sub(start.elapsed()) else {
-                        return Err(OTelSdkError::Timeout(timeout));
-                    };
-                    if remaining.is_zero() {
-                        return Err(OTelSdkError::Timeout(timeout));
-                    }
-                    std::thread::sleep(remaining.min(Duration::from_millis(1)));
-                }
-            }
-        }
     }
 }
 
@@ -268,10 +242,7 @@ impl<P: LogProcessor> TriggerFlightRecorder for Shared<P> {
 
 impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
     fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
-        if record
-            .severity_number()
-            .is_some_and(|severity| severity > self.shared.max_buffered_severity)
-        {
+        if !should_buffer(record, self.shared.max_buffered_severity) {
             let delegate = match self.shared.delegate.read() {
                 Ok(delegate) => delegate,
                 Err(err) => {
@@ -342,17 +313,7 @@ impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
             return;
         }
 
-        while state.records.len() == self.shared.max_records
-            || estimated_size > self.shared.max_buffer_size_bytes - state.buffer_size_bytes
-        {
-            if let Some((_, _, evicted_size)) = state.records.pop_front() {
-                state.buffer_size_bytes -= evicted_size;
-            } else {
-                break;
-            }
-        }
-        state.buffer_size_bytes += estimated_size;
-        state.records.push_back(buffered_log);
+        state.buffer.push_overwriting(buffered_log);
     }
 
     fn force_flush(&self) -> OTelSdkResult {
@@ -361,7 +322,13 @@ impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
 
     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         let start = Instant::now();
-        let _trigger_guard = self.shared.lock_trigger_with_timeout(timeout)?;
+        let _trigger_guard =
+            lock_with_timeout(&self.shared.trigger_lock, timeout).map_err(|err| match err {
+                TimedLockError::Poisoned => OTelSdkError::InternalFailure(
+                    "FlightRecorderLogProcessor trigger mutex poisoned".into(),
+                ),
+                TimedLockError::Timeout => OTelSdkError::Timeout(timeout),
+            })?;
 
         {
             let mut state = self
@@ -373,8 +340,7 @@ impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
                 return Err(OTelSdkError::AlreadyShutdown);
             }
             state.is_shutdown = true;
-            state.records.clear();
-            state.buffer_size_bytes = 0;
+            state.buffer.clear();
         }
 
         let remaining = timeout.saturating_sub(start.elapsed());

--- a/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
@@ -536,6 +536,12 @@ mod tests {
         record
     }
 
+    fn owned_record(body: String) -> SdkLogRecord {
+        let mut record = SdkLogRecord::new();
+        record.set_body(AnyValue::from(body));
+        record
+    }
+
     fn bodies(processor: &TestProcessor) -> Vec<String> {
         processor
             .records
@@ -818,6 +824,54 @@ mod tests {
         processor
             .shutdown_with_timeout(Duration::from_secs(1))
             .unwrap();
+    }
+
+    #[test]
+    fn concurrent_emit_and_handoff_stress_preserves_all_records() {
+        let delegate = TestProcessor::new(true);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_records(4_096)
+            .with_max_buffer_size_bytes(16 * 1024 * 1024)
+            .build();
+        let processor = Arc::new(processor);
+        let running = Arc::new(AtomicBool::new(true));
+
+        let trigger_thread = {
+            let trigger = trigger.clone();
+            let running = running.clone();
+            std::thread::spawn(move || {
+                while running.load(Ordering::Acquire) {
+                    trigger.handoff().unwrap();
+                    std::thread::yield_now();
+                }
+            })
+        };
+        let mut workers = Vec::new();
+        for worker in 0..4 {
+            let processor = processor.clone();
+            workers.push(std::thread::spawn(move || {
+                let instrumentation = InstrumentationScope::builder("stress").build();
+                for sequence in 0..500 {
+                    processor.emit(
+                        &mut owned_record(format!("{worker}:{sequence}")),
+                        &instrumentation,
+                    );
+                }
+            }));
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+        running.store(false, Ordering::Release);
+        trigger_thread.join().unwrap();
+        trigger.handoff().unwrap();
+
+        let exported = bodies(&delegate);
+        assert_eq!(exported.len(), 2_000);
+        let mut unique = exported;
+        unique.sort();
+        unique.dedup();
+        assert_eq!(unique.len(), 2_000);
     }
 
     #[test]

--- a/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex, MutexGuard, RwLock, TryLockError};
 use std::time::{Duration, Instant};
 
 const DEFAULT_MAX_RECORDS: usize = 2_048;
+const DEFAULT_MAX_BUFFERED_SEVERITY: Severity = Severity::Info4;
 
 type BufferedLog = (SdkLogRecord, InstrumentationScope);
 
@@ -19,6 +20,12 @@ type BufferedLog = (SdkLogRecord, InstrumentationScope);
 /// [`FlightRecorderTrigger::trigger`] drains the current snapshot into the
 /// wrapped processor and then force-flushes it. Calling
 /// [`LogProcessor::force_flush`] has the same effect.
+///
+/// By default, records in the TRACE, DEBUG, and INFO severity ranges are
+/// buffered, while WARN, ERROR, and FATAL records bypass the buffer and are
+/// immediately handed to the wrapped processor. Records without a severity are
+/// buffered. The threshold can be changed with
+/// [`FlightRecorderLogProcessorBuilder::with_max_buffered_severity`].
 ///
 /// When wrapping a [`crate::logs::BatchLogProcessor`], configure its queue to
 /// have at least `max_records` free slots when a trigger starts. Triggers are
@@ -39,6 +46,7 @@ impl<P: LogProcessor> Debug for FlightRecorderLogProcessor<P> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("FlightRecorderLogProcessor")
             .field("max_records", &self.shared.max_records)
+            .field("max_buffered_severity", &self.shared.max_buffered_severity)
             .finish_non_exhaustive()
     }
 }
@@ -49,6 +57,7 @@ impl<P: LogProcessor> FlightRecorderLogProcessor<P> {
         FlightRecorderLogProcessorBuilder {
             delegate,
             max_records: DEFAULT_MAX_RECORDS,
+            max_buffered_severity: DEFAULT_MAX_BUFFERED_SEVERITY,
         }
     }
 }
@@ -58,6 +67,7 @@ impl<P: LogProcessor> FlightRecorderLogProcessor<P> {
 pub struct FlightRecorderLogProcessorBuilder<P: LogProcessor> {
     delegate: P,
     max_records: usize,
+    max_buffered_severity: Severity,
 }
 
 impl<P: LogProcessor + 'static> FlightRecorderLogProcessorBuilder<P> {
@@ -68,6 +78,16 @@ impl<P: LogProcessor + 'static> FlightRecorderLogProcessorBuilder<P> {
     /// [`build`](Self::build) panics if `max_records` is zero.
     pub fn with_max_records(mut self, max_records: usize) -> Self {
         self.max_records = max_records;
+        self
+    }
+
+    /// Sets the highest severity retained by the flight recorder.
+    ///
+    /// Records with a higher severity bypass the ring buffer and are handed
+    /// directly to the wrapped processor. Records without a severity are
+    /// buffered.
+    pub fn with_max_buffered_severity(mut self, severity: Severity) -> Self {
+        self.max_buffered_severity = severity;
         self
     }
 
@@ -90,6 +110,7 @@ impl<P: LogProcessor + 'static> FlightRecorderLogProcessorBuilder<P> {
             }),
             trigger_lock: Mutex::new(()),
             max_records: self.max_records,
+            max_buffered_severity: self.max_buffered_severity,
         });
         let trigger = FlightRecorderTrigger {
             inner: shared.clone(),
@@ -133,6 +154,7 @@ struct Shared<P: LogProcessor> {
     state: Mutex<State>,
     trigger_lock: Mutex<()>,
     max_records: usize,
+    max_buffered_severity: Severity,
 }
 
 struct State {
@@ -147,6 +169,15 @@ impl<P: LogProcessor> Shared<P> {
             .lock()
             .map_err(|err| mutex_error("trigger", err))?;
 
+        let delegate = self
+            .delegate
+            .write()
+            .map_err(|err| lock_error("delegate", err))?;
+
+        // Export records that bypassed the recorder before replaying the
+        // contextual snapshot.
+        delegate.force_flush()?;
+
         let snapshot = {
             let mut state = self
                 .state
@@ -158,10 +189,9 @@ impl<P: LogProcessor> Shared<P> {
             std::mem::take(&mut state.records)
         };
 
-        let delegate = self
-            .delegate
-            .read()
-            .map_err(|err| lock_error("delegate", err))?;
+        if snapshot.is_empty() {
+            return Ok(());
+        }
         for (mut record, instrumentation) in snapshot {
             delegate.emit(&mut record, &instrumentation);
         }
@@ -201,6 +231,42 @@ impl<P: LogProcessor> TriggerFlightRecorder for Shared<P> {
 
 impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
     fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+        if record
+            .severity_number()
+            .is_some_and(|severity| severity > self.shared.max_buffered_severity)
+        {
+            let delegate = match self.shared.delegate.read() {
+                Ok(delegate) => delegate,
+                Err(err) => {
+                    otel_warn!(
+                        name: "FlightRecorderLogProcessor.DelegateLockFailed",
+                        error = format!("{err}")
+                    );
+                    return;
+                }
+            };
+            let state = match self.shared.state.lock() {
+                Ok(state) => state,
+                Err(err) => {
+                    otel_warn!(
+                        name: "FlightRecorderLogProcessor.BufferLockFailed",
+                        error = format!("{err}")
+                    );
+                    return;
+                }
+            };
+            if state.is_shutdown {
+                otel_warn!(
+                    name: "FlightRecorderLogProcessor.EmitAfterShutdown",
+                    message = "FlightRecorderLogProcessor dropped a log emitted after shutdown."
+                );
+                return;
+            }
+            drop(state);
+            delegate.emit(record, instrumentation);
+            return;
+        }
+
         let buffered_log = (record.clone(), instrumentation.clone());
         let mut state = match self.shared.state.lock() {
             Ok(state) => state,
@@ -251,7 +317,7 @@ impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
         let remaining = timeout.saturating_sub(start.elapsed());
         self.shared
             .delegate
-            .read()
+            .write()
             .map_err(|err| lock_error("delegate", err))?
             .shutdown_with_timeout(remaining)
     }
@@ -384,6 +450,12 @@ mod tests {
         record
     }
 
+    fn record_with_severity(body: &'static str, severity: Severity) -> SdkLogRecord {
+        let mut record = record(body);
+        record.set_severity_number(severity);
+        record
+    }
+
     fn bodies(processor: &TestProcessor) -> Vec<String> {
         processor
             .records
@@ -409,7 +481,7 @@ mod tests {
 
         trigger.trigger().unwrap();
         assert_eq!(bodies(&delegate), ["one", "two"]);
-        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 1);
+        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 2);
     }
 
     #[test]
@@ -440,7 +512,7 @@ mod tests {
         trigger.trigger().unwrap();
 
         assert_eq!(bodies(&delegate), ["one", "two"]);
-        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 2);
+        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 4);
     }
 
     #[test]
@@ -488,7 +560,7 @@ mod tests {
         second_thread.join().unwrap().unwrap();
 
         assert_eq!(bodies(&delegate), ["one"]);
-        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 2);
+        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 3);
     }
 
     #[test]
@@ -501,7 +573,51 @@ mod tests {
         processor.force_flush().unwrap();
 
         assert_eq!(bodies(&delegate), ["one"]);
-        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 1);
+        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn higher_severity_records_bypass_the_buffer() {
+        let delegate = TestProcessor::new(true);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record_with_severity("info", Severity::Info), &scope);
+        processor.emit(&mut record_with_severity("warn", Severity::Warn), &scope);
+
+        assert_eq!(bodies(&delegate), ["warn"]);
+        trigger.trigger().unwrap();
+        assert_eq!(bodies(&delegate), ["warn", "info"]);
+    }
+
+    #[test]
+    fn higher_severity_records_are_dropped_after_shutdown() {
+        let delegate = TestProcessor::new(true);
+        let (processor, _trigger) = FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor
+            .shutdown_with_timeout(Duration::from_secs(1))
+            .unwrap();
+        processor.emit(&mut record_with_severity("warn", Severity::Warn), &scope);
+
+        assert!(bodies(&delegate).is_empty());
+    }
+
+    #[test]
+    fn buffered_severity_threshold_is_configurable() {
+        let delegate = TestProcessor::new(true);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_buffered_severity(Severity::Warn4)
+            .build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record_with_severity("warn", Severity::Warn), &scope);
+        processor.emit(&mut record_with_severity("error", Severity::Error), &scope);
+
+        assert_eq!(bodies(&delegate), ["error"]);
+        trigger.trigger().unwrap();
+        assert_eq!(bodies(&delegate), ["error", "warn"]);
     }
 
     #[test]

--- a/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
@@ -160,6 +160,16 @@ pub struct FlightRecorderTrigger {
 }
 
 impl FlightRecorderTrigger {
+    /// Hands the current snapshot to the wrapped processor without flushing it.
+    ///
+    /// This avoids waiting for exporter completion, but it is still
+    /// synchronous: acquiring recorder locks and the wrapped processor's
+    /// `emit` implementation may block. Existing records in a bounded delegate
+    /// queue count against the capacity available to the snapshot.
+    pub fn handoff(&self) -> OTelSdkResult {
+        self.inner.handoff()
+    }
+
     /// Drains and exports the current flight-recorder snapshot.
     ///
     /// Concurrent triggers are serialized. Records emitted while a snapshot is
@@ -179,6 +189,7 @@ impl Debug for FlightRecorderTrigger {
 }
 
 trait TriggerFlightRecorder: Send + Sync {
+    fn handoff(&self) -> OTelSdkResult;
     fn trigger(&self) -> OTelSdkResult;
 }
 
@@ -198,7 +209,7 @@ struct State {
 }
 
 impl<P: LogProcessor> Shared<P> {
-    fn trigger_and_flush(&self) -> OTelSdkResult {
+    fn replay_snapshot(&self, flush: bool) -> OTelSdkResult {
         let _trigger_guard = self
             .trigger_lock
             .lock()
@@ -209,9 +220,11 @@ impl<P: LogProcessor> Shared<P> {
             .write()
             .map_err(|err| lock_error("delegate", err))?;
 
-        // Export records that bypassed the recorder before replaying the
-        // contextual snapshot.
-        delegate.force_flush()?;
+        if flush {
+            // Export records that bypassed the recorder before replaying the
+            // contextual snapshot.
+            delegate.force_flush()?;
+        }
 
         let snapshot = {
             let mut state = self
@@ -230,13 +243,21 @@ impl<P: LogProcessor> Shared<P> {
         for (mut record, instrumentation, _) in snapshot {
             delegate.emit(&mut record, &instrumentation);
         }
-        delegate.force_flush()
+        if flush {
+            delegate.force_flush()
+        } else {
+            Ok(())
+        }
     }
 }
 
 impl<P: LogProcessor> TriggerFlightRecorder for Shared<P> {
+    fn handoff(&self) -> OTelSdkResult {
+        self.replay_snapshot(false)
+    }
+
     fn trigger(&self) -> OTelSdkResult {
-        self.trigger_and_flush()
+        self.replay_snapshot(true)
     }
 }
 
@@ -317,7 +338,7 @@ impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
     }
 
     fn force_flush(&self) -> OTelSdkResult {
-        self.shared.trigger_and_flush()
+        self.shared.replay_snapshot(true)
     }
 
     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
@@ -452,6 +473,23 @@ mod tests {
         block_next_emit: Arc<AtomicBool>,
     }
 
+    #[derive(Debug)]
+    struct FailingFlushProcessor;
+
+    impl LogProcessor for FailingFlushProcessor {
+        fn emit(&self, _record: &mut SdkLogRecord, _instrumentation: &InstrumentationScope) {}
+
+        fn force_flush(&self) -> OTelSdkResult {
+            Err(OTelSdkError::InternalFailure(
+                "delegate flush failed".into(),
+            ))
+        }
+
+        fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+            Ok(())
+        }
+    }
+
     impl LogProcessor for BlockingProcessor {
         fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
             if self.block_next_emit.swap(false, Ordering::Relaxed) {
@@ -511,6 +549,48 @@ mod tests {
         trigger.trigger().unwrap();
         assert_eq!(bodies(&delegate), ["one", "two"]);
         assert_eq!(delegate.flushes.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn handoff_replays_without_flushing_delegate() {
+        let delegate = TestProcessor::new(true);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record("one"), &scope);
+        trigger.handoff().unwrap();
+
+        assert_eq!(bodies(&delegate), ["one"]);
+        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn handoff_does_not_reorder_existing_delegate_records() {
+        let delegate = TestProcessor::new(true);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record("info"), &scope);
+        processor.emit(&mut record_with_severity("warn", Severity::Warn), &scope);
+        trigger.handoff().unwrap();
+
+        assert_eq!(bodies(&delegate), ["warn", "info"]);
+    }
+
+    #[test]
+    fn handoff_succeeds_when_delegate_flush_would_fail() {
+        let (processor, trigger) =
+            FlightRecorderLogProcessor::builder(FailingFlushProcessor).build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record("one"), &scope);
+        trigger.handoff().unwrap();
+
+        processor.emit(&mut record("two"), &scope);
+        assert!(matches!(
+            trigger.trigger(),
+            Err(OTelSdkError::InternalFailure(_))
+        ));
     }
 
     #[test]

--- a/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/flight_recorder_log_processor.rs
@@ -1,0 +1,573 @@
+use crate::error::{OTelSdkError, OTelSdkResult};
+use crate::logs::{LogProcessor, SdkLogRecord};
+use crate::Resource;
+use opentelemetry::logs::Severity;
+use opentelemetry::{otel_warn, InstrumentationScope};
+use std::collections::VecDeque;
+use std::fmt::{self, Debug, Formatter};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock, TryLockError};
+use std::time::{Duration, Instant};
+
+const DEFAULT_MAX_RECORDS: usize = 2_048;
+
+type BufferedLog = (SdkLogRecord, InstrumentationScope);
+
+/// A log processor that retains recent logs until explicitly triggered.
+///
+/// Records are held in an application-wide, per-processor bounded ring buffer.
+/// When the buffer is full, the oldest record is overwritten. Calling
+/// [`FlightRecorderTrigger::trigger`] drains the current snapshot into the
+/// wrapped processor and then force-flushes it. Calling
+/// [`LogProcessor::force_flush`] has the same effect.
+///
+/// When wrapping a [`crate::logs::BatchLogProcessor`], configure its queue to
+/// have at least `max_records` free slots when a trigger starts. Triggers are
+/// serialized and each trigger flushes the wrapped processor before another
+/// snapshot is replayed, so a queue of at least `max_records` is sufficient when
+/// this flight recorder is its only producer.
+///
+/// Snapshot handoff is at-most-once and best-effort. [`LogProcessor::emit`]
+/// cannot report whether a wrapped processor accepted a record, so records
+/// rejected by an undersized or full delegate queue cannot be restored.
+///
+/// Untriggered records are discarded during shutdown.
+pub struct FlightRecorderLogProcessor<P: LogProcessor> {
+    shared: Arc<Shared<P>>,
+}
+
+impl<P: LogProcessor> Debug for FlightRecorderLogProcessor<P> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FlightRecorderLogProcessor")
+            .field("max_records", &self.shared.max_records)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<P: LogProcessor> FlightRecorderLogProcessor<P> {
+    /// Creates a builder wrapping `delegate`.
+    pub fn builder(delegate: P) -> FlightRecorderLogProcessorBuilder<P> {
+        FlightRecorderLogProcessorBuilder {
+            delegate,
+            max_records: DEFAULT_MAX_RECORDS,
+        }
+    }
+}
+
+/// Configures a [`FlightRecorderLogProcessor`].
+#[derive(Debug)]
+pub struct FlightRecorderLogProcessorBuilder<P: LogProcessor> {
+    delegate: P,
+    max_records: usize,
+}
+
+impl<P: LogProcessor + 'static> FlightRecorderLogProcessorBuilder<P> {
+    /// Sets the maximum number of records retained by the flight recorder.
+    ///
+    /// # Panics
+    ///
+    /// [`build`](Self::build) panics if `max_records` is zero.
+    pub fn with_max_records(mut self, max_records: usize) -> Self {
+        self.max_records = max_records;
+        self
+    }
+
+    /// Builds the processor and its cloneable trigger handle.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_records` is zero.
+    pub fn build(self) -> (FlightRecorderLogProcessor<P>, FlightRecorderTrigger) {
+        assert!(
+            self.max_records > 0,
+            "flight recorder max_records must be greater than zero"
+        );
+
+        let shared = Arc::new(Shared {
+            delegate: RwLock::new(self.delegate),
+            state: Mutex::new(State {
+                records: VecDeque::new(),
+                is_shutdown: false,
+            }),
+            trigger_lock: Mutex::new(()),
+            max_records: self.max_records,
+        });
+        let trigger = FlightRecorderTrigger {
+            inner: shared.clone(),
+        };
+
+        (FlightRecorderLogProcessor { shared }, trigger)
+    }
+}
+
+/// A cloneable handle that exports the flight recorder's current snapshot.
+#[derive(Clone)]
+pub struct FlightRecorderTrigger {
+    inner: Arc<dyn TriggerFlightRecorder>,
+}
+
+impl FlightRecorderTrigger {
+    /// Drains and exports the current flight-recorder snapshot.
+    ///
+    /// Concurrent triggers are serialized. Records emitted while a snapshot is
+    /// being replayed are retained for the next trigger. A successful result
+    /// means the wrapped processor's `force_flush` succeeded; it cannot confirm
+    /// that every individual `emit` was accepted by the wrapped processor.
+    pub fn trigger(&self) -> OTelSdkResult {
+        self.inner.trigger()
+    }
+}
+
+impl Debug for FlightRecorderTrigger {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FlightRecorderTrigger")
+            .finish_non_exhaustive()
+    }
+}
+
+trait TriggerFlightRecorder: Send + Sync {
+    fn trigger(&self) -> OTelSdkResult;
+}
+
+struct Shared<P: LogProcessor> {
+    delegate: RwLock<P>,
+    state: Mutex<State>,
+    trigger_lock: Mutex<()>,
+    max_records: usize,
+}
+
+struct State {
+    records: VecDeque<BufferedLog>,
+    is_shutdown: bool,
+}
+
+impl<P: LogProcessor> Shared<P> {
+    fn trigger_and_flush(&self) -> OTelSdkResult {
+        let _trigger_guard = self
+            .trigger_lock
+            .lock()
+            .map_err(|err| mutex_error("trigger", err))?;
+
+        let snapshot = {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|err| mutex_error("buffer", err))?;
+            if state.is_shutdown {
+                return Err(OTelSdkError::AlreadyShutdown);
+            }
+            std::mem::take(&mut state.records)
+        };
+
+        let delegate = self
+            .delegate
+            .read()
+            .map_err(|err| lock_error("delegate", err))?;
+        for (mut record, instrumentation) in snapshot {
+            delegate.emit(&mut record, &instrumentation);
+        }
+        delegate.force_flush()
+    }
+
+    fn lock_trigger_with_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<MutexGuard<'_, ()>, OTelSdkError> {
+        let start = Instant::now();
+        loop {
+            match self.trigger_lock.try_lock() {
+                Ok(guard) => return Ok(guard),
+                Err(TryLockError::Poisoned(err)) => {
+                    return Err(mutex_error("trigger", err));
+                }
+                Err(TryLockError::WouldBlock) => {
+                    let Some(remaining) = timeout.checked_sub(start.elapsed()) else {
+                        return Err(OTelSdkError::Timeout(timeout));
+                    };
+                    if remaining.is_zero() {
+                        return Err(OTelSdkError::Timeout(timeout));
+                    }
+                    std::thread::sleep(remaining.min(Duration::from_millis(1)));
+                }
+            }
+        }
+    }
+}
+
+impl<P: LogProcessor> TriggerFlightRecorder for Shared<P> {
+    fn trigger(&self) -> OTelSdkResult {
+        self.trigger_and_flush()
+    }
+}
+
+impl<P: LogProcessor> LogProcessor for FlightRecorderLogProcessor<P> {
+    fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+        let buffered_log = (record.clone(), instrumentation.clone());
+        let mut state = match self.shared.state.lock() {
+            Ok(state) => state,
+            Err(err) => {
+                otel_warn!(
+                    name: "FlightRecorderLogProcessor.BufferLockFailed",
+                    error = format!("{err}")
+                );
+                return;
+            }
+        };
+
+        if state.is_shutdown {
+            otel_warn!(
+                name: "FlightRecorderLogProcessor.EmitAfterShutdown",
+                message = "FlightRecorderLogProcessor dropped a log emitted after shutdown."
+            );
+            return;
+        }
+
+        if state.records.len() == self.shared.max_records {
+            state.records.pop_front();
+        }
+        state.records.push_back(buffered_log);
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        self.shared.trigger_and_flush()
+    }
+
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
+        let start = Instant::now();
+        let _trigger_guard = self.shared.lock_trigger_with_timeout(timeout)?;
+
+        {
+            let mut state = self
+                .shared
+                .state
+                .lock()
+                .map_err(|err| mutex_error("buffer", err))?;
+            if state.is_shutdown {
+                return Err(OTelSdkError::AlreadyShutdown);
+            }
+            state.is_shutdown = true;
+            state.records.clear();
+        }
+
+        let remaining = timeout.saturating_sub(start.elapsed());
+        self.shared
+            .delegate
+            .read()
+            .map_err(|err| lock_error("delegate", err))?
+            .shutdown_with_timeout(remaining)
+    }
+
+    fn event_enabled(&self, level: Severity, target: &str, name: Option<&str>) -> bool {
+        match self.shared.delegate.read() {
+            Ok(delegate) => delegate.event_enabled(level, target, name),
+            Err(err) => {
+                otel_warn!(
+                    name: "FlightRecorderLogProcessor.DelegateLockFailed",
+                    error = format!("{err}")
+                );
+                true
+            }
+        }
+    }
+
+    fn set_resource(&mut self, resource: &Resource) {
+        match self.shared.delegate.write() {
+            Ok(mut delegate) => delegate.set_resource(resource),
+            Err(err) => {
+                otel_warn!(
+                    name: "FlightRecorderLogProcessor.DelegateLockFailed",
+                    error = format!("{err}")
+                );
+            }
+        }
+    }
+}
+
+fn mutex_error<T>(name: &str, err: std::sync::PoisonError<T>) -> OTelSdkError {
+    OTelSdkError::InternalFailure(format!(
+        "FlightRecorderLogProcessor {name} mutex poisoned: {err}"
+    ))
+}
+
+fn lock_error<T>(name: &str, err: std::sync::PoisonError<T>) -> OTelSdkError {
+    OTelSdkError::InternalFailure(format!(
+        "FlightRecorderLogProcessor {name} lock poisoned: {err}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::logs::{AnyValue, LogRecord};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Barrier;
+
+    #[derive(Debug, Clone)]
+    struct TestProcessor {
+        records: Arc<Mutex<Vec<BufferedLog>>>,
+        flushes: Arc<AtomicUsize>,
+        shutdown: Arc<AtomicBool>,
+        enabled: bool,
+        resource: Arc<Mutex<Option<Resource>>>,
+    }
+
+    impl TestProcessor {
+        fn new(enabled: bool) -> Self {
+            Self {
+                records: Arc::new(Mutex::new(Vec::new())),
+                flushes: Arc::new(AtomicUsize::new(0)),
+                shutdown: Arc::new(AtomicBool::new(false)),
+                enabled,
+                resource: Arc::new(Mutex::new(None)),
+            }
+        }
+    }
+
+    impl LogProcessor for TestProcessor {
+        fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+            self.records
+                .lock()
+                .unwrap()
+                .push((record.clone(), instrumentation.clone()));
+        }
+
+        fn force_flush(&self) -> OTelSdkResult {
+            self.flushes.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+            self.shutdown.store(true, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn event_enabled(&self, _level: Severity, _target: &str, _name: Option<&str>) -> bool {
+            self.enabled
+        }
+
+        fn set_resource(&mut self, resource: &Resource) {
+            *self.resource.lock().unwrap() = Some(resource.clone());
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct BlockingProcessor {
+        records: Arc<Mutex<Vec<BufferedLog>>>,
+        emit_started: Arc<Barrier>,
+        release_emit: Arc<Barrier>,
+        block_next_emit: Arc<AtomicBool>,
+    }
+
+    impl LogProcessor for BlockingProcessor {
+        fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+            if self.block_next_emit.swap(false, Ordering::Relaxed) {
+                self.emit_started.wait();
+                self.release_emit.wait();
+            }
+            self.records
+                .lock()
+                .unwrap()
+                .push((record.clone(), instrumentation.clone()));
+        }
+
+        fn force_flush(&self) -> OTelSdkResult {
+            Ok(())
+        }
+
+        fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+            Ok(())
+        }
+    }
+
+    fn record(body: &'static str) -> SdkLogRecord {
+        let mut record = SdkLogRecord::new();
+        record.set_body(AnyValue::from(body));
+        record
+    }
+
+    fn bodies(processor: &TestProcessor) -> Vec<String> {
+        processor
+            .records
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(record, _)| match record.body() {
+                Some(AnyValue::String(value)) => value.to_string(),
+                body => panic!("unexpected body: {body:?}"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn records_are_exported_only_when_triggered() {
+        let delegate = TestProcessor::new(true);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record("one"), &scope);
+        processor.emit(&mut record("two"), &scope);
+        assert!(bodies(&delegate).is_empty());
+
+        trigger.trigger().unwrap();
+        assert_eq!(bodies(&delegate), ["one", "two"]);
+        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn oldest_records_are_overwritten() {
+        let delegate = TestProcessor::new(true);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_records(2)
+            .build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record("one"), &scope);
+        processor.emit(&mut record("two"), &scope);
+        processor.emit(&mut record("three"), &scope);
+        trigger.trigger().unwrap();
+
+        assert_eq!(bodies(&delegate), ["two", "three"]);
+    }
+
+    #[test]
+    fn trigger_starts_a_new_snapshot() {
+        let delegate = TestProcessor::new(true);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record("one"), &scope);
+        trigger.trigger().unwrap();
+        processor.emit(&mut record("two"), &scope);
+        trigger.trigger().unwrap();
+
+        assert_eq!(bodies(&delegate), ["one", "two"]);
+        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn records_emitted_during_replay_remain_for_the_next_trigger() {
+        let delegate = BlockingProcessor {
+            records: Arc::new(Mutex::new(Vec::new())),
+            emit_started: Arc::new(Barrier::new(2)),
+            release_emit: Arc::new(Barrier::new(2)),
+            block_next_emit: Arc::new(AtomicBool::new(true)),
+        };
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record("one"), &scope);
+        let first_trigger = trigger.clone();
+        let trigger_thread = std::thread::spawn(move || first_trigger.trigger());
+        delegate.emit_started.wait();
+
+        processor.emit(&mut record("two"), &scope);
+        delegate.release_emit.wait();
+        trigger_thread.join().unwrap().unwrap();
+
+        assert_eq!(
+            delegate.records.lock().unwrap()[0].0.body(),
+            Some(&AnyValue::from("one"))
+        );
+        trigger.trigger().unwrap();
+        let exported = delegate.records.lock().unwrap();
+        assert_eq!(exported.len(), 2);
+        assert_eq!(exported[1].0.body(), Some(&AnyValue::from("two")));
+    }
+
+    #[test]
+    fn concurrent_triggers_do_not_duplicate_records() {
+        let delegate = TestProcessor::new(true);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = InstrumentationScope::builder("test").build();
+        processor.emit(&mut record("one"), &scope);
+
+        let first = trigger.clone();
+        let second = trigger.clone();
+        let first_thread = std::thread::spawn(move || first.trigger());
+        let second_thread = std::thread::spawn(move || second.trigger());
+        first_thread.join().unwrap().unwrap();
+        second_thread.join().unwrap().unwrap();
+
+        assert_eq!(bodies(&delegate), ["one"]);
+        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn force_flush_exports_the_snapshot() {
+        let delegate = TestProcessor::new(true);
+        let (processor, _trigger) = FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record("one"), &scope);
+        processor.force_flush().unwrap();
+
+        assert_eq!(bodies(&delegate), ["one"]);
+        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn shutdown_discards_untriggered_records() {
+        let delegate = TestProcessor::new(true);
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record("discarded"), &scope);
+        processor
+            .shutdown_with_timeout(Duration::from_secs(1))
+            .unwrap();
+
+        assert!(bodies(&delegate).is_empty());
+        assert!(delegate.shutdown.load(Ordering::Relaxed));
+        assert!(matches!(
+            trigger.trigger(),
+            Err(OTelSdkError::AlreadyShutdown)
+        ));
+    }
+
+    #[test]
+    fn shutdown_timeout_includes_waiting_for_an_active_trigger() {
+        let delegate = BlockingProcessor {
+            records: Arc::new(Mutex::new(Vec::new())),
+            emit_started: Arc::new(Barrier::new(2)),
+            release_emit: Arc::new(Barrier::new(2)),
+            block_next_emit: Arc::new(AtomicBool::new(true)),
+        };
+        let (processor, trigger) = FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = InstrumentationScope::builder("test").build();
+        processor.emit(&mut record("one"), &scope);
+
+        let trigger_thread = std::thread::spawn(move || trigger.trigger());
+        delegate.emit_started.wait();
+        assert!(matches!(
+            processor.shutdown_with_timeout(Duration::from_millis(10)),
+            Err(OTelSdkError::Timeout(_))
+        ));
+
+        delegate.release_emit.wait();
+        trigger_thread.join().unwrap().unwrap();
+        processor
+            .shutdown_with_timeout(Duration::from_secs(1))
+            .unwrap();
+    }
+
+    #[test]
+    fn delegates_resource_and_event_enabled() {
+        let delegate = TestProcessor::new(false);
+        let (mut processor, _trigger) =
+            FlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let resource = Resource::builder_empty().with_service_name("test").build();
+
+        processor.set_resource(&resource);
+
+        assert_eq!(*delegate.resource.lock().unwrap(), Some(resource));
+        assert!(!processor.event_enabled(Severity::Info, "target", None));
+    }
+
+    #[test]
+    #[should_panic(expected = "flight recorder max_records must be greater than zero")]
+    fn zero_capacity_panics() {
+        let delegate = TestProcessor::new(true);
+        let _ = FlightRecorderLogProcessor::builder(delegate)
+            .with_max_records(0)
+            .build();
+    }
+}

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -38,7 +38,8 @@ pub use record::{SdkLogRecord, TraceContext};
 #[cfg_attr(docsrs, doc(cfg(feature = "experimental_logs_flight_recorder")))]
 pub use scoped_flight_recorder_log_processor::{
     ScopedFlightRecorder, ScopedFlightRecorderLogProcessor,
-    ScopedFlightRecorderLogProcessorBuilder, ScopedFlightRecorderScope,
+    ScopedFlightRecorderLogProcessorBuilder, ScopedFlightRecorderOverflowPolicy,
+    ScopedFlightRecorderScope, ScopedFlightRecorderStartError,
 };
 pub use simple_log_processor::SimpleLogProcessor;
 

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -1,6 +1,8 @@
 //! # OpenTelemetry Log SDK
 mod batch_log_processor;
 mod export;
+#[cfg(feature = "experimental_logs_flight_recorder")]
+mod flight_recorder_log_processor;
 mod log_processor;
 mod logger;
 mod logger_provider;
@@ -19,6 +21,11 @@ pub use batch_log_processor::{
     BatchConfig, BatchConfigBuilder, BatchLogProcessor, BatchLogProcessorBuilder,
 };
 pub use export::{LogBatch, LogExporter};
+#[cfg(feature = "experimental_logs_flight_recorder")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental_logs_flight_recorder")))]
+pub use flight_recorder_log_processor::{
+    FlightRecorderLogProcessor, FlightRecorderLogProcessorBuilder, FlightRecorderTrigger,
+};
 pub use log_processor::LogProcessor;
 pub use logger::SdkLogger;
 pub use logger_provider::{LoggerProviderBuilder, SdkLoggerProvider};

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -7,6 +7,8 @@ mod log_processor;
 mod logger;
 mod logger_provider;
 pub(crate) mod record;
+#[cfg(feature = "experimental_logs_flight_recorder")]
+mod scoped_flight_recorder_log_processor;
 mod simple_log_processor;
 
 /// In-Memory log exporter for testing purpose.
@@ -30,6 +32,12 @@ pub use log_processor::LogProcessor;
 pub use logger::SdkLogger;
 pub use logger_provider::{LoggerProviderBuilder, SdkLoggerProvider};
 pub use record::{SdkLogRecord, TraceContext};
+#[cfg(feature = "experimental_logs_flight_recorder")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental_logs_flight_recorder")))]
+pub use scoped_flight_recorder_log_processor::{
+    ScopedFlightRecorder, ScopedFlightRecorderLogProcessor,
+    ScopedFlightRecorderLogProcessorBuilder, ScopedFlightRecorderScope,
+};
 pub use simple_log_processor::SimpleLogProcessor;
 
 #[cfg(feature = "experimental_logs_batch_log_processor_with_async_runtime")]

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -2,6 +2,8 @@
 mod batch_log_processor;
 mod export;
 #[cfg(feature = "experimental_logs_flight_recorder")]
+mod flight_recorder;
+#[cfg(feature = "experimental_logs_flight_recorder")]
 mod flight_recorder_log_processor;
 mod log_processor;
 mod logger;

--- a/opentelemetry-sdk/src/logs/mod.rs
+++ b/opentelemetry-sdk/src/logs/mod.rs
@@ -38,8 +38,8 @@ pub use record::{SdkLogRecord, TraceContext};
 #[cfg_attr(docsrs, doc(cfg(feature = "experimental_logs_flight_recorder")))]
 pub use scoped_flight_recorder_log_processor::{
     ScopedFlightRecorder, ScopedFlightRecorderLogProcessor,
-    ScopedFlightRecorderLogProcessorBuilder, ScopedFlightRecorderOverflowPolicy,
-    ScopedFlightRecorderScope, ScopedFlightRecorderStartError,
+    ScopedFlightRecorderLogProcessorBuilder, ScopedFlightRecorderOperationError,
+    ScopedFlightRecorderOverflowPolicy, ScopedFlightRecorderScope, ScopedFlightRecorderStartError,
 };
 pub use simple_log_processor::SimpleLogProcessor;
 

--- a/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
@@ -1,4 +1,5 @@
 use crate::error::{OTelSdkError, OTelSdkResult};
+use crate::logs::flight_recorder::estimated_log_size;
 use crate::logs::{LogProcessor, SdkLogRecord};
 use crate::Resource;
 use opentelemetry::logs::Severity;
@@ -11,11 +12,14 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock, TryLockError, Weak};
 use std::time::{Duration, Instant};
 
-const DEFAULT_MAX_RECORDS_PER_SCOPE: usize = 2_048;
-const DEFAULT_MAX_ACTIVE_SCOPES: usize = 1_024;
+const DEFAULT_MAX_RECORDS_PER_SCOPE: usize = 256;
+const DEFAULT_MAX_ACTIVE_SCOPES: usize = 128;
+const DEFAULT_MAX_BUFFER_SIZE_BYTES_PER_SCOPE: usize = 256 * 1024;
+const DEFAULT_MAX_TOTAL_BUFFER_SIZE_BYTES: usize = 16 * 1024 * 1024;
+const DEFAULT_MAX_RECORD_SIZE_BYTES: usize = 64 * 1024;
 const DEFAULT_MAX_BUFFERED_SEVERITY: Severity = Severity::Info4;
 
-type BufferedLog = (SdkLogRecord, InstrumentationScope);
+type BufferedLog = (SdkLogRecord, InstrumentationScope, usize);
 
 static NEXT_PROCESSOR_ID: AtomicUsize = AtomicUsize::new(1);
 
@@ -37,6 +41,15 @@ impl<P: LogProcessor> Debug for ScopedFlightRecorderLogProcessor<P> {
         f.debug_struct("ScopedFlightRecorderLogProcessor")
             .field("max_records_per_scope", &self.shared.max_records_per_scope)
             .field("max_active_scopes", &self.shared.max_active_scopes)
+            .field(
+                "max_buffer_size_bytes_per_scope",
+                &self.shared.max_buffer_size_bytes_per_scope,
+            )
+            .field(
+                "max_total_buffer_size_bytes",
+                &self.shared.memory_budget.limit,
+            )
+            .field("max_record_size_bytes", &self.shared.max_record_size_bytes)
             .field("max_buffered_severity", &self.shared.max_buffered_severity)
             .finish_non_exhaustive()
     }
@@ -49,6 +62,9 @@ impl<P: LogProcessor> ScopedFlightRecorderLogProcessor<P> {
             delegate,
             max_records_per_scope: DEFAULT_MAX_RECORDS_PER_SCOPE,
             max_active_scopes: DEFAULT_MAX_ACTIVE_SCOPES,
+            max_buffer_size_bytes_per_scope: DEFAULT_MAX_BUFFER_SIZE_BYTES_PER_SCOPE,
+            max_total_buffer_size_bytes: DEFAULT_MAX_TOTAL_BUFFER_SIZE_BYTES,
+            max_record_size_bytes: DEFAULT_MAX_RECORD_SIZE_BYTES,
             max_buffered_severity: DEFAULT_MAX_BUFFERED_SEVERITY,
         }
     }
@@ -60,6 +76,9 @@ pub struct ScopedFlightRecorderLogProcessorBuilder<P: LogProcessor> {
     delegate: P,
     max_records_per_scope: usize,
     max_active_scopes: usize,
+    max_buffer_size_bytes_per_scope: usize,
+    max_total_buffer_size_bytes: usize,
+    max_record_size_bytes: usize,
     max_buffered_severity: Severity,
 }
 
@@ -73,6 +92,30 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderLogProcessorBuilder<P> {
     /// Sets the maximum number of simultaneously active recording scopes.
     pub fn with_max_active_scopes(mut self, max_active_scopes: usize) -> Self {
         self.max_active_scopes = max_active_scopes;
+        self
+    }
+
+    /// Sets the maximum estimated memory retained by each active scope.
+    pub fn with_max_buffer_size_bytes_per_scope(
+        mut self,
+        max_buffer_size_bytes_per_scope: usize,
+    ) -> Self {
+        self.max_buffer_size_bytes_per_scope = max_buffer_size_bytes_per_scope;
+        self
+    }
+
+    /// Sets the aggregate estimated memory retained across all active scopes.
+    pub fn with_max_total_buffer_size_bytes(mut self, max_total_buffer_size_bytes: usize) -> Self {
+        self.max_total_buffer_size_bytes = max_total_buffer_size_bytes;
+        self
+    }
+
+    /// Sets the maximum estimated size of an individual buffered record.
+    ///
+    /// Larger records bypass the recorder and follow the wrapped processor's
+    /// normal path.
+    pub fn with_max_record_size_bytes(mut self, max_record_size_bytes: usize) -> Self {
+        self.max_record_size_bytes = max_record_size_bytes;
         self
     }
 
@@ -96,6 +139,18 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderLogProcessorBuilder<P> {
             self.max_active_scopes > 0,
             "scoped flight recorder max_active_scopes must be greater than zero"
         );
+        assert!(
+            self.max_buffer_size_bytes_per_scope > 0,
+            "scoped flight recorder max_buffer_size_bytes_per_scope must be greater than zero"
+        );
+        assert!(
+            self.max_total_buffer_size_bytes > 0,
+            "scoped flight recorder max_total_buffer_size_bytes must be greater than zero"
+        );
+        assert!(
+            self.max_record_size_bytes > 0,
+            "scoped flight recorder max_record_size_bytes must be greater than zero"
+        );
 
         let shared = Arc::new(ScopedShared {
             delegate: RwLock::new(self.delegate),
@@ -106,6 +161,9 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderLogProcessorBuilder<P> {
             processor_id: NEXT_PROCESSOR_ID.fetch_add(1, Ordering::Relaxed),
             max_records_per_scope: self.max_records_per_scope,
             max_active_scopes: self.max_active_scopes,
+            max_buffer_size_bytes_per_scope: self.max_buffer_size_bytes_per_scope,
+            max_record_size_bytes: self.max_record_size_bytes,
+            memory_budget: Arc::new(MemoryBudget::new(self.max_total_buffer_size_bytes)),
             max_buffered_severity: self.max_buffered_severity,
         });
         let recorder = ScopedFlightRecorder {
@@ -203,12 +261,16 @@ struct ScopeBuffer {
     id: usize,
     processor_id: usize,
     max_records: usize,
+    max_buffer_size_bytes: usize,
+    memory_budget: Arc<MemoryBudget>,
+    accounted_bytes: AtomicUsize,
     state: Mutex<ScopeState>,
 }
 
 struct ScopeState {
     status: ScopeStatus,
     records: VecDeque<BufferedLog>,
+    buffer_size_bytes: usize,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -223,6 +285,7 @@ impl ScopeBuffer {
         &self,
         record: &SdkLogRecord,
         instrumentation: &InstrumentationScope,
+        estimated_size: usize,
     ) -> Result<bool, OTelSdkError> {
         let mut state = self
             .state
@@ -231,25 +294,60 @@ impl ScopeBuffer {
         if state.status != ScopeStatus::Recording {
             return Ok(false);
         }
-        if state.records.len() == self.max_records {
+        let mut remaining_records = state.records.len();
+        let mut remaining_bytes = state.buffer_size_bytes;
+        let mut eviction_count = 0;
+        let mut eviction_bytes = 0;
+        for (_, _, size) in &state.records {
+            if remaining_records < self.max_records
+                && estimated_size <= self.max_buffer_size_bytes - remaining_bytes
+            {
+                break;
+            }
+            remaining_records -= 1;
+            remaining_bytes -= size;
+            eviction_count += 1;
+            eviction_bytes += size;
+        }
+
+        let additional_bytes = estimated_size.saturating_sub(eviction_bytes);
+        if !self.memory_budget.try_reserve(additional_bytes) {
+            return Ok(false);
+        }
+
+        for _ in 0..eviction_count {
             state.records.pop_front();
         }
+        if eviction_bytes > estimated_size {
+            self.memory_budget.release(eviction_bytes - estimated_size);
+        }
+        state.buffer_size_bytes = remaining_bytes + estimated_size;
+        self.accounted_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |accounted| {
+                Some(accounted - eviction_bytes + estimated_size)
+            })
+            .expect("scope byte accounting must not underflow");
         state
             .records
-            .push_back((record.clone(), instrumentation.clone()));
+            .push_back((record.clone(), instrumentation.clone(), estimated_size));
         Ok(true)
     }
 
-    fn take_and_passthrough(&self) -> Result<VecDeque<BufferedLog>, OTelSdkError> {
+    fn take_and_passthrough(&self) -> Result<BufferedSnapshot, OTelSdkError> {
         let mut state = self
             .state
             .lock()
             .map_err(|err| mutex_error("scope buffer", err))?;
         if state.status != ScopeStatus::Recording {
-            return Ok(VecDeque::new());
+            return Ok(BufferedSnapshot::empty(self.memory_budget.clone()));
         }
         state.status = ScopeStatus::Passthrough;
-        Ok(std::mem::take(&mut state.records))
+        state.buffer_size_bytes = 0;
+        self.accounted_bytes.store(0, Ordering::Release);
+        Ok(BufferedSnapshot {
+            records: std::mem::take(&mut state.records),
+            memory_budget: self.memory_budget.clone(),
+        })
     }
 
     fn discard(&self) {
@@ -257,6 +355,8 @@ impl ScopeBuffer {
             Ok(mut state) => {
                 state.status = ScopeStatus::Discarded;
                 state.records.clear();
+                state.buffer_size_bytes = 0;
+                self.release_all_accounted_bytes();
             }
             Err(err) => {
                 otel_warn!(
@@ -264,6 +364,81 @@ impl ScopeBuffer {
                     error = format!("{err}")
                 );
             }
+        }
+    }
+
+    fn release_all_accounted_bytes(&self) {
+        let bytes = self.accounted_bytes.swap(0, Ordering::AcqRel);
+        self.memory_budget.release(bytes);
+    }
+}
+
+struct BufferedSnapshot {
+    records: VecDeque<BufferedLog>,
+    memory_budget: Arc<MemoryBudget>,
+}
+
+impl BufferedSnapshot {
+    fn empty(memory_budget: Arc<MemoryBudget>) -> Self {
+        Self {
+            records: VecDeque::new(),
+            memory_budget,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    fn pop_front(&mut self) -> Option<BufferedLog> {
+        self.records.pop_front()
+    }
+
+    fn release(&self, bytes: usize) {
+        self.memory_budget.release(bytes);
+    }
+}
+
+impl Drop for BufferedSnapshot {
+    fn drop(&mut self) {
+        let bytes = self.records.iter().map(|(_, _, size)| size).sum();
+        self.memory_budget.release(bytes);
+    }
+}
+
+impl Drop for ScopeBuffer {
+    fn drop(&mut self) {
+        self.release_all_accounted_bytes();
+    }
+}
+
+struct MemoryBudget {
+    used: AtomicUsize,
+    limit: usize,
+}
+
+impl MemoryBudget {
+    fn new(limit: usize) -> Self {
+        Self {
+            used: AtomicUsize::new(0),
+            limit,
+        }
+    }
+
+    fn try_reserve(&self, bytes: usize) -> bool {
+        if bytes == 0 {
+            return true;
+        }
+        self.used
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |used| {
+                used.checked_add(bytes).filter(|total| *total <= self.limit)
+            })
+            .is_ok()
+    }
+
+    fn release(&self, bytes: usize) {
+        if bytes > 0 {
+            self.used.fetch_sub(bytes, Ordering::AcqRel);
         }
     }
 }
@@ -277,6 +452,9 @@ struct ScopedShared<P: LogProcessor> {
     processor_id: usize,
     max_records_per_scope: usize,
     max_active_scopes: usize,
+    max_buffer_size_bytes_per_scope: usize,
+    max_record_size_bytes: usize,
+    memory_budget: Arc<MemoryBudget>,
     max_buffered_severity: Severity,
 }
 
@@ -313,12 +491,13 @@ impl<P: LogProcessor> ScopedShared<P> {
         delegate.force_flush()?;
 
         for buffer in buffers {
-            let snapshot = buffer.take_and_passthrough()?;
+            let mut snapshot = buffer.take_and_passthrough()?;
             if snapshot.is_empty() {
                 continue;
             }
-            for (mut record, instrumentation) in snapshot {
+            while let Some((mut record, instrumentation, estimated_size)) = snapshot.pop_front() {
                 delegate.emit(&mut record, &instrumentation);
+                snapshot.release(estimated_size);
             }
             // Bound each handoff to one scope so a delegate queue sized for
             // max_records_per_scope does not need capacity for every active
@@ -387,9 +566,13 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
             id,
             processor_id: self.processor_id,
             max_records: self.max_records_per_scope,
+            max_buffer_size_bytes: self.max_buffer_size_bytes_per_scope,
+            memory_budget: self.memory_budget.clone(),
+            accounted_bytes: AtomicUsize::new(0),
             state: Mutex::new(ScopeState {
                 status: ScopeStatus::Recording,
                 records: VecDeque::new(),
+                buffer_size_bytes: 0,
             }),
         });
         scopes.insert(id, Arc::downgrade(&buffer));
@@ -425,6 +608,13 @@ impl<P: LogProcessor + 'static> LogProcessor for ScopedFlightRecorderLogProcesso
             severity <= self.shared.max_buffered_severity
         });
         if should_buffer {
+            let estimated_size = estimated_log_size(record, instrumentation);
+            if estimated_size > self.shared.max_record_size_bytes
+                || estimated_size > self.shared.max_buffer_size_bytes_per_scope
+            {
+                self.shared.emit_to_delegate(record, instrumentation);
+                return;
+            }
             let buffer = Context::map_current(|context| {
                 context
                     .get::<ScopedBufferContext>()
@@ -432,7 +622,7 @@ impl<P: LogProcessor + 'static> LogProcessor for ScopedFlightRecorderLogProcesso
             });
             if let Some(buffer) = buffer {
                 if buffer.processor_id == self.shared.processor_id {
-                    match buffer.try_buffer(record, instrumentation) {
+                    match buffer.try_buffer(record, instrumentation, estimated_size) {
                         Ok(true) => return,
                         Ok(false) => {}
                         Err(err) => {
@@ -545,7 +735,7 @@ mod tests {
                 self.dropped.fetch_add(1, Ordering::Relaxed);
                 return;
             }
-            pending.push((record.clone(), instrumentation.clone()));
+            pending.push((record.clone(), instrumentation.clone(), 0));
         }
 
         fn force_flush(&self) -> OTelSdkResult {
@@ -573,7 +763,7 @@ mod tests {
             self.records
                 .lock()
                 .unwrap()
-                .push((record.clone(), instrumentation.clone()));
+                .push((record.clone(), instrumentation.clone(), 0));
         }
 
         fn force_flush(&self) -> OTelSdkResult {
@@ -599,7 +789,7 @@ mod tests {
             .lock()
             .unwrap()
             .iter()
-            .map(|(record, _)| match record.body() {
+            .map(|(record, _, _)| match record.body() {
                 Some(AnyValue::String(value)) => value.to_string(),
                 body => panic!("unexpected body: {body:?}"),
             })
@@ -747,6 +937,148 @@ mod tests {
         scope.trigger().unwrap();
 
         assert_eq!(bodies(&delegate), ["two", "three"]);
+    }
+
+    #[test]
+    fn scope_byte_capacity_overwrites_oldest_records() {
+        let delegate = TestProcessor::new();
+        let instrumentation = InstrumentationScope::builder("test").build();
+        let estimated_size = estimated_log_size(&record("one", Severity::Info), &instrumentation);
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_buffer_size_bytes_per_scope(estimated_size * 2)
+            .build();
+        let scope = recorder.try_start().unwrap();
+
+        futures_executor::block_on(scope.with_context(async {
+            processor.emit(&mut record("one", Severity::Info), &instrumentation);
+            processor.emit(&mut record("two", Severity::Info), &instrumentation);
+            processor.emit(&mut record("six", Severity::Info), &instrumentation);
+        }));
+        scope.trigger().unwrap();
+
+        assert_eq!(bodies(&delegate), ["two", "six"]);
+    }
+
+    #[test]
+    fn aggregate_byte_capacity_is_shared_across_scopes() {
+        let delegate = TestProcessor::new();
+        let instrumentation = InstrumentationScope::builder("test").build();
+        let estimated_size = estimated_log_size(&record("first", Severity::Info), &instrumentation);
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_buffer_size_bytes_per_scope(estimated_size * 2)
+            .with_max_total_buffer_size_bytes(estimated_size)
+            .build();
+        let first = recorder.try_start().unwrap();
+        let second = recorder.try_start().unwrap();
+
+        futures_executor::block_on(first.with_context(async {
+            processor.emit(&mut record("first", Severity::Info), &instrumentation);
+        }));
+        futures_executor::block_on(second.with_context(async {
+            processor.emit(&mut record("other", Severity::Info), &instrumentation);
+        }));
+        assert_eq!(bodies(&delegate), ["other"]);
+
+        first.discard();
+        futures_executor::block_on(second.with_context(async {
+            processor.emit(&mut record("third", Severity::Info), &instrumentation);
+        }));
+        second.trigger().unwrap();
+
+        assert_eq!(bodies(&delegate), ["other", "third"]);
+    }
+
+    #[test]
+    fn failed_aggregate_reservation_preserves_existing_snapshot() {
+        const LARGE_BODY: &str =
+            "a much larger record that requires more aggregate capacity than the existing record";
+
+        let delegate = TestProcessor::new();
+        let instrumentation = InstrumentationScope::builder("test").build();
+        let small_size = estimated_log_size(&record("a", Severity::Info), &instrumentation);
+        let large_size = estimated_log_size(&record(LARGE_BODY, Severity::Info), &instrumentation);
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_records_per_scope(1)
+            .with_max_buffer_size_bytes_per_scope(large_size)
+            .with_max_total_buffer_size_bytes(small_size * 2)
+            .build();
+        let first = recorder.try_start().unwrap();
+        let second = recorder.try_start().unwrap();
+
+        futures_executor::block_on(first.with_context(async {
+            processor.emit(&mut record("a", Severity::Info), &instrumentation);
+        }));
+        futures_executor::block_on(second.with_context(async {
+            processor.emit(&mut record("b", Severity::Info), &instrumentation);
+        }));
+        futures_executor::block_on(first.with_context(async {
+            processor.emit(&mut record(LARGE_BODY, Severity::Info), &instrumentation);
+        }));
+
+        assert_eq!(bodies(&delegate), [LARGE_BODY]);
+        first.trigger().unwrap();
+        assert_eq!(bodies(&delegate), [LARGE_BODY, "a"]);
+        second.discard();
+    }
+
+    #[test]
+    fn aggregate_byte_capacity_is_released_by_scope_lifecycle() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) =
+            ScopedFlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let instrumentation = InstrumentationScope::builder("test").build();
+
+        let discarded = recorder.try_start().unwrap();
+        futures_executor::block_on(discarded.with_context(async {
+            processor.emit(&mut record("discard", Severity::Info), &instrumentation);
+        }));
+        assert!(processor.shared.memory_budget.used.load(Ordering::Acquire) > 0);
+        discarded.discard();
+        assert_eq!(
+            processor.shared.memory_budget.used.load(Ordering::Acquire),
+            0
+        );
+
+        let triggered = recorder.try_start().unwrap();
+        futures_executor::block_on(triggered.with_context(async {
+            processor.emit(&mut record("trigger", Severity::Info), &instrumentation);
+        }));
+        triggered.trigger().unwrap();
+        assert_eq!(
+            processor.shared.memory_budget.used.load(Ordering::Acquire),
+            0
+        );
+
+        let dropped = recorder.try_start().unwrap();
+        futures_executor::block_on(dropped.with_context(async {
+            processor.emit(&mut record("dropped", Severity::Info), &instrumentation);
+        }));
+        assert!(processor.shared.memory_budget.used.load(Ordering::Acquire) > 0);
+        drop(dropped);
+        assert_eq!(
+            processor.shared.memory_budget.used.load(Ordering::Acquire),
+            0
+        );
+    }
+
+    #[test]
+    fn oversized_scoped_records_bypass_the_buffer() {
+        let delegate = TestProcessor::new();
+        let instrumentation = InstrumentationScope::builder("test").build();
+        let estimated_size =
+            estimated_log_size(&record("oversized", Severity::Info), &instrumentation);
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_record_size_bytes(estimated_size - 1)
+            .build();
+        let scope = recorder.try_start().unwrap();
+
+        futures_executor::block_on(scope.with_context(async {
+            processor.emit(&mut record("oversized", Severity::Info), &instrumentation);
+        }));
+
+        assert_eq!(bodies(&delegate), ["oversized"]);
+        scope.trigger().unwrap();
+        assert_eq!(bodies(&delegate), ["oversized"]);
     }
 
     #[test]

--- a/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
@@ -123,6 +123,48 @@ impl fmt::Display for ScopedFlightRecorderStartError {
 
 impl Error for ScopedFlightRecorderStartError {}
 
+/// Failure from [`ScopedFlightRecorder::record_on_error`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ScopedFlightRecorderOperationError<E> {
+    /// A recording scope could not be admitted.
+    Start(ScopedFlightRecorderStartError),
+    /// The operation failed and its snapshot was handed off successfully.
+    Operation(E),
+    /// The operation failed and snapshot handoff also failed.
+    Handoff {
+        /// The original operation error.
+        operation: E,
+        /// The snapshot handoff error.
+        handoff: OTelSdkError,
+    },
+}
+
+impl<E: fmt::Display> fmt::Display for ScopedFlightRecorderOperationError<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Start(err) => write!(f, "flight recorder scope admission failed: {err}"),
+            Self::Operation(err) => write!(f, "recorded operation failed: {err}"),
+            Self::Handoff { operation, handoff } => {
+                write!(
+                    f,
+                    "recorded operation failed ({operation}) and snapshot handoff failed: {handoff}"
+                )
+            }
+        }
+    }
+}
+
+impl<E: Error + 'static> Error for ScopedFlightRecorderOperationError<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Start(err) => Some(err),
+            Self::Operation(err) => Some(err),
+            Self::Handoff { handoff, .. } => Some(handoff),
+        }
+    }
+}
+
 impl<P: LogProcessor + 'static> ScopedFlightRecorderLogProcessorBuilder<P> {
     /// Sets the maximum number of records retained by each active scope.
     pub fn with_max_records_per_scope(mut self, max_records: usize) -> Self {
@@ -247,6 +289,37 @@ impl ScopedFlightRecorder {
                 inner: self.inner.clone(),
                 buffer,
             })
+    }
+
+    /// Runs a fallible operation in a recording scope.
+    ///
+    /// Successful operations discard their buffered logs. Failed operations
+    /// hand off their snapshot without waiting for delegate flush completion.
+    /// Cancelling or dropping this future discards the in-progress snapshot.
+    /// Use the lower-level scope API when failure handling must call
+    /// [`ScopedFlightRecorderScope::trigger`] and wait for a flush.
+    pub async fn record_on_error<F, T, E>(
+        &self,
+        future: F,
+    ) -> Result<T, ScopedFlightRecorderOperationError<E>>
+    where
+        F: Future<Output = Result<T, E>>,
+    {
+        let scope = self
+            .try_start()
+            .map_err(ScopedFlightRecorderOperationError::Start)?;
+        match scope.with_context(future).await {
+            Ok(value) => {
+                scope.discard();
+                Ok(value)
+            }
+            Err(operation) => match scope.handoff() {
+                Ok(()) => Err(ScopedFlightRecorderOperationError::Operation(operation)),
+                Err(handoff) => {
+                    Err(ScopedFlightRecorderOperationError::Handoff { operation, handoff })
+                }
+            },
+        }
     }
 }
 
@@ -930,6 +1003,68 @@ mod tests {
 
         assert_eq!(bodies(&delegate), ["first"]);
         second.discard();
+    }
+
+    #[test]
+    fn record_on_error_discards_success_and_hands_off_failure() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) =
+            ScopedFlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let instrumentation = InstrumentationScope::builder("test").build();
+
+        let success = futures_executor::block_on(recorder.record_on_error(async {
+            processor.emit(&mut record("success", Severity::Info), &instrumentation);
+            Ok::<_, &'static str>("ok")
+        }));
+        assert_eq!(success.unwrap(), "ok");
+        assert!(bodies(&delegate).is_empty());
+
+        let failure = futures_executor::block_on(recorder.record_on_error(async {
+            processor.emit(&mut record("failure", Severity::Info), &instrumentation);
+            Err::<(), _>("operation failed")
+        }));
+        assert!(matches!(
+            failure,
+            Err(ScopedFlightRecorderOperationError::Operation(
+                "operation failed"
+            ))
+        ));
+        assert_eq!(bodies(&delegate), ["failure"]);
+    }
+
+    #[test]
+    fn record_on_error_preserves_start_and_handoff_failures() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate)
+            .with_max_active_scopes(1)
+            .build();
+        let active = recorder.try_start().unwrap();
+
+        let rejected = futures_executor::block_on(
+            recorder.record_on_error(async { Ok::<_, &'static str>(()) }),
+        );
+        assert!(matches!(
+            rejected,
+            Err(ScopedFlightRecorderOperationError::Start(
+                ScopedFlightRecorderStartError::ScopeLimitReached
+            ))
+        ));
+        active.discard();
+        drop(active);
+
+        let handoff_failure = futures_executor::block_on(recorder.record_on_error(async {
+            processor
+                .shutdown_with_timeout(Duration::from_secs(1))
+                .unwrap();
+            Err::<(), _>("operation failed")
+        }));
+        match handoff_failure {
+            Err(ScopedFlightRecorderOperationError::Handoff {
+                operation: "operation failed",
+                handoff: OTelSdkError::AlreadyShutdown,
+            }) => {}
+            other => panic!("unexpected result: {other:?}"),
+        }
     }
 
     #[test]

--- a/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
@@ -1,0 +1,729 @@
+use crate::error::{OTelSdkError, OTelSdkResult};
+use crate::logs::{LogProcessor, SdkLogRecord};
+use crate::Resource;
+use opentelemetry::logs::Severity;
+use opentelemetry::{otel_warn, Context, InstrumentationScope};
+use std::collections::{HashMap, VecDeque};
+use std::fmt::{self, Debug, Formatter};
+use std::future::{poll_fn, Future};
+use std::pin::pin;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock, TryLockError, Weak};
+use std::time::{Duration, Instant};
+
+const DEFAULT_MAX_RECORDS_PER_SCOPE: usize = 2_048;
+const DEFAULT_MAX_ACTIVE_SCOPES: usize = 1_024;
+const DEFAULT_MAX_BUFFERED_SEVERITY: Severity = Severity::Info4;
+
+type BufferedLog = (SdkLogRecord, InstrumentationScope);
+
+static NEXT_PROCESSOR_ID: AtomicUsize = AtomicUsize::new(1);
+
+/// A log processor that retains low-severity logs in operation-scoped buffers.
+///
+/// A scope is created with [`ScopedFlightRecorder::try_start`], then propagated
+/// with [`ScopedFlightRecorderScope::with_context`]. TRACE, DEBUG, and INFO
+/// records emitted inside that context are buffered by default. WARN and higher
+/// records, logs outside an active scope, and logs emitted after a scope is
+/// triggered follow the wrapped processor's normal path.
+///
+/// Dropping a scope without triggering it discards its buffered records.
+pub struct ScopedFlightRecorderLogProcessor<P: LogProcessor> {
+    shared: Arc<ScopedShared<P>>,
+}
+
+impl<P: LogProcessor> Debug for ScopedFlightRecorderLogProcessor<P> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScopedFlightRecorderLogProcessor")
+            .field("max_records_per_scope", &self.shared.max_records_per_scope)
+            .field("max_active_scopes", &self.shared.max_active_scopes)
+            .field("max_buffered_severity", &self.shared.max_buffered_severity)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<P: LogProcessor> ScopedFlightRecorderLogProcessor<P> {
+    /// Creates a builder wrapping `delegate`.
+    pub fn builder(delegate: P) -> ScopedFlightRecorderLogProcessorBuilder<P> {
+        ScopedFlightRecorderLogProcessorBuilder {
+            delegate,
+            max_records_per_scope: DEFAULT_MAX_RECORDS_PER_SCOPE,
+            max_active_scopes: DEFAULT_MAX_ACTIVE_SCOPES,
+            max_buffered_severity: DEFAULT_MAX_BUFFERED_SEVERITY,
+        }
+    }
+}
+
+/// Configures a [`ScopedFlightRecorderLogProcessor`].
+#[derive(Debug)]
+pub struct ScopedFlightRecorderLogProcessorBuilder<P: LogProcessor> {
+    delegate: P,
+    max_records_per_scope: usize,
+    max_active_scopes: usize,
+    max_buffered_severity: Severity,
+}
+
+impl<P: LogProcessor + 'static> ScopedFlightRecorderLogProcessorBuilder<P> {
+    /// Sets the maximum number of records retained by each active scope.
+    pub fn with_max_records_per_scope(mut self, max_records: usize) -> Self {
+        self.max_records_per_scope = max_records;
+        self
+    }
+
+    /// Sets the maximum number of simultaneously active recording scopes.
+    pub fn with_max_active_scopes(mut self, max_active_scopes: usize) -> Self {
+        self.max_active_scopes = max_active_scopes;
+        self
+    }
+
+    /// Sets the highest severity retained in operation-scoped buffers.
+    pub fn with_max_buffered_severity(mut self, severity: Severity) -> Self {
+        self.max_buffered_severity = severity;
+        self
+    }
+
+    /// Builds the processor and the handle used to create recording scopes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either configured capacity is zero.
+    pub fn build(self) -> (ScopedFlightRecorderLogProcessor<P>, ScopedFlightRecorder) {
+        assert!(
+            self.max_records_per_scope > 0,
+            "scoped flight recorder max_records_per_scope must be greater than zero"
+        );
+        assert!(
+            self.max_active_scopes > 0,
+            "scoped flight recorder max_active_scopes must be greater than zero"
+        );
+
+        let shared = Arc::new(ScopedShared {
+            delegate: RwLock::new(self.delegate),
+            trigger_lock: Mutex::new(()),
+            scopes: Mutex::new(HashMap::new()),
+            next_scope_id: AtomicUsize::new(1),
+            is_shutdown: AtomicBool::new(false),
+            processor_id: NEXT_PROCESSOR_ID.fetch_add(1, Ordering::Relaxed),
+            max_records_per_scope: self.max_records_per_scope,
+            max_active_scopes: self.max_active_scopes,
+            max_buffered_severity: self.max_buffered_severity,
+        });
+        let recorder = ScopedFlightRecorder {
+            inner: shared.clone(),
+        };
+
+        (ScopedFlightRecorderLogProcessor { shared }, recorder)
+    }
+}
+
+/// Creates operation-scoped flight-recorder buffers.
+#[derive(Clone)]
+pub struct ScopedFlightRecorder {
+    inner: Arc<dyn ScopedFlightRecorderCore>,
+}
+
+impl ScopedFlightRecorder {
+    /// Starts a recording scope.
+    ///
+    /// Returns `None` when the configured active-scope limit has been reached or
+    /// the processor has shut down. Logs without a scope use the normal path.
+    pub fn try_start(&self) -> Option<ScopedFlightRecorderScope> {
+        self.inner
+            .try_start()
+            .map(|buffer| ScopedFlightRecorderScope {
+                inner: self.inner.clone(),
+                buffer,
+            })
+    }
+}
+
+impl Debug for ScopedFlightRecorder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScopedFlightRecorder")
+            .finish_non_exhaustive()
+    }
+}
+
+/// An operation-scoped flight recorder.
+#[derive(Clone)]
+pub struct ScopedFlightRecorderScope {
+    inner: Arc<dyn ScopedFlightRecorderCore>,
+    buffer: Arc<ScopeBuffer>,
+}
+
+impl ScopedFlightRecorderScope {
+    /// Runs `future` with this recording scope attached to the current
+    /// OpenTelemetry context whenever the future is polled.
+    ///
+    /// Independently spawned tasks do not automatically inherit this context.
+    /// Wrap those task futures with `with_context` as well when their logs
+    /// should belong to the same scope.
+    pub async fn with_context<F: Future>(&self, future: F) -> F::Output {
+        let context = Context::current_with_value(ScopedBufferContext {
+            buffer: self.buffer.clone(),
+        });
+        let mut future = pin!(future);
+        poll_fn(|task_context| {
+            let _guard = context.clone().attach();
+            future.as_mut().poll(task_context)
+        })
+        .await
+    }
+
+    /// Exports this scope's buffered snapshot and switches it to passthrough.
+    pub fn trigger(&self) -> OTelSdkResult {
+        self.inner.trigger(&self.buffer)
+    }
+
+    /// Discards this scope's buffered records.
+    pub fn discard(&self) {
+        self.buffer.discard();
+    }
+}
+
+impl Debug for ScopedFlightRecorderScope {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScopedFlightRecorderScope")
+            .field("id", &self.buffer.id)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone)]
+struct ScopedBufferContext {
+    buffer: Arc<ScopeBuffer>,
+}
+
+trait ScopedFlightRecorderCore: Send + Sync {
+    fn try_start(&self) -> Option<Arc<ScopeBuffer>>;
+    fn trigger(&self, buffer: &Arc<ScopeBuffer>) -> OTelSdkResult;
+}
+
+struct ScopeBuffer {
+    id: usize,
+    processor_id: usize,
+    max_records: usize,
+    state: Mutex<ScopeState>,
+}
+
+struct ScopeState {
+    status: ScopeStatus,
+    records: VecDeque<BufferedLog>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ScopeStatus {
+    Recording,
+    Passthrough,
+    Discarded,
+}
+
+impl ScopeBuffer {
+    fn try_buffer(
+        &self,
+        record: &SdkLogRecord,
+        instrumentation: &InstrumentationScope,
+    ) -> Result<bool, OTelSdkError> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|err| mutex_error("scope buffer", err))?;
+        if state.status != ScopeStatus::Recording {
+            return Ok(false);
+        }
+        if state.records.len() == self.max_records {
+            state.records.pop_front();
+        }
+        state
+            .records
+            .push_back((record.clone(), instrumentation.clone()));
+        Ok(true)
+    }
+
+    fn take_and_passthrough(&self) -> Result<VecDeque<BufferedLog>, OTelSdkError> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|err| mutex_error("scope buffer", err))?;
+        if state.status != ScopeStatus::Recording {
+            return Ok(VecDeque::new());
+        }
+        state.status = ScopeStatus::Passthrough;
+        Ok(std::mem::take(&mut state.records))
+    }
+
+    fn discard(&self) {
+        match self.state.lock() {
+            Ok(mut state) => {
+                state.status = ScopeStatus::Discarded;
+                state.records.clear();
+            }
+            Err(err) => {
+                otel_warn!(
+                    name: "ScopedFlightRecorderLogProcessor.BufferLockFailed",
+                    error = format!("{err}")
+                );
+            }
+        }
+    }
+}
+
+struct ScopedShared<P: LogProcessor> {
+    delegate: RwLock<P>,
+    trigger_lock: Mutex<()>,
+    scopes: Mutex<HashMap<usize, Weak<ScopeBuffer>>>,
+    next_scope_id: AtomicUsize,
+    is_shutdown: AtomicBool,
+    processor_id: usize,
+    max_records_per_scope: usize,
+    max_active_scopes: usize,
+    max_buffered_severity: Severity,
+}
+
+impl<P: LogProcessor> ScopedShared<P> {
+    fn emit_to_delegate(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+        let delegate = match self.delegate.read() {
+            Ok(delegate) => delegate,
+            Err(err) => {
+                otel_warn!(
+                    name: "ScopedFlightRecorderLogProcessor.DelegateLockFailed",
+                    error = format!("{err}")
+                );
+                return;
+            }
+        };
+        if self.is_shutdown.load(Ordering::Acquire) {
+            otel_warn!(
+                name: "ScopedFlightRecorderLogProcessor.EmitAfterShutdown",
+                message = "ScopedFlightRecorderLogProcessor dropped a log emitted after shutdown."
+            );
+            return;
+        }
+        delegate.emit(record, instrumentation);
+    }
+
+    fn flush_snapshots(
+        &self,
+        buffers: impl IntoIterator<Item = Arc<ScopeBuffer>>,
+    ) -> OTelSdkResult {
+        let delegate = self
+            .delegate
+            .write()
+            .map_err(|err| lock_error("delegate", err))?;
+        delegate.force_flush()?;
+
+        let mut emitted = false;
+        for buffer in buffers {
+            for (mut record, instrumentation) in buffer.take_and_passthrough()? {
+                emitted = true;
+                delegate.emit(&mut record, &instrumentation);
+            }
+        }
+        if emitted {
+            delegate.force_flush()
+        } else {
+            Ok(())
+        }
+    }
+
+    fn active_buffers(&self) -> Result<Vec<Arc<ScopeBuffer>>, OTelSdkError> {
+        let mut scopes = self
+            .scopes
+            .lock()
+            .map_err(|err| mutex_error("scope registry", err))?;
+        let mut buffers = Vec::with_capacity(scopes.len());
+        scopes.retain(|_, buffer| {
+            if let Some(buffer) = buffer.upgrade() {
+                buffers.push(buffer);
+                true
+            } else {
+                false
+            }
+        });
+        Ok(buffers)
+    }
+
+    fn lock_trigger_with_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<MutexGuard<'_, ()>, OTelSdkError> {
+        let start = Instant::now();
+        loop {
+            match self.trigger_lock.try_lock() {
+                Ok(guard) => return Ok(guard),
+                Err(TryLockError::Poisoned(err)) => {
+                    return Err(mutex_error("trigger", err));
+                }
+                Err(TryLockError::WouldBlock) => {
+                    let Some(remaining) = timeout.checked_sub(start.elapsed()) else {
+                        return Err(OTelSdkError::Timeout(timeout));
+                    };
+                    if remaining.is_zero() {
+                        return Err(OTelSdkError::Timeout(timeout));
+                    }
+                    std::thread::sleep(remaining.min(Duration::from_millis(1)));
+                }
+            }
+        }
+    }
+}
+
+impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
+    fn try_start(&self) -> Option<Arc<ScopeBuffer>> {
+        if self.is_shutdown.load(Ordering::Acquire) {
+            return None;
+        }
+        let mut scopes = self.scopes.lock().ok()?;
+        scopes.retain(|_, buffer| buffer.strong_count() > 0);
+        if self.is_shutdown.load(Ordering::Acquire) || scopes.len() >= self.max_active_scopes {
+            return None;
+        }
+
+        let id = self.next_scope_id.fetch_add(1, Ordering::Relaxed);
+        let buffer = Arc::new(ScopeBuffer {
+            id,
+            processor_id: self.processor_id,
+            max_records: self.max_records_per_scope,
+            state: Mutex::new(ScopeState {
+                status: ScopeStatus::Recording,
+                records: VecDeque::new(),
+            }),
+        });
+        scopes.insert(id, Arc::downgrade(&buffer));
+        Some(buffer)
+    }
+
+    fn trigger(&self, buffer: &Arc<ScopeBuffer>) -> OTelSdkResult {
+        if self.is_shutdown.load(Ordering::Acquire) {
+            return Err(OTelSdkError::AlreadyShutdown);
+        }
+        let _trigger_guard = self
+            .trigger_lock
+            .lock()
+            .map_err(|err| mutex_error("trigger", err))?;
+        if self.is_shutdown.load(Ordering::Acquire) {
+            return Err(OTelSdkError::AlreadyShutdown);
+        }
+        self.flush_snapshots([buffer.clone()])
+    }
+}
+
+impl<P: LogProcessor + 'static> LogProcessor for ScopedFlightRecorderLogProcessor<P> {
+    fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+        if self.shared.is_shutdown.load(Ordering::Acquire) {
+            otel_warn!(
+                name: "ScopedFlightRecorderLogProcessor.EmitAfterShutdown",
+                message = "ScopedFlightRecorderLogProcessor dropped a log emitted after shutdown."
+            );
+            return;
+        }
+
+        let should_buffer = record.severity_number().map_or(true, |severity| {
+            severity <= self.shared.max_buffered_severity
+        });
+        if should_buffer {
+            let buffer = Context::map_current(|context| {
+                context
+                    .get::<ScopedBufferContext>()
+                    .map(|context| context.buffer.clone())
+            });
+            if let Some(buffer) = buffer {
+                if buffer.processor_id == self.shared.processor_id {
+                    match buffer.try_buffer(record, instrumentation) {
+                        Ok(true) => return,
+                        Ok(false) => {}
+                        Err(err) => {
+                            otel_warn!(
+                                name: "ScopedFlightRecorderLogProcessor.BufferLockFailed",
+                                error = format!("{err}")
+                            );
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
+        self.shared.emit_to_delegate(record, instrumentation);
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        let _trigger_guard = self
+            .shared
+            .trigger_lock
+            .lock()
+            .map_err(|err| mutex_error("trigger", err))?;
+        if self.shared.is_shutdown.load(Ordering::Acquire) {
+            return Err(OTelSdkError::AlreadyShutdown);
+        }
+        let buffers = self.shared.active_buffers()?;
+        self.shared.flush_snapshots(buffers)
+    }
+
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
+        let start = Instant::now();
+        let _trigger_guard = self.shared.lock_trigger_with_timeout(timeout)?;
+        if self.shared.is_shutdown.swap(true, Ordering::AcqRel) {
+            return Err(OTelSdkError::AlreadyShutdown);
+        }
+        for buffer in self.shared.active_buffers()? {
+            buffer.discard();
+        }
+        let remaining = timeout.saturating_sub(start.elapsed());
+        self.shared
+            .delegate
+            .write()
+            .map_err(|err| lock_error("delegate", err))?
+            .shutdown_with_timeout(remaining)
+    }
+
+    fn event_enabled(&self, level: Severity, target: &str, name: Option<&str>) -> bool {
+        match self.shared.delegate.read() {
+            Ok(delegate) => delegate.event_enabled(level, target, name),
+            Err(err) => {
+                otel_warn!(
+                    name: "ScopedFlightRecorderLogProcessor.DelegateLockFailed",
+                    error = format!("{err}")
+                );
+                true
+            }
+        }
+    }
+
+    fn set_resource(&mut self, resource: &Resource) {
+        match self.shared.delegate.write() {
+            Ok(mut delegate) => delegate.set_resource(resource),
+            Err(err) => {
+                otel_warn!(
+                    name: "ScopedFlightRecorderLogProcessor.DelegateLockFailed",
+                    error = format!("{err}")
+                );
+            }
+        }
+    }
+}
+
+fn mutex_error<T>(name: &str, err: std::sync::PoisonError<T>) -> OTelSdkError {
+    OTelSdkError::InternalFailure(format!(
+        "ScopedFlightRecorderLogProcessor {name} mutex poisoned: {err}"
+    ))
+}
+
+fn lock_error<T>(name: &str, err: std::sync::PoisonError<T>) -> OTelSdkError {
+    OTelSdkError::InternalFailure(format!(
+        "ScopedFlightRecorderLogProcessor {name} lock poisoned: {err}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::logs::{AnyValue, LogRecord};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug, Clone)]
+    struct TestProcessor {
+        records: Arc<Mutex<Vec<BufferedLog>>>,
+        flushes: Arc<AtomicUsize>,
+    }
+
+    impl TestProcessor {
+        fn new() -> Self {
+            Self {
+                records: Arc::new(Mutex::new(Vec::new())),
+                flushes: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    impl LogProcessor for TestProcessor {
+        fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+            self.records
+                .lock()
+                .unwrap()
+                .push((record.clone(), instrumentation.clone()));
+        }
+
+        fn force_flush(&self) -> OTelSdkResult {
+            self.flushes.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+            Ok(())
+        }
+    }
+
+    fn record(body: &'static str, severity: Severity) -> SdkLogRecord {
+        let mut record = SdkLogRecord::new();
+        record.set_body(AnyValue::from(body));
+        record.set_severity_number(severity);
+        record
+    }
+
+    fn bodies(processor: &TestProcessor) -> Vec<String> {
+        processor
+            .records
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(record, _)| match record.body() {
+                Some(AnyValue::String(value)) => value.to_string(),
+                body => panic!("unexpected body: {body:?}"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn scopes_are_isolated() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) =
+            ScopedFlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let first = recorder.try_start().unwrap();
+        let second = recorder.try_start().unwrap();
+        let instrumentation = InstrumentationScope::builder("test").build();
+
+        futures_executor::block_on(first.with_context(async {
+            processor.emit(&mut record("first", Severity::Info), &instrumentation);
+        }));
+        futures_executor::block_on(second.with_context(async {
+            processor.emit(&mut record("second", Severity::Info), &instrumentation);
+        }));
+        first.trigger().unwrap();
+
+        assert_eq!(bodies(&delegate), ["first"]);
+        second.discard();
+    }
+
+    #[test]
+    fn logs_outside_a_scope_and_high_severity_logs_bypass() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) =
+            ScopedFlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = recorder.try_start().unwrap();
+        let instrumentation = InstrumentationScope::builder("test").build();
+
+        processor.emit(&mut record("outside", Severity::Info), &instrumentation);
+        futures_executor::block_on(scope.with_context(async {
+            processor.emit(&mut record("warn", Severity::Warn), &instrumentation);
+            processor.emit(&mut record("info", Severity::Info), &instrumentation);
+        }));
+
+        assert_eq!(bodies(&delegate), ["outside", "warn"]);
+        scope.trigger().unwrap();
+        assert_eq!(bodies(&delegate), ["outside", "warn", "info"]);
+    }
+
+    #[test]
+    fn triggered_scope_switches_to_passthrough() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) =
+            ScopedFlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = recorder.try_start().unwrap();
+        let instrumentation = InstrumentationScope::builder("test").build();
+
+        futures_executor::block_on(scope.with_context(async {
+            processor.emit(&mut record("before", Severity::Info), &instrumentation);
+        }));
+        scope.trigger().unwrap();
+        futures_executor::block_on(scope.with_context(async {
+            processor.emit(&mut record("after", Severity::Info), &instrumentation);
+        }));
+
+        assert_eq!(bodies(&delegate), ["before", "after"]);
+    }
+
+    #[test]
+    fn active_scope_limit_is_enforced_and_reclaimed() {
+        let delegate = TestProcessor::new();
+        let (_processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate)
+            .with_max_active_scopes(1)
+            .build();
+
+        let first = recorder.try_start().unwrap();
+        assert!(recorder.try_start().is_none());
+        drop(first);
+        assert!(recorder.try_start().is_some());
+    }
+
+    #[test]
+    fn force_flush_triggers_all_active_scopes() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) =
+            ScopedFlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let first = recorder.try_start().unwrap();
+        let second = recorder.try_start().unwrap();
+        let instrumentation = InstrumentationScope::builder("test").build();
+
+        futures_executor::block_on(first.with_context(async {
+            processor.emit(&mut record("first", Severity::Info), &instrumentation);
+        }));
+        futures_executor::block_on(second.with_context(async {
+            processor.emit(&mut record("second", Severity::Info), &instrumentation);
+        }));
+        processor.force_flush().unwrap();
+
+        let mut exported = bodies(&delegate);
+        exported.sort();
+        assert_eq!(exported, ["first", "second"]);
+    }
+
+    #[test]
+    fn scope_capacity_overwrites_oldest_records() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_records_per_scope(2)
+            .build();
+        let scope = recorder.try_start().unwrap();
+        let instrumentation = InstrumentationScope::builder("test").build();
+
+        futures_executor::block_on(scope.with_context(async {
+            processor.emit(&mut record("one", Severity::Info), &instrumentation);
+            processor.emit(&mut record("two", Severity::Info), &instrumentation);
+            processor.emit(&mut record("three", Severity::Info), &instrumentation);
+        }));
+        scope.trigger().unwrap();
+
+        assert_eq!(bodies(&delegate), ["two", "three"]);
+    }
+
+    #[test]
+    fn discarded_scope_does_not_export() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) =
+            ScopedFlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = recorder.try_start().unwrap();
+        let instrumentation = InstrumentationScope::builder("test").build();
+
+        futures_executor::block_on(scope.with_context(async {
+            processor.emit(&mut record("discarded", Severity::Info), &instrumentation);
+        }));
+        scope.discard();
+        scope.trigger().unwrap();
+
+        assert!(bodies(&delegate).is_empty());
+    }
+
+    #[test]
+    fn shutdown_discards_scopes_and_prevents_new_ones() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) =
+            ScopedFlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = recorder.try_start().unwrap();
+        let instrumentation = InstrumentationScope::builder("test").build();
+
+        futures_executor::block_on(scope.with_context(async {
+            processor.emit(&mut record("discarded", Severity::Info), &instrumentation);
+        }));
+        processor
+            .shutdown_with_timeout(Duration::from_secs(1))
+            .unwrap();
+
+        assert!(recorder.try_start().is_none());
+        assert!(matches!(
+            scope.trigger(),
+            Err(OTelSdkError::AlreadyShutdown)
+        ));
+        assert!(bodies(&delegate).is_empty());
+    }
+}

--- a/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
@@ -5,6 +5,7 @@ use crate::Resource;
 use opentelemetry::logs::Severity;
 use opentelemetry::{otel_warn, Context, InstrumentationScope};
 use std::collections::{HashMap, VecDeque};
+use std::error::Error;
 use std::fmt::{self, Debug, Formatter};
 use std::future::{poll_fn, Future};
 use std::pin::pin;
@@ -18,6 +19,8 @@ const DEFAULT_MAX_BUFFER_SIZE_BYTES_PER_SCOPE: usize = 256 * 1024;
 const DEFAULT_MAX_TOTAL_BUFFER_SIZE_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_MAX_RECORD_SIZE_BYTES: usize = 64 * 1024;
 const DEFAULT_MAX_BUFFERED_SEVERITY: Severity = Severity::Info4;
+const DEFAULT_OVERFLOW_POLICY: ScopedFlightRecorderOverflowPolicy =
+    ScopedFlightRecorderOverflowPolicy::Drop;
 
 type BufferedLog = (SdkLogRecord, InstrumentationScope, usize);
 
@@ -50,6 +53,7 @@ impl<P: LogProcessor> Debug for ScopedFlightRecorderLogProcessor<P> {
                 &self.shared.memory_budget.limit,
             )
             .field("max_record_size_bytes", &self.shared.max_record_size_bytes)
+            .field("overflow_policy", &self.shared.overflow_policy)
             .field("max_buffered_severity", &self.shared.max_buffered_severity)
             .finish_non_exhaustive()
     }
@@ -65,6 +69,7 @@ impl<P: LogProcessor> ScopedFlightRecorderLogProcessor<P> {
             max_buffer_size_bytes_per_scope: DEFAULT_MAX_BUFFER_SIZE_BYTES_PER_SCOPE,
             max_total_buffer_size_bytes: DEFAULT_MAX_TOTAL_BUFFER_SIZE_BYTES,
             max_record_size_bytes: DEFAULT_MAX_RECORD_SIZE_BYTES,
+            overflow_policy: DEFAULT_OVERFLOW_POLICY,
             max_buffered_severity: DEFAULT_MAX_BUFFERED_SEVERITY,
         }
     }
@@ -79,8 +84,43 @@ pub struct ScopedFlightRecorderLogProcessorBuilder<P: LogProcessor> {
     max_buffer_size_bytes_per_scope: usize,
     max_total_buffer_size_bytes: usize,
     max_record_size_bytes: usize,
+    overflow_policy: ScopedFlightRecorderOverflowPolicy,
     max_buffered_severity: Severity,
 }
+
+/// Behavior for low-severity records that cannot be retained.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ScopedFlightRecorderOverflowPolicy {
+    /// Drops the incoming record, preserving the recorder's ingestion savings.
+    Drop,
+    /// Sends the incoming record through the wrapped processor.
+    Export,
+}
+
+/// The reason a new recording scope could not be admitted.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ScopedFlightRecorderStartError {
+    /// The configured active-scope limit has been reached.
+    ScopeLimitReached,
+    /// The processor has shut down.
+    Shutdown,
+    /// The active-scope registry is unavailable.
+    InternalFailure,
+}
+
+impl fmt::Display for ScopedFlightRecorderStartError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ScopeLimitReached => f.write_str("flight recorder active-scope limit reached"),
+            Self::Shutdown => f.write_str("flight recorder processor is shut down"),
+            Self::InternalFailure => f.write_str("flight recorder scope registry is unavailable"),
+        }
+    }
+}
+
+impl Error for ScopedFlightRecorderStartError {}
 
 impl<P: LogProcessor + 'static> ScopedFlightRecorderLogProcessorBuilder<P> {
     /// Sets the maximum number of records retained by each active scope.
@@ -112,10 +152,19 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderLogProcessorBuilder<P> {
 
     /// Sets the maximum estimated size of an individual buffered record.
     ///
-    /// Larger records bypass the recorder and follow the wrapped processor's
-    /// normal path.
+    /// Larger records are handled by the configured overflow policy.
     pub fn with_max_record_size_bytes(mut self, max_record_size_bytes: usize) -> Self {
         self.max_record_size_bytes = max_record_size_bytes;
+        self
+    }
+
+    /// Sets how low-severity records are handled when recorder limits prevent
+    /// them from being buffered.
+    pub fn with_overflow_policy(
+        mut self,
+        overflow_policy: ScopedFlightRecorderOverflowPolicy,
+    ) -> Self {
+        self.overflow_policy = overflow_policy;
         self
     }
 
@@ -164,6 +213,7 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderLogProcessorBuilder<P> {
             max_buffer_size_bytes_per_scope: self.max_buffer_size_bytes_per_scope,
             max_record_size_bytes: self.max_record_size_bytes,
             memory_budget: Arc::new(MemoryBudget::new(self.max_total_buffer_size_bytes)),
+            overflow_policy: self.overflow_policy,
             max_buffered_severity: self.max_buffered_severity,
         });
         let recorder = ScopedFlightRecorder {
@@ -183,9 +233,10 @@ pub struct ScopedFlightRecorder {
 impl ScopedFlightRecorder {
     /// Starts a recording scope.
     ///
-    /// Returns `None` when the configured active-scope limit has been reached or
-    /// the processor has shut down. Logs without a scope use the normal path.
-    pub fn try_start(&self) -> Option<ScopedFlightRecorderScope> {
+    /// Returns an explicit error when the configured active-scope limit has
+    /// been reached, the processor has shut down, or admission cannot inspect
+    /// the active-scope registry.
+    pub fn try_start(&self) -> Result<ScopedFlightRecorderScope, ScopedFlightRecorderStartError> {
         self.inner
             .try_start()
             .map(|buffer| ScopedFlightRecorderScope {
@@ -253,7 +304,7 @@ struct ScopedBufferContext {
 }
 
 trait ScopedFlightRecorderCore: Send + Sync {
-    fn try_start(&self) -> Option<Arc<ScopeBuffer>>;
+    fn try_start(&self) -> Result<Arc<ScopeBuffer>, ScopedFlightRecorderStartError>;
     fn trigger(&self, buffer: &Arc<ScopeBuffer>) -> OTelSdkResult;
 }
 
@@ -280,19 +331,25 @@ enum ScopeStatus {
     Discarded,
 }
 
+enum BufferResult {
+    Buffered,
+    Passthrough,
+    Overflow,
+}
+
 impl ScopeBuffer {
     fn try_buffer(
         &self,
         record: &SdkLogRecord,
         instrumentation: &InstrumentationScope,
         estimated_size: usize,
-    ) -> Result<bool, OTelSdkError> {
+    ) -> Result<BufferResult, OTelSdkError> {
         let mut state = self
             .state
             .lock()
             .map_err(|err| mutex_error("scope buffer", err))?;
         if state.status != ScopeStatus::Recording {
-            return Ok(false);
+            return Ok(BufferResult::Passthrough);
         }
         let mut remaining_records = state.records.len();
         let mut remaining_bytes = state.buffer_size_bytes;
@@ -312,7 +369,7 @@ impl ScopeBuffer {
 
         let additional_bytes = estimated_size.saturating_sub(eviction_bytes);
         if !self.memory_budget.try_reserve(additional_bytes) {
-            return Ok(false);
+            return Ok(BufferResult::Overflow);
         }
 
         for _ in 0..eviction_count {
@@ -330,7 +387,7 @@ impl ScopeBuffer {
         state
             .records
             .push_back((record.clone(), instrumentation.clone(), estimated_size));
-        Ok(true)
+        Ok(BufferResult::Buffered)
     }
 
     fn take_and_passthrough(&self) -> Result<BufferedSnapshot, OTelSdkError> {
@@ -455,6 +512,7 @@ struct ScopedShared<P: LogProcessor> {
     max_buffer_size_bytes_per_scope: usize,
     max_record_size_bytes: usize,
     memory_budget: Arc<MemoryBudget>,
+    overflow_policy: ScopedFlightRecorderOverflowPolicy,
     max_buffered_severity: Severity,
 }
 
@@ -551,14 +609,20 @@ impl<P: LogProcessor> ScopedShared<P> {
 }
 
 impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
-    fn try_start(&self) -> Option<Arc<ScopeBuffer>> {
+    fn try_start(&self) -> Result<Arc<ScopeBuffer>, ScopedFlightRecorderStartError> {
         if self.is_shutdown.load(Ordering::Acquire) {
-            return None;
+            return Err(ScopedFlightRecorderStartError::Shutdown);
         }
-        let mut scopes = self.scopes.lock().ok()?;
+        let mut scopes = self
+            .scopes
+            .lock()
+            .map_err(|_| ScopedFlightRecorderStartError::InternalFailure)?;
         scopes.retain(|_, buffer| buffer.strong_count() > 0);
-        if self.is_shutdown.load(Ordering::Acquire) || scopes.len() >= self.max_active_scopes {
-            return None;
+        if self.is_shutdown.load(Ordering::Acquire) {
+            return Err(ScopedFlightRecorderStartError::Shutdown);
+        }
+        if scopes.len() >= self.max_active_scopes {
+            return Err(ScopedFlightRecorderStartError::ScopeLimitReached);
         }
 
         let id = self.next_scope_id.fetch_add(1, Ordering::Relaxed);
@@ -576,7 +640,7 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
             }),
         });
         scopes.insert(id, Arc::downgrade(&buffer));
-        Some(buffer)
+        Ok(buffer)
     }
 
     fn trigger(&self, buffer: &Arc<ScopeBuffer>) -> OTelSdkResult {
@@ -608,13 +672,6 @@ impl<P: LogProcessor + 'static> LogProcessor for ScopedFlightRecorderLogProcesso
             severity <= self.shared.max_buffered_severity
         });
         if should_buffer {
-            let estimated_size = estimated_log_size(record, instrumentation);
-            if estimated_size > self.shared.max_record_size_bytes
-                || estimated_size > self.shared.max_buffer_size_bytes_per_scope
-            {
-                self.shared.emit_to_delegate(record, instrumentation);
-                return;
-            }
             let buffer = Context::map_current(|context| {
                 context
                     .get::<ScopedBufferContext>()
@@ -622,9 +679,27 @@ impl<P: LogProcessor + 'static> LogProcessor for ScopedFlightRecorderLogProcesso
             });
             if let Some(buffer) = buffer {
                 if buffer.processor_id == self.shared.processor_id {
+                    let estimated_size = estimated_log_size(record, instrumentation);
+                    if estimated_size > self.shared.max_record_size_bytes
+                        || estimated_size > self.shared.max_buffer_size_bytes_per_scope
+                    {
+                        if self.shared.overflow_policy == ScopedFlightRecorderOverflowPolicy::Export
+                        {
+                            self.shared.emit_to_delegate(record, instrumentation);
+                        }
+                        return;
+                    }
                     match buffer.try_buffer(record, instrumentation, estimated_size) {
-                        Ok(true) => return,
-                        Ok(false) => {}
+                        Ok(BufferResult::Buffered) => return,
+                        Ok(BufferResult::Passthrough) => {}
+                        Ok(BufferResult::Overflow) => {
+                            if self.shared.overflow_policy
+                                == ScopedFlightRecorderOverflowPolicy::Export
+                            {
+                                self.shared.emit_to_delegate(record, instrumentation);
+                            }
+                            return;
+                        }
                         Err(err) => {
                             otel_warn!(
                                 name: "ScopedFlightRecorderLogProcessor.BufferLockFailed",
@@ -863,9 +938,12 @@ mod tests {
             .build();
 
         let first = recorder.try_start().unwrap();
-        assert!(recorder.try_start().is_none());
+        assert_eq!(
+            recorder.try_start().unwrap_err(),
+            ScopedFlightRecorderStartError::ScopeLimitReached
+        );
         drop(first);
-        assert!(recorder.try_start().is_some());
+        assert!(recorder.try_start().is_ok());
     }
 
     #[test]
@@ -967,6 +1045,7 @@ mod tests {
         let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
             .with_max_buffer_size_bytes_per_scope(estimated_size * 2)
             .with_max_total_buffer_size_bytes(estimated_size)
+            .with_overflow_policy(ScopedFlightRecorderOverflowPolicy::Export)
             .build();
         let first = recorder.try_start().unwrap();
         let second = recorder.try_start().unwrap();
@@ -989,6 +1068,29 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_overflow_drops_by_default() {
+        let delegate = TestProcessor::new();
+        let instrumentation = InstrumentationScope::builder("test").build();
+        let estimated_size = estimated_log_size(&record("first", Severity::Info), &instrumentation);
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_total_buffer_size_bytes(estimated_size)
+            .build();
+        let first = recorder.try_start().unwrap();
+        let second = recorder.try_start().unwrap();
+
+        futures_executor::block_on(first.with_context(async {
+            processor.emit(&mut record("first", Severity::Info), &instrumentation);
+        }));
+        futures_executor::block_on(second.with_context(async {
+            processor.emit(&mut record("other", Severity::Info), &instrumentation);
+        }));
+
+        assert!(bodies(&delegate).is_empty());
+        first.discard();
+        second.discard();
+    }
+
+    #[test]
     fn failed_aggregate_reservation_preserves_existing_snapshot() {
         const LARGE_BODY: &str =
             "a much larger record that requires more aggregate capacity than the existing record";
@@ -1001,6 +1103,7 @@ mod tests {
             .with_max_records_per_scope(1)
             .with_max_buffer_size_bytes_per_scope(large_size)
             .with_max_total_buffer_size_bytes(small_size * 2)
+            .with_overflow_policy(ScopedFlightRecorderOverflowPolicy::Export)
             .build();
         let first = recorder.try_start().unwrap();
         let second = recorder.try_start().unwrap();
@@ -1069,6 +1172,7 @@ mod tests {
             estimated_log_size(&record("oversized", Severity::Info), &instrumentation);
         let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
             .with_max_record_size_bytes(estimated_size - 1)
+            .with_overflow_policy(ScopedFlightRecorderOverflowPolicy::Export)
             .build();
         let scope = recorder.try_start().unwrap();
 
@@ -1078,6 +1182,41 @@ mod tests {
 
         assert_eq!(bodies(&delegate), ["oversized"]);
         scope.trigger().unwrap();
+        assert_eq!(bodies(&delegate), ["oversized"]);
+    }
+
+    #[test]
+    fn oversized_scoped_records_drop_by_default() {
+        let delegate = TestProcessor::new();
+        let instrumentation = InstrumentationScope::builder("test").build();
+        let estimated_size =
+            estimated_log_size(&record("oversized", Severity::Info), &instrumentation);
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_record_size_bytes(estimated_size - 1)
+            .build();
+        let scope = recorder.try_start().unwrap();
+
+        futures_executor::block_on(scope.with_context(async {
+            processor.emit(&mut record("oversized", Severity::Info), &instrumentation);
+        }));
+
+        assert!(bodies(&delegate).is_empty());
+        scope.trigger().unwrap();
+        assert!(bodies(&delegate).is_empty());
+    }
+
+    #[test]
+    fn oversized_records_outside_a_scope_follow_the_normal_path() {
+        let delegate = TestProcessor::new();
+        let instrumentation = InstrumentationScope::builder("test").build();
+        let estimated_size =
+            estimated_log_size(&record("oversized", Severity::Info), &instrumentation);
+        let (processor, _recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_record_size_bytes(estimated_size - 1)
+            .build();
+
+        processor.emit(&mut record("oversized", Severity::Info), &instrumentation);
+
         assert_eq!(bodies(&delegate), ["oversized"]);
     }
 
@@ -1113,7 +1252,10 @@ mod tests {
             .shutdown_with_timeout(Duration::from_secs(1))
             .unwrap();
 
-        assert!(recorder.try_start().is_none());
+        assert_eq!(
+            recorder.try_start().unwrap_err(),
+            ScopedFlightRecorderStartError::Shutdown
+        );
         assert!(matches!(
             scope.trigger(),
             Err(OTelSdkError::AlreadyShutdown)

--- a/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
@@ -1,5 +1,7 @@
 use crate::error::{OTelSdkError, OTelSdkResult};
-use crate::logs::flight_recorder::estimated_log_size;
+use crate::logs::flight_recorder::{
+    estimated_log_size, lock_with_timeout, should_buffer, BufferedLog, LogBuffer, TimedLockError,
+};
 use crate::logs::{LogProcessor, SdkLogRecord};
 use crate::Resource;
 use opentelemetry::logs::Severity;
@@ -10,7 +12,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::future::{poll_fn, Future};
 use std::pin::pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard, RwLock, TryLockError, Weak};
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::{Duration, Instant};
 
 const DEFAULT_MAX_RECORDS_PER_SCOPE: usize = 256;
@@ -21,8 +23,6 @@ const DEFAULT_MAX_RECORD_SIZE_BYTES: usize = 64 * 1024;
 const DEFAULT_MAX_BUFFERED_SEVERITY: Severity = Severity::Info4;
 const DEFAULT_OVERFLOW_POLICY: ScopedFlightRecorderOverflowPolicy =
     ScopedFlightRecorderOverflowPolicy::Drop;
-
-type BufferedLog = (SdkLogRecord, InstrumentationScope, usize);
 
 static NEXT_PROCESSOR_ID: AtomicUsize = AtomicUsize::new(1);
 
@@ -311,8 +311,6 @@ trait ScopedFlightRecorderCore: Send + Sync {
 struct ScopeBuffer {
     id: usize,
     processor_id: usize,
-    max_records: usize,
-    max_buffer_size_bytes: usize,
     memory_budget: Arc<MemoryBudget>,
     accounted_bytes: AtomicUsize,
     state: Mutex<ScopeState>,
@@ -320,8 +318,7 @@ struct ScopeBuffer {
 
 struct ScopeState {
     status: ScopeStatus,
-    records: VecDeque<BufferedLog>,
-    buffer_size_bytes: usize,
+    buffer: LogBuffer,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -351,42 +348,24 @@ impl ScopeBuffer {
         if state.status != ScopeStatus::Recording {
             return Ok(BufferResult::Passthrough);
         }
-        let mut remaining_records = state.records.len();
-        let mut remaining_bytes = state.buffer_size_bytes;
-        let mut eviction_count = 0;
-        let mut eviction_bytes = 0;
-        for (_, _, size) in &state.records {
-            if remaining_records < self.max_records
-                && estimated_size <= self.max_buffer_size_bytes - remaining_bytes
-            {
-                break;
-            }
-            remaining_records -= 1;
-            remaining_bytes -= size;
-            eviction_count += 1;
-            eviction_bytes += size;
-        }
-
-        let additional_bytes = estimated_size.saturating_sub(eviction_bytes);
+        let plan = state.buffer.plan_insertion(estimated_size);
+        let additional_bytes = estimated_size.saturating_sub(plan.bytes);
         if !self.memory_budget.try_reserve(additional_bytes) {
             return Ok(BufferResult::Overflow);
         }
 
-        for _ in 0..eviction_count {
-            state.records.pop_front();
+        if plan.bytes > estimated_size {
+            self.memory_budget.release(plan.bytes - estimated_size);
         }
-        if eviction_bytes > estimated_size {
-            self.memory_budget.release(eviction_bytes - estimated_size);
-        }
-        state.buffer_size_bytes = remaining_bytes + estimated_size;
         self.accounted_bytes
             .fetch_update(Ordering::AcqRel, Ordering::Acquire, |accounted| {
-                Some(accounted - eviction_bytes + estimated_size)
+                Some(accounted - plan.bytes + estimated_size)
             })
             .expect("scope byte accounting must not underflow");
-        state
-            .records
-            .push_back((record.clone(), instrumentation.clone(), estimated_size));
+        state.buffer.insert(
+            (record.clone(), instrumentation.clone(), estimated_size),
+            plan,
+        );
         Ok(BufferResult::Buffered)
     }
 
@@ -399,10 +378,9 @@ impl ScopeBuffer {
             return Ok(BufferedSnapshot::empty(self.memory_budget.clone()));
         }
         state.status = ScopeStatus::Passthrough;
-        state.buffer_size_bytes = 0;
         self.accounted_bytes.store(0, Ordering::Release);
         Ok(BufferedSnapshot {
-            records: std::mem::take(&mut state.records),
+            records: state.buffer.take(),
             memory_budget: self.memory_budget.clone(),
         })
     }
@@ -411,8 +389,7 @@ impl ScopeBuffer {
         match self.state.lock() {
             Ok(mut state) => {
                 state.status = ScopeStatus::Discarded;
-                state.records.clear();
-                state.buffer_size_bytes = 0;
+                state.buffer.clear();
                 self.release_all_accounted_bytes();
             }
             Err(err) => {
@@ -582,30 +559,6 @@ impl<P: LogProcessor> ScopedShared<P> {
         });
         Ok(buffers)
     }
-
-    fn lock_trigger_with_timeout(
-        &self,
-        timeout: Duration,
-    ) -> Result<MutexGuard<'_, ()>, OTelSdkError> {
-        let start = Instant::now();
-        loop {
-            match self.trigger_lock.try_lock() {
-                Ok(guard) => return Ok(guard),
-                Err(TryLockError::Poisoned(err)) => {
-                    return Err(mutex_error("trigger", err));
-                }
-                Err(TryLockError::WouldBlock) => {
-                    let Some(remaining) = timeout.checked_sub(start.elapsed()) else {
-                        return Err(OTelSdkError::Timeout(timeout));
-                    };
-                    if remaining.is_zero() {
-                        return Err(OTelSdkError::Timeout(timeout));
-                    }
-                    std::thread::sleep(remaining.min(Duration::from_millis(1)));
-                }
-            }
-        }
-    }
 }
 
 impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
@@ -629,14 +582,14 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
         let buffer = Arc::new(ScopeBuffer {
             id,
             processor_id: self.processor_id,
-            max_records: self.max_records_per_scope,
-            max_buffer_size_bytes: self.max_buffer_size_bytes_per_scope,
             memory_budget: self.memory_budget.clone(),
             accounted_bytes: AtomicUsize::new(0),
             state: Mutex::new(ScopeState {
                 status: ScopeStatus::Recording,
-                records: VecDeque::new(),
-                buffer_size_bytes: 0,
+                buffer: LogBuffer::new(
+                    self.max_records_per_scope,
+                    self.max_buffer_size_bytes_per_scope,
+                ),
             }),
         });
         scopes.insert(id, Arc::downgrade(&buffer));
@@ -668,10 +621,7 @@ impl<P: LogProcessor + 'static> LogProcessor for ScopedFlightRecorderLogProcesso
             return;
         }
 
-        let should_buffer = record.severity_number().map_or(true, |severity| {
-            severity <= self.shared.max_buffered_severity
-        });
-        if should_buffer {
+        if should_buffer(record, self.shared.max_buffered_severity) {
             let buffer = Context::map_current(|context| {
                 context
                     .get::<ScopedBufferContext>()
@@ -730,7 +680,13 @@ impl<P: LogProcessor + 'static> LogProcessor for ScopedFlightRecorderLogProcesso
 
     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         let start = Instant::now();
-        let _trigger_guard = self.shared.lock_trigger_with_timeout(timeout)?;
+        let _trigger_guard =
+            lock_with_timeout(&self.shared.trigger_lock, timeout).map_err(|err| match err {
+                TimedLockError::Poisoned => OTelSdkError::InternalFailure(
+                    "ScopedFlightRecorderLogProcessor trigger mutex poisoned".into(),
+                ),
+                TimedLockError::Timeout => OTelSdkError::Timeout(timeout),
+            })?;
         if self.shared.is_shutdown.swap(true, Ordering::AcqRel) {
             return Err(OTelSdkError::AlreadyShutdown);
         }

--- a/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
@@ -284,6 +284,15 @@ impl ScopedFlightRecorderScope {
         self.inner.trigger(&self.buffer)
     }
 
+    /// Hands this scope's buffered snapshot to the wrapped processor and
+    /// switches the scope to passthrough without flushing the delegate.
+    ///
+    /// This avoids waiting for exporter completion, but acquiring recorder
+    /// locks and the wrapped processor's `emit` implementation may still block.
+    pub fn handoff(&self) -> OTelSdkResult {
+        self.inner.handoff(&self.buffer)
+    }
+
     /// Discards this scope's buffered records.
     pub fn discard(&self) {
         self.buffer.discard();
@@ -305,6 +314,7 @@ struct ScopedBufferContext {
 
 trait ScopedFlightRecorderCore: Send + Sync {
     fn try_start(&self) -> Result<Arc<ScopeBuffer>, ScopedFlightRecorderStartError>;
+    fn handoff(&self, buffer: &Arc<ScopeBuffer>) -> OTelSdkResult;
     fn trigger(&self, buffer: &Arc<ScopeBuffer>) -> OTelSdkResult;
 }
 
@@ -543,6 +553,19 @@ impl<P: LogProcessor> ScopedShared<P> {
         Ok(())
     }
 
+    fn handoff_snapshot(&self, buffer: Arc<ScopeBuffer>) -> OTelSdkResult {
+        let delegate = self
+            .delegate
+            .write()
+            .map_err(|err| lock_error("delegate", err))?;
+        let mut snapshot = buffer.take_and_passthrough()?;
+        while let Some((mut record, instrumentation, estimated_size)) = snapshot.pop_front() {
+            delegate.emit(&mut record, &instrumentation);
+            snapshot.release(estimated_size);
+        }
+        Ok(())
+    }
+
     fn active_buffers(&self) -> Result<Vec<Arc<ScopeBuffer>>, OTelSdkError> {
         let mut scopes = self
             .scopes
@@ -594,6 +617,20 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
         });
         scopes.insert(id, Arc::downgrade(&buffer));
         Ok(buffer)
+    }
+
+    fn handoff(&self, buffer: &Arc<ScopeBuffer>) -> OTelSdkResult {
+        if self.is_shutdown.load(Ordering::Acquire) {
+            return Err(OTelSdkError::AlreadyShutdown);
+        }
+        let _trigger_guard = self
+            .trigger_lock
+            .lock()
+            .map_err(|err| mutex_error("trigger", err))?;
+        if self.is_shutdown.load(Ordering::Acquire) {
+            return Err(OTelSdkError::AlreadyShutdown);
+        }
+        self.handoff_snapshot(buffer.clone())
     }
 
     fn trigger(&self, buffer: &Arc<ScopeBuffer>) -> OTelSdkResult {
@@ -884,6 +921,23 @@ mod tests {
         }));
 
         assert_eq!(bodies(&delegate), ["before", "after"]);
+    }
+
+    #[test]
+    fn handoff_replays_without_flushing_delegate() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) =
+            ScopedFlightRecorderLogProcessor::builder(delegate.clone()).build();
+        let scope = recorder.try_start().unwrap();
+        let instrumentation = InstrumentationScope::builder("test").build();
+
+        futures_executor::block_on(scope.with_context(async {
+            processor.emit(&mut record("before", Severity::Info), &instrumentation);
+        }));
+        scope.handoff().unwrap();
+
+        assert_eq!(bodies(&delegate), ["before"]);
+        assert_eq!(delegate.flushes.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
@@ -1,6 +1,7 @@
 use crate::error::{OTelSdkError, OTelSdkResult};
 use crate::logs::flight_recorder::{
-    estimated_log_size, lock_with_timeout, should_buffer, BufferedLog, LogBuffer, TimedLockError,
+    estimated_log_size, lock_with_timeout, should_buffer, BufferedLog, FlightRecorderMetrics,
+    LogBuffer, TimedLockError,
 };
 use crate::logs::{LogProcessor, SdkLogRecord};
 use crate::Resource;
@@ -215,6 +216,9 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderLogProcessorBuilder<P> {
             memory_budget: Arc::new(MemoryBudget::new(self.max_total_buffer_size_bytes)),
             overflow_policy: self.overflow_policy,
             max_buffered_severity: self.max_buffered_severity,
+            metrics: Arc::new(FlightRecorderMetrics::new(
+                "scoped_flight_recorder_log_processor",
+            )),
         });
         let recorder = ScopedFlightRecorder {
             inner: shared.clone(),
@@ -321,7 +325,9 @@ trait ScopedFlightRecorderCore: Send + Sync {
 struct ScopeBuffer {
     id: usize,
     processor_id: usize,
+    max_record_size_bytes: usize,
     memory_budget: Arc<MemoryBudget>,
+    metrics: Arc<FlightRecorderMetrics>,
     accounted_bytes: AtomicUsize,
     state: Mutex<ScopeState>,
 }
@@ -339,9 +345,10 @@ enum ScopeStatus {
 }
 
 enum BufferResult {
-    Buffered,
+    Buffered { evicted: usize },
     Passthrough,
     Overflow,
+    Oversized,
 }
 
 impl ScopeBuffer {
@@ -357,6 +364,9 @@ impl ScopeBuffer {
             .map_err(|err| mutex_error("scope buffer", err))?;
         if state.status != ScopeStatus::Recording {
             return Ok(BufferResult::Passthrough);
+        }
+        if estimated_size > self.max_record_size_bytes || !state.buffer.can_fit(estimated_size) {
+            return Ok(BufferResult::Oversized);
         }
         let plan = state.buffer.plan_insertion(estimated_size);
         let additional_bytes = estimated_size.saturating_sub(plan.bytes);
@@ -376,7 +386,9 @@ impl ScopeBuffer {
             (record.clone(), instrumentation.clone(), estimated_size),
             plan,
         );
-        Ok(BufferResult::Buffered)
+        Ok(BufferResult::Buffered {
+            evicted: plan.count,
+        })
     }
 
     fn take_and_passthrough(&self) -> Result<BufferedSnapshot, OTelSdkError> {
@@ -398,9 +410,13 @@ impl ScopeBuffer {
     fn discard(&self) {
         match self.state.lock() {
             Ok(mut state) => {
+                if state.status != ScopeStatus::Recording {
+                    return;
+                }
                 state.status = ScopeStatus::Discarded;
                 state.buffer.clear();
                 self.release_all_accounted_bytes();
+                self.metrics.scope_discarded();
             }
             Err(err) => {
                 otel_warn!(
@@ -452,6 +468,13 @@ impl Drop for BufferedSnapshot {
 
 impl Drop for ScopeBuffer {
     fn drop(&mut self) {
+        if self
+            .state
+            .get_mut()
+            .is_ok_and(|state| state.status == ScopeStatus::Recording)
+        {
+            self.metrics.scope_discarded();
+        }
         self.release_all_accounted_bytes();
     }
 }
@@ -501,6 +524,7 @@ struct ScopedShared<P: LogProcessor> {
     memory_budget: Arc<MemoryBudget>,
     overflow_policy: ScopedFlightRecorderOverflowPolicy,
     max_buffered_severity: Severity,
+    metrics: Arc<FlightRecorderMetrics>,
 }
 
 impl<P: LogProcessor> ScopedShared<P> {
@@ -540,6 +564,7 @@ impl<P: LogProcessor> ScopedShared<P> {
             if snapshot.is_empty() {
                 continue;
             }
+            self.metrics.replayed(snapshot.records.len());
             while let Some((mut record, instrumentation, estimated_size)) = snapshot.pop_front() {
                 delegate.emit(&mut record, &instrumentation);
                 snapshot.release(estimated_size);
@@ -559,6 +584,7 @@ impl<P: LogProcessor> ScopedShared<P> {
             .write()
             .map_err(|err| lock_error("delegate", err))?;
         let mut snapshot = buffer.take_and_passthrough()?;
+        self.metrics.replayed(snapshot.records.len());
         while let Some((mut record, instrumentation, estimated_size)) = snapshot.pop_front() {
             delegate.emit(&mut record, &instrumentation);
             snapshot.release(estimated_size);
@@ -587,17 +613,20 @@ impl<P: LogProcessor> ScopedShared<P> {
 impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
     fn try_start(&self) -> Result<Arc<ScopeBuffer>, ScopedFlightRecorderStartError> {
         if self.is_shutdown.load(Ordering::Acquire) {
+            self.metrics.scope_rejected();
             return Err(ScopedFlightRecorderStartError::Shutdown);
         }
-        let mut scopes = self
-            .scopes
-            .lock()
-            .map_err(|_| ScopedFlightRecorderStartError::InternalFailure)?;
+        let mut scopes = self.scopes.lock().map_err(|_| {
+            self.metrics.scope_rejected();
+            ScopedFlightRecorderStartError::InternalFailure
+        })?;
         scopes.retain(|_, buffer| buffer.strong_count() > 0);
         if self.is_shutdown.load(Ordering::Acquire) {
+            self.metrics.scope_rejected();
             return Err(ScopedFlightRecorderStartError::Shutdown);
         }
         if scopes.len() >= self.max_active_scopes {
+            self.metrics.scope_rejected();
             return Err(ScopedFlightRecorderStartError::ScopeLimitReached);
         }
 
@@ -605,7 +634,9 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
         let buffer = Arc::new(ScopeBuffer {
             id,
             processor_id: self.processor_id,
+            max_record_size_bytes: self.max_record_size_bytes,
             memory_budget: self.memory_budget.clone(),
+            metrics: self.metrics.clone(),
             accounted_bytes: AtomicUsize::new(0),
             state: Mutex::new(ScopeState {
                 status: ScopeStatus::Recording,
@@ -616,6 +647,7 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
             }),
         });
         scopes.insert(id, Arc::downgrade(&buffer));
+        self.metrics.scope_admitted();
         Ok(buffer)
     }
 
@@ -630,7 +662,9 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
         if self.is_shutdown.load(Ordering::Acquire) {
             return Err(OTelSdkError::AlreadyShutdown);
         }
-        self.handoff_snapshot(buffer.clone())
+        self.handoff_snapshot(buffer.clone())?;
+        self.metrics.handed_off();
+        Ok(())
     }
 
     fn trigger(&self, buffer: &Arc<ScopeBuffer>) -> OTelSdkResult {
@@ -644,7 +678,9 @@ impl<P: LogProcessor + 'static> ScopedFlightRecorderCore for ScopedShared<P> {
         if self.is_shutdown.load(Ordering::Acquire) {
             return Err(OTelSdkError::AlreadyShutdown);
         }
-        self.flush_snapshots([buffer.clone()])
+        self.flush_snapshots([buffer.clone()])?;
+        self.metrics.triggered();
+        Ok(())
     }
 }
 
@@ -667,23 +703,32 @@ impl<P: LogProcessor + 'static> LogProcessor for ScopedFlightRecorderLogProcesso
             if let Some(buffer) = buffer {
                 if buffer.processor_id == self.shared.processor_id {
                     let estimated_size = estimated_log_size(record, instrumentation);
-                    if estimated_size > self.shared.max_record_size_bytes
-                        || estimated_size > self.shared.max_buffer_size_bytes_per_scope
-                    {
-                        if self.shared.overflow_policy == ScopedFlightRecorderOverflowPolicy::Export
-                        {
-                            self.shared.emit_to_delegate(record, instrumentation);
-                        }
-                        return;
-                    }
                     match buffer.try_buffer(record, instrumentation, estimated_size) {
-                        Ok(BufferResult::Buffered) => return,
+                        Ok(BufferResult::Buffered { evicted }) => {
+                            self.shared.metrics.buffered(1);
+                            self.shared.metrics.evicted(evicted);
+                            return;
+                        }
                         Ok(BufferResult::Passthrough) => {}
                         Ok(BufferResult::Overflow) => {
                             if self.shared.overflow_policy
                                 == ScopedFlightRecorderOverflowPolicy::Export
                             {
+                                self.shared.metrics.capacity_overflow(true);
                                 self.shared.emit_to_delegate(record, instrumentation);
+                            } else {
+                                self.shared.metrics.capacity_overflow(false);
+                            }
+                            return;
+                        }
+                        Ok(BufferResult::Oversized) => {
+                            if self.shared.overflow_policy
+                                == ScopedFlightRecorderOverflowPolicy::Export
+                            {
+                                self.shared.metrics.oversized(true);
+                                self.shared.emit_to_delegate(record, instrumentation);
+                            } else {
+                                self.shared.metrics.oversized(false);
                             }
                             return;
                         }
@@ -712,7 +757,9 @@ impl<P: LogProcessor + 'static> LogProcessor for ScopedFlightRecorderLogProcesso
             return Err(OTelSdkError::AlreadyShutdown);
         }
         let buffers = self.shared.active_buffers()?;
-        self.shared.flush_snapshots(buffers)
+        self.shared.flush_snapshots(buffers)?;
+        self.shared.metrics.triggered();
+        Ok(())
     }
 
     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
@@ -1231,6 +1278,25 @@ mod tests {
     }
 
     #[test]
+    fn oversized_records_after_trigger_follow_the_normal_path() {
+        let delegate = TestProcessor::new();
+        let instrumentation = InstrumentationScope::builder("test").build();
+        let estimated_size =
+            estimated_log_size(&record("oversized", Severity::Info), &instrumentation);
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_record_size_bytes(estimated_size - 1)
+            .build();
+        let scope = recorder.try_start().unwrap();
+        scope.trigger().unwrap();
+
+        futures_executor::block_on(scope.with_context(async {
+            processor.emit(&mut record("oversized", Severity::Info), &instrumentation);
+        }));
+
+        assert_eq!(bodies(&delegate), ["oversized"]);
+    }
+
+    #[test]
     fn discarded_scope_does_not_export() {
         let delegate = TestProcessor::new();
         let (processor, recorder) =
@@ -1271,5 +1337,77 @@ mod tests {
             Err(OTelSdkError::AlreadyShutdown)
         ));
         assert!(bodies(&delegate).is_empty());
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    #[test]
+    #[ignore]
+    fn self_diagnostics_report_scope_admission_rejection_and_discard() {
+        use crate::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+
+        let metric_exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(metric_exporter.clone())
+            .build();
+        opentelemetry::global::set_meter_provider(meter_provider.clone());
+
+        let delegate = TestProcessor::new();
+        let (_processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate)
+            .with_max_active_scopes(1)
+            .build();
+        let scope = recorder.try_start().unwrap();
+        assert_eq!(
+            recorder.try_start().unwrap_err(),
+            ScopedFlightRecorderStartError::ScopeLimitReached
+        );
+        scope.discard();
+        meter_provider.force_flush().unwrap();
+
+        assert_eq!(
+            diagnostic_action_total(&metric_exporter, "scope_admitted"),
+            1
+        );
+        assert_eq!(
+            diagnostic_action_total(&metric_exporter, "scope_rejected"),
+            1
+        );
+        assert_eq!(
+            diagnostic_action_total(&metric_exporter, "scope_discarded"),
+            1
+        );
+
+        meter_provider.shutdown().unwrap();
+    }
+
+    #[cfg(feature = "experimental_metrics_bound_instruments")]
+    fn diagnostic_action_total(
+        exporter: &crate::metrics::InMemoryMetricExporter,
+        action: &str,
+    ) -> u64 {
+        use crate::metrics::data::{AggregatedMetrics, MetricData};
+
+        exporter
+            .get_finished_metrics()
+            .unwrap()
+            .iter()
+            .flat_map(|resource| &resource.scope_metrics)
+            .flat_map(|scope| &scope.metrics)
+            .filter(|metric| {
+                metric
+                    .name
+                    .starts_with("otel.sdk.processor.log.flight_recorder.")
+            })
+            .filter_map(|metric| match &metric.data {
+                AggregatedMetrics::U64(MetricData::Sum(sum)) => Some(sum),
+                _ => None,
+            })
+            .flat_map(|sum| sum.data_points())
+            .filter(|point| {
+                point.attributes().any(|attribute| {
+                    attribute.key.as_str() == "action" && attribute.value.as_str() == action
+                })
+            })
+            .map(|point| point.value())
+            .sum()
     }
 }

--- a/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
@@ -971,6 +971,13 @@ mod tests {
         record
     }
 
+    fn owned_record(body: String, severity: Severity) -> SdkLogRecord {
+        let mut record = SdkLogRecord::new();
+        record.set_body(AnyValue::from(body));
+        record.set_severity_number(severity);
+        record
+    }
+
     fn bodies(processor: &TestProcessor) -> Vec<String> {
         processor
             .records
@@ -1472,6 +1479,95 @@ mod tests {
             Err(OTelSdkError::AlreadyShutdown)
         ));
         assert!(bodies(&delegate).is_empty());
+    }
+
+    #[test]
+    fn concurrent_scoped_emit_handoff_and_discard_stress_is_isolated() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_records_per_scope(128)
+            .build();
+        let processor = Arc::new(processor);
+        let mut workers = Vec::new();
+
+        for worker in 0..8 {
+            let processor = processor.clone();
+            let recorder = recorder.clone();
+            workers.push(std::thread::spawn(move || {
+                let scope = recorder.try_start().unwrap();
+                let instrumentation = InstrumentationScope::builder("stress").build();
+                futures_executor::block_on(scope.with_context(async {
+                    for sequence in 0..100 {
+                        processor.emit(
+                            &mut owned_record(format!("{worker}:{sequence}"), Severity::Info),
+                            &instrumentation,
+                        );
+                    }
+                }));
+                if worker % 2 == 0 {
+                    scope.handoff().unwrap();
+                } else {
+                    scope.discard();
+                }
+            }));
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+
+        let exported = bodies(&delegate);
+        assert_eq!(exported.len(), 400);
+        assert!(exported.iter().all(|body| {
+            body.split_once(':')
+                .and_then(|(worker, _)| worker.parse::<usize>().ok())
+                .is_some_and(|worker| worker % 2 == 0)
+        }));
+        processor
+            .shutdown_with_timeout(Duration::from_secs(1))
+            .unwrap();
+    }
+
+    #[test]
+    fn concurrent_scoped_emit_handoff_and_shutdown_liveness_stress() {
+        let delegate = TestProcessor::new();
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate).build();
+        let processor = Arc::new(processor);
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let mut workers = Vec::new();
+
+        for worker in 0..2 {
+            let scope = recorder.try_start().unwrap();
+            let processor = processor.clone();
+            let barrier = barrier.clone();
+            workers.push(std::thread::spawn(move || {
+                let instrumentation = InstrumentationScope::builder("stress").build();
+                barrier.wait();
+                futures_executor::block_on(scope.with_context(async {
+                    for sequence in 0..50 {
+                        processor.emit(
+                            &mut owned_record(format!("{worker}:{sequence}"), Severity::Info),
+                            &instrumentation,
+                        );
+                    }
+                }));
+                assert!(matches!(
+                    scope.handoff(),
+                    Ok(()) | Err(OTelSdkError::AlreadyShutdown)
+                ));
+            }));
+        }
+
+        barrier.wait();
+        processor
+            .shutdown_with_timeout(Duration::from_secs(1))
+            .unwrap();
+        for worker in workers {
+            worker.join().unwrap();
+        }
+        assert_eq!(
+            recorder.try_start().unwrap_err(),
+            ScopedFlightRecorderStartError::Shutdown
+        );
     }
 
     #[cfg(feature = "experimental_metrics_bound_instruments")]

--- a/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/scoped_flight_recorder_log_processor.rs
@@ -312,18 +312,21 @@ impl<P: LogProcessor> ScopedShared<P> {
             .map_err(|err| lock_error("delegate", err))?;
         delegate.force_flush()?;
 
-        let mut emitted = false;
         for buffer in buffers {
-            for (mut record, instrumentation) in buffer.take_and_passthrough()? {
-                emitted = true;
+            let snapshot = buffer.take_and_passthrough()?;
+            if snapshot.is_empty() {
+                continue;
+            }
+            for (mut record, instrumentation) in snapshot {
                 delegate.emit(&mut record, &instrumentation);
             }
+            // Bound each handoff to one scope so a delegate queue sized for
+            // max_records_per_scope does not need capacity for every active
+            // scope at once.
+            delegate.force_flush()?;
         }
-        if emitted {
-            delegate.force_flush()
-        } else {
-            Ok(())
-        }
+
+        Ok(())
     }
 
     fn active_buffers(&self) -> Result<Vec<Arc<ScopeBuffer>>, OTelSdkError> {
@@ -527,6 +530,35 @@ mod tests {
         flushes: Arc<AtomicUsize>,
     }
 
+    #[derive(Debug, Clone)]
+    struct BoundedQueueProcessor {
+        pending: Arc<Mutex<Vec<BufferedLog>>>,
+        exported: Arc<Mutex<Vec<BufferedLog>>>,
+        dropped: Arc<AtomicUsize>,
+        capacity: usize,
+    }
+
+    impl LogProcessor for BoundedQueueProcessor {
+        fn emit(&self, record: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+            let mut pending = self.pending.lock().unwrap();
+            if pending.len() == self.capacity {
+                self.dropped.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+            pending.push((record.clone(), instrumentation.clone()));
+        }
+
+        fn force_flush(&self) -> OTelSdkResult {
+            let mut pending = self.pending.lock().unwrap();
+            self.exported.lock().unwrap().extend(pending.drain(..));
+            Ok(())
+        }
+
+        fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+            Ok(())
+        }
+    }
+
     impl TestProcessor {
         fn new() -> Self {
             Self {
@@ -666,6 +698,36 @@ mod tests {
         let mut exported = bodies(&delegate);
         exported.sort();
         assert_eq!(exported, ["first", "second"]);
+    }
+
+    #[test]
+    fn force_flush_replays_each_scope_within_delegate_queue_capacity() {
+        let delegate = BoundedQueueProcessor {
+            pending: Arc::new(Mutex::new(Vec::new())),
+            exported: Arc::new(Mutex::new(Vec::new())),
+            dropped: Arc::new(AtomicUsize::new(0)),
+            capacity: 2,
+        };
+        let (processor, recorder) = ScopedFlightRecorderLogProcessor::builder(delegate.clone())
+            .with_max_records_per_scope(2)
+            .build();
+        let first = recorder.try_start().unwrap();
+        let second = recorder.try_start().unwrap();
+        let instrumentation = InstrumentationScope::builder("test").build();
+
+        futures_executor::block_on(first.with_context(async {
+            processor.emit(&mut record("first-1", Severity::Info), &instrumentation);
+            processor.emit(&mut record("first-2", Severity::Info), &instrumentation);
+        }));
+        futures_executor::block_on(second.with_context(async {
+            processor.emit(&mut record("second-1", Severity::Info), &instrumentation);
+            processor.emit(&mut record("second-2", Severity::Info), &instrumentation);
+        }));
+
+        processor.force_flush().unwrap();
+
+        assert_eq!(delegate.dropped.load(Ordering::Relaxed), 0);
+        assert_eq!(delegate.exported.lock().unwrap().len(), 4);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an experimental, feature-gated global `FlightRecorderLogProcessor` with a bounded ring buffer and cloneable trigger
- route WARN and higher-severity records through the wrapped processor while buffering TRACE through INFO by default
- add a framework-neutral `ScopedFlightRecorderLogProcessor` that propagates isolated operation buffers through OpenTelemetry `Context`
- bound scoped memory by records per scope and maximum active scopes
- add a Hyper demo using request scopes and OTLP export
- add a process-level fake-collector test proving concurrent request isolation, normal WARN/ERROR routing, and triggered INFO export

## Prototype semantics

- global and operation-scoped recorder variants are available
- scoped logs outside an attached context follow the normal export path
- successful scopes discard buffered records; triggered scopes drain and switch to passthrough
- independently spawned tasks must explicitly propagate the recording scope
- `force_flush` drains global snapshots or all active scoped snapshots
- handoff is at-most-once and depends on sufficient capacity in a wrapped batch processor

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p opentelemetry_sdk --all-targets --all-features -- -Dwarnings`
- `cargo test -p opentelemetry_sdk --all-features --lib`
- `cargo check -p opentelemetry_sdk --no-default-features --features experimental_logs_flight_recorder`
- `cargo clippy -p logs-flight-recorder --all-targets --all-features -- -Dwarnings`
- `cargo test -p logs-flight-recorder --all-features`

The full precommit script could not complete in the development environment because system `pkg-config` and OpenSSL development packages were unavailable.