### PR TITLE
fix(otlp): honor gRPC RetryInfo for unavailable

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -7,6 +7,9 @@
   OTLP/HTTP request bodies are now limited to 64 MiB by default, before and
   after compression; oversized requests are discarded without being sent or
   retried.
+- Honor positive gRPC `RetryInfo` delays returned with `Unavailable` responses.
+  `Unavailable` responses without a positive delay continue to use exponential
+  backoff.
 - Fix OTLP/HTTP retry classification to retry only status codes 429, 502, 503,
   and 504, as required by the OTLP specification. The exporter now also honors
   `Retry-After` on 503 responses. Other HTTP error responses, including 500,

--- a/opentelemetry-otlp/src/retry_classification.rs
+++ b/opentelemetry-otlp/src/retry_classification.rs
@@ -135,12 +135,19 @@ pub mod grpc {
                 RetryErrorType::NonRetryable
             }
 
+            // UNAVAILABLE may include RetryInfo to signal an explicit throttle delay.
+            tonic::Code::Unavailable => match retry_delay.filter(|delay| !delay.is_zero()) {
+                Some(delay) => {
+                    RetryErrorType::Throttled(delay.min(std::time::Duration::from_secs(600)))
+                }
+                None => RetryErrorType::Retryable,
+            },
+
             // Retryable errors per OTLP specification
             tonic::Code::Cancelled
             | tonic::Code::DeadlineExceeded
             | tonic::Code::Aborted
             | tonic::Code::OutOfRange
-            | tonic::Code::Unavailable
             | tonic::Code::DataLoss => RetryErrorType::Retryable,
 
             // Non-retryable errors per OTLP specification
@@ -315,6 +322,75 @@ mod tests {
             let result = classify_tonic_status(&status);
             // Per OTLP spec: RESOURCE_EXHAUSTED without RetryInfo is non-retryable
             assert_eq!(result, RetryErrorType::NonRetryable);
+        }
+
+        #[test]
+        fn test_grpc_unavailable_with_retry_info() {
+            let error_details =
+                ErrorDetails::with_retry_info(Some(std::time::Duration::from_secs(45)));
+            let status = tonic::Status::with_error_details(
+                tonic::Code::Unavailable,
+                "service unavailable",
+                error_details,
+            );
+
+            assert_eq!(
+                classify_tonic_status(&status),
+                RetryErrorType::Throttled(std::time::Duration::from_secs(45))
+            );
+        }
+
+        #[test]
+        fn test_grpc_unavailable_with_fractional_retry_info() {
+            let error_details =
+                ErrorDetails::with_retry_info(Some(std::time::Duration::from_millis(500)));
+            let status = tonic::Status::with_error_details(
+                tonic::Code::Unavailable,
+                "service unavailable",
+                error_details,
+            );
+
+            assert_eq!(
+                classify_tonic_status(&status),
+                RetryErrorType::Throttled(std::time::Duration::from_millis(500))
+            );
+        }
+
+        #[test]
+        fn test_grpc_unavailable_with_large_retry_info_capped() {
+            let error_details =
+                ErrorDetails::with_retry_info(Some(std::time::Duration::from_secs(900)));
+            let status = tonic::Status::with_error_details(
+                tonic::Code::Unavailable,
+                "service unavailable",
+                error_details,
+            );
+
+            assert_eq!(
+                classify_tonic_status(&status),
+                RetryErrorType::Throttled(std::time::Duration::from_secs(600))
+            );
+        }
+
+        #[test]
+        fn test_grpc_unavailable_without_positive_retry_info() {
+            let without_retry_info =
+                tonic::Status::new(tonic::Code::Unavailable, "service unavailable");
+            assert_eq!(
+                classify_tonic_status(&without_retry_info),
+                RetryErrorType::Retryable
+            );
+
+            let error_details = ErrorDetails::with_retry_info(Some(std::time::Duration::ZERO));
+            let zero_retry_info = tonic::Status::with_error_details(
+                tonic::Code::Unavailable,
+                "service unavailable",
+                error_details,
+            );
+            assert_eq!(
+                classify_tonic_status(&zero_retry_info),
+                RetryErrorType::Retryable
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Honor server-provided gRPC `RetryInfo` delays on OTLP `Unavailable` responses, as specified by the OTLP throttling protocol.

## Before

- `Unavailable` was classified as retryable regardless of attached error details.
- A server-provided `RetryInfo.retry_delay` was ignored.
- Retries therefore used the exporter's normal exponential-backoff delay instead of the server-requested delay.

## After

- `Unavailable` with a positive `RetryInfo.retry_delay` is classified as throttled and honors the server delay.
- `Unavailable` without `RetryInfo`, or with a zero delay, continues to use normal exponential backoff.
- Fractional delays are preserved and large delays retain the existing ten-minute classifier cap.
- Existing `ResourceExhausted` classification remains unchanged.

The change adds focused coverage for positive, fractional, capped, missing, and zero-delay `RetryInfo` behavior.
