### PR TITLE
refactor(http): seal ResponseExt trait

### DIFF
--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -301,8 +301,15 @@ pub mod hyper {
     }
 }
 
+mod private {
+    pub trait Sealed {}
+    impl<T> Sealed for http::Response<T> {}
+}
+
 /// Methods to make working with responses from the [`HttpClient`] trait easier.
-pub trait ResponseExt: Sized {
+///
+/// This trait is sealed and cannot be implemented outside of this crate.
+pub trait ResponseExt: private::Sealed + Sized {
     /// Turn a response into an error if the HTTP status does not indicate success (200 - 299).
     fn error_for_status(self) -> Result<Self, HttpError>;
 }

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -290,10 +290,16 @@ mod build_tests {
     // tonic transport needs an active reactor to construct its channel.
     #[tokio::test]
     async fn build_with_default_transport() {
-        // Verify that `MetricExporter::builder().build()` succeeds
-        // when at least one transport feature is enabled.
-        let result = MetricExporter::builder().build();
-        assert!(result.is_ok(), "build() should succeed: {:?}", result.err());
+        // Unset the temporality env var so parallel tests (e.g.
+        // invalid_env_var_returns_error) that set it to invalid values
+        // don't cause this build to fail.
+        temp_env::with_var_unset(
+            super::OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
+            || {
+                let result = MetricExporter::builder().build();
+                assert!(result.is_ok(), "build() should succeed: {:?}", result.err());
+            },
+        );
     }
 }
 


### PR DESCRIPTION
## Changes

**1. Seal the `ResponseExt` trait** in `opentelemetry-http` so it cannot be implemented by downstream crates.

The trait provides a single convenience method (`error_for_status`) with a blanket impl for `http::Response<T>`. There is no reason for external code to implement this trait -- they only need to call its method. Sealing it gives us freedom to evolve the trait (add methods with default impls, change signatures) without breaking downstream.

Uses the standard Rust sealed-trait pattern: a `private::Sealed` supertrait implemented only for `http::Response<T>`.

**Impact:**
- Calling code is unaffected -- `response.error_for_status()` continues to work.
- No one can `impl ResponseExt for MyType` any more (this was never useful since the blanket impl already covers all `Response<T>`).
- Only internal consumer is `opentelemetry-zipkin`, which compiles and works unchanged.

**2. Fix pre-existing flaky test** in `opentelemetry-otlp`.

`metric::build_tests::build_with_default_transport` could fail when the parallel `invalid_env_var_returns_error` test set `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` to `"invalid"`. Fixed by wrapping the test body with `temp_env::with_var_unset` to isolate it from env var pollution.

Supersedes #3701 (branch protection blocked force-push).