### PR TITLE
docs(otlp): fix stale with_protocol docs and complete gRPC trait summary

### DIFF
--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -291,13 +291,25 @@ pub trait WithExportConfig {
     ///
     /// Note: Programmatically setting this will override any value set via the environment variable.
     fn with_endpoint<T: Into<String>>(self, endpoint: T) -> Self;
-    /// Set the protocol to use when communicating with the collector.
+    /// Set the transport protocol to use when communicating with the collector.
     ///
-    /// Note that protocols that are not supported by exporters will be ignored. The exporter
-    /// will use default protocol in this case.
+    /// This is mainly useful on the HTTP transport to choose between
+    /// [`Protocol::HttpBinary`] (protobuf) and [`Protocol::HttpJson`].
+    /// Which of these is the default depends on which cargo features are
+    /// enabled (priority: `http-json` > `http-proto` > `grpc-tonic`).
+    /// Setting a protocol that conflicts with the chosen transport
+    /// (e.g. [`Protocol::Grpc`] on an HTTP builder) will cause `build()`
+    /// to return an error.
     ///
-    /// ## Note
-    /// All exporters in this crate only support one protocol, thus choosing the protocol is a no-op at the moment.
+    /// Note that `with_protocol()` is only available after a transport has
+    /// been selected via `.with_http()` or `.with_tonic()`. If you call
+    /// `.builder().build()` directly without selecting a transport, the
+    /// transport is chosen automatically from the
+    /// `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable and enabled
+    /// cargo features - `with_protocol()` is not involved in that path.
+    ///
+    /// Note: Programmatically setting this will override any value set via the
+    /// `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable.
     fn with_protocol(self, protocol: Protocol) -> Self;
     /// Set the timeout to the collector.
     ///

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -295,8 +295,6 @@ pub trait WithExportConfig {
     ///
     /// This is mainly useful on the HTTP transport to choose between
     /// [`Protocol::HttpBinary`] (protobuf) and [`Protocol::HttpJson`].
-    /// Which of these is the default depends on which cargo features are
-    /// enabled (priority: `http-json` > `http-proto` > `grpc-tonic`).
     /// Setting a protocol that conflicts with the chosen transport
     /// (e.g. [`Protocol::Grpc`] on an HTTP builder) will cause `build()`
     /// to return an error.

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -326,7 +326,7 @@
 //!
 //! Requires the `grpc-tonic` feature. The methods below come from two traits:
 //! - [`WithExportConfig`]: `with_endpoint`, `with_timeout` (shared with HTTP)
-//! - [`WithTonicConfig`]: `with_metadata`, `with_compression`, `with_tls_config`, `with_channel`, `with_interceptor`
+//! - [`WithTonicConfig`]: `with_metadata`, `with_compression`, `with_tls_config`, `with_channel`, `with_interceptor`, `with_retry_policy`
 //!
 //! The examples here use [`SpanExporter`], but the same builder methods are
 //! available on [`MetricExporter`] and [`LogExporter`].


### PR DESCRIPTION
> [!NOTE]
> This replaces #3703 (approved by @lalitb) because we cannot update branches pushed to origin.

## Changes

**`WithExportConfig::with_protocol` doc** (exporter/mod.rs):

The doc comment claimed "All exporters in this crate only support one protocol, thus choosing the protocol is a no-op at the moment." This has been stale since the typestate builder was introduced: protocol selection now matters for HTTP sub-protocol choice (`HttpBinary` vs `HttpJson`) and is validated against the chosen transport (setting `Grpc` on an HTTP builder returns an error).

Replaced with accurate documentation that explains:
- The primary use case (HTTP sub-protocol selection)
- What happens on transport mismatch (build error)
- How default protocol depends on enabled cargo features
- That `with_protocol()` is only available after transport selection, and is not involved in the auto-select builder path
- Precedence over environment variables

**gRPC config trait summary** (lib.rs):

The `WithTonicConfig` method listing in the "gRPC (tonic) - all configuration options" section was missing `with_retry_policy`, which was added as part of the retry stabilisation (#3672). Added it to keep the summary complete.