### PR TITLE
fix(otlp): align HTTP retry classification with spec

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+- Fix OTLP/HTTP retry classification to retry only status codes 429, 502, 503,
+  and 504, as required by the OTLP specification. The exporter now also honors
+  `Retry-After` on 503 responses. Other HTTP error responses, including 500,
+  are now treated as non-retryable.
 - **Breaking** Removed experimental retry feature flags (`grpc-tonic-with-retry`,
   `http-proto-with-retry`, `http-json-with-retry`). Retry support is now always
   included for both gRPC and HTTP exporters and works with all processor types,

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -1723,6 +1723,24 @@ mod tests {
         }
 
         #[test]
+        fn does_not_retry_on_unlisted_server_error() {
+            let mock = Arc::new(SequencedMockClient::new(vec![http::Response::builder()
+                .status(500)
+                .body(Bytes::new())
+                .unwrap()]));
+            let client = make_client(mock.clone(), retry_policy());
+
+            let result = futures_executor::block_on(client.export_http_with_retry(
+                (),
+                build_test_body,
+                "test",
+            ));
+
+            assert!(result.is_err());
+            assert_eq!(mock.attempt_count(), 1);
+        }
+
+        #[test]
         fn retries_on_429_with_retry_after() {
             let mock = Arc::new(SequencedMockClient::new(vec![
                 http::Response::builder()
@@ -1747,6 +1765,33 @@ mod tests {
             assert!(result.is_ok());
             assert_eq!(mock.attempt_count(), 2);
             // Should have honored the 1s Retry-After
+            assert!(start.elapsed() >= std::time::Duration::from_millis(900));
+        }
+
+        #[test]
+        fn retries_on_503_with_retry_after() {
+            let mock = Arc::new(SequencedMockClient::new(vec![
+                http::Response::builder()
+                    .status(503)
+                    .header("retry-after", "1")
+                    .body(Bytes::new())
+                    .unwrap(),
+                http::Response::builder()
+                    .status(200)
+                    .body(Bytes::new())
+                    .unwrap(),
+            ]));
+            let client = make_client(mock.clone(), retry_policy());
+
+            let start = std::time::Instant::now();
+            let result = futures_executor::block_on(client.export_http_with_retry(
+                (),
+                build_test_body,
+                "test",
+            ));
+
+            assert!(result.is_ok());
+            assert_eq!(mock.attempt_count(), 2);
             assert!(start.elapsed() >= std::time::Duration::from_millis(900));
         }
 

--- a/opentelemetry-otlp/src/retry_classification.rs
+++ b/opentelemetry-otlp/src/retry_classification.rs
@@ -31,22 +31,21 @@ pub mod http {
         retry_after_header: Option<&str>,
     ) -> RetryErrorType {
         match status_code {
-            // 429 Too Many Requests - check for Retry-After
-            429 => {
+            // OTLP/HTTP throttling responses may provide an explicit retry delay.
+            429 | 503 => {
                 if let Some(retry_after) = retry_after_header {
                     if let Some(duration) = parse_retry_after(retry_after) {
                         return RetryErrorType::Throttled(duration);
                     }
                 }
-                // Fallback to retryable if no valid Retry-After
                 RetryErrorType::Retryable
             }
-            // 5xx Server errors - retryable
-            500..=599 => RetryErrorType::Retryable,
-            // 4xx Client errors (except 429) - not retryable
-            400..=499 => RetryErrorType::NonRetryable,
-            // Other codes - retryable (network issues, etc.)
-            _ => RetryErrorType::Retryable,
+            // Other retryable response codes defined by OTLP/HTTP.
+            502 | 504 => RetryErrorType::Retryable,
+            // The HTTP exporter uses status 0 for failures without a response.
+            0 => RetryErrorType::Retryable,
+            // All other HTTP response status codes must not be retried.
+            _ => RetryErrorType::NonRetryable,
         }
     }
 
@@ -171,90 +170,103 @@ mod tests {
         use std::time::Duration;
 
         #[test]
-        fn test_http_429_with_retry_after_seconds() {
-            let result = classify_http_error(429, Some("30"));
-            assert_eq!(result, RetryErrorType::Throttled(Duration::from_secs(30)));
+        fn test_http_throttling_responses_with_retry_after_seconds() {
+            for status_code in [429, 503] {
+                let result = classify_http_error(status_code, Some("30"));
+                assert_eq!(result, RetryErrorType::Throttled(Duration::from_secs(30)));
+            }
         }
 
         #[test]
-        fn test_http_429_with_large_retry_after_capped() {
-            let result = classify_http_error(429, Some("900")); // 15 minutes
-            assert_eq!(
-                result,
-                RetryErrorType::Throttled(std::time::Duration::from_secs(600))
-            ); // Capped at 10 minutes
+        fn test_http_throttling_responses_with_large_retry_after_capped() {
+            for status_code in [429, 503] {
+                let result = classify_http_error(status_code, Some("900")); // 15 minutes
+                assert_eq!(
+                    result,
+                    RetryErrorType::Throttled(std::time::Duration::from_secs(600))
+                ); // Capped at 10 minutes
+            }
         }
 
         #[test]
-        fn test_http_429_with_invalid_retry_after() {
-            let result = classify_http_error(429, Some("invalid"));
-            assert_eq!(result, RetryErrorType::Retryable); // Fallback
+        fn test_http_throttling_responses_with_invalid_retry_after() {
+            for status_code in [429, 503] {
+                let result = classify_http_error(status_code, Some("invalid"));
+                assert_eq!(result, RetryErrorType::Retryable); // Fallback
+            }
         }
 
         #[test]
-        fn test_http_429_without_retry_after() {
-            let result = classify_http_error(429, None);
-            assert_eq!(result, RetryErrorType::Retryable); // Fallback
+        fn test_http_throttling_responses_without_retry_after() {
+            for status_code in [429, 503] {
+                let result = classify_http_error(status_code, None);
+                assert_eq!(result, RetryErrorType::Retryable); // Fallback
+            }
         }
 
         #[test]
-        fn test_http_5xx_errors() {
-            assert_eq!(classify_http_error(500, None), RetryErrorType::Retryable);
+        fn test_http_retryable_response_codes() {
             assert_eq!(classify_http_error(502, None), RetryErrorType::Retryable);
             assert_eq!(classify_http_error(503, None), RetryErrorType::Retryable);
-            assert_eq!(classify_http_error(599, None), RetryErrorType::Retryable);
+            assert_eq!(classify_http_error(504, None), RetryErrorType::Retryable);
         }
 
         #[test]
-        fn test_http_4xx_errors() {
-            assert_eq!(classify_http_error(400, None), RetryErrorType::NonRetryable);
-            assert_eq!(classify_http_error(401, None), RetryErrorType::NonRetryable);
-            assert_eq!(classify_http_error(403, None), RetryErrorType::NonRetryable);
-            assert_eq!(classify_http_error(404, None), RetryErrorType::NonRetryable);
-            assert_eq!(classify_http_error(499, None), RetryErrorType::NonRetryable);
+        fn test_http_non_retryable_response_codes() {
+            for status_code in [400, 401, 403, 404, 408, 499, 500, 501, 505, 599] {
+                assert_eq!(
+                    classify_http_error(status_code, None),
+                    RetryErrorType::NonRetryable
+                );
+            }
         }
 
         #[test]
-        fn test_http_other_errors() {
-            assert_eq!(classify_http_error(100, None), RetryErrorType::Retryable);
-            assert_eq!(classify_http_error(200, None), RetryErrorType::Retryable);
-            assert_eq!(classify_http_error(300, None), RetryErrorType::Retryable);
+        fn test_http_network_error_is_retryable() {
+            assert_eq!(classify_http_error(0, None), RetryErrorType::Retryable);
         }
 
         #[test]
         #[cfg(feature = "httpdate")]
-        fn test_http_429_with_retry_after_valid_date() {
+        fn test_http_throttling_responses_with_retry_after_valid_date() {
             use std::time::SystemTime;
 
             // Create a time 30 seconds in the future
             let future_time = SystemTime::now() + Duration::from_secs(30);
             let date_str = httpdate::fmt_http_date(future_time);
-            let result = classify_http_error(429, Some(&date_str));
-            match result {
-                RetryErrorType::Throttled(duration) => {
-                    let secs = duration.as_secs();
-                    assert!(
-                        (29..=30).contains(&secs),
-                        "Expected ~30 seconds, got {}",
-                        secs
-                    );
+            for status_code in [429, 503] {
+                let result = classify_http_error(status_code, Some(&date_str));
+                match result {
+                    RetryErrorType::Throttled(duration) => {
+                        let secs = duration.as_secs();
+                        assert!(
+                            (29..=30).contains(&secs),
+                            "Expected ~30 seconds, got {}",
+                            secs
+                        );
+                    }
+                    _ => panic!("Expected Throttled, got {:?}", result),
                 }
-                _ => panic!("Expected Throttled, got {:?}", result),
             }
         }
 
         #[test]
         #[cfg(feature = "httpdate")]
-        fn test_http_429_with_retry_after_invalid_date() {
-            let result = classify_http_error(429, Some("Not a valid date"));
-            assert_eq!(result, RetryErrorType::Retryable); // Falls back to retryable
+        fn test_http_throttling_responses_with_retry_after_invalid_date() {
+            for status_code in [429, 503] {
+                let result = classify_http_error(status_code, Some("Not a valid date"));
+                assert_eq!(result, RetryErrorType::Retryable); // Falls back to retryable
+            }
         }
 
         #[test]
         #[cfg(feature = "httpdate")]
-        fn test_http_429_with_retry_after_malformed_date() {
-            let result = classify_http_error(429, Some("Sun, 99 Nov 9999 99:99:99 GMT"));
-            assert_eq!(result, RetryErrorType::Retryable); // Falls back to retryable
+        fn test_http_throttling_responses_with_retry_after_malformed_date() {
+            for status_code in [429, 503] {
+                let result =
+                    classify_http_error(status_code, Some("Sun, 99 Nov 9999 99:99:99 GMT"));
+                assert_eq!(result, RetryErrorType::Retryable); // Falls back to retryable
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Align OTLP/HTTP retry classification with the OTLP specification and honor server throttling instructions on `503 Service Unavailable` responses.

## Before

- `429 Too Many Requests` was retried and honored `Retry-After`.
- Every `5xx` response, including `500`, `501`, and `505`-`599`, was retried.
- `503` was retried but its `Retry-After` header was ignored in favor of normal exponential backoff.
- Transport and network failures were retried.

## After

- Only the OTLP-defined retryable response codes are retried: `429`, `502`, `503`, and `504`.
- Both `429` and `503` honor a valid `Retry-After` header.
- Other HTTP error responses, including `500`, are treated as non-retryable.
- Transport and network failures remain retryable.

The change adds classifier coverage for the complete status-code behavior and exporter-level coverage proving that `500` is not retried and `503 Retry-After` delays the next attempt.
