### PR TITLE
fix(otlp): enforce complete export deadline

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- Apply `HyperClient`'s configured timeout to the complete response body, not
+  only request dispatch and response headers.
+
 - **Breaking** Sealed the `ResponseExt` trait so it can no longer be implemented by
   downstream crates. The trait provides a blanket implementation for all
   `http::Response<T>` types, so calling code is unaffected -- only

--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Apply `HyperClient`'s configured timeout to the complete response body, not
   only request dispatch and response headers.
+- Add `HttpClientTimeout`, a request extension that lets exporters communicate
+  a shorter per-request timeout to HTTP clients. The built-in clients honor it
+  through complete response-body collection.
 
 - **Breaking** Sealed the `ResponseExt` trait so it can no longer be implemented by
   downstream crates. The trait provides a blanket implementation for all

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -233,31 +233,34 @@ pub mod hyper {
                     .headers_mut()
                     .insert(http::header::AUTHORIZATION, authorization.clone());
             }
-            let mut response = time::timeout(self.timeout, self.inner.request(request)).await??;
-            let capacity = response
-                .body()
-                .size_hint()
-                .upper()
-                .unwrap_or(0)
-                .min(MAX_RESPONSE_BODY_BYTES as u64) as usize;
-            let mut body_bytes = bytes::BytesMut::with_capacity(capacity);
-            let status = response.status();
-            let headers = std::mem::take(response.headers_mut());
-            let mut body = response.into_body();
-            while let Some(frame) = body.frame().await {
-                let frame = frame?;
-                if let Ok(chunk) = frame.into_data() {
-                    if body_bytes.len() + chunk.len() > MAX_RESPONSE_BODY_BYTES {
-                        return Err(Box::new(ResponseBodyTooLarge));
+            time::timeout(self.timeout, async {
+                let mut response = self.inner.request(request).await?;
+                let capacity = response
+                    .body()
+                    .size_hint()
+                    .upper()
+                    .unwrap_or(0)
+                    .min(MAX_RESPONSE_BODY_BYTES as u64) as usize;
+                let mut body_bytes = bytes::BytesMut::with_capacity(capacity);
+                let status = response.status();
+                let headers = std::mem::take(response.headers_mut());
+                let mut body = response.into_body();
+                while let Some(frame) = body.frame().await {
+                    let frame = frame?;
+                    if let Ok(chunk) = frame.into_data() {
+                        if body_bytes.len() + chunk.len() > MAX_RESPONSE_BODY_BYTES {
+                            return Err(Box::new(ResponseBodyTooLarge) as HttpError);
+                        }
+                        body_bytes.extend_from_slice(&chunk);
                     }
-                    body_bytes.extend_from_slice(&chunk);
                 }
-            }
-            let mut http_response = Response::builder()
-                .status(status)
-                .body(body_bytes.freeze())?;
-            *http_response.headers_mut() = headers;
-            Ok(http_response)
+                let mut http_response = Response::builder()
+                    .status(status)
+                    .body(body_bytes.freeze())?;
+                *http_response.headers_mut() = headers;
+                Ok(http_response)
+            })
+            .await?
         }
     }
 }
@@ -518,6 +521,25 @@ Connection: close\r\n\r\n",
             addr
         }
 
+        #[cfg(feature = "hyper")]
+        async fn start_stalled_body_server() -> SocketAddr {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            tokio::spawn(async move {
+                if let Ok((mut socket, _)) = listener.accept().await {
+                    let mut buf = [0u8; 1024];
+                    let _ = socket.read(&mut buf).await;
+                    let _ = socket
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\nConnection: close\r\n\r\n",
+                        )
+                        .await;
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
+            });
+            addr
+        }
+
         async fn assert_within_limit(client: &dyn HttpClient, addr: SocketAddr) {
             let request = Request::builder()
                 .method("POST")
@@ -622,6 +644,31 @@ Connection: close\r\n\r\n",
                 None,
             );
             assert_exceeds_limit(&client, addr).await;
+        }
+
+        #[cfg(feature = "hyper")]
+        #[tokio::test]
+        async fn hyper_timeout_covers_response_body() {
+            let addr = start_stalled_body_server().await;
+            let client = crate::hyper::HyperClient::with_default_connector(
+                std::time::Duration::from_millis(25),
+                None,
+            );
+            let request = Request::post(format!("http://{addr}/"))
+                .body(Bytes::new())
+                .unwrap();
+
+            let error = tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                client.send_bytes(request),
+            )
+            .await
+            .expect("HyperClient must enforce its configured timeout")
+            .expect_err("stalled response body must time out");
+
+            assert!(error
+                .downcast_ref::<tokio::time::error::Elapsed>()
+                .is_some());
         }
     }
 }

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use std::fmt::Debug;
+use std::time::Duration;
 
 #[doc(no_inline)]
 pub use bytes::Bytes;
@@ -62,6 +63,25 @@ impl Extractor for HeaderExtractor<'_> {
 
 pub type HttpError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+/// A per-request timeout that an [`HttpClient`] implementation should honor.
+///
+/// Exporters insert this value into [`Request::extensions`] to communicate the
+/// maximum time available for the request. Clients may impose a shorter limit.
+#[derive(Clone, Copy, Debug)]
+pub struct HttpClientTimeout(Duration);
+
+impl HttpClientTimeout {
+    /// Creates a per-request HTTP client timeout.
+    pub fn new(timeout: Duration) -> Self {
+        Self(timeout)
+    }
+
+    /// Returns the requested timeout.
+    pub fn duration(self) -> Duration {
+        self.0
+    }
+}
+
 /// A minimal interface necessary for sending requests over HTTP.
 /// Used primarily for exporting telemetry over HTTP. Also used for fetching
 /// sampling strategies for JaegerRemoteSampler
@@ -76,6 +96,9 @@ pub trait HttpClient: Debug + Send + Sync {
     ///
     /// Returns an error if it can't connect to the server or the request could not be completed,
     /// e.g. because of a timeout, infinite redirects, or a loss of connection.
+    ///
+    /// Implementations should honor [`HttpClientTimeout`] in the request's
+    /// extensions and apply it to the complete response body.
     async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError>;
 }
 
@@ -101,14 +124,19 @@ mod reqwest {
     use crate::ResponseBodyTooLarge;
 
     use super::{
-        async_trait, Bytes, HttpClient, HttpError, Request, Response, MAX_RESPONSE_BODY_BYTES,
+        async_trait, Bytes, HttpClient, HttpClientTimeout, HttpError, Request, Response,
+        MAX_RESPONSE_BODY_BYTES,
     };
 
     #[async_trait]
     impl HttpClient for reqwest::Client {
         async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
             otel_debug!(name: "ReqwestClient.Send");
-            let request = request.try_into()?;
+            let timeout = request.extensions().get::<HttpClientTimeout>().copied();
+            let mut request: reqwest::Request = request.try_into()?;
+            if let Some(timeout) = timeout {
+                *request.timeout_mut() = Some(timeout.duration());
+            }
             let mut response = self.execute(request).await?;
             let capacity = response
                 .content_length()
@@ -141,7 +169,11 @@ mod reqwest {
         async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
             use std::io::Read;
             otel_debug!(name: "ReqwestBlockingClient.Send");
-            let request = request.try_into()?;
+            let timeout = request.extensions().get::<HttpClientTimeout>().copied();
+            let mut request: reqwest::blocking::Request = request.try_into()?;
+            if let Some(timeout) = timeout {
+                *request.timeout_mut() = Some(timeout.duration());
+            }
             let mut response = self.execute(request)?;
             let capacity = response
                 .content_length()
@@ -226,6 +258,12 @@ pub mod hyper {
     {
         async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError> {
             otel_debug!(name: "HyperClient.Send");
+            let request_timeout = request
+                .extensions()
+                .get::<super::HttpClientTimeout>()
+                .map(|timeout| timeout.duration())
+                .unwrap_or(self.timeout)
+                .min(self.timeout);
             let (parts, body) = request.into_parts();
             let mut request = Request::from_parts(parts, Full::from(body));
             if let Some(ref authorization) = self.authorization {
@@ -233,7 +271,7 @@ pub mod hyper {
                     .headers_mut()
                     .insert(http::header::AUTHORIZATION, authorization.clone());
             }
-            time::timeout(self.timeout, async {
+            time::timeout(request_timeout, async {
                 let mut response = self.inner.request(request).await?;
                 let capacity = response
                     .body()
@@ -521,7 +559,7 @@ Connection: close\r\n\r\n",
             addr
         }
 
-        #[cfg(feature = "hyper")]
+        #[cfg(any(feature = "hyper", feature = "reqwest"))]
         async fn start_stalled_body_server() -> SocketAddr {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             let addr = listener.local_addr().unwrap();
@@ -538,6 +576,38 @@ Connection: close\r\n\r\n",
                 }
             });
             addr
+        }
+
+        #[cfg(feature = "reqwest-blocking")]
+        fn start_blocking_stalled_body_server() -> SocketAddr {
+            use std::io::{Read, Write};
+            use std::net::TcpListener;
+
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            std::thread::spawn(move || {
+                if let Ok((mut socket, _)) = listener.accept() {
+                    let mut buf = [0u8; 1024];
+                    let _ = socket.read(&mut buf);
+                    let _ = socket.write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\nConnection: close\r\n\r\n",
+                    );
+                    std::thread::sleep(std::time::Duration::from_secs(1));
+                }
+            });
+            addr
+        }
+
+        fn request_with_timeout(addr: SocketAddr) -> Request<Bytes> {
+            let mut request = Request::post(format!("http://{addr}/"))
+                .body(Bytes::new())
+                .unwrap();
+            request
+                .extensions_mut()
+                .insert(crate::HttpClientTimeout::new(
+                    std::time::Duration::from_millis(25),
+                ));
+            request
         }
 
         async fn assert_within_limit(client: &dyn HttpClient, addr: SocketAddr) {
@@ -669,6 +739,58 @@ Connection: close\r\n\r\n",
             assert!(error
                 .downcast_ref::<tokio::time::error::Elapsed>()
                 .is_some());
+        }
+
+        #[cfg(feature = "reqwest")]
+        #[tokio::test]
+        async fn reqwest_honors_per_request_timeout_during_response_body() {
+            let addr = start_stalled_body_server().await;
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(1))
+                .build()
+                .unwrap();
+
+            tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                client.send_bytes(request_with_timeout(addr)),
+            )
+            .await
+            .expect("per-request timeout must bound reqwest response collection")
+            .expect_err("stalled response body must time out");
+        }
+
+        #[cfg(feature = "reqwest-blocking")]
+        #[test]
+        fn reqwest_blocking_honors_per_request_timeout_during_response_body() {
+            let addr = start_blocking_stalled_body_server();
+            let client = reqwest::blocking::Client::builder()
+                .timeout(std::time::Duration::from_secs(1))
+                .build()
+                .unwrap();
+            let start = std::time::Instant::now();
+
+            futures_executor::block_on(client.send_bytes(request_with_timeout(addr)))
+                .expect_err("stalled response body must time out");
+
+            assert!(start.elapsed() < std::time::Duration::from_millis(200));
+        }
+
+        #[cfg(feature = "hyper")]
+        #[tokio::test]
+        async fn hyper_honors_per_request_timeout_during_response_body() {
+            let addr = start_stalled_body_server().await;
+            let client = crate::hyper::HyperClient::with_default_connector(
+                std::time::Duration::from_secs(1),
+                None,
+            );
+
+            tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                client.send_bytes(request_with_timeout(addr)),
+            )
+            .await
+            .expect("per-request timeout must bound Hyper response collection")
+            .expect_err("stalled response body must time out");
         }
     }
 }

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -34,6 +34,10 @@ release:
 
 ### Other changes
 
+- Enforce the configured exporter timeout across the complete batch export,
+  including all attempts, backoff, HTTP response bodies, and gRPC response
+  decoding and trailers. Each retry now receives only the remaining timeout.
+
 - **Breaking** Removed `Default` from the `TonicExporterBuilderSet` and
   `HttpExporterBuilderSet` typestate markers. This also removes `Default` from
   the transport-selected exporter builders (e.g.

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -422,24 +422,39 @@ impl OtlpHttpClient {
     {
         use crate::retry::retry_with_backoff;
 
+        let export_start = std::time::Instant::now();
         // Build request body once before retry loop
         let (body, content_type, content_encoding) = build_body_fn(self, data)
             .map_err(opentelemetry_sdk::error::OTelSdkError::InternalFailure)?;
+        let retry_budget = self.timeout.saturating_sub(export_start.elapsed());
+        if retry_budget.is_zero() {
+            return Err(opentelemetry_sdk::error::OTelSdkError::InternalFailure(
+                "OTLP export deadline exceeded".to_string(),
+            ));
+        }
 
         let retry_data = Arc::new(HttpRetryData {
             body,
             headers: self.headers.clone(),
             endpoint: self.collector_endpoint.to_string(),
         });
+        let retry_data = &retry_data;
 
         let response_body = retry_with_backoff(
             &self.retry_policy,
-            self.timeout,
+            retry_budget,
             classify_http_export_error,
             operation_name,
-            || async {
-                self.export_http_once(&retry_data, content_type, content_encoding, operation_name)
-                    .await
+            || HttpExportError::new(0, "OTLP export deadline exceeded".to_string()),
+            |remaining| async move {
+                self.export_http_once(
+                    retry_data,
+                    content_type,
+                    content_encoding,
+                    operation_name,
+                    remaining,
+                )
+                .await
             },
         )
         .await
@@ -461,7 +476,9 @@ impl OtlpHttpClient {
         content_type: &'static str,
         content_encoding: Option<&'static str>,
         _operation_name: &'static str,
+        remaining: Duration,
     ) -> Result<Bytes, HttpExportError> {
+        let attempt_start = std::time::Instant::now();
         // Get client
         let client = self
             .client
@@ -484,6 +501,16 @@ impl OtlpHttpClient {
         let mut request = request_builder
             .body(retry_data.body.clone().into())
             .map_err(|e| HttpExportError::new(400, format!("Failed to build HTTP request: {e}")))?;
+        let request_timeout = remaining.saturating_sub(attempt_start.elapsed());
+        if request_timeout.is_zero() {
+            return Err(HttpExportError::new(
+                0,
+                "OTLP export deadline exceeded".to_string(),
+            ));
+        }
+        request
+            .extensions_mut()
+            .insert(opentelemetry_http::HttpClientTimeout::new(request_timeout));
 
         for (k, v) in retry_data.headers.iter() {
             request.headers_mut().insert(k.clone(), v.clone());
@@ -832,7 +859,10 @@ impl HasHttpConfig for HttpExporterBuilder {
 ///
 /// This trait is sealed and cannot be implemented for types outside this crate.
 pub trait WithHttpConfig: super::sealed::WithHttpConfig {
-    /// Assign client implementation
+    /// Assign a client implementation.
+    ///
+    /// The client must honor [`opentelemetry_http::HttpClientTimeout`] request
+    /// extensions for the exporter timeout to be a hard upper bound.
     fn with_http_client<T: HttpClient + 'static>(self, client: T) -> Self;
 
     /// Set additional headers to send to the collector.
@@ -1877,6 +1907,36 @@ mod tests {
             fail_count: usize,
         }
 
+        #[derive(Debug, Default)]
+        struct BudgetRecordingMockClient {
+            attempts: AtomicUsize,
+            budgets: std::sync::Mutex<Vec<Duration>>,
+        }
+
+        #[async_trait::async_trait]
+        impl HttpClient for BudgetRecordingMockClient {
+            async fn send_bytes(
+                &self,
+                request: http::Request<Bytes>,
+            ) -> Result<http::Response<Bytes>, opentelemetry_http::HttpError> {
+                let budget = request
+                    .extensions()
+                    .get::<opentelemetry_http::HttpClientTimeout>()
+                    .expect("exporter must provide a per-attempt timeout")
+                    .duration();
+                self.budgets.lock().unwrap().push(budget);
+
+                if self.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err("connection refused".into())
+                } else {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .body(Bytes::new())
+                        .unwrap())
+                }
+            }
+        }
+
         impl NetworkFailureMockClient {
             fn new(fail_count: usize) -> Self {
                 Self {
@@ -1983,6 +2043,19 @@ mod tests {
             let error = result.unwrap_err().to_string();
             assert!(error.contains("request will not be sent"));
             assert_eq!(mock.attempt_count(), 0);
+        }
+
+        #[test]
+        fn retries_receive_decreasing_request_timeouts() {
+            let mock = Arc::new(BudgetRecordingMockClient::default());
+            let client = make_client(mock.clone(), retry_policy());
+
+            futures_executor::block_on(client.export_http_with_retry((), build_test_body, "test"))
+                .unwrap();
+
+            let budgets = mock.budgets.lock().unwrap();
+            assert_eq!(budgets.len(), 2);
+            assert!(budgets[1] < budgets[0]);
         }
 
         #[test]

--- a/opentelemetry-otlp/src/exporter/tonic/logs.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/logs.rs
@@ -67,15 +67,16 @@ impl TonicLogsClient {
 impl LogExporter for TonicLogsClient {
     async fn export(&self, batch: LogBatch<'_>) -> OTelSdkResult {
         let batch = Arc::new(batch);
+        let batch = &batch;
 
         match super::tonic_retry_with_backoff(
             &self.retry_policy,
             self.timeout,
             crate::retry_classification::grpc::classify_tonic_status,
             "TonicLogsClient.Export",
-            || async {
-                let batch_clone = Arc::clone(&batch);
-
+            |remaining| async move {
+                let attempt_start = std::time::Instant::now();
+                let batch_clone = Arc::clone(batch);
                 // Execute the export operation
                 let (mut client, metadata, extensions) = self
                     .inner
@@ -101,12 +102,20 @@ impl LogExporter for TonicLogsClient {
 
                 otel_debug!(name: "TonicLogsClient.ExportStarted");
 
-                client
-                    .export(Request::from_parts(
-                        metadata,
-                        extensions,
-                        ExportLogsServiceRequest { resource_logs },
-                    ))
+                let mut request = Request::from_parts(
+                    metadata,
+                    extensions,
+                    ExportLogsServiceRequest { resource_logs },
+                );
+                let request_timeout = remaining.saturating_sub(attempt_start.elapsed());
+                if request_timeout.is_zero() {
+                    return Err(tonic::Status::deadline_exceeded(
+                        "OTLP export deadline exceeded",
+                    ));
+                }
+                request.set_timeout(request_timeout);
+
+                super::tonic_request_with_timeout(request_timeout, client.export(request))
                     .await
                     .map(|response| {
                         otel_debug!(name: "TonicLogsClient.ExportSucceeded");

--- a/opentelemetry-otlp/src/exporter/tonic/metrics.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/metrics.rs
@@ -66,7 +66,8 @@ impl MetricsClient for TonicMetricsClient {
             self.timeout,
             crate::retry_classification::grpc::classify_tonic_status,
             "TonicMetricsClient.Export",
-            || async {
+            |remaining| async move {
+                let attempt_start = std::time::Instant::now();
                 // Execute the export operation
                 let (mut client, metadata, extensions) = self
                     .inner
@@ -90,12 +91,20 @@ impl MetricsClient for TonicMetricsClient {
 
                 otel_debug!(name: "TonicMetricsClient.ExportStarted");
 
-                client
-                    .export(Request::from_parts(
-                        metadata,
-                        extensions,
-                        ExportMetricsServiceRequest::from(metrics),
-                    ))
+                let mut request = Request::from_parts(
+                    metadata,
+                    extensions,
+                    ExportMetricsServiceRequest::from(metrics),
+                );
+                let request_timeout = remaining.saturating_sub(attempt_start.elapsed());
+                if request_timeout.is_zero() {
+                    return Err(tonic::Status::deadline_exceeded(
+                        "OTLP export deadline exceeded",
+                    ));
+                }
+                request.set_timeout(request_timeout);
+
+                super::tonic_request_with_timeout(request_timeout, client.export(request))
                     .await
                     .map(|response| {
                         otel_debug!(name: "TonicMetricsClient.ExportSucceeded");

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -441,10 +441,34 @@ async fn tonic_retry_with_backoff<F, Fut, T>(
     operation: F,
 ) -> Result<T, tonic::Status>
 where
-    F: Fn() -> Fut,
+    F: Fn(std::time::Duration) -> Fut,
     Fut: Future<Output = Result<T, tonic::Status>>,
 {
-    retry_with_backoff(policy, timeout, classify_fn, operation_name, operation).await
+    retry_with_backoff(
+        policy,
+        timeout,
+        classify_fn,
+        operation_name,
+        || tonic::Status::deadline_exceeded("OTLP export deadline exceeded"),
+        operation,
+    )
+    .await
+}
+
+#[cfg(all(
+    feature = "grpc-tonic",
+    any(feature = "trace", feature = "metrics", feature = "logs")
+))]
+async fn tonic_request_with_timeout<F, T>(
+    timeout: std::time::Duration,
+    request: F,
+) -> Result<T, tonic::Status>
+where
+    F: Future<Output = Result<T, tonic::Status>>,
+{
+    tokio::time::timeout(timeout, request)
+        .await
+        .map_err(|_| tonic::Status::deadline_exceeded("OTLP export deadline exceeded"))?
 }
 
 #[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
@@ -684,8 +708,8 @@ pub trait WithTonicConfig: super::sealed::WithTonicConfig {
     /// this will override tls config and should only be used
     /// when working with non-HTTP transports.
     ///
-    /// Users MUST make sure the timeout is
-    /// the same as the channel's timeout.
+    /// The exporter applies its remaining timeout to each complete RPC. A
+    /// shorter timeout configured on the channel may end an attempt earlier.
     fn with_channel(self, channel: tonic::transport::Channel) -> Self;
 
     /// Use a custom `interceptor` to modify each outbound request.
@@ -820,6 +844,20 @@ mod tests {
     use crate::{OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_TRACES_HEADERS};
     use http::{HeaderMap, HeaderName, HeaderValue};
     use tonic::metadata::{MetadataMap, MetadataValue};
+
+    #[tokio::test]
+    #[cfg(any(feature = "trace", feature = "metrics", feature = "logs"))]
+    async fn tonic_response_body_stall_is_bounded_by_timeout() {
+        let result =
+            super::tonic_request_with_timeout(std::time::Duration::from_millis(10), async {
+                // The generated tonic client future remains pending while it
+                // decodes the response body and trailers.
+                std::future::pending::<Result<(), tonic::Status>>().await
+            })
+            .await;
+
+        assert_eq!(result.unwrap_err().code(), tonic::Code::DeadlineExceeded);
+    }
 
     // Scheme-resolution unit tests. These are intentionally free of env vars, a
     // tokio runtime, and TLS features so they run under every feature

--- a/opentelemetry-otlp/src/exporter/tonic/trace.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/trace.rs
@@ -69,15 +69,16 @@ impl TonicTracesClient {
 impl SpanExporter for TonicTracesClient {
     async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
         let batch = Arc::new(batch);
+        let batch = &batch;
 
         match super::tonic_retry_with_backoff(
             &self.retry_policy,
             self.timeout,
             crate::retry_classification::grpc::classify_tonic_status,
             "TonicTracesClient.Export",
-            || async {
-                let batch_clone = Arc::clone(&batch);
-
+            |remaining| async move {
+                let attempt_start = std::time::Instant::now();
+                let batch_clone = Arc::clone(batch);
                 // Execute the export operation
                 let (mut client, metadata, extensions) = self
                     .inner
@@ -104,12 +105,20 @@ impl SpanExporter for TonicTracesClient {
 
                 otel_debug!(name: "TonicTracesClient.ExportStarted");
 
-                client
-                    .export(Request::from_parts(
-                        metadata,
-                        extensions,
-                        ExportTraceServiceRequest { resource_spans },
-                    ))
+                let mut request = Request::from_parts(
+                    metadata,
+                    extensions,
+                    ExportTraceServiceRequest { resource_spans },
+                );
+                let request_timeout = remaining.saturating_sub(attempt_start.elapsed());
+                if request_timeout.is_zero() {
+                    return Err(tonic::Status::deadline_exceeded(
+                        "OTLP export deadline exceeded",
+                    ));
+                }
+                request.set_timeout(request_timeout);
+
+                super::tonic_request_with_timeout(request_timeout, client.export(request))
                     .await
                     .map(|response| {
                         otel_debug!(name: "TonicTracesClient.ExportSucceeded");

--- a/opentelemetry-otlp/src/retry.rs
+++ b/opentelemetry-otlp/src/retry.rs
@@ -78,14 +78,9 @@ fn generate_jitter(max_jitter: Duration) -> Duration {
 /// on a bare OS thread (the SDK's default batch processors), `std::thread::sleep`
 /// is used instead.
 ///
-/// A time budget (deadline) bounds the total retry duration. If the budget is exhausted,
-/// the function returns the last error without further retries.
-///
-/// **Note:** The deadline governs whether to start another retry and caps inter-retry
-/// sleep durations, but it does not cancel an in-flight export operation. On dedicated
-/// threads (the SDK's default batch processors), individual export calls do not have a
-/// timeout today, so a single slow export can exceed the deadline. This is an existing
-/// limitation.
+/// A time budget (deadline) bounds the complete operation, including attempts and
+/// backoff. Each attempt receives the remaining budget so the transport can apply
+/// it to the request. A result that arrives after the deadline is rejected.
 ///
 /// # Arguments
 ///
@@ -93,24 +88,27 @@ fn generate_jitter(max_jitter: Duration) -> Duration {
 /// * `deadline` - Maximum total time allowed for all retry attempts combined.
 /// * `error_classifier` - Function to classify errors for retry decisions.
 /// * `operation_name` - The name of the operation being retried.
-/// * `operation` - The operation to be retried.
+/// * `deadline_error` - Creates the error returned when the deadline expires.
+/// * `operation` - The operation to be retried, passed its remaining time budget.
 ///
 /// # Returns
 ///
 /// A `Result` containing the operation's result or an error if max retries are reached
 /// or a non-retryable error occurs.
-pub(crate) async fn retry_with_backoff<F, Fut, T, E, C>(
+pub(crate) async fn retry_with_backoff<F, Fut, T, E, C, D>(
     policy: &RetryPolicy,
     deadline: Duration,
     error_classifier: C,
     operation_name: &str,
+    deadline_error: D,
     mut operation: F,
 ) -> Result<T, E>
 where
-    F: FnMut() -> Fut,
+    F: FnMut(Duration) -> Fut,
     E: std::fmt::Debug,
     Fut: Future<Output = Result<T, E>>,
     C: Fn(&E) -> RetryErrorType,
+    D: Fn() -> E,
 {
     let start = Instant::now();
     let mut attempt = 0;
@@ -122,8 +120,23 @@ where
     let mut delay_cap = policy.max_delay;
 
     loop {
-        match operation().await {
-            Ok(result) => return Ok(result),
+        let remaining = deadline.saturating_sub(start.elapsed());
+        if remaining.is_zero() {
+            return Err(deadline_error());
+        }
+
+        match operation(remaining).await {
+            Ok(result) => {
+                if start.elapsed() >= deadline {
+                    otel_warn!(name: "Export.Failed.DeadlineExceeded",
+                        operation = operation_name,
+                        retries = attempt,
+                        message = "OTLP export completed after its deadline - telemetry data will be lost"
+                    );
+                    return Err(deadline_error());
+                }
+                return Ok(result);
+            }
             Err(err) => {
                 // Check time budget before deciding to retry
                 let elapsed = start.elapsed();
@@ -134,7 +147,7 @@ where
                         elapsed_ms = elapsed.as_millis(),
                         message = "OTLP export deadline exceeded - telemetry data will be lost"
                     );
-                    return Err(err);
+                    return Err(deadline_error());
                 }
 
                 let error_type = error_classifier(&err);
@@ -296,7 +309,8 @@ mod tests {
                 Duration::from_secs(10),
                 |_| classification.clone(),
                 "test_operation",
-                || {
+                Default::default,
+                |_| {
                     attempts.fetch_add(1, Ordering::SeqCst);
                     Box::pin(async { Err::<(), _>(()) })
                 },
@@ -329,11 +343,64 @@ mod tests {
             deadline,
             |_: &()| RetryErrorType::Retryable,
             "test_operation",
-            || Box::pin(async { Ok::<_, ()>("success") }),
+            Default::default,
+            |_| Box::pin(async { Ok::<_, ()>("success") }),
         )
         .await;
 
         assert_eq!(result, Ok("success"));
+    }
+
+    #[test]
+    fn test_success_after_deadline_is_rejected_without_tokio() {
+        let deadline = Duration::from_millis(20);
+        let result = futures_executor::block_on(retry_with_backoff(
+            &RetryPolicy::disabled(),
+            deadline,
+            |_: &&str| RetryErrorType::NonRetryable,
+            "test_operation",
+            || "deadline",
+            |remaining| {
+                Box::pin(async move {
+                    std::thread::sleep(remaining.saturating_add(Duration::from_millis(10)));
+                    Ok::<_, &str>("late success")
+                })
+            },
+        ));
+
+        assert_eq!(result, Err("deadline"));
+    }
+
+    #[tokio::test]
+    async fn test_each_attempt_receives_remaining_budget() {
+        let policy = policy(1, 20, 20, 0);
+        let attempts = AtomicUsize::new(0);
+        let budgets = std::sync::Mutex::new(Vec::new());
+
+        let result = retry_with_backoff(
+            &policy,
+            Duration::from_secs(1),
+            |_: &()| RetryErrorType::Retryable,
+            "test_operation",
+            Default::default,
+            |remaining| {
+                budgets.lock().unwrap().push(remaining);
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async move {
+                    if attempt == 0 {
+                        Err(())
+                    } else {
+                        Ok("success")
+                    }
+                })
+            },
+        )
+        .await;
+
+        assert_eq!(result, Ok("success"));
+        let budgets = budgets.lock().unwrap();
+        assert_eq!(budgets.len(), 2);
+        assert!(budgets[1] < budgets[0]);
     }
 
     #[tokio::test]
@@ -347,7 +414,8 @@ mod tests {
             deadline,
             |_: &&str| RetryErrorType::Retryable,
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async move {
                     if attempt < 2 {
@@ -375,7 +443,8 @@ mod tests {
             deadline,
             |_: &&str| RetryErrorType::Retryable,
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async { Err::<(), _>("error") })
             },
@@ -397,7 +466,8 @@ mod tests {
             deadline,
             |_: &()| RetryErrorType::NonRetryable,
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async { Err::<(), _>(()) })
             },
@@ -430,7 +500,8 @@ mod tests {
             deadline,
             |_: &()| RetryErrorType::Throttled(Duration::from_millis(50)),
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async move {
                     if attempt < 1 {
@@ -464,7 +535,8 @@ mod tests {
             Duration::from_secs(2),
             |_: &usize| RetryErrorType::Throttled(Duration::from_millis(20)),
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async move {
                     if attempt < 2 {
@@ -502,7 +574,8 @@ mod tests {
                 }
             },
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async move {
                     if attempt < 2 {
@@ -543,7 +616,8 @@ mod tests {
                 }
             },
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async move {
                     if attempt < 3 {
@@ -595,7 +669,8 @@ mod tests {
                 }
             },
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async move {
                     if attempt < 3 {
@@ -631,7 +706,8 @@ mod tests {
             deadline,
             |_: &()| RetryErrorType::Retryable,
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async { Err::<(), _>(()) })
             },
@@ -660,7 +736,8 @@ mod tests {
             short_deadline,
             |_: &()| RetryErrorType::Throttled(Duration::from_secs(120)),
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async { Err::<(), _>(()) })
             },
@@ -688,7 +765,8 @@ mod tests {
             deadline,
             |_: &&str| RetryErrorType::Retryable,
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async move {
                     if attempt < 2 {
@@ -719,7 +797,8 @@ mod tests {
             deadline,
             |_: &()| RetryErrorType::Retryable,
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async { Err::<(), _>(()) })
             },
@@ -745,7 +824,8 @@ mod tests {
             deadline,
             |_: &()| RetryErrorType::Throttled(Duration::from_millis(50)),
             "test_operation",
-            || {
+            Default::default,
+            |_| {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst);
                 Box::pin(async move {
                     if attempt < 1 {


### PR DESCRIPTION
Makes the configured OTLP timeout a total export budget covering serialization, every retry attempt, backoff, HTTP response bodies, and gRPC response decoding and trailers.

Adds `HttpClientTimeout` for communicating the remaining per-attempt budget to HTTP clients. Built-in reqwest and Hyper clients honor it, while tonic applies the remaining budget around the complete generated RPC future and sends `grpc-timeout`.

Includes dedicated-thread late-success coverage, decreasing retry-budget tests, response-body stall tests for every built-in HTTP client, and tonic response-body stall coverage.

Depends on #3725.

The full precommit script reaches its workspace feature-matrix phase, then encounters the existing cargo-hack integration-test manifest failure involving `opentelemetry-appender-tracing`.