### PR TITLE
refactor(otlp)!: remove the `serialize` feature

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -52,6 +52,15 @@ release:
   Endpoints with an explicit scheme (e.g., `http://`, `https://`, `unix://`) are unaffected.
   [#774](https://github.com/open-telemetry/opentelemetry-rust/issues/774)
   [#984](https://github.com/open-telemetry/opentelemetry-rust/issues/984)
+- **Breaking** Removed the `serialize` feature flag. This feature gated
+  `Serialize`/`Deserialize` derives on `Protocol` and `Compression`, but the
+  derived representations were incorrect (Rust variant names instead of spec
+  values) and the feature had no known consumers. The equivalent feature was
+  removed from the core `opentelemetry` crate in 2022.
+  **Migration**: Remove `serialize` from your feature list. If you need serde
+  support for these types, implement it in your own code using the existing
+  `Display`/`FromStr` impls.
+  [#3708](https://github.com/open-telemetry/opentelemetry-rust/pull/3708)
 - **Breaking** Removed `reqwest-rustls-webpki-roots` feature. The `webpki-roots` cargo feature was
   removed from `reqwest` in v0.13.0, making this feature broken for anyone resolving `reqwest >= 0.13.0`.
   **Migration**: Use `reqwest-rustls` instead (now correctly uses `reqwest/rustls` with platform native

--- a/opentelemetry-otlp/Cargo.toml
+++ b/opentelemetry-otlp/Cargo.toml
@@ -40,7 +40,6 @@ tokio = { workspace = true, features = ["sync", "rt", "time"], optional = true }
 reqwest = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 httpdate = { version = "1.0.3", optional = true }
-serde = { workspace = true, features = ["derive"], optional = true }
 thiserror = { workspace = true }
 serde_json = { workspace = true, optional = true }
 
@@ -64,9 +63,6 @@ trace = ["opentelemetry/trace", "opentelemetry_sdk/trace", "opentelemetry-proto/
 metrics = ["opentelemetry/metrics", "opentelemetry_sdk/metrics", "opentelemetry-proto/metrics"]
 logs = ["opentelemetry/logs", "opentelemetry_sdk/logs", "opentelemetry-proto/logs"]
 internal-logs = ["opentelemetry_sdk/internal-logs", "opentelemetry/internal-logs"]
-
-# add ons
-serialize = ["serde", "serde_json"]
 
 default = ["http-proto", "reqwest-blocking-client", "trace", "metrics", "logs", "internal-logs"]
 

--- a/opentelemetry-otlp/allowed-external-types.toml
+++ b/opentelemetry-otlp/allowed-external-types.toml
@@ -5,12 +5,6 @@
 allowed_external_types = [
     "opentelemetry_http::*",
     "opentelemetry_sdk::*",
-    # serde
-    "serde::de::Deserialize",
-    "serde::ser::Serialize",
-    ## serde: Required for serde version 1.0.222 or greater.
-    "serde_core::de::Deserialize",
-    "serde_core::ser::Serialize",
     # tonic is a pre 1.0 crate
     "tonic::metadata::map::MetadataMap",
     "tonic::transport::channel::tls::ClientTlsConfig",

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -7,8 +7,6 @@ use crate::exporter::http::HttpExporterBuilder;
 #[cfg(feature = "grpc-tonic")]
 use crate::exporter::tonic::TonicExporterBuilder;
 use crate::Protocol;
-#[cfg(feature = "serialize")]
-use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use std::time::Duration;
@@ -151,7 +149,6 @@ pub enum ExporterBuildError {
 }
 
 /// The compression algorithm to use when sending data.
-#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Compression {
     /// Compresses data using gzip.

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -268,7 +268,6 @@
 //! * `logs`: Includes the logs exporters.
 //!
 //! The following feature flags generate additional code and types:
-//! * `serialize`: Enables serialization support for type defined in this crate via `serde`.
 //!
 //! The following feature flags offer additional configurations on gRPC:
 //!
@@ -759,11 +758,7 @@ pub use crate::exporter::http::HttpExporterBuilder;
 #[cfg(feature = "grpc-tonic")]
 pub use crate::exporter::tonic::TonicExporterBuilder;
 
-#[cfg(feature = "serialize")]
-use serde::{Deserialize, Serialize};
-
 /// The communication protocol to use when exporting data.
-#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Protocol {
     /// GRPC protocol


### PR DESCRIPTION
## Changes

Remove the `serialize` feature flag from `opentelemetry-otlp`. This feature gated `Serialize`/`Deserialize` derives on exactly two types: `Protocol` and `Compression`. This looks vestigial; there used to be more behind the flag, now i'm not really sure we need a feature to give folks the ability to serialize/deserialize these two types alone. 

### What's removed
- The `serialize` feature flag in `Cargo.toml`
- The `serde` optional dependency (no longer needed; `serde_json` remains for `http-json`)
- `#[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]` on `Protocol` and `Compression`
- Serde entries in `allowed-external-types.toml`
- Documentation reference to the feature

## Breaking change

Users who depend on `opentelemetry-otlp` with `features = ["serialize"]` will get a compilation error. The migration is to remove the feature flag and, if serde support is needed, implement it in application code using the existing `Display`/`FromStr` impls.
