### PR TITLE
fix(otlp): return reqwest client build errors

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -34,6 +34,11 @@ release:
 
 ### Other changes
 
+- Return an exporter build error when construction of a built-in reqwest HTTP
+  client fails instead of silently falling back to a client without the
+  exporter-configured timeout. Failure to spawn the blocking client's setup
+  thread, or a panic in that thread, is also returned instead of panicking.
+
 - **Breaking** Removed `Default` from the `TonicExporterBuilderSet` and
   `HttpExporterBuilderSet` typestate markers. This also removes `Default` from
   the transport-selected exporter builders (e.g.

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -243,12 +243,15 @@ impl HttpExporterBuilder {
         if http_client.is_none() {
             #[cfg(feature = "reqwest-client")]
             {
-                http_client = Some(Arc::new(
-                    reqwest::Client::builder()
-                        .timeout(timeout)
-                        .build()
-                        .unwrap_or_default(),
-                ) as Arc<dyn HttpClient>);
+                let client = reqwest::Client::builder()
+                    .timeout(timeout)
+                    .build()
+                    .map_err(|error| {
+                        ExporterBuildError::InternalFailure(format!(
+                            "Failed to build reqwest HTTP client: {error}"
+                        ))
+                    })?;
+                http_client = Some(Arc::new(client) as Arc<dyn HttpClient>);
             }
             #[cfg(all(not(feature = "reqwest-client"), feature = "hyper-client"))]
             {
@@ -263,16 +266,25 @@ impl HttpExporterBuilder {
             ))]
             {
                 let timeout_clone = timeout;
-                http_client = Some(Arc::new(
-                    std::thread::spawn(move || {
+                let client = std::thread::Builder::new()
+                    .spawn(move || {
                         reqwest::blocking::Client::builder()
                             .timeout(timeout_clone)
                             .build()
-                            .unwrap_or_else(|_| reqwest::blocking::Client::new())
                     })
+                    .map_err(|_| ExporterBuildError::ThreadSpawnFailed)?
                     .join()
-                    .unwrap(), // TODO: Return ExporterBuildError::ThreadSpawnFailed
-                ) as Arc<dyn HttpClient>);
+                    .map_err(|_| {
+                        ExporterBuildError::InternalFailure(
+                            "HTTP client construction thread panicked".to_string(),
+                        )
+                    })?;
+                let client = client.map_err(|error| {
+                    ExporterBuildError::InternalFailure(format!(
+                        "Failed to build blocking reqwest HTTP client: {error}"
+                    ))
+                })?;
+                http_client = Some(Arc::new(client) as Arc<dyn HttpClient>);
             }
         }
 


### PR DESCRIPTION
## Summary

The OTLP HTTP exporter previously discarded errors from constructing its built-in reqwest client and silently substituted a default client. That fallback did not preserve the exporter-configured timeout, so exporter construction could succeed with behavior different from the requested configuration.

This change returns `ExporterBuildError::InternalFailure` when construction of either the async or blocking reqwest client fails.

For the blocking client, it also replaces panic-prone thread handling:

- A failure to spawn the client setup thread returns the existing `ExporterBuildError::ThreadSpawnFailed`.
- A panic in the setup thread returns `ExporterBuildError::InternalFailure`.

Custom HTTP clients and the Hyper client are unchanged. This PR is intentionally limited to `opentelemetry-otlp`; the deprecated Zipkin exporter is unchanged.