### PR TITLE
fix(otlp): handle enum environment values consistently

### DIFF
--- a/opentelemetry-otlp/CHANGELOG.md
+++ b/opentelemetry-otlp/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## vNext
 
+- Interpret protocol, compression, and metrics temporality environment values
+  case-insensitively. Treat empty values as unset, and warn and ignore invalid,
+  non-Unicode, or feature-unavailable enum values so resolution can continue
+  to the next environment variable or default. Compression `none` explicitly
+  disables compression, including when a generic compression value is set.
+  Programmatic configuration remains strict.
+
 ### Retry
 
 - Retries are now enabled by default for OTLP/HTTP and OTLP/gRPC. The default

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -319,7 +319,36 @@ impl HttpExporterBuilder {
         &self,
         env_override: &str,
     ) -> Result<Option<crate::Compression>, super::ExporterBuildError> {
-        super::resolve_compression_from_env(self.http_config.compression, env_override)
+        super::resolve_compression_from_env(
+            self.http_config.compression,
+            env_override,
+            |compression| match compression {
+                crate::Compression::Gzip => {
+                    #[cfg(feature = "gzip-http")]
+                    {
+                        Ok(())
+                    }
+                    #[cfg(not(feature = "gzip-http"))]
+                    {
+                        Err(
+                            "feature 'gzip-http' is required to use the compression algorithm 'gzip'",
+                        )
+                    }
+                }
+                crate::Compression::Zstd => {
+                    #[cfg(feature = "zstd-http")]
+                    {
+                        Ok(())
+                    }
+                    #[cfg(not(feature = "zstd-http"))]
+                    {
+                        Err(
+                            "feature 'zstd-http' is required to use the compression algorithm 'zstd'",
+                        )
+                    }
+                }
+            },
+        )
     }
 
     /// Create a span exporter with the current configuration
@@ -1699,7 +1728,10 @@ mod tests {
                     let result = builder
                         .resolve_compression("NONEXISTENT_SIGNAL_COMPRESSION")
                         .unwrap();
+                    #[cfg(feature = "gzip-http")]
                     assert_eq!(result, Some(crate::Compression::Gzip));
+                    #[cfg(not(feature = "gzip-http"))]
+                    assert_eq!(result, None);
                 },
             );
         }

--- a/opentelemetry-otlp/src/exporter/http/mod.rs
+++ b/opentelemetry-otlp/src/exporter/http/mod.rs
@@ -205,30 +205,6 @@ impl HttpExporterBuilder {
 
         let compression = self.resolve_compression(signal_compression_var)?;
 
-        // Validate compression is supported at build time
-        if let Some(compression_alg) = &compression {
-            match compression_alg {
-                crate::Compression::Gzip => {
-                    #[cfg(not(feature = "gzip-http"))]
-                    {
-                        return Err(ExporterBuildError::UnsupportedCompressionAlgorithm(
-                            "gzip compression requested but gzip-http feature not enabled"
-                                .to_string(),
-                        ));
-                    }
-                }
-                crate::Compression::Zstd => {
-                    #[cfg(not(feature = "zstd-http"))]
-                    {
-                        return Err(ExporterBuildError::UnsupportedCompressionAlgorithm(
-                            "zstd compression requested but zstd-http feature not enabled"
-                                .to_string(),
-                        ));
-                    }
-                }
-            }
-        }
-
         let timeout = resolve_timeout(signal_timeout_var, self.exporter_config.timeout.as_ref());
 
         #[allow(unused_mut)] // TODO - clippy thinks mut is not needed, but it is
@@ -323,30 +299,17 @@ impl HttpExporterBuilder {
             self.http_config.compression,
             env_override,
             |compression| match compression {
-                crate::Compression::Gzip => {
-                    #[cfg(feature = "gzip-http")]
-                    {
-                        Ok(())
-                    }
-                    #[cfg(not(feature = "gzip-http"))]
-                    {
-                        Err(
-                            "feature 'gzip-http' is required to use the compression algorithm 'gzip'",
-                        )
-                    }
+                crate::Compression::Gzip if !cfg!(feature = "gzip-http") => {
+                    Err(ExporterBuildError::UnsupportedCompressionAlgorithm(
+                        "gzip compression requested but gzip-http feature not enabled".into(),
+                    ))
                 }
-                crate::Compression::Zstd => {
-                    #[cfg(feature = "zstd-http")]
-                    {
-                        Ok(())
-                    }
-                    #[cfg(not(feature = "zstd-http"))]
-                    {
-                        Err(
-                            "feature 'zstd-http' is required to use the compression algorithm 'zstd'",
-                        )
-                    }
+                crate::Compression::Zstd if !cfg!(feature = "zstd-http") => {
+                    Err(ExporterBuildError::UnsupportedCompressionAlgorithm(
+                        "zstd compression requested but zstd-http feature not enabled".into(),
+                    ))
                 }
+                _ => Ok(compression),
             },
         )
     }

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -244,62 +244,31 @@ impl FromStr for Compression {
 /// 3. Generic OTEL_EXPORTER_OTLP_COMPRESSION
 /// 4. None (default)
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
-fn resolve_compression_from_env<F>(
+fn resolve_compression_from_env<T>(
     config_compression: Option<Compression>,
     signal_env_var: &str,
-    validate_compression: F,
-) -> Result<Option<Compression>, ExporterBuildError>
-where
-    F: Fn(Compression) -> Result<(), &'static str>,
-{
+    convert: impl Fn(Compression) -> Result<T, ExporterBuildError>,
+) -> Result<Option<T>, ExporterBuildError> {
     if let Some(compression) = config_compression {
-        return Ok(Some(compression));
+        return convert(compression).map(Some);
     }
-
-    match parse_compression_env_var(signal_env_var, &validate_compression) {
-        CompressionEnvValue::Enabled(compression) => Ok(Some(compression)),
-        CompressionEnvValue::Disabled => Ok(None),
-        CompressionEnvValue::UnsetOrIgnored => {
-            match parse_compression_env_var(OTEL_EXPORTER_OTLP_COMPRESSION, &validate_compression) {
-                CompressionEnvValue::Enabled(compression) => Ok(Some(compression)),
-                CompressionEnvValue::Disabled | CompressionEnvValue::UnsetOrIgnored => Ok(None),
-            }
+    for name in [signal_env_var, OTEL_EXPORTER_OTLP_COMPRESSION] {
+        let Some(value) = read_enum_env_var(name) else {
+            continue;
+        };
+        if value.eq_ignore_ascii_case("none") {
+            return Ok(None);
+        }
+        match value
+            .to_ascii_lowercase()
+            .parse::<Compression>()
+            .and_then(&convert)
+        {
+            Ok(compression) => return Ok(Some(compression)),
+            Err(error) => warn_ignored_enum_env_var(name, &value, error),
         }
     }
-}
-
-#[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
-enum CompressionEnvValue {
-    UnsetOrIgnored,
-    Disabled,
-    Enabled(Compression),
-}
-
-#[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
-fn parse_compression_env_var<F>(name: &str, validate_compression: &F) -> CompressionEnvValue
-where
-    F: Fn(Compression) -> Result<(), &'static str>,
-{
-    let Some(value) = read_enum_env_var(name) else {
-        return CompressionEnvValue::UnsetOrIgnored;
-    };
-    if value.eq_ignore_ascii_case("none") {
-        return CompressionEnvValue::Disabled;
-    }
-
-    match value.to_ascii_lowercase().parse::<Compression>() {
-        Ok(compression) => match validate_compression(compression) {
-            Ok(()) => CompressionEnvValue::Enabled(compression),
-            Err(reason) => {
-                warn_ignored_enum_env_var(name, &value, reason);
-                CompressionEnvValue::UnsetOrIgnored
-            }
-        },
-        Err(error) => {
-            warn_ignored_enum_env_var(name, &value, error);
-            CompressionEnvValue::UnsetOrIgnored
-        }
-    }
+    Ok(None)
 }
 
 /// Resolve whether the connection should be insecure (no TLS).
@@ -893,76 +862,57 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_compression_env_falls_back_to_generic() {
-        run_env_test(
-            vec![
-                ("MY_CUSTOM_COMPRESSION_VAR", ""),
-                (OTEL_EXPORTER_OTLP_COMPRESSION, "gzip"),
-            ],
-            || {
-                assert_eq!(
-                    resolve_compression_from_env(None, "MY_CUSTOM_COMPRESSION_VAR", |_| Ok(()))
-                        .unwrap(),
-                    Some(Compression::Gzip)
-                );
-            },
-        );
+    fn compression_env_precedence() {
+        for (signal, generic, expected) in [
+            ("", "gzip", Some(Compression::Gzip)),
+            ("invalid", "GZIP", Some(Compression::Gzip)),
+            ("ZSTD", "gzip", Some(Compression::Zstd)),
+            ("NoNe", "gzip", None),
+            ("invalid", "none", None),
+            ("invalid", "invalid", None),
+        ] {
+            run_env_test(
+                vec![
+                    ("MY_CUSTOM_COMPRESSION_VAR", signal),
+                    (OTEL_EXPORTER_OTLP_COMPRESSION, generic),
+                ],
+                || {
+                    assert_eq!(
+                        resolve_compression_from_env(None, "MY_CUSTOM_COMPRESSION_VAR", Ok)
+                            .unwrap(),
+                        expected,
+                        "signal={signal}, generic={generic}"
+                    )
+                },
+            );
+        }
     }
 
     #[test]
-    fn test_invalid_compression_env_falls_back_to_generic_case_insensitively() {
-        run_env_test(
-            vec![
-                ("MY_CUSTOM_COMPRESSION_VAR", "invalid"),
-                (OTEL_EXPORTER_OTLP_COMPRESSION, "GZIP"),
-            ],
-            || {
-                assert_eq!(
-                    resolve_compression_from_env(None, "MY_CUSTOM_COMPRESSION_VAR", |_| Ok(()))
-                        .unwrap(),
-                    Some(Compression::Gzip)
-                );
-            },
-        );
-    }
-
-    #[test]
-    fn test_unavailable_compression_env_falls_back_to_generic() {
+    fn unavailable_compression_env_falls_back_but_programmatic_config_errors() {
         run_env_test(
             vec![
                 ("MY_CUSTOM_COMPRESSION_VAR", "gzip"),
                 (OTEL_EXPORTER_OTLP_COMPRESSION, "zstd"),
             ],
             || {
+                let convert = |compression| match compression {
+                    Compression::Gzip => Err(
+                        super::ExporterBuildError::UnsupportedCompressionAlgorithm("gzip".into()),
+                    ),
+                    Compression::Zstd => Ok(compression),
+                };
                 assert_eq!(
-                    resolve_compression_from_env(
-                        None,
-                        "MY_CUSTOM_COMPRESSION_VAR",
-                        |compression| match compression {
-                            Compression::Gzip => Err("gzip is unavailable"),
-                            Compression::Zstd => Ok(()),
-                        }
-                    )
-                    .unwrap(),
+                    resolve_compression_from_env(None, "MY_CUSTOM_COMPRESSION_VAR", convert)
+                        .unwrap(),
                     Some(Compression::Zstd)
                 );
-            },
-        );
-    }
-
-    #[test]
-    fn test_none_compression_env_prevents_generic_fallback() {
-        run_env_test(
-            vec![
-                ("MY_CUSTOM_COMPRESSION_VAR", "NoNe"),
-                (OTEL_EXPORTER_OTLP_COMPRESSION, "gzip"),
-            ],
-            || {
-                assert_eq!(
-                    resolve_compression_from_env(None, "MY_CUSTOM_COMPRESSION_VAR", |_| Ok(()))
-                        .unwrap(),
-                    None
-                );
+                assert!(resolve_compression_from_env(
+                    Some(Compression::Gzip),
+                    "MY_CUSTOM_COMPRESSION_VAR",
+                    convert
+                )
+                .is_err());
             },
         );
     }
@@ -983,8 +933,7 @@ mod tests {
             ],
             || {
                 assert_eq!(
-                    resolve_compression_from_env(None, "MY_CUSTOM_COMPRESSION_VAR", |_| Ok(()))
-                        .unwrap(),
+                    resolve_compression_from_env(None, "MY_CUSTOM_COMPRESSION_VAR", Ok).unwrap(),
                     Some(Compression::Zstd)
                 );
             },

--- a/opentelemetry-otlp/src/exporter/mod.rs
+++ b/opentelemetry-otlp/src/exporter/mod.rs
@@ -159,6 +159,52 @@ pub enum ExporterBuildError {
     InternalFailure(String),
 }
 
+#[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
+pub(crate) fn read_enum_env_var(name: &str) -> Option<String> {
+    match std::env::var(name) {
+        Ok(value) if value.is_empty() => None,
+        Ok(value) => Some(value),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            warn_ignored_enum_env_var(name, "<non-Unicode>", "value is not valid Unicode");
+            None
+        }
+    }
+}
+
+#[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
+pub(crate) fn warn_ignored_enum_env_var(
+    environment_variable: &str,
+    value: &str,
+    reason: impl std::fmt::Display,
+) {
+    let reason = reason.to_string();
+    let message = format!("Ignoring value '{value}' for {environment_variable}: {reason}");
+    opentelemetry::otel_warn!(
+        name: "Exporter.Config.InvalidEnvironmentVariable",
+        message = message.as_str(),
+        environment_variable = environment_variable,
+        value = value,
+        reason = reason.as_str()
+    );
+}
+
+#[cfg(all(
+    any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"),
+    not(all(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))
+))]
+pub(crate) fn warn_missing_protocol_feature(
+    environment_variable: &str,
+    value: &str,
+    feature: &str,
+) {
+    warn_ignored_enum_env_var(
+        environment_variable,
+        value,
+        format!("feature '{feature}' is not enabled"),
+    );
+}
+
 /// The compression algorithm to use when sending data.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -198,18 +244,61 @@ impl FromStr for Compression {
 /// 3. Generic OTEL_EXPORTER_OTLP_COMPRESSION
 /// 4. None (default)
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
-fn resolve_compression_from_env(
+fn resolve_compression_from_env<F>(
     config_compression: Option<Compression>,
     signal_env_var: &str,
-) -> Result<Option<Compression>, ExporterBuildError> {
+    validate_compression: F,
+) -> Result<Option<Compression>, ExporterBuildError>
+where
+    F: Fn(Compression) -> Result<(), &'static str>,
+{
     if let Some(compression) = config_compression {
-        Ok(Some(compression))
-    } else if let Ok(compression) = std::env::var(signal_env_var) {
-        Ok(Some(compression.parse::<Compression>()?))
-    } else if let Ok(compression) = std::env::var(OTEL_EXPORTER_OTLP_COMPRESSION) {
-        Ok(Some(compression.parse::<Compression>()?))
-    } else {
-        Ok(None)
+        return Ok(Some(compression));
+    }
+
+    match parse_compression_env_var(signal_env_var, &validate_compression) {
+        CompressionEnvValue::Enabled(compression) => Ok(Some(compression)),
+        CompressionEnvValue::Disabled => Ok(None),
+        CompressionEnvValue::UnsetOrIgnored => {
+            match parse_compression_env_var(OTEL_EXPORTER_OTLP_COMPRESSION, &validate_compression) {
+                CompressionEnvValue::Enabled(compression) => Ok(Some(compression)),
+                CompressionEnvValue::Disabled | CompressionEnvValue::UnsetOrIgnored => Ok(None),
+            }
+        }
+    }
+}
+
+#[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
+enum CompressionEnvValue {
+    UnsetOrIgnored,
+    Disabled,
+    Enabled(Compression),
+}
+
+#[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
+fn parse_compression_env_var<F>(name: &str, validate_compression: &F) -> CompressionEnvValue
+where
+    F: Fn(Compression) -> Result<(), &'static str>,
+{
+    let Some(value) = read_enum_env_var(name) else {
+        return CompressionEnvValue::UnsetOrIgnored;
+    };
+    if value.eq_ignore_ascii_case("none") {
+        return CompressionEnvValue::Disabled;
+    }
+
+    match value.to_ascii_lowercase().parse::<Compression>() {
+        Ok(compression) => match validate_compression(compression) {
+            Ok(()) => CompressionEnvValue::Enabled(compression),
+            Err(reason) => {
+                warn_ignored_enum_env_var(name, &value, reason);
+                CompressionEnvValue::UnsetOrIgnored
+            }
+        },
+        Err(error) => {
+            warn_ignored_enum_env_var(name, &value, error);
+            CompressionEnvValue::UnsetOrIgnored
+        }
     }
 }
 
@@ -420,6 +509,8 @@ fn parse_header_key_value_string(key_value_string: &str) -> Option<(&str, String
 #[cfg(test)]
 #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
 mod tests {
+    use super::{resolve_compression_from_env, Compression, OTEL_EXPORTER_OTLP_COMPRESSION};
+
     pub(crate) fn run_env_test<T, F>(env_vars: T, f: F)
     where
         F: FnOnce(),
@@ -799,6 +890,105 @@ mod tests {
             let protocol = super::resolve_protocol(crate::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, None);
             assert_eq!(protocol, Protocol::feature_default());
         });
+    }
+
+    #[test]
+    fn test_empty_compression_env_falls_back_to_generic() {
+        run_env_test(
+            vec![
+                ("MY_CUSTOM_COMPRESSION_VAR", ""),
+                (OTEL_EXPORTER_OTLP_COMPRESSION, "gzip"),
+            ],
+            || {
+                assert_eq!(
+                    resolve_compression_from_env(None, "MY_CUSTOM_COMPRESSION_VAR", |_| Ok(()))
+                        .unwrap(),
+                    Some(Compression::Gzip)
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_invalid_compression_env_falls_back_to_generic_case_insensitively() {
+        run_env_test(
+            vec![
+                ("MY_CUSTOM_COMPRESSION_VAR", "invalid"),
+                (OTEL_EXPORTER_OTLP_COMPRESSION, "GZIP"),
+            ],
+            || {
+                assert_eq!(
+                    resolve_compression_from_env(None, "MY_CUSTOM_COMPRESSION_VAR", |_| Ok(()))
+                        .unwrap(),
+                    Some(Compression::Gzip)
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_unavailable_compression_env_falls_back_to_generic() {
+        run_env_test(
+            vec![
+                ("MY_CUSTOM_COMPRESSION_VAR", "gzip"),
+                (OTEL_EXPORTER_OTLP_COMPRESSION, "zstd"),
+            ],
+            || {
+                assert_eq!(
+                    resolve_compression_from_env(
+                        None,
+                        "MY_CUSTOM_COMPRESSION_VAR",
+                        |compression| match compression {
+                            Compression::Gzip => Err("gzip is unavailable"),
+                            Compression::Zstd => Ok(()),
+                        }
+                    )
+                    .unwrap(),
+                    Some(Compression::Zstd)
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_none_compression_env_prevents_generic_fallback() {
+        run_env_test(
+            vec![
+                ("MY_CUSTOM_COMPRESSION_VAR", "NoNe"),
+                (OTEL_EXPORTER_OTLP_COMPRESSION, "gzip"),
+            ],
+            || {
+                assert_eq!(
+                    resolve_compression_from_env(None, "MY_CUSTOM_COMPRESSION_VAR", |_| Ok(()))
+                        .unwrap(),
+                    None
+                );
+            },
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_non_unicode_compression_env_falls_back_to_generic() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        temp_env::with_vars(
+            [
+                (
+                    "MY_CUSTOM_COMPRESSION_VAR",
+                    Some(OsStr::from_bytes(b"\x80")),
+                ),
+                (OTEL_EXPORTER_OTLP_COMPRESSION, Some(OsStr::new("zstd"))),
+            ],
+            || {
+                assert_eq!(
+                    resolve_compression_from_env(None, "MY_CUSTOM_COMPRESSION_VAR", |_| Ok(()))
+                        .unwrap(),
+                    Some(Compression::Zstd)
+                );
+            },
+        );
     }
 
     #[cfg(all(feature = "grpc-tonic", feature = "trace"))]

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -349,7 +349,36 @@ impl TonicExporterBuilder {
         &self,
         env_override: &str,
     ) -> Result<Option<CompressionEncoding>, ExporterBuildError> {
-        super::resolve_compression_from_env(self.tonic_config.compression, env_override)?
+        super::resolve_compression_from_env(
+            self.tonic_config.compression,
+            env_override,
+            |compression| match compression {
+                Compression::Gzip => {
+                    #[cfg(feature = "gzip-tonic")]
+                    {
+                        Ok(())
+                    }
+                    #[cfg(not(feature = "gzip-tonic"))]
+                    {
+                        Err(
+                            "feature 'gzip-tonic' is required to use the compression algorithm 'gzip'",
+                        )
+                    }
+                }
+                Compression::Zstd => {
+                    #[cfg(feature = "zstd-tonic")]
+                    {
+                        Ok(())
+                    }
+                    #[cfg(not(feature = "zstd-tonic"))]
+                    {
+                        Err(
+                            "feature 'zstd-tonic' is required to use the compression algorithm 'zstd'",
+                        )
+                    }
+                }
+            },
+        )?
             .map(|c| c.try_into())
             .transpose()
     }

--- a/opentelemetry-otlp/src/exporter/tonic/mod.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/mod.rs
@@ -349,38 +349,9 @@ impl TonicExporterBuilder {
         &self,
         env_override: &str,
     ) -> Result<Option<CompressionEncoding>, ExporterBuildError> {
-        super::resolve_compression_from_env(
-            self.tonic_config.compression,
-            env_override,
-            |compression| match compression {
-                Compression::Gzip => {
-                    #[cfg(feature = "gzip-tonic")]
-                    {
-                        Ok(())
-                    }
-                    #[cfg(not(feature = "gzip-tonic"))]
-                    {
-                        Err(
-                            "feature 'gzip-tonic' is required to use the compression algorithm 'gzip'",
-                        )
-                    }
-                }
-                Compression::Zstd => {
-                    #[cfg(feature = "zstd-tonic")]
-                    {
-                        Ok(())
-                    }
-                    #[cfg(not(feature = "zstd-tonic"))]
-                    {
-                        Err(
-                            "feature 'zstd-tonic' is required to use the compression algorithm 'zstd'",
-                        )
-                    }
-                }
-            },
-        )?
-            .map(|c| c.try_into())
-            .transpose()
+        super::resolve_compression_from_env(self.tonic_config.compression, env_override, |c| {
+            c.try_into()
+        })
     }
 
     /// Build a new tonic log exporter

--- a/opentelemetry-otlp/src/lib.rs
+++ b/opentelemetry-otlp/src/lib.rs
@@ -223,7 +223,7 @@
 //! | `OTEL_EXPORTER_OTLP_PROTOCOL` | Transport protocol. Valid values: `grpc`, `http/protobuf`, `http/json`. Requires the corresponding crate feature. | Feature-dependent |
 //! | `OTEL_EXPORTER_OTLP_TIMEOUT` | Maximum wait time (in milliseconds) for the backend to process each batch. | `10000` |
 //! | `OTEL_EXPORTER_OTLP_HEADERS` | Key-value pairs for request headers. Format: `key1=value1,key2=value2`. Values are URL-decoded. | (none) |
-//! | `OTEL_EXPORTER_OTLP_COMPRESSION` | Compression algorithm. Valid values: `gzip`, `zstd`. | (none) |
+//! | `OTEL_EXPORTER_OTLP_COMPRESSION` | Compression algorithm. Valid values: `gzip`, `zstd`, `none`. | `none` |
 //! | `OTEL_EXPORTER_OTLP_INSECURE` | Whether to disable TLS for gRPC connections. Only applies to gRPC; HTTP security is determined by URL scheme. Valid values: `true`, `false` (case-insensitive). | `false` |
 //!
 //! ## Traces
@@ -777,20 +777,16 @@ impl Protocol {
     }
 
     /// Attempts to parse a protocol from the given environment variable.
-    ///
-    /// Returns `None` if:
-    /// - The environment variable is not set
-    /// - The value doesn't match a known protocol
-    /// - The specified protocol's feature is not enabled
     pub(crate) fn parse_from_env_var(env_var: &str) -> Option<Self> {
         use crate::exporter::{
             OTEL_EXPORTER_OTLP_PROTOCOL_GRPC, OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_JSON,
             OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF,
         };
 
-        let protocol = std::env::var(env_var).ok()?;
+        let protocol = crate::exporter::read_enum_env_var(env_var)?;
+        let normalized = protocol.to_ascii_lowercase();
 
-        match protocol.as_str() {
+        match normalized.as_str() {
             OTEL_EXPORTER_OTLP_PROTOCOL_GRPC => {
                 #[cfg(feature = "grpc-tonic")]
                 {
@@ -798,9 +794,10 @@ impl Protocol {
                 }
                 #[cfg(not(feature = "grpc-tonic"))]
                 {
-                    opentelemetry::otel_warn!(
-                        name: "Protocol.InvalidFeatureCombination",
-                        message = format!("Protocol '{}' requested but 'grpc-tonic' feature is not enabled", OTEL_EXPORTER_OTLP_PROTOCOL_GRPC)
+                    crate::exporter::warn_missing_protocol_feature(
+                        env_var,
+                        &protocol,
+                        "grpc-tonic",
                     );
                     None
                 }
@@ -812,9 +809,10 @@ impl Protocol {
                 }
                 #[cfg(not(feature = "http-proto"))]
                 {
-                    opentelemetry::otel_warn!(
-                        name: "Protocol.InvalidFeatureCombination",
-                        message = format!("Protocol '{}' requested but 'http-proto' feature is not enabled", OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF)
+                    crate::exporter::warn_missing_protocol_feature(
+                        env_var,
+                        &protocol,
+                        "http-proto",
                     );
                     None
                 }
@@ -826,14 +824,18 @@ impl Protocol {
                 }
                 #[cfg(not(feature = "http-json"))]
                 {
-                    opentelemetry::otel_warn!(
-                        name: "Protocol.InvalidFeatureCombination",
-                        message = format!("Protocol '{}' requested but 'http-json' feature is not enabled", OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_JSON)
-                    );
+                    crate::exporter::warn_missing_protocol_feature(env_var, &protocol, "http-json");
                     None
                 }
             }
-            _ => None,
+            _ => {
+                crate::exporter::warn_ignored_enum_env_var(
+                    env_var,
+                    &protocol,
+                    "expected 'grpc', 'http/protobuf', or 'http/json'",
+                );
+                None
+            }
         }
     }
 

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -82,17 +82,26 @@ impl LogExporterBuilder<NoExporterBuilderSet> {
     /// explicitly select a transport and access transport-specific configuration.
     #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
     pub fn build(self) -> Result<LogExporter, ExporterBuildError> {
-        // NOTE: The transport-specific builder will call resolve_protocol again
-        // internally (for HTTP sub-protocol selection or tonic validation), but
-        // that's harmless — the result is the same.
         let protocol = crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, None);
         match protocol {
             #[cfg(feature = "grpc-tonic")]
-            crate::Protocol::Grpc => self.with_tonic().build(),
+            crate::Protocol::Grpc => {
+                let mut builder = self.with_tonic();
+                builder.client.0.exporter_config.protocol = Some(protocol);
+                builder.build()
+            }
             #[cfg(feature = "http-proto")]
-            crate::Protocol::HttpBinary => self.with_http().build(),
+            crate::Protocol::HttpBinary => {
+                let mut builder = self.with_http();
+                builder.client.0.exporter_config.protocol = Some(protocol);
+                builder.build()
+            }
             #[cfg(feature = "http-json")]
-            crate::Protocol::HttpJson => self.with_http().build(),
+            crate::Protocol::HttpJson => {
+                let mut builder = self.with_http();
+                builder.client.0.exporter_config.protocol = Some(protocol);
+                builder.build()
+            }
         }
     }
 }

--- a/opentelemetry-otlp/src/logs.rs
+++ b/opentelemetry-otlp/src/logs.rs
@@ -82,26 +82,16 @@ impl LogExporterBuilder<NoExporterBuilderSet> {
     /// explicitly select a transport and access transport-specific configuration.
     #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
     pub fn build(self) -> Result<LogExporter, ExporterBuildError> {
+        use crate::WithExportConfig;
+
         let protocol = crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL, None);
         match protocol {
             #[cfg(feature = "grpc-tonic")]
-            crate::Protocol::Grpc => {
-                let mut builder = self.with_tonic();
-                builder.client.0.exporter_config.protocol = Some(protocol);
-                builder.build()
-            }
+            crate::Protocol::Grpc => self.with_tonic().with_protocol(protocol).build(),
             #[cfg(feature = "http-proto")]
-            crate::Protocol::HttpBinary => {
-                let mut builder = self.with_http();
-                builder.client.0.exporter_config.protocol = Some(protocol);
-                builder.build()
-            }
+            crate::Protocol::HttpBinary => self.with_http().with_protocol(protocol).build(),
             #[cfg(feature = "http-json")]
-            crate::Protocol::HttpJson => {
-                let mut builder = self.with_http();
-                builder.client.0.exporter_config.protocol = Some(protocol);
-                builder.build()
-            }
+            crate::Protocol::HttpJson => self.with_http().with_protocol(protocol).build(),
         }
     }
 }

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -76,17 +76,26 @@ impl MetricExporterBuilder<NoExporterBuilderSet> {
     /// explicitly select a transport and access transport-specific configuration.
     #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
     pub fn build(self) -> Result<MetricExporter, ExporterBuildError> {
-        // NOTE: The transport-specific builder will call resolve_protocol again
-        // internally (for HTTP sub-protocol selection or tonic validation), but
-        // that's harmless — the result is the same.
         let protocol = crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, None);
         match protocol {
             #[cfg(feature = "grpc-tonic")]
-            crate::Protocol::Grpc => self.with_tonic().build(),
+            crate::Protocol::Grpc => {
+                let mut builder = self.with_tonic();
+                builder.client.0.exporter_config.protocol = Some(protocol);
+                builder.build()
+            }
             #[cfg(feature = "http-proto")]
-            crate::Protocol::HttpBinary => self.with_http().build(),
+            crate::Protocol::HttpBinary => {
+                let mut builder = self.with_http();
+                builder.client.0.exporter_config.protocol = Some(protocol);
+                builder.build()
+            }
             #[cfg(feature = "http-json")]
-            crate::Protocol::HttpJson => self.with_http().build(),
+            crate::Protocol::HttpJson => {
+                let mut builder = self.with_http();
+                builder.client.0.exporter_config.protocol = Some(protocol);
+                builder.build()
+            }
         }
     }
 
@@ -126,26 +135,32 @@ impl<C> MetricExporterBuilder<C> {
 /// 2. OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE environment variable
 /// 3. Default (Cumulative)
 #[cfg(any(feature = "http-proto", feature = "http-json", feature = "grpc-tonic"))]
-fn resolve_temporality(provided: Option<Temporality>) -> Result<Temporality, ExporterBuildError> {
+fn resolve_temporality(provided: Option<Temporality>) -> Temporality {
     if let Some(temporality) = provided {
-        return Ok(temporality);
+        return temporality;
     }
-    if let Ok(val) = std::env::var(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE) {
-        return val
-            .parse::<Temporality>()
-            .map_err(|_| ExporterBuildError::InvalidConfig {
-                name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE.to_string(),
-                reason: format!("Invalid value '{val}'. Expected: cumulative, delta, or lowmemory"),
-            });
+
+    if let Some(value) =
+        crate::exporter::read_enum_env_var(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE)
+    {
+        return value.parse::<Temporality>().unwrap_or_else(|_| {
+            crate::exporter::warn_ignored_enum_env_var(
+                OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
+                &value,
+                "expected 'cumulative', 'delta', or 'lowmemory'",
+            );
+            Temporality::default()
+        });
     }
-    Ok(Temporality::default())
+
+    Temporality::default()
 }
 
 #[cfg(feature = "grpc-tonic")]
 impl MetricExporterBuilder<TonicExporterBuilderSet> {
     /// Build the [MetricExporter] with the gRPC Tonic transport.
     pub fn build(self) -> Result<MetricExporter, ExporterBuildError> {
-        let temporality = resolve_temporality(self.temporality)?;
+        let temporality = resolve_temporality(self.temporality);
         let exporter = self.client.0.build_metrics_exporter(temporality)?;
         opentelemetry::otel_debug!(name: "MetricExporterBuilt");
         Ok(exporter)
@@ -156,7 +171,7 @@ impl MetricExporterBuilder<TonicExporterBuilderSet> {
 impl MetricExporterBuilder<HttpExporterBuilderSet> {
     /// Build the [MetricExporter] with the HTTP transport.
     pub fn build(self) -> Result<MetricExporter, ExporterBuildError> {
-        let temporality = resolve_temporality(self.temporality)?;
+        let temporality = resolve_temporality(self.temporality);
         let exporter = self.client.0.build_metrics_exporter(temporality)?;
         Ok(exporter)
     }
@@ -330,7 +345,7 @@ mod tests {
                 "cumulative",
             )],
             || {
-                let result = resolve_temporality(Some(Temporality::Delta)).unwrap();
+                let result = resolve_temporality(Some(Temporality::Delta));
                 assert_eq!(result, Temporality::Delta);
             },
         );
@@ -341,7 +356,7 @@ mod tests {
         run_env_test(
             vec![(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, "delta")],
             || {
-                let result = resolve_temporality(None).unwrap();
+                let result = resolve_temporality(None);
                 assert_eq!(result, Temporality::Delta);
             },
         );
@@ -355,7 +370,7 @@ mod tests {
                 "lowmemory",
             )],
             || {
-                let result = resolve_temporality(None).unwrap();
+                let result = resolve_temporality(None);
                 assert_eq!(result, Temporality::LowMemory);
             },
         );
@@ -366,19 +381,30 @@ mod tests {
         run_env_test(
             vec![(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, "Delta")],
             || {
-                let result = resolve_temporality(None).unwrap();
+                let result = resolve_temporality(None);
                 assert_eq!(result, Temporality::Delta);
             },
         );
     }
 
     #[test]
-    fn invalid_env_var_returns_error() {
+    fn invalid_env_var_uses_default() {
         run_env_test(
             vec![(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, "invalid")],
             || {
                 let result = resolve_temporality(None);
-                assert!(result.is_err());
+                assert_eq!(result, Temporality::Cumulative);
+            },
+        );
+    }
+
+    #[test]
+    fn empty_env_var_uses_default() {
+        run_env_test(
+            vec![(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, "")],
+            || {
+                let result = resolve_temporality(None);
+                assert_eq!(result, Temporality::Cumulative);
             },
         );
     }
@@ -386,7 +412,7 @@ mod tests {
     #[test]
     fn test_use_default_when_nothing_set() {
         temp_env::with_var_unset(OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE, || {
-            let result = resolve_temporality(None).unwrap();
+            let result = resolve_temporality(None);
             assert_eq!(result, Temporality::Cumulative);
         });
     }

--- a/opentelemetry-otlp/src/metric.rs
+++ b/opentelemetry-otlp/src/metric.rs
@@ -76,26 +76,16 @@ impl MetricExporterBuilder<NoExporterBuilderSet> {
     /// explicitly select a transport and access transport-specific configuration.
     #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
     pub fn build(self) -> Result<MetricExporter, ExporterBuildError> {
+        use crate::WithExportConfig;
+
         let protocol = crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, None);
         match protocol {
             #[cfg(feature = "grpc-tonic")]
-            crate::Protocol::Grpc => {
-                let mut builder = self.with_tonic();
-                builder.client.0.exporter_config.protocol = Some(protocol);
-                builder.build()
-            }
+            crate::Protocol::Grpc => self.with_tonic().with_protocol(protocol).build(),
             #[cfg(feature = "http-proto")]
-            crate::Protocol::HttpBinary => {
-                let mut builder = self.with_http();
-                builder.client.0.exporter_config.protocol = Some(protocol);
-                builder.build()
-            }
+            crate::Protocol::HttpBinary => self.with_http().with_protocol(protocol).build(),
             #[cfg(feature = "http-json")]
-            crate::Protocol::HttpJson => {
-                let mut builder = self.with_http();
-                builder.client.0.exporter_config.protocol = Some(protocol);
-                builder.build()
-            }
+            crate::Protocol::HttpJson => self.with_http().with_protocol(protocol).build(),
         }
     }
 

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -81,26 +81,16 @@ impl SpanExporterBuilder<NoExporterBuilderSet> {
     /// explicitly select a transport and access transport-specific configuration.
     #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
     pub fn build(self) -> Result<SpanExporter, ExporterBuildError> {
+        use crate::WithExportConfig;
+
         let protocol = crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, None);
         match protocol {
             #[cfg(feature = "grpc-tonic")]
-            crate::Protocol::Grpc => {
-                let mut builder = self.with_tonic();
-                builder.client.0.exporter_config.protocol = Some(protocol);
-                builder.build()
-            }
+            crate::Protocol::Grpc => self.with_tonic().with_protocol(protocol).build(),
             #[cfg(feature = "http-proto")]
-            crate::Protocol::HttpBinary => {
-                let mut builder = self.with_http();
-                builder.client.0.exporter_config.protocol = Some(protocol);
-                builder.build()
-            }
+            crate::Protocol::HttpBinary => self.with_http().with_protocol(protocol).build(),
             #[cfg(feature = "http-json")]
-            crate::Protocol::HttpJson => {
-                let mut builder = self.with_http();
-                builder.client.0.exporter_config.protocol = Some(protocol);
-                builder.build()
-            }
+            crate::Protocol::HttpJson => self.with_http().with_protocol(protocol).build(),
         }
     }
 }
@@ -297,61 +287,27 @@ mod tests {
     #[test]
     fn build_auto_select_ignores_invalid_protocol_env_values() {
         let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
+        let _guard = rt.enter();
+        for (signal, generic, expect_grpc) in [
+            ("not-a-protocol", "GRPC", true),
+            ("HTTP/PROTOBUF", "grpc", false),
+            ("not-a-protocol", "also-not-a-protocol", false),
+        ] {
             temp_env::with_vars(
                 [
-                    (
-                        super::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
-                        Some("not-a-protocol"),
-                    ),
-                    (crate::OTEL_EXPORTER_OTLP_PROTOCOL, Some("GRPC")),
+                    (super::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, Some(signal)),
+                    (crate::OTEL_EXPORTER_OTLP_PROTOCOL, Some(generic)),
                 ],
                 || {
                     let exporter = SpanExporter::builder().build().unwrap();
-                    assert!(matches!(
-                        exporter.client,
-                        super::SupportedTransportClient::Tonic(_)
-                    ));
+                    assert_eq!(
+                        matches!(exporter.client, super::SupportedTransportClient::Tonic(_)),
+                        expect_grpc,
+                        "signal={signal}, generic={generic}"
+                    );
                 },
             );
-
-            temp_env::with_vars(
-                [
-                    (
-                        super::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
-                        Some("HTTP/PROTOBUF"),
-                    ),
-                    (crate::OTEL_EXPORTER_OTLP_PROTOCOL, Some("grpc")),
-                ],
-                || {
-                    let exporter = SpanExporter::builder().build().unwrap();
-                    assert!(matches!(
-                        exporter.client,
-                        super::SupportedTransportClient::Http(_)
-                    ));
-                },
-            );
-
-            temp_env::with_vars(
-                [
-                    (
-                        super::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
-                        Some("not-a-protocol"),
-                    ),
-                    (
-                        crate::OTEL_EXPORTER_OTLP_PROTOCOL,
-                        Some("also-not-a-protocol"),
-                    ),
-                ],
-                || {
-                    let exporter = SpanExporter::builder().build().unwrap();
-                    assert!(matches!(
-                        exporter.client,
-                        super::SupportedTransportClient::Http(_)
-                    ));
-                },
-            );
-        });
+        }
     }
 
     #[cfg(all(feature = "http-proto", not(feature = "grpc-tonic")))]

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -81,17 +81,26 @@ impl SpanExporterBuilder<NoExporterBuilderSet> {
     /// explicitly select a transport and access transport-specific configuration.
     #[cfg(any(feature = "grpc-tonic", feature = "http-proto", feature = "http-json"))]
     pub fn build(self) -> Result<SpanExporter, ExporterBuildError> {
-        // NOTE: The transport-specific builder will call resolve_protocol again
-        // internally (for HTTP sub-protocol selection or tonic validation), but
-        // that's harmless — the result is the same.
         let protocol = crate::exporter::resolve_protocol(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, None);
         match protocol {
             #[cfg(feature = "grpc-tonic")]
-            crate::Protocol::Grpc => self.with_tonic().build(),
+            crate::Protocol::Grpc => {
+                let mut builder = self.with_tonic();
+                builder.client.0.exporter_config.protocol = Some(protocol);
+                builder.build()
+            }
             #[cfg(feature = "http-proto")]
-            crate::Protocol::HttpBinary => self.with_http().build(),
+            crate::Protocol::HttpBinary => {
+                let mut builder = self.with_http();
+                builder.client.0.exporter_config.protocol = Some(protocol);
+                builder.build()
+            }
             #[cfg(feature = "http-json")]
-            crate::Protocol::HttpJson => self.with_http().build(),
+            crate::Protocol::HttpJson => {
+                let mut builder = self.with_http();
+                builder.client.0.exporter_config.protocol = Some(protocol);
+                builder.build()
+            }
         }
     }
 }
@@ -280,6 +289,112 @@ mod tests {
                 },
             );
         });
+    }
+
+    /// Invalid enum values are warned about and ignored, so resolution
+    /// continues to the next source in the precedence chain.
+    #[cfg(all(feature = "grpc-tonic", feature = "http-proto"))]
+    #[test]
+    fn build_auto_select_ignores_invalid_protocol_env_values() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            temp_env::with_vars(
+                [
+                    (
+                        super::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
+                        Some("not-a-protocol"),
+                    ),
+                    (crate::OTEL_EXPORTER_OTLP_PROTOCOL, Some("GRPC")),
+                ],
+                || {
+                    let exporter = SpanExporter::builder().build().unwrap();
+                    assert!(matches!(
+                        exporter.client,
+                        super::SupportedTransportClient::Tonic(_)
+                    ));
+                },
+            );
+
+            temp_env::with_vars(
+                [
+                    (
+                        super::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
+                        Some("HTTP/PROTOBUF"),
+                    ),
+                    (crate::OTEL_EXPORTER_OTLP_PROTOCOL, Some("grpc")),
+                ],
+                || {
+                    let exporter = SpanExporter::builder().build().unwrap();
+                    assert!(matches!(
+                        exporter.client,
+                        super::SupportedTransportClient::Http(_)
+                    ));
+                },
+            );
+
+            temp_env::with_vars(
+                [
+                    (
+                        super::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
+                        Some("not-a-protocol"),
+                    ),
+                    (
+                        crate::OTEL_EXPORTER_OTLP_PROTOCOL,
+                        Some("also-not-a-protocol"),
+                    ),
+                ],
+                || {
+                    let exporter = SpanExporter::builder().build().unwrap();
+                    assert!(matches!(
+                        exporter.client,
+                        super::SupportedTransportClient::Http(_)
+                    ));
+                },
+            );
+        });
+    }
+
+    #[cfg(all(feature = "http-proto", not(feature = "grpc-tonic")))]
+    #[test]
+    fn build_auto_select_ignores_protocol_with_disabled_feature() {
+        temp_env::with_vars(
+            [
+                (super::OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, None::<&str>),
+                (crate::OTEL_EXPORTER_OTLP_PROTOCOL, Some("grpc")),
+            ],
+            || {
+                let exporter = SpanExporter::builder().build().unwrap();
+                assert!(matches!(
+                    exporter.client,
+                    super::SupportedTransportClient::Http(_)
+                ));
+            },
+        );
+    }
+
+    #[cfg(all(
+        any(feature = "http-proto", feature = "http-json"),
+        feature = "gzip-http"
+    ))]
+    #[test]
+    fn build_http_succeeds_with_invalid_compression_env_value() {
+        temp_env::with_vars(
+            [
+                (
+                    super::OTEL_EXPORTER_OTLP_TRACES_COMPRESSION,
+                    Some("not-compression"),
+                ),
+                (crate::OTEL_EXPORTER_OTLP_COMPRESSION, Some("GZIP")),
+            ],
+            || {
+                let result = SpanExporter::builder().with_http().build();
+                assert!(
+                    result.is_ok(),
+                    "invalid signal compression should fall back to generic: {:?}",
+                    result.err()
+                );
+            },
+        );
     }
 
     /// Verifies that explicitly selecting tonic transport with an HTTP protocol


### PR DESCRIPTION
## Changes

Fix OTLP environment parsing so invalid compression or metrics temporality values do not fail exporter construction. Apply consistent parsing rules to protocol, compression, and temporality: accept values case-insensitively, treat empty values as unset, and warn and ignore invalid values or values requiring disabled features.

For protocol and compression, ignored signal-specific values fall back to the generic setting, then the default. For example, invalid `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` with generic compression `gzip` uses gzip when supported. Explicit `none` disables compression and stops fallback. Invalid temporality falls back to cumulative.

Programmatic configuration remains strict. This extracts the environment-parsing fix from #3692 without changing public error types.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (not applicable; no public API changes)
