### PR TITLE
fix(opentelemetry): drop the std::f64 test import that breaks the beta build

### DIFF
--- a/opentelemetry/src/common.rs
+++ b/opentelemetry/src/common.rs
@@ -632,7 +632,6 @@ mod tests {
 
     use rand::random;
     use std::collections::hash_map::DefaultHasher;
-    use std::f64;
 
     #[test]
     fn kv_float_equality() {


### PR DESCRIPTION
Fixes #

## Changes

The test module in `opentelemetry/src/common.rs` imports `std::f64`, which shadows the primitive type. Every
`f64::NAN`, `f64::INFINITY`, `f64::NEG_INFINITY`, `f64::MAX`, `f64::MIN` and `f64::MIN_POSITIVE` in that module
therefore resolves to the deprecated module constant rather than the associated constant on the type.
`rustc 1.99.0-beta.1` deprecates those constants and the crate denies warnings under `cfg(test)`, so
`test (ubuntu-latest, beta)` fails to compile on `main` today with 13 errors.

Deleting the import is the whole fix: the call sites already spell the associated constants, and they resolve
correctly once `f64` means the primitive type again.

`cargo test --workspace --all-features --lib`, which is what `scripts/test.sh` runs, passes on beta where `main`
does not compile, and is unchanged on stable. The beta job is `continue-on-error`, so nothing was blocked; the
point is that its early warning has been red since 1.99.0-beta.1 landed, and this restores it before 1.99 reaches
stable. No CHANGELOG entry and no new tests: the change is inside `#[cfg(test)]`, so nothing user-visible changes,
and the existing tests are what proves it.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)

Assisted-By: Claude Fable 5
