### PR TITLE
ci: pin Rust toolchain and automate monthly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,8 @@ updates:
           - "patch"
     cooldown:
       default-days: 7
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       run: rustup show active-toolchain
     - name: Install Rust beta
       if: ${{ matrix.rust == 'beta' }}
-      run: rustup toolchain install beta --profile minimal --component rustfmt,clippy
+      run: rustup toolchain install beta --profile minimal --component rustfmt
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,11 +56,6 @@ jobs:
       run: bash ./scripts/test.sh
       env:
         RUSTUP_TOOLCHAIN: ${{ matrix.rust == 'beta' && 'beta' || '' }}
-    - name: Lint with Rust beta
-      if: ${{ matrix.rust == 'beta' }}
-      run: cargo clippy --workspace --all-targets --all-features -- -Dwarnings
-      env:
-        RUSTUP_TOOLCHAIN: beta
   # Targeted Miri regression check for SDK default resource construction.
   # Broader Miri support and CI policy are tracked in #3554.
   miri:
@@ -95,10 +90,10 @@ jobs:
         persist-credentials: false
         submodules: true
     - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
-    - name: Resolve stable Rust pinned by rust-toolchain.toml
-      run: rustup show active-toolchain
       with:
           tool: cargo-hack
+    - name: Resolve stable Rust pinned by rust-toolchain.toml
+      run: rustup show active-toolchain
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -132,6 +127,8 @@ jobs:
       - name: external-type-check
         working-directory: ${{ matrix.member }}
         run: cargo check-external-types --all-features --config allowed-external-types.toml
+        env:
+          RUSTUP_TOOLCHAIN: nightly-2025-05-04
   msrv:
     strategy:
       matrix:
@@ -149,10 +146,10 @@ jobs:
           persist-credentials: false
           submodules: true
       - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
-      - name: Resolve stable Rust pinned by rust-toolchain.toml
-        run: rustup show active-toolchain
         with:
           tool: cargo-msrv
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -292,3 +289,5 @@ jobs:
           tool: cargo-shear
       - name: cargo shear
         run: cargo shear --expand
+        env:
+          RUSTUP_TOOLCHAIN: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
   test:
     strategy:
       matrix:
-        # test both stable and beta versions of Rust on ubuntu-latest
+        # `stable` means the version pinned in rust-toolchain.toml. The label is
+        # retained because branch rules may require the existing check names.
+        # Beta uses the moving beta channel and is non-blocking.
         os: [ubuntu-latest]
         rust: [stable, beta]
-        # test only stable version of Rust on Windows and MacOS
+        # Run stable (pinned per rust-toolchain.toml) on additional platforms.
         include:
           - rust: stable
             os: windows-latest
@@ -41,17 +43,24 @@ jobs:
       with:
         persist-credentials: false
         submodules: true
-    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
-      with:
-        toolchain: ${{ matrix.rust }}
-        components: rustfmt
-    - name: "Set rustup profile"
-      run: rustup set profile minimal
+    - name: Resolve stable Rust pinned by rust-toolchain.toml
+      if: ${{ matrix.rust == 'stable' }}
+      run: rustup show active-toolchain
+    - name: Install Rust beta
+      if: ${{ matrix.rust == 'beta' }}
+      run: rustup toolchain install beta --profile minimal --component rustfmt,clippy
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
       run: bash ./scripts/test.sh
+      env:
+        RUSTUP_TOOLCHAIN: ${{ matrix.rust == 'beta' && 'beta' || '' }}
+    - name: Lint with Rust beta
+      if: ${{ matrix.rust == 'beta' }}
+      run: cargo clippy --workspace --all-targets --all-features -- -Dwarnings
+      env:
+        RUSTUP_TOOLCHAIN: beta
   # Targeted Miri regression check for SDK default resource construction.
   # Broader Miri support and CI policy are tracked in #3554.
   miri:
@@ -85,11 +94,9 @@ jobs:
       with:
         persist-credentials: false
         submodules: true
-    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
-      with:
-        toolchain: stable
-        components: rustfmt, clippy
     - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
+    - name: Resolve stable Rust pinned by rust-toolchain.toml
+      run: rustup show active-toolchain
       with:
           tool: cargo-hack
     - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -141,10 +148,9 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
-        with:
-          toolchain: stable
       - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
         with:
           tool: cargo-msrv
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -197,10 +203,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
-        with:
-          toolchain: stable
-          components: rustfmt
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -223,10 +227,10 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
-        with:
-          toolchain: stable
-          components: rustfmt,llvm-tools-preview
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
+      - name: Install llvm-tools-preview for pinned stable Rust
+        run: rustup component add llvm-tools-preview
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -251,10 +255,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
-        with:
-          toolchain: stable
-          components: rustfmt
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -22,10 +22,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
-        with:
-          toolchain: stable
-          components: rustfmt
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -25,3 +25,5 @@ jobs:
         run: rustup show active-toolchain
       - name: cargo-semver-checks
         uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
+        with:
+          rust-toolchain: manual

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -21,10 +21,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
-        with:
-          toolchain: stable
-          components: rustfmt
+      - name: Resolve stable Rust pinned by rust-toolchain.toml
+        run: rustup show active-toolchain
       - name: cargo-semver-checks
         uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,20 @@ GitHub pull requests (PRs).
 git clone --recurse-submodule https://github.com/open-telemetry/opentelemetry-rust
 ```
 
+### Rust toolchain
+
+The repository pins the Rust version used for local development and required CI
+in [`rust-toolchain.toml`](rust-toolchain.toml). This keeps local checks and CI
+on the same compiler and prevents a new Rust release from breaking unrelated
+pull requests.
+
+Run `cargo` from within the repository so `rustup` applies the pinned toolchain.
+The non-blocking beta CI lane explicitly overrides the pin to provide early
+warning of upcoming compiler changes.
+
+Dependabot checks monthly for a new Rust release. Update pull requests should
+include any lint or compile fixes required by the new compiler.
+
 Enter the newly created directory and add your fork as a new remote:
 
 ```sh

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.98.0"
+profile = "minimal"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Changes

- Pin the repository development and required CI toolchain to Rust 1.98.0.
- Keep the existing non-blocking beta lane running tests only.
- Explicitly preserve the nightly toolchains required by Miri, external-types, and cargo-shear.
- Configure Dependabot to check monthly for Rust toolchain updates.
- Document how the repository pin affects local development and CI.

This applies the deterministic toolchain approach used in `opentelemetry-rust-contrib`, preventing unrelated CI failures when the stable Rust channel advances.

## Validation

- Stable tests passed on Linux and macOS; Windows is still running.
- Beta tests passed.
- Lint, docs, coverage, examples, integration tests, external-types, cargo-shear, and Miri passed.
- `actionlint` passed for all changed workflows.
