### PR TITLE
feat(otlp): configure response body limits

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## vNext
 
-- Limit HTTP response body reads to 4 MiB in built-in HTTP clients (`reqwest` async/blocking and `hyper`) by enforcing the cap while streaming response chunks and reads that exceed the limit are aborted to prevent unbounded memory allocation.
+- Built-in HTTP clients (`ReqwestClient`, `ReqwestBlockingClient`, `HyperClient`) now enforce a
+  configurable response body size limit (default 4 MiB) while streaming response chunks. Reads
+  that exceed the limit are aborted and return `ResponseBodyTooLarge`. If the server advertises a
+  `Content-Length` exceeding the limit, the response is rejected immediately without reading the
+  body. Use `with_max_response_body_size()` to override the default.
 
 - Return HTTP error responses from the built-in reqwest and hyper clients instead
   of converting 4xx and 5xx statuses into transport errors. This preserves the

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -90,16 +90,24 @@ pub trait HttpClient: Debug + Send + Sync {
     async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError>;
 }
 
-#[cfg(any(feature = "reqwest", feature = "hyper"))]
-const MAX_RESPONSE_BODY_BYTES: usize = 4 * 1024 * 1024;
+/// Default maximum response body size (4 MiB), as recommended by the
+/// [OTLP specification](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp-response).
+pub const DEFAULT_MAX_RESPONSE_BODY_BYTES: usize = 4 * 1024 * 1024;
 
 /// Error returned when an HTTP response body exceeds the configured size limit.
 #[derive(Debug)]
-pub struct ResponseBodyTooLarge;
+pub struct ResponseBodyTooLarge {
+    /// The configured limit that was exceeded.
+    pub limit: usize,
+}
 
 impl std::fmt::Display for ResponseBodyTooLarge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "response body exceeded maximum allowed 4 MiB limit")
+        write!(
+            f,
+            "response body exceeded maximum allowed {} byte limit",
+            self.limit
+        )
     }
 }
 
@@ -112,60 +120,107 @@ mod reqwest {
     use crate::ResponseBodyTooLarge;
 
     use super::{
-        async_trait, Bytes, HttpClient, HttpError, Request, Response, MAX_RESPONSE_BODY_BYTES,
+        async_trait, Bytes, HttpClient, HttpError, Request, Response,
+        DEFAULT_MAX_RESPONSE_BODY_BYTES,
     };
 
+    /// Async reqwest HTTP client with a configurable response body size limit.
+    #[derive(Debug, Clone)]
+    pub struct ReqwestClient {
+        inner: reqwest::Client,
+        max_response_body_size: usize,
+    }
+
+    impl ReqwestClient {
+        pub fn new(client: reqwest::Client) -> Self {
+            Self {
+                inner: client,
+                max_response_body_size: DEFAULT_MAX_RESPONSE_BODY_BYTES,
+            }
+        }
+
+        pub fn with_max_response_body_size(mut self, size: usize) -> Self {
+            self.max_response_body_size = size;
+            self
+        }
+    }
+
+    impl Default for ReqwestClient {
+        fn default() -> Self {
+            Self::new(reqwest::Client::new())
+        }
+    }
+
     #[async_trait]
-    impl HttpClient for reqwest::Client {
+    impl HttpClient for ReqwestClient {
         async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
             otel_debug!(name: "ReqwestClient.Send");
+            let max_size = self.max_response_body_size;
             let request = request.try_into()?;
-            let mut response = self.execute(request).await?;
-            let capacity = response
-                .content_length()
-                .unwrap_or(0)
-                .min(MAX_RESPONSE_BODY_BYTES as u64) as usize;
+            let mut response = self.inner.execute(request).await?;
+            let capacity = response.content_length().unwrap_or(0).min(max_size as u64) as usize;
 
             let mut body_bytes = bytes::BytesMut::with_capacity(capacity);
-
             let status = response.status();
             let headers = std::mem::take(response.headers_mut());
             while let Some(chunk) = response.chunk().await? {
-                if body_bytes.len() + chunk.len() > MAX_RESPONSE_BODY_BYTES {
-                    return Err(Box::new(ResponseBodyTooLarge));
+                if body_bytes.len() + chunk.len() > max_size {
+                    return Err(Box::new(ResponseBodyTooLarge { limit: max_size }));
                 }
                 body_bytes.extend_from_slice(&chunk);
             }
             let mut http_response = Response::builder()
                 .status(status)
                 .body(body_bytes.freeze())?;
-
             *http_response.headers_mut() = headers;
             Ok(http_response)
+        }
+    }
+
+    /// Blocking reqwest HTTP client with a configurable response body size limit.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "reqwest-blocking")]
+    #[derive(Debug, Clone)]
+    pub struct ReqwestBlockingClient {
+        inner: reqwest::blocking::Client,
+        max_response_body_size: usize,
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "reqwest-blocking")]
+    impl ReqwestBlockingClient {
+        pub fn new(client: reqwest::blocking::Client) -> Self {
+            Self {
+                inner: client,
+                max_response_body_size: DEFAULT_MAX_RESPONSE_BODY_BYTES,
+            }
+        }
+
+        pub fn with_max_response_body_size(mut self, size: usize) -> Self {
+            self.max_response_body_size = size;
+            self
         }
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "reqwest-blocking")]
     #[async_trait]
-    impl HttpClient for reqwest::blocking::Client {
+    impl HttpClient for ReqwestBlockingClient {
         async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
             use std::io::Read;
             otel_debug!(name: "ReqwestBlockingClient.Send");
+            let max_size = self.max_response_body_size;
             let request = request.try_into()?;
-            let mut response = self.execute(request)?;
-            let capacity = response
-                .content_length()
-                .unwrap_or(0)
-                .min(MAX_RESPONSE_BODY_BYTES as u64) as usize;
+            let mut response = self.inner.execute(request)?;
+            let capacity = response.content_length().unwrap_or(0).min(max_size as u64) as usize;
             let status = response.status();
             let headers = std::mem::take(response.headers_mut());
             let mut body_bytes = Vec::with_capacity(capacity);
             response
-                .take(MAX_RESPONSE_BODY_BYTES as u64 + 1)
+                .take(max_size as u64 + 1)
                 .read_to_end(&mut body_bytes)?;
-            if body_bytes.len() > MAX_RESPONSE_BODY_BYTES {
-                return Err(Box::new(ResponseBodyTooLarge));
+            if body_bytes.len() > max_size {
+                return Err(Box::new(ResponseBodyTooLarge { limit: max_size }));
             }
             let mut http_response = Response::builder()
                 .status(status)
@@ -176,10 +231,16 @@ mod reqwest {
     }
 }
 
+#[cfg(all(feature = "reqwest-blocking", not(target_arch = "wasm32")))]
+pub use reqwest::ReqwestBlockingClient;
+#[cfg(feature = "reqwest")]
+pub use reqwest::ReqwestClient;
+
 #[cfg(feature = "hyper")]
 pub mod hyper {
     use super::{
-        async_trait, Bytes, HttpClient, HttpError, Request, Response, MAX_RESPONSE_BODY_BYTES,
+        async_trait, Bytes, HttpClient, HttpError, Request, Response,
+        DEFAULT_MAX_RESPONSE_BODY_BYTES,
     };
     use crate::ResponseBodyTooLarge;
     use http::HeaderValue;
@@ -204,6 +265,7 @@ pub mod hyper {
         inner: Client<C, Body>,
         timeout: Duration,
         authorization: Option<HeaderValue>,
+        max_response_body_size: usize,
     }
 
     impl<C> HyperClient<C>
@@ -217,7 +279,14 @@ pub mod hyper {
                 inner,
                 timeout,
                 authorization,
+                max_response_body_size: DEFAULT_MAX_RESPONSE_BODY_BYTES,
             }
+        }
+
+        /// Set the maximum response body size in bytes.
+        pub fn with_max_response_body_size(mut self, size: usize) -> Self {
+            self.max_response_body_size = size;
+            self
         }
     }
 
@@ -239,6 +308,7 @@ pub mod hyper {
     {
         async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
             otel_debug!(name: "HyperClient.Send");
+            let max_size = self.max_response_body_size;
             let (parts, body) = request.into_parts();
             let mut request = Request::from_parts(parts, Body(Full::from(body)));
             if let Some(ref authorization) = self.authorization {
@@ -252,7 +322,7 @@ pub mod hyper {
                 .size_hint()
                 .upper()
                 .unwrap_or(0)
-                .min(MAX_RESPONSE_BODY_BYTES as u64) as usize;
+                .min(max_size as u64) as usize;
             let mut body_bytes = bytes::BytesMut::with_capacity(capacity);
             let status = response.status();
             let headers = std::mem::take(response.headers_mut());
@@ -260,8 +330,8 @@ pub mod hyper {
             while let Some(frame) = body.frame().await {
                 let frame = frame?;
                 if let Ok(chunk) = frame.into_data() {
-                    if body_bytes.len() + chunk.len() > MAX_RESPONSE_BODY_BYTES {
-                        return Err(Box::new(ResponseBodyTooLarge));
+                    if body_bytes.len() + chunk.len() > max_size {
+                        return Err(Box::new(ResponseBodyTooLarge { limit: max_size }));
                     }
                     body_bytes.extend_from_slice(&chunk);
                 }
@@ -465,7 +535,7 @@ Connection: close\r\n\r\n",
     #[test]
     fn reqwest_blocking_preserves_error_response_status_and_headers() {
         let (address, server) = spawn_error_response_server();
-        let client = ::reqwest::blocking::Client::new();
+        let client = crate::ReqwestBlockingClient::new(::reqwest::blocking::Client::new());
         let request = Request::post(format!("http://{address}/v1/traces"))
             .body(Bytes::new())
             .unwrap();
@@ -480,7 +550,7 @@ Connection: close\r\n\r\n",
     #[test]
     fn reqwest_async_preserves_error_response_status_and_headers() {
         let (address, server) = spawn_error_response_server();
-        let client = ::reqwest::Client::new();
+        let client = crate::ReqwestClient::new(::reqwest::Client::new());
         let request = Request::post(format!("http://{address}/v1/traces"))
             .body(Bytes::new())
             .unwrap();
@@ -522,8 +592,8 @@ Connection: close\r\n\r\n",
         any(feature = "reqwest", feature = "reqwest-blocking", feature = "hyper")
     ))]
     mod body_limit_tests {
-        use super::MAX_RESPONSE_BODY_BYTES;
         use crate::HttpClient;
+        use crate::DEFAULT_MAX_RESPONSE_BODY_BYTES;
         use bytes::Bytes;
         use http::Request;
         use std::net::SocketAddr;
@@ -603,36 +673,32 @@ Connection: close\r\n\r\n",
         #[tokio::test]
         async fn reqwest_body_within_limit() {
             let addr = start_server(100).await;
-            assert_within_limit(&reqwest::Client::new(), addr).await;
+            let client = crate::ReqwestClient::new(reqwest::Client::new());
+            assert_within_limit(&client, addr).await;
         }
 
         #[cfg(feature = "reqwest")]
         #[tokio::test]
         async fn reqwest_body_exceeds_limit() {
-            let addr = start_server(MAX_RESPONSE_BODY_BYTES + 1).await;
-            assert_exceeds_limit(&reqwest::Client::new(), addr).await;
+            let addr = start_server(DEFAULT_MAX_RESPONSE_BODY_BYTES + 1).await;
+            let client = crate::ReqwestClient::new(reqwest::Client::new());
+            assert_exceeds_limit(&client, addr).await;
         }
 
         #[cfg(feature = "reqwest-blocking")]
         #[test]
         fn reqwest_blocking_body_within_limit() {
             let addr = start_blocking_server(100);
-
-            futures_executor::block_on(assert_within_limit(
-                &reqwest::blocking::Client::new(),
-                addr,
-            ));
+            let client = crate::ReqwestBlockingClient::new(reqwest::blocking::Client::new());
+            futures_executor::block_on(assert_within_limit(&client, addr));
         }
 
         #[cfg(feature = "reqwest-blocking")]
         #[test]
         fn reqwest_blocking_body_exceeds_limit() {
-            let addr = start_blocking_server(MAX_RESPONSE_BODY_BYTES + 1);
-
-            futures_executor::block_on(assert_exceeds_limit(
-                &reqwest::blocking::Client::new(),
-                addr,
-            ));
+            let addr = start_blocking_server(DEFAULT_MAX_RESPONSE_BODY_BYTES + 1);
+            let client = crate::ReqwestBlockingClient::new(reqwest::blocking::Client::new());
+            futures_executor::block_on(assert_exceeds_limit(&client, addr));
         }
 
         #[cfg(feature = "hyper")]
@@ -648,7 +714,7 @@ Connection: close\r\n\r\n",
         #[cfg(feature = "hyper")]
         #[tokio::test]
         async fn hyper_body_exceeds_limit() {
-            let addr = start_server(MAX_RESPONSE_BODY_BYTES + 1).await;
+            let addr = start_server(DEFAULT_MAX_RESPONSE_BODY_BYTES + 1).await;
             let client = crate::hyper::HyperClient::with_default_connector(
                 std::time::Duration::from_secs(5),
                 None,

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -158,9 +158,13 @@ mod reqwest {
             let max_size = self.max_response_body_size;
             let request = request.try_into()?;
             let mut response = self.inner.execute(request).await?;
-            let capacity = response.content_length().unwrap_or(0).min(max_size as u64) as usize;
+            // Short-circuit if we already know the response is too long.
+            let content_length = response.content_length().unwrap_or(0);
+            if content_length > max_size as u64 {
+                return Err(Box::new(ResponseBodyTooLarge { limit: max_size }));
+            }
 
-            let mut body_bytes = bytes::BytesMut::with_capacity(capacity);
+            let mut body_bytes = bytes::BytesMut::with_capacity(content_length as usize);
             let status = response.status();
             let headers = std::mem::take(response.headers_mut());
             while let Some(chunk) = response.chunk().await? {
@@ -174,6 +178,15 @@ mod reqwest {
                 .body(body_bytes.freeze())?;
             *http_response.headers_mut() = headers;
             Ok(http_response)
+        }
+    }
+
+    /// Blanket impl so callers can pass `reqwest::Client` directly.
+    /// Uses the default response body size limit.
+    #[async_trait]
+    impl HttpClient for reqwest::Client {
+        async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
+            ReqwestClient::new(self.clone()).send_bytes(request).await
         }
     }
 
@@ -212,12 +225,16 @@ mod reqwest {
             let max_size = self.max_response_body_size;
             let request = request.try_into()?;
             let mut response = self.inner.execute(request)?;
-            let capacity = response.content_length().unwrap_or(0).min(max_size as u64) as usize;
+            // Short-circuit if we already know the response is too long.
+            let content_length = response.content_length().unwrap_or(0);
+            if content_length > max_size as u64 {
+                return Err(Box::new(ResponseBodyTooLarge { limit: max_size }));
+            }
             let status = response.status();
             let headers = std::mem::take(response.headers_mut());
-            let mut body_bytes = Vec::with_capacity(capacity);
+            let mut body_bytes = Vec::with_capacity(content_length as usize);
             response
-                .take(max_size as u64 + 1)
+                .take((max_size as u64).saturating_add(1))
                 .read_to_end(&mut body_bytes)?;
             if body_bytes.len() > max_size {
                 return Err(Box::new(ResponseBodyTooLarge { limit: max_size }));
@@ -227,6 +244,19 @@ mod reqwest {
                 .body(Bytes::from(body_bytes))?;
             *http_response.headers_mut() = headers;
             Ok(http_response)
+        }
+    }
+
+    /// Blanket impl so callers can pass `reqwest::blocking::Client` directly.
+    /// Uses the default response body size limit.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "reqwest-blocking")]
+    #[async_trait]
+    impl HttpClient for reqwest::blocking::Client {
+        async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
+            ReqwestBlockingClient::new(self.clone())
+                .send_bytes(request)
+                .await
         }
     }
 }
@@ -317,13 +347,12 @@ pub mod hyper {
                     .insert(http::header::AUTHORIZATION, authorization.clone());
             }
             let mut response = time::timeout(self.timeout, self.inner.request(request)).await??;
-            let capacity = response
-                .body()
-                .size_hint()
-                .upper()
-                .unwrap_or(0)
-                .min(max_size as u64) as usize;
-            let mut body_bytes = bytes::BytesMut::with_capacity(capacity);
+            // Short-circuit if we already know the response is too long.
+            let size_hint = response.body().size_hint().upper().unwrap_or(0);
+            if size_hint > max_size as u64 {
+                return Err(Box::new(ResponseBodyTooLarge { limit: max_size }));
+            }
+            let mut body_bytes = bytes::BytesMut::with_capacity(size_hint as usize);
             let status = response.status();
             let headers = std::mem::take(response.headers_mut());
             let mut body = response.into_body();
@@ -715,6 +744,43 @@ Connection: close\r\n\r\n",
         #[tokio::test]
         async fn hyper_body_exceeds_limit() {
             let addr = start_server(DEFAULT_MAX_RESPONSE_BODY_BYTES + 1).await;
+            let client = crate::hyper::HyperClient::with_default_connector(
+                std::time::Duration::from_secs(5),
+                None,
+            );
+            assert_exceeds_limit(&client, addr).await;
+        }
+
+        /// Server that sends an oversized body without Content-Length (close-delimited).
+        async fn start_server_no_content_length(body_size: usize) -> SocketAddr {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            tokio::spawn(async move {
+                if let Ok((mut socket, _)) = listener.accept().await {
+                    let mut buf = [0u8; 1024];
+                    let _ = socket.read(&mut buf).await;
+                    let body = vec![b'a'; body_size];
+                    let response = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n";
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.write_all(&body).await;
+                    let _ = socket.shutdown().await;
+                }
+            });
+            addr
+        }
+
+        #[cfg(feature = "reqwest")]
+        #[tokio::test]
+        async fn reqwest_body_exceeds_limit_no_content_length() {
+            let addr = start_server_no_content_length(DEFAULT_MAX_RESPONSE_BODY_BYTES + 1).await;
+            let client = crate::ReqwestClient::new(reqwest::Client::new());
+            assert_exceeds_limit(&client, addr).await;
+        }
+
+        #[cfg(feature = "hyper")]
+        #[tokio::test]
+        async fn hyper_body_exceeds_limit_no_content_length() {
+            let addr = start_server_no_content_length(DEFAULT_MAX_RESPONSE_BODY_BYTES + 1).await;
             let client = crate::hyper::HyperClient::with_default_connector(
                 std::time::Duration::from_secs(5),
                 None,

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -7,6 +7,9 @@
   OTLP/HTTP request bodies are now limited to 64 MiB by default, before and
   after compression; oversized requests are discarded without being sent or
   retried.
+- OTLP/HTTP response bodies are now limited to 4 MiB by default. Responses
+  exceeding this limit are classified as non-retryable errors (`ResponseBodyTooLarge`).
+  This prevents unbounded memory allocation from misconfigured or malicious servers.
 - Honor positive gRPC `RetryInfo` delays returned with `Unavailable` responses.
   `Unavailable` responses without a positive delay continue to use exponential
   backoff.

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -7,9 +7,7 @@ use crate::{
 };
 use http::{HeaderName, HeaderValue, Uri};
 use opentelemetry::otel_debug;
-use opentelemetry_http::{
-    Bytes, HttpClient, ResponseBodyTooLarge, DEFAULT_MAX_RESPONSE_BODY_BYTES,
-};
+use opentelemetry_http::{Bytes, HttpClient, ResponseBodyTooLarge};
 use opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema;
 #[cfg(feature = "logs")]
 use opentelemetry_proto::transform::logs::tonic::group_logs_by_resource_and_scope;
@@ -329,9 +327,6 @@ impl HttpExporterBuilder {
         if let Some(max_request_body_size) = self.http_config.max_request_body_size {
             client.max_request_body_size = max_request_body_size;
         }
-        if let Some(max_response_body_size) = self.http_config.max_response_body_size {
-            client.max_response_body_size = max_response_body_size;
-        }
         Ok(client)
     }
 
@@ -419,7 +414,6 @@ pub(crate) struct OtlpHttpClient {
     compression: Option<crate::Compression>,
     retry_policy: RetryPolicy,
     max_request_body_size: usize,
-    max_response_body_size: usize,
     #[allow(dead_code)]
     // <allow dead> would be removed once we support set_resource for metrics and traces.
     resource: opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema,
@@ -649,7 +643,6 @@ impl OtlpHttpClient {
             compression,
             retry_policy: retry_policy.unwrap_or_default(),
             max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
-            max_response_body_size: DEFAULT_MAX_RESPONSE_BODY_BYTES,
             resource: ResourceAttributesWithSchema::default(),
         }
     }
@@ -849,6 +842,11 @@ pub trait WithHttpConfig {
     ///
     /// Responses exceeding this limit are treated as non-retryable errors.
     /// The default is 4 MiB, as recommended by the OTLP specification.
+    ///
+    /// This only applies to the automatically created default HTTP client.
+    /// If you provide a custom client via [`with_http_client`](Self::with_http_client),
+    /// configure the response size limit on that client directly (e.g. using
+    /// [`ReqwestClient::with_max_response_body_size`](opentelemetry_http::ReqwestClient::with_max_response_body_size)).
     fn with_max_response_body_size(self, max_size: usize) -> Self;
 }
 

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -7,7 +7,9 @@ use crate::{
 };
 use http::{HeaderName, HeaderValue, Uri};
 use opentelemetry::otel_debug;
-use opentelemetry_http::{Bytes, HttpClient, ResponseBodyTooLarge};
+use opentelemetry_http::{
+    Bytes, HttpClient, ResponseBodyTooLarge, DEFAULT_MAX_RESPONSE_BODY_BYTES,
+};
 use opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema;
 #[cfg(feature = "logs")]
 use opentelemetry_proto::transform::logs::tonic::group_logs_by_resource_and_scope;
@@ -128,6 +130,9 @@ pub(crate) struct HttpConfig {
 
     /// Maximum HTTP request body size, before and after compression.
     max_request_body_size: Option<usize>,
+
+    /// Maximum HTTP response body size the client will accept.
+    max_response_body_size: Option<usize>,
 }
 
 /// Configuration for the OTLP HTTP exporter.
@@ -239,21 +244,31 @@ impl HttpExporterBuilder {
         // 1. reqwest-client (async)
         // 2. hyper-client
         // 3. reqwest-blocking-client (default)
+        #[allow(unused_variables)]
+        let max_response_body_size = self
+            .http_config
+            .max_response_body_size
+            .unwrap_or(opentelemetry_http::DEFAULT_MAX_RESPONSE_BODY_BYTES);
+
         if http_client.is_none() {
             #[cfg(feature = "reqwest-client")]
             {
+                use opentelemetry_http::ReqwestClient;
+                let inner = reqwest::Client::builder()
+                    .timeout(timeout)
+                    .build()
+                    .unwrap_or_default();
                 http_client = Some(Arc::new(
-                    reqwest::Client::builder()
-                        .timeout(timeout)
-                        .build()
-                        .unwrap_or_default(),
+                    ReqwestClient::new(inner).with_max_response_body_size(max_response_body_size),
                 ) as Arc<dyn HttpClient>);
             }
             #[cfg(all(not(feature = "reqwest-client"), feature = "hyper-client"))]
             {
                 // TODO - support configuring custom connector and executor
-                http_client = Some(Arc::new(HyperClient::with_default_connector(timeout, None))
-                    as Arc<dyn HttpClient>);
+                http_client = Some(Arc::new(
+                    HyperClient::with_default_connector(timeout, None)
+                        .with_max_response_body_size(max_response_body_size),
+                ) as Arc<dyn HttpClient>);
             }
             #[cfg(all(
                 not(feature = "reqwest-client"),
@@ -261,16 +276,19 @@ impl HttpExporterBuilder {
                 feature = "reqwest-blocking-client"
             ))]
             {
+                use opentelemetry_http::ReqwestBlockingClient;
                 let timeout_clone = timeout;
+                let inner = std::thread::spawn(move || {
+                    reqwest::blocking::Client::builder()
+                        .timeout(timeout_clone)
+                        .build()
+                        .unwrap_or_else(|_| reqwest::blocking::Client::new())
+                })
+                .join()
+                .unwrap(); // TODO: Return ExporterBuildError::ThreadSpawnFailed
                 http_client = Some(Arc::new(
-                    std::thread::spawn(move || {
-                        reqwest::blocking::Client::builder()
-                            .timeout(timeout_clone)
-                            .build()
-                            .unwrap_or_else(|_| reqwest::blocking::Client::new())
-                    })
-                    .join()
-                    .unwrap(), // TODO: Return ExporterBuildError::ThreadSpawnFailed
+                    ReqwestBlockingClient::new(inner)
+                        .with_max_response_body_size(max_response_body_size),
                 ) as Arc<dyn HttpClient>);
             }
         }
@@ -310,6 +328,9 @@ impl HttpExporterBuilder {
         );
         if let Some(max_request_body_size) = self.http_config.max_request_body_size {
             client.max_request_body_size = max_request_body_size;
+        }
+        if let Some(max_response_body_size) = self.http_config.max_response_body_size {
+            client.max_response_body_size = max_response_body_size;
         }
         Ok(client)
     }
@@ -398,6 +419,7 @@ pub(crate) struct OtlpHttpClient {
     compression: Option<crate::Compression>,
     retry_policy: RetryPolicy,
     max_request_body_size: usize,
+    max_response_body_size: usize,
     #[allow(dead_code)]
     // <allow dead> would be removed once we support set_resource for metrics and traces.
     resource: opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema,
@@ -627,6 +649,7 @@ impl OtlpHttpClient {
             compression,
             retry_policy: retry_policy.unwrap_or_default(),
             max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
+            max_response_body_size: DEFAULT_MAX_RESPONSE_BODY_BYTES,
             resource: ResourceAttributesWithSchema::default(),
         }
     }
@@ -821,6 +844,12 @@ pub trait WithHttpConfig {
     /// size or telemetry item size if requests exceed the configured limit.
     /// The default is 64 MiB.
     fn with_max_request_body_size(self, max_size: usize) -> Self;
+
+    /// Set the maximum HTTP response body size in bytes that the client will accept.
+    ///
+    /// Responses exceeding this limit are treated as non-retryable errors.
+    /// The default is 4 MiB, as recommended by the OTLP specification.
+    fn with_max_response_body_size(self, max_size: usize) -> Self;
 }
 
 impl<B: HasHttpConfig> WithHttpConfig for B {
@@ -853,6 +882,11 @@ impl<B: HasHttpConfig> WithHttpConfig for B {
 
     fn with_max_request_body_size(mut self, max_size: usize) -> Self {
         self.http_client_config().max_request_body_size = Some(max_size);
+        self
+    }
+
+    fn with_max_response_body_size(mut self, max_size: usize) -> Self {
+        self.http_client_config().max_response_body_size = Some(max_size);
         self
     }
 }
@@ -1102,6 +1136,7 @@ mod tests {
                 compression: None,
                 retry_policy: None,
                 max_request_body_size: None,
+                max_response_body_size: None,
             },
             exporter_config: crate::exporter::ExportConfig::default(),
         };
@@ -1819,7 +1854,9 @@ mod tests {
                 _request: http::Request<Bytes>,
             ) -> Result<http::Response<Bytes>, opentelemetry_http::HttpError> {
                 self.attempts.fetch_add(1, Ordering::SeqCst);
-                Err(Box::new(opentelemetry_http::ResponseBodyTooLarge))
+                Err(Box::new(opentelemetry_http::ResponseBodyTooLarge {
+                    limit: opentelemetry_http::DEFAULT_MAX_RESPONSE_BODY_BYTES,
+                }))
             }
         }
 
@@ -1936,7 +1973,7 @@ mod tests {
             assert_eq!(mock.attempt_count(), 1);
             assert!(error
                 .to_string()
-                .contains("response body exceeded maximum allowed 4 MiB limit"));
+                .contains("response body exceeded maximum allowed"));
         }
 
         #[test]

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -534,13 +534,16 @@
 //! # #[cfg(all(feature = "trace", feature = "http-proto", feature = "reqwest-client"))]
 //! # {
 //! use opentelemetry_otlp::WithHttpConfig;
+//! use opentelemetry_http::ReqwestClient;
 //!
 //! // reqwest async client (requires the `reqwest-client` feature)
-//! let http_client = reqwest::Client::builder()
-//!     .timeout(std::time::Duration::from_secs(5))
-//!     // .danger_accept_invalid_certs(true) // for testing only
-//!     .build()
-//!     .expect("Failed to build reqwest client");
+//! let http_client = ReqwestClient::new(
+//!     reqwest::Client::builder()
+//!         .timeout(std::time::Duration::from_secs(5))
+//!         // .danger_accept_invalid_certs(true) // for testing only
+//!         .build()
+//!         .expect("Failed to build reqwest client"),
+//! );
 //!
 //! let exporter = opentelemetry_otlp::SpanExporter::builder()
 //!     .with_http()

--- a/opentelemetry-zipkin/CHANGELOG.md
+++ b/opentelemetry-zipkin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- The default HTTP clients now enforce a 4 MiB response body size limit.
+  Responses exceeding this limit are rejected as errors.
+
 ## 0.32.0
 
 Released 2026-May-08

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -46,19 +46,19 @@ impl Default for ZipkinExporterBuilder {
 
         ZipkinExporterBuilder {
             #[cfg(feature = "reqwest-blocking-client")]
-            client: Some(Arc::new(
+            client: Some(Arc::new(opentelemetry_http::ReqwestBlockingClient::new(
                 reqwest::blocking::Client::builder()
                     .timeout(timeout)
                     .build()
                     .unwrap_or_else(|_| reqwest::blocking::Client::new()),
-            )),
+            ))),
             #[cfg(all(not(feature = "reqwest-blocking-client"), feature = "reqwest-client"))]
-            client: Some(Arc::new(
+            client: Some(Arc::new(opentelemetry_http::ReqwestClient::new(
                 reqwest::Client::builder()
                     .timeout(timeout)
                     .build()
                     .unwrap_or_else(|_| reqwest::Client::new()),
-            )),
+            ))),
             #[cfg(all(
                 not(feature = "reqwest-client"),
                 not(feature = "reqwest-blocking-client")


### PR DESCRIPTION
This is a small change stacked on #3501, and allows configurable response body limits. I've also addressed a couple of small nits from @cijothomas from that PR: 

 - Short-circuit on `Content-Length`: if the server advertises a body size exceeding the limit, reject immediately without reading any bytes
 - Added an opentelemetry-otlp changelog entry for the response body limit (since that's what end users directly consume)
 - Updated opentelemetry-http changelog to mention ResponseBodyTooLarge


Design discussion issue (if applicable) #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
