### PR TITLE
docs(http): mark status handling change as breaking

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -17,9 +17,12 @@
   client request bodies.
 - Limit HTTP response body reads to 4 MiB in built-in HTTP clients (`reqwest` async/blocking and `hyper`) by enforcing the cap while streaming response chunks and reads that exceed the limit are aborted to prevent unbounded memory allocation.
 
-- Return HTTP error responses from the built-in reqwest and hyper clients instead
-  of converting 4xx and 5xx statuses into transport errors. This preserves the
-  response status and headers for exporter retry classification.
+- **Breaking** Built-in reqwest and hyper clients now return HTTP 4xx and 5xx
+  responses as `Ok(Response<Bytes>)` instead of `Err(HttpError)`. Here, `Ok`
+  means that the transport completed the request and received an HTTP response;
+  it does not imply a successful HTTP status. This preserves the response status
+  and headers for exporter retry classification. Transport failures and timeouts
+  continue to return `Err`.
   If your code relied on `send_bytes` returning `Err` for non-success statuses,
   call `ResponseExt::error_for_status()` on the response instead.
 - **Breaking** Removed `reqwest-rustls-webpki-roots` feature. The `webpki-roots` cargo feature was


### PR DESCRIPTION
Marks the built-in client status-handling change as breaking. The changelog retains the migration guidance for callers that want non-2xx responses converted into errors and clarifies that transport failures and timeouts still return `Err`.