### PR TITLE
refactor(http): remove unused hyper body type

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -6,6 +6,9 @@
   `Request<Vec<u8>>`. Implement and call `HttpClient::send_bytes` instead,
   converting existing requests with `request.map(Bytes::from)` when needed.
 
+- **Breaking:** Remove `opentelemetry_http::hyper::Body`, which is no longer used
+  by any public constructor. Use `http_body_util::Full<Bytes>` for custom Hyper
+  client request bodies.
 - Limit HTTP response body reads to 4 MiB in built-in HTTP clients (`reqwest` async/blocking and `hyper`) by enforcing the cap while streaming response chunks and reads that exceed the limit are aborted to prevent unbounded memory allocation.
 
 - Return HTTP error responses from the built-in reqwest and hyper clients instead

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -173,15 +173,13 @@ pub mod hyper {
     use crate::ResponseBodyTooLarge;
     use http::HeaderValue;
     use http_body_util::{BodyExt, Full};
-    use hyper::body::{Body as HttpBody, Frame};
+    use hyper::body::Body as _;
     use hyper_util::client::legacy::{
         connect::{Connect, HttpConnector},
         Client,
     };
     use opentelemetry::otel_debug;
     use std::fmt::Debug;
-    use std::pin::Pin;
-    use std::task::{self, Poll};
     use std::time::Duration;
     use tokio::time;
 
@@ -190,7 +188,7 @@ pub mod hyper {
     where
         C: Connect + Clone + Send + Sync + 'static,
     {
-        inner: Client<C, Body>,
+        inner: Client<C, Full<Bytes>>,
         timeout: Duration,
         authorization: Option<HeaderValue>,
     }
@@ -229,7 +227,7 @@ pub mod hyper {
         async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
             otel_debug!(name: "HyperClient.Send");
             let (parts, body) = request.into_parts();
-            let mut request = Request::from_parts(parts, Body(Full::from(body)));
+            let mut request = Request::from_parts(parts, Full::from(body));
             if let Some(ref authorization) = self.authorization {
                 request
                     .headers_mut()
@@ -260,32 +258,6 @@ pub mod hyper {
                 .body(body_bytes.freeze())?;
             *http_response.headers_mut() = headers;
             Ok(http_response)
-        }
-    }
-
-    pub struct Body(Full<Bytes>);
-
-    impl HttpBody for Body {
-        type Data = Bytes;
-        type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-
-        #[inline]
-        fn poll_frame(
-            self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
-        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-            let inner_body = unsafe { self.map_unchecked_mut(|b| &mut b.0) };
-            inner_body.poll_frame(cx).map_err(Into::into)
-        }
-
-        #[inline]
-        fn is_end_stream(&self) -> bool {
-            self.0.is_end_stream()
-        }
-
-        #[inline]
-        fn size_hint(&self) -> hyper::body::SizeHint {
-            self.0.size_hint()
         }
     }
 }


### PR DESCRIPTION
Remove the unused public `opentelemetry_http::hyper::Body` wrapper and use `http_body_util::Full<Bytes>` directly. This also removes its unsafe pin projection. I can't see any usages of this via the github search and it's unnecessarily available through our public API. 

Validated with all-feature and Hyper-only `opentelemetry-http` tests, clippy, and the OTLP Hyper client check.