### PR TITLE
chore(otlp): tighten external-type allowlist to exact public API types

### DIFF
--- a/opentelemetry-otlp/allowed-external-types.toml
+++ b/opentelemetry-otlp/allowed-external-types.toml
@@ -3,19 +3,24 @@
 # This is used with cargo-check-external-types to reduce the surface area of downstream crates from
 # the public API. Ideally this can have a few exceptions as possible.
 allowed_external_types = [
-    "opentelemetry_http::*",
-    "opentelemetry_sdk::*",
-    # serde
-    "serde::de::Deserialize",
-    "serde::ser::Serialize",
-    ## serde: Required for serde version 1.0.222 or greater.
+    # opentelemetry-http
+    "opentelemetry_http::HttpClient",
+
+    # opentelemetry-sdk
+    "opentelemetry_sdk::logs::export::LogExporter",
+    "opentelemetry_sdk::metrics::exporter::PushMetricExporter",
+    "opentelemetry_sdk::metrics::Temporality",
+    "opentelemetry_sdk::trace::export::SpanExporter",
+
+    # serde (serde_core re-export used since serde 1.0.222+)
     "serde_core::de::Deserialize",
     "serde_core::ser::Serialize",
-    # tonic is a pre 1.0 crate
+
+    # tonic (pre-1.0 crate)
     "tonic::metadata::map::MetadataMap",
+    "tonic::service::interceptor::Interceptor",
+    "tonic::transport::channel::Channel",
     "tonic::transport::channel::tls::ClientTlsConfig",
     "tonic::transport::tls::Certificate",
     "tonic::transport::tls::Identity",
-    "tonic::transport::channel::Channel",
-    "tonic::service::interceptor::Interceptor",
 ]


### PR DESCRIPTION
## Changes

Replace broad `opentelemetry_sdk::*` and `opentelemetry_http::*` wildcards in `opentelemetry-otlp/allowed-external-types.toml` with the specific types that actually appear in the public API:

**`opentelemetry_http`** (was `::*`):
- `opentelemetry_http::HttpClient`

**`opentelemetry_sdk`** (was `::*`):
- `opentelemetry_sdk::logs::export::LogExporter`
- `opentelemetry_sdk::metrics::exporter::PushMetricExporter`
- `opentelemetry_sdk::metrics::Temporality`
- `opentelemetry_sdk::trace::export::SpanExporter`

I can imagine that we might want to narrow this down _even more_ as we go about the final OTLP stabilisation bits. 

Also:
- Removed stale `serde::de::Deserialize` / `serde::ser::Serialize` entries (only the `serde_core::` variants are referenced since serde 1.0.222+)
- Removed the now-unused `tonic::status::Status` entry (internalised by #3672)

## Motivation

The wildcards defeat the purpose of `cargo-check-external-types` -- new types from these crates could leak into the public API without CI catching them. With explicit entries, any accidental new public API surface will fail the external-types check.

## Validation

Verified locally with the same toolchain and version CI uses (`nightly-2025-05-04`, `cargo-check-external-types@0.2.0`):

```
$ cargo +nightly-2025-05-04 check-external-types --all-features --config allowed-external-types.toml
0 errors, 0 warnings emitted
```