### PR TITLE
fix(otlp): back off repeated throttled retries

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Honor positive gRPC `RetryInfo` delays returned with `Unavailable` responses.
   `Unavailable` responses without a positive delay continue to use exponential
   backoff.
+- Continue exponential backoff from server-provided `RetryInfo` and `Retry-After`
+  delays when subsequent export attempts fail, rather than reusing or dropping
+  below the server-requested delay.
 - Fix OTLP/HTTP retry classification to retry only status codes 429, 502, 503,
   and 504, as required by the OTLP specification. The exporter now also honors
   `Retry-After` on 503 responses. Other HTTP error responses, including 500,

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -148,7 +148,12 @@ where
 {
     let start = Instant::now();
     let mut attempt = 0;
-    let mut delay = policy.initial_delay_ms;
+    let mut delay = Duration::from_millis(policy.initial_delay_ms);
+    // The delay cap may be raised beyond the configured max if a server-provided
+    // throttle delay exceeds it, since retrying sooner than the server requested
+    // would defeat the purpose of backpressure signalling. The overall exporter
+    // timeout remains the final bound.
+    let mut delay_cap = Duration::from_millis(policy.max_delay_ms);
 
     loop {
         match operation().await {
@@ -178,9 +183,8 @@ where
                     }
                     RetryErrorType::Retryable if attempt < policy.max_retries => {
                         attempt += 1;
-                        let jitter = generate_jitter(policy.jitter_ms);
-                        let delay_ms = std::cmp::min(delay + jitter, policy.max_delay_ms);
-                        let sleep_duration = Duration::from_millis(delay_ms);
+                        let jitter = Duration::from_millis(generate_jitter(policy.jitter_ms));
+                        let sleep_duration = delay.saturating_add(jitter).min(delay_cap);
 
                         // If the backoff delay would consume all remaining budget, fail now
                         let remaining = deadline.saturating_sub(start.elapsed());
@@ -200,16 +204,25 @@ where
                             message = "OTLP export failed with retryable error - retrying"
                         );
                         sleep_for(sleep_duration).await;
-                        delay = std::cmp::min(delay * 2, policy.max_delay_ms);
+                        delay = delay.saturating_mul(2).min(delay_cap);
                     }
                     RetryErrorType::Throttled(server_delay) if attempt < policy.max_retries => {
                         attempt += 1;
-                        // Cap server-provided delay to prevent excessive blocking
-                        let capped_delay = server_delay.min(MAX_THROTTLE_DURATION);
+                        let capped_server_delay = server_delay.min(MAX_THROTTLE_DURATION);
+
+                        // RetryInfo is the base for subsequent exponential backoff. A later
+                        // RetryInfo may extend, but must not shorten, the current backoff.
+                        delay_cap = delay_cap.max(capped_server_delay);
+                        if !capped_server_delay.is_zero() {
+                            delay = delay.max(capped_server_delay);
+                        }
+
+                        let jitter = Duration::from_millis(generate_jitter(policy.jitter_ms));
+                        let sleep_duration = delay.saturating_add(jitter).min(delay_cap);
 
                         // If the throttle delay would consume all remaining budget, fail now
                         let remaining = deadline.saturating_sub(start.elapsed());
-                        if capped_delay >= remaining {
+                        if sleep_duration >= remaining {
                             otel_warn!(name: "Export.Failed.DeadlineExceeded",
                                 operation = operation_name,
                                 retries = attempt,
@@ -221,12 +234,12 @@ where
                         otel_info!(name: "Export.InProgress.Throttled",
                             operation = operation_name,
                             attempt = attempt,
-                            delay_ms = capped_delay.as_millis(),
-                            server_requested_ms = server_delay.as_millis(),
+                            delay_ms = sleep_duration.as_millis(),
+                            server_requested_ms = capped_server_delay.as_millis(),
                             message = "OTLP export throttled by OTLP endpoint - delaying and retrying"
                         );
-                        sleep_for(capped_delay).await;
-                        // Don't update exponential backoff delay since server provided specific timing
+                        sleep_for(sleep_duration).await;
+                        delay = delay.saturating_mul(2).min(delay_cap);
                     }
                     _ => {
                         // Max retries reached
@@ -387,7 +400,7 @@ mod tests {
     async fn test_retry_throttled_uses_server_delay() {
         let policy = RetryPolicy {
             max_retries: 2,
-            initial_delay_ms: 1000, // high default delay
+            initial_delay_ms: 10, // small default delay
             max_delay_ms: 5000,
             jitter_ms: 0,
         };
@@ -416,9 +429,130 @@ mod tests {
         let elapsed = start.elapsed();
         assert_eq!(result, Ok("success"));
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
-        // Should have waited ~50ms (the server delay), not 1000ms (the default)
+        // Should have waited ~50ms (the server delay raises it from the 10ms default)
         assert!(elapsed >= Duration::from_millis(50));
-        assert!(elapsed < Duration::from_millis(500));
+        assert!(elapsed < Duration::from_millis(200));
+    }
+
+    #[tokio::test]
+    async fn test_repeated_throttling_increases_server_delay() {
+        let policy = RetryPolicy {
+            max_retries: 2,
+            initial_delay_ms: 10,
+            max_delay_ms: 100,
+            jitter_ms: 0,
+        };
+        let attempts = AtomicUsize::new(0);
+        let start = Instant::now();
+
+        let result = retry_with_backoff(
+            &policy,
+            Duration::from_secs(2),
+            |_: &usize| RetryErrorType::Throttled(Duration::from_millis(20)),
+            "test_operation",
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move {
+                    if attempt < 2 {
+                        Err(attempt)
+                    } else {
+                        Ok("success")
+                    }
+                })
+            },
+        )
+        .await;
+
+        assert_eq!(result, Ok("success"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert!(start.elapsed() >= Duration::from_millis(55));
+    }
+
+    #[tokio::test]
+    async fn test_retryable_error_continues_from_server_delay() {
+        let policy = RetryPolicy {
+            max_retries: 2,
+            initial_delay_ms: 10,
+            max_delay_ms: 100,
+            jitter_ms: 0,
+        };
+        let attempts = AtomicUsize::new(0);
+        let start = Instant::now();
+
+        let result = retry_with_backoff(
+            &policy,
+            Duration::from_secs(2),
+            |attempt: &usize| {
+                if *attempt == 0 {
+                    RetryErrorType::Throttled(Duration::from_millis(20))
+                } else {
+                    RetryErrorType::Retryable
+                }
+            },
+            "test_operation",
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move {
+                    if attempt < 2 {
+                        Err(attempt)
+                    } else {
+                        Ok("success")
+                    }
+                })
+            },
+        )
+        .await;
+
+        assert_eq!(result, Ok("success"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        // First: throttled 20ms, second: retryable 40ms (doubled from 20ms base)
+        assert!(start.elapsed() >= Duration::from_millis(55));
+    }
+
+    #[tokio::test]
+    async fn test_throttle_after_normal_backoff_does_not_reduce_delay() {
+        let policy = RetryPolicy {
+            max_retries: 3,
+            initial_delay_ms: 50,
+            max_delay_ms: 500,
+            jitter_ms: 0,
+        };
+        let attempts = AtomicUsize::new(0);
+        let start = Instant::now();
+
+        let result = retry_with_backoff(
+            &policy,
+            Duration::from_secs(5),
+            |attempt: &usize| {
+                if *attempt == 1 {
+                    // Server asks for 20ms, but backoff has already grown to 100ms
+                    RetryErrorType::Throttled(Duration::from_millis(20))
+                } else {
+                    RetryErrorType::Retryable
+                }
+            },
+            "test_operation",
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move {
+                    if attempt < 3 {
+                        Err(attempt)
+                    } else {
+                        Ok("success")
+                    }
+                })
+            },
+        )
+        .await;
+
+        assert_eq!(result, Ok("success"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 4);
+        // Attempt 0 fails Retryable: sleep 50ms, delay -> 100ms
+        // Attempt 1 fails Throttled(20ms): delay = max(100ms, 20ms) = 100ms, sleep 100ms, delay -> 200ms
+        // Attempt 2 fails Retryable: sleep 200ms, delay -> 400ms
+        // Attempt 3 succeeds
+        // Total: 50 + 100 + 200 = 350ms
+        assert!(start.elapsed() >= Duration::from_millis(340));
     }
 
     #[tokio::test]
@@ -560,7 +694,7 @@ mod tests {
     fn test_retry_throttled_uses_server_delay_no_tokio() {
         let policy = RetryPolicy {
             max_retries: 2,
-            initial_delay_ms: 1000,
+            initial_delay_ms: 10,
             max_delay_ms: 5000,
             jitter_ms: 0,
         };
@@ -588,8 +722,8 @@ mod tests {
         let elapsed = start.elapsed();
         assert_eq!(result, Ok("success"));
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
-        // Should have waited ~50ms (the server delay), not 1000ms (the default)
+        // Should have waited ~50ms (the server delay raises it from the 10ms default)
         assert!(elapsed >= Duration::from_millis(50));
-        assert!(elapsed < Duration::from_millis(500));
+        assert!(elapsed < Duration::from_millis(200));
     }
 }

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -41,8 +41,8 @@ pub enum RetryErrorType {
     NonRetryable,
     /// Error is retryable with exponential backoff (e.g., server error, network timeout).
     Retryable,
-    /// Error indicates throttling - wait for the specified duration before retrying.
-    /// This overrides exponential backoff timing.
+    /// Error indicates throttling - wait for at least the specified duration before retrying.
+    /// The server delay seeds exponential backoff: subsequent retries grow from it.
     Throttled(Duration),
 }
 
@@ -106,6 +106,12 @@ fn generate_jitter(max_jitter: u64) -> u64 {
 ///
 /// This function provides retry behavior by classifying errors and honoring server-provided
 /// throttling hints (e.g., HTTP Retry-After, gRPC RetryInfo).
+///
+/// When a throttle delay is received, it seeds the exponential backoff: the delay is set
+/// to `max(current_delay, server_delay)` and subsequent retries double from there. If the
+/// server delay exceeds the configured `max_delay_ms`, the backoff cap is raised to
+/// `MAX_THROTTLE_DURATION` (30 seconds) so that repeated failures produce increasing
+/// delays rather than getting stuck at the server value.
 ///
 /// Delays between retries adapt to the calling context: when running inside a Tokio
 /// runtime (gRPC/async HTTP exporters), `tokio::time::sleep` is used cooperatively;
@@ -212,7 +218,12 @@ where
 
                         // RetryInfo is the base for subsequent exponential backoff. A later
                         // RetryInfo may extend, but must not shorten, the current backoff.
-                        delay_cap = delay_cap.max(capped_server_delay);
+                        // When the server delay exceeds the configured max, allow backoff
+                        // to grow up to MAX_THROTTLE_DURATION so repeated failures
+                        // produce increasing delays rather than getting stuck.
+                        if capped_server_delay > delay_cap {
+                            delay_cap = MAX_THROTTLE_DURATION;
+                        }
                         if !capped_server_delay.is_zero() {
                             delay = delay.max(capped_server_delay);
                         }
@@ -396,11 +407,21 @@ mod tests {
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
+    // -- Throttle/backoff interaction tests --
+    //
+    // These tests form a progression: server delay within max_delay_ms (the
+    // easy case where the configured cap doesn't constrain growth), then
+    // server delay exceeding max_delay_ms (the case where the cap must be
+    // lifted to MAX_THROTTLE_DURATION to allow continued growth).
+
     #[tokio::test]
-    async fn test_retry_throttled_uses_server_delay() {
+    async fn test_throttle_seeds_backoff_within_max() {
+        // Server delay (50ms) is below max_delay_ms (5000ms), so the
+        // configured cap never constrains growth. Verifies the basic
+        // mechanism: server delay raises the backoff base from initial.
         let policy = RetryPolicy {
             max_retries: 2,
-            initial_delay_ms: 10, // small default delay
+            initial_delay_ms: 10,
             max_delay_ms: 5000,
             jitter_ms: 0,
         };
@@ -429,13 +450,15 @@ mod tests {
         let elapsed = start.elapsed();
         assert_eq!(result, Ok("success"));
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
-        // Should have waited ~50ms (the server delay raises it from the 10ms default)
         assert!(elapsed >= Duration::from_millis(50));
         assert!(elapsed < Duration::from_millis(200));
     }
 
     #[tokio::test]
-    async fn test_repeated_throttling_increases_server_delay() {
+    async fn test_repeated_throttle_doubles_within_max() {
+        // Repeated throttles (20ms each) with max_delay_ms = 100ms. Server
+        // delay is within the cap, so doubling works without needing to lift
+        // the cap: 20ms -> 40ms. Total >= 55ms.
         let policy = RetryPolicy {
             max_retries: 2,
             initial_delay_ms: 10,
@@ -469,7 +492,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_retryable_error_continues_from_server_delay() {
+    async fn test_retryable_after_throttle_continues_backoff_within_max() {
+        // Throttle (20ms) then a retryable error, with max_delay_ms = 100ms.
+        // Server delay is within the cap, so backoff doubles normally:
+        // 20ms (throttled) -> 40ms (retryable, doubled from 20ms base).
         let policy = RetryPolicy {
             max_retries: 2,
             initial_delay_ms: 10,
@@ -507,6 +533,67 @@ mod tests {
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
         // First: throttled 20ms, second: retryable 40ms (doubled from 20ms base)
         assert!(start.elapsed() >= Duration::from_millis(55));
+    }
+
+    #[tokio::test]
+    async fn test_retryable_after_throttle_continues_backoff_exceeding_max() {
+        // Same shape as the test above, but the server delay (100ms) exceeds
+        // max_delay_ms (50ms). This is the critical case: the cap must be
+        // lifted to MAX_THROTTLE_DURATION so that doubling actually grows
+        // the delay instead of clamping it back to the server value.
+        let policy = RetryPolicy {
+            max_retries: 3,
+            initial_delay_ms: 10,
+            max_delay_ms: 50, // intentionally below server delay
+            jitter_ms: 0,
+        };
+        let attempts = AtomicUsize::new(0);
+        let start = Instant::now();
+
+        let result = retry_with_backoff(
+            &policy,
+            Duration::from_secs(10),
+            |attempt: &usize| {
+                if *attempt == 0 {
+                    // Server asks for 100ms, which exceeds max_delay_ms (50ms)
+                    RetryErrorType::Throttled(Duration::from_millis(100))
+                } else {
+                    RetryErrorType::Retryable
+                }
+            },
+            "test_operation",
+            || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move {
+                    if attempt < 3 {
+                        Err(attempt)
+                    } else {
+                        Ok("success")
+                    }
+                })
+            },
+        )
+        .await;
+
+        assert_eq!(result, Ok("success"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 4);
+        // Attempt 0 fails Throttled(100ms): delay = max(10ms, 100ms) = 100ms,
+        //   sleep 100ms, delay -> 200ms (doubled, NOT capped back to 100ms)
+        // Attempt 1 fails Retryable: sleep 200ms, delay -> 400ms
+        // Attempt 2 fails Retryable: sleep 400ms, delay -> 800ms
+        // Attempt 3 succeeds
+        // Total: 100 + 200 + 400 = 700ms
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(680),
+            "Expected >= 680ms (backoff should grow beyond server delay), got {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < Duration::from_millis(1500),
+            "Expected < 1500ms, got {:?}",
+            elapsed
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

After a server-provided `RetryInfo` or `Retry-After` delay, subsequent export failures now continue exponential backoff from the server-requested delay rather than reusing a fixed value or dropping back to the policy initial.

## Before

- Repeated throttling reused the same server delay indefinitely.
- A retryable error following a throttle fell back to the 100ms policy initial.
- No jitter was applied to throttled retries.

## After

- Server delay seeds the exponential backoff base via `delay.max(server_delay)`.
- Repeated or mixed failures double from there, capped by the effective maximum.
- Jitter applies uniformly to all retry sleeps.
- A server delay never reduces an already-grown backoff.
- The overall exporter timeout remains the final bound.

Aligns with the `RetryInfo` guidance:
> If retrying requests also fail, clients should use an exponential backoff
> scheme to increase gradually the delay between retries based on `retry_delay`.

## Cross-SDK comparison

As the exact mechanism is somewhat underspecified in the spec, i've had a look at the golang and dotnet SDKs for reference. All three use the the server-provided delay as a minimum, and subsequent failures back off from there.

| Aspect | Go (`cenkalti/backoff`) | .NET | This PR |
|---|---|---|---|
| Throttle: current sleep | `max(backoff, throttle)` | Exact server delay | `max(backoff, throttle)` + jitter |
| Throttle: effect on next retry | None (backoff state independent) | `next_base = throttle * 1.5` | `delay = max(delay, throttle); delay *= 2` |
| Server delay < current backoff | Backoff wins (independent sequence) | Sleeps shorter server delay | Backoff wins (never reduces) |
| Multiplier | 1.5 | 1.5 | 2 |
| Jitter on throttled retries | Yes (built into backoff lib) | No (exact server delay) | Yes (additive) |

Go keeps its exponential backoff sequence independent of throttle events and uses `max` per attempt. .NET seeds the next backoff base from the throttle but sleeps the exact server delay on the current attempt (can go below current
backoff). This PR merges the throttle into the backoff state and never reduces it, which is more conservative but equally spec-compliant since the spec requires waiting "at least `retry_delay`."

Relates to #3061

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)

