### PR TITLE
refactor(otlp): remove obsolete exporter placeholder

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -27,6 +27,9 @@ release:
 
 ### Other changes
 
+- **Breaking** Remove the obsolete, doc-hidden `NoExporterConfig` placeholder
+  left over from the removed pipeline API. No replacement is needed when using
+  the current signal exporter builders.
 - Return an exporter build error for invalid OTLP/HTTP endpoint environment
   variables instead of silently falling back to another endpoint or localhost.
   Empty endpoint environment variables are now treated as unset.

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -850,11 +850,6 @@ impl Protocol {
     }
 }
 
-#[derive(Debug, Default)]
-#[doc(hidden)]
-/// Placeholder type when no exporter pipeline has been configured in telemetry pipeline.
-pub struct NoExporterConfig(());
-
 /// Re-exported types from the `tonic` crate.
 #[cfg(feature = "grpc-tonic")]
 pub mod tonic_types {


### PR DESCRIPTION
## Summary

- remove the public, doc-hidden `NoExporterConfig` placeholder left over from the removed pipeline API
- document the breaking API cleanup and clarify that no replacement is needed

`NoExporterConfig` has no remaining references in the crate. The current `SpanExporter`, `MetricExporter`, and `LogExporter` builder APIs do not use it.
