### PR TITLE
test(otlp): add real HTTP retry integration tests

### DIFF
--- a/opentelemetry-otlp/tests/integration_test/Cargo.toml
+++ b/opentelemetry-otlp/tests/integration_test/Cargo.toml
@@ -11,7 +11,6 @@ autobenches = false
 opentelemetry = { path = "../../../opentelemetry", features = [] }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "testing"] }
 opentelemetry-proto = { path = "../../../opentelemetry-proto", features = ["gen-tonic-messages", "trace", "logs", "metrics", "with-serde"] }
-prost = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 serde_json = { workspace = true }
 testcontainers = { version = "0.27.2", features = ["http_wait"] }
@@ -24,6 +23,7 @@ opentelemetry-otlp = { path = "../../../opentelemetry-otlp", default-features = 
 
 [dev-dependencies]
 ctor = { workspace = true }
+prost = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/opentelemetry-otlp/tests/integration_test/Cargo.toml
+++ b/opentelemetry-otlp/tests/integration_test/Cargo.toml
@@ -11,6 +11,7 @@ autobenches = false
 opentelemetry = { path = "../../../opentelemetry", features = [] }
 opentelemetry_sdk = { path = "../../../opentelemetry-sdk", features = ["rt-tokio", "testing"] }
 opentelemetry-proto = { path = "../../../opentelemetry-proto", features = ["gen-tonic-messages", "trace", "logs", "metrics", "with-serde"] }
+prost = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 serde_json = { workspace = true }
 testcontainers = { version = "0.27.2", features = ["http_wait"] }
@@ -30,7 +31,17 @@ opentelemetry-appender-tracing = { path = "../../../opentelemetry-appender-traci
 
 [features]
 hyper-client = ["opentelemetry-otlp/hyper-client", "opentelemetry-otlp/http-proto", "opentelemetry-otlp/trace", "opentelemetry-otlp/logs", "opentelemetry-otlp/metrics", "internal-logs"]
-reqwest-client = ["opentelemetry-otlp/reqwest-client", "opentelemetry-otlp/http-proto", "opentelemetry-otlp/trace","opentelemetry-otlp/logs", "opentelemetry-otlp/metrics", "internal-logs"]
+reqwest-client = [
+    "opentelemetry-otlp/reqwest-client",
+    "opentelemetry-otlp/http-proto",
+    "opentelemetry-otlp/trace",
+    "opentelemetry-otlp/logs",
+    "opentelemetry-otlp/metrics",
+    "opentelemetry_sdk/experimental_logs_batch_log_processor_with_async_runtime",
+    "opentelemetry_sdk/experimental_metrics_periodicreader_with_async_runtime",
+    "opentelemetry_sdk/experimental_trace_batch_span_processor_with_async_runtime",
+    "internal-logs",
+]
 reqwest-blocking-client = ["opentelemetry-otlp/reqwest-blocking-client", "opentelemetry-otlp/http-proto", "opentelemetry-otlp/trace","opentelemetry-otlp/logs", "opentelemetry-otlp/metrics", "internal-logs"]
 tonic-client = ["opentelemetry-otlp/grpc-tonic", "opentelemetry-otlp/trace", "opentelemetry-otlp/logs", "opentelemetry-otlp/metrics", "internal-logs"]
 internal-logs = ["opentelemetry-otlp/internal-logs"]

--- a/opentelemetry-otlp/tests/integration_test/README.md
+++ b/opentelemetry-otlp/tests/integration_test/README.md
@@ -10,6 +10,10 @@ The tests connect directly to the collector on `localhost:4317` and
 `localhost:4318`, push data through, and then check that what they expect has
 popped back out into the files output by the collector.
 
+Retry tests use an in-process fake OTLP endpoint instead of the collector. The
+endpoint returns scripted failures so the tests can verify exporter retry
+behavior through a real HTTP client.
+
 ## Pre-requisites
 
 * Docker, for the test container

--- a/opentelemetry-otlp/tests/integration_test/src/fake_otlp_http.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/fake_otlp_http.rs
@@ -81,6 +81,8 @@ impl FakeOtlpHttpEndpoint {
 
                 let response = responses
                     .pop_front()
+                    // Fall back to 500 if more requests arrive than scripted responses;
+                    // this makes unexpected extra requests fail visibly in assertions.
                     .unwrap_or_else(|| ScriptedHttpResponse::new(500));
                 if let Err(error) = write_response(&mut stream, response).await {
                     server_errors.lock().unwrap().push(error.to_string());

--- a/opentelemetry-otlp/tests/integration_test/src/fake_otlp_http.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/fake_otlp_http.rs
@@ -1,0 +1,231 @@
+use std::collections::{HashMap, VecDeque};
+use std::io;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+
+const MAX_REQUEST_SIZE: usize = 1024 * 1024;
+
+#[derive(Debug)]
+pub struct ScriptedHttpResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+}
+
+impl ScriptedHttpResponse {
+    pub fn new(status: u16) -> Self {
+        Self {
+            status,
+            headers: Vec::new(),
+        }
+    }
+
+    pub fn with_header(mut self, name: &str, value: &str) -> Self {
+        self.headers.push((name.to_owned(), value.to_owned()));
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CapturedHttpRequest {
+    pub request_line: String,
+    pub headers: HashMap<String, String>,
+    pub body: Vec<u8>,
+    pub received_at: Instant,
+}
+
+#[derive(Debug)]
+pub struct FakeOtlpHttpEndpoint {
+    address: SocketAddr,
+    requests: Arc<Mutex<Vec<CapturedHttpRequest>>>,
+    errors: Arc<Mutex<Vec<String>>>,
+    server: JoinHandle<()>,
+}
+
+impl FakeOtlpHttpEndpoint {
+    pub async fn start(responses: Vec<ScriptedHttpResponse>) -> io::Result<Self> {
+        assert!(
+            !responses.is_empty(),
+            "fake OTLP endpoint requires at least one response"
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captured_requests = Arc::clone(&requests);
+        let errors = Arc::new(Mutex::new(Vec::new()));
+        let server_errors = Arc::clone(&errors);
+        let mut responses = VecDeque::from(responses);
+
+        let server = tokio::spawn(async move {
+            loop {
+                let (mut stream, _) = match listener.accept().await {
+                    Ok(connection) => connection,
+                    Err(error) => {
+                        server_errors.lock().unwrap().push(error.to_string());
+                        break;
+                    }
+                };
+                let request = match read_request(&mut stream).await {
+                    Ok(request) => request,
+                    Err(error) => {
+                        server_errors.lock().unwrap().push(error.to_string());
+                        continue;
+                    }
+                };
+                captured_requests.lock().unwrap().push(request);
+
+                let response = responses
+                    .pop_front()
+                    .unwrap_or_else(|| ScriptedHttpResponse::new(500));
+                if let Err(error) = write_response(&mut stream, response).await {
+                    server_errors.lock().unwrap().push(error.to_string());
+                }
+            }
+        });
+
+        Ok(Self {
+            address,
+            requests,
+            errors,
+            server,
+        })
+    }
+
+    pub fn endpoint(&self, path: &str) -> String {
+        format!("http://{}{}", self.address, path)
+    }
+
+    pub fn requests(&self) -> Vec<CapturedHttpRequest> {
+        let errors = self.errors.lock().unwrap();
+        assert!(
+            errors.is_empty(),
+            "fake OTLP endpoint encountered errors: {errors:?}"
+        );
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl Drop for FakeOtlpHttpEndpoint {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+async fn read_request(stream: &mut TcpStream) -> io::Result<CapturedHttpRequest> {
+    let mut bytes = Vec::new();
+    let header_end = loop {
+        if bytes.len() >= MAX_REQUEST_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "request headers exceeded size limit",
+            ));
+        }
+
+        let mut buffer = [0; 4096];
+        let read = stream.read(&mut buffer).await?;
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "connection closed before request headers",
+            ));
+        }
+        bytes.extend_from_slice(&buffer[..read]);
+
+        if let Some(position) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+            break position + 4;
+        }
+    };
+
+    let header_text = std::str::from_utf8(&bytes[..header_end]).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("request headers were not valid UTF-8: {error}"),
+        )
+    })?;
+    let mut lines = header_text.split("\r\n");
+    let request_line = lines.next().unwrap_or_default().to_owned();
+    let mut headers = HashMap::new();
+    for line in lines.filter(|line| !line.is_empty()) {
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("malformed request header: {line}"),
+            ));
+        };
+        headers.insert(name.to_ascii_lowercase(), value.trim().to_owned());
+    }
+
+    if headers.contains_key("transfer-encoding") {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "fake OTLP endpoint does not support transfer-encoding",
+        ));
+    }
+    let content_length = headers
+        .get("content-length")
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "OTLP request did not include content-length",
+            )
+        })?
+        .parse::<usize>()
+        .map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid content-length: {error}"),
+            )
+        })?;
+    if header_end + content_length > MAX_REQUEST_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "request body exceeded size limit",
+        ));
+    }
+
+    while bytes.len() < header_end + content_length {
+        let mut buffer = [0; 4096];
+        let read = stream.read(&mut buffer).await?;
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "connection closed before request body",
+            ));
+        }
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+
+    Ok(CapturedHttpRequest {
+        request_line,
+        headers,
+        body: bytes[header_end..header_end + content_length].to_vec(),
+        received_at: Instant::now(),
+    })
+}
+
+async fn write_response(stream: &mut TcpStream, response: ScriptedHttpResponse) -> io::Result<()> {
+    let reason = match response.status {
+        200 => "OK",
+        400 => "Bad Request",
+        429 => "Too Many Requests",
+        500 => "Internal Server Error",
+        503 => "Service Unavailable",
+        _ => "Test Response",
+    };
+    let mut head = format!(
+        "HTTP/1.1 {} {}\r\nContent-Length: 0\r\nConnection: close\r\n",
+        response.status, reason
+    );
+    for (name, value) in response.headers {
+        head.push_str(&format!("{name}: {value}\r\n"));
+    }
+    head.push_str("\r\n");
+
+    stream.write_all(head.as_bytes()).await?;
+    stream.shutdown().await
+}

--- a/opentelemetry-otlp/tests/integration_test/src/lib.rs
+++ b/opentelemetry-otlp/tests/integration_test/src/lib.rs
@@ -1,3 +1,9 @@
+#[cfg(any(
+    feature = "hyper-client",
+    feature = "reqwest-client",
+    feature = "reqwest-blocking-client"
+))]
+pub mod fake_otlp_http;
 pub mod logs_asserter;
 #[cfg(any(
     feature = "hyper-client",

--- a/opentelemetry-otlp/tests/integration_test/tests/http_retry.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/http_retry.rs
@@ -1,0 +1,256 @@
+#![cfg(all(unix, feature = "reqwest-client"))]
+
+use std::time::Duration;
+
+use anyhow::Result;
+use integration_test_runner::fake_otlp_http::{
+    CapturedHttpRequest, FakeOtlpHttpEndpoint, ScriptedHttpResponse,
+};
+use opentelemetry::logs::{LogRecord, Logger, LoggerProvider};
+use opentelemetry::metrics::MeterProvider;
+use opentelemetry::trace::{Span, Tracer, TracerProvider};
+use opentelemetry_otlp::{
+    LogExporter, MetricExporter, RetryPolicy, SpanExporter, WithExportConfig, WithHttpConfig,
+};
+use opentelemetry_sdk::logs::log_processor_with_async_runtime::BatchLogProcessor;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader;
+use opentelemetry_sdk::metrics::{SdkMeterProvider, Temporality};
+use opentelemetry_sdk::runtime::Tokio;
+use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use prost::Message;
+
+#[derive(Clone, Copy, Debug)]
+enum Signal {
+    Traces,
+    Logs,
+    Metrics,
+}
+
+impl Signal {
+    const ALL: [Self; 3] = [Self::Traces, Self::Logs, Self::Metrics];
+
+    fn path(self) -> &'static str {
+        match self {
+            Self::Traces => "/v1/traces",
+            Self::Logs => "/v1/logs",
+            Self::Metrics => "/v1/metrics",
+        }
+    }
+
+    fn item_count(self, body: &[u8]) -> usize {
+        match self {
+            Self::Traces => {
+                use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+
+                ExportTraceServiceRequest::decode(body)
+                    .expect("failed to decode OTLP trace request")
+                    .resource_spans
+                    .iter()
+                    .flat_map(|resource| &resource.scope_spans)
+                    .map(|scope| scope.spans.len())
+                    .sum()
+            }
+            Self::Logs => {
+                use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+
+                ExportLogsServiceRequest::decode(body)
+                    .expect("failed to decode OTLP log request")
+                    .resource_logs
+                    .iter()
+                    .flat_map(|resource| &resource.scope_logs)
+                    .map(|scope| scope.log_records.len())
+                    .sum()
+            }
+            Self::Metrics => {
+                use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+
+                ExportMetricsServiceRequest::decode(body)
+                    .expect("failed to decode OTLP metric request")
+                    .resource_metrics
+                    .iter()
+                    .flat_map(|resource| &resource.scope_metrics)
+                    .map(|scope| scope.metrics.len())
+                    .sum()
+            }
+        }
+    }
+}
+
+fn retry_policy() -> RetryPolicy {
+    RetryPolicy {
+        max_retries: 3,
+        initial_delay_ms: 10,
+        max_delay_ms: 10,
+        jitter_ms: 0,
+    }
+}
+
+fn assert_otlp_requests(signal: Signal, requests: &[CapturedHttpRequest], expected_count: usize) {
+    assert_eq!(requests.len(), expected_count);
+    for request in requests {
+        assert_eq!(
+            request.request_line,
+            format!("POST {} HTTP/1.1", signal.path())
+        );
+        assert_eq!(
+            request.headers.get("content-type").map(String::as_str),
+            Some("application/x-protobuf")
+        );
+        assert!(!request.body.is_empty(), "OTLP request body was empty");
+        assert_eq!(signal.item_count(&request.body), 1);
+    }
+}
+
+async fn export_to(
+    signal: Signal,
+    endpoint: &FakeOtlpHttpEndpoint,
+) -> opentelemetry_sdk::error::OTelSdkResult {
+    let endpoint = endpoint.endpoint(signal.path());
+    match signal {
+        Signal::Traces => {
+            let exporter = SpanExporter::builder()
+                .with_http()
+                .with_endpoint(endpoint)
+                .with_timeout(Duration::from_secs(5))
+                .with_retry_policy(retry_policy())
+                .build()
+                .expect("failed to build OTLP HTTP span exporter");
+
+            let processor = BatchSpanProcessor::builder(exporter, Tokio).build();
+            let provider = SdkTracerProvider::builder()
+                .with_span_processor(processor)
+                .build();
+            tokio::task::spawn_blocking(move || {
+                let tracer = provider.tracer("http-retry-test");
+                let mut span = tracer.start("http-retry-test");
+                span.end();
+                provider.shutdown()
+            })
+            .await
+            .expect("OTLP trace pipeline task panicked")
+        }
+        Signal::Logs => {
+            let exporter = LogExporter::builder()
+                .with_http()
+                .with_endpoint(endpoint)
+                .with_timeout(Duration::from_secs(5))
+                .with_retry_policy(retry_policy())
+                .build()
+                .expect("failed to build OTLP HTTP log exporter");
+
+            let processor = BatchLogProcessor::builder(exporter, Tokio).build();
+            let provider = SdkLoggerProvider::builder()
+                .with_log_processor(processor)
+                .build();
+            tokio::task::spawn_blocking(move || {
+                let logger = provider.logger("http-retry-test");
+                let mut record = logger.create_log_record();
+                record.set_observed_timestamp(std::time::SystemTime::now());
+                record.set_body("http-retry-test".into());
+                logger.emit(record);
+                provider.shutdown()
+            })
+            .await
+            .expect("OTLP log pipeline task panicked")
+        }
+        Signal::Metrics => {
+            let exporter = MetricExporter::builder()
+                .with_http()
+                .with_endpoint(endpoint)
+                .with_timeout(Duration::from_secs(5))
+                .with_retry_policy(retry_policy())
+                .with_temporality(Temporality::Cumulative)
+                .build()
+                .expect("failed to build OTLP HTTP metric exporter");
+
+            let reader = PeriodicReader::builder(exporter, Tokio).build();
+            let provider = SdkMeterProvider::builder().with_reader(reader).build();
+            tokio::task::spawn_blocking(move || {
+                let meter = provider.meter("http-retry-test");
+                let counter = meter.u64_counter("http-retry-test").build();
+                counter.add(1, &[]);
+                provider.shutdown()
+            })
+            .await
+            .expect("OTLP metric pipeline task panicked")
+        }
+    }
+}
+
+async fn assert_retries_service_unavailable(signal: Signal) -> Result<()> {
+    let endpoint = FakeOtlpHttpEndpoint::start(vec![
+        ScriptedHttpResponse::new(503),
+        ScriptedHttpResponse::new(200),
+    ])
+    .await?;
+
+    export_to(signal, &endpoint).await?;
+
+    assert_otlp_requests(signal, &endpoint.requests(), 2);
+    Ok(())
+}
+
+async fn assert_does_not_retry_bad_request(signal: Signal) -> Result<()> {
+    let endpoint = FakeOtlpHttpEndpoint::start(vec![ScriptedHttpResponse::new(400)]).await?;
+
+    assert!(export_to(signal, &endpoint).await.is_err());
+
+    assert_otlp_requests(signal, &endpoint.requests(), 1);
+    Ok(())
+}
+
+async fn assert_honors_retry_after(signal: Signal) -> Result<()> {
+    let endpoint = FakeOtlpHttpEndpoint::start(vec![
+        ScriptedHttpResponse::new(429).with_header("Retry-After", "1"),
+        ScriptedHttpResponse::new(200),
+    ])
+    .await?;
+
+    export_to(signal, &endpoint).await?;
+
+    let requests = endpoint.requests();
+    assert_otlp_requests(signal, &requests, 2);
+    assert!(
+        requests[1]
+            .received_at
+            .duration_since(requests[0].received_at)
+            >= Duration::from_secs(1),
+        "{signal:?} exporter retried before the Retry-After delay elapsed"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn retries_service_unavailable_then_succeeds() -> Result<()> {
+    let [traces, logs, metrics] = Signal::ALL;
+    tokio::try_join!(
+        assert_retries_service_unavailable(traces),
+        assert_retries_service_unavailable(logs),
+        assert_retries_service_unavailable(metrics)
+    )?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn does_not_retry_bad_request() -> Result<()> {
+    let [traces, logs, metrics] = Signal::ALL;
+    tokio::try_join!(
+        assert_does_not_retry_bad_request(traces),
+        assert_does_not_retry_bad_request(logs),
+        assert_does_not_retry_bad_request(metrics)
+    )?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn honors_retry_after_before_retrying() -> Result<()> {
+    let [traces, logs, metrics] = Signal::ALL;
+    tokio::try_join!(
+        assert_honors_retry_after(traces),
+        assert_honors_retry_after(logs),
+        assert_honors_retry_after(metrics)
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
## Changes

- Add an in-process scripted OTLP/HTTP endpoint for integration tests.
- Exercise the real async reqwest exporter through local SDK providers.
- Emit traces, logs, and metrics using their public APIs.
- Cover:
  - \`503\` retry followed by success
  - \`400\` without retry
  - \`429 Retry-After\` throttling followed by success
- Assert request counts, retry timing, OTLP paths, content types, and decoded protobuf payloads.

## Why

Existing retry tests mock \`HttpClient\`, while the Collector integration tests exercise successful ingestion. This adds coverage across the complete user-facing path:

\`telemetry API → SDK provider → processor/reader → exporter → reqwest → HTTP response → retry classification → retry\`

This guards against transport-level behavior that mocked clients cannot detect, such as losing HTTP status codes or \`Retry-After\` headers.

## Scope

This intentionally starts with OTLP traces, logs, and metrics over HTTP/protobuf using the async reqwest client. Additional HTTP clients, gRPC, and failure scenarios can build on the fake endpoint in follow-up PRs.