### PR TITLE
fix(otlp): widen retry timing assertions for CI tolerance

### DIFF
--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -451,7 +451,7 @@ mod tests {
         assert_eq!(result, Ok("success"));
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
         assert!(elapsed >= Duration::from_millis(50));
-        assert!(elapsed < Duration::from_millis(200));
+        assert!(elapsed < Duration::from_millis(500));
     }
 
     #[tokio::test]
@@ -672,7 +672,7 @@ mod tests {
         // Should have stopped before exhausting 100 retries due to deadline
         assert!(attempts.load(Ordering::SeqCst) < 10);
         // Shouldn't have taken much longer than the deadline
-        assert!(elapsed < Duration::from_millis(300));
+        assert!(elapsed < Duration::from_millis(500));
     }
 
     #[tokio::test]
@@ -774,7 +774,7 @@ mod tests {
         // Should have stopped before exhausting 100 retries due to deadline
         assert!(attempts.load(Ordering::SeqCst) < 10);
         // Shouldn't have taken much longer than the deadline
-        assert!(elapsed < Duration::from_millis(300));
+        assert!(elapsed < Duration::from_millis(500));
     }
 
     #[test]
@@ -811,6 +811,6 @@ mod tests {
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
         // Should have waited ~50ms (the server delay raises it from the 10ms default)
         assert!(elapsed >= Duration::from_millis(50));
-        assert!(elapsed < Duration::from_millis(200));
+        assert!(elapsed < Duration::from_millis(500));
     }
 }


### PR DESCRIPTION
Fixes a flaky test failure on macOS CI runners introduced in #3637.

## Changes

Four retry tests assert upper bounds on elapsed time that are too tight for loaded CI runners (particularly macOS). Thread scheduling jitter can push elapsed time past the bounds, causing spurious failures.

Widens all tight upper bounds from 200-300ms to 500ms. The tests still prove correct behavior (e.g. 50ms server delay used instead of 1000ms default, or deadline-bounded exit near 120ms) while giving CI sufficient headroom.

Affected tests:
- `test_retry_throttled_uses_server_delay` (200ms -> 500ms)
- `test_retry_throttled_uses_server_delay_no_tokio` (200ms -> 500ms)
- `test_retry_deadline_exceeded` (300ms -> 500ms)
- `test_retry_deadline_exceeded_no_tokio` (300ms -> 500ms)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)

No changelog needed (test-only change).