### PR TITLE
perf(sdk): reduce span processor export allocations

### DIFF
--- a/opentelemetry-otlp/src/exporter/http/trace.rs
+++ b/opentelemetry-otlp/src/exporter/http/trace.rs
@@ -3,13 +3,14 @@ use crate::Protocol;
 use opentelemetry::{otel_debug, otel_warn};
 use opentelemetry_sdk::{
     error::{OTelSdkError, OTelSdkResult},
-    trace::{SpanData, SpanExporter},
+    trace::{SpanBatch, SpanData, SpanExporter},
 };
 #[cfg(feature = "http-proto")]
 use prost::Message;
 
 impl SpanExporter for OtlpHttpClient {
-    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
+        let batch: Vec<SpanData> = batch.iter().cloned().collect();
         let response_body = self
             .export_http_with_retry(
                 batch,

--- a/opentelemetry-otlp/src/exporter/tonic/trace.rs
+++ b/opentelemetry-otlp/src/exporter/tonic/trace.rs
@@ -9,7 +9,7 @@ use opentelemetry_proto::transform::trace::tonic::group_spans_by_resource_and_sc
 use opentelemetry_sdk::error::OTelSdkError;
 use opentelemetry_sdk::{
     error::OTelSdkResult,
-    trace::{SpanData, SpanExporter},
+    trace::{SpanBatch, SpanData, SpanExporter},
 };
 use tonic::{codegen::CompressionEncoding, service::Interceptor, transport::Channel, Request};
 
@@ -67,7 +67,8 @@ impl TonicTracesClient {
 }
 
 impl SpanExporter for TonicTracesClient {
-    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
+        let batch: Vec<SpanData> = batch.iter().cloned().collect();
         let batch = Arc::new(batch);
 
         match super::tonic_retry_with_backoff(

--- a/opentelemetry-otlp/src/span.rs
+++ b/opentelemetry-otlp/src/span.rs
@@ -5,7 +5,7 @@
 use std::fmt::Debug;
 
 use opentelemetry_sdk::error::OTelSdkResult;
-use opentelemetry_sdk::trace::SpanData;
+use opentelemetry_sdk::trace::SpanBatch;
 
 use crate::ExporterBuildError;
 #[cfg(feature = "grpc-tonic")]
@@ -179,7 +179,7 @@ impl SpanExporter {
 }
 
 impl opentelemetry_sdk::trace::SpanExporter for SpanExporter {
-    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
         match &self.client {
             #[cfg(feature = "grpc-tonic")]
             SupportedTransportClient::Tonic(client) => client.export(batch).await,

--- a/opentelemetry-sdk/CHANGELOG.md
+++ b/opentelemetry-sdk/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+- **Breaking** `SpanExporter::export` now accepts a borrowed `SpanBatch<'_>`
+  instead of `Vec<SpanData>`. Exporters that retain spans after the export
+  future completes must clone them. This allows `BatchSpanProcessor` to reuse
+  its export buffer and avoids allocating a one-element vector in
+  `SimpleSpanProcessor`.
 - Publicly export the `OTEL_*`/`OTEL_*_DEFAULT` environment variable name and
   default value constants for `BatchSpanProcessor` (`opentelemetry_sdk::trace`),
   `BatchLogProcessor` (`opentelemetry_sdk::logs`), and `PeriodicReader`

--- a/opentelemetry-sdk/benches/batch_span_processor.rs
+++ b/opentelemetry-sdk/benches/batch_span_processor.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use opentelemetry::time::now;
 use opentelemetry::trace::{
     SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState,
@@ -12,7 +12,11 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 
 fn get_span_data() -> Vec<SpanData> {
-    (0..200)
+    get_span_data_with_count(200)
+}
+
+fn get_span_data_with_count(count: usize) -> Vec<SpanData> {
+    (0..count)
         .map(|_| SpanData {
             span_context: SpanContext::new(
                 TraceId::from(12),
@@ -34,7 +38,7 @@ fn get_span_data() -> Vec<SpanData> {
             status: Status::Unset,
             instrumentation_scope: Default::default(),
         })
-        .collect::<Vec<SpanData>>()
+        .collect()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -81,11 +85,51 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
+fn steady_state_export_benchmark(c: &mut Criterion) {
+    const SPAN_COUNT: usize = 4_096;
+
+    let mut group = c.benchmark_group("BatchSpanProcessor/steady_state");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(SPAN_COUNT as u64));
+
+    for batch_size in [1, 64, 512] {
+        let processor = BatchSpanProcessor::builder(NoopSpanExporter::new())
+            .with_batch_config(
+                BatchConfigBuilder::default()
+                    .with_max_queue_size(SPAN_COUNT * 2)
+                    .with_max_export_batch_size(batch_size)
+                    .build(),
+            )
+            .build();
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("batch_size_{batch_size}")),
+            &batch_size,
+            |b, _| {
+                b.iter_batched(
+                    || get_span_data_with_count(SPAN_COUNT),
+                    |spans| {
+                        for span in spans {
+                            processor.on_end(span);
+                        }
+                        processor.force_flush().unwrap();
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+
+        processor.shutdown().unwrap();
+    }
+
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default()
         .warm_up_time(std::time::Duration::from_secs(1))
         .measurement_time(std::time::Duration::from_secs(2));
-    targets = criterion_benchmark
+    targets = criterion_benchmark, steady_state_export_benchmark
 }
 criterion_main!(benches);

--- a/opentelemetry-sdk/benches/context.rs
+++ b/opentelemetry-sdk/benches/context.rs
@@ -9,7 +9,7 @@ use opentelemetry::{
 };
 use opentelemetry_sdk::{
     error::OTelSdkResult,
-    trace::{Sampler, SdkTracerProvider, SpanData, SpanExporter},
+    trace::{Sampler, SdkTracerProvider, SpanBatch, SpanExporter},
 };
 #[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
@@ -166,7 +166,7 @@ fn parent_sampled_tracer(inner_sampler: Sampler) -> (SdkTracerProvider, BoxedTra
 struct NoopExporter;
 
 impl SpanExporter for NoopExporter {
-    async fn export(&self, _spans: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, _spans: SpanBatch<'_>) -> OTelSdkResult {
         Ok(())
     }
 }

--- a/opentelemetry-sdk/benches/span.rs
+++ b/opentelemetry-sdk/benches/span.rs
@@ -27,7 +27,7 @@ use opentelemetry::{
 };
 use opentelemetry_sdk::{
     error::OTelSdkResult,
-    trace::{self as sdktrace, SpanData, SpanExporter},
+    trace::{self as sdktrace, SpanExporter},
 };
 #[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
@@ -155,7 +155,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 struct VoidExporter;
 
 impl SpanExporter for VoidExporter {
-    async fn export(&self, _spans: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, _spans: sdktrace::SpanBatch<'_>) -> OTelSdkResult {
         Ok(())
     }
 }

--- a/opentelemetry-sdk/benches/span_builder.rs
+++ b/opentelemetry-sdk/benches/span_builder.rs
@@ -4,10 +4,7 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_sdk::error::OTelSdkResult;
-use opentelemetry_sdk::{
-    trace as sdktrace,
-    trace::{SpanData, SpanExporter},
-};
+use opentelemetry_sdk::{trace as sdktrace, trace::SpanExporter};
 #[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
 
@@ -65,7 +62,7 @@ fn not_sampled_provider() -> (sdktrace::SdkTracerProvider, sdktrace::SdkTracer) 
 struct NoopExporter;
 
 impl SpanExporter for NoopExporter {
-    async fn export(&self, _spans: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, _spans: sdktrace::SpanBatch<'_>) -> OTelSdkResult {
         Ok(())
     }
 }

--- a/opentelemetry-sdk/benches/trace.rs
+++ b/opentelemetry-sdk/benches/trace.rs
@@ -5,7 +5,7 @@ use opentelemetry::{
 };
 use opentelemetry_sdk::{
     error::OTelSdkResult,
-    trace::{self as sdktrace, SpanData, SpanExporter},
+    trace::{self as sdktrace, SpanExporter},
 };
 #[cfg(all(not(target_os = "windows"), feature = "bench_profiling"))]
 use pprof::criterion::{Output, PProfProfiler};
@@ -59,7 +59,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 struct VoidExporter;
 
 impl SpanExporter for VoidExporter {
-    async fn export(&self, _spans: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, _spans: sdktrace::SpanBatch<'_>) -> OTelSdkResult {
         Ok(())
     }
 }

--- a/opentelemetry-sdk/src/testing/trace/span_exporters.rs
+++ b/opentelemetry-sdk/src/testing/trace/span_exporters.rs
@@ -1,6 +1,6 @@
 use crate::error::{OTelSdkError, OTelSdkResult};
 use crate::{
-    trace::{SpanData, SpanExporter},
+    trace::{SpanBatch, SpanData, SpanExporter},
     trace::{SpanEvents, SpanLinks},
     ExportError,
 };
@@ -42,8 +42,8 @@ pub struct TestSpanExporter {
 }
 
 impl SpanExporter for TestSpanExporter {
-    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
-        batch.into_iter().try_for_each(|span_data| {
+    async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
+        batch.iter().cloned().try_for_each(|span_data| {
             self.tx_export
                 .send(span_data)
                 .map_err(|err| OTelSdkError::InternalFailure(format!("Export failed: {err:?}")))
@@ -111,7 +111,7 @@ impl NoopSpanExporter {
 }
 
 impl SpanExporter for NoopSpanExporter {
-    async fn export(&self, _: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, _: SpanBatch<'_>) -> OTelSdkResult {
         Ok(())
     }
 }

--- a/opentelemetry-sdk/src/trace/export.rs
+++ b/opentelemetry-sdk/src/trace/export.rs
@@ -7,6 +7,42 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 use std::time::{Duration, SystemTime};
 
+/// A batch of spans to be exported by a [`SpanExporter`].
+///
+/// The batch borrows span data from the processor for the duration of the
+/// export operation.
+#[derive(Debug)]
+pub struct SpanBatch<'a> {
+    spans: &'a [SpanData],
+}
+
+impl<'a> SpanBatch<'a> {
+    /// Creates a batch from a slice of span data.
+    pub fn new(spans: &'a [SpanData]) -> Self {
+        Self { spans }
+    }
+
+    /// Returns an iterator over the spans in this batch.
+    pub fn iter(&self) -> std::slice::Iter<'a, SpanData> {
+        self.spans.iter()
+    }
+
+    /// Returns the spans in this batch as a slice.
+    pub fn as_slice(&self) -> &'a [SpanData] {
+        self.spans
+    }
+
+    /// Returns the number of spans in this batch.
+    pub fn len(&self) -> usize {
+        self.spans.len()
+    }
+
+    /// Returns `true` if this batch contains no spans.
+    pub fn is_empty(&self) -> bool {
+        self.spans.is_empty()
+    }
+}
+
 /// `SpanExporter` defines the interface that protocol-specific exporters must
 /// implement so that they can be plugged into OpenTelemetry SDK and support
 /// sending of telemetry data.
@@ -27,9 +63,12 @@ pub trait SpanExporter: Send + Sync + Debug {
     ///
     /// Any retry logic that is required by the exporter is the responsibility
     /// of the exporter.
+    ///
+    /// Exporters that need to retain span data after the returned future
+    /// completes must clone the relevant spans.
     fn export(
         &self,
-        batch: Vec<SpanData>,
+        batch: SpanBatch<'_>,
     ) -> impl std::future::Future<Output = OTelSdkResult> + Send;
 
     /// Shuts down the exporter. Called when SDK is shut down. This is an

--- a/opentelemetry-sdk/src/trace/export.rs
+++ b/opentelemetry-sdk/src/trace/export.rs
@@ -17,29 +17,13 @@ pub struct SpanBatch<'a> {
 }
 
 impl<'a> SpanBatch<'a> {
-    /// Creates a batch from a slice of span data.
-    pub fn new(spans: &'a [SpanData]) -> Self {
+    pub(crate) fn new(spans: &'a [SpanData]) -> Self {
         Self { spans }
     }
 
     /// Returns an iterator over the spans in this batch.
     pub fn iter(&self) -> std::slice::Iter<'a, SpanData> {
         self.spans.iter()
-    }
-
-    /// Returns the spans in this batch as a slice.
-    pub fn as_slice(&self) -> &'a [SpanData] {
-        self.spans
-    }
-
-    /// Returns the number of spans in this batch.
-    pub fn len(&self) -> usize {
-        self.spans.len()
-    }
-
-    /// Returns `true` if this batch contains no spans.
-    pub fn is_empty(&self) -> bool {
-        self.spans.is_empty()
     }
 }
 

--- a/opentelemetry-sdk/src/trace/in_memory_exporter.rs
+++ b/opentelemetry-sdk/src/trace/in_memory_exporter.rs
@@ -1,6 +1,6 @@
 use crate::error::{OTelSdkError, OTelSdkResult};
 use crate::resource::Resource;
-use crate::trace::{SpanData, SpanExporter};
+use crate::trace::{SpanBatch, SpanData, SpanExporter};
 use std::sync::{atomic::AtomicBool, Arc, Mutex};
 use std::time::Duration;
 
@@ -152,13 +152,11 @@ impl InMemorySpanExporter {
 }
 
 impl SpanExporter for InMemorySpanExporter {
-    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
-        let result = self
-            .spans
+    async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
+        self.spans
             .lock()
-            .map(|mut spans_guard| spans_guard.append(&mut batch.clone()))
-            .map_err(|err| OTelSdkError::InternalFailure(format!("Failed to lock spans: {err:?}")));
-        result
+            .map(|mut spans_guard| spans_guard.extend(batch.iter().cloned()))
+            .map_err(|err| OTelSdkError::InternalFailure(format!("Failed to lock spans: {err:?}")))
     }
 
     fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {

--- a/opentelemetry-sdk/src/trace/mod.rs
+++ b/opentelemetry-sdk/src/trace/mod.rs
@@ -23,7 +23,7 @@ mod tracer;
 
 pub use config::Config;
 pub use events::SpanEvents;
-pub use export::{SpanData, SpanExporter};
+pub use export::{SpanBatch, SpanData, SpanExporter};
 
 /// In-Memory span exporter for testing purpose.
 #[cfg(any(feature = "testing", test))]

--- a/opentelemetry-sdk/src/trace/runtime_tests.rs
+++ b/opentelemetry-sdk/src/trace/runtime_tests.rs
@@ -26,7 +26,8 @@ struct SpanCountExporter {
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
 impl SpanExporter for SpanCountExporter {
     async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
-        self.span_count.fetch_add(batch.len(), Ordering::SeqCst);
+        self.span_count
+            .fetch_add(batch.iter().len(), Ordering::SeqCst);
         Ok(())
     }
 }

--- a/opentelemetry-sdk/src/trace/runtime_tests.rs
+++ b/opentelemetry-sdk/src/trace/runtime_tests.rs
@@ -4,7 +4,7 @@
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
 use crate::runtime::RuntimeChannel;
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
-use crate::trace::SpanExporter;
+use crate::trace::{SpanBatch, SpanExporter};
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
 use crate::{error::OTelSdkResult, runtime};
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
@@ -25,7 +25,7 @@ struct SpanCountExporter {
 
 #[cfg(any(feature = "rt-tokio", feature = "rt-tokio-current-thread"))]
 impl SpanExporter for SpanCountExporter {
-    async fn export(&self, batch: Vec<crate::trace::SpanData>) -> OTelSdkResult {
+    async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
         self.span_count.fetch_add(batch.len(), Ordering::SeqCst);
         Ok(())
     }

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -1670,7 +1670,8 @@ mod tests {
             let _ = self.export_started.try_send(());
             // Block until the test releases the export.
             let _ = self.release.lock().unwrap().recv();
-            self.exported_count.fetch_add(batch.len(), Ordering::SeqCst);
+            self.exported_count
+                .fetch_add(batch.iter().len(), Ordering::SeqCst);
             Ok(())
         }
     }
@@ -1747,7 +1748,7 @@ mod tests {
 
     impl SpanExporter for CountingSpanExporter {
         async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
-            self.count.fetch_add(batch.len(), Ordering::SeqCst);
+            self.count.fetch_add(batch.iter().len(), Ordering::SeqCst);
             // Simulate slow export to cause queue buildup and drops
             std::thread::sleep(Duration::from_millis(20));
             Ok(())
@@ -1836,7 +1837,7 @@ mod tests {
                 // Simulate slow export
                 std::thread::sleep(Duration::from_millis(50));
                 self.exported_count
-                    .fetch_add(batch.len(), Ordering::Relaxed);
+                    .fetch_add(batch.iter().len(), Ordering::Relaxed);
                 Ok(())
             }
 

--- a/opentelemetry-sdk/src/trace/span_processor.rs
+++ b/opentelemetry-sdk/src/trace/span_processor.rs
@@ -37,7 +37,7 @@
 use crate::error::{OTelSdkError, OTelSdkResult};
 use crate::resource::Resource;
 use crate::trace::Span;
-use crate::trace::{SpanData, SpanExporter};
+use crate::trace::{SpanBatch, SpanData, SpanExporter};
 use opentelemetry::Context;
 #[cfg(feature = "experimental_metrics_bound_instruments")]
 use opentelemetry::KeyValue;
@@ -327,7 +327,8 @@ impl<T: SpanExporter> SpanProcessor for SimpleSpanProcessor<T> {
                 // exporter, independent of the export outcome, per semconv.
                 #[cfg(feature = "experimental_metrics_bound_instruments")]
                 self.processed_success.add(1);
-                futures_executor::block_on(exporter.export(vec![span]))
+                let batch = [span];
+                futures_executor::block_on(exporter.export(SpanBatch::new(&batch)))
             }
             Err(_) => Err(OTelSdkError::InternalFailure(
                 "SimpleSpanProcessor mutex poison".into(),
@@ -780,14 +781,9 @@ impl BatchSpanProcessor {
             return OTelSdkResult::Ok(());
         }
 
-        // Splitting off batch clears the existing batch capacity, and is ready
-        // for re-use in the next export. The newly returned vec! from split_off
-        // is passed to the exporter.
-        // TODO: Compared to Logs, this requires new allocation for vec for
-        // every export. See if this can be optimized by
-        // *not* requiring ownership in the exporter.
-        let export = exporter.export(batch.split_off(0));
+        let export = exporter.export(SpanBatch::new(batch.as_slice()));
         let export_result = futures_executor::block_on(export);
+        batch.clear();
 
         match export_result {
             Ok(_) => OTelSdkResult::Ok(()),
@@ -1242,7 +1238,7 @@ mod tests {
     };
     use crate::trace::InMemorySpanExporterBuilder;
     use crate::trace::{BatchConfig, BatchConfigBuilder, SpanEvents, SpanLinks};
-    use crate::trace::{SpanData, SpanExporter};
+    use crate::trace::{SpanBatch, SpanData, SpanExporter};
     use opentelemetry::trace::{SpanContext, SpanId, SpanKind, Status};
     use std::fmt::Debug;
     use std::time::Duration;
@@ -1467,9 +1463,9 @@ mod tests {
     }
 
     impl SpanExporter for MockSpanExporter {
-        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
             let exported_spans = self.exported_spans.clone();
-            exported_spans.lock().unwrap().extend(batch);
+            exported_spans.lock().unwrap().extend(batch.iter().cloned());
             Ok(())
         }
 
@@ -1480,6 +1476,23 @@ mod tests {
             let mut exported_resource = self.exported_resource.lock().unwrap();
             *exported_resource = Some(resource.clone());
         }
+    }
+
+    #[test]
+    fn batchspanprocessor_reuses_export_batch_capacity() {
+        let exporter = MockSpanExporter::new();
+        let mut batch = Vec::with_capacity(8);
+        batch.push(create_test_span("test"));
+        let capacity = batch.capacity();
+        let mut last_export_time = Instant::now();
+
+        let result =
+            BatchSpanProcessor::export_batch_sync(&exporter, &mut batch, &mut last_export_time);
+
+        assert!(result.is_ok());
+        assert!(batch.is_empty());
+        assert_eq!(batch.capacity(), capacity);
+        assert_eq!(exporter.exported_spans.lock().unwrap().len(), 1);
     }
 
     #[test]
@@ -1653,7 +1666,7 @@ mod tests {
     }
 
     impl SpanExporter for BlockingExporter {
-        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
             let _ = self.export_started.try_send(());
             // Block until the test releases the export.
             let _ = self.release.lock().unwrap().recv();
@@ -1733,7 +1746,7 @@ mod tests {
     }
 
     impl SpanExporter for CountingSpanExporter {
-        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+        async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
             self.count.fetch_add(batch.len(), Ordering::SeqCst);
             // Simulate slow export to cause queue buildup and drops
             std::thread::sleep(Duration::from_millis(20));
@@ -1819,7 +1832,7 @@ mod tests {
         }
 
         impl SpanExporter for SlowExporter {
-            async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+            async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
                 // Simulate slow export
                 std::thread::sleep(Duration::from_millis(50));
                 self.exported_count
@@ -1889,7 +1902,7 @@ mod tests {
         }
 
         impl SpanExporter for TrackingExporter {
-            async fn export(&self, _batch: Vec<SpanData>) -> OTelSdkResult {
+            async fn export(&self, _batch: SpanBatch<'_>) -> OTelSdkResult {
                 self.export_calls.fetch_add(1, Ordering::SeqCst);
                 let inflight = self.active.fetch_add(1, Ordering::SeqCst) + 1;
                 self.max_inflight.fetch_max(inflight, Ordering::SeqCst);

--- a/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
+++ b/opentelemetry-sdk/src/trace/span_processor_with_async_runtime.rs
@@ -4,7 +4,7 @@ use crate::runtime::{to_interval_stream, RuntimeChannel, TrySend};
 use crate::trace::BatchConfig;
 use crate::trace::Span;
 use crate::trace::SpanProcessor;
-use crate::trace::{SpanData, SpanExporter};
+use crate::trace::{SpanBatch, SpanData, SpanExporter};
 use futures_channel::oneshot;
 use futures_util::{
     future::{self, BoxFuture, Either},
@@ -330,7 +330,7 @@ impl<E: SpanExporter + 'static, R: RuntimeChannel> BatchSpanProcessorInternal<E,
         }
 
         let exporter_guard = exporter.read().await;
-        let export = exporter_guard.export(batch);
+        let export = exporter_guard.export(SpanBatch::new(&batch));
         let timeout = runtime.delay(max_export_timeout);
 
         pin_mut!(export);
@@ -455,7 +455,7 @@ mod tests {
         OTEL_BSP_MAX_QUEUE_SIZE_DEFAULT, OTEL_BSP_SCHEDULE_DELAY, OTEL_BSP_SCHEDULE_DELAY_DEFAULT,
     };
     use crate::trace::{BatchConfig, BatchConfigBuilder, InMemorySpanExporterBuilder};
-    use crate::trace::{SpanData, SpanExporter};
+    use crate::trace::{SpanBatch, SpanExporter};
     use futures_util::Future;
     use std::fmt::Debug;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -482,7 +482,7 @@ mod tests {
         D: Fn(Duration) -> DS + 'static + Send + Sync,
         DS: Future<Output = ()> + Send + Sync + 'static,
     {
-        async fn export(&self, _batch: Vec<SpanData>) -> OTelSdkResult {
+        async fn export(&self, _batch: SpanBatch<'_>) -> OTelSdkResult {
             (self.delay_fn)(self.delay_for).await;
             Ok(())
         }
@@ -505,7 +505,7 @@ mod tests {
     }
 
     impl SpanExporter for TrackingExporter {
-        async fn export(&self, _batch: Vec<SpanData>) -> crate::error::OTelSdkResult {
+        async fn export(&self, _batch: SpanBatch<'_>) -> crate::error::OTelSdkResult {
             // Increment in-flight counter and note any overlap.
             let inflight = self.active.fetch_add(1, Ordering::SeqCst) + 1;
             if inflight > 1 {

--- a/opentelemetry-stdout/src/trace/exporter.rs
+++ b/opentelemetry-stdout/src/trace/exporter.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use core::fmt;
 use opentelemetry_sdk::error::{OTelSdkError, OTelSdkResult};
-use opentelemetry_sdk::trace::SpanData;
+use opentelemetry_sdk::trace::SpanBatch;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use opentelemetry_sdk::resource::Resource;
@@ -31,7 +31,7 @@ impl Default for SpanExporter {
 
 impl opentelemetry_sdk::trace::SpanExporter for SpanExporter {
     /// Write Spans to stdout
-    async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+    async fn export(&self, batch: SpanBatch<'_>) -> OTelSdkResult {
         if self.is_shutdown.load(Ordering::SeqCst) {
             Err(OTelSdkError::AlreadyShutdown)
         } else {
@@ -69,8 +69,8 @@ impl opentelemetry_sdk::trace::SpanExporter for SpanExporter {
     }
 }
 
-fn print_spans(batch: Vec<SpanData>) {
-    for (i, span) in batch.into_iter().enumerate() {
+fn print_spans(batch: SpanBatch<'_>) {
+    for (i, span) in batch.iter().enumerate() {
         println!("Span #{i}");
         println!("\tInstrumentation Scope");
         println!("\t\tName         : {:?}", span.instrumentation_scope.name());

--- a/opentelemetry-zipkin/src/exporter/mod.rs
+++ b/opentelemetry-zipkin/src/exporter/mod.rs
@@ -119,12 +119,13 @@ impl ZipkinExporterBuilder {
 }
 
 async fn zipkin_export(
-    batch: Vec<trace::SpanData>,
+    batch: trace::SpanBatch<'_>,
     uploader: uploader::Uploader,
     local_endpoint: Endpoint,
 ) -> OTelSdkResult {
     let zipkin_spans = batch
-        .into_iter()
+        .iter()
+        .cloned()
         .map(|span| model::into_zipkin_span(local_endpoint.clone(), span))
         .collect();
 
@@ -133,7 +134,7 @@ async fn zipkin_export(
 
 impl trace::SpanExporter for ZipkinExporter {
     /// Export spans to Zipkin collector.
-    async fn export(&self, batch: Vec<trace::SpanData>) -> OTelSdkResult {
+    async fn export(&self, batch: trace::SpanBatch<'_>) -> OTelSdkResult {
         zipkin_export(batch, self.uploader.clone(), self.local_endpoint.clone()).await
     }
 }


### PR DESCRIPTION
## Changes

Updates the Trace SDK exporter interface to use a borrowed `SpanBatch`, similar to the `LogBatch` change in #2057.

This avoids unnecessary allocations in the span processors:

- `SimpleSpanProcessor` uses a stack-allocated single-span batch instead of `vec![span]`.
- `BatchSpanProcessor` clears and reuses its batch buffer instead of allocating through `split_off(0)`.

Exporters that require ownership, including OTLP exporters, continue to copy the spans at their existing ownership boundary. OTLP serialization and transport behavior are otherwise unchanged.

## API change

`SpanExporter::export` now accepts `SpanBatch<'_>` instead of `Vec<SpanData>`.

`SpanBatch` exposes only `iter()` to keep the new public API minimal.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [x] Changes in public API reviewed (if applicable)
