### PR TITLE
refactor(otlp): stabilize retry policy API

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -29,6 +29,13 @@ release:
 
 - **Breaking** Make retry implementation details crate-private. `RetryPolicy`
   remains available from the crate root as the supported retry configuration API.
+- **Breaking** Make the `retry` and `retry_classification` modules crate-private,
+  removing their retry engine, error type, and protocol classifiers from the
+  public API. `RetryPolicy` remains available from the crate root with private
+  fields and fluent configuration methods. Replace imports from
+  `opentelemetry_otlp::retry` with `opentelemetry_otlp::RetryPolicy`, and replace
+  struct literals with its `with_*` methods.
+  [#3672](https://github.com/open-telemetry/opentelemetry-rust/pull/3672)
 - Return an exporter build error for invalid OTLP/HTTP endpoint environment
   variables instead of silently falling back to another endpoint or localhost.
   Empty endpoint environment variables are now treated as unset.

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -13,6 +13,13 @@
   `http-json-with-retry`, remove those feature flags. No migration action is
   required for users who did not enable them.
   [#3621](https://github.com/open-telemetry/opentelemetry-rust/pull/3621)
+- **Breaking** Make the `retry` and `retry_classification` modules crate-private,
+  removing their retry engine, error type, and protocol classifiers from the
+  public API. `RetryPolicy` remains available from the crate root with private
+  fields and fluent configuration methods. Replace imports from
+  `opentelemetry_otlp::retry` with `opentelemetry_otlp::RetryPolicy`, and replace
+  struct literals with its `with_*` methods.
+  [#3672](https://github.com/open-telemetry/opentelemetry-rust/pull/3672)
 
 #### Retry fixes
 
@@ -27,13 +34,6 @@ release:
 
 ### Other changes
 
-- **Breaking** Make the `retry` and `retry_classification` modules crate-private,
-  removing their retry engine, error type, and protocol classifiers from the
-  public API. `RetryPolicy` remains available from the crate root with private
-  fields and fluent configuration methods. Replace imports from
-  `opentelemetry_otlp::retry` with `opentelemetry_otlp::RetryPolicy`, and replace
-  struct literals with its `with_*` methods.
-  [#3672](https://github.com/open-telemetry/opentelemetry-rust/pull/3672)
 - Return an exporter build error for invalid OTLP/HTTP endpoint environment
   variables instead of silently falling back to another endpoint or localhost.
   Empty endpoint environment variables are now treated as unset.

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -27,8 +27,6 @@ release:
 
 ### Other changes
 
-- **Breaking** Make retry implementation details crate-private. `RetryPolicy`
-  remains available from the crate root as the supported retry configuration API.
 - **Breaking** Make the `retry` and `retry_classification` modules crate-private,
   removing their retry engine, error type, and protocol classifiers from the
   public API. `RetryPolicy` remains available from the crate root with private

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -27,6 +27,8 @@ release:
 
 ### Other changes
 
+- **Breaking** Make retry implementation details crate-private. `RetryPolicy`
+  remains available from the crate root as the supported retry configuration API.
 - Return an exporter build error for invalid OTLP/HTTP endpoint environment
   variables instead of silently falling back to another endpoint or localhost.
   Empty endpoint environment variables are now treated as unset.

--- a/opentelemetry-otlp/allowed-external-types.toml
+++ b/opentelemetry-otlp/allowed-external-types.toml
@@ -18,7 +18,4 @@ allowed_external_types = [
     "tonic::transport::tls::Identity",
     "tonic::transport::channel::Channel",
     "tonic::service::interceptor::Interceptor",
-
-    # For retries
-    "tonic::status::Status"
 ]

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -1429,6 +1429,7 @@ mod tests {
         use super::super::OtlpHttpClient;
         use opentelemetry_http::{Bytes, HttpClient};
         use std::collections::HashMap;
+        use std::time::Duration;
 
         #[derive(Debug)]
         struct MockHttpClient;
@@ -1747,21 +1748,20 @@ mod tests {
             use crate::RetryPolicy;
             use crate::WithHttpConfig;
 
-            let custom_policy = RetryPolicy {
-                max_retries: 5,
-                initial_delay_ms: 200,
-                max_delay_ms: 3200,
-                jitter_ms: 50,
-            };
+            let custom_policy = RetryPolicy::default()
+                .with_max_retries(5)
+                .with_initial_delay(Duration::from_millis(200))
+                .with_max_delay(Duration::from_millis(3200))
+                .with_max_jitter(Duration::from_millis(50));
 
             let builder = HttpExporterBuilder::default().with_retry_policy(custom_policy);
 
             // Verify the retry policy was set
             let retry_policy = builder.http_config.retry_policy.as_ref().unwrap();
             assert_eq!(retry_policy.max_retries, 5);
-            assert_eq!(retry_policy.initial_delay_ms, 200);
-            assert_eq!(retry_policy.max_delay_ms, 3200);
-            assert_eq!(retry_policy.jitter_ms, 50);
+            assert_eq!(retry_policy.initial_delay, Duration::from_millis(200));
+            assert_eq!(retry_policy.max_delay, Duration::from_millis(3200));
+            assert_eq!(retry_policy.max_jitter, Duration::from_millis(50));
         }
 
         #[cfg(feature = "http-proto")]
@@ -1771,9 +1771,12 @@ mod tests {
 
             // Verify the recommended default values are used.
             assert_eq!(client.retry_policy.max_retries, 3);
-            assert_eq!(client.retry_policy.initial_delay_ms, 100);
-            assert_eq!(client.retry_policy.max_delay_ms, 1600);
-            assert_eq!(client.retry_policy.jitter_ms, 100);
+            assert_eq!(
+                client.retry_policy.initial_delay,
+                Duration::from_millis(100)
+            );
+            assert_eq!(client.retry_policy.max_delay, Duration::from_millis(1600));
+            assert_eq!(client.retry_policy.max_jitter, Duration::from_millis(100));
         }
 
         #[cfg(feature = "http-proto")]
@@ -1781,12 +1784,11 @@ mod tests {
         fn test_custom_retry_policy_used() {
             use crate::RetryPolicy;
 
-            let custom_policy = RetryPolicy {
-                max_retries: 7,
-                initial_delay_ms: 500,
-                max_delay_ms: 5000,
-                jitter_ms: 200,
-            };
+            let custom_policy = RetryPolicy::default()
+                .with_max_retries(7)
+                .with_initial_delay(Duration::from_millis(500))
+                .with_max_delay(Duration::from_millis(5000))
+                .with_max_jitter(Duration::from_millis(200));
 
             let client = OtlpHttpClient::new(
                 std::sync::Arc::new(MockHttpClient),
@@ -1800,9 +1802,12 @@ mod tests {
 
             // Verify custom values are used
             assert_eq!(client.retry_policy.max_retries, 7);
-            assert_eq!(client.retry_policy.initial_delay_ms, 500);
-            assert_eq!(client.retry_policy.max_delay_ms, 5000);
-            assert_eq!(client.retry_policy.jitter_ms, 200);
+            assert_eq!(
+                client.retry_policy.initial_delay,
+                Duration::from_millis(500)
+            );
+            assert_eq!(client.retry_policy.max_delay, Duration::from_millis(5000));
+            assert_eq!(client.retry_policy.max_jitter, Duration::from_millis(200));
         }
     }
 
@@ -1816,6 +1821,7 @@ mod tests {
         use std::collections::HashMap;
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
+        use std::time::Duration;
 
         /// Mock HTTP client that returns a sequence of responses controlled by an attempt counter.
         #[derive(Debug)]
@@ -1948,12 +1954,11 @@ mod tests {
         }
 
         fn retry_policy() -> RetryPolicy {
-            RetryPolicy {
-                max_retries: 3,
-                initial_delay_ms: 1,
-                max_delay_ms: 10,
-                jitter_ms: 0,
-            }
+            RetryPolicy::default()
+                .with_max_retries(3)
+                .with_initial_delay(Duration::from_millis(1))
+                .with_max_delay(Duration::from_millis(10))
+                .with_max_jitter(Duration::ZERO)
         }
 
         #[test]

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -25,8 +25,9 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use crate::retry::{RetryErrorType, RetryPolicy};
+use crate::retry::RetryErrorType;
 use crate::retry_classification::http::classify_http_error;
+use crate::RetryPolicy;
 
 // Recommended by the OTLP/HTTP specification:
 // https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp-request
@@ -1743,7 +1744,7 @@ mod tests {
         #[test]
         fn test_with_retry_policy() {
             use super::super::HttpExporterBuilder;
-            use crate::retry::RetryPolicy;
+            use crate::RetryPolicy;
             use crate::WithHttpConfig;
 
             let custom_policy = RetryPolicy {
@@ -1778,7 +1779,7 @@ mod tests {
         #[cfg(feature = "http-proto")]
         #[test]
         fn test_custom_retry_policy_used() {
-            use crate::retry::RetryPolicy;
+            use crate::RetryPolicy;
 
             let custom_policy = RetryPolicy {
                 max_retries: 7,
@@ -1810,7 +1811,7 @@ mod tests {
     #[cfg(feature = "http-proto")]
     mod retry_integration_tests {
         use super::super::OtlpHttpClient;
-        use crate::retry::RetryPolicy;
+        use crate::RetryPolicy;
         use opentelemetry_http::{Bytes, HttpClient};
         use std::collections::HashMap;
         use std::sync::atomic::{AtomicUsize, Ordering};

--- a/opentelemetry-otlp/src/exporter/tonic/logs.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/logs.rs
@@ -13,7 +13,7 @@ use opentelemetry_proto::transform::logs::tonic::group_logs_by_resource_and_scop
 
 use super::BoxInterceptor;
 
-use crate::retry::RetryPolicy;
+use crate::RetryPolicy;
 
 pub(crate) struct TonicLogsClient {
     inner: Mutex<Option<ClientInner>>,

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -12,7 +12,7 @@ use tonic::{codegen::CompressionEncoding, service::Interceptor, transport::Chann
 use super::BoxInterceptor;
 use crate::metric::MetricsClient;
 
-use crate::retry::RetryPolicy;
+use crate::RetryPolicy;
 
 pub(crate) struct TonicMetricsClient {
     inner: Mutex<Option<ClientInner>>,

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -26,7 +26,7 @@ use crate::{exporter::ExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_O
     any(feature = "trace", feature = "metrics", feature = "logs")
 ))]
 use crate::retry::retry_with_backoff;
-use crate::retry::RetryPolicy;
+use crate::RetryPolicy;
 #[cfg(all(
     feature = "grpc-tonic",
     any(feature = "trace", feature = "metrics", feature = "logs")
@@ -1086,7 +1086,7 @@ mod tests {
 
     #[test]
     fn test_with_retry_policy() {
-        use crate::retry::RetryPolicy;
+        use crate::RetryPolicy;
         use crate::WithTonicConfig;
 
         let custom_policy = RetryPolicy {

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -1089,21 +1089,29 @@ mod tests {
         use crate::RetryPolicy;
         use crate::WithTonicConfig;
 
-        let custom_policy = RetryPolicy {
-            max_retries: 5,
-            initial_delay_ms: 200,
-            max_delay_ms: 3200,
-            jitter_ms: 50,
-        };
+        let custom_policy = RetryPolicy::default()
+            .with_max_retries(5)
+            .with_initial_delay(std::time::Duration::from_millis(200))
+            .with_max_delay(std::time::Duration::from_millis(3200))
+            .with_max_jitter(std::time::Duration::from_millis(50));
 
         let builder = TonicExporterBuilder::default().with_retry_policy(custom_policy);
 
         // Verify the retry policy was set
         let retry_policy = builder.tonic_config.retry_policy.as_ref().unwrap();
         assert_eq!(retry_policy.max_retries, 5);
-        assert_eq!(retry_policy.initial_delay_ms, 200);
-        assert_eq!(retry_policy.max_delay_ms, 3200);
-        assert_eq!(retry_policy.jitter_ms, 50);
+        assert_eq!(
+            retry_policy.initial_delay,
+            std::time::Duration::from_millis(200)
+        );
+        assert_eq!(
+            retry_policy.max_delay,
+            std::time::Duration::from_millis(3200)
+        );
+        assert_eq!(
+            retry_policy.max_jitter,
+            std::time::Duration::from_millis(50)
+        );
     }
 
     #[test]

--- a/opentelemetry-otlp/src/exporter/tonic/trace.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/trace.rs
@@ -15,7 +15,7 @@ use tonic::{codegen::CompressionEncoding, service::Interceptor, transport::Chann
 
 use super::BoxInterceptor;
 
-use crate::retry::RetryPolicy;
+use crate::RetryPolicy;
 
 pub(crate) struct TonicTracesClient {
     inner: Mutex<Option<ClientInner>>,

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -658,12 +658,15 @@ mod metric;
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 mod span;
 
-#[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
-pub mod retry_classification;
+#[cfg(all(
+    any(feature = "trace", feature = "metrics", feature = "logs"),
+    any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json")
+))]
+mod retry_classification;
 
 /// Retry logic for exporting telemetry data.
 #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
-pub mod retry;
+mod retry;
 
 pub use crate::exporter::Compression;
 pub use crate::exporter::ExporterBuildError;

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -453,15 +453,17 @@
 //! # #[cfg(all(feature = "trace", feature = "grpc-tonic"))]
 //! # {
 //! use opentelemetry_otlp::{WithTonicConfig, RetryPolicy};
+//! use std::time::Duration;
 //!
 //! let exporter = opentelemetry_otlp::SpanExporter::builder()
 //!     .with_tonic()
-//!     .with_retry_policy(RetryPolicy {
-//!         max_retries: 5,        // number of attempts after the first failure
-//!         initial_delay_ms: 500, // delay before the first retry
-//!         max_delay_ms: 30_000,  // cap on the delay between retries
-//!         jitter_ms: 100,        // upper bound for random jitter added by the exporter
-//!     })
+//!     .with_retry_policy(
+//!         RetryPolicy::default()
+//!             .with_max_retries(5)
+//!             .with_initial_delay(Duration::from_millis(500))
+//!             .with_max_delay(Duration::from_secs(30))
+//!             .with_max_jitter(Duration::from_millis(100)),
+//!     )
 //!     .build()
 //!     .expect("Failed to build SpanExporter");
 //! # }
@@ -560,15 +562,17 @@
 //! # #[cfg(all(feature = "trace", feature = "http-proto"))]
 //! # {
 //! use opentelemetry_otlp::{WithHttpConfig, RetryPolicy};
+//! use std::time::Duration;
 //!
 //! let exporter = opentelemetry_otlp::SpanExporter::builder()
 //!     .with_http()
-//!     .with_retry_policy(RetryPolicy {
-//!         max_retries: 5,        // number of attempts after the first failure
-//!         initial_delay_ms: 500, // delay before the first retry
-//!         max_delay_ms: 30_000,  // cap on the delay between retries
-//!         jitter_ms: 100,        // upper bound for random jitter added by the exporter
-//!     })
+//!     .with_retry_policy(
+//!         RetryPolicy::default()
+//!             .with_max_retries(5)
+//!             .with_initial_delay(Duration::from_millis(500))
+//!             .with_max_delay(Duration::from_secs(30))
+//!             .with_max_jitter(Duration::from_millis(100)),
+//!     )
 //!     .build()
 //!     .expect("Failed to build SpanExporter");
 //! # }
@@ -678,6 +682,8 @@ mod retry_classification;
 ))]
 mod retry;
 
+// RetryPolicy configures transport builders even when no signal is enabled, so
+// it is available under a broader feature gate than the execution modules above.
 #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
 mod retry_policy;
 

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -658,15 +658,28 @@ mod metric;
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
 mod span;
 
-#[cfg(all(
-    any(feature = "trace", feature = "metrics", feature = "logs"),
-    any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json")
+#[cfg(any(
+    feature = "http-proto",
+    feature = "http-json",
+    all(
+        feature = "grpc-tonic",
+        any(feature = "trace", feature = "metrics", feature = "logs")
+    )
 ))]
 mod retry_classification;
 
-/// Retry logic for exporting telemetry data.
-#[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
+#[cfg(any(
+    feature = "http-proto",
+    feature = "http-json",
+    all(
+        feature = "grpc-tonic",
+        any(feature = "trace", feature = "metrics", feature = "logs")
+    )
+))]
 mod retry;
+
+#[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
+mod retry_policy;
 
 pub use crate::exporter::Compression;
 pub use crate::exporter::ExporterBuildError;
@@ -712,7 +725,7 @@ pub use crate::exporter::{
 };
 
 #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
-pub use retry::RetryPolicy;
+pub use retry_policy::RetryPolicy;
 
 /// Type to indicate the builder does not have a client set.
 #[derive(Debug, Default, Clone)]

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -1,22 +1,10 @@
-//! This module provides functionality for retrying operations with exponential backoff and jitter.
-//!
-//! The `RetryPolicy` struct defines the configuration for the retry behavior, including the maximum
-//! number of retries, initial delay, maximum delay, and jitter.
-//!
-//! The `retry_with_backoff` function retries the given operation according to the
-//! specified retry policy, using exponential backoff and jitter to determine the delay between
-//! retries. The function uses error classification to determine retry behavior and can honor
-//! server-provided throttling hints.
+//! Internal retry execution with exponential backoff, jitter, and throttling hints.
 
-#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
+use crate::retry_policy::RetryPolicy;
 use opentelemetry::{otel_debug, otel_info, otel_warn};
-#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 use std::collections::hash_map::DefaultHasher;
-#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 use std::future::Future;
-#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 use std::hash::Hasher;
-#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 use std::time::{Duration, Instant, SystemTime};
 
 /// Sleeps for the given duration.
@@ -28,7 +16,6 @@ use std::time::{Duration, Instant, SystemTime};
 /// Note: `tokio` is not a default feature, so default builds
 /// (`reqwest-blocking-client`) always use `std::thread::sleep`. It is pulled in
 /// by `grpc-tonic`, `reqwest-client`, and `hyper-client`.
-#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 async fn sleep_for(duration: Duration) {
     #[cfg(feature = "tokio")]
     {
@@ -42,7 +29,6 @@ async fn sleep_for(duration: Duration) {
 
 /// Classification of errors for retry purposes.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 pub(crate) enum RetryErrorType {
     /// Error is not retryable (e.g., authentication failure, bad request).
     NonRetryable,
@@ -53,61 +39,12 @@ pub(crate) enum RetryErrorType {
     Throttled(Duration),
 }
 
-/// Configuration for retry policy.
-///
-/// The default is [`RetryPolicy::recommended()`]. Use
-/// [`RetryPolicy::disabled()`] to perform a single export attempt without
-/// retrying.
-#[derive(Debug, Clone)]
-pub struct RetryPolicy {
-    /// Maximum number of retry attempts.
-    pub max_retries: usize,
-    /// Initial delay in milliseconds before the first retry.
-    pub initial_delay_ms: u64,
-    /// Maximum delay in milliseconds between retries.
-    pub max_delay_ms: u64,
-    /// Maximum jitter in milliseconds to add to the delay.
-    pub jitter_ms: u64,
-}
-
-impl Default for RetryPolicy {
-    /// Returns the recommended OTLP retry policy.
-    fn default() -> Self {
-        Self::recommended()
-    }
-}
-
-impl RetryPolicy {
-    /// Returns a retry policy that performs a single export attempt with no retries.
-    pub fn disabled() -> Self {
-        Self {
-            max_retries: 0,
-            initial_delay_ms: 0,
-            max_delay_ms: 0,
-            jitter_ms: 0,
-        }
-    }
-
-    /// Recommended retry policy per the OTLP spec: 3 retries with exponential
-    /// backoff (100ms initial, 1600ms max, 100ms jitter).
-    pub fn recommended() -> Self {
-        Self {
-            max_retries: 3,
-            initial_delay_ms: 100,
-            max_delay_ms: 1600,
-            jitter_ms: 100,
-        }
-    }
-}
-
 /// Maximum duration a server-provided throttle delay (Retry-After / RetryInfo) is allowed
 /// to block the export thread. Any server-provided delay exceeding this cap is truncated.
 /// This prevents a misbehaving server from stalling the export pipeline indefinitely.
-#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 const MAX_THROTTLE_DURATION: Duration = Duration::from_secs(30);
 
 // Generates a random jitter value up to max_jitter
-#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 fn generate_jitter(max_jitter: u64) -> u64 {
     let nanos = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -156,7 +93,6 @@ fn generate_jitter(max_jitter: u64) -> u64 {
 ///
 /// A `Result` containing the operation's result or an error if max retries are reached
 /// or a non-retryable error occurs.
-#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 pub(crate) async fn retry_with_backoff<F, Fut, T, E, C>(
     policy: &RetryPolicy,
     deadline: Duration,
@@ -285,7 +221,7 @@ where
     }
 }
 
-#[cfg(all(test, any(feature = "trace", feature = "metrics", feature = "logs")))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -44,8 +44,8 @@ pub(crate) enum RetryErrorType {
 /// This prevents a misbehaving server from stalling the export pipeline indefinitely.
 const MAX_THROTTLE_DURATION: Duration = Duration::from_secs(30);
 
-// Generates a random jitter value up to max_jitter
-fn generate_jitter(max_jitter: u64) -> u64 {
+// Generates a random jitter value up to max_jitter at millisecond resolution.
+fn generate_jitter(max_jitter: Duration) -> Duration {
     let nanos = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
@@ -53,7 +53,13 @@ fn generate_jitter(max_jitter: u64) -> u64 {
 
     let mut hasher = DefaultHasher::default();
     hasher.write_u32(nanos);
-    hasher.finish() % (max_jitter + 1)
+    let max_jitter_ms = max_jitter.as_millis().min(u64::MAX as u128) as u64;
+    let jitter_ms = if max_jitter_ms == u64::MAX {
+        hasher.finish()
+    } else {
+        hasher.finish() % (max_jitter_ms + 1)
+    };
+    Duration::from_millis(jitter_ms)
 }
 
 /// Retries the given operation with exponential backoff, jitter, and error classification.
@@ -108,12 +114,12 @@ where
 {
     let start = Instant::now();
     let mut attempt = 0;
-    let mut delay = Duration::from_millis(policy.initial_delay_ms);
+    let mut delay = policy.initial_delay;
     // The delay cap may be raised beyond the configured max if a server-provided
     // throttle delay exceeds it, since retrying sooner than the server requested
     // would defeat the purpose of backpressure signalling. The overall exporter
     // timeout remains the final bound.
-    let mut delay_cap = Duration::from_millis(policy.max_delay_ms);
+    let mut delay_cap = policy.max_delay;
 
     loop {
         match operation().await {
@@ -143,7 +149,7 @@ where
                     }
                     RetryErrorType::Retryable if attempt < policy.max_retries => {
                         attempt += 1;
-                        let jitter = Duration::from_millis(generate_jitter(policy.jitter_ms));
+                        let jitter = generate_jitter(policy.max_jitter);
                         let sleep_duration = delay.saturating_add(jitter).min(delay_cap);
 
                         // If the backoff delay would consume all remaining budget, fail now
@@ -182,7 +188,7 @@ where
                             delay = delay.max(capped_server_delay);
                         }
 
-                        let jitter = Duration::from_millis(generate_jitter(policy.jitter_ms));
+                        let jitter = generate_jitter(policy.max_jitter);
                         let sleep_duration = delay.saturating_add(jitter).min(delay_cap);
 
                         // If the throttle delay would consume all remaining budget, fail now
@@ -226,38 +232,56 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    fn policy(
+        max_retries: usize,
+        initial_delay_ms: u64,
+        max_delay_ms: u64,
+        max_jitter_ms: u64,
+    ) -> RetryPolicy {
+        RetryPolicy::default()
+            .with_max_retries(max_retries)
+            .with_initial_delay(Duration::from_millis(initial_delay_ms))
+            .with_max_delay(Duration::from_millis(max_delay_ms))
+            .with_max_jitter(Duration::from_millis(max_jitter_ms))
+    }
+
     #[test]
     fn test_generate_jitter() {
-        let max_jitter = 100;
+        let max_jitter = Duration::from_millis(100);
         let jitter = generate_jitter(max_jitter);
         assert!(jitter <= max_jitter);
+    }
+
+    #[test]
+    fn test_generate_jitter_handles_max_duration() {
+        assert!(generate_jitter(Duration::MAX) <= Duration::from_millis(u64::MAX));
     }
 
     #[test]
     fn test_default_retry_policy() {
         let policy = RetryPolicy::default();
         assert_eq!(policy.max_retries, 3);
-        assert_eq!(policy.initial_delay_ms, 100);
-        assert_eq!(policy.max_delay_ms, 1600);
-        assert_eq!(policy.jitter_ms, 100);
+        assert_eq!(policy.initial_delay, Duration::from_millis(100));
+        assert_eq!(policy.max_delay, Duration::from_millis(1600));
+        assert_eq!(policy.max_jitter, Duration::from_millis(100));
     }
 
     #[test]
     fn test_recommended_retry_policy() {
         let policy = RetryPolicy::recommended();
         assert_eq!(policy.max_retries, 3);
-        assert_eq!(policy.initial_delay_ms, 100);
-        assert_eq!(policy.max_delay_ms, 1600);
-        assert_eq!(policy.jitter_ms, 100);
+        assert_eq!(policy.initial_delay, Duration::from_millis(100));
+        assert_eq!(policy.max_delay, Duration::from_millis(1600));
+        assert_eq!(policy.max_jitter, Duration::from_millis(100));
     }
 
     #[test]
     fn test_disabled_retry_policy() {
         let policy = RetryPolicy::disabled();
         assert_eq!(policy.max_retries, 0);
-        assert_eq!(policy.initial_delay_ms, 0);
-        assert_eq!(policy.max_delay_ms, 0);
-        assert_eq!(policy.jitter_ms, 0);
+        assert_eq!(policy.initial_delay, Duration::ZERO);
+        assert_eq!(policy.max_delay, Duration::ZERO);
+        assert_eq!(policy.max_jitter, Duration::ZERO);
     }
 
     #[tokio::test]
@@ -314,12 +338,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_retry_succeeds_after_retries() {
-        let policy = RetryPolicy {
-            max_retries: 3,
-            initial_delay_ms: 10,
-            max_delay_ms: 100,
-            jitter_ms: 5,
-        };
+        let policy = policy(3, 10, 100, 5);
         let deadline = Duration::from_secs(10);
         let attempts = AtomicUsize::new(0);
 
@@ -347,12 +366,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_retry_fails_after_max_retries() {
-        let policy = RetryPolicy {
-            max_retries: 3,
-            initial_delay_ms: 10,
-            max_delay_ms: 100,
-            jitter_ms: 5,
-        };
+        let policy = policy(3, 10, 100, 5);
         let deadline = Duration::from_secs(10);
         let attempts = AtomicUsize::new(0);
 
@@ -406,12 +420,7 @@ mod tests {
         // Server delay (50ms) is below max_delay_ms (5000ms), so the
         // configured cap never constrains growth. Verifies the basic
         // mechanism: server delay raises the backoff base from initial.
-        let policy = RetryPolicy {
-            max_retries: 2,
-            initial_delay_ms: 10,
-            max_delay_ms: 5000,
-            jitter_ms: 0,
-        };
+        let policy = policy(2, 10, 5000, 0);
         let deadline = Duration::from_secs(10);
         let attempts = AtomicUsize::new(0);
 
@@ -446,12 +455,7 @@ mod tests {
         // Repeated throttles (20ms each) with max_delay_ms = 100ms. Server
         // delay is within the cap, so doubling works without needing to lift
         // the cap: 20ms -> 40ms. Total >= 55ms.
-        let policy = RetryPolicy {
-            max_retries: 2,
-            initial_delay_ms: 10,
-            max_delay_ms: 100,
-            jitter_ms: 0,
-        };
+        let policy = policy(2, 10, 100, 0);
         let attempts = AtomicUsize::new(0);
         let start = Instant::now();
 
@@ -483,12 +487,7 @@ mod tests {
         // Throttle (20ms) then a retryable error, with max_delay_ms = 100ms.
         // Server delay is within the cap, so backoff doubles normally:
         // 20ms (throttled) -> 40ms (retryable, doubled from 20ms base).
-        let policy = RetryPolicy {
-            max_retries: 2,
-            initial_delay_ms: 10,
-            max_delay_ms: 100,
-            jitter_ms: 0,
-        };
+        let policy = policy(2, 10, 100, 0);
         let attempts = AtomicUsize::new(0);
         let start = Instant::now();
 
@@ -528,12 +527,7 @@ mod tests {
         // max_delay_ms (50ms). This is the critical case: the cap must be
         // lifted to MAX_THROTTLE_DURATION so that doubling actually grows
         // the delay instead of clamping it back to the server value.
-        let policy = RetryPolicy {
-            max_retries: 3,
-            initial_delay_ms: 10,
-            max_delay_ms: 50, // intentionally below server delay
-            jitter_ms: 0,
-        };
+        let policy = policy(3, 10, 50, 0); // max delay intentionally below server delay
         let attempts = AtomicUsize::new(0);
         let start = Instant::now();
 
@@ -585,12 +579,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_throttle_after_normal_backoff_does_not_reduce_delay() {
-        let policy = RetryPolicy {
-            max_retries: 3,
-            initial_delay_ms: 50,
-            max_delay_ms: 500,
-            jitter_ms: 0,
-        };
+        let policy = policy(3, 50, 500, 0);
         let attempts = AtomicUsize::new(0);
         let start = Instant::now();
 
@@ -631,13 +620,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_retry_deadline_exceeded() {
-        let policy = RetryPolicy {
-            max_retries: 100, // many retries allowed
-            initial_delay_ms: 50,
-            max_delay_ms: 200,
-            jitter_ms: 0,
-        };
-        // Very short deadline
+        let policy = policy(100, 50, 200, 0); // many retries allowed
+                                              // Very short deadline
         let deadline = Duration::from_millis(120);
         let attempts = AtomicUsize::new(0);
 
@@ -664,12 +648,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_retry_throttle_capped_at_max() {
-        let policy = RetryPolicy {
-            max_retries: 2,
-            initial_delay_ms: 10,
-            max_delay_ms: 100,
-            jitter_ms: 0,
-        };
+        let policy = policy(2, 10, 100, 0);
         let attempts = AtomicUsize::new(0);
 
         let start = Instant::now();
@@ -699,12 +678,7 @@ mod tests {
 
     #[test]
     fn test_retry_succeeds_after_retries_no_tokio() {
-        let policy = RetryPolicy {
-            max_retries: 3,
-            initial_delay_ms: 10,
-            max_delay_ms: 100,
-            jitter_ms: 5,
-        };
+        let policy = policy(3, 10, 100, 5);
         let deadline = Duration::from_secs(10);
         let attempts = AtomicUsize::new(0);
 
@@ -735,12 +709,7 @@ mod tests {
 
     #[test]
     fn test_retry_deadline_exceeded_no_tokio() {
-        let policy = RetryPolicy {
-            max_retries: 100,
-            initial_delay_ms: 50,
-            max_delay_ms: 200,
-            jitter_ms: 0,
-        };
+        let policy = policy(100, 50, 200, 0);
         let deadline = Duration::from_millis(120);
         let attempts = AtomicUsize::new(0);
 
@@ -766,12 +735,7 @@ mod tests {
 
     #[test]
     fn test_retry_throttled_uses_server_delay_no_tokio() {
-        let policy = RetryPolicy {
-            max_retries: 2,
-            initial_delay_ms: 10,
-            max_delay_ms: 5000,
-            jitter_ms: 0,
-        };
+        let policy = policy(2, 10, 5000, 0);
         let deadline = Duration::from_secs(10);
         let attempts = AtomicUsize::new(0);
 

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -8,10 +8,15 @@
 //! retries. The function uses error classification to determine retry behavior and can honor
 //! server-provided throttling hints.
 
+#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 use opentelemetry::{otel_debug, otel_info, otel_warn};
+#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 use std::collections::hash_map::DefaultHasher;
+#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 use std::future::Future;
+#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 use std::hash::Hasher;
+#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 use std::time::{Duration, Instant, SystemTime};
 
 /// Sleeps for the given duration.
@@ -23,6 +28,7 @@ use std::time::{Duration, Instant, SystemTime};
 /// Note: `tokio` is not a default feature, so default builds
 /// (`reqwest-blocking-client`) always use `std::thread::sleep`. It is pulled in
 /// by `grpc-tonic`, `reqwest-client`, and `hyper-client`.
+#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 async fn sleep_for(duration: Duration) {
     #[cfg(feature = "tokio")]
     {
@@ -36,7 +42,8 @@ async fn sleep_for(duration: Duration) {
 
 /// Classification of errors for retry purposes.
 #[derive(Debug, Clone, PartialEq)]
-pub enum RetryErrorType {
+#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
+pub(crate) enum RetryErrorType {
     /// Error is not retryable (e.g., authentication failure, bad request).
     NonRetryable,
     /// Error is retryable with exponential backoff (e.g., server error, network timeout).
@@ -96,9 +103,11 @@ impl RetryPolicy {
 /// Maximum duration a server-provided throttle delay (Retry-After / RetryInfo) is allowed
 /// to block the export thread. Any server-provided delay exceeding this cap is truncated.
 /// This prevents a misbehaving server from stalling the export pipeline indefinitely.
+#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 const MAX_THROTTLE_DURATION: Duration = Duration::from_secs(30);
 
 // Generates a random jitter value up to max_jitter
+#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
 fn generate_jitter(max_jitter: u64) -> u64 {
     let nanos = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -147,7 +156,8 @@ fn generate_jitter(max_jitter: u64) -> u64 {
 ///
 /// A `Result` containing the operation's result or an error if max retries are reached
 /// or a non-retryable error occurs.
-pub async fn retry_with_backoff<F, Fut, T, E, C>(
+#[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
+pub(crate) async fn retry_with_backoff<F, Fut, T, E, C>(
     policy: &RetryPolicy,
     deadline: Duration,
     error_classifier: C,
@@ -275,7 +285,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "trace", feature = "metrics", feature = "logs")))]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/opentelemetry-otlp/src/retry_classification.rs
+++ b/opentelemetry-otlp/src/retry_classification.rs
@@ -7,13 +7,11 @@
 use crate::retry::RetryErrorType;
 
 #[cfg(feature = "grpc-tonic")]
-use tonic;
-
-#[cfg(feature = "grpc-tonic")]
 use tonic_types::StatusExt;
 
 /// HTTP-specific error classification with Retry-After header support.
-pub mod http {
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
+pub(crate) mod http {
     use super::*;
     use std::time::Duration;
 
@@ -26,7 +24,7 @@ pub mod http {
     /// # Retry-After Header Formats
     /// * Seconds: "120"
     /// * HTTP Date: "Fri, 31 Dec 1999 23:59:59 GMT"
-    pub fn classify_http_error(
+    pub(crate) fn classify_http_error(
         status_code: u16,
         retry_after_header: Option<&str>,
     ) -> RetryErrorType {
@@ -93,12 +91,12 @@ pub mod http {
 
 /// gRPC-specific error classification with RetryInfo support.
 #[cfg(feature = "grpc-tonic")]
-pub mod grpc {
+pub(crate) mod grpc {
     use super::*;
 
     /// Classifies a tonic::Status error
     #[cfg(feature = "grpc-tonic")]
-    pub fn classify_tonic_status(status: &tonic::Status) -> RetryErrorType {
+    pub(crate) fn classify_tonic_status(status: &tonic::Status) -> RetryErrorType {
         // Use tonic-types to extract RetryInfo - this is the proper way!
         let retry_delay = status
             .get_details_retry_info()
@@ -171,6 +169,7 @@ pub mod grpc {
 mod tests {
     // Tests for HTTP error classification
 
+    #[cfg(any(feature = "http-proto", feature = "http-json"))]
     mod http_tests {
         use crate::retry::RetryErrorType;
         use crate::retry_classification::http::*;

--- a/opentelemetry-otlp/src/retry_policy.rs
+++ b/opentelemetry-otlp/src/retry_policy.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 /// Configuration for retry policy.
 ///
 /// The default is [`RetryPolicy::recommended()`]. Use
@@ -5,14 +7,10 @@
 /// retrying.
 #[derive(Debug, Clone)]
 pub struct RetryPolicy {
-    /// Maximum number of retry attempts.
-    pub max_retries: usize,
-    /// Initial delay in milliseconds before the first retry.
-    pub initial_delay_ms: u64,
-    /// Maximum delay in milliseconds between retries.
-    pub max_delay_ms: u64,
-    /// Maximum jitter in milliseconds to add to the delay.
-    pub jitter_ms: u64,
+    pub(crate) max_retries: usize,
+    pub(crate) initial_delay: Duration,
+    pub(crate) max_delay: Duration,
+    pub(crate) max_jitter: Duration,
 }
 
 impl Default for RetryPolicy {
@@ -27,9 +25,9 @@ impl RetryPolicy {
     pub fn disabled() -> Self {
         Self {
             max_retries: 0,
-            initial_delay_ms: 0,
-            max_delay_ms: 0,
-            jitter_ms: 0,
+            initial_delay: Duration::ZERO,
+            max_delay: Duration::ZERO,
+            max_jitter: Duration::ZERO,
         }
     }
 
@@ -38,9 +36,33 @@ impl RetryPolicy {
     pub fn recommended() -> Self {
         Self {
             max_retries: 3,
-            initial_delay_ms: 100,
-            max_delay_ms: 1600,
-            jitter_ms: 100,
+            initial_delay: Duration::from_millis(100),
+            max_delay: Duration::from_millis(1600),
+            max_jitter: Duration::from_millis(100),
         }
+    }
+
+    /// Sets the maximum number of retry attempts after the initial export attempt.
+    pub fn with_max_retries(mut self, max_retries: usize) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    /// Sets the delay before the first retry attempt.
+    pub fn with_initial_delay(mut self, initial_delay: Duration) -> Self {
+        self.initial_delay = initial_delay;
+        self
+    }
+
+    /// Sets the maximum delay between retry attempts.
+    pub fn with_max_delay(mut self, max_delay: Duration) -> Self {
+        self.max_delay = max_delay;
+        self
+    }
+
+    /// Sets the maximum random jitter added to each retry delay.
+    pub fn with_max_jitter(mut self, max_jitter: Duration) -> Self {
+        self.max_jitter = max_jitter;
+        self
     }
 }

--- a/opentelemetry-otlp/src/retry_policy.rs
+++ b/opentelemetry-otlp/src/retry_policy.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 ///
 /// The default is [`RetryPolicy::recommended()`]. Use
 /// [`RetryPolicy::disabled()`] to perform a single export attempt without
-/// retrying.
+/// retrying, or customize the recommended behavior with the `with_*` methods.
 #[derive(Debug, Clone)]
 pub struct RetryPolicy {
     pub(crate) max_retries: usize,
@@ -31,8 +31,8 @@ impl RetryPolicy {
         }
     }
 
-    /// Recommended retry policy per the OTLP spec: 3 retries with exponential
-    /// backoff (100ms initial, 1600ms max, 100ms jitter).
+    /// Returns the recommended policy: 3 retries with exponential backoff
+    /// (100ms initial, 1600ms maximum, and up to 100ms jitter).
     pub fn recommended() -> Self {
         Self {
             max_retries: 3,
@@ -55,6 +55,8 @@ impl RetryPolicy {
     }
 
     /// Sets the maximum delay between retry attempts.
+    ///
+    /// A server-provided throttling delay may raise this limit.
     pub fn with_max_delay(mut self, max_delay: Duration) -> Self {
         self.max_delay = max_delay;
         self

--- a/opentelemetry-otlp/src/retry_policy.rs
+++ b/opentelemetry-otlp/src/retry_policy.rs
@@ -1,0 +1,46 @@
+/// Configuration for retry policy.
+///
+/// The default is [`RetryPolicy::recommended()`]. Use
+/// [`RetryPolicy::disabled()`] to perform a single export attempt without
+/// retrying.
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    /// Maximum number of retry attempts.
+    pub max_retries: usize,
+    /// Initial delay in milliseconds before the first retry.
+    pub initial_delay_ms: u64,
+    /// Maximum delay in milliseconds between retries.
+    pub max_delay_ms: u64,
+    /// Maximum jitter in milliseconds to add to the delay.
+    pub jitter_ms: u64,
+}
+
+impl Default for RetryPolicy {
+    /// Returns the recommended OTLP retry policy.
+    fn default() -> Self {
+        Self::recommended()
+    }
+}
+
+impl RetryPolicy {
+    /// Returns a retry policy that performs a single export attempt with no retries.
+    pub fn disabled() -> Self {
+        Self {
+            max_retries: 0,
+            initial_delay_ms: 0,
+            max_delay_ms: 0,
+            jitter_ms: 0,
+        }
+    }
+
+    /// Recommended retry policy per the OTLP spec: 3 retries with exponential
+    /// backoff (100ms initial, 1600ms max, 100ms jitter).
+    pub fn recommended() -> Self {
+        Self {
+            max_retries: 3,
+            initial_delay_ms: 100,
+            max_delay_ms: 1600,
+            jitter_ms: 100,
+        }
+    }
+}

--- a/opentelemetry-otlp/tests/integration_test/tests/http_retry.rs
+++ b/opentelemetry-otlp/tests/integration_test/tests/http_retry.rs
@@ -79,12 +79,11 @@ impl Signal {
 }
 
 fn retry_policy() -> RetryPolicy {
-    RetryPolicy {
-        max_retries: 3,
-        initial_delay_ms: 10,
-        max_delay_ms: 10,
-        jitter_ms: 0,
-    }
+    RetryPolicy::default()
+        .with_max_retries(3)
+        .with_initial_delay(Duration::from_millis(10))
+        .with_max_delay(Duration::from_millis(10))
+        .with_max_jitter(Duration::ZERO)
 }
 
 fn assert_otlp_requests(signal: Signal, requests: &[CapturedHttpRequest], expected_count: usize) {


### PR DESCRIPTION
## Summary

Prepare the OTLP retry API for stabilization by defining a small, evolvable public configuration surface and keeping transport-specific execution details internal.

- retain `RetryPolicy` at the crate root as the only supported retry API
- make the retry engine, error type, protocol classifiers, and implementation modules crate-private
- replace public policy fields with `Duration`-based fluent configuration methods
- separate public policy configuration from the retry execution engine
- tighten feature gates so retry internals compile only for transport and signal combinations that use them
- make jitter generation safe for maximum `Duration` values
- update examples and migration guidance for the stabilized API shape

## API impact

This removes the previously public retry implementation modules and prevents construction of `RetryPolicy` with struct literals. Users should import `opentelemetry_otlp::RetryPolicy` and configure custom policies through its `with_*` methods.

The resulting public surface can evolve without exposing classifier semantics, transport dependency types, engine signatures, or policy storage details as semver commitments.