### PR TITLE
docs: explain filtering options and processor tradeoffs

### DIFF
--- a/docs/logs.md
+++ b/docs/logs.md
@@ -59,6 +59,34 @@ records reach that bridge.
 
 [issue #2877]: https://github.com/open-telemetry/opentelemetry-rust/issues/2877
 
+## Filtering log records
+
+Use logging-framework filters when possible: they reject events before an
+OpenTelemetry log record is created. A custom [`LogProcessor`] is useful when
+the decision requires the completed `SdkLogRecord`, its instrumentation scope,
+runtime configuration, or other processor state.
+
+A filtering processor should wrap the processor that exports or batches
+records. In its `emit` method, evaluate the filtering condition and call the
+wrapped processor only when the record should be kept. Register only the
+wrapper with `SdkLoggerProvider`. Registering both processors separately does
+not form a pipeline; each registered processor receives the record
+independently.
+
+The runnable [logs-advanced example] uses an attribute value as its filtering
+condition. A processor could instead filter by severity, event name, scope,
+body, external configuration, or any other information available to it. The
+example also demonstrates forwarding processor lifecycle methods and composing
+the filter with `SimpleLogProcessor`; a production application can wrap
+`BatchLogProcessor` in the same way.
+
+`LogProcessor::event_enabled` can reject records earlier, but it receives only
+severity, target, and event name. Conditions that require any other record data
+must be evaluated in `emit`.
+
+[`LogProcessor`]: https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/logs/trait.LogProcessor.html
+[logs-advanced example]: ../examples/logs-advanced/
+
 ## OpenTelemetry Log Bridge API
 
 Do **not** use the OpenTelemetry Log Bridge API (part of the `opentelemetry`

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -61,10 +61,26 @@ records reach that bridge.
 
 ## Filtering log records
 
-Use logging-framework filters when possible: they reject events before an
-OpenTelemetry log record is created. A custom [`LogProcessor`] is useful when
-the decision requires the completed `SdkLogRecord`, its instrumentation scope,
-runtime configuration, or other processor state.
+Filtering in a processor is one option. The appropriate place depends on what
+information the decision needs and where you want to manage the policy:
+
+- **Logging library:** Filtering before the OpenTelemetry bridge avoids creating
+  and processing rejected log records. `tracing` offers flexible
+  [filtering capabilities] through `tracing-subscriber`, including level and
+  target filters, `EnvFilter`, custom predicates, and per-layer filters. These
+  filters use information available to the logging library, before SDK
+  processing or downstream enrichment.
+- **SDK processor:** A custom [`LogProcessor`] can inspect the `SdkLogRecord`,
+  instrumentation scope, or application-local state and reject records before
+  batching and export. Record creation and any earlier processing have already
+  occurred, and the processor implementation is maintained in the application.
+- **Collector or telemetry pipeline:** Filtering downstream can centralize
+  policy across applications and use data added by pipeline processors. It
+  still incurs the application-side work and transport cost of sending records
+  to that point in the pipeline.
+
+If you have a reason to filter in an SDK processor, the following approach
+shows how to compose it with other processors.
 
 A filtering processor should wrap the processor that exports or batches
 records. In its `emit` method, evaluate the filtering condition and call the
@@ -85,6 +101,7 @@ severity, target, and event name. Conditions that require any other record data
 must be evaluated in `emit`.
 
 [`LogProcessor`]: https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/logs/trait.LogProcessor.html
+[filtering capabilities]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/index.html
 [logs-advanced example]: ../examples/logs-advanced/
 
 ## OpenTelemetry Log Bridge API

--- a/docs/traces.md
+++ b/docs/traces.md
@@ -60,6 +60,11 @@ log guidance.
 
 ## Filtering spans
 
+Processor filtering is one option for controlling which spans are exported.
+The choice between SDK sampling, processor filtering, and decisions in a
+Collector or telemetry pipeline depends on the information needed, the costs
+you want to avoid, and whether the decision must apply to an entire trace.
+
 > **Warning:** Filtering individual spans can produce incomplete or broken
 > traces. For example, an exported child span may refer to a parent span that
 > was discarded. A processor's decision does not coordinate with other spans
@@ -71,14 +76,18 @@ log guidance.
 > it can make a common keep/drop decision. Tail sampling cannot recover spans
 > already discarded by SDK sampling or filtering.
 
-Prefer a sampler when the filtering decision can use information available at
-span creation, including initial attributes. A sampler that returns `Drop`
-avoids recording and processing that span. Use a custom [`SpanProcessor`] when
-the decision requires the finished `SpanData` or other processor state, such as
-an attribute added during the span's lifetime, its final status, or runtime
-configuration.
+SDK sampling can use information available at span creation, including initial
+attributes. A sampler that returns `Drop` avoids recording and processing that
+span, but cannot use its final status or attributes added later. A custom
+[`SpanProcessor`] can use the finished `SpanData` or application-local state
+and avoid downstream batching and export costs, but recording costs have
+already been incurred. Filtering or sampling in a Collector or telemetry
+pipeline can centralize policy across services, but still incurs SDK processing
+and transport costs to that point. Tail sampling also needs resources to
+buffer spans while awaiting a decision.
 
-For end-of-span filtering, wrap the processor that exports or batches spans.
+If you have a reason to filter finished spans in an SDK processor and accept
+the trace-completeness tradeoff, wrap the processor that exports or batches spans.
 Evaluate the filtering condition in `on_end` and call the wrapped processor
 only when the span should be kept. Register only the wrapper with
 `SdkTracerProvider`. Registering the filter and exporter-backed processor

--- a/docs/traces.md
+++ b/docs/traces.md
@@ -58,6 +58,33 @@ log guidance.
    express these concepts, but these are a workaround, not the recommended
    path for edge spans.
 
+## Filtering spans
+
+Prefer a sampler when the filtering decision can use information available at
+span creation, including initial attributes. A sampler that returns `Drop`
+avoids recording and processing that span. Use a custom [`SpanProcessor`] when
+the decision requires the finished `SpanData` or other processor state, such as
+an attribute added during the span's lifetime, its final status, or runtime
+configuration.
+
+For end-of-span filtering, wrap the processor that exports or batches spans.
+Evaluate the filtering condition in `on_end` and call the wrapped processor
+only when the span should be kept. Register only the wrapper with
+`SdkTracerProvider`. Registering the filter and exporter-backed processor
+separately does not form a pipeline; every registered processor receives the
+span independently.
+
+The [`SpanProcessor::on_end` example] uses an attribute value as its filtering
+condition. A processor could instead use the span name, status, duration,
+instrumentation scope, external configuration, or any other available
+information. The example also demonstrates forwarding processor lifecycle
+methods and composing the filter with another processor.
+
+Filtering individual finished spans can produce a partial trace. For example,
+an exported child can refer to a parent span that the processor discarded. Use
+parent-aware head sampling or Collector tail sampling when the decision should
+apply consistently to an entire trace.
+
 ## See Also
 
 - [OpenTelemetry Traces Specification](https://opentelemetry.io/docs/specs/otel/trace/)
@@ -82,6 +109,8 @@ to the depth in [metrics.md](metrics.md):
 
 [`tracing`]: https://crates.io/crates/tracing
 [`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry
+[`SpanProcessor`]: https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/trace/trait.SpanProcessor.html
+[`SpanProcessor::on_end` example]: ../opentelemetry-sdk/src/trace/span_processor.rs
 [opentelemetry-rust-contrib]: https://github.com/open-telemetry/opentelemetry-rust-contrib
 [`opentelemetry-instrumentation-tower`]: https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-instrumentation-tower
 [`opentelemetry-instrumentation-actix-web`]: https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-instrumentation-actix-web

--- a/docs/traces.md
+++ b/docs/traces.md
@@ -60,6 +60,17 @@ log guidance.
 
 ## Filtering spans
 
+> **Warning:** Filtering individual spans can produce incomplete or broken
+> traces. For example, an exported child span may refer to a parent span that
+> was discarded. A processor's decision does not coordinate with other spans
+> in the trace, including spans in other services.
+>
+> For coordinated decisions based on completed spans, prefer [tail-based
+> sampling] in the OpenTelemetry Collector or another telemetry pipeline.
+> Route all spans belonging to a trace to the same tail-sampling instance so
+> it can make a common keep/drop decision. Tail sampling cannot recover spans
+> already discarded by SDK sampling or filtering.
+
 Prefer a sampler when the filtering decision can use information available at
 span creation, including initial attributes. A sampler that returns `Drop`
 avoids recording and processing that span. Use a custom [`SpanProcessor`] when
@@ -79,11 +90,6 @@ condition. A processor could instead use the span name, status, duration,
 instrumentation scope, external configuration, or any other available
 information. The example also demonstrates forwarding processor lifecycle
 methods and composing the filter with another processor.
-
-Filtering individual finished spans can produce a partial trace. For example,
-an exported child can refer to a parent span that the processor discarded. Use
-parent-aware head sampling or Collector tail sampling when the decision should
-apply consistently to an entire trace.
 
 ## See Also
 
@@ -110,6 +116,7 @@ to the depth in [metrics.md](metrics.md):
 [`tracing`]: https://crates.io/crates/tracing
 [`tracing-opentelemetry`]: https://crates.io/crates/tracing-opentelemetry
 [`SpanProcessor`]: https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/trace/trait.SpanProcessor.html
+[tail-based sampling]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor
 [`SpanProcessor::on_end` example]: ../opentelemetry-sdk/src/trace/span_processor.rs
 [opentelemetry-rust-contrib]: https://github.com/open-telemetry/opentelemetry-rust-contrib
 [`opentelemetry-instrumentation-tower`]: https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-instrumentation-tower

--- a/examples/logs-advanced/README.md
+++ b/examples/logs-advanced/README.md
@@ -1,13 +1,20 @@
 # OpenTelemetry Log Processor Implementation and Composition - Example
 
-This example builds on top of the `logs-basic`, showing how to implement `LogProcessor`s correctly.
+This example builds on top of `logs-basic`, showing how to implement and
+compose `LogProcessor`s correctly.
 
-The `EnrichmentProcessor` simulates a processor adding information
-to the log captured by the OpenTelemetry SDK, which correctly ensures that the
-downstream processor's filtering is captured, avoiding unnecessary work.
+`FilteringLogProcessor` drops records whose `event_id` attribute is `20`.
+`EnrichmentLogProcessor` adds an attribute to records that pass the filter.
+Both wrap and delegate to the next processor, preserving its lifecycle and
+early `event_enabled` decisions. The filter is outermost so dropped records do
+not incur enrichment work.
+
+The stdout exporter therefore receives only the record with `event_id=50`.
+The filter uses an attribute for illustration, but it could use any information
+available to `LogProcessor::emit`.
 
 ## Usage
 
 ```shell
-cargo run
+cargo run -p logs-advanced
 ```

--- a/examples/logs-advanced/src/main.rs
+++ b/examples/logs-advanced/src/main.rs
@@ -1,4 +1,4 @@
-use opentelemetry::logs::{LogRecord, Severity};
+use opentelemetry::logs::{AnyValue, LogRecord, Severity};
 use opentelemetry::InstrumentationScope;
 use opentelemetry_appender_tracing::layer;
 use opentelemetry_sdk::error::OTelSdkResult;
@@ -9,14 +9,16 @@ use tracing_subscriber::{prelude::*, EnvFilter};
 
 fn main() {
     let exporter = opentelemetry_stdout::LogExporter::default();
-    let enriching_processor = EnrichmentLogProcessor::new(SimpleLogProcessor::new(exporter));
+    let processor = FilteringLogProcessor::new(EnrichmentLogProcessor::new(
+        SimpleLogProcessor::new(exporter),
+    ));
     let provider: SdkLoggerProvider = SdkLoggerProvider::builder()
         .with_resource(
             Resource::builder()
                 .with_service_name("log-appender-tracing-example")
                 .build(),
         )
-        .with_log_processor(enriching_processor)
+        .with_log_processor(processor)
         .build();
 
     // To prevent a telemetry-induced-telemetry loop, OpenTelemetry's own internal
@@ -57,12 +59,57 @@ fn main() {
     let _ = provider.shutdown();
 }
 
+/// A log processor that drops records when `event_id` is `20` and delegates
+/// all other records to the wrapped processor.
+#[derive(Debug)]
+pub struct FilteringLogProcessor<P: LogProcessor> {
+    delegate: P,
+}
+
+impl<P: LogProcessor> FilteringLogProcessor<P> {
+    pub fn new(delegate: P) -> Self {
+        Self { delegate }
+    }
+}
+
+impl<P: LogProcessor> LogProcessor for FilteringLogProcessor<P> {
+    fn emit(&self, data: &mut SdkLogRecord, instrumentation: &InstrumentationScope) {
+        let should_drop = data
+            .attributes_iter()
+            .any(|(key, value)| key.as_str() == "event_id" && value == &AnyValue::Int(20));
+
+        if !should_drop {
+            self.delegate.emit(data, instrumentation);
+        }
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        self.delegate.force_flush()
+    }
+
+    fn shutdown_with_timeout(&self, timeout: std::time::Duration) -> OTelSdkResult {
+        self.delegate.shutdown_with_timeout(timeout)
+    }
+
+    fn shutdown(&self) -> OTelSdkResult {
+        self.delegate.shutdown()
+    }
+
+    fn set_resource(&mut self, resource: &Resource) {
+        self.delegate.set_resource(resource);
+    }
+
+    fn event_enabled(&self, level: Severity, target: &str, name: Option<&str>) -> bool {
+        self.delegate.event_enabled(level, target, name)
+    }
+}
+
 /// A log processor that enriches log records with additional attributes before
 /// delegating to an underlying processor.
 ///
-/// If this were implemented as a standalone processor in a chain (e.g.,
-/// EnrichmentProcessor -> SimpleLogProcessor), the performance benefits of the
-/// `event_enabled` check would be nullified. Here's why:
+/// If this and the downstream processor were registered separately with the
+/// provider, the performance benefits of the `event_enabled` check would be
+/// nullified. Here's why:
 ///
 /// - The `event_enabled` method is crucial for performance - it allows processors
 ///   to skip expensive operations for logs that will ultimately be filtered out

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -128,9 +128,21 @@ pub trait SpanProcessor: Send + Sync + std::fmt::Debug {
     ///
     /// # Filtering completed spans
     ///
+    /// **Warning:** Filtering individual spans can produce incomplete or broken
+    /// traces, such as an exported child whose parent was discarded. This does
+    /// not coordinate filtering across spans or services. For coordinated
+    /// decisions based on completed spans, prefer [tail-based sampling] in the
+    /// OpenTelemetry Collector or another telemetry pipeline. All spans in a
+    /// trace must reach the same tail-sampling instance; it cannot recover spans
+    /// already discarded by SDK sampling or filtering.
+    ///
+    /// [tail-based sampling]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor
+    ///
     /// A filtering processor can wrap another processor and delegate only the
     /// spans that satisfy its condition. This example uses an attribute, but the
     /// condition can use any information in [`SpanData`] or other processor state.
+    /// Register only the wrapper with [`SdkTracerProvider`](crate::trace::SdkTracerProvider), since separately
+    /// registered processors receive spans independently.
     ///
     /// ```rust
     /// use opentelemetry::{Context, Value};

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -126,6 +126,62 @@ pub trait SpanProcessor: Send + Sync + std::fmt::Debug {
     /// }
     /// ```
     ///
+    /// # Filtering completed spans
+    ///
+    /// A filtering processor can wrap another processor and delegate only the
+    /// spans that satisfy its condition. This example uses an attribute, but the
+    /// condition can use any information in [`SpanData`] or other processor state.
+    ///
+    /// ```rust
+    /// use opentelemetry::{Context, Value};
+    /// use opentelemetry_sdk::{
+    ///     error::OTelSdkResult,
+    ///     trace::{Span, SpanData, SpanProcessor},
+    ///     Resource,
+    /// };
+    /// use std::time::Duration;
+    ///
+    /// #[derive(Debug)]
+    /// struct FilteringSpanProcessor<P> {
+    ///     next: P,
+    /// }
+    ///
+    /// impl<P> FilteringSpanProcessor<P> {
+    ///     fn new(next: P) -> Self {
+    ///         Self { next }
+    ///     }
+    /// }
+    ///
+    /// impl<P: SpanProcessor> SpanProcessor for FilteringSpanProcessor<P> {
+    ///     fn on_start(&self, span: &mut Span, cx: &Context) {
+    ///         self.next.on_start(span, cx);
+    ///     }
+    ///
+    ///     fn on_end(&self, span: SpanData) {
+    ///         let should_drop = span.attributes.iter().any(|attribute| {
+    ///             attribute.key.as_str() == "example.drop"
+    ///                 && attribute.value == Value::Bool(true)
+    ///         });
+    ///
+    ///         if !should_drop {
+    ///             self.next.on_end(span);
+    ///         }
+    ///     }
+    ///
+    ///     fn force_flush(&self) -> OTelSdkResult {
+    ///         self.next.force_flush()
+    ///     }
+    ///
+    ///     fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
+    ///         self.next.shutdown_with_timeout(timeout)
+    ///     }
+    ///
+    ///     fn set_resource(&mut self, resource: &Resource) {
+    ///         self.next.set_resource(resource);
+    ///     }
+    /// }
+    /// ```
+    ///
     /// [`on_start`]: SpanProcessor::on_start
     /// [`Context::current()`]: opentelemetry::Context::current
     ///

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -138,8 +138,9 @@ pub trait SpanProcessor: Send + Sync + std::fmt::Debug {
     ///
     /// [tail-based sampling]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor
     ///
-    /// A filtering processor can wrap another processor and delegate only the
-    /// spans that satisfy its condition. This example uses an attribute, but the
+    /// If SDK processor filtering fits your requirements and you accept this
+    /// tradeoff, wrap another processor and delegate only the spans that satisfy
+    /// your condition. This example uses an attribute, but the
     /// condition can use any information in [`SpanData`] or other processor state.
     /// Register only the wrapper with [`SdkTracerProvider`](crate::trace::SdkTracerProvider), since separately
     /// registered processors receive spans independently.


### PR DESCRIPTION
## Changes

Explain the tradeoffs between filtering in the logging library, an SDK processor, and the Collector or telemetry pipeline, including `tracing-subscriber`'s filtering capabilities. Present processor filtering as an option for applications with a reason to use it, with guidance on wrapping downstream processors and forwarding lifecycle methods.

Extend `logs-advanced` with a filtering processor composed with the existing enrichment processor, and add a compiling `SpanProcessor::on_end` example. Both use attributes for illustration; filtering conditions can use other available information or processor state.

Warn that filtering individual spans can produce incomplete or broken traces. Recommend tail sampling in the Collector or pipeline for coordinated decisions based on completed spans, and explain that it cannot recover spans already discarded by the SDK.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (not applicable; the runnable example and doctest cover the documentation)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes (not applicable; documentation and examples only)
* [x] Changes in public API reviewed (not applicable; no public API changes)
