### PR TITLE
chore(otlp): remove Default from typestate marker types

### DIFF
--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -152,6 +152,7 @@ pub enum ExporterBuildError {
 
 /// The compression algorithm to use when sending data.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serialize", serde(rename_all = "lowercase"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Compression {
     /// Compresses data using gzip.

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -743,14 +743,14 @@ pub struct NoExporterBuilderSet;
 #[cfg(feature = "grpc-tonic")]
 // This is for clippy to work with only the grpc-tonic feature enabled
 #[allow(unused)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct TonicExporterBuilderSet(TonicExporterBuilder);
 
 /// Type to hold the [HttpExporterBuilder] and indicate it has been set.
 ///
 /// Allowing access to [HttpExporterBuilder] specific configuration methods.
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct HttpExporterBuilderSet(HttpExporterBuilder);
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
@@ -768,12 +768,15 @@ use serde::{Deserialize, Serialize};
 pub enum Protocol {
     /// GRPC protocol
     #[cfg(feature = "grpc-tonic")]
+    #[cfg_attr(feature = "serialize", serde(rename = "grpc"))]
     Grpc,
     /// HTTP protocol with binary protobuf
     #[cfg(feature = "http-proto")]
+    #[cfg_attr(feature = "serialize", serde(rename = "http/protobuf"))]
     HttpBinary,
     /// HTTP protocol with JSON payload
     #[cfg(feature = "http-json")]
+    #[cfg_attr(feature = "serialize", serde(rename = "http/json"))]
     HttpJson,
 }
 
@@ -872,10 +875,7 @@ impl Protocol {
     }
 }
 
-#[derive(Debug, Default)]
-#[doc(hidden)]
-/// Placeholder type when no exporter pipeline has been configured in telemetry pipeline.
-pub struct NoExporterConfig(());
+
 
 /// Re-exported types from the `tonic` crate.
 #[cfg(feature = "grpc-tonic")]


### PR DESCRIPTION
## Changes

Remove derived `Default` implementations from the typestate marker types
`TonicExporterBuilderSet` and `HttpExporterBuilderSet`, and remove the
entirely unused `NoExporterConfig` type.

### `Default` removal

These types are typestate markers that enforce the exporter builder flow:

```
builder() → with_tonic() / with_http() → build()
```

Having `Default` on them means a user could bypass the intended API:
```rust
// Before: this compiles, skipping the with_tonic() step
let exporter = SpanExporterBuilder::<TonicExporterBuilderSet>::default().build()?;
```

After this change, users must go through the intended builder path.

`NoExporterBuilderSet` **keeps** its `Default` since it is the initial state
and the exporter builders (`SpanExporterBuilder`, `MetricExporterBuilder`,
`LogExporterBuilder`) derive `Default` on the generic struct, which requires
the type parameter to be `Default`.

### `NoExporterConfig` removal

`NoExporterConfig` was `#[doc(hidden)]` and not referenced anywhere in the
crate. Removed as dead code.