### PR TITLE
fix(otlp): widen retry timing assertion for CI tolerance

### DIFF
--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -451,7 +451,7 @@ mod tests {
         assert_eq!(result, Ok("success"));
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
         assert!(elapsed >= Duration::from_millis(50));
-        assert!(elapsed < Duration::from_millis(200));
+        assert!(elapsed < Duration::from_millis(500));
     }
 
     #[tokio::test]
@@ -811,6 +811,6 @@ mod tests {
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
         // Should have waited ~50ms (the server delay raises it from the 10ms default)
         assert!(elapsed >= Duration::from_millis(50));
-        assert!(elapsed < Duration::from_millis(200));
+        assert!(elapsed < Duration::from_millis(500));
     }
 }


### PR DESCRIPTION
Fixes a flaky test failure on macOS CI runners introduced in #3637.

## Changes

The `test_retry_throttled_uses_server_delay` and `test_retry_throttled_uses_server_delay_no_tokio` tests assert that a 50ms throttle delay completes in under 200ms. On loaded CI runners (particularly macOS), thread scheduling jitter can push elapsed time past that bound, causing spurious failures.

Widens the upper bound from 200ms to 500ms. This still proves the 50ms server delay is used rather than the 1000ms `initial_delay_ms`, while giving CI sufficient headroom.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)

No changelog needed (test-only change).