### PR TITLE
refactor(http): remove deprecated send method

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+- **Breaking** Removed the deprecated `HttpClient::send` method, which accepted
+  `Request<Vec<u8>>`. Implement and call `HttpClient::send_bytes` instead,
+  converting existing requests with `request.map(Bytes::from)` when needed.
+
 - Limit HTTP response body reads to 4 MiB in built-in HTTP clients (`reqwest` async/blocking and `hyper`) by enforcing the cap while streaming response chunks and reads that exceed the limit are aborted to prevent unbounded memory allocation.
 
 - Return HTTP error responses from the built-in reqwest and hyper clients instead

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -70,17 +70,6 @@ pub type HttpError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// users to bring their choice of HTTP client.
 #[async_trait]
 pub trait HttpClient: Debug + Send + Sync {
-    /// Send the specified HTTP request with `Vec<u8>` payload
-    ///
-    /// Returns the HTTP response including the status code and body.
-    ///
-    /// Returns an error if it can't connect to the server or the request could not be completed,
-    /// e.g. because of a timeout, infinite redirects, or a loss of connection.
-    #[deprecated(note = "Use `send_bytes` with `Bytes` payload instead.")]
-    async fn send(&self, request: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
-        self.send_bytes(request.map(Into::into)).await
-    }
-
     /// Send the specified HTTP request with `Bytes` payload.
     ///
     /// Returns the HTTP response including the status code and body.


### PR DESCRIPTION
## Summary

- remove the deprecated `HttpClient::send` method that accepted `Request<Vec<u8>>`
- retain `HttpClient::send_bytes` as the single request-sending API
- document migration using `request.map(Bytes::from)` when converting existing requests

## Rationale

`HttpClient::send` has been deprecated since 0.28 and only forwards to `send_bytes`. Removing it before stabilizing `opentelemetry-http` avoids carrying the obsolete body representation as a long-term compatibility commitment. Current `HttpClient` implementations already need to implement `send_bytes`.