### PR TITLE
refactor(otlp): seal exporter configuration traits

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -79,12 +79,6 @@ release:
   `WithTonicConfig`. These traits remain public for calling configuration
   methods on OTLP builders, but can no longer be implemented for external
   types.
-- Return an exporter build error for invalid OTLP/HTTP endpoint environment
-  variables instead of silently falling back to another endpoint or localhost.
-  Empty endpoint environment variables are now treated as unset.
-- Add `WithHttpConfig::with_max_request_body_size`. OTLP/HTTP request bodies
-  are now limited to 64 MiB by default, before and after compression; oversized
-  requests are discarded without being sent or retried.
 - Add support for INSECURE environment variables for gRPC (env-var-only, no builder method, per spec):
   `OTEL_EXPORTER_OTLP_INSECURE` (generic), `OTEL_EXPORTER_OTLP_TRACES_INSECURE`,
   `OTEL_EXPORTER_OTLP_METRICS_INSECURE`, `OTEL_EXPORTER_OTLP_LOGS_INSECURE`.

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -75,6 +75,16 @@ release:
   OTLP/HTTP request bodies are now limited to 64 MiB by default, before and
   after compression; oversized requests are discarded without being sent or
   retried.
+- **Breaking** Seal `WithExportConfig`, `WithHttpConfig`, and
+  `WithTonicConfig`. These traits remain public for calling configuration
+  methods on OTLP builders, but can no longer be implemented for external
+  types.
+- Return an exporter build error for invalid OTLP/HTTP endpoint environment
+  variables instead of silently falling back to another endpoint or localhost.
+  Empty endpoint environment variables are now treated as unset.
+- Add `WithHttpConfig::with_max_request_body_size`. OTLP/HTTP request bodies
+  are now limited to 64 MiB by default, before and after compression; oversized
+  requests are discarded without being sent or retried.
 - Add support for INSECURE environment variables for gRPC (env-var-only, no builder method, per spec):
   `OTEL_EXPORTER_OTLP_INSECURE` (generic), `OTEL_EXPORTER_OTLP_TRACES_INSECURE`,
   `OTEL_EXPORTER_OTLP_METRICS_INSECURE`, `OTEL_EXPORTER_OTLP_LOGS_INSECURE`.

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -829,7 +829,9 @@ impl HasHttpConfig for HttpExporterBuilder {
 ///     .with_headers(std::collections::HashMap::new());
 /// # }
 /// ```
-pub trait WithHttpConfig {
+///
+/// This trait is sealed and cannot be implemented for types outside this crate.
+pub trait WithHttpConfig: super::sealed::WithHttpConfig {
     /// Assign client implementation
     fn with_http_client<T: HttpClient + 'static>(self, client: T) -> Self;
 
@@ -850,6 +852,8 @@ pub trait WithHttpConfig {
     /// The default is 64 MiB.
     fn with_max_request_body_size(self, max_size: usize) -> Self;
 }
+
+impl<B: HasHttpConfig> super::sealed::WithHttpConfig for B {}
 
 impl<B: HasHttpConfig> WithHttpConfig for B {
     fn with_http_client<T: HttpClient + 'static>(mut self, client: T) -> Self {

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -58,6 +58,16 @@ pub(crate) mod http;
 #[cfg(feature = "grpc-tonic")]
 pub(crate) mod tonic;
 
+mod sealed {
+    pub trait WithExportConfig {}
+
+    #[cfg(any(feature = "http-proto", feature = "http-json"))]
+    pub trait WithHttpConfig {}
+
+    #[cfg(feature = "grpc-tonic")]
+    pub trait WithTonicConfig {}
+}
+
 /// Configuration for the OTLP exporter.
 #[derive(Debug, Default)]
 pub(crate) struct ExportConfig {
@@ -283,7 +293,9 @@ impl HasExportConfig for HttpExporterBuilder {
 ///     .with_endpoint("http://localhost:7201");
 /// # }
 /// ```
-pub trait WithExportConfig {
+///
+/// This trait is sealed and cannot be implemented for types outside this crate.
+pub trait WithExportConfig: sealed::WithExportConfig {
     /// Set the address of the OTLP collector. If not set or set to empty string, the default address is used.
     ///
     /// Note: Programmatically setting this will override any value set via the environment variable.
@@ -301,6 +313,8 @@ pub trait WithExportConfig {
     /// Note: Programmatically setting this will override any value set via the environment variable.
     fn with_timeout(self, timeout: Duration) -> Self;
 }
+
+impl<B: HasExportConfig> sealed::WithExportConfig for B {}
 
 impl<B: HasExportConfig> WithExportConfig for B {
     fn with_endpoint<T: Into<String>>(mut self, endpoint: T) -> Self {

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -643,7 +643,9 @@ impl HasTonicConfig for TonicExporterBuilder {
 ///     .with_compression(opentelemetry_otlp::Compression::Gzip);
 /// # }
 /// ```
-pub trait WithTonicConfig {
+///
+/// This trait is sealed and cannot be implemented for types outside this crate.
+pub trait WithTonicConfig: super::sealed::WithTonicConfig {
     /// Set the TLS settings for the collector endpoint.
     #[cfg(any(
         feature = "tls",
@@ -760,6 +762,8 @@ pub trait WithTonicConfig {
     /// Set the retry policy for gRPC requests.
     fn with_retry_policy(self, policy: RetryPolicy) -> Self;
 }
+
+impl<B: HasTonicConfig> super::sealed::WithTonicConfig for B {}
 
 impl<B: HasTonicConfig> WithTonicConfig for B {
     #[cfg(any(


### PR DESCRIPTION
## Summary

- seal `WithExportConfig`, `WithHttpConfig`, and `WithTonicConfig` with private supertraits
- keep all three traits public for importing and calling their existing configuration methods
- clarify the trait contract in rustdoc
- consolidate the changelog so it no longer instructs external `WithHttpConfig` implementations to add a method

These traits provide extension methods for OTLP-owned builders. External implementations have no access to the private builder configuration they are designed to modify, but leaving the traits open would make every future method addition a breaking change.

Normal exporter builder usage is unchanged. Only implementing these traits for downstream-owned types is no longer supported.