### PR TITLE
chore(sdk): replace useless format call

### DIFF
--- a/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
+++ b/opentelemetry-sdk/src/trace/sampler/jaeger_remote/sampler.rs
@@ -216,7 +216,7 @@ impl JaegerRemoteSampler {
                             otel_warn!(
                                 name: "JaegerRemoteSampler.FailedToFetchStrategy",
                                 message= "Failed to fetch the sampling strategy from the remote endpoint. The last successfully fetched configuration will be used if available; otherwise, the default sampler will be applied until a successful configuration fetch.",
-                                reason = format!("{}", err_msg),
+                                reason = err_msg.to_string(),
                             );
                         }
                     };


### PR DESCRIPTION
 A new lint has crept in with our floating Clippy version following the Rust 1.98.0 stable release. This fixes it.

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
