### PR TITLE
chore(sdk): use strong_count for queue capacity callback liveness check

### DIFF
--- a/opentelemetry-sdk/src/logs/batch_log_processor.rs
+++ b/opentelemetry-sdk/src/logs/batch_log_processor.rs
@@ -422,10 +422,11 @@ impl BatchLogProcessor {
                 )
                 .with_unit("{log_record}")
                 .with_callback(move |observer| {
-                    // The capacity value is constant; the Weak upgrade is only a
-                    // liveness guard so a dropped processor stops emitting this
-                    // otherwise-unregisterable callback.
-                    if capacity_state.upgrade().is_some() {
+                    // The capacity value is constant; this is only a liveness
+                    // guard so a dropped processor stops emitting this
+                    // otherwise-unregisterable callback. `strong_count()` is
+                    // sufficient since the callback never reads the state.
+                    if capacity_state.strong_count() > 0 {
                         observer.observe(capacity_value, &capacity_attrs);
                     }
                 })


### PR DESCRIPTION
Follow-up to #3611 addressing a review comment that was missed before merge.

The `otel.sdk.processor.log.queue.capacity` observable callback observes a constant and never reads through the `Weak`. It only needs a liveness check, so `strong_count() > 0` expresses the intent more directly than `upgrade()`, which does a CAS to materialize an `Arc` and immediately drops it. Not a perf concern since it only runs at collection time.

No behavior change; no CHANGELOG entry.