### PR TITLE
docs: fix OTLP HTTP with_endpoint example (endpoint used verbatim)

### DIFF
--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -486,9 +486,10 @@
 //!
 //! let exporter = opentelemetry_otlp::SpanExporter::builder()
 //!     .with_http()
-//!     // Target URL, used verbatim: the signal path is NOT appended, so include it
-//!     // yourself (e.g. /v1/traces). Defaults to http://localhost:4318/v1/traces.
-//!     // Set OTEL_EXPORTER_OTLP_ENDPOINT to have the signal path appended automatically.
+//!     // Target URL, used verbatim: include the signal path, e.g. /v1/traces.
+//!     // OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is also used verbatim.
+//!     // OTEL_EXPORTER_OTLP_ENDPOINT is a base URL and appends /v1/traces automatically.
+//!     // Defaults to http://localhost:4318/v1/traces.
 //!     .with_endpoint("http://my-collector:4318/v1/traces")
 //!     // Per-export timeout. Defaults to 10 s.
 //!     // Env var: OTEL_EXPORTER_OTLP_TRACES_TIMEOUT (or OTEL_EXPORTER_OTLP_TIMEOUT).

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -486,10 +486,10 @@
 //!
 //! let exporter = opentelemetry_otlp::SpanExporter::builder()
 //!     .with_http()
-//!     // Target base URL. Defaults to http://localhost:4318.
-//!     // The path /v1/traces (or /v1/metrics, /v1/logs) is appended automatically.
-//!     // Env var: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (or OTEL_EXPORTER_OTLP_ENDPOINT).
-//!     .with_endpoint("http://my-collector:4318")
+//!     // Target URL, used verbatim: the signal path is NOT appended, so include it
+//!     // yourself (e.g. /v1/traces). Defaults to http://localhost:4318/v1/traces.
+//!     // Set OTEL_EXPORTER_OTLP_ENDPOINT to have the signal path appended automatically.
+//!     .with_endpoint("http://my-collector:4318/v1/traces")
 //!     // Per-export timeout. Defaults to 10 s.
 //!     // Env var: OTEL_EXPORTER_OTLP_TRACES_TIMEOUT (or OTEL_EXPORTER_OTLP_TIMEOUT).
 //!     .with_timeout(Duration::from_secs(5))


### PR DESCRIPTION
Towards #3427

## Changes

The HTTP transport example in the `opentelemetry-otlp` crate-level docs stated that `.with_endpoint()` appends the signal path (`/v1/traces`, etc.) automatically. It doesn't: `resolve_http_endpoint` uses the provided endpoint verbatim, and only the generic `OTEL_EXPORTER_OTLP_ENDPOINT` env var appends the signal path (confirmed by the crate's own tests, e.g. `.with_endpoint(".../v1/tracesbutnotreally")` staying verbatim).

This corrects the doc comment and the example so users include the signal path themselves, and points to `OTEL_EXPORTER_OTLP_ENDPOINT` for automatic appending. The gRPC example and the env-var table were already correct and are untouched.

Docs-only change; no code or public API changes.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [ ] Unit tests added/updated (if applicable) — N/A (docs only)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes — N/A (docs only)
* [ ] Changes in public API reviewed (if applicable) — N/A
