### PR TITLE
chore(otlp): remove Default from typestate marker types

### DIFF
--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -743,14 +743,14 @@ pub struct NoExporterBuilderSet;
 #[cfg(feature = "grpc-tonic")]
 // This is for clippy to work with only the grpc-tonic feature enabled
 #[allow(unused)]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct TonicExporterBuilderSet(TonicExporterBuilder);
 
 /// Type to hold the [HttpExporterBuilder] and indicate it has been set.
 ///
 /// Allowing access to [HttpExporterBuilder] specific configuration methods.
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct HttpExporterBuilderSet(HttpExporterBuilder);
 
 #[cfg(any(feature = "http-proto", feature = "http-json"))]
@@ -872,10 +872,6 @@ impl Protocol {
     }
 }
 
-#[derive(Debug, Default)]
-#[doc(hidden)]
-/// Placeholder type when no exporter pipeline has been configured in telemetry pipeline.
-pub struct NoExporterConfig(());
 
 /// Re-exported types from the `tonic` crate.
 #[cfg(feature = "grpc-tonic")]


### PR DESCRIPTION
## Changes

Remove derived `Default` implementations from the typestate marker types
`TonicExporterBuilderSet` and `HttpExporterBuilderSet`, and remove the
entirely unused `NoExporterConfig` type.

### `Default` removal

These types are typestate markers that enforce the exporter builder flow:

```
builder() → with_tonic() / with_http() → build()
```

Having `Default` on them means a user could bypass the intended API:
```rust
// Before: this compiles, skipping the with_tonic() step
let exporter = SpanExporterBuilder::<TonicExporterBuilderSet>::default().build()?;
```

After this change, users must go through the intended builder path.

`NoExporterBuilderSet` **keeps** its `Default` since it is the initial state
and the exporter builders (`SpanExporterBuilder`, `MetricExporterBuilder`,
`LogExporterBuilder`) derive `Default` on the generic struct, which requires
the type parameter to be `Default`.

### `NoExporterConfig` removal

`NoExporterConfig` was `#[doc(hidden)]` and not referenced anywhere in the
crate. Removed as dead code.