### PR TITLE
fix(context)!: replace over-broad FutureExt with precise extension traits

### DIFF
--- a/examples/tracing-http-propagator/src/server.rs
+++ b/examples/tracing-http-propagator/src/server.rs
@@ -6,7 +6,7 @@ use opentelemetry::{
     global::{self, BoxedTracer},
     logs::LogRecord,
     propagation::TextMapCompositePropagator,
-    trace::{FutureExt, Span, SpanKind, TraceContextExt, Tracer},
+    trace::{FutureContextExt, Span, SpanKind, TraceContextExt, Tracer},
     Context, InstrumentationScope, KeyValue,
 };
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -17,6 +17,8 @@
   Gated behind the `experimental_context_observer` feature flag.
 - `otel_info!`, `otel_warn!`, `otel_debug!`, and `otel_error!` macros now accept quoted-key fields
   (e.g. `"otel.component.type" = "value"`) for dotted attribute names.
+- **Added** `FutureContextExt`, `StreamContextExt`, and `SinkContextExt` traits, providing `with_context` / `with_current_context` for futures, streams, and sinks respectively (#3291).
+- **Breaking** Removed the blanket `impl<T> FutureExt for T` implementation, which exposed `with_context` on *every* type and could collide with similarly named methods from other crates (e.g. `anyhow::Context::with_context`). `FutureExt` is now `#[deprecated]` and has no implementation; migrate to the new traits above (`FutureContextExt` for futures). A type implementing more than one of `Future`/`Stream`/`Sink` must now disambiguate the call (e.g. `FutureContextExt::with_context(value, cx)`).
 - **Added** `BoundGauge<T>` and `BoundUpDownCounter<T>` types (and the
   corresponding `Gauge::bind()` / `UpDownCounter::bind()` methods), completing
   the experimental bound-instrument API across all sync instruments

--- a/opentelemetry/src/context.rs
+++ b/opentelemetry/src/context.rs
@@ -26,7 +26,8 @@ use std::sync::OnceLock;
 mod future_ext;
 
 #[cfg(feature = "futures")]
-pub use future_ext::{FutureExt, WithContext};
+#[allow(deprecated)]
+pub use future_ext::{FutureContextExt, FutureExt, SinkContextExt, StreamContextExt, WithContext};
 
 #[cfg(feature = "experimental_context_observer")]
 pub use context_observer::*;

--- a/opentelemetry/src/context/future_ext.rs
+++ b/opentelemetry/src/context/future_ext.rs
@@ -5,7 +5,6 @@ use pin_project_lite::pin_project;
 use std::pin::Pin;
 use std::task::Context as TaskContext;
 use std::task::Poll;
-impl<T: Sized> FutureExt for T {}
 
 impl<T: std::future::Future> std::future::Future for WithContext<T> {
     type Output = T::Output;
@@ -79,14 +78,19 @@ where
 }
 
 /// Extension trait allowing futures, streams, and sinks to be traced with a span.
+///
+/// This trait relied on an overly general blanket implementation
+/// (`impl<T> FutureExt for T`) that exposed `with_context` on *every* type, which
+/// could collide with similarly named methods from other crates (for example
+/// `anyhow::Context::with_context`). It is replaced by the precise
+/// [`FutureContextExt`], [`StreamContextExt`], and [`SinkContextExt`] traits.
+#[deprecated(
+    since = "0.33.0",
+    note = "overly general; use FutureContextExt, StreamContextExt, or SinkContextExt instead"
+)]
 pub trait FutureExt: Sized {
     /// Attaches the provided [`Context`] to this type, returning a `WithContext`
     /// wrapper.
-    ///
-    /// When the wrapped type is a future, stream, or sink, the attached context
-    /// will be set as current while it is being polled.
-    ///
-    /// [`Context`]: Context
     fn with_context(self, otel_cx: Context) -> WithContext<Self> {
         WithContext {
             inner: self,
@@ -96,13 +100,160 @@ pub trait FutureExt: Sized {
 
     /// Attaches the current [`Context`] to this type, returning a `WithContext`
     /// wrapper.
-    ///
-    /// When the wrapped type is a future, stream, or sink, the attached context
-    /// will be set as the default while it is being polled.
-    ///
-    /// [`Context`]: Context
     fn with_current_context(self) -> WithContext<Self> {
         let otel_cx = Context::current();
         self.with_context(otel_cx)
+    }
+}
+
+// The three extension traits below are almost identical, but must be separate to
+// avoid overlapping blanket-implementation errors. As a result, a type that is more
+// than one of Future, Stream, or Sink must disambiguate the call, e.g.
+// `FutureContextExt::with_context(value, cx)`.
+
+/// Extension trait allowing futures to be traced with a span.
+pub trait FutureContextExt: Sized {
+    /// Attaches the provided [`Context`] to this future; it is set as the current
+    /// context while the future is polled.
+    fn with_context(self, otel_cx: Context) -> WithContext<Self> {
+        WithContext {
+            inner: self,
+            otel_cx,
+        }
+    }
+
+    /// Attaches the current [`Context`] to this future.
+    fn with_current_context(self) -> WithContext<Self> {
+        let otel_cx = Context::current();
+        self.with_context(otel_cx)
+    }
+}
+
+impl<F: std::future::Future> FutureContextExt for F {}
+
+/// Extension trait allowing streams to be traced with a span.
+pub trait StreamContextExt: Sized {
+    /// Attaches the provided [`Context`] to this stream; it is set as the current
+    /// context while the stream is polled.
+    fn with_context(self, otel_cx: Context) -> WithContext<Self> {
+        WithContext {
+            inner: self,
+            otel_cx,
+        }
+    }
+
+    /// Attaches the current [`Context`] to this stream.
+    fn with_current_context(self) -> WithContext<Self> {
+        let otel_cx = Context::current();
+        self.with_context(otel_cx)
+    }
+}
+
+impl<S: Stream> StreamContextExt for S {}
+
+/// Extension trait allowing sinks to be traced with a span.
+///
+/// The `I` type parameter is the sink item type; it only selects the
+/// implementation and does not appear in the trait's methods.
+pub trait SinkContextExt<I>: Sized {
+    /// Attaches the provided [`Context`] to this sink; it is set as the current
+    /// context while the sink is polled.
+    fn with_context(self, otel_cx: Context) -> WithContext<Self> {
+        WithContext {
+            inner: self,
+            otel_cx,
+        }
+    }
+
+    /// Attaches the current [`Context`] to this sink.
+    fn with_current_context(self) -> WithContext<Self> {
+        let otel_cx = Context::current();
+        self.with_context(otel_cx)
+    }
+}
+
+impl<I, S: Sink<I>> SinkContextExt<I> for S {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::Future;
+    use std::task::{RawWaker, RawWakerVTable, Waker};
+
+    struct EmptyStream;
+
+    impl Stream for EmptyStream {
+        type Item = i32;
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(None)
+        }
+    }
+
+    struct NullSink;
+
+    impl Sink<i32> for NullSink {
+        type Error = ();
+
+        fn poll_ready(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<Result<(), ()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, _item: i32) -> Result<(), ()> {
+            Ok(())
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<Result<(), ()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<Result<(), ()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn noop_waker() -> Waker {
+        fn clone(_: *const ()) -> RawWaker {
+            raw()
+        }
+        fn noop(_: *const ()) {}
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+        fn raw() -> RawWaker {
+            RawWaker::new(std::ptr::null(), &VTABLE)
+        }
+        // SAFETY: every vtable function is a no-op that ignores the (null) data pointer.
+        unsafe { Waker::from_raw(raw()) }
+    }
+
+    // `with_context` / `with_current_context` are available on futures, streams, and
+    // sinks via the precise extension traits, and the returned `WithContext` wrapper
+    // forwards to the underlying Future/Stream/Sink. Distinct stream-only and sink-only
+    // types are used on purpose: a type implementing more than one of these would be
+    // ambiguous at the call site.
+    #[test]
+    fn context_extensions_apply_to_future_stream_and_sink() {
+        let waker = noop_waker();
+        let mut cx = TaskContext::from_waker(&waker);
+
+        // Future
+        let mut fut = Box::pin(async {}.with_context(Context::current()));
+        assert_eq!(fut.as_mut().poll(&mut cx), Poll::Ready(()));
+        let mut fut = Box::pin(async {}.with_current_context());
+        assert_eq!(fut.as_mut().poll(&mut cx), Poll::Ready(()));
+
+        // Stream
+        let mut stream = Box::pin(EmptyStream.with_context(Context::current()));
+        assert_eq!(stream.as_mut().poll_next(&mut cx), Poll::Ready(None));
+        let mut stream = Box::pin(EmptyStream.with_current_context());
+        assert_eq!(stream.as_mut().poll_next(&mut cx), Poll::Ready(None));
+
+        // Sink
+        let mut sink = Box::pin(NullSink.with_context(Context::current()));
+        assert_eq!(sink.as_mut().poll_ready(&mut cx), Poll::Ready(Ok(())));
+        assert!(sink.as_mut().start_send(1).is_ok());
+        assert_eq!(sink.as_mut().poll_flush(&mut cx), Poll::Ready(Ok(())));
+        assert_eq!(sink.as_mut().poll_close(&mut cx), Poll::Ready(Ok(())));
+        let mut sink = Box::pin(NullSink.with_current_context());
+        assert_eq!(sink.as_mut().poll_ready(&mut cx), Poll::Ready(Ok(())));
     }
 }

--- a/opentelemetry/src/trace/context.rs
+++ b/opentelemetry/src/trace/context.rs
@@ -7,7 +7,10 @@ use crate::{
 use std::{borrow::Cow, error::Error, sync::Mutex};
 
 // Re-export for compatability. This used to be contained here.
-pub use crate::context::{FutureExt, WithContext};
+#[allow(deprecated)]
+pub use crate::context::{
+    FutureContextExt, FutureExt, SinkContextExt, StreamContextExt, WithContext,
+};
 
 const NOOP_SPAN: SynchronizedSpan = SynchronizedSpan {
     span_context: SpanContext::NONE,

--- a/opentelemetry/src/trace/mod.rs
+++ b/opentelemetry/src/trace/mod.rs
@@ -146,10 +146,10 @@
 //!
 //! #### Async active spans
 //!
-//! Async spans can be propagated with [`TraceContextExt`] and [`FutureExt`].
+//! Async spans can be propagated with [`TraceContextExt`] and [`FutureContextExt`].
 //!
 //! ```
-//! use opentelemetry::{Context, global, trace::{FutureExt, TraceContextExt, Tracer}};
+//! use opentelemetry::{Context, global, trace::{FutureContextExt, TraceContextExt, Tracer}};
 //!
 //! async fn some_work() { }
 //! # async fn in_an_async_context() {
@@ -175,9 +175,11 @@ mod span_context;
 mod tracer;
 mod tracer_provider;
 
+#[allow(deprecated)]
 pub use self::{
     context::{
-        get_active_span, mark_span_as_active, FutureExt, SpanRef, TraceContextExt, WithContext,
+        get_active_span, mark_span_as_active, FutureContextExt, FutureExt, SinkContextExt, SpanRef,
+        StreamContextExt, TraceContextExt, WithContext,
     },
     span::{Span, SpanKind, Status},
     span_context::{SpanContext, TraceState},

--- a/opentelemetry/src/trace/tracer.rs
+++ b/opentelemetry/src/trace/tracer.rs
@@ -73,7 +73,7 @@ use std::time::SystemTime;
 /// ## In Asynchronous Code
 ///
 /// If you are instrumenting code that make use of [`std::future::Future`] or
-/// async/await, be sure to use the [`FutureExt`] trait. This is needed because
+/// async/await, be sure to use the [`FutureContextExt`] trait. This is needed because
 /// the following example _will not_ work:
 ///
 /// ```no_run
@@ -98,7 +98,7 @@ use std::time::SystemTime;
 ///
 /// ```
 /// # async fn run() -> Result<(), ()> {
-/// use opentelemetry::{trace::FutureExt, Context};
+/// use opentelemetry::{trace::FutureContextExt, Context};
 /// let cx = Context::current();
 ///
 /// let my_future = async {
@@ -115,8 +115,8 @@ use std::time::SystemTime;
 /// [`Future::with_context`] attaches a context to the future, ensuring that the
 /// context's lifetime is as long as the future's.
 ///
-/// [`FutureExt`]: crate::trace::FutureExt
-/// [`Future::with_context`]: crate::trace::FutureExt::with_context()
+/// [`FutureContextExt`]: crate::trace::FutureContextExt
+/// [`Future::with_context`]: crate::trace::FutureContextExt::with_context()
 /// [`Context`]: crate::Context
 pub trait Tracer {
     /// The [`Span`] type used by this tracer.


### PR DESCRIPTION
Fixes #3291

The blanket `impl<T> FutureExt for T` puts `with_context()` on literally every type, so it collides with `anyhow::Context::with_context` and you get an inference error at any call site where both traits are in scope. This swaps the blanket impl for three precise traits.

This is breaking, and it has to be. The blanket impl is the collision, there's no way to fix #3291 while keeping it.

Trait shape is lifted from @Kile-Asmussen's #3292, which went stale. Credit there, I just picked it up and finished it off.

## Changes

- removed `impl<T> FutureExt for T`
- added `FutureContextExt`, `StreamContextExt`, `SinkContextExt<I>`. Same `with_context` / `with_current_context` methods, but implemented only for `Future` / `Stream` / `Sink` respectively
- `FutureExt` is deprecated and kept as an inert shell with no impl, so existing `use ...FutureExt` statements still resolve instead of hard-erroring
- threaded the new traits through the re-export chain (`context` → `trace::context` → `trace`)
- migrated the doc examples and the `tracing-http-propagator` example over
- CHANGELOG: Breaking (blanket impl removed), Added (new traits), plus a short migration note

On @cijothomas's ambiguity question: with the blanket impl gone `FutureExt` has no impl at all, so `.with_context()` on a future resolves to `FutureContextExt` unambiguously, even under `use trace::*`. I checked this compiles.

The tradeoff, to be upfront about it: a type that implements more than one of Future/Stream/Sink now needs to disambiguate at the call site. That's a real cost but it's narrow, and it's the price of not shadowing every other crate's `with_context`.

## Testing

Added a stream/sink test covering both new traits. Existing future tests still pass unchanged apart from the import.

## Merge requirement checklist

- [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
- [x] Unit tests added/updated
- [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
- [x] Changes in public API reviewed — yes, and intentional. Breaking, documented in the changelog with migration guidance.

@cijothomas @scottgerring if you'd rather keep the blanket impl and leave #3291 open, say so and I'll close this. Otherwise I think this is the fix.
