### PR TITLE
fix: redact exporter credentials from Debug output

### DIFF
--- a/opentelemetry-http/CHANGELOG.md
+++ b/opentelemetry-http/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+- Redact `HyperClient` authorization values from `Debug` output and mark them
+  sensitive in HTTP headers.
+
 - **Breaking** Sealed the `ResponseExt` trait so it can no longer be implemented by
   downstream crates. The trait provides a blanket implementation for all
   `http::Response<T>` types, so calling code is unaffected -- only

--- a/opentelemetry-http/src/lib.rs
+++ b/opentelemetry-http/src/lib.rs
@@ -76,6 +76,9 @@ pub trait HttpClient: Debug + Send + Sync {
     ///
     /// Returns an error if it can't connect to the server or the request could not be completed,
     /// e.g. because of a timeout, infinite redirects, or a loss of connection.
+    ///
+    /// Implementations must ensure their [`Debug`] output does not expose
+    /// authentication headers or other credentials.
     async fn send_bytes(&self, request: Request<Bytes>) -> Result<Response<Bytes>, HttpError>;
 }
 
@@ -183,7 +186,7 @@ pub mod hyper {
     use std::time::Duration;
     use tokio::time;
 
-    #[derive(Debug, Clone)]
+    #[derive(Clone)]
     pub struct HyperClient<C = HttpConnector>
     where
         C: Connect + Clone + Send + Sync + 'static,
@@ -200,6 +203,10 @@ pub mod hyper {
         pub fn new(connector: C, timeout: Duration, authorization: Option<HeaderValue>) -> Self {
             // TODO - support custom executor
             let inner = Client::builder(hyper_util::rt::TokioExecutor::new()).build(connector);
+            let authorization = authorization.map(|mut value| {
+                value.set_sensitive(true);
+                value
+            });
             Self {
                 inner,
                 timeout,
@@ -258,6 +265,44 @@ pub mod hyper {
                 .body(body_bytes.freeze())?;
             *http_response.headers_mut() = headers;
             Ok(http_response)
+        }
+    }
+
+    impl<C> Debug for HyperClient<C>
+    where
+        C: Connect + Clone + Send + Sync + 'static,
+    {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter
+                .debug_struct("HyperClient")
+                .field("inner", &self.inner)
+                .field("timeout", &self.timeout)
+                .field(
+                    "authorization",
+                    &self.authorization.as_ref().map(|_| "[REDACTED]"),
+                )
+                .finish()
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn debug_redacts_authorization() {
+            const SECRET: &str = "sentinel-hyper-secret";
+            let client = HyperClient::with_default_connector(
+                Duration::from_secs(1),
+                Some(HeaderValue::from_static(SECRET)),
+            );
+
+            let authorization = client.authorization.as_ref().unwrap();
+            assert_eq!(authorization.to_str().unwrap(), SECRET);
+            assert!(authorization.is_sensitive());
+            let debug = format!("{client:?}");
+            assert!(!debug.contains(SECRET));
+            assert!(debug.contains("[REDACTED]"));
         }
     }
 }

--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -34,6 +34,12 @@ release:
 
 ### Other changes
 
+- Redact configured HTTP headers and gRPC metadata from exporter `Debug` output,
+  together with TLS, client, channel, and interceptor configuration that may
+  contain sensitive values. HTTP header and gRPC metadata values are also marked
+  sensitive before requests are sent. Collector endpoint values remain visible
+  in `Debug` output and internal diagnostics.
+
 - **Breaking** Removed `Default` from the `TonicExporterBuilderSet` and
   `HttpExporterBuilderSet` typestate markers. This also removes `Default` from
   the transport-selected exporter builders (e.g.

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -21,6 +21,7 @@ use opentelemetry_sdk::trace::SpanData;
 use prost::Message;
 use std::collections::HashMap;
 use std::env;
+use std::fmt::{Debug, Formatter};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -113,7 +114,7 @@ mod trace;
 use opentelemetry_http::hyper::HyperClient;
 
 /// Configuration of the http transport
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub(crate) struct HttpConfig {
     /// Select the HTTP client
     client: Option<Arc<dyn HttpClient>>,
@@ -129,6 +130,19 @@ pub(crate) struct HttpConfig {
 
     /// Maximum HTTP request body size, before and after compression.
     max_request_body_size: Option<usize>,
+}
+
+impl Debug for HttpConfig {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HttpConfig")
+            .field("client_configured", &self.client.is_some())
+            .field("header_count", &self.headers.as_ref().map(HashMap::len))
+            .field("compression", &self.compression)
+            .field("retry_policy", &self.retry_policy)
+            .field("max_request_body_size", &self.max_request_body_size)
+            .finish()
+    }
 }
 
 /// Configuration for the OTLP HTTP exporter.
@@ -299,6 +313,7 @@ impl HttpExporterBuilder {
         {
             add_header_from_string(&input, &mut headers);
         }
+        mark_header_values_sensitive(&mut headers);
 
         let mut client = OtlpHttpClient::new(
             http_client,
@@ -389,7 +404,6 @@ impl HttpExporterBuilder {
     }
 }
 
-#[derive(Debug)]
 pub(crate) struct OtlpHttpClient {
     client: Mutex<Option<Arc<dyn HttpClient>>>,
     collector_endpoint: Uri,
@@ -402,6 +416,21 @@ pub(crate) struct OtlpHttpClient {
     #[allow(dead_code)]
     // <allow dead> would be removed once we support set_resource for metrics and traces.
     resource: opentelemetry_proto::transform::common::tonic::ResourceAttributesWithSchema,
+}
+
+impl Debug for OtlpHttpClient {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("OtlpHttpClient")
+            .field("collector_endpoint", &self.collector_endpoint)
+            .field("header_count", &self.headers.len())
+            .field("protocol", &self.protocol)
+            .field("timeout", &self.timeout)
+            .field("compression", &self.compression)
+            .field("retry_policy", &self.retry_policy)
+            .field("max_request_body_size", &self.max_request_body_size)
+            .finish_non_exhaustive()
+    }
 }
 
 impl OtlpHttpClient {
@@ -804,6 +833,12 @@ fn add_header_from_string(input: &str, headers: &mut HashMap<HeaderName, HeaderV
     }));
 }
 
+fn mark_header_values_sensitive(headers: &mut HashMap<HeaderName, HeaderValue>) {
+    for value in headers.values_mut() {
+        value.set_sensitive(true);
+    }
+}
+
 /// Expose interface for modifying builder config.
 pub(crate) trait HasHttpConfig {
     /// Return a mutable reference to the config within the exporter builders.
@@ -891,7 +926,7 @@ impl<B: HasHttpConfig> WithHttpConfig for B {
 
 #[cfg(test)]
 mod tests {
-    use crate::exporter::http::HttpConfig;
+    use crate::exporter::http::{HttpConfig, OtlpHttpClient};
     use crate::exporter::tests::run_env_test;
     use crate::{
         WithExportConfig, WithHttpConfig, OTEL_EXPORTER_OTLP_ENDPOINT,
@@ -899,6 +934,66 @@ mod tests {
     };
 
     use super::{build_endpoint_uri, resolve_http_endpoint, HttpExporterBuilder};
+
+    const SECRET: &str = "sentinel-http-secret";
+
+    struct CredentialDebugClient;
+
+    impl std::fmt::Debug for CredentialDebugClient {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str(SECRET)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl opentelemetry_http::HttpClient for CredentialDebugClient {
+        async fn send_bytes(
+            &self,
+            _request: http::Request<opentelemetry_http::Bytes>,
+        ) -> Result<http::Response<opentelemetry_http::Bytes>, opentelemetry_http::HttpError>
+        {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn debug_redacts_http_credentials() {
+        let builder = crate::SpanExporter::builder()
+            .with_http()
+            .with_http_client(CredentialDebugClient)
+            .with_headers(std::collections::HashMap::from([(
+                "authorization".to_string(),
+                SECRET.to_string(),
+            )]));
+        assert!(!format!("{builder:?}").contains(SECRET));
+
+        let mut headers = std::collections::HashMap::from([(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_static(SECRET),
+        )]);
+        super::mark_header_values_sensitive(&mut headers);
+        assert_eq!(
+            headers.get(&http::header::AUTHORIZATION).unwrap(),
+            http::HeaderValue::from_static(SECRET)
+        );
+        assert!(headers.values().all(http::HeaderValue::is_sensitive));
+
+        #[cfg(feature = "http-proto")]
+        let protocol = crate::Protocol::HttpBinary;
+        #[cfg(all(not(feature = "http-proto"), feature = "http-json"))]
+        let protocol = crate::Protocol::HttpJson;
+        let client = OtlpHttpClient::new(
+            std::sync::Arc::new(CredentialDebugClient),
+            "http://localhost:4318/v1/traces".parse().unwrap(),
+            headers,
+            protocol,
+            std::time::Duration::from_secs(10),
+            None,
+            None,
+        );
+        let exporter = crate::SpanExporter::from_http(client);
+        assert!(!format!("{exporter:?}").contains(SECRET));
+    }
 
     #[test]
     fn test_append_signal_path_to_generic_env() {

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use http::{HeaderMap, HeaderName, HeaderValue};
 use opentelemetry::otel_debug;
 use tonic::codec::CompressionEncoding;
-use tonic::metadata::{KeyAndValueRef, MetadataMap};
+use tonic::metadata::{KeyAndMutValueRef, KeyAndValueRef, MetadataMap};
 use tonic::service::Interceptor;
 use tonic::transport::Channel;
 #[cfg(any(
@@ -44,7 +44,7 @@ pub(crate) mod trace;
 /// Configuration for [tonic]
 ///
 /// [tonic]: https://github.com/hyperium/tonic
-#[derive(Debug, Default)]
+#[derive(Default)]
 #[non_exhaustive]
 pub(crate) struct TonicConfig {
     /// Custom metadata entries to send to the collector.
@@ -62,6 +62,28 @@ pub(crate) struct TonicConfig {
     pub(crate) interceptor: Option<BoxInterceptor>,
     /// The retry policy to use for gRPC requests.
     pub(crate) retry_policy: Option<RetryPolicy>,
+}
+
+impl Debug for TonicConfig {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut debug = formatter.debug_struct("TonicConfig");
+        debug.field(
+            "metadata_count",
+            &self.metadata.as_ref().map(MetadataMap::len),
+        );
+        #[cfg(any(
+            feature = "tls-ring",
+            feature = "tls-aws-lc",
+            feature = "tls-provider-agnostic"
+        ))]
+        debug.field("tls_configured", &self.tls_config.is_some());
+        debug
+            .field("compression", &self.compression)
+            .field("channel_configured", &self.channel.is_some())
+            .field("interceptor_configured", &self.interceptor.is_some())
+            .field("retry_policy", &self.retry_policy)
+            .finish()
+    }
 }
 
 impl TryFrom<Compression> for tonic::codec::CompressionEncoding {
@@ -224,10 +246,11 @@ impl TonicExporterBuilder {
 
         let (headers_from_env, headers_for_logging) = parse_headers_from_env(signal_headers_var);
 
-        let metadata = merge_metadata_with_headers_from_env(
+        let mut metadata = merge_metadata_with_headers_from_env(
             self.tonic_config.metadata.unwrap_or_default(),
             headers_from_env,
         );
+        mark_metadata_values_sensitive(&mut metadata);
 
         let add_metadata = move |mut req: tonic::Request<()>| {
             for key_and_value in metadata.iter() {
@@ -590,6 +613,15 @@ fn merge_metadata_with_headers_from_env(
     }
 }
 
+fn mark_metadata_values_sensitive(metadata: &mut MetadataMap) {
+    for entry in metadata.iter_mut() {
+        match entry {
+            KeyAndMutValueRef::Ascii(_, value) => value.set_sensitive(true),
+            KeyAndMutValueRef::Binary(_, value) => value.set_sensitive(true),
+        }
+    }
+}
+
 fn parse_headers_from_env(signal_headers_var: &str) -> (HeaderMap, Vec<String>) {
     let mut headers = Vec::new();
 
@@ -780,7 +812,9 @@ impl<B: HasTonicConfig> WithTonicConfig for B {
             .into_headers();
         existing_headers.extend(metadata.into_headers());
 
-        self.tonic_config().metadata = Some(MetadataMap::from_headers(existing_headers));
+        let mut metadata = MetadataMap::from_headers(existing_headers);
+        mark_metadata_values_sensitive(&mut metadata);
+        self.tonic_config().metadata = Some(metadata);
         self
     }
 
@@ -907,6 +941,37 @@ mod tests {
                 .unwrap()
                 .len()
         );
+    }
+
+    #[test]
+    fn debug_redacts_metadata_values() {
+        const SECRET: &str = "sentinel-tonic-secret";
+        let mut metadata = MetadataMap::new();
+        metadata.insert("authorization", MetadataValue::from_static(SECRET));
+        metadata.insert_bin(
+            "authorization-bin",
+            MetadataValue::from_bytes(SECRET.as_bytes()),
+        );
+
+        let builder = TonicExporterBuilder::default().with_metadata(metadata);
+        let metadata = builder.tonic_config.metadata.as_ref().unwrap();
+        let value = metadata.get("authorization").unwrap();
+        assert_eq!(value.to_str().unwrap(), SECRET);
+        assert!(value.is_sensitive());
+        let binary_value = metadata.get_bin("authorization-bin").unwrap();
+        assert_eq!(binary_value.to_bytes().unwrap().as_ref(), SECRET.as_bytes());
+        assert!(binary_value.is_sensitive());
+
+        let debug = format!("{builder:?}");
+        assert!(!debug.contains(SECRET));
+        assert!(debug.contains("metadata_count"));
+
+        let mut metadata = MetadataMap::new();
+        metadata.insert("authorization", MetadataValue::from_static(SECRET));
+        let public_builder = crate::SpanExporter::builder()
+            .with_tonic()
+            .with_metadata(metadata);
+        assert!(!format!("{public_builder:?}").contains(SECRET));
     }
 
     #[test]


### PR DESCRIPTION
This is preventive hardening of `Debug` output, not a fix for a known credential leak in the SDK’s internal logging, and is not a stability or release blocker.

Applications may print an exporter or builder while troubleshooting configuration. Derived `Debug` output can include configured credentials even when the application only intended to inspect the surrounding configuration. This change makes that operation safer by summarizing configuration and marking HTTP headers and gRPC metadata as sensitive, following the existing Rust HTTP ecosystem pattern.

Credentials remain accessible and are sent unchanged; this does not prevent applications from explicitly printing them. Collector endpoints remain visible. Regression tests check that credentials remain usable while being omitted from debug output.