### PR TITLE
refactor(http): seal ResponseExt trait

### DIFF
--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -301,8 +301,15 @@ pub mod hyper {
     }
 }
 
+mod private {
+    pub trait Sealed {}
+    impl<T> Sealed for http::Response<T> {}
+}
+
 /// Methods to make working with responses from the [`HttpClient`] trait easier.
-pub trait ResponseExt: Sized {
+///
+/// This trait is sealed and cannot be implemented outside of this crate.
+pub trait ResponseExt: private::Sealed + Sized {
     /// Turn a response into an error if the HTTP status does not indicate success (200 - 299).
     fn error_for_status(self) -> Result<Self, HttpError>;
 }


### PR DESCRIPTION
## Changes

Seal the `ResponseExt` trait in `opentelemetry-http` so it cannot be implemented by downstream crates.

The trait provides a single convenience method (`error_for_status`) with a blanket impl for `http::Response<T>`. There is no reason for external code to implement this trait -- they only need to call its method. Sealing it gives us freedom to evolve the trait (add methods with default impls, change signatures) without breaking downstream.

### Implementation

Uses the standard Rust sealed-trait pattern: a `private::Sealed` supertrait implemented only for `http::Response<T>`.

### Impact

- **Calling code is unaffected** -- `response.error_for_status()` continues to work.
- **No one can `impl ResponseExt for MyType`** any more (this was never useful since the blanket impl already covers all `Response<T>`).
- Only internal consumer is `opentelemetry-zipkin`, which compiles and works unchanged.

## Merge requirement

None -- this is a non-breaking API refinement (restricting implementors of a trait that only had a blanket impl).