### PR TITLE
fix(sdk): drop NaN/Infinity measurements in Histogram, Sum, LastValue, PrecomputedSum

### DIFF
--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## vNext
 
+- Fixed `Histogram`, `Sum`, `LastValue`, and `PrecomputedSum` aggregators (and
+  their bound-instrument handles) silently accepting NaN/Infinity
+  measurements. For `Histogram` and `Sum`, a single NaN measurement
+  permanently corrupted the cumulative `sum`/total for the rest of the
+  process's lifetime (`x + NaN == NaN`); `LastValue` and `PrecomputedSum`
+  self-healed on the next valid measurement but still exported one bad value
+  in the meantime, and `PrecomputedSum` under delta temporality corrupted two
+  export cycles. Non-finite measurements are now dropped before recording,
+  matching `ExponentialHistogram`'s existing behavior.
+  ([#3656](https://github.com/open-telemetry/opentelemetry-rust/issues/3656))
 - Publicly export the `OTEL_*`/`OTEL_*_DEFAULT` environment variable name and
   default value constants for `BatchSpanProcessor` (`opentelemetry_sdk::trace`),
   `BatchLogProcessor` (`opentelemetry_sdk::logs`), and `PeriodicReader`

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -86,6 +86,11 @@ struct BoundHistogramHandle<T: Number> {
 impl<T: Number> BoundMeasure<T> for BoundHistogramHandle<T> {
     fn call(&self, measurement: T) {
         let f = measurement.into_float();
+        // Mirror unbound Histogram::call: ignore NaN and infinity so `sum` and
+        // bucket counts can't be permanently corrupted.
+        if !f.is_finite() {
+            return;
+        }
         let index = self.bounds.partition_point(|&x| x < f);
         self.tracker.aggregator.update((measurement, index));
         self.tracker.has_been_updated.store(true, Ordering::Release);
@@ -255,6 +260,12 @@ where
 {
     fn call(&self, measurement: T, attrs: &[KeyValue]) {
         let f = measurement.into_float();
+        // Ignore NaN and infinity: `x < NaN` is always false, so NaN would land
+        // in bucket 0 and, via `Buckets::total += value`, permanently corrupt
+        // `sum` since `x + NaN == NaN` for any `x`.
+        if !f.is_finite() {
+            return;
+        }
         // This search will return an index in the range `[0, bounds.len()]`, where
         // it will return `bounds.len()` if value is greater than the last element
         // of `bounds`. This aligns with the buckets in that the length of buckets
@@ -328,5 +339,32 @@ mod tests {
         assert_eq!(dp.data_points[0].bucket_counts[1], 2); // 2, 3
         assert_eq!(dp.data_points[0].bucket_counts[2], 3); // 4, 5, 6
         assert_eq!(dp.data_points[0].bucket_counts[3], 4); // 7, 8, 9, 10
+    }
+
+    #[test]
+    fn nan_and_infinity_are_ignored() {
+        let hist = Histogram::<f64>::new(
+            Temporality::Cumulative,
+            AttributeSetFilter::new(None),
+            vec![1.0, 3.0, 6.0],
+            true,
+            true,
+            2000,
+        );
+        Measure::call(&hist, 1.0, &[]);
+        Measure::call(&hist, f64::NAN, &[]);
+        Measure::call(&hist, f64::INFINITY, &[]);
+        Measure::call(&hist, f64::NEG_INFINITY, &[]);
+        Measure::call(&hist, 2.0, &[]);
+
+        let (count, dp) = ComputeAggregation::call(&hist, None);
+        let dp = dp.unwrap();
+        let AggregatedMetrics::F64(MetricData::Histogram(dp)) = dp else {
+            unreachable!()
+        };
+        assert_eq!(count, 1);
+        assert_eq!(dp.data_points[0].count, 2);
+        assert_eq!(dp.data_points[0].sum, 3.0);
+        assert!(!dp.data_points[0].sum.is_nan());
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/histogram.rs
+++ b/opentelemetry-sdk/src/metrics/internal/histogram.rs
@@ -368,3 +368,39 @@ mod tests {
         assert!(!dp.data_points[0].sum.is_nan());
     }
 }
+
+#[cfg(all(test, feature = "experimental_metrics_bound_instruments"))]
+mod bound_tests {
+    use super::*;
+
+    #[test]
+    fn bound_nan_and_infinity_are_ignored() {
+        let hist = Histogram::<f64>::new(
+            Temporality::Cumulative,
+            AttributeSetFilter::new(None),
+            vec![1.0, 3.0, 6.0],
+            true,
+            true,
+            2000,
+        );
+        let attrs = [KeyValue::new("k", "v")];
+        let bound = Measure::bind(&hist, &attrs);
+
+        bound.call(1.0);
+        bound.call(f64::NAN);
+        bound.call(f64::INFINITY);
+        bound.call(f64::NEG_INFINITY);
+        bound.call(2.0);
+
+        let (count, dp) = ComputeAggregation::call(&hist, None);
+        let dp = dp.unwrap();
+        let AggregatedMetrics::F64(MetricData::Histogram(dp)) = dp else {
+            unreachable!()
+        };
+        assert_eq!(count, 1);
+        assert_eq!(dp.data_points[0].count, 2);
+        assert_eq!(dp.data_points[0].sum, 3.0);
+        assert!(!dp.data_points[0].sum.is_nan());
+        assert_eq!(dp.data_points[0].attributes, attrs.to_vec());
+    }
+}

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -27,6 +27,11 @@ struct BoundLastValueHandle<T: Number> {
 #[cfg(feature = "experimental_metrics_bound_instruments")]
 impl<T: Number> BoundMeasure<T> for BoundLastValueHandle<T> {
     fn call(&self, measurement: T) {
+        // Mirror unbound LastValue::call: ignore NaN and infinity so a bad
+        // measurement can't be exported before the next valid one overwrites it.
+        if !measurement.into_float().is_finite() {
+            return;
+        }
         self.tracker.aggregator.update(measurement);
         self.tracker.has_been_updated.store(true, Ordering::Release);
     }
@@ -168,6 +173,12 @@ where
     T: Number,
 {
     fn call(&self, measurement: T, attrs: &[KeyValue]) {
+        // Ignore NaN and infinity: `Assign::update` overwrites unconditionally,
+        // so a bad value would still be exported once before the next valid
+        // measurement replaces it.
+        if !measurement.into_float().is_finite() {
+            return;
+        }
         self.filter.apply(attrs, |filtered| {
             self.value_map.measure(measurement, filtered);
         })
@@ -197,6 +208,30 @@ where
             _ => self.cumulative(data),
         };
         (len, new.map(T::make_aggregated_metrics))
+    }
+}
+
+#[cfg(test)]
+mod nan_guard_tests {
+    use super::*;
+    use crate::metrics::data::{AggregatedMetrics, MetricData};
+
+    #[test]
+    fn nan_and_infinity_are_ignored() {
+        let last_value =
+            LastValue::<f64>::new(Temporality::Cumulative, AttributeSetFilter::new(None), 2000);
+        Measure::call(&last_value, 1.0, &[]);
+        Measure::call(&last_value, f64::NAN, &[]);
+        Measure::call(&last_value, f64::INFINITY, &[]);
+        Measure::call(&last_value, f64::NEG_INFINITY, &[]);
+
+        let (count, dp) = ComputeAggregation::call(&last_value, None);
+        let dp = dp.unwrap();
+        let AggregatedMetrics::F64(MetricData::Gauge(dp)) = dp else {
+            unreachable!()
+        };
+        assert_eq!(count, 1);
+        assert_eq!(dp.data_points[0].value, 1.0);
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/internal/last_value.rs
+++ b/opentelemetry-sdk/src/metrics/internal/last_value.rs
@@ -305,4 +305,26 @@ mod tests {
             "bound_count should drop to 0 after handle drops"
         );
     }
+
+    #[test]
+    fn bound_nan_and_infinity_are_ignored() {
+        let last_value =
+            LastValue::<f64>::new(Temporality::Cumulative, AttributeSetFilter::new(None), 2000);
+        let attrs = [KeyValue::new("k", "v")];
+        let bound = Measure::bind(&last_value, &attrs);
+
+        bound.call(1.0);
+        bound.call(f64::NAN);
+        bound.call(f64::INFINITY);
+        bound.call(f64::NEG_INFINITY);
+
+        let (count, dp) = ComputeAggregation::call(&last_value, None);
+        let dp = dp.unwrap();
+        let AggregatedMetrics::F64(MetricData::Gauge(dp)) = dp else {
+            unreachable!()
+        };
+        assert_eq!(count, 1);
+        assert_eq!(dp.data_points[0].value, 1.0);
+        assert_eq!(dp.data_points[0].attributes, attrs.to_vec());
+    }
 }

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -30,6 +30,12 @@ struct BoundPrecomputedSumHandle<T: Number> {
 #[cfg(feature = "experimental_metrics_bound_instruments")]
 impl<T: Number> BoundMeasure<T> for BoundPrecomputedSumHandle<T> {
     fn call(&self, measurement: T) {
+        // Mirror unbound PrecomputedSum::call: ignore NaN and infinity so a bad
+        // value can't get cached in `reported` and poison the delta computed
+        // against the next valid measurement.
+        if !measurement.into_float().is_finite() {
+            return;
+        }
         self.tracker.aggregator.update(measurement);
         self.tracker.has_been_updated.store(true, Ordering::Release);
     }
@@ -171,6 +177,12 @@ where
     T: Number,
 {
     fn call(&self, measurement: T, attrs: &[KeyValue]) {
+        // Ignore NaN and infinity: a cached NaN in `reported` poisons the delta
+        // computed against the *next* valid measurement too
+        // (`valid_val - NaN == NaN`), so a single bad value corrupts two cycles.
+        if !measurement.into_float().is_finite() {
+            return;
+        }
         self.filter.apply(attrs, |filtered| {
             self.value_map.measure(measurement, filtered);
         })
@@ -200,6 +212,34 @@ where
             _ => self.cumulative(data),
         };
         (len, new.map(T::make_aggregated_metrics))
+    }
+}
+
+#[cfg(test)]
+mod nan_guard_tests {
+    use super::*;
+    use crate::metrics::data::{AggregatedMetrics, MetricData};
+
+    #[test]
+    fn nan_and_infinity_are_ignored() {
+        let pre_sum = PrecomputedSum::<f64>::new(
+            Temporality::Cumulative,
+            AttributeSetFilter::new(None),
+            true,
+            2000,
+        );
+        Measure::call(&pre_sum, 1.0, &[]);
+        Measure::call(&pre_sum, f64::NAN, &[]);
+        Measure::call(&pre_sum, f64::INFINITY, &[]);
+        Measure::call(&pre_sum, f64::NEG_INFINITY, &[]);
+
+        let (count, dp) = ComputeAggregation::call(&pre_sum, None);
+        let dp = dp.unwrap();
+        let AggregatedMetrics::F64(MetricData::Sum(dp)) = dp else {
+            unreachable!()
+        };
+        assert_eq!(count, 1);
+        assert_eq!(dp.data_points[0].value, 1.0);
     }
 }
 

--- a/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/precomputed_sum.rs
@@ -241,6 +241,59 @@ mod nan_guard_tests {
         assert_eq!(count, 1);
         assert_eq!(dp.data_points[0].value, 1.0);
     }
+
+    #[test]
+    fn nan_in_delta_temporality_leaves_baseline_cleared() {
+        // Under Delta temporality, dropping a NaN measurement leaves `value_map`
+        // unobserved for that collection cycle. When `drain_and_reset` runs,
+        // `new_reported` does not include the attribute set, which clears the
+        // baseline in `reported`. Consequently, a subsequent valid observation
+        // calculates delta against 0 rather than the previous valid value (100),
+        // re-counting the earlier observation.
+        //
+        // This mirrors the behavior of missing/skipped observations in async instruments
+        // today. Baseline recovery across unobserved cycles without unbounded memory
+        // growth (stale-attribute eviction) is tracked separately.
+        let pre_sum = PrecomputedSum::<f64>::new(
+            Temporality::Delta,
+            AttributeSetFilter::new(None),
+            true,
+            2000,
+        );
+
+        // 1. Initial valid measurement: 100.0
+        Measure::call(&pre_sum, 100.0, &[]);
+        let (count, dp) = ComputeAggregation::call(&pre_sum, None);
+        let dp = dp.unwrap();
+        let AggregatedMetrics::F64(MetricData::Sum(dp)) = dp else {
+            unreachable!()
+        };
+        assert_eq!(count, 1);
+        assert_eq!(dp.data_points[0].value, 100.0);
+
+        // 2. Bad measurement: NaN (dropped by the guard)
+        Measure::call(&pre_sum, f64::NAN, &[]);
+        let (count, dp) = ComputeAggregation::call(&pre_sum, None);
+        // Since NaN was ignored, no points were updated; collection returns count 0
+        assert_eq!(count, 0);
+        let dp = dp.unwrap();
+        let AggregatedMetrics::F64(MetricData::Sum(dp)) = dp else {
+            unreachable!()
+        };
+        assert!(dp.data_points.is_empty());
+
+        // 3. Next valid measurement: 110.0
+        Measure::call(&pre_sum, 110.0, &[]);
+        let (count, dp) = ComputeAggregation::call(&pre_sum, None);
+        let dp = dp.unwrap();
+        let AggregatedMetrics::F64(MetricData::Sum(dp)) = dp else {
+            unreachable!()
+        };
+        assert_eq!(count, 1);
+        // Document current behavior: baseline was cleared when cycle 2 had no observation,
+        // so delta is 110.0 - 0.0 = 110.0 rather than 110.0 - 100.0 = 10.0.
+        assert_eq!(dp.data_points[0].value, 110.0);
+    }
 }
 
 #[cfg(all(test, feature = "experimental_metrics_bound_instruments"))]
@@ -310,5 +363,31 @@ mod tests {
             .next()
             .expect("entry should still exist post-drop");
         assert_eq!(entry.bound_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn bound_nan_and_infinity_are_ignored() {
+        let pre_sum = PrecomputedSum::<f64>::new(
+            Temporality::Cumulative,
+            AttributeSetFilter::new(None),
+            true,
+            2000,
+        );
+        let attrs = [KeyValue::new("k", "v")];
+        let bound = Measure::bind(&pre_sum, &attrs);
+
+        bound.call(1.0);
+        bound.call(f64::NAN);
+        bound.call(f64::INFINITY);
+        bound.call(f64::NEG_INFINITY);
+
+        let (count, dp) = ComputeAggregation::call(&pre_sum, None);
+        let dp = dp.unwrap();
+        let AggregatedMetrics::F64(MetricData::Sum(dp)) = dp else {
+            unreachable!()
+        };
+        assert_eq!(count, 1);
+        assert_eq!(dp.data_points[0].value, 1.0);
+        assert_eq!(dp.data_points[0].attributes, attrs.to_vec());
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -56,6 +56,11 @@ struct BoundSumHandle<T: Number> {
 #[cfg(feature = "experimental_metrics_bound_instruments")]
 impl<T: Number> BoundMeasure<T> for BoundSumHandle<T> {
     fn call(&self, measurement: T) {
+        // Mirror unbound Sum::call: ignore NaN and infinity so the cumulative
+        // total can't be permanently corrupted (`x + NaN == NaN`).
+        if !measurement.into_float().is_finite() {
+            return;
+        }
         self.tracker.aggregator.update(measurement);
         self.tracker.has_been_updated.store(true, Ordering::Release);
     }
@@ -180,6 +185,12 @@ where
     T: Number,
 {
     fn call(&self, measurement: T, attrs: &[KeyValue]) {
+        // Ignore NaN and infinity: `F64AtomicTracker::add`'s CAS loop computes
+        // `current + NaN == NaN`, which would permanently poison the cumulative
+        // total for the rest of the process's lifetime.
+        if !measurement.into_float().is_finite() {
+            return;
+        }
         self.filter.apply(attrs, |filtered| {
             self.value_map.measure(measurement, filtered);
         })
@@ -211,5 +222,34 @@ where
             _ => self.cumulative(data),
         };
         (len, new.map(T::make_aggregated_metrics))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nan_and_infinity_are_ignored() {
+        let sum = Sum::<f64>::new(
+            Temporality::Cumulative,
+            AttributeSetFilter::new(None),
+            false,
+            2000,
+        );
+        Measure::call(&sum, 1.0, &[]);
+        Measure::call(&sum, f64::NAN, &[]);
+        Measure::call(&sum, f64::INFINITY, &[]);
+        Measure::call(&sum, f64::NEG_INFINITY, &[]);
+        Measure::call(&sum, 2.0, &[]);
+
+        let (count, dp) = ComputeAggregation::call(&sum, None);
+        let dp = dp.unwrap();
+        let AggregatedMetrics::F64(MetricData::Sum(dp)) = dp else {
+            unreachable!()
+        };
+        assert_eq!(count, 1);
+        assert_eq!(dp.data_points[0].value, 3.0);
+        assert!(!dp.data_points[0].value.is_nan());
     }
 }

--- a/opentelemetry-sdk/src/metrics/internal/sum.rs
+++ b/opentelemetry-sdk/src/metrics/internal/sum.rs
@@ -253,3 +253,36 @@ mod tests {
         assert!(!dp.data_points[0].value.is_nan());
     }
 }
+
+#[cfg(all(test, feature = "experimental_metrics_bound_instruments"))]
+mod bound_tests {
+    use super::*;
+
+    #[test]
+    fn bound_nan_and_infinity_are_ignored() {
+        let sum = Sum::<f64>::new(
+            Temporality::Cumulative,
+            AttributeSetFilter::new(None),
+            false,
+            2000,
+        );
+        let attrs = [KeyValue::new("k", "v")];
+        let bound = Measure::bind(&sum, &attrs);
+
+        bound.call(1.0);
+        bound.call(f64::NAN);
+        bound.call(f64::INFINITY);
+        bound.call(f64::NEG_INFINITY);
+        bound.call(2.0);
+
+        let (count, dp) = ComputeAggregation::call(&sum, None);
+        let dp = dp.unwrap();
+        let AggregatedMetrics::F64(MetricData::Sum(dp)) = dp else {
+            unreachable!()
+        };
+        assert_eq!(count, 1);
+        assert_eq!(dp.data_points[0].value, 3.0);
+        assert!(!dp.data_points[0].value.is_nan());
+        assert_eq!(dp.data_points[0].attributes, attrs.to_vec());
+    }
+}


### PR DESCRIPTION
Fixes #3656.

Turns out the NaN/Infinity poisoning wasn't just a histogram sum problem. Once I checked the other aggregators (as discussed in the issue comments), they all had the same gap except ExponentialHistogram, which already guards for it.

What was broken:
- Histogram: total += value with no finiteness check, so one NaN poisons sum forever. Also NaN gets miscounted into bucket 0 since partition_point treats x < NaN as always false.
- Sum: same additive corruption, current + NaN is NaN forever after that.
- LastValue: just overwrites on the next call, so it recovers, but still exports one bad value in between.
- PrecomputedSum: also overwrite based, but under delta temporality the cached NaN poisons the delta for the next cycle too, so a single bad value corrupts two exports.
- Every bound handle (behind experimental_metrics_bound_instruments) has the exact same unguarded path as its unbound counterpart.

Fix is just copying ExponentialHistogram's existing check (measurement not finite -> drop it) into all four aggregators, at both the unbound call and the bound handle call, so it happens before any lock or map work.

Added one test per aggregator recording NaN/Inf alongside valid values and checking the bad ones get dropped. Ran the full metrics internal test suite plus clippy and fmt, all clean. Updated the changelog too.