### PR TITLE
chore(deps): group GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,5 +17,17 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
+      minor-and-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github/codeql-action/*"
+        update-types:
+          - "minor"
+          - "patch"
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Summary

- group all `github/codeql-action/*` components so `init`, `autobuild`, and `analyze` update atomically
- group other minor and patch GitHub Actions updates into one monthly PR
- keep major action updates separate for individual review

This prevents mixed CodeQL versions, which currently cause the split Dependabot PRs to fail CI, while reducing routine dependency PR volume.