### PR TITLE
feat(otlp): limit HTTP request body size

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+- **Breaking** Add the required `WithHttpConfig::with_max_request_body_size`
+  method. External implementations of `WithHttpConfig` must implement it.
+  OTLP/HTTP request bodies are now limited to 64 MiB by default, before and
+  after compression; oversized requests are discarded without being sent or
+  retried.
 - Fix OTLP/HTTP retry classification to retry only status codes 429, 502, 503,
   and 504, as required by the OTLP specification. The exporter now also honors
   `Retry-After` on 503 responses. Other HTTP error responses, including 500,

--- a/opentelemetry-otlp/src/exporter/http/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/http/metrics.rs
@@ -10,14 +10,12 @@ use super::OtlpHttpClient;
 
 impl MetricsClient for OtlpHttpClient {
     async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
-        let build_body_wrapper = |client: &OtlpHttpClient, metrics: &ResourceMetrics| {
-            client
-                .build_metrics_export_body(metrics)
-                .ok_or_else(|| "Failed to serialize metrics".to_string())
-        };
-
         let response_body = self
-            .export_http_with_retry(metrics, build_body_wrapper, "HttpMetricsClient.Export")
+            .export_http_with_retry(
+                metrics,
+                OtlpHttpClient::build_metrics_export_body,
+                "HttpMetricsClient.Export",
+            )
             .await?;
 
         handle_partial_success(&response_body, self.protocol);

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -28,6 +28,10 @@ use std::time::Duration;
 use crate::retry::{RetryErrorType, RetryPolicy};
 use crate::retry_classification::http::classify_http_error;
 
+// Recommended by the OTLP/HTTP specification:
+// https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp-request
+const DEFAULT_MAX_REQUEST_BODY_SIZE: usize = 64 * 1024 * 1024;
+
 // Shared HTTP retry functionality
 /// HTTP-specific error wrapper for retry classification
 #[derive(Debug)]
@@ -104,6 +108,9 @@ pub(crate) struct HttpConfig {
 
     /// The retry policy to use for HTTP requests.
     retry_policy: Option<RetryPolicy>,
+
+    /// Maximum HTTP request body size, before and after compression.
+    max_request_body_size: Option<usize>,
 }
 
 /// Configuration for the OTLP HTTP exporter.
@@ -275,7 +282,7 @@ impl HttpExporterBuilder {
             add_header_from_string(&input, &mut headers);
         }
 
-        Ok(OtlpHttpClient::new(
+        let mut client = OtlpHttpClient::new(
             http_client,
             endpoint,
             headers,
@@ -283,7 +290,11 @@ impl HttpExporterBuilder {
             timeout,
             compression,
             self.http_config.retry_policy.take(),
-        ))
+        );
+        if let Some(max_request_body_size) = self.http_config.max_request_body_size {
+            client.max_request_body_size = max_request_body_size;
+        }
+        Ok(client)
     }
 
     fn resolve_compression(
@@ -369,6 +380,7 @@ pub(crate) struct OtlpHttpClient {
     timeout: Duration,
     compression: Option<crate::Compression>,
     retry_policy: RetryPolicy,
+    max_request_body_size: usize,
     #[allow(dead_code)]
     // <allow dead> would be removed once we support set_resource for metrics and traces.
     resource: opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema,
@@ -509,7 +521,9 @@ impl OtlpHttpClient {
     /// has been enabled. If the user has requested it but the feature has not been enabled,
     /// we should catch this at exporter build time and never get here.
     fn process_body(&self, body: Vec<u8>) -> Result<(Vec<u8>, Option<&'static str>), String> {
-        match self.compression {
+        self.validate_request_body_size(&body, "uncompressed")?;
+
+        let (processed_body, content_encoding) = match self.compression {
             #[cfg(feature = "gzip-http")]
             Some(crate::Compression::Gzip) => {
                 use flate2::{write::GzEncoder, Compression};
@@ -518,23 +532,47 @@ impl OtlpHttpClient {
                 let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
                 encoder.write_all(&body).map_err(|e| e.to_string())?;
                 let compressed = encoder.finish().map_err(|e| e.to_string())?;
-                Ok((compressed, Some("gzip")))
+                (compressed, Some("gzip"))
             }
             #[cfg(not(feature = "gzip-http"))]
             Some(crate::Compression::Gzip) => {
-                Err("gzip compression requested but gzip-http feature not enabled".to_string())
+                return Err(
+                    "gzip compression requested but gzip-http feature not enabled".to_string(),
+                );
             }
             #[cfg(feature = "zstd-http")]
             Some(crate::Compression::Zstd) => {
                 let compressed = zstd::bulk::compress(&body, 0).map_err(|e| e.to_string())?;
-                Ok((compressed, Some("zstd")))
+                (compressed, Some("zstd"))
             }
             #[cfg(not(feature = "zstd-http"))]
             Some(crate::Compression::Zstd) => {
-                Err("zstd compression requested but zstd-http feature not enabled".to_string())
+                return Err(
+                    "zstd compression requested but zstd-http feature not enabled".to_string(),
+                );
             }
-            None => Ok((body, None)),
+            None => (body, None),
+        };
+
+        if content_encoding.is_some() {
+            self.validate_request_body_size(&processed_body, "compressed")?;
         }
+
+        Ok((processed_body, content_encoding))
+    }
+
+    fn validate_request_body_size(
+        &self,
+        body: &[u8],
+        representation: &'static str,
+    ) -> Result<(), String> {
+        if body.len() > self.max_request_body_size {
+            return Err(format!(
+                "OTLP HTTP {representation} request body is {} bytes, exceeding the configured limit of {} bytes; request will not be sent and telemetry data will be discarded; reduce the batch size, telemetry item size, or configure a larger limit",
+                body.len(), self.max_request_body_size
+            ));
+        }
+        Ok(())
     }
 
     #[allow(clippy::mutable_key_type)] // http headers are not mutated
@@ -555,6 +593,7 @@ impl OtlpHttpClient {
             timeout,
             compression,
             retry_policy: retry_policy.unwrap_or_default(),
+            max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
             resource: ResourceAttributesWithSchema::default(),
         }
     }
@@ -572,7 +611,9 @@ impl OtlpHttpClient {
             #[cfg(feature = "http-json")]
             Protocol::HttpJson => match serde_json::to_string_pretty(&req) {
                 Ok(json) => (json.into_bytes(), "application/json"),
-                Err(e) => return Err(e.to_string()),
+                Err(e) => {
+                    return Err(format!("failed to serialize traces to OTLP/HTTP JSON: {e}"));
+                }
             },
             #[cfg(feature = "http-proto")]
             Protocol::HttpBinary => (req.encode_to_vec(), "application/x-protobuf"),
@@ -599,7 +640,9 @@ impl OtlpHttpClient {
             #[cfg(feature = "http-json")]
             Protocol::HttpJson => match serde_json::to_string_pretty(&req) {
                 Ok(json) => (json.into_bytes(), "application/json"),
-                Err(e) => return Err(e.to_string()),
+                Err(e) => {
+                    return Err(format!("failed to serialize logs to OTLP/HTTP JSON: {e}"));
+                }
             },
             #[cfg(feature = "http-proto")]
             Protocol::HttpBinary => (req.encode_to_vec(), "application/x-protobuf"),
@@ -617,7 +660,7 @@ impl OtlpHttpClient {
     fn build_metrics_export_body(
         &self,
         metrics: &ResourceMetrics,
-    ) -> Option<(Vec<u8>, &'static str, Option<&'static str>)> {
+    ) -> Result<(Vec<u8>, &'static str, Option<&'static str>), String> {
         use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 
         let req: ExportMetricsServiceRequest = metrics.into();
@@ -627,8 +670,9 @@ impl OtlpHttpClient {
             Protocol::HttpJson => match serde_json::to_string_pretty(&req) {
                 Ok(json) => (json.into_bytes(), "application/json"),
                 Err(e) => {
-                    otel_debug!(name: "JsonSerializationFaied", error = e.to_string());
-                    return None;
+                    return Err(format!(
+                        "failed to serialize metrics to OTLP/HTTP JSON: {e}"
+                    ));
                 }
             },
             #[cfg(feature = "http-proto")]
@@ -639,15 +683,8 @@ impl OtlpHttpClient {
             }
         };
 
-        match self.process_body(body) {
-            Ok((processed_body, content_encoding)) => {
-                Some((processed_body, content_type, content_encoding))
-            }
-            Err(e) => {
-                otel_debug!(name: "CompressionFailed", error = e);
-                None
-            }
-        }
+        let (processed_body, content_encoding) = self.process_body(body)?;
+        Ok((processed_body, content_type, content_encoding))
     }
 }
 
@@ -743,6 +780,14 @@ pub trait WithHttpConfig {
 
     /// Set the retry policy for HTTP requests.
     fn with_retry_policy(self, policy: RetryPolicy) -> Self;
+
+    /// Set the maximum HTTP request body size in bytes.
+    ///
+    /// The limit is enforced both before and after compression. Requests that
+    /// exceed it are discarded without being sent or retried. Reduce the batch
+    /// size or telemetry item size if requests exceed the configured limit.
+    /// The default is 64 MiB.
+    fn with_max_request_body_size(self, max_size: usize) -> Self;
 }
 
 impl<B: HasHttpConfig> WithHttpConfig for B {
@@ -770,6 +815,11 @@ impl<B: HasHttpConfig> WithHttpConfig for B {
 
     fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
         self.http_client_config().retry_policy = Some(policy);
+        self
+    }
+
+    fn with_max_request_body_size(mut self, max_size: usize) -> Self {
+        self.http_client_config().max_request_body_size = Some(max_size);
         self
     }
 }
@@ -1017,8 +1067,8 @@ mod tests {
                 client: None,
                 headers: Some(initial_headers),
                 compression: None,
-
                 retry_policy: None,
+                max_request_body_size: None,
             },
             exporter_config: crate::exporter::ExportConfig::default(),
         };
@@ -1106,6 +1156,27 @@ mod tests {
             assert_eq!(decompressed, test_data);
             // Verify compression actually happened (compressed should be different)
             assert_ne!(compressed_body, test_data.to_vec());
+        }
+
+        #[cfg(all(feature = "http-proto", feature = "gzip-http"))]
+        #[test]
+        fn request_body_limit_applies_before_and_after_compression() {
+            let mut client = OtlpHttpClient::new(
+                std::sync::Arc::new(MockHttpClient),
+                "http://localhost:4318".parse().unwrap(),
+                std::collections::HashMap::new(),
+                crate::Protocol::HttpBinary,
+                std::time::Duration::from_secs(10),
+                Some(crate::Compression::Gzip),
+                None,
+            );
+            client.max_request_body_size = 1;
+
+            let uncompressed_error = client.process_body(vec![0; 2]).unwrap_err();
+            assert!(uncompressed_error.contains("uncompressed request body is 2 bytes"));
+
+            let compressed_error = client.process_body(vec![0]).unwrap_err();
+            assert!(compressed_error.contains("compressed request body is"));
         }
 
         #[cfg(all(feature = "http-proto", feature = "zstd-http"))]
@@ -1258,6 +1329,42 @@ mod tests {
                 compression,
                 None,
             )
+        }
+
+        #[cfg(feature = "http-proto")]
+        #[test]
+        fn request_body_at_configured_limit_is_accepted() {
+            let mut client = create_test_client(crate::Protocol::HttpBinary, None);
+            client.max_request_body_size = 4;
+
+            let (body, content_encoding) = client.process_body(vec![0; 4]).unwrap();
+
+            assert_eq!(body.len(), 4);
+            assert_eq!(content_encoding, None);
+        }
+
+        #[cfg(feature = "http-proto")]
+        #[test]
+        fn request_body_over_configured_limit_is_rejected() {
+            let mut client = create_test_client(crate::Protocol::HttpBinary, None);
+            client.max_request_body_size = 4;
+
+            let error = client.process_body(vec![0; 5]).unwrap_err();
+
+            assert!(error.contains("uncompressed request body is 5 bytes"));
+            assert!(error.contains("configured limit of 4 bytes"));
+            assert!(error.contains("request will not be sent"));
+        }
+
+        #[cfg(feature = "http-proto")]
+        #[test]
+        fn default_request_body_limit_is_64_mib() {
+            let client = create_test_client(crate::Protocol::HttpBinary, None);
+
+            assert_eq!(
+                client.max_request_body_size,
+                super::super::DEFAULT_MAX_REQUEST_BODY_SIZE
+            );
         }
 
         fn create_test_span_data() -> opentelemetry_sdk::trace::SpanData {
@@ -1433,16 +1540,15 @@ mod tests {
             not(feature = "gzip-http")
         ))]
         #[test]
-        fn test_build_metrics_export_body_compression_error_returns_none() {
+        fn test_build_metrics_export_body_returns_compression_error() {
             use opentelemetry_sdk::metrics::data::ResourceMetrics;
 
             let client =
                 create_test_client(crate::Protocol::HttpBinary, Some(crate::Compression::Gzip));
             let metrics = ResourceMetrics::default();
 
-            // Should return None when compression fails (feature not enabled)
-            let result = client.build_metrics_export_body(&metrics);
-            assert!(result.is_none());
+            let error = client.build_metrics_export_body(&metrics).unwrap_err();
+            assert!(error.contains("gzip-http feature not enabled"));
         }
 
         #[test]
@@ -1493,6 +1599,16 @@ mod tests {
                 result,
                 Err(ExporterBuildError::UnsupportedCompressionAlgorithm(_))
             ));
+        }
+
+        #[test]
+        fn test_with_max_request_body_size() {
+            use super::super::HttpExporterBuilder;
+            use crate::WithHttpConfig;
+
+            let builder = HttpExporterBuilder::default().with_max_request_body_size(1024);
+
+            assert_eq!(builder.http_config.max_request_body_size, Some(1024));
         }
 
         #[test]
@@ -1659,6 +1775,14 @@ mod tests {
             Ok((vec![1, 2, 3], "application/x-protobuf", None))
         }
 
+        fn build_processed_test_body(
+            client: &OtlpHttpClient,
+            _data: (),
+        ) -> Result<(Vec<u8>, &'static str, Option<&'static str>), String> {
+            let (body, content_encoding) = client.process_body(vec![1, 2, 3])?;
+            Ok((body, "application/x-protobuf", content_encoding))
+        }
+
         fn make_client(mock: Arc<dyn HttpClient>, retry_policy: RetryPolicy) -> OtlpHttpClient {
             OtlpHttpClient::new(
                 mock,
@@ -1678,6 +1802,26 @@ mod tests {
                 max_delay_ms: 10,
                 jitter_ms: 0,
             }
+        }
+
+        #[test]
+        fn oversized_request_is_not_sent_or_retried() {
+            let mock = Arc::new(SequencedMockClient::new(vec![http::Response::builder()
+                .status(200)
+                .body(Bytes::new())
+                .unwrap()]));
+            let mut client = make_client(mock.clone(), retry_policy());
+            client.max_request_body_size = 2;
+
+            let result = futures_executor::block_on(client.export_http_with_retry(
+                (),
+                build_processed_test_body,
+                "test",
+            ));
+
+            let error = result.unwrap_err().to_string();
+            assert!(error.contains("request will not be sent"));
+            assert_eq!(mock.attempt_count(), 0);
         }
 
         #[test]

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -471,7 +471,8 @@
 //!
 //! Requires the `http-proto` (default) or `http-json` feature. The methods below come from:
 //! - [`WithExportConfig`]: `with_endpoint`, `with_timeout`, `with_protocol`
-//! - [`WithHttpConfig`]: `with_headers`, `with_compression`, `with_http_client`
+//! - [`WithHttpConfig`]: `with_headers`, `with_compression`, `with_http_client`,
+//!   `with_retry_policy`, `with_max_request_body_size`
 //!
 //! The examples here use [`SpanExporter`], but the same builder methods are
 //! available on [`MetricExporter`] and [`LogExporter`].
@@ -505,6 +506,9 @@
 //!     // Compression. Requires the `gzip-http` or `zstd-http` feature.
 //!     // Env var: OTEL_EXPORTER_OTLP_TRACES_COMPRESSION (or OTEL_EXPORTER_OTLP_COMPRESSION).
 //!     .with_compression(Compression::Gzip)
+//!     // Maximum serialized HTTP request size before and after compression.
+//!     // Defaults to the OTLP-recommended 64 MiB.
+//!     .with_max_request_body_size(64 * 1024 * 1024)
 //!     .build()
 //!     .expect("Failed to build SpanExporter");
 //! # }

--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -632,7 +632,6 @@ mod tests {
 
     use rand::random;
     use std::collections::hash_map::DefaultHasher;
-    use std::f64;
 
     #[test]
     fn kv_float_equality() {


### PR DESCRIPTION
## Summary

Implements the [OTLP/HTTP request body size requirements](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp-request). This is a `SHOULD`, but it is straightforward enough so let's do it in pursuit of our OTLP stabilisation. There is a similar requirement for gRPC but we will look at that separately. 

OTLP/HTTP request bodies are now limited to 64 MiB by default. The limit is checked before compression and, when compression is enabled, against the compressed body as well - this might seem academic, but compression can in some cases make payloads _larger_, so we may as well be thorough. Users can configure it with `WithHttpConfig::with_max_request_body_size`.

## Oversized request behavior

An oversized request causes the export operation to fail before any HTTP request is made. It is not sent or retried, and the error explains that the telemetry was discarded and suggests reducing the batch size or telemetry item size, or configuring a larger limit.

This hard failure is intentional. The OTLP specification says that, when the limit is exceeded, the client **MUST NOT** make the request and **SHOULD** record that it was discarded. The exporter does not attempt to split, truncate, or re-batch the request. Re-batching at this layer would add complex signal-specific behavior and is not required by the specification. Users should instead adjust their telemetry processor or batch configuration, reduce unusually large telemetry items, or set a limit compatible with their collector.

## Changes

- Add a 64 MiB default OTLP/HTTP request body limit.
- Validate the serialized body before compression and the resulting body after compression.
- Add `WithHttpConfig::with_max_request_body_size` for programmatic configuration.
- Ensure oversized requests do not enter the HTTP send or retry path.
- Preserve actionable serialization, compression, and size-limit errors for metrics exports.
- Document the behavior and public API in the crate documentation and changelog.

## Public API

Adding `WithHttpConfig::with_max_request_body_size` is a breaking change for external implementations of the public `WithHttpConfig` trait. Those implementations must add the new required method.

## Merge requirement checklist

- [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
- [x] Unit tests added/updated
- [x] Appropriate `CHANGELOG.md` updated
- [x] Changes in public API reviewed
