### PR TITLE
refactor(otlp): internalize transport builders

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -73,6 +73,18 @@ release:
   to builders where no transport has been selected, matching the span and log
   exporter builders. Select a transport once; `with_temporality()` remains
   available before or after transport selection.
+- **Breaking** Remove the public `HttpExporterBuilder` and
+  `TonicExporterBuilder` transport-first APIs. Configure transports through the
+  signal builders instead:
+  - Replace `HttpExporterBuilder::default()` with the corresponding signal
+    exporter builder followed by `.with_http()`, then replace
+    `.build_span_exporter()` or `.build_log_exporter()` with `.build()`.
+  - Replace `.build_metrics_exporter(temporality)` with
+    `.with_temporality(temporality).build()`.
+  - Replace `TonicExporterBuilder::default()` with the corresponding signal
+    exporter builder followed by `.with_tonic()`.
+  Transport-specific configuration methods remain available after
+  `.with_http()` or `.with_tonic()`.
 - Return an exporter build error for invalid OTLP/HTTP endpoint environment
   variables instead of silently falling back to another endpoint or localhost.
   Empty endpoint environment variables are now treated as unset.

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -159,7 +159,7 @@ pub(crate) struct HttpConfig {
 /// ```
 ///
 #[derive(Debug)]
-pub struct HttpExporterBuilder {
+pub(crate) struct HttpExporterBuilder {
     pub(crate) exporter_config: ExportConfig,
     pub(crate) http_config: HttpConfig,
 }
@@ -324,7 +324,7 @@ impl HttpExporterBuilder {
 
     /// Create a span exporter with the current configuration
     #[cfg(feature = "trace")]
-    pub fn build_span_exporter(mut self) -> Result<crate::SpanExporter, ExporterBuildError> {
+    pub(crate) fn build_span_exporter(mut self) -> Result<crate::SpanExporter, ExporterBuildError> {
         use crate::{
             OTEL_EXPORTER_OTLP_TRACES_COMPRESSION, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
             OTEL_EXPORTER_OTLP_TRACES_HEADERS, OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
@@ -345,7 +345,7 @@ impl HttpExporterBuilder {
 
     /// Create a log exporter with the current configuration
     #[cfg(feature = "logs")]
-    pub fn build_log_exporter(mut self) -> Result<crate::LogExporter, ExporterBuildError> {
+    pub(crate) fn build_log_exporter(mut self) -> Result<crate::LogExporter, ExporterBuildError> {
         use crate::{
             OTEL_EXPORTER_OTLP_LOGS_COMPRESSION, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
             OTEL_EXPORTER_OTLP_LOGS_HEADERS, OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
@@ -366,7 +366,7 @@ impl HttpExporterBuilder {
 
     /// Create a metrics exporter with the current configuration
     #[cfg(feature = "metrics")]
-    pub fn build_metrics_exporter(
+    pub(crate) fn build_metrics_exporter(
         mut self,
         temporality: opentelemetry_sdk::metrics::Temporality,
     ) -> Result<crate::MetricExporter, ExporterBuildError> {
@@ -894,11 +894,11 @@ mod tests {
     use crate::exporter::http::HttpConfig;
     use crate::exporter::tests::run_env_test;
     use crate::{
-        HttpExporterBuilder, WithExportConfig, WithHttpConfig, OTEL_EXPORTER_OTLP_ENDPOINT,
+        WithExportConfig, WithHttpConfig, OTEL_EXPORTER_OTLP_ENDPOINT,
         OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
     };
 
-    use super::{build_endpoint_uri, resolve_http_endpoint};
+    use super::{build_endpoint_uri, resolve_http_endpoint, HttpExporterBuilder};
 
     #[test]
     fn test_append_signal_path_to_generic_env() {

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -428,7 +428,7 @@ mod tests {
     #[cfg(any(feature = "http-proto", feature = "http-json"))]
     #[test]
     fn test_default_http_endpoint() {
-        let exporter_builder = crate::HttpExporterBuilder::default();
+        let exporter_builder = crate::exporter::http::HttpExporterBuilder::default();
 
         assert_eq!(exporter_builder.exporter_config.endpoint, None);
     }
@@ -476,7 +476,7 @@ mod tests {
     #[cfg(feature = "grpc-tonic")]
     #[test]
     fn test_default_tonic_endpoint() {
-        let exporter_builder = crate::TonicExporterBuilder::default();
+        let exporter_builder = crate::exporter::tonic::TonicExporterBuilder::default();
 
         assert_eq!(exporter_builder.exporter_config.endpoint, None);
     }

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -124,7 +124,7 @@ impl TryFrom<Compression> for tonic::codec::CompressionEncoding {
 /// # }
 /// ```
 #[derive(Debug)]
-pub struct TonicExporterBuilder {
+pub(crate) struct TonicExporterBuilder {
     pub(crate) tonic_config: TonicConfig,
     pub(crate) exporter_config: ExportConfig,
 }
@@ -822,7 +822,9 @@ mod tests {
     use crate::exporter::tonic::WithTonicConfig;
     #[cfg(feature = "grpc-tonic")]
     use crate::exporter::Compression;
-    use crate::{TonicExporterBuilder, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT};
+    use crate::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+
+    use super::TonicExporterBuilder;
     use crate::{OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_TRACES_HEADERS};
     use http::{HeaderMap, HeaderName, HeaderValue};
     use tonic::metadata::{MetadataMap, MetadataValue};

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -714,8 +714,12 @@ pub use crate::logs::{
 };
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
+use crate::exporter::http::HttpExporterBuilder;
+#[cfg(any(feature = "http-proto", feature = "http-json"))]
 pub use crate::exporter::http::WithHttpConfig;
 
+#[cfg(feature = "grpc-tonic")]
+use crate::exporter::tonic::TonicExporterBuilder;
 #[cfg(feature = "grpc-tonic")]
 pub use crate::exporter::tonic::WithTonicConfig;
 
@@ -734,27 +738,17 @@ pub use retry_policy::RetryPolicy;
 #[derive(Debug, Default, Clone)]
 pub struct NoExporterBuilderSet;
 
-/// Type to hold the [TonicExporterBuilder] and indicate it has been set.
-///
-/// Allowing access to [TonicExporterBuilder] specific configuration methods.
+/// Type indicating that the tonic transport has been selected.
 #[cfg(feature = "grpc-tonic")]
 // This is for clippy to work with only the grpc-tonic feature enabled
 #[allow(unused)]
 #[derive(Debug)]
 pub struct TonicExporterBuilderSet(TonicExporterBuilder);
 
-/// Type to hold the [HttpExporterBuilder] and indicate it has been set.
-///
-/// Allowing access to [HttpExporterBuilder] specific configuration methods.
+/// Type indicating that the HTTP transport has been selected.
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
 #[derive(Debug)]
 pub struct HttpExporterBuilderSet(HttpExporterBuilder);
-
-#[cfg(any(feature = "http-proto", feature = "http-json"))]
-pub use crate::exporter::http::HttpExporterBuilder;
-
-#[cfg(feature = "grpc-tonic")]
-pub use crate::exporter::tonic::TonicExporterBuilder;
 
 /// The communication protocol to use when exporting data.
 #[non_exhaustive]

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -11,10 +11,16 @@ use std::time;
 use crate::{exporter::HasExportConfig, ExporterBuildError, NoExporterBuilderSet};
 
 #[cfg(feature = "grpc-tonic")]
-use crate::{exporter::tonic::HasTonicConfig, TonicExporterBuilder, TonicExporterBuilderSet};
+use crate::{
+    exporter::tonic::{HasTonicConfig, TonicExporterBuilder},
+    TonicExporterBuilderSet,
+};
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
-use crate::{exporter::http::HasHttpConfig, HttpExporterBuilder, HttpExporterBuilderSet};
+use crate::{
+    exporter::http::{HasHttpConfig, HttpExporterBuilder},
+    HttpExporterBuilderSet,
+};
 
 /// Compression algorithm to use, defaults to none.
 pub const OTEL_EXPORTER_OTLP_LOGS_COMPRESSION: &str = "OTEL_EXPORTER_OTLP_LOGS_COMPRESSION";


### PR DESCRIPTION
## Summary

- make `HttpExporterBuilder` and `TonicExporterBuilder` crate-private
- remove their root-level re-exports
- keep the public signal builders and `.with_http()` / `.with_tonic()` configuration paths unchanged
- document direct migrations for span, log, and metric exporters

The raw transport builders duplicate the supported signal-first API and expose transport implementation structure as part of the semver contract. After this change, exporters are consistently created through `SpanExporter::builder()`, `MetricExporter::builder()`, or `LogExporter::builder()`.

## Migration

| Previous API | Replacement |
| --- | --- |
| `HttpExporterBuilder::default().build_span_exporter()` | `SpanExporter::builder().with_http().build()` |
| `HttpExporterBuilder::default().build_log_exporter()` | `LogExporter::builder().with_http().build()` |
| `HttpExporterBuilder::default().build_metrics_exporter(temporality)` | `MetricExporter::builder().with_http().with_temporality(temporality).build()` |
| `TonicExporterBuilder::default()` | The corresponding signal builder followed by `.with_tonic()` |

Transport configuration continues to chain after selecting the transport. For example, custom HTTP client configuration migrates as follows:

```rust
// Before
let exporter = HttpExporterBuilder::default()
    .with_http_client(client)
    .with_endpoint(endpoint)
    .build_span_exporter()?;

// After
let exporter = SpanExporter::builder()
    .with_http()
    .with_http_client(client)
    .with_endpoint(endpoint)
    .build()?;
```

Headers, TLS configuration, metadata, interceptors, compression, retry policy, request body limits, endpoints, and timeouts remain available through the signal builders after `.with_http()` or `.with_tonic()`.


### Reusing shared HTTP configuration

Code that previously returned a concrete `HttpExporterBuilder` can instead use a generic helper to configure any HTTP-selected signal builder:

```rust
fn configure_http<B>(builder: B) -> B
where
    B: WithExportConfig + WithHttpConfig,
{
    builder
        .with_timeout(Duration::from_secs(5))
        .with_compression(Compression::Gzip)
}

let span_exporter = configure_http(SpanExporter::builder().with_http()).build()?;
let log_exporter = configure_http(LogExporter::builder().with_http()).build()?;
```
