### PR TITLE
fix: cap tracestate at the 32 list-members the spec allows

### DIFF
--- a/opentelemetry-jaeger-propagator/CHANGELOG.md
+++ b/opentelemetry-jaeger-propagator/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+- Cap the `tracestate` built by `Propagator::extract` at the 32 list-members the W3C
+  trace-context specification allows, following the limit `TraceState` now enforces in
+  the `opentelemetry` crate. A carrier holding more `uberctx-` entries than that no
+  longer produces an oversized `tracestate`.
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+- Fix `TraceState` accepting more than the 32 list-members the W3C trace-context
+  specification allows. `from_str`, `from_key_value` and `insert` now keep at most
+  32, dropping members from the end of the list as the specification prescribes, so
+  neither a parsed nor a locally built `tracestate` can exceed the limit.
 - `otel_info!`, `otel_warn!`, `otel_debug!`, and `otel_error!` macros now accept quoted-key fields
   (e.g. `"otel.component.type" = "value"`) for dotted attribute names.
 - **Added** `BoundGauge<T>` and `BoundUpDownCounter<T>` types (and the

--- a/opentelemetry/src/trace/span_context.rs
+++ b/opentelemetry/src/trace/span_context.rs
@@ -14,6 +14,8 @@ use thiserror::Error;
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub struct TraceState(Option<VecDeque<(String, String)>>);
 
+const MAX_LIST_MEMBERS: usize = 32;
+
 impl TraceState {
     /// The default `TraceState`, as a constant
     pub const NONE: TraceState = TraceState(None);
@@ -61,7 +63,10 @@ impl TraceState {
         !(value.contains(',') || value.contains('='))
     }
 
-    /// Creates a new `TraceState` from the given key-value collection.
+    /// Creates a new `TraceState` from the given key-value collection, keeping at most the 32
+    /// list-members the [W3C specification] allows.
+    ///
+    /// [W3C specification]: https://www.w3.org/TR/trace-context/#tracestate-header-field-values
     ///
     /// # Examples
     ///
@@ -82,6 +87,7 @@ impl TraceState {
     {
         let ordered_data = trace_state
             .into_iter()
+            .take(MAX_LIST_MEMBERS)
             .map(|(key, value)| {
                 let (key, value) = (key.to_string(), value.to_string());
                 if !TraceState::valid_key(key.as_str()) {
@@ -120,6 +126,9 @@ impl TraceState {
     /// invalid per the [W3 Spec] an `Err` is returned, else a new `TraceState` with the
     /// updated key/value is returned.
     ///
+    /// A `TraceState` holds at most the 32 list-members the [W3 Spec] allows. Inserting into a full
+    /// `TraceState` keeps the inserted pair and drops the last list-member.
+    ///
     /// [W3 Spec]: https://www.w3.org/TR/trace-context/#mutating-the-tracestate-field
     pub fn insert<K, V>(&self, key: K, value: V) -> TraceStateResult<TraceState>
     where
@@ -136,6 +145,9 @@ impl TraceState {
 
         let mut trace_state = self.delete_from_deque(&key);
         let kvs = trace_state.0.get_or_insert(VecDeque::with_capacity(1));
+        if kvs.len() >= MAX_LIST_MEMBERS {
+            kvs.truncate(MAX_LIST_MEMBERS - 1);
+        }
 
         kvs.push_front((key, value));
 
@@ -193,10 +205,9 @@ impl FromStr for TraceState {
     type Err = TraceStateError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let list_members: Vec<&str> = s.split_terminator(',').collect();
-        let mut key_value_pairs: Vec<(String, String)> = Vec::with_capacity(list_members.len());
+        let mut key_value_pairs: Vec<(String, String)> = Vec::new();
 
-        for list_member in list_members {
+        for list_member in s.split_terminator(',').take(MAX_LIST_MEMBERS) {
             match list_member.find('=') {
                 None => return Err(TraceStateError::List(list_member.to_string())),
                 Some(separator_index) => {
@@ -495,5 +506,73 @@ mod tests {
         let iter = ts.into_iter();
         assert_eq!(iter.size_hint(), (2, Some(2)));
         assert_eq!(iter.len(), 2);
+    }
+
+    #[test]
+    fn test_tracestate_from_str_keeps_at_most_32_list_members() {
+        let header = (0..64)
+            .map(|i| format!("key{i}=value{i}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let trace_state = TraceState::from_str(&header).unwrap();
+
+        assert_eq!(trace_state.into_iter().count(), 32);
+        assert_eq!(trace_state.get("key0"), Some("value0"));
+        assert_eq!(trace_state.get("key31"), Some("value31"));
+        assert_eq!(trace_state.get("key32"), None);
+    }
+    #[test]
+    fn test_tracestate_from_str_ignores_invalid_members_beyond_the_limit() {
+        let mut members: Vec<String> = (0..32).map(|i| format!("key{i}=value{i}")).collect();
+        members.push("invalid-no-separator".to_string());
+        let trace_state = TraceState::from_str(&members.join(",")).unwrap();
+
+        assert_eq!(trace_state.into_iter().count(), 32);
+    }
+    #[test]
+    fn test_tracestate_from_str_rejects_invalid_members_within_the_limit() {
+        let mut members: Vec<String> = (0..31).map(|i| format!("key{i}=value{i}")).collect();
+        members.push("invalid-no-separator".to_string());
+
+        assert!(TraceState::from_str(&members.join(",")).is_err());
+    }
+    #[test]
+    fn test_tracestate_from_key_value_keeps_at_most_32_list_members() {
+        let kvs: Vec<(String, String)> = (0..64)
+            .map(|i| (format!("key{i}"), format!("value{i}")))
+            .collect();
+        let trace_state = TraceState::from_key_value(kvs).unwrap();
+
+        assert_eq!(trace_state.into_iter().count(), 32);
+        assert_eq!(trace_state.get("key0"), Some("value0"));
+        assert_eq!(trace_state.get("key32"), None);
+    }
+    #[test]
+    fn test_tracestate_insert_keeps_at_most_32_list_members() {
+        let mut trace_state = TraceState::default();
+        for i in 0..64 {
+            trace_state = trace_state
+                .insert(format!("key{i}"), format!("value{i}"))
+                .unwrap();
+        }
+
+        assert_eq!(trace_state.into_iter().count(), 32);
+        assert_eq!(trace_state.get("key63"), Some("value63"));
+        assert_eq!(trace_state.get("key32"), Some("value32"));
+        assert_eq!(trace_state.get("key31"), None);
+    }
+    #[test]
+    fn test_tracestate_insert_of_an_existing_key_evicts_nothing() {
+        let mut trace_state = TraceState::default();
+        for i in 0..32 {
+            trace_state = trace_state
+                .insert(format!("key{i}"), format!("value{i}"))
+                .unwrap();
+        }
+        let updated = trace_state.insert("key20", "updated").unwrap();
+
+        assert_eq!(updated.into_iter().count(), 32);
+        assert_eq!(updated.get("key20"), Some("updated"));
+        assert_eq!(updated.get("key0"), Some("value0"));
     }
 }

--- a/opentelemetry/src/trace/span_context.rs
+++ b/opentelemetry/src/trace/span_context.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 ///
 /// Please review the [W3C specification] for details on this field.
 ///
-/// [W3C specification]: https://www.w3.org/TR/trace-context/#tracestate-header
+/// [W3C specification]: https://www.w3.org/TR/trace-context-2/#tracestate-header
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub struct TraceState(Option<VecDeque<(String, String)>>);
 
@@ -22,7 +22,7 @@ impl TraceState {
 
     /// Validates that the given `TraceState` list-member key is valid per the [W3 Spec].
     ///
-    /// [W3 Spec]: https://www.w3.org/TR/trace-context/#key
+    /// [W3 Spec]: https://www.w3.org/TR/trace-context-2/#key
     fn valid_key(key: &str) -> bool {
         if key.len() > 256 {
             return false;
@@ -54,7 +54,7 @@ impl TraceState {
 
     /// Validates that the given `TraceState` list-member value is valid per the [W3 Spec].
     ///
-    /// [W3 Spec]: https://www.w3.org/TR/trace-context/#value
+    /// [W3 Spec]: https://www.w3.org/TR/trace-context-2/#value
     fn valid_value(value: &str) -> bool {
         if value.len() > 256 {
             return false;
@@ -64,9 +64,11 @@ impl TraceState {
     }
 
     /// Creates a new `TraceState` from the given key-value collection, keeping at most the 32
-    /// list-members the [W3C specification] allows.
+    /// list-members the [W3C specification] allows. Pairs beyond the 32nd are dropped without
+    /// being validated, so a key or value that would otherwise make this return an `Err` has no
+    /// effect if it only appears past the limit.
     ///
-    /// [W3C specification]: https://www.w3.org/TR/trace-context/#tracestate-header-field-values
+    /// [W3C specification]: https://www.w3.org/TR/trace-context-2/#tracestate-header-field-values
     ///
     /// # Examples
     ///
@@ -129,7 +131,7 @@ impl TraceState {
     /// A `TraceState` holds at most the 32 list-members the [W3 Spec] allows. Inserting into a full
     /// `TraceState` keeps the inserted pair and drops the last list-member.
     ///
-    /// [W3 Spec]: https://www.w3.org/TR/trace-context/#mutating-the-tracestate-field
+    /// [W3 Spec]: https://www.w3.org/TR/trace-context-2/#mutating-the-tracestate-field
     pub fn insert<K, V>(&self, key: K, value: V) -> TraceStateResult<TraceState>
     where
         K: Into<String>,
@@ -160,7 +162,7 @@ impl TraceState {
     ///
     /// If the key is not in `TraceState`. The original `TraceState` will be cloned and returned.
     ///
-    /// [W3 Spec]: https://www.w3.org/TR/trace-context/#mutating-the-tracestate-field
+    /// [W3 Spec]: https://www.w3.org/TR/trace-context-2/#mutating-the-tracestate-field
     pub fn delete<K: Into<String>>(&self, key: K) -> TraceStateResult<TraceState> {
         let key = key.into();
         if !TraceState::valid_key(key.as_str()) {
@@ -275,20 +277,20 @@ type TraceStateResult<T> = Result<T, TraceStateError>;
 pub enum TraceStateError {
     /// The key is invalid.
     ///
-    /// See <https://www.w3.org/TR/trace-context/#key> for requirement for keys.
-    #[error("{0} is not a valid key in TraceState, see https://www.w3.org/TR/trace-context/#key for more details")]
+    /// See <https://www.w3.org/TR/trace-context-2/#key> for requirement for keys.
+    #[error("{0} is not a valid key in TraceState, see https://www.w3.org/TR/trace-context-2/#key for more details")]
     Key(String),
 
     /// The value is invalid.
     ///
-    /// See <https://www.w3.org/TR/trace-context/#value> for requirement for values.
-    #[error("{0} is not a valid value in TraceState, see https://www.w3.org/TR/trace-context/#value for more details")]
+    /// See <https://www.w3.org/TR/trace-context-2/#value> for requirement for values.
+    #[error("{0} is not a valid value in TraceState, see https://www.w3.org/TR/trace-context-2/#value for more details")]
     Value(String),
 
     /// The list is invalid.
     ///
-    /// See <https://www.w3.org/TR/trace-context/#list> for requirement for list members.
-    #[error("{0} is not a valid list member in TraceState, see https://www.w3.org/TR/trace-context/#list for more details")]
+    /// See <https://www.w3.org/TR/trace-context-2/#list> for requirement for list members.
+    #[error("{0} is not a valid list member in TraceState, see https://www.w3.org/TR/trace-context-2/#list for more details")]
     List(String),
 }
 
@@ -520,6 +522,12 @@ mod tests {
         assert_eq!(trace_state.get("key0"), Some("value0"));
         assert_eq!(trace_state.get("key31"), Some("value31"));
         assert_eq!(trace_state.get("key32"), None);
+
+        let expected_header = (0..32)
+            .map(|i| format!("key{i}=value{i}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        assert_eq!(trace_state.header(), expected_header);
     }
     #[test]
     fn test_tracestate_from_str_ignores_invalid_members_beyond_the_limit() {


### PR DESCRIPTION
Part of #2757

## Changes

The W3C spec allows "a maximum of 32 list-members in a list" (section 3.3.1.1). This crate enforced that
nowhere. `from_str` kept every comma-separated member of an inbound `tracestate`, and `from_key_value` and
`insert` would build a larger one locally: 64 inserts produced an 875-character header on inject, past the 512
characters section 3.3.1.5 asks vendors to propagate at minimum, and a parser holding to the limit dropped half
of those members at the next hop.

All three entry points now keep at most 32 members and drop from the end of the list, which is the direction
section 3.3.1.5 prescribes for truncation. `insert` keeps the new member and evicts the oldest, as
`opentelemetry-go`'s `Insert` does. Parsing stops at the 32nd member, so an oversized inbound
header is neither scanned nor allocated past the limit.

Two behaviour changes for callers. A `tracestate` with more than 32 members now yields the first 32 instead of
all of them, and a malformed member past the 32nd no longer fails the whole header, because
`TraceContextPropagator::extract` maps an `Err` to `TraceState::default()` and erroring would discard 32 legal
members because of a 33rd. A malformed member within the limit still returns `Err`, unchanged. Building past
the limit no longer grows the state: `from_key_value` takes the first 32 pairs, so a pair past the 32nd is not
validated either, and `insert` evicts.

Six tests, three per direction. Parsing: the cap, an invalid member beyond the limit being ignored, an invalid
member within the limit still failing. Building: `from_key_value` keeping the first 32, `insert` keeping the
newest 32, `insert` of an existing key evicting nothing. Reverting a direction's cap fails its first two; the
third guards behaviour the change must not alter.

One caller changes behaviour with it: `opentelemetry-jaeger-propagator` builds a `TraceState` from every
`uberctx-` carrier entry through `from_key_value`, so a carrier with 200 of them now yields 32 members instead
of 200. That crate is deprecated, but the change is user-visible, so its CHANGELOG has a line too.

`insert` could have returned an `Err` at capacity instead, since it already returns a `Result`. I did not take
that route: the spec puts the newest member at the front and truncates from the end, so refusing the caller's
own entry is the one outcome it argues against, and none of Go, C++, Python or Ruby errors here either.
`opentelemetry-js` is adding its mutation half in #6964. `baggage.rs` in this crate already caps entries and
total length.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)

Validated locally with the full `scripts/precommit.sh` that AGENTS.md requires for changes under
`opentelemetry/src/`, and with `cargo semver-checks check-release -p opentelemetry`, which reports no semver
update required.

Assisted-By: Claude Fable 5
