### PR TITLE
fix(stdout): use primitive negative infinity constant

### DIFF
--- a/opentelemetry-stdout/src/metrics/exporter.rs
+++ b/opentelemetry-stdout/src/metrics/exporter.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use core::{f64, fmt};
+use core::fmt;
 use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
 use opentelemetry_sdk::metrics::Temporality;
 use opentelemetry_sdk::{


### PR DESCRIPTION
Remove the `core::f64` module import so `f64::NEG_INFINITY` resolves to the primitive associated constant. This fixes the deprecation promoted to an error by beta Clippy.

Verified with `cargo +beta clippy -p opentelemetry-stdout --all-targets --all-features -- -Dwarnings`.