### PR TITLE
feat(metrics): prototype opt-in instruments behind experimental feature

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,6 +10,7 @@ Status: **Work-In-Progress**
 * [Metrics API](#metrics-api)
   * [Meter](#meter)
   * [Instruments](#instruments)
+  * [Opt-In Instruments](#opt-in-instruments)
   * [Reporting measurements - use array slices for
     attributes](#reporting-measurements---use-array-slices-for-attributes)
   * [Reporting measurements via synchronous
@@ -126,6 +127,53 @@ path. Instead, the cloned instance should be stored and reused.
 > invalid names. Refer to the [OpenTelemetry
   Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-name-syntax)
   for the valid syntax.
+
+### Opt-In Instruments
+
+This is an experimental prototype of
+[specification PR #4809](https://github.com/open-telemetry/opentelemetry-specification/pull/4809).
+Enable `experimental_metrics_opt_in` on `opentelemetry` for the advisory API and
+on `opentelemetry_sdk` for SDK support. The SDK feature also enables the API
+feature. Neither is enabled by default.
+
+Instrumentation authors can mark expensive, high-cardinality, or specialized
+instruments as disabled by default with `with_opt_in()`. Application owners can
+enable selected instruments with a matching SDK View:
+
+```rust
+use opentelemetry::metrics::MeterProvider as _;
+use opentelemetry_sdk::metrics::{Instrument, SdkMeterProvider, Stream};
+
+let provider = SdkMeterProvider::builder()
+  .with_view(|instrument: &Instrument| {
+    (instrument.name() == "runtime.scheduler.queue.depth").then(|| {
+      Stream::builder().with_enabled(true).build().unwrap()
+    })
+  })
+  .build();
+let meter = provider.meter("runtime");
+let queue_depth = meter
+  .u64_gauge("runtime.scheduler.queue.depth")
+  .with_opt_in()
+  .build();
+
+queue_depth.record(12, &[]);
+```
+
+An opt-in instrument produces no metric data unless a matching View sets
+`with_enabled(true)`. Other stream settings, including an aggregation, do not
+enable it. Conversely, `with_enabled(false)` drops that View's stream for any
+matching instrument, including non-opt-in instruments, regardless of aggregation.
+`with_enabled(true)` does not override `Aggregation::Drop`. Other matching Views
+can still produce streams; disabling one stream is not an instrument-wide veto.
+The enabled state is resolved
+when the instrument is built; Views cannot be changed after the provider is
+built.
+
+Call `add()` and `record()` normally, without an enabled check. The SDK drops
+measurements for disabled instruments and does not invoke callbacks for disabled
+observable instruments. An `Enabled` query, where supported, is only an optional
+optimization to avoid expensive measurement preparation, not a required guard.
 
 :stop_sign: You should avoid changing the order of attributes while reporting
 measurements.

--- a/examples/metrics-advanced/Cargo.toml
+++ b/examples/metrics-advanced/Cargo.toml
@@ -12,6 +12,9 @@ name = "metrics-advanced"
 path = "src/main.rs"
 bench = false
 
+[features]
+experimental_metrics_opt_in = ["opentelemetry/experimental_metrics_opt_in", "opentelemetry_sdk/experimental_metrics_opt_in"]
+
 [dependencies]
 opentelemetry = { workspace = true, features = ["metrics"] }
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }

--- a/examples/metrics-advanced/README.md
+++ b/examples/metrics-advanced/README.md
@@ -1,9 +1,9 @@
 # Metric SDK Advanced Configuration Example
 
-This example shows how to customize the OpenTelemetry Rust Metric SDK. This
-shows how to change temporality, how to customize the aggregation using the
-concept of "Views" etc. The examples write output to stdout, but could be
-replaced with other exporters.
+This example shows how to customize the OpenTelemetry Rust Metric SDK. It
+demonstrates changing temporality, configuring streams with Views, changing
+aggregation and cardinality, and enabling an instrument marked as opt-in. The
+examples write output to stdout, but could be replaced with other exporters.
 
 ## Usage
 
@@ -12,3 +12,14 @@ Run the following, and the Metrics will be written out to stdout.
 ```shell
 $ cargo run
 ```
+
+To include the experimental opt-in metric example, run from the repository root:
+
+```shell
+cargo run -p metrics-advanced --features experimental_metrics_opt_in
+```
+
+The output includes `my_opt_in_counter`, enabled by a matching View. Removing
+that View leaves the instrument disabled; recording calls remain unchanged.
+This prototype follows [specification PR #4809](https://github.com/open-telemetry/opentelemetry-specification/pull/4809)
+and its API may change.

--- a/examples/metrics-advanced/src/main.rs
+++ b/examples/metrics-advanced/src/main.rs
@@ -63,6 +63,18 @@ fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
         }
     };
 
+    // for example 4
+    // Instrumentation authors can mark costly or high-cardinality metrics as
+    // opt-in. A matching view must explicitly enable them.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    let enable_opt_in_metrics = |i: &Instrument| {
+        if i.name() == "my_opt_in_counter" {
+            Stream::builder().with_enabled(true).build().ok()
+        } else {
+            None
+        }
+    };
+
     // Build exporter using Delta Temporality.
     let exporter = opentelemetry_stdout::MetricExporterBuilder::default()
         .with_temporality(Temporality::Delta)
@@ -72,13 +84,15 @@ fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
         .with_service_name("metrics-advanced-example")
         .build();
 
-    let provider = SdkMeterProvider::builder()
+    let provider_builder = SdkMeterProvider::builder()
         .with_periodic_exporter(exporter)
         .with_resource(resource)
         .with_view(my_view_rename_and_unit)
         .with_view(my_view_change_cardinality)
-        .with_view(my_view_change_aggregation)
-        .build();
+        .with_view(my_view_change_aggregation);
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    let provider_builder = provider_builder.with_view(enable_opt_in_metrics);
+    let provider = provider_builder.build();
     global::set_meter_provider(provider.clone());
     provider
 }
@@ -159,6 +173,17 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // next record is commented/uncommented, then exponential histogram will
     // have a different scale.
     histogram3.record(0.4, &[KeyValue::new("mykey1", "v1")]);
+
+    // Example 4 - Enable an opt-in metric using a View.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    {
+        let opt_in_counter = meter
+            .u64_counter("my_opt_in_counter")
+            .with_description("An instrument that is disabled by default")
+            .with_opt_in()
+            .build();
+        opt_in_counter.add(1, &[]);
+    }
 
     // Metrics are exported by default every 60 seconds when using stdout exporter,
     // however shutting down the MeterProvider here instantly flushes

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+- Added prototype support for opt-in metric instruments and the
+  `Stream::builder().with_enabled(bool)` View setting proposed in OpenTelemetry
+  Specification PR #4809. Opt-in instruments are dropped by default and can be
+  enabled only by a matching View with `enabled` set to `true`. Requires the
+  `experimental_metrics_opt_in` feature, which also enables the API feature.
 - Publicly export the `OTEL_*`/`OTEL_*_DEFAULT` environment variable name and
   default value constants for `BatchSpanProcessor` (`opentelemetry_sdk::trace`),
   `BatchLogProcessor` (`opentelemetry_sdk::logs`), and `PeriodicReader`

--- a/opentelemetry-sdk/Cargo.toml
+++ b/opentelemetry-sdk/Cargo.toml
@@ -60,6 +60,7 @@ experimental_logs_batch_log_processor_with_async_runtime = ["logs", "experimenta
 experimental_trace_batch_span_processor_with_async_runtime = ["tokio/sync", "trace", "experimental_async_runtime"]
 experimental_metrics_disable_name_validation = ["metrics"]
 experimental_metrics_bound_instruments = ["metrics", "opentelemetry/experimental_metrics_bound_instruments"]
+experimental_metrics_opt_in = ["metrics", "opentelemetry/experimental_metrics_opt_in"]
 bench_profiling = []
 
 [[bench]]

--- a/opentelemetry-sdk/src/metrics/instrument.rs
+++ b/opentelemetry-sdk/src/metrics/instrument.rs
@@ -106,6 +106,9 @@ pub struct Instrument {
     pub(crate) unit: Cow<'static, str>,
     /// The instrumentation that created the instrument.
     pub(crate) scope: InstrumentationScope,
+    /// Whether the instrument is disabled unless explicitly enabled by a view.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    pub(crate) opt_in: bool,
 }
 
 impl Instrument {
@@ -127,6 +130,12 @@ impl Instrument {
     /// Instrument scope.
     pub fn scope(&self) -> &InstrumentationScope {
         &self.scope
+    }
+
+    /// Whether this instrument is disabled unless explicitly enabled by a view.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    pub fn is_opt_in(&self) -> bool {
+        self.opt_in
     }
 }
 
@@ -153,6 +162,8 @@ pub struct StreamBuilder {
     aggregation: Option<Aggregation>,
     allowed_attribute_keys: Option<Arc<HashSet<Key>>>,
     cardinality_limit: Option<usize>,
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    enabled: Option<bool>,
 }
 
 impl StreamBuilder {
@@ -203,6 +214,18 @@ impl StreamBuilder {
     /// Set the stream cardinality limit. If this is not set, the default limit of 2000 will be used.
     pub fn with_cardinality_limit(mut self, limit: usize) -> Self {
         self.cardinality_limit = Some(limit);
+        self
+    }
+
+    /// Sets whether this view's stream is enabled for matching instruments.
+    ///
+    /// If unset, opt-in instruments are dropped. Setting this to `true` enables
+    /// them, unless the aggregation is [`Aggregation::Drop`]. Setting this to
+    /// `false` drops this stream for any instrument, regardless of aggregation.
+    /// Other matching views may still produce streams for the same instrument.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    pub fn with_enabled(mut self, enabled: bool) -> Self {
+        self.enabled = Some(enabled);
         self
     }
 
@@ -277,6 +300,8 @@ impl StreamBuilder {
             aggregation: self.aggregation,
             allowed_attribute_keys: self.allowed_attribute_keys,
             cardinality_limit: self.cardinality_limit,
+            #[cfg(feature = "experimental_metrics_opt_in")]
+            enabled: self.enabled,
         })
     }
 }
@@ -324,6 +349,10 @@ pub struct Stream {
 
     /// Cardinality limit for the stream.
     pub(crate) cardinality_limit: Option<usize>,
+
+    /// Whether matching instruments are explicitly enabled or disabled.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    pub(crate) enabled: Option<bool>,
 }
 
 impl Stream {

--- a/opentelemetry-sdk/src/metrics/meter.rs
+++ b/opentelemetry-sdk/src/metrics/meter.rs
@@ -96,6 +96,8 @@ impl SdkMeter {
                 builder.description,
                 builder.unit,
                 None,
+                #[cfg(feature = "experimental_metrics_opt_in")]
+                builder.opt_in,
             )
             .map(|i| Counter::new(Arc::new(i)))
         {
@@ -138,6 +140,8 @@ impl SdkMeter {
             builder.description,
             builder.unit,
             None,
+            #[cfg(feature = "experimental_metrics_opt_in")]
+            builder.opt_in,
         ) {
             Ok(ms) => {
                 if ms.is_empty() {
@@ -197,6 +201,8 @@ impl SdkMeter {
             builder.description,
             builder.unit,
             None,
+            #[cfg(feature = "experimental_metrics_opt_in")]
+            builder.opt_in,
         ) {
             Ok(ms) => {
                 if ms.is_empty() {
@@ -256,6 +262,8 @@ impl SdkMeter {
             builder.description,
             builder.unit,
             None,
+            #[cfg(feature = "experimental_metrics_opt_in")]
+            builder.opt_in,
         ) {
             Ok(ms) => {
                 if ms.is_empty() {
@@ -317,6 +325,8 @@ impl SdkMeter {
                 builder.description,
                 builder.unit,
                 None,
+                #[cfg(feature = "experimental_metrics_opt_in")]
+                builder.opt_in,
             )
             .map(|i| UpDownCounter::new(Arc::new(i)))
         {
@@ -361,6 +371,8 @@ impl SdkMeter {
                 builder.description,
                 builder.unit,
                 None,
+                #[cfg(feature = "experimental_metrics_opt_in")]
+                builder.opt_in,
             )
             .map(|i| Gauge::new(Arc::new(i)))
         {
@@ -420,6 +432,8 @@ impl SdkMeter {
                 builder.description,
                 builder.unit,
                 builder.boundaries,
+                #[cfg(feature = "experimental_metrics_opt_in")]
+                builder.opt_in,
             )
             .map(|i| Histogram::new(Arc::new(i)))
         {
@@ -652,8 +666,17 @@ where
         description: Option<Cow<'static, str>>,
         unit: Option<Cow<'static, str>>,
         boundaries: Option<Vec<f64>>,
+        #[cfg(feature = "experimental_metrics_opt_in")] opt_in: bool,
     ) -> MetricResult<ResolvedMeasures<T>> {
-        let aggregators = self.measures(kind, name, description, unit, boundaries)?;
+        let aggregators = self.measures(
+            kind,
+            name,
+            description,
+            unit,
+            boundaries,
+            #[cfg(feature = "experimental_metrics_opt_in")]
+            opt_in,
+        )?;
         Ok(ResolvedMeasures {
             measures: aggregators,
         })
@@ -666,6 +689,7 @@ where
         description: Option<Cow<'static, str>>,
         unit: Option<Cow<'static, str>>,
         boundaries: Option<Vec<f64>>,
+        #[cfg(feature = "experimental_metrics_opt_in")] opt_in: bool,
     ) -> MetricResult<Vec<Arc<dyn internal::Measure<T>>>> {
         let inst = Instrument {
             name,
@@ -673,6 +697,8 @@ where
             unit: unit.unwrap_or_default(),
             kind,
             scope: self.meter.scope.clone(),
+            #[cfg(feature = "experimental_metrics_opt_in")]
+            opt_in,
         };
 
         self.resolve.measures(inst, boundaries)

--- a/opentelemetry-sdk/src/metrics/mod.rs
+++ b/opentelemetry-sdk/src/metrics/mod.rs
@@ -1841,6 +1841,132 @@ mod tests {
         assert_eq!(dp.max(), Some(15.0));
     }
 
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn opt_in_counter_is_disabled_by_default() {
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+
+        let counter = meter_provider
+            .meter("test")
+            .u64_counter("opt_in_counter")
+            .with_opt_in()
+            .build();
+
+        counter.add(1, &[]);
+        meter_provider.force_flush().unwrap();
+        assert!(exporter.get_finished_metrics().unwrap().is_empty());
+    }
+
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn aggregation_only_view_does_not_enable_opt_in_counter() {
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .with_view(|instrument: &Instrument| {
+                (instrument.name() == "opt_in_counter").then(|| {
+                    Stream::builder()
+                        .with_aggregation(Aggregation::Sum)
+                        .build()
+                        .unwrap()
+                })
+            })
+            .build();
+
+        let counter = meter_provider
+            .meter("test")
+            .u64_counter("opt_in_counter")
+            .with_opt_in()
+            .build();
+
+        counter.add(1, &[]);
+        meter_provider.force_flush().unwrap();
+        assert!(exporter.get_finished_metrics().unwrap().is_empty());
+    }
+
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn enabled_view_activates_opt_in_counter() {
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .with_view(|instrument: &Instrument| {
+                (instrument.name() == "opt_in_counter")
+                    .then(|| Stream::builder().with_enabled(true).build().unwrap())
+            })
+            .build();
+
+        let counter = meter_provider
+            .meter("test")
+            .u64_counter("opt_in_counter")
+            .with_opt_in()
+            .build();
+
+        counter.add(1, &[]);
+        meter_provider.force_flush().unwrap();
+        let resource_metrics = exporter.get_finished_metrics().unwrap();
+        assert_eq!(resource_metrics[0].scope_metrics[0].metrics.len(), 1);
+        assert_eq!(
+            resource_metrics[0].scope_metrics[0].metrics[0].name,
+            "opt_in_counter"
+        );
+    }
+
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn disabled_view_overrides_non_drop_aggregation() {
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .with_view(|instrument: &Instrument| {
+                (instrument.name() == "disabled_counter").then(|| {
+                    Stream::builder()
+                        .with_enabled(false)
+                        .with_aggregation(Aggregation::Sum)
+                        .build()
+                        .unwrap()
+                })
+            })
+            .build();
+
+        let counter = meter_provider
+            .meter("test")
+            .u64_counter("disabled_counter")
+            .build();
+
+        counter.add(1, &[]);
+        meter_provider.force_flush().unwrap();
+        assert!(exporter.get_finished_metrics().unwrap().is_empty());
+    }
+
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn disabled_opt_in_observable_does_not_invoke_callback() {
+        let exporter = InMemoryMetricExporter::default();
+        let meter_provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+        let callback_invoked = Arc::new(AtomicBool::new(false));
+        let callback_state = Arc::clone(&callback_invoked);
+
+        let _counter = meter_provider
+            .meter("test")
+            .u64_observable_counter("opt_in_observable_counter")
+            .with_opt_in()
+            .with_callback(move |observer| {
+                callback_state.store(true, Ordering::SeqCst);
+                observer.observe(1, &[]);
+            })
+            .build();
+
+        meter_provider.force_flush().unwrap();
+        assert!(!callback_invoked.load(Ordering::SeqCst));
+        assert!(exporter.get_finished_metrics().unwrap().is_empty());
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn counter_with_drop_aggregation_is_dropped() {
         // Run this test with stdout enabled to see output.

--- a/opentelemetry-sdk/src/metrics/pipeline.rs
+++ b/opentelemetry-sdk/src/metrics/pipeline.rs
@@ -269,6 +269,11 @@ where
             };
             matched = true;
 
+            #[cfg(feature = "experimental_metrics_opt_in")]
+            if stream.enabled == Some(false) || (inst.opt_in && stream.enabled != Some(true)) {
+                continue;
+            }
+
             if stream.name.is_none() {
                 stream.name = Some(inst.name.clone());
             }
@@ -325,6 +330,11 @@ where
         }
 
         // Apply implicit default view if no explicit matched, or if all views failed.
+        #[cfg(feature = "experimental_metrics_opt_in")]
+        if inst.opt_in {
+            return Ok(measures);
+        }
+
         let mut stream = Stream {
             name: Some(inst.name),
             description: Some(inst.description),
@@ -332,6 +342,8 @@ where
             aggregation: None,
             allowed_attribute_keys: None,
             cardinality_limit: None,
+            #[cfg(feature = "experimental_metrics_opt_in")]
+            enabled: None,
         };
 
         // Override default histogram boundaries if provided.

--- a/opentelemetry/CHANGELOG.md
+++ b/opentelemetry/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- Added prototype support for the Metrics `OptIn` advisory parameter through
+  `with_opt_in()` on instrument builders, behind `experimental_metrics_opt_in`.
 - Fix `TraceState` accepting more than the 32 list-members the W3C trace-context
   specification allows. `from_str`, `from_key_value` and `insert` now keep at most
   32, dropping members from the end of the list as the specification prescribes, so

--- a/opentelemetry/Cargo.toml
+++ b/opentelemetry/Cargo.toml
@@ -40,6 +40,7 @@ testing = ["trace"]
 logs = []
 internal-logs = ["tracing"]
 experimental_metrics_bound_instruments = ["metrics"]
+experimental_metrics_opt_in = ["metrics"]
 experimental_context_observer = []
 
 [dev-dependencies]

--- a/opentelemetry/src/metrics/instruments/mod.rs
+++ b/opentelemetry/src/metrics/instruments/mod.rs
@@ -72,6 +72,10 @@ pub struct HistogramBuilder<'a, T> {
     /// Bucket boundaries for the histogram.
     pub boundaries: Option<Vec<f64>>,
 
+    /// Whether the instrument is disabled unless explicitly enabled by a view.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    pub opt_in: bool,
+
     // boundaries: Vec<T>,
     _marker: marker::PhantomData<T>,
 }
@@ -85,6 +89,8 @@ impl<'a, T> HistogramBuilder<'a, T> {
             description: None,
             unit: None,
             boundaries: None,
+            #[cfg(feature = "experimental_metrics_opt_in")]
+            opt_in: false,
             _marker: marker::PhantomData,
         }
     }
@@ -104,6 +110,16 @@ impl<'a, T> HistogramBuilder<'a, T> {
     /// - No longer than 63 characters
     pub fn with_unit<S: Into<Cow<'static, str>>>(mut self, unit: S) -> Self {
         self.unit = Some(unit.into());
+        self
+    }
+
+    /// Marks this instrument as opt-in.
+    ///
+    /// Opt-in instruments are disabled unless a matching SDK view explicitly
+    /// enables them.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    pub fn with_opt_in(mut self) -> Self {
+        self.opt_in = true;
         self
     }
 
@@ -174,6 +190,10 @@ pub struct InstrumentBuilder<'a, T> {
     /// Unit of the instrument.
     pub unit: Option<Cow<'static, str>>,
 
+    /// Whether the instrument is disabled unless explicitly enabled by a view.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    pub opt_in: bool,
+
     _marker: marker::PhantomData<T>,
 }
 
@@ -185,6 +205,8 @@ impl<'a, T> InstrumentBuilder<'a, T> {
             name,
             description: None,
             unit: None,
+            #[cfg(feature = "experimental_metrics_opt_in")]
+            opt_in: false,
             _marker: marker::PhantomData,
         }
     }
@@ -204,6 +226,16 @@ impl<'a, T> InstrumentBuilder<'a, T> {
     /// - No longer than 63 characters
     pub fn with_unit<S: Into<Cow<'static, str>>>(mut self, unit: S) -> Self {
         self.unit = Some(unit.into());
+        self
+    }
+
+    /// Marks this instrument as opt-in.
+    ///
+    /// Opt-in instruments are disabled unless a matching SDK view explicitly
+    /// enables them.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    pub fn with_opt_in(mut self) -> Self {
+        self.opt_in = true;
         self
     }
 }
@@ -231,7 +263,10 @@ build_instrument!(f64_up_down_counter, UpDownCounter<f64>);
 
 impl<T> fmt::Debug for InstrumentBuilder<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("InstrumentBuilder")
+        let mut debug = f.debug_struct("InstrumentBuilder");
+        #[cfg(feature = "experimental_metrics_opt_in")]
+        debug.field("opt_in", &self.opt_in);
+        debug
             .field("name", &self.name)
             .field("description", &self.description)
             .field("unit", &self.unit)
@@ -242,7 +277,10 @@ impl<T> fmt::Debug for InstrumentBuilder<'_, T> {
 
 impl<T> fmt::Debug for HistogramBuilder<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("HistogramBuilder")
+        let mut debug = f.debug_struct("HistogramBuilder");
+        #[cfg(feature = "experimental_metrics_opt_in")]
+        debug.field("opt_in", &self.opt_in);
+        debug
             .field("name", &self.name)
             .field("description", &self.description)
             .field("unit", &self.unit)
@@ -280,6 +318,10 @@ pub struct AsyncInstrumentBuilder<'a, I, M> {
     /// Unit of the instrument.
     pub unit: Option<Cow<'static, str>>,
 
+    /// Whether the instrument is disabled unless explicitly enabled by a view.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    pub opt_in: bool,
+
     /// Callbacks to be called for this instrument.
     pub callbacks: Vec<Callback<M>>,
 
@@ -294,6 +336,8 @@ impl<'a, I, M> AsyncInstrumentBuilder<'a, I, M> {
             name,
             description: None,
             unit: None,
+            #[cfg(feature = "experimental_metrics_opt_in")]
+            opt_in: false,
             _inst: marker::PhantomData,
             callbacks: Vec::new(),
         }
@@ -314,6 +358,16 @@ impl<'a, I, M> AsyncInstrumentBuilder<'a, I, M> {
     /// - No longer than 63 characters
     pub fn with_unit<S: Into<Cow<'static, str>>>(mut self, unit: S) -> Self {
         self.unit = Some(unit.into());
+        self
+    }
+
+    /// Marks this instrument as opt-in.
+    ///
+    /// Opt-in instruments are disabled unless a matching SDK view explicitly
+    /// enables them.
+    #[cfg(feature = "experimental_metrics_opt_in")]
+    pub fn with_opt_in(mut self) -> Self {
+        self.opt_in = true;
         self
     }
 
@@ -361,7 +415,10 @@ where
     I: AsyncInstrument<M>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("InstrumentBuilder")
+        let mut debug = f.debug_struct("InstrumentBuilder");
+        #[cfg(feature = "experimental_metrics_opt_in")]
+        debug.field("opt_in", &self.opt_in);
+        debug
             .field("name", &self.name)
             .field("description", &self.description)
             .field("unit", &self.unit)


### PR DESCRIPTION
Related specification proposal: https://github.com/open-telemetry/opentelemetry-specification/pull/4809

## Changes

Draft prototype for feedback on the OptIn advisory parameter and View stream enablement.

- Add `experimental_metrics_opt_in` to the API and SDK crates, disabled by default. The SDK feature also enables the API feature.
- Add `with_opt_in()` to synchronous, histogram, and observable instrument builders.
- Add tri-state View stream enablement through `StreamBuilder::with_enabled(bool)` and expose `Instrument::is_opt_in()` to View selectors.
- Drop opt-in streams unless a matching View explicitly enables them. Aggregation-only Views do not enable opt-in instruments; `enabled=false` disables any matching stream. Explicit Drop aggregation remains effective.
- Keep `is_enabled()` out of scope. Recording calls are unguarded; disabled observable instruments do not register callbacks.
- Add five behavior tests, metrics documentation, changelog entries, and an explicitly feature-gated advanced example.

Run the example with:
```sh
cargo run -p metrics-advanced --features experimental_metrics_opt_in
```

## Review Focus

This is experimental, not a claim of full specification compliance. Feedback is welcome on API naming and the user-facing overlap between stream `enabled` and Drop aggregation. Existing independent-View behavior is retained; composable Views and instrument `Enabled()` are not introduced here.

## Validation

- Passed `cargo fmt --all` and `git diff --check`.
- Passed all-target/all-feature Clippy with `-Dwarnings` for `opentelemetry` and `opentelemetry_sdk`.
- Passed both crates' all-feature library tests (SDK: 400 passed, 25 ignored).
- Passed metrics-only API/SDK checks without the experimental feature, an API check with the feature, and the five prototype tests with explicit SDK feature activation.
- Passed SDK feature-off metrics tests: 136 passed, 1 ignored.
- Checked the advanced example without the feature and ran it with the feature; the opt-in counter exported value 1.
- Full `scripts/precommit.sh` attempted but blocked by local OpenSSL detection: `openssl-sys` cannot execute/find `pkg-config`. The full workspace/feature matrix remains unverified.

## Merge requirement checklist

- [ ] CONTRIBUTING guidelines followed
- [x] Unit tests added/updated
- [x] Appropriate CHANGELOG files updated
- [ ] Changes in public API reviewed
