### PR TITLE
refactor(otlp): restrict metric transport selection

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -69,6 +69,10 @@ release:
   `http://localhost:4317`. Omit `.with_endpoint(...)` to let the selected
   transport use its correct default, or provide the appropriate URL explicitly.
   [#3690](https://github.com/open-telemetry/opentelemetry-rust/issues/3690)
+- **Breaking** Restrict `MetricExporterBuilder::with_http()` and `with_tonic()`
+  to builders where no transport has been selected, matching the span and log
+  exporter builders. Select a transport once; `with_temporality()` remains
+  available before or after transport selection.
 - Return an exporter build error for invalid OTLP/HTTP endpoint environment
   variables instead of silently falling back to another endpoint or localhost.
   Empty endpoint environment variables are now treated as unset.

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -89,9 +89,7 @@ impl MetricExporterBuilder<NoExporterBuilderSet> {
             crate::Protocol::HttpJson => self.with_http().build(),
         }
     }
-}
 
-impl<C> MetricExporterBuilder<C> {
     /// With the gRPC Tonic transport.
     #[cfg(feature = "grpc-tonic")]
     pub fn with_tonic(self) -> MetricExporterBuilder<TonicExporterBuilderSet> {
@@ -109,7 +107,9 @@ impl<C> MetricExporterBuilder<C> {
             temporality: self.temporality,
         }
     }
+}
 
+impl<C> MetricExporterBuilder<C> {
     /// Set the temporality for the metrics.
     ///
     /// Note: Programmatically setting this will override any value set via the environment variable.


### PR DESCRIPTION
## Summary

- allow `MetricExporterBuilder::with_http()` and `with_tonic()` only before a transport is selected
- align metric exporter builders with span and log exporter builders
- keep `with_temporality()` available before and after transport selection

Repeated transport selection no longer compiles. Keep only the final intended transport call. Normal builder usage is unchanged.

## Validation

- all-feature OTLP library tests and doc tests
- metrics with gRPC-only and HTTP/protobuf-only checks