### PR TITLE
fix(otlp): use spec-compliant values for Protocol and Compression serde

### DIFF
--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -152,6 +152,7 @@ pub enum ExporterBuildError {
 
 /// The compression algorithm to use when sending data.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serialize", serde(rename_all = "lowercase"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Compression {
     /// Compresses data using gzip.
@@ -825,5 +826,68 @@ mod tests {
                 assert!(!insecure);
             },
         );
+    }
+
+    #[cfg(feature = "serialize")]
+    mod serde_tests {
+        use super::super::Compression;
+        use crate::Protocol;
+
+        #[test]
+        fn compression_serializes_to_spec_values() {
+            assert_eq!(
+                serde_json::to_string(&Compression::Gzip).unwrap(),
+                r#""gzip""#
+            );
+            assert_eq!(
+                serde_json::to_string(&Compression::Zstd).unwrap(),
+                r#""zstd""#
+            );
+        }
+
+        #[test]
+        fn compression_deserializes_from_spec_values() {
+            assert_eq!(
+                serde_json::from_str::<Compression>(r#""gzip""#).unwrap(),
+                Compression::Gzip
+            );
+            assert_eq!(
+                serde_json::from_str::<Compression>(r#""zstd""#).unwrap(),
+                Compression::Zstd
+            );
+        }
+
+        #[cfg(feature = "grpc-tonic")]
+        #[test]
+        fn protocol_grpc_roundtrips_with_spec_value() {
+            let json = serde_json::to_string(&Protocol::Grpc).unwrap();
+            assert_eq!(json, r#""grpc""#);
+            assert_eq!(
+                serde_json::from_str::<Protocol>(&json).unwrap(),
+                Protocol::Grpc
+            );
+        }
+
+        #[cfg(feature = "http-proto")]
+        #[test]
+        fn protocol_http_binary_roundtrips_with_spec_value() {
+            let json = serde_json::to_string(&Protocol::HttpBinary).unwrap();
+            assert_eq!(json, r#""http/protobuf""#);
+            assert_eq!(
+                serde_json::from_str::<Protocol>(&json).unwrap(),
+                Protocol::HttpBinary
+            );
+        }
+
+        #[cfg(feature = "http-json")]
+        #[test]
+        fn protocol_http_json_roundtrips_with_spec_value() {
+            let json = serde_json::to_string(&Protocol::HttpJson).unwrap();
+            assert_eq!(json, r#""http/json""#);
+            assert_eq!(
+                serde_json::from_str::<Protocol>(&json).unwrap(),
+                Protocol::HttpJson
+            );
+        }
     }
 }

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -743,14 +743,14 @@ pub struct NoExporterBuilderSet;
 #[cfg(feature = "grpc-tonic")]
 // This is for clippy to work with only the grpc-tonic feature enabled
 #[allow(unused)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct TonicExporterBuilderSet(TonicExporterBuilder);
 
 /// Type to hold the [HttpExporterBuilder] and indicate it has been set.
 ///
 /// Allowing access to [HttpExporterBuilder] specific configuration methods.
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct HttpExporterBuilderSet(HttpExporterBuilder);
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
@@ -768,12 +768,15 @@ use serde::{Deserialize, Serialize};
 pub enum Protocol {
     /// GRPC protocol
     #[cfg(feature = "grpc-tonic")]
+    #[cfg_attr(feature = "serialize", serde(rename = "grpc"))]
     Grpc,
     /// HTTP protocol with binary protobuf
     #[cfg(feature = "http-proto")]
+    #[cfg_attr(feature = "serialize", serde(rename = "http/protobuf"))]
     HttpBinary,
     /// HTTP protocol with JSON payload
     #[cfg(feature = "http-json")]
+    #[cfg_attr(feature = "serialize", serde(rename = "http/json"))]
     HttpJson,
 }
 


### PR DESCRIPTION
## Changes

The `serialize` feature's derived `Serialize`/`Deserialize` implementations for `Protocol` and `Compression` were using Rust variant names instead of the spec-defined values.

**Before**
| Variant | Serialised as |
|---|---|
| `Protocol::Grpc` | `"Grpc"` |
| `Protocol::HttpBinary` | `"HttpBinary"` |
| `Protocol::HttpJson` | `"HttpJson"` |
| `Compression::Gzip` | `"Gzip"` |
| `Compression::Zstd` | `"Zstd"` |

**After**

| Variant | Serialised as |
|---|---|
| `Protocol::Grpc` | `"grpc"` |
| `Protocol::HttpBinary` | `"http/protobuf"` |
| `Protocol::HttpJson` | `"http/json"` |
| `Compression::Gzip` | `"gzip"` |
| `Compression::Zstd` | `"zstd"` |

These now match the values used in `OTEL_EXPORTER_OTLP_PROTOCOL` and `OTEL_EXPORTER_OTLP_COMPRESSION` environment variables, as well as the existing `Display`/`FromStr` implementations.

## Implementation

- Add `#[serde(rename = ...)]` to each `Protocol` variant (per-variant, since the spec values aren't a simple case transformation)
- Add `#[serde(rename_all = "lowercase")]` to `Compression`
- All serde attributes are gated behind `#[cfg_attr(feature = "serialize", ...)]`

## Breaking change

This is a **breaking change for the `serialize` feature only**. Anyone deserialising `Protocol` or `Compression` from previously-serialised data using the old Rust variant names will need to migrate their stored data. The `serialize` feature is not widely used and the old values were clearly incorrect, so the migration burden should be minimal.

## Tests

Added 5 roundtrip tests covering all variants of both enums.