### PR TITLE
fix(otlp): enable retries by default

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -28,8 +28,8 @@
   async-runtime processors.
   The default `RetryPolicy` follows the OTLP specification's retry requirement,
   using exponential backoff with up to 3 retries (4 attempts total). Configure
-  `.with_retry_policy(...)` explicitly to customize the policy or disable
-  retries.
+  `.with_retry_policy(...)` explicitly to customize the policy, or use
+  `.with_retry_policy(RetryPolicy::disabled())` to disable retries.
   **Migration**: Remove the experimental retry feature flags from your `Cargo.toml`.
   [#3621](https://github.com/open-telemetry/opentelemetry-rust/pull/3621)
 - Add support for INSECURE environment variables for gRPC (env-var-only, no builder method, per spec):

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Retry
 
-- **Breaking:** Retries are now enabled by default for OTLP/HTTP and OTLP/gRPC.
-  No feature flag or builder opt-in is required. The default policy uses
-  exponential backoff and jitter with up to 3 retries (4 attempts total). Use
+- Retries are now enabled by default for OTLP/HTTP and OTLP/gRPC. No feature
+  flag or builder opt-in is required. The default policy uses exponential
+  backoff and jitter with up to 3 retries (4 attempts total). Use
   `.with_retry_policy(RetryPolicy::disabled())` to disable retries, or provide
   a custom `RetryPolicy` to change the behavior.
 - **Migration**: Remove the experimental retry feature flags

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## vNext
 
+### Retry
+
+- **Breaking:** Retries are now enabled by default for OTLP/HTTP and OTLP/gRPC.
+  No feature flag or builder opt-in is required. The default policy uses
+  exponential backoff and jitter with up to 3 retries (4 attempts total). Use
+  `.with_retry_policy(RetryPolicy::disabled())` to disable retries, or provide
+  a custom `RetryPolicy` to change the behavior.
+- **Migration**: Remove the experimental retry feature flags
+  (`grpc-tonic-with-retry`, `http-proto-with-retry`,
+  `http-json-with-retry`) from `Cargo.toml`. Retry support is now always
+  included and works with both the default thread-based processors and the
+  experimental async-runtime processors.
+  [#3621](https://github.com/open-telemetry/opentelemetry-rust/pull/3621)
+
+#### Retry fixes
+
+The following fixes apply to retry behavior that was experimental before this
+release:
+
+- Retry only HTTP status codes 429, 502, 503, and 504, as required by the OTLP
+  specification. The exporter now also honors `Retry-After` on 503 responses.
+- Honor positive gRPC `RetryInfo` delays returned with `Unavailable` responses.
+- Continue exponential backoff from server-provided `RetryInfo` and
+  `Retry-After` delays when subsequent export attempts fail.
+
+### Other changes
+
 - Return an exporter build error for invalid OTLP/HTTP endpoint environment
   variables instead of silently falling back to another endpoint or localhost.
   Empty endpoint environment variables are now treated as unset.
@@ -10,28 +37,6 @@
   OTLP/HTTP request bodies are now limited to 64 MiB by default, before and
   after compression; oversized requests are discarded without being sent or
   retried.
-- Honor positive gRPC `RetryInfo` delays returned with `Unavailable` responses.
-  `Unavailable` responses without a positive delay continue to use exponential
-  backoff.
-- Continue exponential backoff from server-provided `RetryInfo` and `Retry-After`
-  delays when subsequent export attempts fail, rather than reusing or dropping
-  below the server-requested delay.
-- Fix OTLP/HTTP retry classification to retry only status codes 429, 502, 503,
-  and 504, as required by the OTLP specification. The exporter now also honors
-  `Retry-After` on 503 responses. Other HTTP error responses, including 500,
-  are now treated as non-retryable.
-- **Breaking** Removed experimental retry feature flags (`grpc-tonic-with-retry`,
-  `http-proto-with-retry`, `http-json-with-retry`). Retry support is now always
-  included for both gRPC and HTTP exporters and works with all processor types,
-  including the default `BatchSpanProcessor`, `BatchLogProcessor`, and
-  `PeriodicReader` (which use a dedicated OS thread), as well as the experimental
-  async-runtime processors.
-  The default `RetryPolicy` follows the OTLP specification's retry requirement,
-  using exponential backoff with up to 3 retries (4 attempts total). Configure
-  `.with_retry_policy(...)` explicitly to customize the policy, or use
-  `.with_retry_policy(RetryPolicy::disabled())` to disable retries.
-  **Migration**: Remove the experimental retry feature flags from your `Cargo.toml`.
-  [#3621](https://github.com/open-telemetry/opentelemetry-rust/pull/3621)
 - Add support for INSECURE environment variables for gRPC (env-var-only, no builder method, per spec):
   `OTEL_EXPORTER_OTLP_INSECURE` (generic), `OTEL_EXPORTER_OTLP_TRACES_INSECURE`,
   `OTEL_EXPORTER_OTLP_METRICS_INSECURE`, `OTEL_EXPORTER_OTLP_LOGS_INSECURE`.

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -12,9 +12,7 @@
 - **Migration for users of the experimental retry features:** If your
   `Cargo.toml` enables `grpc-tonic-with-retry`, `http-proto-with-retry`, or
   `http-json-with-retry`, remove those feature flags. No migration action is
-  required for users who did not enable them. Retry support is now always
-  included and works with both the default thread-based processors and the
-  experimental async-runtime processors.
+  required for users who did not enable them.
   [#3621](https://github.com/open-telemetry/opentelemetry-rust/pull/3621)
 
 #### Retry fixes

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -4,11 +4,10 @@
 
 ### Retry
 
-- Retries are now enabled by default for OTLP/HTTP and OTLP/gRPC. No feature
-  flag or builder opt-in is required. The default policy uses exponential
-  backoff and jitter with up to 3 retries (4 attempts total). Use
-  `.with_retry_policy(RetryPolicy::disabled())` to disable retries, or provide
-  a custom `RetryPolicy` to change the behavior.
+- Retries are now enabled by default for OTLP/HTTP and OTLP/gRPC. The default
+  policy uses exponential backoff and jitter with up to 3 retries (4 attempts
+  total). Use `.with_retry_policy(RetryPolicy::disabled())` to disable retries,
+  or provide a custom `RetryPolicy` to change the behavior.
 - **Migration for users of the experimental retry features:** If your
   `Cargo.toml` enables `grpc-tonic-with-retry`, `http-proto-with-retry`, or
   `http-json-with-retry`, remove those feature flags. No migration action is

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -26,29 +26,11 @@
   including the default `BatchSpanProcessor`, `BatchLogProcessor`, and
   `PeriodicReader` (which use a dedicated OS thread), as well as the experimental
   async-runtime processors.
-  The default `RetryPolicy` performs no retries (preserving existing behaviour).
-  To enable retries, configure a policy via `.with_retry_policy(RetryPolicy::recommended())`
-  which provides exponential backoff with up to 3 retries (4 attempts total).
+  The default `RetryPolicy` follows the OTLP specification's retry requirement,
+  using exponential backoff with up to 3 retries (4 attempts total). Configure
+  `.with_retry_policy(...)` explicitly to customize the policy or disable
+  retries.
   **Migration**: Remove the experimental retry feature flags from your `Cargo.toml`.
-  If you were relying on them to enable retry, configure a policy explicitly instead:
-  ```rust
-  // HTTP
-  use opentelemetry_otlp::{WithHttpConfig, RetryPolicy};
-
-  let exporter = opentelemetry_otlp::SpanExporter::builder()
-      .with_http()
-      .with_retry_policy(RetryPolicy::recommended())
-      .build()?;
-  ```
-  ```rust
-  // gRPC (tonic)
-  use opentelemetry_otlp::{WithTonicConfig, RetryPolicy};
-
-  let exporter = opentelemetry_otlp::SpanExporter::builder()
-      .with_tonic()
-      .with_retry_policy(RetryPolicy::recommended())
-      .build()?;
-  ```
   [#3621](https://github.com/open-telemetry/opentelemetry-rust/pull/3621)
 - Add support for INSECURE environment variables for gRPC (env-var-only, no builder method, per spec):
   `OTEL_EXPORTER_OTLP_INSECURE` (generic), `OTEL_EXPORTER_OTLP_TRACES_INSECURE`,

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -9,9 +9,10 @@
   backoff and jitter with up to 3 retries (4 attempts total). Use
   `.with_retry_policy(RetryPolicy::disabled())` to disable retries, or provide
   a custom `RetryPolicy` to change the behavior.
-- **Migration**: Remove the experimental retry feature flags
-  (`grpc-tonic-with-retry`, `http-proto-with-retry`,
-  `http-json-with-retry`) from `Cargo.toml`. Retry support is now always
+- **Migration for users of the experimental retry features:** If your
+  `Cargo.toml` enables `grpc-tonic-with-retry`, `http-proto-with-retry`, or
+  `http-json-with-retry`, remove those feature flags. No migration action is
+  required for users who did not enable them. Retry support is now always
   included and works with both the default thread-based processors and the
   experimental async-runtime processors.
   [#3621](https://github.com/open-telemetry/opentelemetry-rust/pull/3621)

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -1768,8 +1768,8 @@ mod tests {
         fn test_default_retry_policy_when_none_configured() {
             let client = create_test_client(crate::Protocol::HttpBinary, None);
 
-            // Verify default values are used (default = no retry)
-            assert_eq!(client.retry_policy.max_retries, 0);
+            // Verify the recommended default values are used.
+            assert_eq!(client.retry_policy.max_retries, 3);
             assert_eq!(client.retry_policy.initial_delay_ms, 100);
             assert_eq!(client.retry_policy.max_delay_ms, 1600);
             assert_eq!(client.retry_policy.jitter_ms, 100);

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -71,7 +71,9 @@ impl RetryPolicy {
     pub fn disabled() -> Self {
         Self {
             max_retries: 0,
-            ..Self::recommended()
+            initial_delay_ms: 0,
+            max_delay_ms: 0,
+            jitter_ms: 0,
         }
     }
 
@@ -303,9 +305,9 @@ mod tests {
     fn test_disabled_retry_policy() {
         let policy = RetryPolicy::disabled();
         assert_eq!(policy.max_retries, 0);
-        assert_eq!(policy.initial_delay_ms, 100);
-        assert_eq!(policy.max_delay_ms, 1600);
-        assert_eq!(policy.jitter_ms, 100);
+        assert_eq!(policy.initial_delay_ms, 0);
+        assert_eq!(policy.max_delay_ms, 0);
+        assert_eq!(policy.jitter_ms, 0);
     }
 
     #[test]

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -60,15 +60,9 @@ pub struct RetryPolicy {
 }
 
 impl Default for RetryPolicy {
-    /// Default retry policy performs no retries (single attempt only).
-    /// Use `RetryPolicy::recommended()` or configure explicitly to enable retry.
+    /// Returns the recommended OTLP retry policy.
     fn default() -> Self {
-        Self {
-            max_retries: 0,
-            initial_delay_ms: 100,
-            max_delay_ms: 1600,
-            jitter_ms: 100,
-        }
+        Self::recommended()
     }
 }
 
@@ -282,7 +276,7 @@ mod tests {
     #[test]
     fn test_default_retry_policy() {
         let policy = RetryPolicy::default();
-        assert_eq!(policy.max_retries, 0);
+        assert_eq!(policy.max_retries, 3);
         assert_eq!(policy.initial_delay_ms, 100);
         assert_eq!(policy.max_delay_ms, 1600);
         assert_eq!(policy.jitter_ms, 100);

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -47,6 +47,10 @@ pub enum RetryErrorType {
 }
 
 /// Configuration for retry policy.
+///
+/// The default is [`RetryPolicy::recommended()`]. Use
+/// [`RetryPolicy::disabled()`] to perform a single export attempt without
+/// retrying.
 #[derive(Debug, Clone)]
 pub struct RetryPolicy {
     /// Maximum number of retry attempts.
@@ -308,6 +312,30 @@ mod tests {
         assert_eq!(policy.initial_delay_ms, 0);
         assert_eq!(policy.max_delay_ms, 0);
         assert_eq!(policy.jitter_ms, 0);
+    }
+
+    #[tokio::test]
+    async fn test_disabled_retry_policy_performs_single_attempt() {
+        for classification in [
+            RetryErrorType::Retryable,
+            RetryErrorType::Throttled(Duration::from_secs(5)),
+        ] {
+            let attempts = AtomicUsize::new(0);
+            let result = retry_with_backoff(
+                &RetryPolicy::disabled(),
+                Duration::from_secs(10),
+                |_| classification.clone(),
+                "test_operation",
+                || {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Box::pin(async { Err::<(), _>(()) })
+                },
+            )
+            .await;
+
+            assert_eq!(result, Err(()));
+            assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        }
     }
 
     #[test]

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -67,6 +67,14 @@ impl Default for RetryPolicy {
 }
 
 impl RetryPolicy {
+    /// Returns a retry policy that performs a single export attempt with no retries.
+    pub fn disabled() -> Self {
+        Self {
+            max_retries: 0,
+            ..Self::recommended()
+        }
+    }
+
     /// Recommended retry policy per the OTLP spec: 3 retries with exponential
     /// backoff (100ms initial, 1600ms max, 100ms jitter).
     pub fn recommended() -> Self {
@@ -286,6 +294,15 @@ mod tests {
     fn test_recommended_retry_policy() {
         let policy = RetryPolicy::recommended();
         assert_eq!(policy.max_retries, 3);
+        assert_eq!(policy.initial_delay_ms, 100);
+        assert_eq!(policy.max_delay_ms, 1600);
+        assert_eq!(policy.jitter_ms, 100);
+    }
+
+    #[test]
+    fn test_disabled_retry_policy() {
+        let policy = RetryPolicy::disabled();
+        assert_eq!(policy.max_retries, 0);
         assert_eq!(policy.initial_delay_ms, 100);
         assert_eq!(policy.max_delay_ms, 1600);
         assert_eq!(policy.jitter_ms, 100);


### PR DESCRIPTION
## Summary

- enable retries by default for transient OTLP/HTTP and OTLP/gRPC export failures, using the recommended exponential-backoff policy with up to 3 retries (4 attempts total)
- add `RetryPolicy::disabled()` as a clear single-attempt opt-out while preserving custom policies through `.with_retry_policy(...)`
- consolidate the unreleased retry changelog and scope feature-flag migration to users who enabled the old experimental flags