### PR TITLE
ci(http): check external API types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
   external-types:
     strategy:
       matrix:
-        member: [opentelemetry, opentelemetry-sdk, opentelemetry-otlp, opentelemetry-zipkin]
+        member: [opentelemetry, opentelemetry-sdk, opentelemetry-http, opentelemetry-otlp, opentelemetry-zipkin]
     runs-on: ubuntu-latest # TODO: Check if this could be covered for Windows. The step used currently fails on Windows.
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/opentelemetry-http/allowed-external-types.toml
+++ b/opentelemetry-http/allowed-external-types.toml
@@ -1,0 +1,20 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+# This is used with cargo-check-external-types to reduce the surface area of downstream crates from
+# the public API. Ideally this can have as few exceptions as possible.
+allowed_external_types = [
+    # Public HTTP client contract and propagation adapters.
+    "bytes::bytes::Bytes",
+    "http::header::map::HeaderMap",
+    "http::header::value::HeaderValue",
+    "http::request::Request",
+    "http::response::Response",
+
+    # HyperClient's public default connector and generic connector bound.
+    "hyper_util::client::legacy::connect::http::HttpConnector",
+    "hyper_util::client::legacy::connect::sealed::Connect",
+
+    # Traits implemented by the public propagation adapters.
+    "opentelemetry::propagation::Extractor",
+    "opentelemetry::propagation::Injector",
+]


### PR DESCRIPTION
## Changes

Add `opentelemetry-http` to the external-types CI matrix and define its intentional external API dependencies:

- `bytes` and `http` types used by the HTTP client contract and propagation adapters
- OpenTelemetry propagation traits implemented by the public adapters
- `hyper-util` connector types and bounds exposed by `HyperClient`

This ensures future changes to these external API dependencies require explicit review.
