### PR TITLE
refactor(otlp): make exporter option enums extensible

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -39,6 +39,14 @@ release:
   breaking downstream users. External exhaustive matches must add a wildcard
   arm. Constructing existing variants and passing them to exporter builders is
   unchanged.
+  ```rust
+  let protocol_name = match protocol {
+      Protocol::Grpc => "grpc",
+      Protocol::HttpBinary => "http/protobuf",
+      Protocol::HttpJson => "http/json",
+      _ => "unknown", // Required because Protocol is non-exhaustive.
+  };
+  ```
 - Return an exporter build error for invalid OTLP/HTTP endpoint environment
   variables instead of silently falling back to another endpoint or localhost.
   Empty endpoint environment variables are now treated as unset.

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -34,6 +34,11 @@ release:
 
 ### Other changes
 
+- **Breaking** Mark `Protocol` and `Compression` as non-exhaustive so new OTLP
+  protocols, encodings, and compression algorithms can be added without
+  breaking downstream users. External exhaustive matches must add a wildcard
+  arm. Constructing existing variants and passing them to exporter builders is
+  unchanged.
 - Return an exporter build error for invalid OTLP/HTTP endpoint environment
   variables instead of silently falling back to another endpoint or localhost.
   Empty endpoint environment variables are now treated as unset.

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -152,6 +152,7 @@ pub enum ExporterBuildError {
 
 /// The compression algorithm to use when sending data.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Compression {
     /// Compresses data using gzip.

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -764,6 +764,7 @@ use serde::{Deserialize, Serialize};
 
 /// The communication protocol to use when exporting data.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Protocol {
     /// GRPC protocol


### PR DESCRIPTION
## Summary

- mark `Protocol` as non-exhaustive
- mark `Compression` as non-exhaustive
- document the exhaustive-match migration

This preserves the ability to add future OTLP transports, encodings, and compression algorithms without forcing a major-version release.

Normal exporter configuration is unchanged: existing variants can still be constructed and passed to `.with_protocol(...)` and `.with_compression(...)`. Only external exhaustive matches must add a wildcard arm.