### PR TITLE
refactor(otlp): internalize protocol environment resolution

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -34,6 +34,10 @@ release:
 
 ### Other changes
 
+- **Breaking** Make `Protocol::from_env()` crate-private. Exporter builders
+  already resolve `OTEL_EXPORTER_OTLP_PROTOCOL` when built; applications that
+  need to inspect the raw environment setting should read the variable
+  directly.
 - Return an exporter build error for invalid OTLP/HTTP endpoint environment
   variables instead of silently falling back to another endpoint or localhost.
   Empty endpoint environment variables are now treated as unset.

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -785,7 +785,7 @@ impl Protocol {
     /// - The environment variable is not set
     /// - The value doesn't match a known protocol
     /// - The specified protocol's feature is not enabled
-    pub fn from_env() -> Option<Self> {
+    pub(crate) fn from_env() -> Option<Self> {
         Self::parse_from_env_var(OTEL_EXPORTER_OTLP_PROTOCOL)
     }
 


### PR DESCRIPTION
## Summary

- make `Protocol::from_env()` crate-private
- keep environment-driven protocol selection inside the exporter builders
- document migration for applications that inspect the raw environment value

`Protocol::from_env()` is an implementation helper used by internal transport resolution. Keeping it public would commit the stabilized API to global environment access, feature-sensitive parsing, warning behavior, and an ambiguous `Option` result.

The public `Protocol` enum and `.with_protocol(...)` builder configuration remain unchanged.